### PR TITLE
fix: multiple unique constraints on single column

### DIFF
--- a/apps/studio/data/table-editor/table-editor-query-sql.ts
+++ b/apps/studio/data/table-editor/table-editor-query-sql.ts
@@ -162,6 +162,7 @@ export function getTableEditorSql(id?: number) {
                 conkey[1] as ordinal_position
             from pg_catalog.pg_constraint
             where contype = 'u' and cardinality(conkey) = 1
+            group by conrelid, conkey[1]
         ) as uniques on uniques.table_id = a.attrelid and uniques.ordinal_position = a.attnum
         left join (
             select distinct on (conrelid, conkey[1])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Currently if you have a table like:
```sql
create table demo (
  "id" uuid primary key default gen_random_uuid(),
  "name" text not null
);

alter table demo
  add constraint demo_name_key1 unique (name),
  add constraint demo_name_key2 unique (name);
```

You'll see multiple "name" columns in the table editor.

## Testing

Run the SQL above to verify you can only see one name column in your table editor.

## Additional context

Users shouldn't really have multiple unique indexes on the exact same column, but since it's _possible_ our table editor should handle it gracefully.
