### PR TITLE
feat (content api): add top-level schema query

### DIFF
--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -7,6 +7,6 @@ exports[`/api/graphql schema snapshot > should match snapshot 1`] = `
 
 type RootQueryType {
   """Get the GraphQL schema for this endpoint"""
-  schema: String
+  schema: String!
 }"
 `;

--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`/api/graphql schema snapshot > should match snapshot 1`] = `
+"schema {
+  query: RootQueryType
+}
+
+type RootQueryType {
+  """Get the GraphQL schema for this endpoint"""
+  schema: String
+}"
+`;

--- a/apps/docs/app/api/graphql/route.test.ts
+++ b/apps/docs/app/api/graphql/route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST } from './route'
 
-describe('GraphQL API endpoint', () => {
+describe('/api/graphql basic error statuses', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -57,5 +57,28 @@ describe('GraphQL API endpoint', () => {
     const response = await POST(request)
     const json = await response.json()
     expect(json.errors[0].message).toBe('Internal Server Error')
+  })
+})
+
+describe('/api/graphql schema snapshot', () => {
+  it('should match snapshot', async () => {
+    const schemaQuery = `
+        query {
+          schema
+        }
+      `
+    const request = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: schemaQuery }),
+    })
+
+    const response = await POST(request)
+    const json = await response.json()
+    expect(json.errors).toBeUndefined()
+
+    const {
+      data: { schema },
+    } = json
+    expect(schema).toMatchSnapshot()
   })
 })

--- a/apps/docs/app/api/graphql/route.ts
+++ b/apps/docs/app/api/graphql/route.ts
@@ -3,7 +3,6 @@ import { createComplexityLimitRule } from 'graphql-validation-complexity'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { ApiError, convertZodToInvalidRequestError, InvalidRequestError } from '~/app/api/utils'
-import { rootGraphQLResolver } from '~/resources/rootResolver'
 import { rootGraphQLSchema } from '~/resources/rootSchema'
 import { createQueryDepthLimiter } from './validators'
 
@@ -41,7 +40,6 @@ async function handleGraphQLRequest(request: Request): Promise<NextResponse> {
 
   const result = await graphql({
     schema: rootGraphQLSchema,
-    rootValue: rootGraphQLResolver,
     contextValue: { request },
     source: query,
     variableValues: variables,

--- a/apps/docs/resources/rootResolver.ts
+++ b/apps/docs/resources/rootResolver.ts
@@ -1,1 +1,0 @@
-export const rootGraphQLResolver = {}

--- a/apps/docs/resources/rootSchema.ts
+++ b/apps/docs/resources/rootSchema.ts
@@ -1,4 +1,10 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLString, printSchema } from 'graphql'
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  printSchema,
+} from 'graphql'
 
 const GRAPHQL_FIELD_INTROSPECT = 'schema'
 
@@ -10,7 +16,7 @@ async function resolveIntrospect() {
 const introspectRoot = {
   [GRAPHQL_FIELD_INTROSPECT]: {
     description: 'Get the GraphQL schema for this endpoint',
-    type: GraphQLString,
+    type: new GraphQLNonNull(GraphQLString),
     resolve: resolveIntrospect,
   },
 }

--- a/apps/docs/resources/rootSchema.ts
+++ b/apps/docs/resources/rootSchema.ts
@@ -1,8 +1,25 @@
-import { GraphQLObjectType, GraphQLSchema } from 'graphql'
+import { GraphQLObjectType, GraphQLSchema, GraphQLString, printSchema } from 'graphql'
+
+const GRAPHQL_FIELD_INTROSPECT = 'schema'
+
+async function resolveIntrospect() {
+  const schema = printSchema(rootGraphQLSchema)
+  return schema
+}
+
+const introspectRoot = {
+  [GRAPHQL_FIELD_INTROSPECT]: {
+    description: 'Get the GraphQL schema for this endpoint',
+    type: GraphQLString,
+    resolve: resolveIntrospect,
+  },
+}
 
 export const rootGraphQLSchema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: 'RootQueryType',
-    fields: {},
+    fields: {
+      ...introspectRoot,
+    },
   }),
 })


### PR DESCRIPTION
Adds a top-level schema query that returns the stringified GraphQL schema for this endpoint. Useful for LLMs to access the stringified schema for prompting and tool calls.

Query shape:

```
query Search {
  schema
}
```

Query response:

```
{
  "data": {
    "schema": "schema {\n  query: RootQueryType\n}\n\ntype RootQueryType
{\n  \"\"\"Get the GraphQL schema for this endpoint\"\"\"\n  schema:
String\n}"
  }
}
```

Towards DOCS-214