### PR TITLE
fix(docs): update webhook link in database webhooks guide

### DIFF
--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -27,7 +27,7 @@ This video demonstrates how you can create a new customer in Stripe each time a 
 
 ## Creating a webhook
 
-1. Create a new [Database Webhook](https://supabase.com/dashboard/project/_/integrations/hooks) in the Dashboard.
+1. Create a new [Database Webhook](https://supabase.com/dashboard/project/_/integrations/webhooks/overview) in the Dashboard.
 1. Give your Webhook a name.
 1. Select the table you want to hook into.
 1. Select one or more events (table inserts, updates, or deletes) you want to hook into.


### PR DESCRIPTION
Updated the link for creating a new Database Webhook in the documentation to point to the correct overview page.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

![image](https://github.com/user-attachments/assets/c1b97c89-5c1a-418d-b041-7d822e84c626)


## What is the new behavior?

![image](https://github.com/user-attachments/assets/12aafbb3-14f6-4fc0-8561-d7dbb276f492)

