### PR TITLE
Update dotenvx in example commands to be the correct package name

### DIFF
--- a/examples/slack-clone/nextjs-slack-clone-dotenvx/README.md
+++ b/examples/slack-clone/nextjs-slack-clone-dotenvx/README.md
@@ -137,7 +137,7 @@ SUPABASE_AUTH_ADDITIONAL_REDIRECT_URLS=https://<your-app-url>.vercel.app/**
 Encrypt GitHub credentials in dotenv file:
 
 ```bash
-npx dotenvx set SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET "<your-secret>" -f supabase/.env.production
+npx @dotenvx/dotenvx set SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET "<your-secret>" -f supabase/.env.production
 ```
 
 This also creates the encryption key in `supabase/.env.production` and the decryption key in `supabase/.env.keys`.
@@ -145,9 +145,9 @@ This also creates the encryption key in `supabase/.env.production` and the decry
 3. **Deploy to Supabase Remote:**
 
 ```bash
-npx dotenvx run -f supabase/.env.production -- npx supabase link
-npx dotenvx run -f supabase/.env.production -- npx supabase db push
-npx dotenvx run -f supabase/.env.production -- npx supabase config push
+npx @dotenvx/dotenvx run -f supabase/.env.production -- npx supabase link
+npx @dotenvx/dotenvx run -f supabase/.env.production -- npx supabase db push
+npx @dotenvx/dotenvx run -f supabase/.env.production -- npx supabase config push
 ```
 
 ### How to Use with Preview Branches
@@ -159,7 +159,7 @@ Here's how to set up encrypted secrets for your preview branches:
 1. **Generate Key Pair and Encrypt Your Secrets:**
 
 ```bash
-npx dotenvx set SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET "<your-secret>" -f supabase/.env.preview
+npx @dotenvx/dotenvx set SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET "<your-secret>" -f supabase/.env.preview
 ```
 
 This creates a new encryption key in `supabase/.env.preview` and a new decryption key in `supabase/.env.keys`, specifically for your preview branches.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

npx dotenvx ...

gives me the following error:

npx dotenvx       
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/dotenvx - Not found
npm ERR! 404 
npm ERR! 404  'dotenvx@*' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

## What is the new behavior?

Use full package name:

npx @dotenvx/dotenvx

## Additional context

Add any other context or screenshots.
