### PR TITLE
fix: clarify restore project disk sizing behavior

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx
@@ -10,7 +10,8 @@ export const AdditionalMonthlySpend = ({
       <p>
         The new project will start with the same compute size as your current project, but the disk
         size will be slightly larger (1.25×) to ensure the restore completes successfully. You will
-        be able to update the compute size and disk size after the new project is created in{' '}
+        be able to update the compute size and increase the disk size after the new project is
+        created in{' '}
         <span className="font-mono text-xs tracking-tighter text-foreground-light">
           Project Settings &gt; Compute and Disk
         </span>

--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx
@@ -8,8 +8,9 @@ export const AdditionalMonthlySpend = ({
   return (
     <div className="text-sm text-foreground-lighter border-t p-5">
       <p>
-        The new project will have the same compute size and disk size as this project. You will be
-        able to update the compute size and disk size after the new project is created in{' '}
+        The new project will start with the same compute size as your current project, but the disk
+        size will be slightly larger (1.25×) to ensure the restore completes successfully. You will
+        be able to update the compute size and disk size after the new project is created in{' '}
         <span className="font-mono text-xs tracking-tighter text-foreground-light">
           Project Settings &gt; Compute and Disk
         </span>


### PR DESCRIPTION


This pull request updates the user-facing text in the `AdditionalMonthlySpend` component to clarify the initial compute and disk size configuration for new projects during the restore process.

<img width="517" alt="image" src="https://github.com/user-attachments/assets/69a47088-3f8b-4b07-91f8-2d21d0775490" />

User-facing text update:

* [`apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx`](diffhunk://#diff-a276e69f75137f0a0afc61e2695bcbe4a5b7033f6174609260e90dabcc3f2c36L11-R13): Updated the description to specify that the new project's disk size will be slightly larger (1.25×) than the current project's disk size to ensure a successful restore.


