### PR TITLE
chore: add Eduardo to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -32,6 +32,7 @@ David A. Ventimiglia
 Deji I
 Div Arora
 Divit D
+Eduardo Gurgel
 Egor Romanov
 Eleftheria Trivyzaki
 Etienne Stalmans


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

Eduardo is not listed as part of humans.txt

## What is the new behavior?

Eduardo is listed as part of humans.txt

## Additional context

👋 
