### PR TITLE
Set `security definer` in `queue_embeddings` function

### DIFF
--- a/apps/docs/content/guides/ai/automatic-embeddings.mdx
+++ b/apps/docs/content/guides/ai/automatic-embeddings.mdx
@@ -209,6 +209,7 @@ create or replace function util.queue_embeddings()
 returns trigger
 language plpgsql
 security definer
+set search_path = ''
 as $$
 declare
   content_function text = TG_ARGV[0];

--- a/apps/docs/content/guides/ai/automatic-embeddings.mdx
+++ b/apps/docs/content/guides/ai/automatic-embeddings.mdx
@@ -208,6 +208,7 @@ Next we create a trigger function to queue embedding jobs. We'll use this functi
 create or replace function util.queue_embeddings()
 returns trigger
 language plpgsql
+security definer
 as $$
 declare
   content_function text = TG_ARGV[0];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

Associated Issue: #35599 

## What is the current behavior?

When you follow the guide to add the automatic embedding, and a user tries to insert a new document, the trigger fails with the following error:

```json
{
  "code": "42501",
  "details": null,
  "hint": null,
  "message": "permission denied for schema pgmq"
}
```

This is because the `queue_embedding`	in the trigger is executing with the `security invoker` permission, and it doesn't have access to the `pgmq` schema.

## What is the new behavior?

By adding `security definer` to the `queue_embedding` function, the trigger executes correctly without granting access to the `pgmq` schema to the users.
