### PR TITLE
docs: env in quickstarts

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nuxtjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nuxtjs.mdx
@@ -50,15 +50,46 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Query data from the app">
+    <StepHikeCompact.Step step={4}>
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    In `app.vue`, create a Supabase client using your project URL and public API (anon) key:
+    Create a `.env` file and populate with your Supabase connection variables:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />
 
-    Replace the existing content in your `app.vue` file with the following code.
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      <$CodeTabs>
+
+        ```text name=.env.local
+        SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        ```
+
+        ```ts name=nuxt.config.tsx
+        export default defineNuxtConfig({
+          runtimeConfig: {
+            public: {
+              supabaseUrl: process.env.SUPABASE_URL,
+              supabaseAnonKey: process.env.SUPABASE_ANON_KEY,
+            },
+          },
+        });
+        ```
+
+      </$CodeTabs>
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={5}>
+    <StepHikeCompact.Details title="Query data from the app">
+
+    In `app.vue`, create a Supabase client using your config values and replace the existing content with the following code.
 
     </StepHikeCompact.Details>
 
@@ -67,7 +98,8 @@ hideToc: true
       ```vue name=app.vue
       <script setup>
       import { createClient } from '@supabase/supabase-js'
-      const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
+      const config = useRuntimeConfig()
+      const supabase = createClient(config.public.supabaseUrl, config.public.supabaseAnonKey)
       const instruments = ref([])
 
       async function getInstruments() {
@@ -91,7 +123,7 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={5}>
+  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Start the app">
 
     Start the app, navigate to http://localhost:3000 in the browser, open the browser console, and you should see the list of instruments.

--- a/apps/docs/content/guides/getting-started/quickstarts/reactjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/reactjs.mdx
@@ -51,14 +51,34 @@ hideToc: true
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Query data from the app">
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    In `App.jsx`, create a Supabase client using your project URL and public API (anon) key:
+    Create a `.env.local` file and populate with your Supabase connection variables:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />
 
-    Add a `getInstruments` function to fetch the data and display the query result to the page.
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      <$CodeTabs>
+
+        ```text name=.env.local
+        VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        VITE_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        ```
+
+      </$CodeTabs>
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={5}>
+    <StepHikeCompact.Details title="Query data from the app">
+
+    In `App.jsx`, add a `getInstruments` function to fetch the data and display the query result to the page using a Supabase client.
 
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>
@@ -67,7 +87,7 @@ hideToc: true
       import { useEffect, useState } from "react";
       import { createClient } from "@supabase/supabase-js";
 
-      const supabase = createClient("https://<project>.supabase.co", "<your-anon-key>");
+      const supabase = createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY);
 
       function App() {
         const [instruments, setInstruments] = useState([]);
@@ -97,7 +117,7 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={5}>
+  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Start the app">
 
     Start the app, go to http://localhost:5173 in a browser, and open the browser console and you should see the list of instruments.

--- a/apps/docs/content/guides/getting-started/quickstarts/solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/solidjs.mdx
@@ -51,12 +51,34 @@ hideToc: true
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Query data from the app">
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    In `App.jsx`, create a Supabase client using your project URL and public API (anon) key:
+    Create a `.env.local` file and populate with your Supabase connection variables:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      <$CodeTabs>
+
+        ```text name=.env.local
+        VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        VITE_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        ```
+
+      </$CodeTabs>
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={5}>
+    <StepHikeCompact.Details title="Query data from the app">
+
+    In `App.jsx`, create a Supabase client to fetch the instruments data.
 
     Add a `getInstruments` function to fetch the data and display the query result to the page.
 
@@ -92,7 +114,7 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={5}>
+  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Start the app">
 
     Start the app and go to http://localhost:3000 in a browser and you should see the list of instruments.

--- a/apps/docs/content/guides/getting-started/quickstarts/vue.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/vue.mdx
@@ -50,10 +50,10 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Create the Supabase client">
+    <StepHikeCompact.Step step={4}>
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    Create a `/src/lib` directory in your Vue app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client with your project URL and public API (anon) key:
+    Create a `.env.local` file and populate with your Supabase connection variables:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />
@@ -62,17 +62,42 @@ hideToc: true
 
     <StepHikeCompact.Code>
 
-      ```js name=src/lib/supabaseClient.js
-      import { createClient } from '@supabase/supabase-js'
+      <$CodeTabs>
 
-      export const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
-      ```
+        ```text name=.env.local
+        VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        VITE_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        ```
+
+      </$CodeTabs>
 
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={5}>
+    <StepHikeCompact.Details title="Create the Supabase client">
+
+    Create a `/src/lib` directory in your Vue app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client:
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      ```js name=src/lib/supabaseClient.js
+      import { createClient } from '@supabase/supabase-js'
+
+      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+      const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+      export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+      ```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Query data from the app">
 
     Replace the existing content in your `App.vue` file with the following code.
@@ -109,7 +134,7 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={6}>
+  <StepHikeCompact.Step step={7}>
     <StepHikeCompact.Details title="Start the app">
 
     Start the app and go to http://localhost:5173 in a browser and you should see the list of instruments.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Quickstarts](https://supabase.com/docs/guides/getting-started/quickstarts/reactjs)

## What is the current behavior?

In some of the quickstarts `env` values are not used. 

## What is the new behavior?

 `env` files and examples in the following have been added:

- React
- Nuxt
- Vue
- Solid

