### PR TITLE
Bump libpg-query to 17

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -63,7 +63,7 @@
     "js-yaml": "^3.14.1",
     "jsrsasign": "^11.0.0",
     "katex": "^0.16.21",
-    "libpg-query": "15.2.0",
+    "libpg-query": "17.0.0",
     "lodash": "^4.17.21",
     "lucide-react": "*",
     "mdast": "^3.0.0",

--- a/packages/ai-commands/package.json
+++ b/packages/ai-commands/package.json
@@ -29,7 +29,7 @@
     "api-types": "workspace:*",
     "chalk": "^5.3.0",
     "dotenv": "^16.3.1",
-    "libpg-query": "15.2.0",
+    "libpg-query": "17.0.0",
     "mdast-util-from-markdown": "^2.0.0",
     "sql-formatter": "^15.0.0",
     "tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: ^0.16.21
         version: 0.16.21
       libpg-query:
-        specifier: 15.2.0
-        version: 15.2.0(encoding@0.1.13)(supports-color@8.1.1)
+        specifier: 17.0.0
+        version: 17.0.0(encoding@0.1.13)(supports-color@8.1.1)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1509,8 +1509,8 @@ importers:
         specifier: ^16.3.1
         version: 16.3.1
       libpg-query:
-        specifier: 15.2.0
-        version: 15.2.0(encoding@0.1.13)(supports-color@8.1.1)
+        specifier: 17.0.0
+        version: 17.0.0(encoding@0.1.13)(supports-color@8.1.1)
       mdast-util-from-markdown:
         specifier: ^2.0.0
         version: 2.0.0(supports-color@8.1.1)
@@ -10256,6 +10256,9 @@ packages:
   libpg-query@15.2.0:
     resolution: {integrity: sha512-fBi14tsU3/ahtfU0C+/tvmtlt0EJM6kXe0Dl4/cSbiNmJ3IwLIuk3lawwiK5ByXU4sXwyAzbkvSl26jVXzYuaA==}
 
+  libpg-query@17.0.0:
+    resolution: {integrity: sha512-hWmO6xAozwJ6RwDhWq8mQcwMWZwRwh0eaUv/IB9guefpvcDwXAcbS0Whlbl5Hquj7jAY0JvdN6NynF82Ol1oig==}
+
   light-my-request@5.14.0:
     resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
 
@@ -16778,9 +16781,9 @@ snapshots:
 
   '@npmcli/agent@2.2.2(supports-color@8.1.1)':
     dependencies:
-      agent-base: 7.1.1(supports-color@8.1.1)
+      agent-base: 7.1.3
       http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.4(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -24133,7 +24136,7 @@ snapshots:
 
   http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
-      agent-base: 7.1.1(supports-color@8.1.1)
+      agent-base: 7.1.3
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -24825,6 +24828,16 @@ snapshots:
       '@emnapi/runtime': 0.43.1
       '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)(supports-color@8.1.1)
       '@pgsql/types': 15.0.2
+      node-addon-api: 7.1.0
+      node-gyp: 10.1.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  libpg-query@17.0.0(encoding@0.1.13)(supports-color@8.1.1):
+    dependencies:
+      '@emnapi/runtime': 0.43.1
+      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)(supports-color@8.1.1)
       node-addon-api: 7.1.0
       node-gyp: 10.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -26619,7 +26632,7 @@ snapshots:
       make-fetch-happen: 13.0.1(supports-color@8.1.1)
       nopt: 7.2.1
       proc-log: 3.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -28868,7 +28881,7 @@ snapshots:
 
   socks-proxy-agent@8.0.3(supports-color@8.1.1):
     dependencies:
-      agent-base: 7.1.1(supports-color@8.1.1)
+      agent-base: 7.1.3
       debug: 4.4.0(supports-color@8.1.1)
       socks: 2.8.3
     transitivePeerDependencies:


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/34847

We've had several reports of issues with installing dependencies in the repository, caused by the `libpg-query` library. The issue was supposedly fixed [here](https://github.com/pganalyze/libpg_query/pull/277) so just need to bump the library version where it's being used (docs + ai-commands)