### PR TITLE
Fixed pnpm command in local-development.mdx

### DIFF
--- a/apps/docs/content/guides/local-development.mdx
+++ b/apps/docs/content/guides/local-development.mdx
@@ -52,7 +52,7 @@ Develop locally while running the Supabase stack on your machine.
     </TabPanel><TabPanel id="pnpm" label="pnpm">
 
     ```sh
-    pnpm supabase init
+    pnpx supabase init
     ```
 
     </TabPanel><TabPanel id="brew" label="brew">
@@ -82,7 +82,7 @@ Develop locally while running the Supabase stack on your machine.
     </TabPanel><TabPanel id="pnpm" label="pnpm">
 
     ```sh
-    pnpm supabase start
+    pnpx supabase start
     ```
 
     </TabPanel><TabPanel id="brew" label="brew">


### PR DESCRIPTION
Fixed the executable command for pnpm from just `pnpm` to `pnpx` which actually does what the command is expected to be do...

Fixes Issue: #35313

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR fixes a bug in the docs that has an incorrect command for the pnpm package manager

## What is the current behavior?

Currently when trying to run the provided code it throws this error

![Screenshot 2025-04-28 at 12 52 12 AM](https://github.com/user-attachments/assets/843f14e7-d461-4160-890f-7e8af37ce7c5)

## What is the new behavior?

After updating the command to the fixed version it runs as expected
![image](https://github.com/user-attachments/assets/4a734afd-d846-4d86-94cb-2f64141f7fa7)
