### PR TITLE
Fix indentation for solid.js quickstart docs

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/solidjs.mdx
@@ -87,27 +87,27 @@ hideToc: true
 
 
       ```jsx name=src/App.jsx
-        import { createClient } from "@supabase/supabase-js";
-        import { createResource, For } from "solid-js";
+      import { createClient } from "@supabase/supabase-js";
+      import { createResource, For } from "solid-js";
 
-        const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>');
+      const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>');
 
-        async function getInstruments() {
-          const { data } = await supabase.from("instruments").select();
-          return data;
-        }
+      async function getInstruments() {
+        const { data } = await supabase.from("instruments").select();
+        return data;
+      }
 
-        function App() {
-          const [instruments] = createResource(getInstruments);
+      function App() {
+        const [instruments] = createResource(getInstruments);
 
-          return (
-            <ul>
-              <For each={instruments()}>{(instrument) => <li>{instrument.name}</li>}</For>
-            </ul>
-          );
-        }
+        return (
+          <ul>
+            <For each={instruments()}>{(instrument) => <li>{instrument.name}</li>}</For>
+          </ul>
+        );
+      }
 
-        export default App;
+      export default App;
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

Indentation of the solid js code looks funny.

![Screenshot 2025-05-12 at 10 08 46](https://github.com/user-attachments/assets/c0798e99-cb61-4ce4-be2d-d926af704658)

Above is the screenshotted image from [the docs](https://supabase.com/docs/guides/getting-started/quickstarts/solidjs)

## What is the new behavior?

Fixed the indentation