### PR TITLE
Fix scoop command

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.tsx
@@ -81,7 +81,7 @@ export const LocalVersionPopover = () => {
                 </TabsContent_Shadcn_>
                 <TabsContent_Shadcn_ className="mt-2 text-xs" value="windows">
                   <SimpleCodeBlock parentClassName="bg-selection rounded !px-2">
-                    scoop upgrade supabase
+                    scoop update supabase
                   </SimpleCodeBlock>
                 </TabsContent_Shadcn_>
                 <TabsContent_Shadcn_ className="mt-2 text-xs" value="linux">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Command fix

## What is the current behavior?

`upgrade` is not a valid scoop command. The correct command is `update`.

## What is the new behavior?

`scoop update supabase` works.

## Additional context

```
scoop update supabase
supabase: 2.22.6 -> 2.22.12
Updating one outdated app:
Updating 'supabase' (2.22.6 -> 2.22.12)
```
