### PR TITLE
docs: small correction in plan_filter doc for usage

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
@@ -56,7 +56,6 @@ Now we can choose a `statement_cost_filter` value between the total cost for the
 
 {/* prettier-ignore */}
 ```sql
-load 'plan_filter';
 set plan_filter.statement_cost_limit = 50; -- between 2.49 and 135.0
 
 select * from book where id = 1;

--- a/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
@@ -8,19 +8,9 @@ description: 'Block queries over a total cost limit'
 
 ## Enable the extension
 
-`pg_plan_filter` can be enabled on a per connection basis:
+The extension is already enabled by default via `shared_preload_libraries` setting. 
 
-{/* prettier-ignore */}
-```sql
-load 'plan_filter';
-```
-
-or for all connections:
-
-{/* prettier-ignore */}
-```sql
-alter database some_db set session_preload_libraries = 'plan_filter';
-```
+You can simply follow the instructions below.
 
 ## API
 

--- a/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
@@ -8,7 +8,7 @@ description: 'Block queries over a total cost limit'
 
 ## Enable the extension
 
-The extension is already enabled by default via `shared_preload_libraries` setting. 
+The extension is already enabled by default via `shared_preload_libraries` setting.
 
 You can follow the instructions below.
 

--- a/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_plan_filter.mdx
@@ -10,7 +10,7 @@ description: 'Block queries over a total cost limit'
 
 The extension is already enabled by default via `shared_preload_libraries` setting. 
 
-You can simply follow the instructions below.
+You can follow the instructions below.
 
 ## API
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

update the plan filter docs to explain that the extension can just be used directly and is already loaded by default. 