### PR TITLE
Fix local version popover version

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.tsx
@@ -28,15 +28,18 @@ import { getSemver, semverGte, semverLte } from './LocalVersionPopover.utils'
 export const LocalVersionPopover = () => {
   const { data, isSuccess } = useCLIReleaseVersionQuery()
   const currentCliVersion = data?.current
-  const hasLatestCLIVersion = isSuccess && !!data?.latest
+  const latestCliVersion = data?.latest
+  const hasLatestCLIVersion = isSuccess && !!latestCliVersion
 
-  const current = getSemver(data?.current)
-  const latest = getSemver(data?.latest)
+  const current = getSemver(currentCliVersion)
+  const latest = getSemver(latestCliVersion)
 
   const hasUpdate =
-    !!current && !!latest ? data?.current !== data?.latest && semverLte(current, latest) : false
+    !!current && !!latest
+      ? currentCliVersion !== latestCliVersion && semverLte(current, latest)
+      : false
   const isBeta =
-    !!current && !!latest && data?.current !== data?.latest && semverGte(current, latest)
+    !!current && !!latest && currentCliVersion !== latestCliVersion && semverGte(current, latest)
 
   const approximateNextRelease = !!data?.published_at
     ? dayjs(data?.published_at).utc().add(14, 'day').format('DD MMM YYYY')
@@ -180,7 +183,7 @@ export const LocalVersionPopover = () => {
           {hasLatestCLIVersion && hasUpdate && !isBeta && (
             <div className="flex flex-col gap-y-1">
               <p className="text-xs">Available version:</p>
-              <p className="text-sm font-mono">{data.latest}</p>
+              <p className="text-sm font-mono">{latestCliVersion}</p>
             </div>
           )}
         </div>

--- a/apps/studio/pages/api/cli-release-version.ts
+++ b/apps/studio/pages/api/cli-release-version.ts
@@ -8,7 +8,7 @@ type GitHubRepositoryRelease = {
   published_at: string
 }
 
-const current = process.env.CURRENT_CLI_VERSION
+const current = `v${process.env.CURRENT_CLI_VERSION}`
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {


### PR DESCRIPTION
## Context
Noticed that we were incorrectly showing "Update available" when the versions seemingly match
![image](https://github.com/user-attachments/assets/684ac1e9-4f5c-4dc6-8538-c3b75e1b96af)

Realised this was because:
- `latest` from `cli-release-version.ts` endpoint is returned from GH with a `v` prepended
- `current` from our env vars currently doesnt
- This leads to an equality check mismatch, so we just need to add a `v` to `current` to ensure the syntax aligns


