### PR TITLE
remove empty code block websockets.mdx

### DIFF
--- a/apps/docs/content/guides/functions/websockets.mdx
+++ b/apps/docs/content/guides/functions/websockets.mdx
@@ -85,7 +85,7 @@ wss.emit("connection", ws, req);
 
 server.listen(8080);
 
-````
+```
 
 </TabPanel>
 </Tabs>
@@ -168,7 +168,7 @@ return new Response("User is not authenticated", { status: 403 });
 
 });
 
-````
+```
 
 </TabPanel>
 <TabPanel id="protocol" label="Using custom protocol">
@@ -218,7 +218,7 @@ return new Response("User is not authenticated", { status: 403 });
 
 });
 
-````
+```
 
 </TabPanel>
 </Tabs>

--- a/apps/docs/content/guides/functions/websockets.mdx
+++ b/apps/docs/content/guides/functions/websockets.mdx
@@ -85,7 +85,7 @@ wss.emit("connection", ws, req);
 
 server.listen(8080);
 
-```
+````
 
 </TabPanel>
 </Tabs>
@@ -168,7 +168,7 @@ return new Response("User is not authenticated", { status: 403 });
 
 });
 
-```
+````
 
 </TabPanel>
 <TabPanel id="protocol" label="Using custom protocol">
@@ -218,7 +218,7 @@ return new Response("User is not authenticated", { status: 403 });
 
 });
 
-```
+````
 
 </TabPanel>
 </Tabs>
@@ -236,6 +236,6 @@ To prevent that, you can update the `supabase/config.toml` with the following se
 ```toml
 [edge_runtime]
 policy = "per_worker"
-```
+````
 
 When running with `per_worker` policy, Function won't auto-reload on edits. You will need to manually restart it by running `supabase functions serve`.

--- a/apps/docs/content/guides/functions/websockets.mdx
+++ b/apps/docs/content/guides/functions/websockets.mdx
@@ -239,4 +239,3 @@ policy = "per_worker"
 ```
 
 When running with `per_worker` policy, Function won't auto-reload on edits. You will need to manually restart it by running `supabase functions serve`.
-````


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?
-

## What is the new behavior?
-
<img width="879" alt="Screenshot 2025-05-12 at 14 56 36" src="https://github.com/user-attachments/assets/b946fe09-d779-4ed6-af1e-4c29a6d610fa" />

## Additional context

remove empty code block