### PR TITLE
fix: Delay the autofocus of the input in a treeview

### DIFF
--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -59,7 +59,6 @@ export const LOCAL_STORAGE_KEYS = {
 
   SQL_EDITOR_INTELLISENSE: 'supabase_sql-editor-intellisense-enabled',
   SQL_EDITOR_SPLIT_SIZE: 'supabase_sql-editor-split-size',
-  SQL_EDITOR_AI_PANEL_SPLIT_SIZE: 'supabase_sql-editor-ai-panel-split-size',
   // Key to track which schemas are ok to be sent to AI. The project ref is intentionally put at the end for easier search in the browser console.
   SQL_EDITOR_AI_SCHEMA: (ref: string) => `supabase_sql-editor-ai-schema-enabled-${ref}`,
   SQL_EDITOR_AI_OPEN: 'supabase_sql-editor-ai-open',

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -178,14 +178,15 @@ export const sqlEditorState = proxy({
 
   saveFolder: ({ id, name }: { id: string; name: string }) => {
     let storeFolder = sqlEditorState.folders[id]
+    const isNewFolder = id === 'new-folder'
     const hasChanges = storeFolder.folder.name !== name
 
-    if (id === 'new-folder' && sqlEditorState.allFolderNames.includes(name)) {
+    if (isNewFolder && sqlEditorState.allFolderNames.includes(name)) {
       sqlEditorState.removeFolder(id)
-      return toast.error('This folder name already exists')
+      return toast.error('Unable to create new folder: This folder name already exists')
     } else if (hasChanges && sqlEditorState.allFolderNames.includes(name)) {
       storeFolder.status = 'idle'
-      return toast.error('This folder name already exists')
+      return toast.error('Unable to update folder: This folder name already exists')
     }
 
     const originalFolderName = storeFolder.folder.name.slice()

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -108,7 +108,7 @@ const TreeViewItem = forwardRef<
           // [Ivan] For some reason, during initial render, the input loses focus ~50-60% of the time.
           // [Joshen] This is really dirty, but I can't seem to identify why the focus is lost. But am opting
           // for a more deterministic way to prevent accidental onBlur callbacks by checking that the onBlur event
-          // is being triggered within 200ms of the input field being in an edit state. 200ms is just an arbitary
+          // is being triggered within 400ms of the input field being in an edit state. 400ms is just an arbitary
           // value which I think represents an "accidental" on blur
           timeRef.current = Number(new Date())
           input.focus()
@@ -142,7 +142,7 @@ const TreeViewItem = forwardRef<
       const timestamp = Number(new Date())
       const timeDiff = timestamp - timeRef.current
 
-      if (timeDiff < 200) {
+      if (timeDiff < 400) {
         e.preventDefault()
         inputRef?.current?.focus()
       } else {

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -250,7 +250,7 @@ const TreeViewItem = forwardRef<
               // stop keyboard down bubbling up to TreeView.root
               // on enter key, send onEditSubmit callback
               if (e.key === 'Enter') {
-                onEditSubmit?.(localValueState)
+                inputRef.current?.blur()
               } else if (e.key === 'Escape') {
                 setLocalValueState(name)
                 onEditSubmit?.(name)
@@ -258,7 +258,7 @@ const TreeViewItem = forwardRef<
                 e.stopPropagation()
               }
             }}
-            className="block w-full text-sm px-2 py-1 h-7 w"
+            className="block w-full text-sm px-2 py-1 h-7"
             value={localValueState}
           />
         </form>

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -92,38 +92,28 @@ const TreeViewItem = forwardRef<
     const inputRef = useRef<HTMLInputElement>(null)
 
     useEffect(() => {
-      const handleClickOutside = (event: MouseEvent) => {
-        if (inputRef.current && !inputRef.current.contains(event.target as Node)) {
-          onEditSubmit?.(localValueState)
-        }
-      }
-      if (isEditing) document.addEventListener('mousedown', handleClickOutside)
-      return () => {
-        if (isEditing) document.removeEventListener('mousedown', handleClickOutside)
-      }
-    }, [isEditing])
-
-    useEffect(() => {
       if (isEditing) {
-        inputRef.current?.focus()
-
-        // When editing starts, select text up to the last dot
         if (inputRef.current) {
           const input = inputRef.current
 
-          // Need a slight delay to ensure focus is established
           setTimeout(() => {
-            const fileName = input.value
-            const lastDotIndex = fileName.lastIndexOf('.')
-            const startPos = 0
-            const endPos = lastDotIndex > 0 ? lastDotIndex : fileName.length
+            // [Ivan] For some reason, during initial render, the input loses focus ~50-60% of the time.
+            input.focus()
 
-            try {
-              input.setSelectionRange(startPos, endPos)
-            } catch (e) {
-              console.error('Could not set selection range', e)
-            }
-          }, 50)
+            // Need a slight delay to ensure focus is established. When editing starts, select text up to the last dot
+            setTimeout(() => {
+              const fileName = input.value
+              const lastDotIndex = fileName.lastIndexOf('.')
+              const startPos = 0
+              const endPos = lastDotIndex > 0 ? lastDotIndex : fileName.length
+
+              try {
+                input.setSelectionRange(startPos, endPos)
+              } catch (e) {
+                console.error('Could not set selection range', e)
+              }
+            }, 50)
+          }, 150)
         }
       } else {
         setLocalValueState(name)


### PR DESCRIPTION
* Removed `ResizablePanelGroup` components since it wasn't being used for any dynamic panels. Removed the `SQL_EDITOR_AI_PANEL_SPLIT_SIZE` constant also.
* Improved the reliability of the input focus behavior by introducing a double `setTimeout` mechanism to address intermittent focus loss during the initial render.