### PR TITLE
Update all languages to use `->>` operator in JSON query examples

### DIFF
--- a/apps/docs/content/guides/database/json.mdx
+++ b/apps/docs/content/guides/database/json.mdx
@@ -417,7 +417,7 @@ from books;
 ```js
 const { data, error } = await supabase.from('books').select(`
     title,
-    description:  metadata->description,
+    description:  metadata->>description,
     price:        metadata->price,
     low_age:      metadata->ages->0,
     high_age:     metadata->ages->1
@@ -433,7 +433,7 @@ try await supabase
   .select(
     """
       title,
-      description:  metadata->description,
+      description:  metadata->>description,
       price:        metadata->price,
       low_age:      metadata->ages->0,
       high_age:     metadata->ages->1
@@ -448,7 +448,7 @@ try await supabase
 ```kotlin
 val data = supabase.from("books").select(Columns.raw("""
     title,
-    description: metadata->description,
+    description: metadata->>description,
     price: metadata->price,
     low_age: metadata->ages->0,
     high_age: metadata->ages->1
@@ -461,7 +461,7 @@ val data = supabase.from("books").select(Columns.raw("""
 ```python
 data = supabase.from_('books').select("""
   title,
-  description: metadata->description,
+  description: metadata->>description,
   price: metadata->price,
   low_age: metadata->ages->0,
   high_age: metadata->ages->1


### PR DESCRIPTION
- The docs explain "If you want the data returned as `text`, use the `->>` operator."
- Only the SQL example shows this using the `description` field
- All language should use `->>` for the description field

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A small fix to the docs for [JSON query](https://supabase.com/docs/guides/database/json)

## What is the current behavior?

- The docs explain "If you want the data returned as `text`, use the `->>` operator."
- Only the SQL example shows this using the `description` field

## What is the new behavior?

- All language should use `->>` for the description field