### PR TITLE
Fix query block read only catch

### DIFF
--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -194,8 +194,6 @@ export const QueryBlock = ({
   const handleExecute = () => {
     if (!sql || isLoading) return
 
-    console.log('Handle execute')
-
     if (readOnlyError) {
       return setShowWarning('hasWriteOperation')
     }

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -167,9 +167,14 @@ export const QueryBlock = ({
     onSuccess: (data) => {
       onResults?.(data.result)
       setQueryResult(data.result)
+
+      setReadOnlyError(false)
+      setQueryError(undefined)
     },
     onError: (error) => {
-      if (error?.message.includes('permission denied')) {
+      const permissionDenied = error.message.includes('permission denied')
+      const notOwner = error.message.includes('must be owner')
+      if (permissionDenied || notOwner) {
         setReadOnlyError(true)
         if (showRunButtonIfNotReadOnly) setShowWarning('hasWriteOperation')
       } else {
@@ -188,6 +193,8 @@ export const QueryBlock = ({
 
   const handleExecute = () => {
     if (!sql || isLoading) return
+
+    console.log('Handle execute')
 
     if (readOnlyError) {
       return setShowWarning('hasWriteOperation')


### PR DESCRIPTION
## Context

This is related to a [previous change](https://github.com/supabase/supabase/pull/34892) whereby the QueryBlock (which is used in the AI Assistant) now uses the read only connection string first when executing a query in order to ensure that no mutation related queries are ran without a warning first (previously we were depending on manually checking on the client side which wasn't a scalable way)

To check if the query didn't run because it was mutation related, we only checked the error message for "permission denied", but in this case "must be owner ..." is also a valid error that's related, so adding that check as well as the fix

![image](https://github.com/user-attachments/assets/c65180de-a72b-4938-9326-7fa8a6b8d0fd)

The expected UI response will thus be this to show the warning:
![image](https://github.com/user-attachments/assets/f95e706d-53ff-48c0-86f0-15c51f206d93)

