### PR TITLE
Update declarative-database-schemas.mdx

### DIFF
--- a/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
+++ b/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
@@ -42,6 +42,12 @@ create table "employees" (
   </StepHikeCompact.Step>
 </StepHikeCompact>
 
+<Admonition type="note">
+
+Make sure your local database is stopped before diffing your schema.
+
+</Admonition>
+
 <StepHikeCompact>
 
   <StepHikeCompact.Step step={2}>
@@ -63,12 +69,6 @@ supabase db diff -f create_employees_table
 
   </StepHikeCompact.Step>
 </StepHikeCompact>
-
-<Admonition type="note">
-
-Make sure your local database is stopped before diffing your schema.
-
-</Admonition>
 
 <StepHikeCompact>
 


### PR DESCRIPTION
The alert "Make sure your local database is stopped before diffing your schema." appears after completing the diff step. It would be more useful to display it before performing the diff, to ensure that "supabase stop" is executed beforehand and not afterward.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

<img width="884" alt="Screenshot 2025-04-30 at 23 57 45" src="https://github.com/user-attachments/assets/99ab380c-38eb-4ef4-87d5-07b3efd72d78" />

## What is the new behavior?

<img width="948" alt="Screenshot 2025-04-30 at 23 59 44" src="https://github.com/user-attachments/assets/912cf6d8-2c0e-4ff9-8d0e-c4a76dd59ea9" />


Thanks
