### PR TITLE
Update auth-apple.mdx

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -368,7 +368,7 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     ) {
     	install(GoTrue)
     	install(ComposeAuth) {
-    		nativeAppleLogin()
+    		appleNativeLogin()
     	}
     }
     ```


### PR DESCRIPTION
Config name correction based on "AppleLoginConfig"

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?
The native apple login code snippet seems to be calling `appleNativeLogin()` method under `AppleLoginConfig` but the method name is `nativeAppleLogin()`

## What is the new behavior?
Updated the method call to match with the one mentioned in the `AppleLoginConfig`
For reference : [AppleLoginConfig](https://github.com/supabase-community/supabase-kt/blob/495aec15c95e78587a5161e88c4636df6e756dd6/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/AppleLoginConfig.kt#L13)
