### PR TITLE
Fix anchor link on seeding-your-database.mdx

### DIFF
--- a/apps/docs/content/guides/local-development/seeding-your-database.mdx
+++ b/apps/docs/content/guides/local-development/seeding-your-database.mdx
@@ -26,7 +26,7 @@ values
   ('Mexico', 'MX');
 ```
 
-If you want to manage multiple seed files or organize them across different folders, you can configure additional paths or glob patterns in your `config.toml` (see the [next section](#splitting-up-your-seed-data) for details).
+If you want to manage multiple seed files or organize them across different folders, you can configure additional paths or glob patterns in your `config.toml` (see the [next section](#splitting-up-your-seed-file) for details).
 
 ### Splitting up your seed file
 


### PR DESCRIPTION
Fix anchor link pointing to the title: changed from `#splitting-up-your-seed-data` to `#splitting-up-your-seed-file`

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix and docs update

## What is the current behavior?

[Splitting up your seed data](https://supabase.com/docs/guides/local-development/seeding-your-database#splitting-up-your-seed-data)

<img width="478" alt="Screenshot 2025-05-04 at 11 20 10" src="https://github.com/user-attachments/assets/3b67cc65-1866-45dc-baf2-753a08703724" />

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

[Splitting up your seed file](https://supabase.com/docs/guides/local-development/seeding-your-database#splitting-up-your-seed-file)

<img width="483" alt="Screenshot 2025-05-04 at 11 21 13" src="https://github.com/user-attachments/assets/fe53df59-db16-4d00-a987-6ec54d6e582b" />

## Additional context

Thanks
