### PR TITLE
fix: error when telemetry groups unknown

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -172,7 +172,14 @@ export function sendTelemetryEvent(API_URL: string, event: TelemetryEvent, pathn
     ...getSharedTelemetryData(pathname),
     action: event.action,
     custom_properties: 'properties' in event ? event.properties : {},
-    groups: 'groups' in event ? event.groups : {},
+    groups: 'groups' in event ? { ...event.groups } : {},
+  }
+
+  if (body.groups?.project === 'Unknown') {
+    delete body.groups.project
+    if (body.groups?.organization === 'Unknown') {
+      delete body.groups
+    }
   }
 
   return post(`${ensurePlatformSuffix(API_URL)}/telemetry/event`, body, {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fixes GROWTH-339
If project or organization is Unknown (in the case where a user is at org nav level or account nav level), it'll throw an error in the backend but we still want to ensure people only send data of projects they have access to. 