### PR TITLE
Chore/fix papercuts 020525

### DIFF
--- a/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
+  cn,
   Collapsible,
   DropdownMenu,
   DropdownMenuContent,
@@ -70,7 +71,7 @@ const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
         canBypassRls,
       }}
       onSubmit={onSaveChanges}
-      className={[
+      className={cn(
         'bg-surface-100',
         'hover:bg-overlay-hover',
         'data-open:bg-selection',
@@ -80,8 +81,8 @@ const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
         '-space-y-px overflow-hidden',
         'border border-t-0 first:border-t first:!mt-0 hover:border-t hover:-mt-[1px] shadow transition hover:z-50',
         'first:rounded-tl first:rounded-tr',
-        'last:rounded-bl last:rounded-br',
-      ].join(' ')}
+        'last:rounded-bl last:rounded-br'
+      )}
     >
       {({ values, initialValues, handleReset }: any) => {
         const hasChanges = JSON.stringify(values) !== JSON.stringify(initialValues)
@@ -133,9 +134,7 @@ const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
                   {!disabled && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button type="default" className="px-1">
-                          <MoreVertical />
-                        </Button>
+                        <Button type="default" className="px-1" icon={<MoreVertical />} />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent side="bottom" className="w-[120px]">
                         <DropdownMenuItem

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -113,9 +113,9 @@ export function DiskManagementForm() {
             form.reset(formValues)
             setRefetchInterval(false)
             toast.success('Disk configuration changes have been successfully applied!')
-          } else {
-            setRefetchInterval(2000)
           }
+        } else {
+          setRefetchInterval(2000)
         }
       },
       enabled: project != null && !isFlyArchitecture,

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -29,6 +29,7 @@ import { useResourceWarningsQuery } from 'data/usage/resource-warnings-query'
 import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { GB, PROJECT_STATUS } from 'lib/constants'
+import { CloudProvider } from 'shared-data'
 import {
   Button,
   cn,
@@ -55,7 +56,6 @@ import { DiskCountdownRadial } from './ui/DiskCountdownRadial'
 import { DiskType, RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3 } from './ui/DiskManagement.constants'
 import { NoticeBar } from './ui/NoticeBar'
 import { SpendCapDisabledSection } from './ui/SpendCapDisabledSection'
-import { CloudProvider } from 'shared-data'
 
 export function DiskManagementForm() {
   // isLoading is used to avoid a useCheckPermissions() race condition
@@ -113,6 +113,8 @@ export function DiskManagementForm() {
             form.reset(formValues)
             setRefetchInterval(false)
             toast.success('Disk configuration changes have been successfully applied!')
+          } else {
+            setRefetchInterval(2000)
           }
         }
       },

--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
@@ -81,7 +81,7 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
           </p>
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ className="p-0 w-[320px]" align="start">
+      <PopoverContent_Shadcn_ portal className="p-0 w-[320px]" align="start">
         <div className="p-4 flex flex-col text-sm">
           {config.channelName.length === 0 ? (
             <>

--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -281,7 +281,7 @@ const NewFunctionPage = () => {
                 Templates
               </Button>
             </PopoverTrigger_Shadcn_>
-            <PopoverContent_Shadcn_ className="w-[300px] p-0" align="end">
+            <PopoverContent_Shadcn_ portal className="w-[300px] p-0" align="end">
               <Command_Shadcn_>
                 <CommandInput_Shadcn_ placeholder="Search templates..." />
                 <CommandList_Shadcn_>


### PR DESCRIPTION
Fixes a number of identified papercuts:

- Giant icon in database -> roles edit button 
![image](https://github.com/user-attachments/assets/5dc04ed0-e548-4d8b-8e80-ad31aa0b2ca8)

- Popover incorrect positioning in edge functions
![image](https://github.com/user-attachments/assets/564af386-d011-4d9c-ab6a-4d3028491334)

- Popover incorrect positioning in realtime inspector
![image](https://github.com/user-attachments/assets/4399e7a5-b2c9-4a47-8b63-b3ab53afc7c6)

- Realised for the compute and disk page, we only long poll when the user updates the disk size, but once i refresh the page, we no longer long poll despite the changes not being picked up by the worker yet (so we show “changes have been requested” but it’ll never go away until the user refreshes once more)
  - Added to `setRefetchInterval` to 2000 in the `useDiskAttributesQuery` in `DiskManagementForm` if `requested_modification` is in `data`