### PR TITLE
fix: Disable the `convertSqlToSupabaseJs` AI tool

### DIFF
--- a/apps/studio/pages/api/ai/sql/tools.ts
+++ b/apps/studio/pages/api/ai/sql/tools.ts
@@ -2,7 +2,6 @@ import { tool } from 'ai'
 import { stripIndent } from 'common-tags'
 import { z } from 'zod'
 
-import { processSql, renderSupabaseJs } from '@supabase/sql-to-rest'
 import { getDatabaseFunctions } from 'data/database-functions/database-functions-query'
 import { getDatabasePolicies } from 'data/database-policies/database-policies-query'
 import { getEntityDefinitionsSql } from 'data/database/entity-definitions-query'
@@ -51,25 +50,6 @@ export const getTools = ({
         } catch (error) {
           console.error('Failed to execute SQL:', error)
           return `Failed to fetch schema: ${error}`
-        }
-      },
-    }),
-    convertSqlToSupabaseJs: tool({
-      description: 'Convert an sql query into supabase-js client code',
-      parameters: z.object({
-        sql: z
-          .string()
-          .describe(
-            'The sql statement to convert. Only a subset of statements are supported currently. '
-          ),
-      }),
-      execute: async ({ sql }) => {
-        try {
-          const statement = await processSql(sql)
-          const { code } = await renderSupabaseJs(statement)
-          return code
-        } catch (error) {
-          return `Failed to convert SQL: ${error}`
         }
       },
     }),

--- a/apps/studio/pages/api/ai/sql/tools.ts
+++ b/apps/studio/pages/api/ai/sql/tools.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai'
 import { stripIndent } from 'common-tags'
 import { z } from 'zod'
 
+// import { processSql, renderSupabaseJs } from '@supabase/sql-to-rest'
 import { getDatabaseFunctions } from 'data/database-functions/database-functions-query'
 import { getDatabasePolicies } from 'data/database-policies/database-policies-query'
 import { getEntityDefinitionsSql } from 'data/database/entity-definitions-query'
@@ -53,6 +54,28 @@ export const getTools = ({
         }
       },
     }),
+    // [Ivan] The tool relies on `libpg-query` binaries which we've removed intentionally because they couldn't build on MacOS.
+    // Once we figure out a way how to use wasm binaries, we can add it back.
+    //
+    // convertSqlToSupabaseJs: tool({
+    //   description: 'Convert an sql query into supabase-js client code',
+    //   parameters: z.object({
+    //     sql: z
+    //       .string()
+    //       .describe(
+    //         'The sql statement to convert. Only a subset of statements are supported currently. '
+    //       ),
+    //   }),
+    //   execute: async ({ sql }) => {
+    //     try {
+    //       const statement = await processSql(sql)
+    //       const { code } = await renderSupabaseJs(statement)
+    //       return code
+    //     } catch (error) {
+    //       return `Failed to convert SQL: ${error}`
+    //     }
+    //   },
+    // }),
     getRlsKnowledge: tool({
       description:
         'Get existing policies and examples and instructions on how to write RLS policies',


### PR DESCRIPTION
This pull request removes the functionality for converting SQL queries into Supabase.js client code in the `apps/studio/pages/api/ai/sql/tools.ts` file. This is caused by removing the binaries for `libpg-query` because they were causing issues with `pnpm i` on MacOS.