### PR TITLE
Fix horizontal scrolling in table editor when no rows present

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, useRef } from 'react'
+import { forwardRef, memo, Ref, useRef } from 'react'
 import DataGrid, { CalculatedColumn, DataGridHandle } from 'react-data-grid'
 
 import { handleCopyCell } from 'components/grid/SupabaseGrid.utils'
@@ -48,7 +48,7 @@ export const Grid = memo(
         filters,
         onApplyFilters,
       },
-      ref: React.Ref<DataGridHandle> | undefined
+      ref: Ref<DataGridHandle> | undefined
     ) => {
       const tableEditorSnap = useTableEditorStateSnapshot()
       const snap = useTableEditorTableStateSnapshot()
@@ -119,7 +119,7 @@ export const Grid = memo(
           {(rows ?? []).length === 0 && (
             <div
               style={{ height: `calc(100% - 35px)` }}
-              className="absolute top-9 z-[2] p-2 w-full"
+              className="absolute top-9 p-2 w-full z-[1] pointer-events-none"
             >
               {isLoading && <GenericSkeletonLoader />}
               {isError && (
@@ -144,6 +144,7 @@ export const Grid = memo(
                         {
                           <Button
                             type="default"
+                            className="pointer-events-auto"
                             onClick={() => {
                               tableEditorSnap.onImportData()
                               sendEvent({
@@ -167,7 +168,11 @@ export const Grid = memo(
                         The filters applied have returned no results from this table
                       </p>
                       <div className="flex items-center space-x-2 mt-4">
-                        <Button type="default" onClick={() => removeAllFilters()}>
+                        <Button
+                          type="default"
+                          className="pointer-events-auto"
+                          onClick={() => removeAllFilters()}
+                        >
                           Remove all filters
                         </Button>
                       </div>


### PR DESCRIPTION
## Context

We shifted the no rows fallback UI outside of the Grid component's `rowRenderer` prop as the library doesn't handle the UI that well (fallback UI scrolls with the grid, so if you scroll horizontally, the fallback UI just disappears)

As such we shifted the loading, error and no rows UI outside of the Grid component [here](https://github.com/supabase/supabase/pull/35031) but that introduced an issue with horizontal scrolling in these scenarios since the absolutely positioned div was above the Grid component

## Changes involved
- Set the absolutely positioned div to have pointer-events-none so that mouse wheel events pass through it to the Grid
- Set pointer-events-auto to CTA buttons on the absolutely positioned div so that they remain clickable