### PR TITLE
fix: move publication create and update to query route

### DIFF
--- a/apps/studio/data/database-publications/database-publications-create-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-create-mutation.ts
@@ -27,9 +27,6 @@ export async function createDatabasePublication({
   publish_delete = false,
   publish_truncate = false,
 }: DatabasePublicationCreateVariables) {
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
   const { sql } = pgMeta.publications.create({
     name,
     tables,

--- a/apps/studio/data/database-publications/database-publications-create-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-create-mutation.ts
@@ -1,7 +1,8 @@
+import pgMeta from '@supabase/pg-meta'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, post } from 'data/fetchers'
+import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databasePublicationsKeys } from './keys'
 
@@ -29,24 +30,23 @@ export async function createDatabasePublication({
   let headers = new Headers()
   if (connectionString) headers.set('x-connection-encrypted', connectionString)
 
-  const { data, error } = await post('/platform/pg-meta/{ref}/publications', {
-    params: {
-      header: { 'x-connection-encrypted': connectionString! },
-      path: { ref: projectRef },
-    },
-    body: {
-      name,
-      tables,
-      publish_insert,
-      publish_update,
-      publish_delete,
-      publish_truncate,
-    },
-    headers,
+  const { sql } = pgMeta.publications.create({
+    name,
+    tables,
+    publish_insert,
+    publish_update,
+    publish_delete,
+    publish_truncate,
   })
 
-  if (error) handleError(error)
-  return data
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['publication', 'create'],
+  })
+
+  return result
 }
 
 type DatabasePublicationCreateData = Awaited<ReturnType<typeof createDatabasePublication>>

--- a/apps/studio/data/database-publications/database-publications-update-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-update-mutation.ts
@@ -1,7 +1,8 @@
+import pgMeta from '@supabase/pg-meta'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, patch } from 'data/fetchers'
+import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databasePublicationsKeys } from './keys'
 
@@ -26,28 +27,22 @@ export async function updateDatabasePublication({
   publish_delete,
   publish_truncate,
 }: DatabasePublicationUpdateVariables) {
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
-  const body = { id } as any
-  if (tables !== undefined) body.tables = tables
-  if (publish_insert !== undefined) body.publish_insert = publish_insert
-  if (publish_update !== undefined) body.publish_update = publish_update
-  if (publish_delete !== undefined) body.publish_delete = publish_delete
-  if (publish_truncate !== undefined) body.publish_truncate = publish_truncate
-
-  const { data, error } = await patch('/platform/pg-meta/{ref}/publications', {
-    params: {
-      header: { 'x-connection-encrypted': connectionString! },
-      path: { ref: projectRef },
-      query: { id },
-    },
-    body,
-    headers,
+  const { sql } = pgMeta.publications.update(id, {
+    tables,
+    publish_insert,
+    publish_update,
+    publish_delete,
+    publish_truncate,
   })
 
-  if (error) handleError(error)
-  return data
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['publication', 'update', id],
+  })
+
+  return result
 }
 
 type DatabasePublicationUpdateData = Awaited<ReturnType<typeof updateDatabasePublication>>

--- a/packages/pg-meta/test/publications.test.ts
+++ b/packages/pg-meta/test/publications.test.ts
@@ -68,7 +68,7 @@ withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) =>
   )
 
   // Update publication
-  const { sql: updateSql } = pgMeta.publications.update(res!, {
+  const { sql: updateSql } = pgMeta.publications.update(res!.id, {
     name: 'b',
     publish_insert: false,
     tables: [],
@@ -150,12 +150,9 @@ withTestDatabase('tables with uppercase', async ({ executeQuery }) => {
   )
 
   // Update publication
-  const { sql: updateSql } = pgMeta.publications.update(
-    { id: res!.id },
-    {
-      tables: ['T'],
-    }
-  )
+  const { sql: updateSql } = pgMeta.publications.update(res!.id, {
+    tables: ['T'],
+  })
   await executeQuery(updateSql)
 
   // Verify update
@@ -241,7 +238,7 @@ withTestDatabase('update no tables -> all tables', async ({ executeQuery }) => {
   const res = retrieveZod.parse((await executeQuery(retrieveSql))[0])
 
   // Update publication
-  const { sql: updateSql } = pgMeta.publications.update(res!, {
+  const { sql: updateSql } = pgMeta.publications.update(res!.id, {
     tables: null,
   })
   await executeQuery(updateSql)
@@ -287,7 +284,7 @@ withTestDatabase('update all tables -> no tables', async ({ executeQuery }) => {
   const res = retrieveZod.parse((await executeQuery(retrieveSql))[0])
 
   // Update publication
-  const { sql: updateSql } = pgMeta.publications.update(res!, {
+  const { sql: updateSql } = pgMeta.publications.update(res!.id, {
     tables: [],
   })
   await executeQuery(updateSql)


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the new behavior?

- Use the query route for creating and updating publications
- Mirrors exactly the implementation of [pgmeta](https://github.com/supabase/postgres-meta/blob/master/src/lib/PostgresMetaPublications.ts#L78) route

## Additional context

Add any other context or screenshots.
