### PR TITLE
docs: make MAU usage pages clearer

### DIFF
--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-sso.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-sso.mdx
@@ -5,7 +5,7 @@ title: 'Manage Monthly Active SSO Users usage'
 
 ## What you are charged for
 
-You are charged for the number of distinct users who log in or refresh their token during the billing cycle using a SAML 2.0 compatible identity provider. Each unique user is counted only once per billing cycle, regardless of how many times they authenticate. These users are referred to as "SSO MAUs".
+You are charged for the number of distinct users who log in or refresh their token during the billing cycle using a SAML 2.0 compatible identity provider (e.g. Google Workspace, Microsoft Active Directory). Each unique user is counted only once per billing cycle, regardless of how many times they authenticate. These users are referred to as "SSO MAUs".
 
 ### Example
 

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-third-party.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-third-party.mdx
@@ -5,7 +5,7 @@ title: 'Manage Monthly Active Third-Party Users usage'
 
 ## What you are charged for
 
-You are charged for the number of distinct users who log in or refresh their token during the billing cycle using a third-party authentication provider. Each unique user is counted only once per billing cycle, regardless of how many times they authenticate. These users are referred to as "Third-Party MAUs".
+You are charged for the number of distinct users who log in or refresh their token during the billing cycle using a third-party authentication provider (Clerk, Firebase Auth, Auth0, AWS Cognito). Each unique user is counted only once per billing cycle, regardless of how many times they authenticate. These users are referred to as "Third-Party MAUs".
 
 ### Example
 

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
@@ -5,7 +5,7 @@ title: 'Manage Monthly Active Users usage'
 
 ## What you are charged for
 
-You are charged for the number of distinct users who log in or refresh their token during the billing cycle. Each unique user is counted only once per billing cycle, regardless of how many times they authenticate. These users are referred to as "MAUs".
+You are charged for the number of distinct users who log in or refresh their token during the billing cycle (including Social Login with e.g. Google, Facebook, GitHub). Each unique user is counted only once per billing cycle, regardless of how many times they authenticate. These users are referred to as "MAUs".
 
 ### Example
 


### PR DESCRIPTION
Had a support case where customer was confused about the MAU pricing. They thought that pricing for Enterprise SSO (meaning Google Workspace, Microsoft AD) also applies to Social Login like Facebook, Apple, Github.

=> added examples to all three MAU usage pages

