### PR TITLE
fix broken Apple REST API link in auth-apple.mdx

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -14,7 +14,7 @@ To support Sign in with Apple, you need to configure the [Apple provider in the 
 There are three general ways to use Sign in with Apple, depending on the application you're trying to build:
 
 - Sign in on the web or in web-based apps
-  - Using an OAuth flow initiated by Supabase Auth using the [Sign in with Apple REST API](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api).
+  - Using an OAuth flow initiated by Supabase Auth using the [Sign in with Apple REST API](https://developer.apple.com/documentation/signinwithapplerestapi).
   - Using [Sign in with Apple JS](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js) directly in the browser, usually suitable for websites.
 - Sign in natively inside iOS, macOS, watchOS or tvOS apps using [Apple's Authentication Services](https://developer.apple.com/documentation/authenticationservices)
 
@@ -35,7 +35,7 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
 
     Sign in with Apple's OAuth flow is designed for web or browser based sign in methods. It can be used on web-based apps as well as websites, though some users can benefit by using Sign in with Apple JS directly.
 
-    Behind the scenes, Supabase Auth uses the [REST APIs](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api) provided by Apple.
+    Behind the scenes, Supabase Auth uses the [REST APIs](https://developer.apple.com/documentation/signinwithapplerestapi) provided by Apple.
 
     <$Partial path="create_client_snippet.mdx" />
 


### PR DESCRIPTION
- replace broken Sign in with Apple REST API link

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

 docs update

## What is the current behavior?
https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api

![image](https://github.com/user-attachments/assets/0dc872f3-441e-4d11-a14e-9da77484b8cf)

## What is the new behavior?
https://developer.apple.com/documentation/signinwithapplerestapi
![image](https://github.com/user-attachments/assets/62cb01c9-6edc-49e3-894a-70a2336bbd1d)
## Additional context

Add any other context or screenshots.
