### PR TITLE
fix: hide storage settings link from sidebar in self-hosted version

### DIFF
--- a/apps/studio/components/layouts/StorageLayout/StorageMenu.tsx
+++ b/apps/studio/components/layouts/StorageLayout/StorageMenu.tsx
@@ -25,6 +25,7 @@ import {
   InnerSideBarFilterSortDropdownItem,
 } from 'ui-patterns/InnerSideMenu'
 import BucketRow from './BucketRow'
+import { IS_PLATFORM } from 'lib/constants'
 
 const StorageMenu = () => {
   const router = useRouter()
@@ -189,7 +190,8 @@ const StorageMenu = () => {
                 <p className="truncate">Policies</p>
               </Menu.Item>
             </Link>
-            <Link href={`/project/${ref}/settings/storage`}>
+            {IS_PLATFORM && (
+              <Link href={`/project/${ref}/settings/storage`}>
               <Menu.Item rounded>
                 <div className="flex items-center justify-between">
                   <p className="truncate">Settings</p>
@@ -197,6 +199,7 @@ const StorageMenu = () => {
                 </div>
               </Menu.Item>
             </Link>
+          )}
           </div>
         </div>
       </Menu>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

![image](https://github.com/user-attachments/assets/8f151744-d0bc-4026-a752-e6ba138c3b2f)

## What is the new behavior?

![image](https://github.com/user-attachments/assets/e9dcafb0-211d-428c-8c5a-6e1f32c8d5f5)

## Additional context

In self-hosted version the link was storage settings was visible but is inaccessible, added check with IS_PLATFORM to hide it in self-hosted mode.
