### PR TITLE
fix(docs): jwt generator

### DIFF
--- a/apps/docs/components/JwtGenerator/JwtGenerator.tsx
+++ b/apps/docs/components/JwtGenerator/JwtGenerator.tsx
@@ -1,5 +1,5 @@
 import { KJUR } from 'jsrsasign'
-import { useState, ChangeEvent } from 'react'
+import { ChangeEvent, useState } from 'react'
 import { Button, CodeBlock, Input, Select } from 'ui'
 
 const JWT_HEADER = { alg: 'HS256', typ: 'JWT' }
@@ -53,7 +53,7 @@ const generateRandomString = (length: number) => {
   return result
 }
 
-export default function JwtGenerator({}) {
+export default function JwtGenerator() {
   const secret = generateRandomString(40)
 
   const [jwtSecret, setJwtSecret] = useState(secret)
@@ -110,6 +110,7 @@ export default function JwtGenerator({}) {
       <div className="grid mb-8">
         <label htmlFor="token">The JWT will be generated from this info:</label>
         <Input.TextArea
+          key={JSON.stringify(token)}
           id="token"
           type="text"
           rows={6}


### PR DESCRIPTION
Fix a UI display issue for the JWT generator: when the dropdown is used to switch between the anon and service role key, the displayed JWT claims does not change. The actual state changes, and the keys generated are correct, but they just don't display because the text area is uncontrolled and doesn't sync with the state.

Changed the text area to take a key dependent on the state so the displayed UI should change properly.

Does _not_ affect the actually generated API keys. Double-checked that these are the same before and after.