### PR TITLE
fix: add missing groups to events

### DIFF
--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -12,6 +12,7 @@ import {
   useContentUpsertMutation,
 } from 'data/content/content-upsert-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useProfile } from 'lib/profile'
 import uuidv4 from 'lib/uuid'
 import { Dashboards } from 'types'
@@ -54,6 +55,7 @@ export const GridResize = ({
   const { ref } = useParams()
   const { profile } = useProfile()
   const { project } = useProjectContext()
+  const selectedOrg = useSelectedOrganization()
 
   const { mutate: sendEvent } = useSendEventMutation()
   const { mutate: upsertContent } = useContentUpsertMutation()
@@ -134,7 +136,10 @@ export const GridResize = ({
         },
       }
     )
-    sendEvent({ action: 'custom_report_assistant_sql_block_added' })
+    sendEvent({
+      action: 'custom_report_assistant_sql_block_added',
+      groups: { project: ref ?? 'Unknown', organization: selectedOrg?.slug ?? 'Unknown' },
+    })
   }
 
   if (!editableReport) return null

--- a/apps/studio/components/interfaces/Reports/MetricOptions.tsx
+++ b/apps/studio/components/interfaces/Reports/MetricOptions.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'common'
 import { useContentQuery } from 'data/content/content-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useFlag } from 'hooks/ui/useFlag'
 import { Metric, METRIC_CATEGORIES, METRICS } from 'lib/constants/metrics'
 import { Dashboards } from 'types'
@@ -39,6 +40,7 @@ interface MetricOptionsProps {
 
 export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsProps) => {
   const { ref: projectRef } = useParams()
+  const selectedOrganization = useSelectedOrganization()
   const supportSQLBlocks = useFlag('reportsV2')
   const [search, setSearch] = useState('')
 
@@ -142,6 +144,10 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
                             })
                             sendEvent({
                               action: 'custom_report_add_sql_block_clicked',
+                              groups: {
+                                project: projectRef ?? 'Unknown',
+                                organization: selectedOrganization?.slug ?? 'Unknown',
+                              },
                             })
                           }
                         }}

--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -23,6 +23,7 @@ import {
 } from 'data/content/content-upsert-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { Metric, TIME_PERIODS_REPORTS } from 'lib/constants/metrics'
 import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
@@ -42,6 +43,7 @@ const Reports = () => {
   const { id, ref } = useParams()
   const { profile } = useProfile()
   const { project } = useProjectContext()
+  const selectedOrg = useSelectedOrganization()
   const queryClient = useQueryClient()
   const state = useDatabaseSelectorStateSnapshot()
 
@@ -336,7 +338,10 @@ const Reports = () => {
         },
       }
     )
-    sendEvent({ action: 'custom_report_assistant_sql_block_added' })
+    sendEvent({
+      action: 'custom_report_assistant_sql_block_added',
+      groups: { project: ref ?? 'Unknown', organization: selectedOrg?.slug ?? 'Unknown' },
+    })
   }
 
   useEffect(() => {

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -26,6 +26,8 @@ import { AssistantSnippetProps } from './AIAssistant.types'
 import { identifyQueryType } from './AIAssistant.utils'
 import CollapsibleCodeBlock from './CollapsibleCodeBlock'
 import { MessageContext } from './Message'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 
 export const OrderedList = memo(({ children }: { children: ReactNode }) => (
   <ol className="flex flex-col gap-y-4">{children}</ol>
@@ -167,6 +169,8 @@ export const MarkdownPre = ({
   const { mutate: sendEvent } = useSendEventMutation()
   const snap = useAiAssistantStateSnapshot()
   const supportSQLBlocks = useFlag('reportsV2')
+  const project = useSelectedProject()
+  const org = useSelectedOrganization()
 
   const canCreateSQLSnippet = useCheckPermissions(PermissionAction.CREATE, 'user_content', {
     resource: { type: 'sql', owner_id: profile?.id },
@@ -233,6 +237,10 @@ export const MarkdownPre = ({
         ...(queryType === 'mutation'
           ? { category: identifyQueryType(cleanContent) ?? 'unknown' }
           : {}),
+      },
+      groups: {
+        project: project?.ref ?? 'Unknown',
+        organization: org?.slug ?? 'Unknown',
       },
     })
   }

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -188,6 +188,10 @@ const Wizard: NextPageWithLayout = () => {
         properties: {
           instanceSize: form.getValues('instanceSize'),
         },
+        groups: {
+          project: res.ref,
+          organization: res.organization_slug,
+        },
       })
       router.push(`/project/${res.ref}/building`)
     },
@@ -320,6 +324,9 @@ const Wizard: NextPageWithLayout = () => {
         action: 'project_creation_simple_version_confirm_modal_opened',
         properties: {
           instanceSize: values.instanceSize,
+        },
+        groups: {
+          organization: currentOrg?.slug ?? 'Unknown',
         },
       })
       setIsComputeCostsConfirmationModalVisible(true)

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -272,6 +272,10 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
   properties: {
     instanceSize: string
   }
+  groups: {
+    project: string
+    organization: string
+  }
 }
 
 /**
@@ -288,6 +292,9 @@ export interface ProjectCreationSimpleVersionConfirmModalOpenedEvent {
    */
   properties: {
     instanceSize: string
+  }
+  groups: {
+    organization: string
   }
 }
 
@@ -602,6 +609,10 @@ export interface AssistantSuggestionRunQueryClickedEvent {
     queryType: string
     category?: string
   }
+  groups: {
+    project: string
+    organization: string
+  }
 }
 
 /**
@@ -658,6 +669,10 @@ export interface AssistantEditInSqlEditorClickedEvent {
  */
 export interface CustomReportAddSQLBlockClicked {
   action: 'custom_report_add_sql_block_clicked'
+  groups: {
+    project: string
+    organization: string
+  }
 }
 
 /**
@@ -669,6 +684,10 @@ export interface CustomReportAddSQLBlockClicked {
  */
 export interface CustomReportAssistantSQLBlockAdded {
   action: 'custom_report_assistant_sql_block_added'
+  groups: {
+    project: string
+    organization: string
+  }
 }
 
 /**


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- There are some events where we missed out adding project and organization groups. Adding them now. 
- fixes GROWTH-340
- tested events in local and preview to show on posthog