### PR TITLE
fix logs datepicker handling global copy events

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -10,6 +10,7 @@ import TimeSplitInput from 'components/ui/DatePicker/TimeSplitInput'
 import { Button, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Popover_Shadcn_, cn } from 'ui'
 import { LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD } from './Logs.constants'
 import type { DatetimeHelper } from './Logs.types'
+import { copyToClipboard } from 'lib/helpers'
 
 export type DatePickerValue = {
   to: string
@@ -175,12 +176,13 @@ export const LogsDatePicker = ({ onSubmit, helpers, value }: PropsWithChildren<P
     fromDate.setHours(+startTime.HH, +startTime.mm, +startTime.ss)
     toDate.setHours(+endTime.HH, +endTime.mm, +endTime.ss)
 
-    navigator.clipboard.writeText(
+    copyToClipboard(
       JSON.stringify({
         from: fromDate.toISOString(),
         to: toDate.toISOString(),
       })
     )
+
     setCopied(true)
   }
 
@@ -193,13 +195,15 @@ export const LogsDatePicker = ({ onSubmit, helpers, value }: PropsWithChildren<P
   }, [pasted])
 
   useEffect(() => {
-    document.addEventListener('paste', handlePaste)
-    document.addEventListener('copy', handleCopy)
+    if (open) {
+      document.addEventListener('paste', handlePaste)
+      document.addEventListener('copy', handleCopy)
+    }
     return () => {
       document.removeEventListener('paste', handlePaste)
       document.removeEventListener('copy', handleCopy)
     }
-  }, [startDate, endDate])
+  }, [open, startDate, endDate])
 
   const isLargeRange =
     Math.abs(dayjs(startDate).diff(dayjs(endDate), 'days')) >


### PR DESCRIPTION
## Context. 
Logs datepickers allows users to copy a range, useful when you're checking logs for two different services during the same time range. But the event handler is running globally, it should run only when the logs datepicker component is open. 

## To test
- try to copy paste from a log, should work as expected.
- try to select a date range and copy (⌘ C) 
- select another range
- paste (⌘ V)
- should paste the previously copied range