### PR TITLE
Added <$CodeTabs> to Pages Router tab

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -565,10 +565,14 @@ Fill in your `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`:
 
 <StepHikeCompact.Code>
 
+<$CodeTabs>
+
 ```txt .env.local
 NEXT_PUBLIC_SUPABASE_URL=<your_supabase_project_url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your_supabase_anon_key>
 ```
+
+</$CodeTabs>
 
 </StepHikeCompact.Code>
 

--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -565,14 +565,10 @@ Fill in your `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`:
 
 <StepHikeCompact.Code>
 
-<$CodeTabs>
-
-```txt .env.local
+```txt name=.env.local
 NEXT_PUBLIC_SUPABASE_URL=<your_supabase_project_url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your_supabase_anon_key>
 ```
-
-</$CodeTabs>
 
 </StepHikeCompact.Code>
 


### PR DESCRIPTION
There was an inconsistency between the App Router and Pages Router page, which was only a small detail.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs inconsistency fix.

## What is the current behavior?

![image](https://github.com/user-attachments/assets/1a636dd4-4280-4384-89b1-bf362a9aa353)
![image](https://github.com/user-attachments/assets/a267ac17-5205-4d67-b378-f37d55f81c23)

## What is the new behavior?

The .env.local will appear above the code snippets in both tabs.
