### PR TITLE
docs: svelte kit quickstart update

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -51,9 +51,10 @@ hideToc: true
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Create the Supabase client">
 
-    Create a `src/lib` directory in your SvelteKit app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client with your project URL and public API (anon) key:
+  <StepHikeCompact.Details title="Declare Supabase Environment Variables">
+
+    Create a `.env` file at the root of your project and populate with your Supabase connection variables:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />
@@ -62,17 +63,51 @@ hideToc: true
 
     <StepHikeCompact.Code>
 
-      ```js name=src/lib/supabaseClient.js
-        import { createClient } from '@supabase/supabase-js'
+      <$CodeTabs>
 
-        export const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
-      ```
+        ```text name=.env
+        PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        PUBLIC_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        ```
+
+      </$CodeTabs>
 
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={5}>
+    <StepHikeCompact.Details title="Create the Supabase client">
+
+    Create a `src/lib` directory in your SvelteKit app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client:
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      <$CodeTabs>
+
+        ```js name=src/lib/supabaseClient.js
+          import { createClient } from '@supabase/supabase-js';
+        import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+
+        export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
+        ```
+
+        ```ts name=src/lib/supabaseClient.ts
+          import { createClient } from '@supabase/supabase-js';
+        import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+
+        export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
+        ```
+
+      </$CodeTabs>
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Query data from the app">
 
     Use `load` method to fetch the data server-side and display the query results as a simple list.
@@ -82,17 +117,43 @@ hideToc: true
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>
 
+      <$CodeTabs>
 
-      ```js name=src/routes/+page.server.js
-        import { supabase } from "$lib/supabaseClient";
+        ```js name=src/routes/+page.server.js
+          import { supabase } from "$lib/supabaseClient";
 
-        export async function load() {
-          const { data } = await supabase.from("instruments").select();
+          export async function load() {
+            const { data } = await supabase.from("instruments").select();
+            return {
+              instruments: data ?? [],
+            };
+          }
+        ```
+
+        ```ts name=src/routes/+page.server.ts
+        import type { PageServerLoad } from './$types';
+        import { supabase } from '$lib/supabaseClient';
+
+        type Instrument = {
+          id: number;
+          name: string;
+        };
+
+        export const load: PageServerLoad = async () => {
+          const { data, error } = await supabase.from('instruments').select<'instruments', Instrument>();
+
+          if (error) {
+            console.error('Error loading instruments:', error.message);
+            return { instruments: [] };
+          }
+
           return {
             instruments: data ?? [],
           };
-        }
-      ```
+        };
+        ```
+
+      </$CodeTabs>
 
     </StepHikeCompact.Code>
 
@@ -120,7 +181,7 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={6}>
+  <StepHikeCompact.Step step={7}>
     <StepHikeCompact.Details title="Start the app">
 
     Start the app and go to http://localhost:5173 in a browser and you should see the list of instruments.

--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -66,8 +66,8 @@ hideToc: true
       <$CodeTabs>
 
         ```text name=.env
-        PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
-        PUBLIC_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        VITE_PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        VITE_PUBLIC_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
         ```
 
       </$CodeTabs>
@@ -89,16 +89,16 @@ hideToc: true
 
         ```js name=src/lib/supabaseClient.js
           import { createClient } from '@supabase/supabase-js';
-        import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 
-        export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
+        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY)
         ```
 
         ```ts name=src/lib/supabaseClient.ts
           import { createClient } from '@supabase/supabase-js';
-        import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 
-        export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
+        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY)
         ```
 
       </$CodeTabs>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Svelte Kit Quickstart](https://supabase.com/docs/guides/getting-started/quickstarts/sveltekit)

## What is the current behavior?

No env or typescript sections in the docs

## What is the new behavior?

`.env` example added and also choice between js/ts

## Additional context

Close #29425 
