### PR TITLE
revert(ui-patterns): admonition link underline

### DIFF
--- a/packages/ui-patterns/admonition.tsx
+++ b/packages/ui-patterns/admonition.tsx
@@ -103,7 +103,6 @@ export const Admonition = forwardRef<
         {...props}
         className={cn(
           'mb-2',
-          '[&_a]:underline',
           admonitionSVG({ type: typeMapped }),
           admonitionBase({ type: typeMapped }),
           props.className


### PR DESCRIPTION
Admonition link underline was added when admonitions were not "prose", but admonitions are now "prose" again so it is redundant