### PR TITLE
ci(docs): skip preview ssg for storage section

### DIFF
--- a/apps/docs/app/guides/realtime/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/realtime/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import { IS_PROD } from 'common'
 import { GuideTemplate } from '~/features/docs/GuidesMdx.template'
 import {
   genGuideMeta,
@@ -15,12 +16,7 @@ const RealtimeGuidePage = async ({ params }: { params: Params }) => {
   return <GuideTemplate {...data!} />
 }
 
-const generateStaticParams =
-  // [Charis 2025-04-21] For some reason, using the IS_PROD export from common
-  // does not work (its type is a function when this is evaluated?)
-  process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
-    ? genGuidesStaticParams('realtime')
-    : getEmptyArray
+const generateStaticParams = IS_PROD ? genGuidesStaticParams('realtime') : getEmptyArray
 const generateMetadata = genGuideMeta((params: { slug?: string[] }) =>
   getGuidesMarkdown(['realtime', ...(params.slug ?? [])])
 )

--- a/apps/docs/app/guides/storage/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/storage/[[...slug]]/page.tsx
@@ -1,11 +1,11 @@
+import { IS_PROD } from 'common'
+import { GuideTemplate } from '~/features/docs/GuidesMdx.template'
 import {
-  getGuidesMarkdown,
   genGuideMeta,
   genGuidesStaticParams,
+  getGuidesMarkdown,
 } from '~/features/docs/GuidesMdx.utils'
-import { GuideTemplate } from '~/features/docs/GuidesMdx.template'
-
-export const dynamicParams = false
+import { getEmptyArray } from '~/features/helpers.fn'
 
 type Params = { slug?: string[] }
 
@@ -16,10 +16,10 @@ const StorageGuidePage = async ({ params }: { params: Params }) => {
   return <GuideTemplate {...data!} />
 }
 
-const generateStaticParams = genGuidesStaticParams('storage')
+const generateStaticParams = IS_PROD ? genGuidesStaticParams('storage') : getEmptyArray
 const generateMetadata = genGuideMeta((params: { slug?: string[] }) =>
   getGuidesMarkdown(['storage', ...(params.slug ?? [])])
 )
 
 export default StorageGuidePage
-export { generateStaticParams, generateMetadata }
+export { generateMetadata, generateStaticParams }


### PR DESCRIPTION
Since [skipping preview SSG for realtime](https://github.com/supabase/supabase/pull/35183) has worked for a while now with no observable negative effect, going to skip for storage as well.