### PR TITLE
chore(docs): fix comment misspell

### DIFF
--- a/packages/pg-meta/src/query/table-row-query.ts
+++ b/packages/pg-meta/src/query/table-row-query.ts
@@ -206,7 +206,7 @@ export const getTableRowsSql = ({
 
   const selectClause = selectExpressions.join(',')
   const finalQuery = new Query()
-  // Now, we apply our selection logic with the tables truncation  on the _base_query contructed before
+  // Now, we apply our selection logic with the tables truncation on the _base_query constructed before
   const finalQueryChain = finalQuery.from('_base_query').select(selectClause)
   return `${baseSelectQuery}
   ${finalQueryChain.toSql({ isCTE: true, isFinal: true })}`


### PR DESCRIPTION
- Fixing my broken english so: https://github.com/supabase/supabase/actions/runs/14991806341/job/42116688856 can be green again.