### PR TITLE
docs: warning for overloaded functions rpc

### DIFF
--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -61,7 +61,9 @@ At it's most basic a function has the following parts:
 <br />
 
 <Admonition type="caution">
+
 When naming your functions, please make the name of the function unique as overloaded functions are not supported.
+
 </Admonition>
 
 After the Function is created, we have several ways of "executing" the function - either directly inside the database using SQL, or with one of the client libraries.

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -60,6 +60,10 @@ At it's most basic a function has the following parts:
 
 <br />
 
+<Admonition type="caution">
+When naming your functions, please make the name of the function unique as overloaded functions are not supported.
+</Admonition>
+
 After the Function is created, we have several ways of "executing" the function - either directly inside the database using SQL, or with one of the client libraries.
 
 <Tabs


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Database Functions](https://supabase.com/docs/guides/database/functions?queryGroups=language&language=sql#simple-functions)

## What is the current behavior?

No warning that overloaded functions are not supported.

## What is the new behavior?

<img width="2560" alt="Screenshot 2025-04-23 at 19 36 15" src="https://github.com/user-attachments/assets/0fdf7680-e401-4dc2-a666-33a84bb745ab" />


## Additional context

Closes #35144
