### PR TITLE
Chore/update tab labels when entering sql or table editor

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -1,15 +1,16 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useDebounce } from '@uidotdev/usehooks'
+import { FilePlus, FolderPlus, Plus, X } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
 import { useParams } from 'common'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useProfile } from 'lib/profile'
-import { FilePlus, FolderPlus, Plus, X } from 'lucide-react'
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
 import { getAppStateSnapshot } from 'state/app-state'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import {
@@ -37,8 +38,8 @@ export const SQLEditorMenu = () => {
   const { profile } = useProfile()
   const project = useSelectedProject()
   const { ref } = useParams()
-
   const snapV2 = useSqlEditorV2StateSnapshot()
+
   const [search, setSearch] = useState('')
   const [showSearch, setShowSearch] = useState(false)
   const [sort, setSort] = useLocalStorage<'name' | 'inserted_at'>(

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -29,7 +29,7 @@ import {
   useSnippetFolders,
   useSqlEditorV2StateSnapshot,
 } from 'state/sql-editor-v2'
-import { createTabId, getTabsStore, makeTabPermanent, removeTabs } from 'state/tabs'
+import { createTabId, getTabsStore, makeTabPermanent, removeTabs, useTabsStore } from 'state/tabs'
 import { SqlSnippets } from 'types'
 import { Separator, TreeView } from 'ui'
 import {
@@ -40,7 +40,6 @@ import {
   InnerSideMenuSeparator,
 } from 'ui-patterns'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
-import { useSnapshot } from 'valtio'
 import SQLEditorLoadingSnippets from './SQLEditorLoadingSnippets'
 import { formatFolderResponseForTreeView, getLastItemIds, ROOT_NODE } from './SQLEditorNav.utils'
 import { SQLEditorTreeViewItem } from './SQLEditorTreeViewItem'
@@ -61,7 +60,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
   const snapV2 = useSqlEditorV2StateSnapshot()
 
   const tabStore = getTabsStore(projectRef)
-  const tabs = useSnapshot(tabStore)
+  const tabs = useTabsStore(projectRef)
   const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
   const [sectionVisibility, setSectionVisibility] = useLocalStorage<SectionState>(
@@ -540,11 +539,10 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
   }, [projectRef, sharedSqlSnippetsData?.pages])
 
   useEffect(() => {
-    if (projectRef && isSuccess && isSharedSqlSnippetsSuccess && isSQLEditorTabsEnabled) {
+    if (projectRef && isSuccess && isSQLEditorTabsEnabled) {
       sqlEditorTabsCleanup({ ref: projectRef, snippets: allSnippetsInView as any })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSuccess, isSharedSqlSnippetsSuccess, allSnippetsInView])
+  }, [isSuccess, isSharedSqlSnippetsSuccess, allSnippetsInView, isSQLEditorTabsEnabled])
 
   return (
     <>

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -29,7 +29,7 @@ export const SearchList = ({ search }: SearchListProps) => {
       { keepPreviousData: true }
     )
 
-  const { data: count, isLoading: isLoadingCount } = useContentCountQuery(
+  const { data: count } = useContentCountQuery(
     {
       projectRef,
       cumulative: true,

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -21,7 +21,6 @@ import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { PROTECTED_SCHEMAS } from 'lib/constants/schemas'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
-import { useTabsStore } from 'state/tabs'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -61,7 +60,6 @@ const TableEditorMenu = () => {
     'alphabetical'
   )
 
-  const tabs = useTabsStore(ref)
   const { project } = useProjectContext()
   const {
     data,

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -21,7 +21,7 @@ import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { PROTECTED_SCHEMAS } from 'lib/constants/schemas'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
-import { editorEntityTypes, updateTab, useTabsStore } from 'state/tabs'
+import { useTabsStore } from 'state/tabs'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -41,6 +41,7 @@ import {
   InnerSideBarFilters,
 } from 'ui-patterns/InnerSideMenu'
 import { useProjectContext } from '../ProjectLayout/ProjectContext'
+import { tableEditorTabsCleanUp } from '../Tabs/Tabs.utils'
 import EntityListItem from './EntityListItem'
 import { TableMenuEmptyState } from './TableMenuEmptyState'
 
@@ -117,19 +118,11 @@ const TableEditorMenu = () => {
   }, [selectedTable?.schema])
 
   useEffect(() => {
-    // [Joshen] Clean up tab labels if the entity's name was updated, since the entity
-    // could've been renamed outside of the table editor (e.g SQL editor)
-    if (isTableEditorTabsEnabled && ref) {
-      const openTabs = tabs.openTabs
-        .map((id) => tabs.tabsMap[id])
-        .filter((tab) => editorEntityTypes['table']?.includes(tab.type))
-
-      openTabs.forEach((tab) => {
-        const entity = entityTypes?.find((x) => tab.metadata?.tableId === x.id)
-        if (!!entity && entity.name !== tab.label) updateTab(ref, tab.id, { label: entity.name })
-      })
+    // Clean up tabs + recent items for any tables that might have been removed outside of the dashboard session
+    if (isTableEditorTabsEnabled && ref && entityTypes && !searchText) {
+      tableEditorTabsCleanUp({ ref, schemas: [selectedSchema], entities: entityTypes })
     }
-  }, [isTableEditorTabsEnabled, entityTypes])
+  }, [entityTypes])
 
   return (
     <>

--- a/apps/studio/components/layouts/Tabs/Tabs.utils.ts
+++ b/apps/studio/components/layouts/Tabs/Tabs.utils.ts
@@ -58,6 +58,18 @@ export const tableEditorTabsCleanUp = ({
 
   // perform tabs cleanup
   removeTabs(ref, tableEditorTabsToBeCleaned)
+
+  // [Joshen] Validate for opened tabs, if their label matches the entity's name - update label if not
+  // As the entity could've been renamed outside of the table editor
+  // e.g Using the SQL editor to rename the entity
+  const openTabs = tabsStore.openTabs
+    .map((id) => tabsStore.tabsMap[id])
+    .filter((tab) => editorEntityTypes['table']?.includes(tab.type))
+
+  openTabs.forEach((tab) => {
+    const entity = entities?.find((x) => tab.metadata?.tableId === x.id)
+    if (!!entity && entity.name !== tab.label) updateTab(ref, tab.id, { label: entity.name })
+  })
 }
 
 export const sqlEditorTabsCleanup = ({
@@ -97,6 +109,8 @@ export const sqlEditorTabsCleanup = ({
   )
 
   // [Joshen] Validate for opened tabs, if their label matches the snippet's name - update label if not
+  // As the snippets name could've been updated outside of the SQL Editor session
+  // e.g for a shared snippet, the owner could've updated the name of the snippet
   const openSqlTabs = tabsStore.openTabs
     .map((id) => tabsStore.tabsMap[id])
     .filter((tab) => editorEntityTypes['sql']?.includes(tab.type))

--- a/apps/studio/components/layouts/Tabs/Tabs.utils.ts
+++ b/apps/studio/components/layouts/Tabs/Tabs.utils.ts
@@ -5,7 +5,7 @@ import {
   RecentItem,
   removeRecentItems,
 } from 'state/recent-items'
-import { createTabId, getTabsStore, removeTabs } from 'state/tabs'
+import { createTabId, editorEntityTypes, getTabsStore, removeTabs, updateTab } from 'state/tabs'
 
 export const tableEditorTabsCleanUp = ({
   ref,
@@ -65,7 +65,7 @@ export const sqlEditorTabsCleanup = ({
   snippets,
 }: {
   ref: string
-  snippets: { id: string; type: string }[]
+  snippets: { id: string; type: string; name: string }[]
 }) => {
   // these are tabs that are static content
   // these canot be removed from localstorage based on this query request
@@ -95,4 +95,14 @@ export const sqlEditorTabsCleanup = ({
       ? recentItems.filter((item) => !currentContentIds.includes(item.id)).map((item) => item.id)
       : []
   )
+
+  // [Joshen] Validate for opened tabs, if their label matches the snippet's name - update label if not
+  const openSqlTabs = tabsStore.openTabs
+    .map((id) => tabsStore.tabsMap[id])
+    .filter((tab) => editorEntityTypes['sql']?.includes(tab.type))
+
+  openSqlTabs.forEach((tab) => {
+    const snippet = snippets?.find((x) => tab.metadata?.sqlId === x.id)
+    if (!!snippet && snippet.name !== tab.label) updateTab(ref, tab.id, { label: snippet.name })
+  })
 }


### PR DESCRIPTION
Fixes DESIGN-30
Fixes DESIGN-31

## Context
For the SQL and Table Editor, the tab labels could run out of sync with the snippets / entities if they were renamed outside of the editor session.
- e.g Table Editor: If I've got a table opened as a tab, and then I use the SQL Editor to rename the table
- e.g SQL Editor: If I've got a shared snippet open as a tab and the owner (not me) renamed the snippet

## Changes involved
- Added logic to `tableEditorTabsCleanUp` and `sqlEditorTabsCleanup` to validate the tab labels and update accordingly
- Reinstate `tableEditorTabsCleanUp` which I removed in this [PR](https://github.com/supabase/supabase/pull/35198/files#diff-3ab943b1e9608b1c7927b044c51fcd4159ed7cf5d2dae49a458ee6f3f503526f)
  - it handles cleaning up recent items so I shouldn't have removed it
  - the bug which that PR addresses was caused because it was using `entityTypes` to validate the tabs, which updates when we search in the Table Editor
  - Added a check in the dependency array where we call `tableEditorTabsCleanUp` to skip cleaning up when searching

## To test
### Table Editor:
- Open a table in the table editor as a tab and make it persist
- Head to the SQL Editor and rename that table
- Go back to the table editor and verify that the tab label should be updated to match the new table name
- Also just verify that searching in the table editor will not cause the tabs to disappear

### SQL Editor: (A bit more tricky to test)
- Ensure that you have 2 accounts on the same project
- One account creates a SQL snippet and share it to the project
- The other account opens that shared SQL snippet in a tab and persist it
- Back to the previous account, rename that snippet
- To the other account, do a page refresh then verify that the tab label updates to match the snippet name