### PR TITLE
chore: Add a redirect for integration

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2375,6 +2375,12 @@ module.exports = [
     source: '/docs/guides/integrations/zuplo',
     destination: '/partners/integrations/zuplo',
   },
+  // toddle.dev pivoted to nordcraft
+  {
+    permanent: true,
+    source: '/partners/integrations/toddle',
+    destination: '/partners/integrations/nordcraft',
+  },
   {
     permanent: true,
     source: '/docs/guides/platform/oauth-apps/publish-an-oauth-app',


### PR DESCRIPTION
This PR adds a redirect from the Toddle.dev partner to Nordcraft.