### PR TITLE
Use PostgresVersionSelector in ProjectPausedState

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -33,6 +33,7 @@ interface PostgresVersionSelectorProps {
   field: ControllerRenderProps<any, 'postgresVersionSelection'>
   form: UseFormReturn<any>
   layout?: 'vertical' | 'horizontal'
+  label?: string
 }
 
 const formatValue = ({ postgres_engine, release_channel }: ProjectCreationPostgresVersion) => {
@@ -55,6 +56,7 @@ export const PostgresVersionSelector = ({
   field,
   form,
   layout = 'horizontal',
+  label = 'Postgres Version',
 }: PostgresVersionSelectorProps) => {
   const {
     data,
@@ -79,7 +81,7 @@ export const PostgresVersionSelector = ({
   }, [isSuccess, availableVersions, form])
 
   return (
-    <FormItemLayout label="Postgres Version" layout={layout}>
+    <FormItemLayout label={label} layout={layout}>
       <Select_Shadcn_
         value={postgresVersionSelection}
         onValueChange={field.onChange}

--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -2,10 +2,9 @@ import { useEffect } from 'react'
 import { ControllerRenderProps, UseFormReturn } from 'react-hook-form'
 
 import { components } from 'api-types'
-import {
-  ProjectCreationPostgresVersion,
-  useProjectCreationPostgresVersionsQuery,
-} from 'data/config/project-creation-postgres-versions-query'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { useProjectCreationPostgresVersionsQuery } from 'data/config/project-creation-postgres-versions-query'
+import { useProjectUnpausePostgresVersionsQuery } from 'data/config/project-unpause-postgres-versions-query'
 import type { CloudProvider } from 'shared-data'
 import {
   Badge,
@@ -32,11 +31,18 @@ interface PostgresVersionSelectorProps {
   organizationSlug: string | undefined
   field: ControllerRenderProps<any, 'postgresVersionSelection'>
   form: UseFormReturn<any>
+  type?: 'create' | 'unpause'
   layout?: 'vertical' | 'horizontal'
   label?: string
 }
 
-const formatValue = ({ postgres_engine, release_channel }: ProjectCreationPostgresVersion) => {
+const formatValue = ({
+  postgres_engine,
+  release_channel,
+}: {
+  postgres_engine: string
+  release_channel: string
+}) => {
   return `${postgres_engine}|${release_channel}`
 }
 
@@ -55,21 +61,38 @@ export const PostgresVersionSelector = ({
   organizationSlug,
   field,
   form,
+  type = 'create',
   layout = 'horizontal',
   label = 'Postgres Version',
 }: PostgresVersionSelectorProps) => {
+  const { project } = useProjectContext()
+
   const {
-    data,
-    isLoading: isLoadingProjectVersions,
+    data: createVersions,
+    isLoading: isLoadingProjectCreateVersions,
     isSuccess,
-  } = useProjectCreationPostgresVersionsQuery({
-    cloudProvider,
-    dbRegion,
-    organizationSlug,
-  })
-  const availableVersions = (data?.available_versions ?? []).sort((a, b) =>
-    a.version.localeCompare(b.version)
+  } = useProjectCreationPostgresVersionsQuery(
+    {
+      cloudProvider,
+      dbRegion,
+      organizationSlug,
+    },
+    { enabled: type === 'create' }
   )
+
+  const { data: unpauseVersions, isLoading: isLoadingProjectUnpauseVersions } =
+    useProjectUnpausePostgresVersionsQuery(
+      {
+        projectRef: project?.ref,
+      },
+      { enabled: type === 'unpause' }
+    )
+
+  const versions =
+    type === 'create'
+      ? createVersions?.available_versions ?? []
+      : unpauseVersions?.available_versions ?? []
+  const availableVersions = versions.sort((a, b) => a.version.localeCompare(b.version))
   const { postgresVersionSelection } = form.watch()
 
   useEffect(() => {
@@ -85,7 +108,11 @@ export const PostgresVersionSelector = ({
       <Select_Shadcn_
         value={postgresVersionSelection}
         onValueChange={field.onChange}
-        disabled={availableVersions.length === 0 || isLoadingProjectVersions}
+        disabled={
+          availableVersions.length === 0 ||
+          (type === 'create' && isLoadingProjectCreateVersions) ||
+          (type === 'unpause' && isLoadingProjectUnpauseVersions)
+        }
       >
         <SelectTrigger_Shadcn_ className="[&>:nth-child(1)]:w-full [&>:nth-child(1)]:flex [&>:nth-child(1)]:items-start">
           <SelectValue_Shadcn_ placeholder="Select a Postgres version for your project" />

--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -82,9 +82,7 @@ export const PostgresVersionSelector = ({
 
   const { data: unpauseVersions, isLoading: isLoadingProjectUnpauseVersions } =
     useProjectUnpausePostgresVersionsQuery(
-      {
-        projectRef: project?.ref,
-      },
+      { projectRef: project?.ref },
       { enabled: type === 'unpause' }
     )
 

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import { z } from 'zod'
 
 import { useParams } from 'common'
+import { PostgresVersionSelector } from 'components/interfaces/ProjectCreation/PostgresVersionSelector'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import {
@@ -26,28 +27,20 @@ import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useFlag, usePHFlag } from 'hooks/ui/useFlag'
 import { PROJECT_STATUS } from 'lib/constants'
+import { AWS_REGIONS, CloudProvider } from 'shared-data'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
-  Badge,
   Button,
-  FormControl_Shadcn_,
   FormField_Shadcn_,
   Form_Shadcn_,
   Modal,
-  SelectContent_Shadcn_,
-  SelectGroup_Shadcn_,
-  SelectItem_Shadcn_,
-  SelectTrigger_Shadcn_,
-  SelectValue_Shadcn_,
-  Select_Shadcn_,
 } from 'ui'
-import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
-import { PauseDisabledState } from './PauseDisabledState'
-import { RestorePaidPlanProjectNotice } from '../RestorePaidPlanProjectNotice'
 import { useProjectContext } from '../ProjectContext'
+import { RestorePaidPlanProjectNotice } from '../RestorePaidPlanProjectNotice'
+import { PauseDisabledState } from './PauseDisabledState'
 
 export interface ProjectPausedStateProps {
   product?: string
@@ -75,6 +68,8 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
   const enforceNinetyDayUnpauseExpiry = useFlag('enforceNinetyDayUnpauseExpiry')
   const projectVersionSelectionDisabled = useFlag('disableProjectVersionSelection')
   const enableProBenefitWording = usePHFlag('proBenefitWording')
+
+  const region = Object.values(AWS_REGIONS).find((x) => x.code === project?.region)
 
   const orgSlug = selectedOrganization?.slug
   const {
@@ -324,56 +319,15 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                     control={form.control}
                     name="postgresVersionSelection"
                     render={({ field }) => (
-                      <FormItemLayout label="Select the version of Postgres to restore to">
-                        <FormControl_Shadcn_>
-                          <Select_Shadcn_
-                            value={field.value}
-                            onValueChange={field.onChange}
-                            disabled={availableVersions.length <= 1}
-                          >
-                            <SelectTrigger_Shadcn_ className="[&>:nth-child(1)]:w-full [&>:nth-child(1)]:flex [&>:nth-child(1)]:items-start">
-                              <SelectValue_Shadcn_ placeholder="Select a Postgres version" />
-                            </SelectTrigger_Shadcn_>
-                            <SelectContent_Shadcn_>
-                              <SelectGroup_Shadcn_>
-                                {availableVersions.map((value) => {
-                                  const postgresVersion = value.version
-                                    .split('supabase-postgres-')[1]
-                                    ?.replace('-orioledb', '')
-                                  return (
-                                    <SelectItem_Shadcn_
-                                      key={formatValue(value)}
-                                      value={formatValue(value)}
-                                      className="w-full [&>:nth-child(2)]:w-full"
-                                    >
-                                      <div className="flex flex-row items-center justify-between w-full">
-                                        <span className="text-foreground">{postgresVersion}</span>
-                                        <div>
-                                          {value.release_channel !== 'ga' && (
-                                            <Badge variant="warning" className="mr-1 capitalize">
-                                              {value.release_channel}
-                                            </Badge>
-                                          )}
-                                          {value.postgres_engine.includes('oriole-preview') && (
-                                            <span>
-                                              <Badge variant="warning" className="mr-1">
-                                                OrioleDB
-                                              </Badge>
-                                              <Badge variant="warning" className="mr-1">
-                                                Preview
-                                              </Badge>
-                                            </span>
-                                          )}
-                                        </div>
-                                      </div>
-                                    </SelectItem_Shadcn_>
-                                  )
-                                })}
-                              </SelectGroup_Shadcn_>
-                            </SelectContent_Shadcn_>
-                          </Select_Shadcn_>
-                        </FormControl_Shadcn_>
-                      </FormItemLayout>
+                      <PostgresVersionSelector
+                        field={field}
+                        form={form}
+                        label="Select the version of Postgres to restore to"
+                        layout="vertical"
+                        dbRegion={region?.displayName ?? ''}
+                        cloudProvider={(project?.cloud_provider ?? 'AWS') as CloudProvider}
+                        organizationSlug={selectedOrganization?.slug}
+                      />
                     )}
                   />
                 </div>

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -57,7 +57,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
   const { project } = useProjectContext()
   const selectedOrganization = useSelectedOrganization()
   const enforceNinetyDayUnpauseExpiry = useFlag('enforceNinetyDayUnpauseExpiry')
-  const projectVersionSelectionDisabled = useFlag('disableProjectVersionSelection')
+  const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
   const enableProBenefitWording = usePHFlag('proBenefitWording')
 
   const region = Object.values(AWS_REGIONS).find((x) => x.code === project?.region)
@@ -117,7 +117,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
       return toast.error('Unable to restore: project is required')
     }
 
-    if (projectVersionSelectionDisabled) {
+    if (!showPostgresVersionSelector) {
       restoreProject({ ref: project.ref })
     } else {
       const { postgresVersionSelection } = values
@@ -289,7 +289,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
       >
         <Form_Shadcn_ {...form}>
           <form onSubmit={form.handleSubmit(onConfirmRestore)}>
-            {!projectVersionSelectionDisabled && (
+            {showPostgresVersionSelector && (
               <Modal.Content>
                 <div className="space-y-2">
                   <FormField_Shadcn_

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -13,11 +13,7 @@ import { useParams } from 'common'
 import { PostgresVersionSelector } from 'components/interfaces/ProjectCreation/PostgresVersionSelector'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import {
-  PostgresEngine,
-  ProjectUnpausePostgresVersion,
-  ReleaseChannel,
-} from 'data/config/project-unpause-postgres-versions-query'
+import { PostgresEngine, ReleaseChannel } from 'data/config/project-unpause-postgres-versions-query'
 import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-limit-check-query'
 import { useProjectPauseStatusQuery } from 'data/projects/project-pause-status-query'
 import { useProjectRestoreMutation } from 'data/projects/project-restore-mutation'
@@ -48,10 +44,6 @@ export interface ProjectPausedStateProps {
 interface PostgresVersionDetails {
   postgresEngine: PostgresEngine
   releaseChannel: ReleaseChannel
-}
-
-const formatValue = ({ postgres_engine, release_channel }: ProjectUnpausePostgresVersion) => {
-  return `${postgres_engine}|${release_channel}`
 }
 
 export const extractPostgresVersionDetails = (value: string): PostgresVersionDetails => {

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { ExternalLink, PauseCircle } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
@@ -157,13 +157,6 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
       postgresVersionSelection: '',
     },
   })
-
-  useEffect(() => {
-    const defaultValue = availablePostgresVersions?.available_versions[0]
-      ? formatValue(availablePostgresVersions?.available_versions[0])
-      : ''
-    form.setValue('postgresVersionSelection', defaultValue)
-  }, [availablePostgresVersions, form])
 
   return (
     <>

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -17,7 +17,6 @@ import {
   PostgresEngine,
   ProjectUnpausePostgresVersion,
   ReleaseChannel,
-  useProjectUnpausePostgresVersionsQuery,
 } from 'data/config/project-unpause-postgres-versions-query'
 import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-limit-check-query'
 import { useProjectPauseStatusQuery } from 'data/projects/project-pause-status-query'
@@ -98,11 +97,6 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
     { enabled: isFreePlan }
   )
 
-  const { data: availablePostgresVersions } = useProjectUnpausePostgresVersionsQuery({
-    projectRef: project?.ref,
-  })
-  const availableVersions = availablePostgresVersions?.available_versions || []
-
   const hasMembersExceedingFreeTierLimit = (membersExceededLimit || []).length > 0
   const [showConfirmRestore, setShowConfirmRestore] = useState(false)
   const [showFreeProjectLimitWarning, setShowFreeProjectLimitWarning] = useState(false)
@@ -153,9 +147,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     mode: 'onChange',
-    defaultValues: {
-      postgresVersionSelection: '',
-    },
+    defaultValues: { postgresVersionSelection: '' },
   })
 
   return (

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -143,7 +143,7 @@ const Wizard: NextPageWithLayout = () => {
   const { mutate: sendEvent } = useSendEventMutation()
 
   const projectCreationDisabled = useFlag('disableProjectCreationAndUpdate')
-  const projectVersionSelectionDisabled = useFlag('disableProjectVersionSelection')
+  const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
   const cloudProviderEnabled = useFlag('enableFlyCloudProvider')
   const allowOrioleDB = useFlag('allowOrioleDb')
   const { data: membersExceededLimit } = useFreeProjectLimitCheckQuery(
@@ -836,7 +836,7 @@ const Wizard: NextPageWithLayout = () => {
                       />
                     </Panel.Content>
 
-                    {!projectVersionSelectionDisabled && (
+                    {showPostgresVersionSelector && (
                       <Panel.Content>
                         <FormField_Shadcn_
                           control={form.control}


### PR DESCRIPTION
- Reuse existing component so that logic is shared
- Also updated PostgresVersionSelector to handle versions for creating project + unpause project
- Also updated `disableProjectVersionSelection` flag to `showPostgresVersionSelector`
  - Flags should be standardised to be expected to be false by default
  - Because this flag's logic is flipped, in the odd case that Configcat flags do not load properly, this value is defaulted to false and hence users might see the version selector

![image](https://github.com/user-attachments/assets/643ae1b0-3209-4b06-9df1-60f98f6ac561)
