### PR TITLE
fix(docs feedback): route security feedback to security team

### DIFF
--- a/apps/docs/components/Feedback/Feedback.utils.ts
+++ b/apps/docs/components/Feedback/Feedback.utils.ts
@@ -30,6 +30,8 @@ const getLinearTeam = (pathname: string) => {
       return 'Dev Workflows'
     case 'integrations':
       return 'API'
+    case 'security':
+      return 'Security'
     case 'platform':
     case 'monitoring-troubleshooting':
       return 'Infra'


### PR DESCRIPTION
## Before

Feedback on security pages is being routed to general docs feedback.

## After

Feedback on security pages is routed to security team.