### PR TITLE
fix: move extension requests to query route

### DIFF
--- a/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
@@ -1,7 +1,8 @@
+import pgMeta from '@supabase/pg-meta'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { del, handleError } from 'data/fetchers'
+import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
 
@@ -9,27 +10,27 @@ export type DatabaseExtensionDisableVariables = {
   projectRef: string
   connectionString?: string
   id: string
+  cascade?: boolean
 }
 
 export async function disableDatabaseExtension({
   projectRef,
   connectionString,
   id,
+  cascade,
 }: DatabaseExtensionDisableVariables) {
   let headers = new Headers()
   if (connectionString) headers.set('x-connection-encrypted', connectionString)
 
-  const { data, error } = await del('/platform/pg-meta/{ref}/extensions', {
-    params: {
-      header: { 'x-connection-encrypted': connectionString! },
-      path: { ref: projectRef },
-      query: { id },
-    },
-    headers,
+  const { sql } = pgMeta.extensions.remove(id, { cascade })
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['extension', 'delete', id],
   })
 
-  if (error) handleError(error)
-  return data
+  return result
 }
 
 type DatabaseExtensionDisableData = Awaited<ReturnType<typeof disableDatabaseExtension>>

--- a/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
@@ -1,7 +1,7 @@
+import pgMeta from '@supabase/pg-meta'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, post } from 'data/fetchers'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
@@ -28,29 +28,15 @@ export async function enableDatabaseExtension({
   let headers = new Headers()
   if (connectionString) headers.set('x-connection-encrypted', connectionString)
 
-  if (createSchema) {
-    try {
-      await executeSql({
-        projectRef,
-        connectionString,
-        sql: `create schema if not exists ${schema}`,
-      })
-    } catch (error) {
-      throw error
-    }
-  }
-
-  const { data, error } = await post('/platform/pg-meta/{ref}/extensions', {
-    params: {
-      header: { 'x-connection-encrypted': connectionString! },
-      path: { ref: projectRef },
-    },
-    body: { schema, name, version, cascade },
-    headers,
+  const { sql } = pgMeta.extensions.create({ schema, name, version, cascade })
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql: createSchema ? `create schema if not exists ${schema}; ${sql}` : sql,
+    queryKey: ['extension', 'create'],
   })
 
-  if (error) handleError(error)
-  return data
+  return result
 }
 
 type DatabaseExtensionEnableData = Awaited<ReturnType<typeof enableDatabaseExtension>>

--- a/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
@@ -1,4 +1,5 @@
 import pgMeta from '@supabase/pg-meta'
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -32,7 +33,7 @@ export async function enableDatabaseExtension({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: createSchema ? `create schema if not exists ${schema}; ${sql}` : sql,
+    sql: createSchema ? `create schema if not exists ${ident(schema)}; ${sql}` : sql,
     queryKey: ['extension', 'create'],
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the new behavior?

- supports cascade param when deleting extensions
- combine schema creation in one query
- mirrors exactly the [upstream](https://github.com/supabase/postgres-meta/blob/master/src/lib/PostgresMetaExtensions.ts#L52) implementation

## Additional context

Add any other context or screenshots.
