### PR TITLE
Add link to table editor from wrappers

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -79,10 +79,12 @@ const WrapperRow = ({ wrapper }: WrapperRowProps) => {
                   />
                 </Badge>
 
-                <Badge className="pl-5 rounded-l-none gap-2 h-6 font-mono text-[0.75rem]">
-                  <Table2 size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
-                  {table.schema}.{table.table_name}
-                </Badge>
+                <Link href={`/project/${ref}/editor/${table.id}`}>
+                  <Badge className="transition hover:bg-surface-300 pl-5 rounded-l-none gap-2 h-6 font-mono text-[0.75rem]">
+                    <Table2 size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
+                    {table.schema}.{table.table_name}
+                  </Badge>
+                </Link>
               </div>
             )
           })}


### PR DESCRIPTION
Just a nit I ran into: was trying to find an easy way to open the foreign table from the integrations/wrappers page

Adds a link to the foreign table in the table editor where badge is that shows the table's schema and name
![image](https://github.com/user-attachments/assets/42936b5b-274c-4e14-bdcb-8915802ab179)
