### PR TITLE
Chore/replace auth policies rls warnings with security lints

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
@@ -1,4 +1,5 @@
 import type { PostgresPolicy } from '@supabase/postgres-meta'
+import { useQueryClient } from '@tanstack/react-query'
 import { isEmpty } from 'lodash'
 import { HelpCircle } from 'lucide-react'
 import { useRouter } from 'next/router'
@@ -16,6 +17,7 @@ import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 import ProductEmptyState from 'components/to-be-cleaned/ProductEmptyState'
 import InformationBox from 'components/ui/InformationBox'
 import { useDatabasePolicyDeleteMutation } from 'data/database-policies/database-policy-delete-mutation'
+import { lintKeys } from 'data/lint/keys'
 import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
 import ConfirmModal from 'ui-patterns/Dialogs/ConfirmDialog'
 
@@ -38,6 +40,7 @@ const Policies = ({
 }: PoliciesProps) => {
   const router = useRouter()
   const { ref } = useParams()
+  const queryClient = useQueryClient()
   const { project } = useProjectContext()
 
   const [selectedTableToToggleRLS, setSelectedTableToToggleRLS] = useState<{
@@ -57,8 +60,9 @@ const Policies = ({
     },
   })
   const { mutate: deleteDatabasePolicy } = useDatabasePolicyDeleteMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success('Successfully deleted policy!')
+      await queryClient.invalidateQueries(lintKeys.lint(ref))
     },
     onSettled: () => {
       closeConfirmModal()

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
@@ -14,6 +14,7 @@ import { IStandaloneCodeEditor } from 'components/interfaces/SQLEditor/SQLEditor
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabasePolicyUpdateMutation } from 'data/database-policies/database-policy-update-mutation'
 import { databasePoliciesKeys } from 'data/database-policies/keys'
+import { lintKeys } from 'data/lint/keys'
 import { QueryResponseError, useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
@@ -33,9 +34,9 @@ import {
   cn,
 } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
-import { checkIfPolicyHasChanged, generateCreatePolicyQuery } from './PolicyEditorPanel.utils'
 import { LockedCreateQuerySection, LockedRenameQuerySection } from './LockedQuerySection'
 import { PolicyDetailsV2 } from './PolicyDetailsV2'
+import { checkIfPolicyHasChanged, generateCreatePolicyQuery } from './PolicyEditorPanel.utils'
 import { PolicyEditorPanelHeader } from './PolicyEditorPanelHeader'
 import { PolicyTemplates } from './PolicyTemplates'
 import { QueryError } from './QueryError'
@@ -122,7 +123,10 @@ export const PolicyEditorPanel = memo(function ({
   const { mutate: executeMutation, isLoading: isExecuting } = useExecuteSqlMutation({
     onSuccess: async () => {
       // refresh all policies
-      await queryClient.invalidateQueries(databasePoliciesKeys.list(ref))
+      await Promise.all([
+        queryClient.invalidateQueries(databasePoliciesKeys.list(ref)),
+        queryClient.invalidateQueries(lintKeys.lint(ref)),
+      ])
       toast.success('Successfully created new policy')
       onSelectCancel()
     },

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -78,7 +78,12 @@ export const PolicyTableRow = ({
             policies.length === 0 ? '' : 'border-b'
           )}
         >
-          <div className="w-1.5 h-1.5 bg-warning-600 rounded-full" />
+          <div
+            className={cn(
+              'w-1.5 h-1.5 rounded-full',
+              rlsLint.level === 'ERROR' ? 'bg-warning-600' : 'bg-selection'
+            )}
+          />
           <span className={cn('font-bold', rlsLint.level === 'ERROR' ? 'text-warning-600' : '')}>
             {rlsLint.level === 'ERROR' ? 'Warning' : 'Note'}:
           </span>{' '}

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -58,7 +58,6 @@ export const PolicyTableRow = ({
       lint.metadata?.schema === table.schema &&
       (lint.name === 'rls_enabled_no_policy' || lint.name.includes('rls_disabled'))
   )
-  console.log(table.name, { rlsLint })
 
   return (
     <Panel


### PR DESCRIPTION
## Context

There was a confusion raised with the warning label shown in the Auth -> Policies page when a table has RLS disabled, that the table was publicly readable and writable. This warning persists even if the schema of the table is not being exposed through the API (Under Settings -> Data API), which understandably causes unnecessary concern since the table wouldn't be publicly readable or writable in this case specifically
![image](https://github.com/user-attachments/assets/dd8b8986-4138-4648-8d10-31036ad93e9e)

## Changes involved

- The RLS warning in the Auth -> Policies page was showing as long as the table had RLS disabled, so we're going to move to using the lints from the security advisor as the source of truth
![image](https://github.com/user-attachments/assets/585a9a37-ac4f-43df-8b65-5f9a77701389)
- That gives us a few other benefits
  - We don't need to manually check if the schema is exposed through the API since that logic is in the lint itself (e.g below, schema joshen_test is not exposed)
![image](https://github.com/user-attachments/assets/dd1d1cbe-b52f-4750-8b7f-8a43314e9c24)
  - We can also show the new "Info" label for when RLS is enabled but there's no policies (which i reckon is a valid callout)

## To test
- [ ] Verify that the warning label shows if a table under the public schema has RLS disabled
- [ ] Verify that the info label shows if a table has RLS enabled but no policies
- [ ] Verify that the warning label updates to info if you enable RLS on a table in the public schema with no policies
- [ ] Verify that the info label goes away if you create a policy for a table that had RLS enabled and had no policies
- [ ] Verify that the info label shows up if you delete the only policy on a table that has RLS enabled