### PR TITLE
Update query block bar hover behaviour

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -1,21 +1,21 @@
 'use client'
 
-import { useState, ComponentProps, useEffect } from 'react'
 import dayjs from 'dayjs'
+import { useTheme } from 'next-themes'
+import { ComponentProps, useEffect, useState } from 'react'
 import {
   Area,
   Bar,
-  ComposedChart as RechartComposedChart,
-  XAxis,
-  YAxis,
   CartesianGrid,
   Line,
+  ComposedChart as RechartComposedChart,
   ReferenceArea,
   Tooltip,
+  XAxis,
+  YAxis,
 } from 'recharts'
 import { CategoricalChartState } from 'recharts/types/chart/types'
 import { cn } from 'ui'
-import { useTheme } from 'next-themes'
 import ChartHeader from './ChartHeader'
 import ChartHighlightActions from './ChartHighlightActions'
 import {
@@ -24,17 +24,17 @@ import {
   STACKED_CHART_COLORS,
   updateStackedChartColors,
 } from './Charts.constants'
-import { Datum, CommonChartProps } from './Charts.types'
-import { useChartSize, numberFormatter } from './Charts.utils'
-import { ChartHighlight } from './useChartHighlight'
-import NoDataPlaceholder from './NoDataPlaceholder'
-import { MultiAttribute } from './ComposedChartHandler'
+import { CommonChartProps, Datum } from './Charts.types'
+import { numberFormatter, useChartSize } from './Charts.utils'
 import {
   calculateTotalChartAggregate,
   CustomLabel,
   CustomTooltip,
   formatBytes,
 } from './ComposedChart.utils'
+import { MultiAttribute } from './ComposedChartHandler'
+import NoDataPlaceholder from './NoDataPlaceholder'
+import { ChartHighlight } from './useChartHighlight'
 
 export interface BarChartProps<D = Datum> extends CommonChartProps<D> {
   attributes: MultiAttribute[]

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useState } from 'react'
 import dayjs from 'dayjs'
+import { useState } from 'react'
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { DateTimeFormats } from './Charts.constants'
 import { numberFormatter } from './Charts.utils'
 import { MultiAttribute } from './ComposedChartHandler'
-import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
-import { cn } from 'ui'
 
 interface CustomIconProps {
   color: string
@@ -232,4 +231,4 @@ const CustomLabel = ({ payload, attributes, showMaxValue, onLabelHover }: Custom
   )
 }
 
-export { CustomTooltip, CustomLabel }
+export { CustomLabel, CustomTooltip }

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -414,17 +414,11 @@ export const QueryBlock = ({
                   />
                   <YAxis tickLine={false} axisLine={false} tickMargin={4} />
                   <Tooltip content={<ChartTooltipContent className="w-[150px]" />} />
-                  <Bar
-                    radius={1}
-                    dataKey={yKey}
-                    fill="var(--chart-1)"
-                    enableBackground={12}
-                    activeBar={{}}
-                  >
-                    {chartData?.map((_entry: any, index: number) => (
+                  <Bar radius={1} dataKey={yKey}>
+                    {chartData?.map((_: any, index: number) => (
                       <Cell
                         key={`cell-${index}`}
-                        className={`transition-all duration-300`}
+                        className="transition-all duration-100"
                         fill="var(--chart-1)"
                         opacity={focusDataIndex === undefined || focusDataIndex === index ? 1 : 0.4}
                         enableBackground={12}

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -1,6 +1,6 @@
 import { Code, Play } from 'lucide-react'
 import { DragEvent, ReactNode, useEffect, useMemo, useState } from 'react'
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { Bar, BarChart, CartesianGrid, Cell, Tooltip, XAxis, YAxis } from 'recharts'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
@@ -12,9 +12,10 @@ import { QueryResponseError, useExecuteSqlMutation } from 'data/sql/execute-sql-
 import dayjs from 'dayjs'
 import { Parameter, parseParameters } from 'lib/sql-parameters'
 import { Dashboards } from 'types'
-import { ChartContainer, ChartTooltip, ChartTooltipContent, cn, CodeBlock, SQL_ICON } from 'ui'
+import { ChartContainer, ChartTooltipContent, cn, CodeBlock, SQL_ICON } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 import { ButtonTooltip } from '../ButtonTooltip'
+import { CHART_COLORS } from '../Charts/Charts.constants'
 import SqlWarningAdmonition from '../SqlWarningAdmonition'
 import { BlockViewConfiguration } from './BlockViewConfiguration'
 import { EditQueryButton } from './EditQueryButton'
@@ -130,6 +131,7 @@ export const QueryBlock = ({
   const [readOnlyError, setReadOnlyError] = useState(false)
   const [queryError, setQueryError] = useState<QueryResponseError>()
   const [queryResult, setQueryResult] = useState<any[] | undefined>(results)
+  const [focusDataIndex, setFocusDataIndex] = useState<number>()
 
   const formattedQueryResult = useMemo(() => {
     // Make sure Y axis values are numbers
@@ -379,10 +381,9 @@ export const QueryBlock = ({
               <p className="text-foreground-light text-xs">Select columns for the X and Y axes</p>
             </div>
           ) : (
-            <div className={cn('flex-1 w-full')}>
+            <div className="flex-1 w-full">
               <ChartContainer
                 className="aspect-auto px-3 py-2"
-                config={{}}
                 style={{
                   height: maxHeight ? `${maxHeight}px` : undefined,
                   minHeight: maxHeight ? `${maxHeight}px` : undefined,
@@ -392,12 +393,18 @@ export const QueryBlock = ({
                   accessibilityLayer
                   margin={{ left: -20, right: 0, top: 10 }}
                   data={chartData}
+                  onMouseMove={(e: any) => {
+                    if (e.activeTooltipIndex !== focusDataIndex) {
+                      setFocusDataIndex(e.activeTooltipIndex)
+                    }
+                  }}
+                  onMouseLeave={() => setFocusDataIndex(undefined)}
                 >
-                  <CartesianGrid vertical={false} />
+                  <CartesianGrid vertical={false} stroke={CHART_COLORS.AXIS} />
                   <XAxis
-                    tickLine
                     dataKey={xKey}
-                    axisLine={false}
+                    tickLine={{ stroke: CHART_COLORS.AXIS }}
+                    axisLine={{ stroke: CHART_COLORS.AXIS }}
                     interval="preserveStartEnd"
                     tickMargin={4}
                     minTickGap={32}
@@ -406,8 +413,24 @@ export const QueryBlock = ({
                     }
                   />
                   <YAxis tickLine={false} axisLine={false} tickMargin={4} />
-                  <ChartTooltip content={<ChartTooltipContent className="w-[150px]" />} />
-                  <Bar dataKey={yKey} fill="var(--chart-1)" radius={4} />
+                  <Tooltip content={<ChartTooltipContent className="w-[150px]" />} />
+                  <Bar
+                    radius={1}
+                    dataKey={yKey}
+                    fill="var(--chart-1)"
+                    enableBackground={12}
+                    activeBar={{}}
+                  >
+                    {chartData?.map((_entry: any, index: number) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        className={`transition-all duration-300`}
+                        fill="var(--chart-1)"
+                        opacity={focusDataIndex === undefined || focusDataIndex === index ? 1 : 0.4}
+                        enableBackground={12}
+                      />
+                    ))}
+                  </Bar>
                 </BarChart>
               </ChartContainer>
             </div>


### PR DESCRIPTION
For QueryBlock which is used in custom reports SQL blocks and AI Assistant

When a bar is hovered, dim all other bars so it's easier to see which bar is being focused on

## Before

https://github.com/user-attachments/assets/db21476b-5ebb-4264-9af2-79cad38803a3


## After

https://github.com/user-attachments/assets/4c433044-b8e4-4b3f-9d9b-4d6f66404489

