### PR TITLE
fix: update route handler creation path name for Next.js SSR guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -425,7 +425,7 @@ Since this is a Router Handler, use the Supabase client from `@/utils/supabase/s
 
 <$CodeTabs>
 
-```ts name=app/auth/confirm/route.ts
+```ts name=app/api/auth/confirm/route.ts
 import { type EmailOtpType } from '@supabase/supabase-js'
 import { type NextRequest } from 'next/server'
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The current [Next.js](https://supabase.com/docs/guides/auth/server-side/nextjs) SSR implementation guide have a wrong creation path for the authentication route handler

<img width="621" alt="Screenshot 2025-05-12 at 9 14 16 PM" src="https://github.com/user-attachments/assets/9c68a030-0fe9-4d6a-94f4-3d8be6aae456" />

## What is the new behavior?

The router handler path should be created inside `/app/api/` folder (where api routes are defined)
