### PR TITLE
chore: add Paweł Gulbinowicz to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -77,6 +77,7 @@ Paul Caselton
 Paul Cioanca
 Paul Copplestone
 Pavel Borisov
+Paweł Gulbinowicz
 Peter Lyn
 Qiao Han
 Raminder Singh


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Paweł Gulbinowicz is not listed in `humans.txt`.

## What is the new behavior?

Paweł Gulbinowicz is listed in `humans.txt`.

Not applicable.
