### PR TITLE
fix(docs): crawlers page generation for pages with mdx components

### DIFF
--- a/apps/docs/app/api/crawlers/route.ts
+++ b/apps/docs/app/api/crawlers/route.ts
@@ -157,9 +157,7 @@ async function functionDetails(
   return fullDescription + parameters + examples
 }
 
-function mdxToHtml(markdownUnescaped: string): string {
-  const markdown = markdownUnescaped.replace(/(?<!\\)\{/g, '\\{').replace(/(?<!\\)\}/g, '\\}')
-
+function mdxToHtml(markdown: string): string {
   const mdast = fromMarkdown(markdown, {
     extensions: [mdxjs()],
     mdastExtensions: [mdxFromMarkdown()],

--- a/apps/docs/features/docs/GuidesMdx.utils.tsx
+++ b/apps/docs/features/docs/GuidesMdx.utils.tsx
@@ -55,7 +55,9 @@ const getGuidesMarkdownInternal = async (slug: string[]) => {
   try {
     mdx = await readFile(fullPath, 'utf-8')
   } catch {
-    console.error('Error reading Markdown at path: %s', fullPath)
+    // Not using console.error because this includes pages that are genuine
+    // 404s and clutters up the logs
+    console.log('Error reading Markdown at path: %s', fullPath)
     notFound()
   }
 
@@ -165,4 +167,4 @@ function removeRedundantH1(content: string) {
   return content
 }
 
-export { getGuidesMarkdown, genGuidesStaticParams, genGuideMeta, removeRedundantH1 }
+export { genGuideMeta, genGuidesStaticParams, getGuidesMarkdown, removeRedundantH1 }


### PR DESCRIPTION
# Before

Crawlers pages that used MDX components with defined attributes errored. Example: /docs/reference/kotlin/installing

# After

The pages do not error.