### PR TITLE
table filter button updated

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -492,7 +492,7 @@ const RowHeader = () => {
             <Separator orientation="vertical" />
           </div>
           <Button type="text" onClick={() => onSelectAllRows()}>
-            Select all rows in table
+            {filters.length > 0 ? 'Select all filtered rows in table' : 'Select all rows in table'}
           </Button>
         </>
       )}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Rename the button from "Select all rows in table" to "Select all filtered rows in table" only when a filter is applied

## What is the current behavior?

This is not clearer to the user what rows he is selecting (especially when deleting rows).
Issue: #35473 (https://github.com/supabase/supabase/issues/35473)

## What is the new behavior?

This change makes it clearer to users that the selection applies only to the filtered view of the table if a filter is active.

## Additional context

- filters is already available via the useTableFilter() hook at the top of the component.
- The conditional check filters.length > 0 is used to decide which label to show.