### PR TITLE
fix(docs): branch for wrappers docs

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -4,28 +4,95 @@ import { readFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import rehypeSlug from 'rehype-slug'
 import emoji from 'remark-emoji'
-
+import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
 import {
   genGuideMeta,
   genGuidesStaticParams,
   removeRedundantH1,
 } from '~/features/docs/GuidesMdx.utils'
-import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { REVALIDATION_TAGS } from '~/features/helpers.fetch'
 import { GUIDES_DIRECTORY, isValidGuideFrontmatter } from '~/lib/docs'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
 import { removeTitle } from '~/lib/mdx/plugins/remarkRemoveTitle'
 import remarkPyMdownTabs from '~/lib/mdx/plugins/remarkTabs'
-import { REVALIDATION_TAGS } from '~/features/helpers.fetch'
+import { octokit } from '~/lib/octokit'
 
 export const dynamicParams = false
 
 // We fetch these docs at build time from an external repo
 const org = 'supabase'
 const repo = 'wrappers'
-const branch = 'main'
 const docsDir = 'docs/catalog'
 const externalSite = 'https://supabase.github.io/wrappers'
+
+type TagQueryResponse = {
+  repository: {
+    releases: {
+      nodes:
+        | {
+            tagName: string
+          }[]
+        | null
+      pageInfo: {
+        hasNextPage: boolean
+        endCursor: string | null
+      }
+    }
+  }
+}
+
+const tagQuery = `
+    query TagQuery($owner: String!, $name: String!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        releases(
+          orderBy: {
+            field: CREATED_AT,
+            direction: DESC
+          },
+          first: 5,
+          after: $after
+        ) {
+          nodes {
+            tagName
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  `
+
+async function getLatestRelease(after: string | null = null) {
+  try {
+    const {
+      repository: {
+        releases: {
+          nodes,
+          pageInfo: { hasNextPage, endCursor },
+        },
+      },
+    } = await octokit().graphql<TagQueryResponse>(tagQuery, {
+      owner: org,
+      name: repo,
+      after,
+      request: {
+        fetch: (url: RequestInfo | URL, options?: RequestInit) =>
+          fetch(url, { ...options, next: { tags: [REVALIDATION_TAGS.WRAPPERS] } }),
+      },
+    })
+
+    return (
+      nodes?.find((node) => node?.tagName?.match(/^v\d+\.\d+\.\d+/)).tagName ??
+      (hasNextPage && endCursor ? await getLatestRelease(endCursor) : null)
+    )
+  } catch (error) {
+    console.error(`Error fetching release tags for wrappers federated pages: ${error}`)
+    return null
+  }
+}
 
 // Each external docs page is mapped to a local page
 const pageMap = [
@@ -193,8 +260,14 @@ const getContent = async (params: Params) => {
     isExternal = true
     let remoteFile: string
     ;({ remoteFile, meta } = federatedPage)
-    const repoPath = `${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
-    editLink = `${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`
+
+    const tag = await getLatestRelease()
+    if (!tag) {
+      throw new Error('No latest release found for federated wrappers pages')
+    }
+
+    const repoPath = `${org}/${repo}/${tag}/${docsDir}/${remoteFile}`
+    editLink = `${org}/${repo}/blob/${tag}/${docsDir}/${remoteFile}`
 
     const response = await fetch(`https://raw.githubusercontent.com/${repoPath}`, {
       next: { tags: [REVALIDATION_TAGS.WRAPPERS] },
@@ -259,4 +332,4 @@ const generateStaticParams = async () => {
 const generateMetadata = genGuideMeta(getContent)
 
 export default WrappersDocs
-export { generateStaticParams, generateMetadata }
+export { generateMetadata, generateStaticParams }

--- a/apps/docs/lib/octokit.ts
+++ b/apps/docs/lib/octokit.ts
@@ -8,7 +8,7 @@ import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 
 let octokitInstance: Octokit
 
-function octokit() {
+export function octokit() {
   if (!octokitInstance) {
     // https://github.com/gr2m/universal-github-app-jwt?tab=readme-ov-file#converting-pkcs1-to-pkcs8
     const privateKeyPkcs8 = crypto


### PR DESCRIPTION
Wrappers docs should not be pulled from the main branch, which contains unreleased content, but instead from the latest release tag.