### PR TITLE
Add missing type param to PostgresVersionSelector in ProjectPausedState

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -299,6 +299,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                       <PostgresVersionSelector
                         field={field}
                         form={form}
+                        type="unpause"
                         label="Select the version of Postgres to restore to"
                         layout="vertical"
                         dbRegion={region?.displayName ?? ''}


### PR DESCRIPTION
## Context

Only applies to internal since this isn't a user facing feature.

Creating and Restoring projects will show a postgres version selector dropdown, in each scenario we'd be pulling the available versions from different endpoints. The logic is already set up, but forgot a `type` param for the version selector in ProjectPausedState, so we're currently incorrectly showing available versions for creating a project, when restoring a project