### PR TITLE
ci (docs): fix docs lint action on forks

### DIFF
--- a/.github/workflows/docs-lint-v2.yml
+++ b/.github/workflows/docs-lint-v2.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH_NAME: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -o pipefail
           run_lints() {
@@ -76,6 +76,6 @@ jobs:
           LINT_EXIT_CODE=$?
           set -e
           if [[ $LINT_EXIT_CODE -ne 0 ]]; then
-            gh pr comment "$BRANCH_NAME" --body "$LINT_RESULTS"
+            gh pr comment "$PR_NUMBER" --body "$LINT_RESULTS"
             exit 1
           fi


### PR DESCRIPTION
Before:

The docs lint action doesn't run properly on forks because it tries to use the branch name to identify the PR for updating, but the branch name is adapted on forks, so it is not `branch-name`, but `forking-account:branch-name`. I tested the "external" workflow originally by adapting it to work for internal PRs which obviously missed this 🤦🏼‍♀️ 

After:

Use the PR number instead to identify the PR instead.