### PR TITLE
fix (docs): non-platform integrations page

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
@@ -169,9 +169,9 @@ const Content = (props) => {
                   )
                 })}
               </div>
-            ) : (
+            ) : x.url ? (
               <ContentLink url={x.url} icon={x.icon} name={x.name} key={x.name} />
-            )}
+            ) : null}
           </div>
         )
       })}

--- a/packages/common/feature-flags.tsx
+++ b/packages/common/feature-flags.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { FlagValues } from '@vercel/flags/react'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 
@@ -123,9 +125,9 @@ export const FeatureFlagProvider = ({
 
   return (
     <FeatureFlagContext.Provider value={store}>
-      {/* 
+      {/*
         [Joshen] Just support configcat flags in Vercel flags for now for simplicity
-        although I think it should be fairly simply to support PH too 
+        although I think it should be fairly simply to support PH too
       */}
       <FlagValues values={store.configcat} />
       {children}

--- a/packages/common/helpers.ts
+++ b/packages/common/helpers.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useSyncExternalStore } from 'react'
 import type * as React from 'react'
 

--- a/packages/common/hooks/index.ts
+++ b/packages/common/hooks/index.ts
@@ -1,3 +1,5 @@
+'use client'
+
 export * from './useAnchorObserver'
 export * from './useBreakpoint'
 export * from './useConstant'

--- a/packages/common/index.tsx
+++ b/packages/common/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 export * from './auth'
 export * from './constants'
 export * from './database-types'

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { components } from 'api-types'
 import { useRouter } from 'next/compat/router'
 import { usePathname } from 'next/navigation'


### PR DESCRIPTION
There were two bugs when trying to run the integrations page locally with NEXT_PUBLIC_IS_PLATFORM=false:

1. The IS_PLATFORM check imported from common was not evaluating correctly to a boolean. This is because I slapped a 'use client' on the entire common package last year -_-""" which caused all its imports to be evaluated to functions when used in server components. I have now moved the 'use client's down to the submodules that actually need it.

2. When the integrations submenu is empty, the navigation menu errors out because it expects all navigation items to either have children or have links. Have updated this to gracefully hide empty headers.