### PR TITLE
docs: timescaledb snippet

### DIFF
--- a/apps/docs/content/guides/database/extensions/timescaledb.mdx
+++ b/apps/docs/content/guides/database/extensions/timescaledb.mdx
@@ -35,7 +35,7 @@ Supabase projects come with [TimescaleDB Apache 2 Edition](https://docs.timescal
 {/* prettier-ignore */}
 ```sql
 -- Enable the "timescaledb" extension
-create extension timescaledb;
+create extension timescaledb with schema extensions;
 
 -- Disable the "timescaledb" extension
 drop extension if exists timescaledb;
@@ -43,6 +43,10 @@ drop extension if exists timescaledb;
 
 </TabPanel>
 </Tabs>
+
+Even though the SQL code is `create extension`, this is the equivalent of "enabling the extension". To disable an extension you can call `drop extension`.
+
+It's good practice to create the extension within a separate schema (like `extensions`) to keep your `public` schema clean.
 
 ## Usage
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase docs - [TimescaleDB](https://supabase.com/docs/guides/database/extensions/timescaledb?queryGroups=database-method&database-method=sql#enable-the-extension)

## What is the current behavior?

Extensions snippet doesn't install into `extensions` schema

## What is the new behavior?

Snippet changed:

<img width="963" alt="Screenshot 2025-05-06 at 15 29 34" src="https://github.com/user-attachments/assets/23a2cc66-2dd0-4386-9afe-127326177d49" />


## Additional context

Closes #35471 
