### PR TITLE
Remove isValidating check on custom domain cancel action

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -189,7 +189,6 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
               type="default"
               onClick={onCancelCustomDomain}
               loading={isDeleting}
-              disabled={isValidating}
               className="self-end"
             >
               Cancel


### PR DESCRIPTION
As per PR title - the disabled check here seems unnecessary and is blocking a user from restarting the custom domain set up process