### PR TITLE
fix: defaults to create and drop index concurrently

### DIFF
--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -105,7 +105,7 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
     }))
 
   const generatedSQL = `
-CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexType} (${selectedColumns
+CREATE INDEX CONCURRENTLY ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexType} (${selectedColumns
     .map((column) => `"${column}"`)
     .join(', ')});
 `.trim()

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -24,7 +24,7 @@ export async function createDatabaseIndex({
   const { schema, entity, type, columns } = payload
 
   const sql = `
-  CREATE INDEX ON "${schema}"."${entity}" USING ${type} (${columns
+  CREATE INDEX CONCURRENTLY ON "${schema}"."${entity}" USING ${type} (${columns
     .map((column) => `"${column}"`)
     .join(', ')});
   `.trim()

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -16,7 +16,7 @@ export async function deleteDatabaseIndex({
   connectionString,
   name,
 }: DatabaseIndexDeleteVariables) {
-  const sql = `drop index if exists "${name}"`
+  const sql = `drop index concurrently if exists "${name}"`
 
   const { result } = await executeSql({
     projectRef,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When index advisor suggests to create a new index, the assumption is that the database is large enough to benefit from index lookup. This means there is a significant risk of locking out the database from concurrent writes during index creation.

> Creating an index can interfere with regular operation of a database. Normally PostgreSQL locks the table to be indexed against writes and performs the entire index build with a single scan of the table. Other transactions can still read the table, but if they try to insert, update, or delete rows in the table they will block until the index build is finished. This could have a severe effect if the system is a live production database. Very large tables can take many hours to be indexed, and even for smaller tables, an index build can lock out writers for periods that are unacceptably long for a production system.

Due to our api timeout, the immediate effect on such databases is that creating index request will fail.

## What is the new behavior?

We should default to `create index concurrently` to avoid taking locks. The query will return immediately and run in the background for as long as it needs. Errors will be surfaced in postgres logs.

## Additional context

https://github.com/supabase/supabase/pull/35107#discussion_r2077864232

- [ ] flag off on oriole