### PR TITLE
add clearer doc links to disabled projects

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
@@ -180,7 +180,7 @@ export const PauseDisabledState = () => {
             rel="noreferrer"
             href="https://supabase.com/docs/guides/platform/migrating-within-supabase/dashboard-restore"
           >
-            Restore backup to a new Supabase Project guide
+            Restore backup to a new Supabase project guide
           </a>
         </Button>
         <Button asChild type="default" icon={<ExternalLink />}>

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
@@ -131,7 +131,7 @@ export const PauseDisabledState = () => {
         and cannot be restored through the dashboard. However, your data remains intact and can be
         downloaded as a backup.
       </AlertDescription_Shadcn_>
-      <AlertDescription_Shadcn_ className="flex items-center gap-x-2 mt-3">
+      <AlertDescription_Shadcn_ className="gap-x-2 mt-3">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button type="default" icon={<Download />} iconRight={<ChevronDown />}>
@@ -178,9 +178,18 @@ export const PauseDisabledState = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://supabase.com/docs/guides/platform/migrating-and-upgrading-projects#time-limits"
+            href="https://supabase.com/docs/guides/platform/migrating-within-supabase/dashboard-restore"
           >
-            More information
+            Restore backup to a new Supabase Project guide
+          </a>
+        </Button>
+        <Button asChild type="default" icon={<ExternalLink />}>
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://supabase.com/docs/guides/local-development/restoring-downloaded-backup"
+          >
+            Restore backup on your local machine guide
           </a>
         </Button>
       </AlertDescription_Shadcn_>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update docs link on dashboard.

## What is the current behavior?

Current more information link on the disabled project page does not clearly link to the backup restore guides

## What is the new behavior?

Link to the backup restore (local restore and restore to new supabase project) guides directly from the disabled project dashboard.

Removed the flex class for the buttons so that they would be vertical instead of horizontal as well due to the relatively long string labels.

## Additional context

Add any other context or screenshots.
