### PR TITLE
fix (content api): local dev introspection

### DIFF
--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -7,6 +7,6 @@ exports[`/api/graphql schema snapshot > should match snapshot 1`] = `
 
 type RootQueryType {
   """Get the GraphQL schema for this endpoint"""
-  schema: String
+  schema: String!
 }"
 `;

--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`/api/graphql schema snapshot > should match snapshot 1`] = `
+"schema {
+  query: RootQueryType
+}
+
+type RootQueryType {
+  """Get the GraphQL schema for this endpoint"""
+  schema: String
+}"
+`;

--- a/apps/docs/app/api/graphql/route.test.ts
+++ b/apps/docs/app/api/graphql/route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST } from './route'
 
-describe('GraphQL API endpoint', () => {
+describe('/api/graphql basic error statuses', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -57,5 +57,28 @@ describe('GraphQL API endpoint', () => {
     const response = await POST(request)
     const json = await response.json()
     expect(json.errors[0].message).toBe('Internal Server Error')
+  })
+})
+
+describe('/api/graphql schema snapshot', () => {
+  it('should match snapshot', async () => {
+    const schemaQuery = `
+        query {
+          schema
+        }
+      `
+    const request = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: schemaQuery }),
+    })
+
+    const response = await POST(request)
+    const json = await response.json()
+    expect(json.errors).toBeUndefined()
+
+    const {
+      data: { schema },
+    } = json
+    expect(schema).toMatchSnapshot()
   })
 })

--- a/apps/docs/app/api/graphql/route.ts
+++ b/apps/docs/app/api/graphql/route.ts
@@ -3,7 +3,6 @@ import { createComplexityLimitRule } from 'graphql-validation-complexity'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { ApiError, convertZodToInvalidRequestError, InvalidRequestError } from '~/app/api/utils'
-import { rootGraphQLResolver } from '~/resources/rootResolver'
 import { rootGraphQLSchema } from '~/resources/rootSchema'
 import { createQueryDepthLimiter } from './validators'
 
@@ -41,7 +40,6 @@ async function handleGraphQLRequest(request: Request): Promise<NextResponse> {
 
   const result = await graphql({
     schema: rootGraphQLSchema,
-    rootValue: rootGraphQLResolver,
     contextValue: { request },
     source: query,
     variableValues: variables,

--- a/apps/docs/app/api/graphql/route.ts
+++ b/apps/docs/app/api/graphql/route.ts
@@ -3,10 +3,33 @@ import { createComplexityLimitRule } from 'graphql-validation-complexity'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { ApiError, convertZodToInvalidRequestError, InvalidRequestError } from '~/app/api/utils'
+import { BASE_PATH, IS_DEV } from '~/lib/constants'
 import { rootGraphQLSchema } from '~/resources/rootSchema'
 import { createQueryDepthLimiter } from './validators'
 
 export const runtime = 'edge'
+
+const MAX_DEPTH = 9
+
+const validationRules = [
+  ...specifiedRules,
+  createQueryDepthLimiter(MAX_DEPTH),
+  createComplexityLimitRule(1500, {
+    scalarCost: 1,
+    objectCost: 2,
+    listFactor: 10,
+  }),
+]
+
+function isDevGraphiQL(request: Request) {
+  const origin = request.headers.get('Origin')
+  const referrer = request.headers.get('Referer')
+  return (
+    IS_DEV &&
+    origin.startsWith('http://localhost') &&
+    referrer === `${origin}${BASE_PATH ?? ''}/graphiql`
+  )
+}
 
 const graphQLRequestSchema = z.object({
   query: z.string(),
@@ -27,7 +50,7 @@ async function handleGraphQLRequest(request: Request): Promise<NextResponse> {
   }
 
   const { query, variables, operationName } = parsedBody.data
-  const validationErrors = validateGraphQLRequest(query)
+  const validationErrors = validateGraphQLRequest(query, isDevGraphiQL(request))
   if (validationErrors.length > 0) {
     return NextResponse.json({
       errors: validationErrors.map((error) => ({
@@ -48,9 +71,7 @@ async function handleGraphQLRequest(request: Request): Promise<NextResponse> {
   return NextResponse.json(result)
 }
 
-function validateGraphQLRequest(query: string): ReadonlyArray<GraphQLError> {
-  const MAX_DEPTH = 9
-
+function validateGraphQLRequest(query: string, isDevGraphiQL = false): ReadonlyArray<GraphQLError> {
   let documentAST: DocumentNode
   try {
     documentAST = parse(query)
@@ -61,16 +82,8 @@ function validateGraphQLRequest(query: string): ReadonlyArray<GraphQLError> {
       throw error
     }
   }
-  const validationRules = [
-    ...specifiedRules,
-    createQueryDepthLimiter(MAX_DEPTH),
-    createComplexityLimitRule(1500, {
-      scalarCost: 1,
-      objectCost: 2,
-      listFactor: 10,
-    }),
-  ]
-  return validate(rootGraphQLSchema, documentAST, validationRules)
+  const rules = isDevGraphiQL ? specifiedRules : validationRules
+  return validate(rootGraphQLSchema, documentAST, rules)
 }
 
 export async function POST(request: Request): Promise<NextResponse> {

--- a/apps/docs/resources/rootResolver.ts
+++ b/apps/docs/resources/rootResolver.ts
@@ -1,1 +1,0 @@
-export const rootGraphQLResolver = {}

--- a/apps/docs/resources/rootSchema.ts
+++ b/apps/docs/resources/rootSchema.ts
@@ -1,4 +1,10 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLString, printSchema } from 'graphql'
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  printSchema,
+} from 'graphql'
 
 const GRAPHQL_FIELD_INTROSPECT = 'schema'
 
@@ -10,7 +16,7 @@ async function resolveIntrospect() {
 const introspectRoot = {
   [GRAPHQL_FIELD_INTROSPECT]: {
     description: 'Get the GraphQL schema for this endpoint',
-    type: GraphQLString,
+    type: new GraphQLNonNull(GraphQLString),
     resolve: resolveIntrospect,
   },
 }

--- a/apps/docs/resources/rootSchema.ts
+++ b/apps/docs/resources/rootSchema.ts
@@ -1,8 +1,25 @@
-import { GraphQLObjectType, GraphQLSchema } from 'graphql'
+import { GraphQLObjectType, GraphQLSchema, GraphQLString, printSchema } from 'graphql'
+
+const GRAPHQL_FIELD_INTROSPECT = 'schema'
+
+async function resolveIntrospect() {
+  const schema = printSchema(rootGraphQLSchema)
+  return schema
+}
+
+const introspectRoot = {
+  [GRAPHQL_FIELD_INTROSPECT]: {
+    description: 'Get the GraphQL schema for this endpoint',
+    type: GraphQLString,
+    resolve: resolveIntrospect,
+  },
+}
 
 export const rootGraphQLSchema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: 'RootQueryType',
-    fields: {},
+    fields: {
+      ...introspectRoot,
+    },
   }),
 })


### PR DESCRIPTION
The validation rules that are used for security in production are preventing GraphiQL from introspecting the schema in dev. Since this DX feature is incredibly useful, I'm turning off the complexity and depth validations for dev GraphiQL only. Local curls, etc., will still have production-standard validation so it can be tested locally.

Towards DOCS-214