### PR TITLE
fix: ai assistant markdown formatting

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -107,7 +107,7 @@ export const Message = function Message({
                     return (
                       <ReactMarkdown
                         key={`${id}-part-${index}`}
-                        className="space-y-5 [&>*>code]:text-xs [&>*>*>code]:text-xs [&_li]:space-y-4"
+                        className="prose prose-sm [&_ol>li]:pl-4 [&_ol>li]:my-0 [&_li>p]:mt-0 space-y-5 [&>*>code]:text-xs [&>*>*>code]:text-xs [&_li]:space-y-4"
                         remarkPlugins={[remarkGfm]}
                         components={{
                           ...baseMarkdownComponents,
@@ -139,7 +139,7 @@ export const Message = function Message({
                           return (
                             <div
                               key={`${id}-tool-${toolCallId}`}
-                              className="w-auto -ml-[36px] overflow-x-hidden"
+                              className="w-auto overflow-x-hidden"
                             >
                               <QueryBlock
                                 label={args.label || 'SQL Snippet'}
@@ -183,7 +183,7 @@ export const Message = function Message({
               })
             ) : hasTextContent ? (
               <ReactMarkdown
-                className="space-y-5 flex-1 [&>*>code]:text-xs [&>*>*>code]:text-xs min-w-0 [&_li]:space-y-4"
+                className="prose prose-sm [&_ol>li]:pl-4 [&_ol>li]:my-0 space-y-5 flex-1 [&>*>code]:text-xs [&>*>*>code]:text-xs min-w-0 [&_li]:space-y-4"
                 remarkPlugins={[remarkGfm]}
                 components={allMarkdownComponents}
               >


### PR DESCRIPTION
Switches the rendered LLM content in `<ReactMarkdown>` to `prose` which renders lists and inline code better:

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/eb2e07e4-6a45-4605-8089-9adbc3b796cf)|![image](https://github.com/user-attachments/assets/8821e176-3710-43c3-9629-80437ed4e376)|
|![image](https://github.com/user-attachments/assets/38f37db8-c8a3-42d1-8a16-f3357ff46dd6)|![image](https://github.com/user-attachments/assets/5888b6fe-7696-4c6a-bdac-b83e003160b3)|

I also added back left margin to `<QueryBlock>` to make it align better in the chat.

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/3dd4eb46-0e36-415f-887c-c04f551e6bdb)|![image](https://github.com/user-attachments/assets/4dd42577-8b66-4adf-9547-9811dea0ac8a)|

I realizes this was probably intentional (maybe to maximize real estate) so let me know if you disagree. My personal opinion is that alignment is more important than the small amount of extra width, but happy to be wrong.