### PR TITLE
table exports: fix type, add tests

### DIFF
--- a/apps/studio/data/table-rows/table-rows-query.test.ts
+++ b/apps/studio/data/table-rows/table-rows-query.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { executeWithRetry } from './table-rows-query'
+
+describe('executeWithRetry', () => {
+  it('should return the result of the function when successful', async () => {
+    const mockFn = vi.fn().mockResolvedValue('success')
+    const result = await executeWithRetry(mockFn)
+    expect(result).toBe('success')
+    expect(mockFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should retry on 429 errors with exponential backoff', async () => {
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 429, headers: { get: () => '1' } })
+      .mockRejectedValueOnce({ status: 429, headers: { get: () => '1' } })
+      .mockResolvedValue('success')
+
+    const result = await executeWithRetry(mockFn)
+    expect(result).toBe('success')
+    expect(mockFn).toHaveBeenCalledTimes(3)
+  })
+
+  it('should throw error after max retries', async () => {
+    const mockFn = vi.fn().mockRejectedValue({ status: 429, headers: { get: () => '1' } })
+
+    await expect(executeWithRetry(mockFn, 2)).rejects.toMatchObject({ status: 429 })
+    expect(mockFn).toHaveBeenCalledTimes(3) // Initial attempt + 2 retries
+  })
+
+  it('should throw non-429 errors immediately', async () => {
+    const mockFn = vi.fn().mockRejectedValue(new Error('Some other error'))
+
+    await expect(executeWithRetry(mockFn)).rejects.toThrow('Some other error')
+    expect(mockFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -45,11 +45,11 @@ async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function executeWithRetry(
-  fn: () => Promise<any>,
+export async function executeWithRetry<T>(
+  fn: () => Promise<T>,
   maxRetries: number = 3,
   baseDelay: number = 500
-): Promise<any> {
+): Promise<T> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn()
@@ -64,6 +64,7 @@ async function executeWithRetry(
       throw error
     }
   }
+  throw new Error('Max retries reached without success')
 }
 
 // TODO: fetchAllTableRows is used for CSV export, but since it doesn't actually truncate anything, (compare to getTableRows)


### PR DESCRIPTION
- fixes type, it should always return something
- adds some tests in case we update executeWithRetry in the future, we dont want to break that, hard to catch