### PR TITLE
chore: Skip building of `libpg-query`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
       "vinxi>esbuild": "0.25.2",
       "@tanstack/directive-functions-plugin>vite": "6.2.6",
       "@tanstack/react-start-plugin>vite": "6.2.6"
-    }
+    },
+    "neverBuiltDependencies": ["libpg-query"]
   },
   "engines": {
     "pnpm": ">=9",

--- a/packages/ai-commands/package.json
+++ b/packages/ai-commands/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@ai-sdk/openai": "^0.0.72",
     "@types/common-tags": "^1.8.4",
+    "@types/mdast": "^4.0.0",
     "@types/node": "catalog:",
     "api-types": "workspace:*",
     "chalk": "^5.3.0",

--- a/packages/ai-commands/test/sql-util.ts
+++ b/packages/ai-commands/test/sql-util.ts
@@ -1,4 +1,4 @@
-import { A_Const, A_Expr, ColumnRef, CreatePolicyStmt, Node, parseQuery } from 'libpg-query'
+import { A_Const, A_Expr, ColumnRef, CreatePolicyStmt, Node, parseQuery } from 'libpg-query/wasm'
 
 export type PolicyInfo = {
   name: string

--- a/packages/ai-commands/test/util.ts
+++ b/packages/ai-commands/test/util.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
+import type { Code } from 'mdast'
 import { fromMarkdown } from 'mdast-util-from-markdown'
-import type { Code } from 'mdast-util-from-markdown/lib'
 import { format } from 'sql-formatter'
 
 declare global {

--- a/packages/ai-commands/tsconfig.json
+++ b/packages/ai-commands/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "types": ["./test/extensions.d.ts"]
   }
 }

--- a/packages/ai-commands/vitest.setup.ts
+++ b/packages/ai-commands/vitest.setup.ts
@@ -9,3 +9,27 @@ if (!process.env.CI) {
   statSync(envPath)
   config({ path: envPath })
 }
+
+// Modify fetch to support wasm file URLs
+globalThis.fetch = async (input: string | URL | Request) => {
+  if (input instanceof Request) {
+    return fetch(input)
+  }
+
+  const url = new URL(input)
+  if (url.protocol === 'file:' && url.pathname.endsWith('.wasm')) {
+    return fetchFileNode(input, 'application/wasm')
+  }
+
+  return fetch(input)
+}
+
+async function fetchFileNode(input: string | URL, type: string) {
+  const fs = await import('node:fs')
+  const { Readable } = await import('node:stream')
+  const { fileURLToPath } = await import('node:url')
+  const path = fileURLToPath(input)
+  const nodeStream = fs.createReadStream(path)
+  const stream = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>
+  return new Response(stream, { headers: { 'Content-Type': type } })
+}

--- a/packages/ai-commands/vitest.setup.ts
+++ b/packages/ai-commands/vitest.setup.ts
@@ -11,9 +11,9 @@ if (!process.env.CI) {
 }
 
 // Modify fetch to support wasm file URLs
-globalThis.fetch = async (input: string | URL | Request) => {
+globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
   if (input instanceof Request) {
-    return fetch(input)
+    return fetch(input, init)
   }
 
   const url = new URL(input)
@@ -21,7 +21,7 @@ globalThis.fetch = async (input: string | URL | Request) => {
     return fetchFileNode(input, 'application/wasm')
   }
 
-  return fetch(input)
+  return fetch(input, init)
 }
 
 async function fetchFileNode(input: string | URL, type: string) {

--- a/packages/ui-patterns/SqlToRest/index.tsx
+++ b/packages/ui-patterns/SqlToRest/index.tsx
@@ -25,7 +25,7 @@ function FallbackComponent({ error }: FallbackProps) {
 }
 
 // Lazy load client side to prevent hydration issues when browser produces an error
-const SqlToRest = dynamic(() => import('./sql-to-rest'))
+const SqlToRest = dynamic(() => import('./sql-to-rest'), { ssr: false })
 
 export default function SqlToRestWithFallback(props: SqlToRestProps) {
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1496,6 +1496,9 @@ importers:
       '@types/common-tags':
         specifier: ^1.8.4
         version: 1.8.4
+      '@types/mdast':
+        specifier: ^4.0.0
+        version: 4.0.1
       '@types/node':
         specifier: 'catalog:'
         version: 20.12.11
@@ -1613,7 +1616,7 @@ importers:
     dependencies:
       '@mertasan/tailwindcss-variables':
         specifier: ^2.2.3
-        version: 2.7.0(autoprefixer@10.4.16(postcss@8.5.3))(postcss@8.5.3)
+        version: 2.7.0(autoprefixer@10.4.16(postcss@8.4.38))(postcss@8.4.38)
       '@radix-ui/colors':
         specifier: ^0.1.8
         version: 0.1.9
@@ -8669,7 +8672,6 @@ packages:
     resolution: {integrity: sha512-t0q23FIpvHDTtnORW+bDJziGsal5uh9RJTJ1fyH8drd4lICOoXhJ5pLMUZ5C0VQei6dNmwTzzoTRgMkO9JgHEQ==}
     peerDependencies:
       eslint: '>= 5'
-    bundledDependencies: []
 
   eslint-plugin-import@2.29.1:
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
@@ -16596,11 +16598,11 @@ snapshots:
       '@types/react': 18.3.3
       react: 18.3.1
 
-  '@mertasan/tailwindcss-variables@2.7.0(autoprefixer@10.4.16(postcss@8.5.3))(postcss@8.5.3)':
+  '@mertasan/tailwindcss-variables@2.7.0(autoprefixer@10.4.16(postcss@8.4.38))(postcss@8.4.38)':
     dependencies:
-      autoprefixer: 10.4.16(postcss@8.5.3)
+      autoprefixer: 10.4.16(postcss@8.4.38)
       lodash: 4.17.21
-      postcss: 8.5.3
+      postcss: 8.4.38
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
@@ -20501,7 +20503,7 @@ snapshots:
 
   '@types/mdast@4.0.1':
     dependencies:
-      '@types/unist': 3.0.3
+      '@types/unist': 2.0.8
 
   '@types/mdx-js__react@1.5.6':
     dependencies:


### PR DESCRIPTION
* Added `libpg-query` to the `neverBuiltDependencies` list in `package.json` to prevent it from being built during the dependency installation process.
* Updated the import path for `libpg-query` in `packages/ai-commands/test/sql-util.ts` to use the `wasm` version for compatibility.
* Added `"moduleResolution": "bundler"` to the `tsconfig.json` file in `packages/ai-commands` to make the `wasm` version typesafe.