### PR TITLE
fix(docs): update callback url to use token_hash instead of token

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
@@ -643,7 +643,7 @@ const templates = {
 
 function generateConfirmationURL(email_data) {
   // TODO: replace the ref with your project ref
-  return `https://<ref>.supabase.co/auth/v1/verify?token=${email_data.token}&type=${email_data.email_action_type}&redirect_to=${email_data.redirect_to}`
+  return `https://<ref>.supabase.co/auth/v1/verify?token=${email_data.token_hash}&type=${email_data.email_action_type}&redirect_to=${email_data.redirect_to}`
 }
 
 Deno.serve(async (req) => {
@@ -755,7 +755,7 @@ const templates = {
 
 function generateConfirmationURL(email_data) {
    // TODO: replace the ref with your project ref
-   return `https://<ref>.supabase.co/auth/v1/verify?token=${email_data.token}&type=${email_data.email_action_type}&redirect_to=${email_data.redirect_to}`
+   return `https://<ref>.supabase.co/auth/v1/verify?token=${email_data.token_hash}&type=${email_data.email_action_type}&redirect_to=${email_data.redirect_to}`
 }
 
 async function sendEmailWithPostmark(user: any, email_data: any, serverToken: string): Promise<Response> {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The generated callback URL is using `token` which is incorrect.

## What is the new behavior?

The generated callback URL is using `token_hash` which is correct.

## Additional context

Fix for #35592 
