### PR TITLE
remove lw14 promos

### DIFF
--- a/apps/docs/features/app.providers.tsx
+++ b/apps/docs/features/app.providers.tsx
@@ -11,7 +11,7 @@ import { QueryClientProvider } from './data/queryClient.client'
 import { PageTelemetry } from './telemetry/telemetry.client'
 import { ScrollRestoration } from './ui/helpers.scroll.client'
 import { ThemeSandbox } from './ui/theme.client'
-import { PromoToast } from 'ui-patterns'
+// import { PromoToast } from 'ui-patterns'
 
 /**
  * Global providers that wrap the entire app
@@ -28,7 +28,7 @@ function GlobalProviders({ children }: PropsWithChildren) {
               <CommandProvider>
                 <div className="flex flex-col">
                   <SiteLayout>
-                    <PromoToast />
+                    {/* <PromoToast /> */}
                     {children}
                     <DocsCommandMenu />
                   </SiteLayout>

--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -16,18 +16,6 @@ const Hero = () => {
             <div className="mx-auto max-w-2xl lg:col-span-6 lg:flex lg:items-center justify-center text-center">
               <div className="relative z-10 lg:h-auto pt-[90px] lg:pt-[90px] lg:min-h-[300px] flex flex-col items-center justify-center sm:mx-auto md:w-3/4 lg:mx-0 lg:w-full gap-4 lg:gap-8">
                 <div className="flex flex-col items-center">
-                  <div className="z-40 w-full flex justify-center -mt-4 lg:-mt-12 mb-8">
-                    <AnnouncementBadge
-                      url="/blog/launch-week-14-top-10"
-                      badge="Launch Week 14"
-                      announcement="Top 10 Launches"
-                      className="[&_a]:sm:gap-4 [&_.announcement-badge]:!text-xs [&_.announcement-text]:!text-xs [&_.announcement-badge]:sm:!text-sm [&_.announcement-text]:sm:!text-sm"
-                      style={{
-                        fontFamily:
-                          'Departure Mono, Source Code Pro, Office Code Pro, Menlo, monospace',
-                      }}
-                    />
-                  </div>
                   <h1 className="text-foreground text-4xl sm:text-5xl sm:leading-none lg:text-7xl">
                     <span className="block text-foreground">Build in a weekend</span>
                     <span className="text-brand block md:ml-0">Scale to millions</span>

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -22,7 +22,6 @@ import MetaFaviconsPagesRouter, {
   DEFAULT_FAVICON_ROUTE,
   DEFAULT_FAVICON_THEME_COLOR,
 } from 'common/MetaFavicons/pages-router'
-import { LW14Announcement } from 'ui-patterns/Banners/LW14Announcement'
 import { WwwCommandMenu } from '~/components/CommandMenu'
 import { API_URL, APP_NAME, DEFAULT_META_DESCRIPTION } from '~/lib/constants'
 import useDarkLaunchWeeks from '../hooks/useDarkLaunchWeeks'
@@ -95,7 +94,6 @@ export default function App({ Component, pageProps }: AppProps) {
           >
             <TooltipProvider delayDuration={0}>
               <CommandProvider>
-                <LW14Announcement />
                 <SonnerToaster position="top-right" />
                 <Component {...pageProps} />
                 <WwwCommandMenu />

--- a/packages/ui-patterns/PromoToast/PromoToast.tsx
+++ b/packages/ui-patterns/PromoToast/PromoToast.tsx
@@ -1,20 +1,18 @@
 'use client'
 
-import Image from 'next/image'
+// import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { cn } from 'ui/src/lib/utils/cn'
 import { Button } from 'ui/src/components/Button/Button'
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { useTheme } from 'next-themes'
+// import { useTheme } from 'next-themes'
 import announcement from '../Banners/data.json'
 import './styles.css'
 
-const LW14BG = `/docs/img/launchweek/14/promo-banner-bg.png`
-
 const PromoToast = () => {
   const [visible, setVisible] = useState(false)
-  const { resolvedTheme } = useTheme()
+  // const { resolvedTheme } = useTheme()
 
   useEffect(() => {
     const shouldHide =
@@ -47,9 +45,7 @@ const PromoToast = () => {
             fontFamily: 'Departure Mono, Source Code Pro, Office Code Pro, Menlo, monospace',
           }}
           className="relative z-10 text-foreground flex flex-col text-xl w-full leading-7"
-        >
-          Top 10 Launches
-        </p>
+        ></p>
       </div>
 
       <div className="relative z-10 flex items-center space-x-2">
@@ -62,15 +58,15 @@ const PromoToast = () => {
           Dismiss
         </Button>
       </div>
-      <Image
-        src={LW14BG}
+      {/* <Image
+        src={}
         alt=""
         fill
         sizes="100%"
         quality={100}
         aria-hidden
         className="absolute not-sr-only object-cover z-0 inset-0 w-full h-auto"
-      />
+      /> */}
     </div>
   )
 }


### PR DESCRIPTION
Removing:

- www hero
- www top banner
- docs PromoToast banner

<img width="517" alt="Screenshot 2025-04-24 at 16 27 57" src="https://github.com/user-attachments/assets/3cfb16e1-4057-4b1f-aa25-b4e2e435e796" />
<img width="693" alt="Screenshot 2025-04-24 at 16 28 02" src="https://github.com/user-attachments/assets/03da8db5-7a09-4832-963b-10b09438bea0" />
<img width="395" alt="Screenshot 2025-04-24 at 16 28 08" src="https://github.com/user-attachments/assets/3df0851d-968a-49ed-ad2a-6a58fdbb9ea2" />
