### PR TITLE
feat: deprecated auth ui admonition

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
@@ -9,6 +9,8 @@ sitemapPriority: 0.5
 
 As of 7th Feb 2024, [this repository](https://github.com/supabase-community/auth-ui) is no longer maintained by the Supabase Team. At the moment, the team does not have capacity to give the expected level of care to this repository. We may revisit Auth UI in the future but regrettably have to leave it on hold for now as we focus on other priorities such as improving the Server-Side Rendering (SSR) package and advanced Auth primitives.
 
+As an alternative you can use the [Supabase UI Library](https://supabase.com/ui) which has auth ready blocks to use in your projects.
+
 </Admonition>
 
 Auth UI is a pre-built React component for authenticating users.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Auth UI](http://supabase.com/docs/guides/auth/auth-helpers/auth-ui)

## What is the current behavior?

No link to the Supabase ui library

## What is the new behavior?

<img width="845" alt="Screenshot 2025-05-11 at 17 37 31" src="https://github.com/user-attachments/assets/caf209fc-f998-4c53-b629-ecca09979258" />

