### PR TITLE
Fix/ff results panel height

### DIFF
--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -333,9 +333,9 @@ export const EditorPanel = ({ onChange }: EditorPanelProps) => {
         )}
 
         {results !== undefined && results.length > 0 && (
-          <div className={`max-h-72 shrink-0 flex flex-col`}>
+          <div className={`max-h-72 shrink-0 flex flex-col ${showResults && 'h-full'}`}>
             {showResults && (
-              <div className="border-t flex-1 overflow-auto">
+              <div className="border-t flex-1 overflow-auto ">
                 <Results rows={results} />
               </div>
             )}

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -335,7 +335,7 @@ export const EditorPanel = ({ onChange }: EditorPanelProps) => {
         {results !== undefined && results.length > 0 && (
           <div className={`max-h-72 shrink-0 flex flex-col ${showResults && 'h-full'}`}>
             {showResults && (
-              <div className="border-t flex-1 overflow-auto ">
+              <div className="border-t flex-1 overflow-auto">
                 <Results rows={results} />
               </div>
             )}


### PR DESCRIPTION
fixes the results panel in the inline sql editor — in Firefox it's always hidden 

![screenshot-2025-05-05-at-14 39 32](https://github.com/user-attachments/assets/aa9407d1-415b-4e4e-be3f-4dd962b60564)
