### PR TITLE
chore(content api): reduce max depth

### DIFF
--- a/apps/docs/app/api/graphql/route.ts
+++ b/apps/docs/app/api/graphql/route.ts
@@ -10,7 +10,7 @@ import { createQueryDepthLimiter } from './validators'
 
 export const runtime = 'edge'
 
-const MAX_DEPTH = 9
+const MAX_DEPTH = 5
 
 const validationRules = [
   ...specifiedRules,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29639,7 +29639,7 @@ snapshots:
     dependencies:
       mobx: 6.11.0
       react: 18.3.1
-      use-sync-external-store: 1.4.0(react@18.3.1)
+      use-sync-external-store: 1.5.0(react@18.3.1)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 


### PR DESCRIPTION
Reduce max depth for validation from 9 to 5 because we foresee no legitimate queries that will require anything so deep.

Closes DOCS-214