### PR TITLE
fix: move triggers requests to query route

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
@@ -12,7 +12,7 @@ interface DeleteHookModalProps {
 }
 
 const DeleteHookModal = ({ selectedHook, visible, onClose }: DeleteHookModalProps) => {
-  const { id, name, schema } = selectedHook ?? {}
+  const { name, schema, table } = selectedHook ?? {}
 
   const { project } = useProjectContext()
   const { mutate: deleteDatabaseTrigger, isLoading: isDeleting } = useDatabaseTriggerDeleteMutation(
@@ -28,12 +28,12 @@ const DeleteHookModal = ({ selectedHook, visible, onClose }: DeleteHookModalProp
     if (!project) {
       return console.error('Project ref is required')
     }
-    if (!id) {
+    if (!(name && schema && table)) {
       return toast.error('Unable find selected hook')
     }
 
     deleteDatabaseTrigger({
-      id,
+      id: { name, schema, table },
       projectRef: project.ref,
       connectionString: project.connectionString,
     })

--- a/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
@@ -12,7 +12,7 @@ interface DeleteHookModalProps {
 }
 
 const DeleteHookModal = ({ selectedHook, visible, onClose }: DeleteHookModalProps) => {
-  const { name, schema, table } = selectedHook ?? {}
+  const { name, schema } = selectedHook ?? {}
 
   const { project } = useProjectContext()
   const { mutate: deleteDatabaseTrigger, isLoading: isDeleting } = useDatabaseTriggerDeleteMutation(
@@ -28,12 +28,12 @@ const DeleteHookModal = ({ selectedHook, visible, onClose }: DeleteHookModalProp
     if (!project) {
       return console.error('Project ref is required')
     }
-    if (!(name && schema && table)) {
+    if (!selectedHook) {
       return toast.error('Unable find selected hook')
     }
 
     deleteDatabaseTrigger({
-      id: { name, schema, table },
+      trigger: selectedHook,
       projectRef: project.ref,
       connectionString: project.connectionString,
     })

--- a/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -14,11 +14,12 @@ import {
 } from 'data/edge-functions/edge-functions-query'
 import { getTableEditor } from 'data/table-editor/table-editor-query'
 import { useTablesQuery } from 'data/tables/tables-query'
-import { isValidHttpUrl, tryParseJson, uuidv4 } from 'lib/helpers'
+import { isValidHttpUrl, uuidv4 } from 'lib/helpers'
 import { Button, Checkbox, Form, Input, Listbox, Radio, SidePanel } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import HTTPRequestFields from './HTTPRequestFields'
 import { AVAILABLE_WEBHOOK_TYPES, HOOK_EVENTS } from './Hooks.constants'
+import { PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 export interface EditHookPanelProps {
   visible: boolean
@@ -231,15 +232,13 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
       return value
     })
 
-    const payload: any = {
+    const payload: PGTriggerCreate = {
       events,
       activation: 'AFTER',
       orientation: 'ROW',
-      enabled_mode: 'ORIGIN',
       name: values.name,
       table: selectedTable.name,
       schema: selectedTable.schema,
-      table_id: values.table_id,
       function_name: 'http_request',
       function_schema: 'supabase_functions',
       function_args: [
@@ -262,7 +261,7 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
         projectRef: project?.ref,
         connectionString: project?.connectionString,
         originalTrigger: selectedHook,
-        updatedTrigger: payload,
+        updatedTrigger: { ...payload, enabled_mode: 'ORIGIN' },
       })
     }
   }

--- a/apps/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
@@ -13,19 +13,19 @@ interface DeleteTriggerProps {
 
 export const DeleteTrigger = ({ trigger, visible, setVisible }: DeleteTriggerProps) => {
   const { project } = useProjectContext()
-  const { id, name, schema } = trigger ?? {}
+  const { name, schema, table } = trigger ?? {}
 
   const { mutate: deleteDatabaseTrigger, isLoading } = useDatabaseTriggerDeleteMutation()
 
   async function handleDelete() {
     if (!project) return console.error('Project is required')
-    if (!id) return console.error('Trigger ID is required')
+    if (!(name && schema && table)) return console.error('Trigger ID is required')
 
     deleteDatabaseTrigger(
       {
         projectRef: project.ref,
         connectionString: project.connectionString,
-        id,
+        id: { name, schema, table },
       },
       {
         onSuccess: () => {

--- a/apps/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
@@ -13,19 +13,19 @@ interface DeleteTriggerProps {
 
 export const DeleteTrigger = ({ trigger, visible, setVisible }: DeleteTriggerProps) => {
   const { project } = useProjectContext()
-  const { name, schema, table } = trigger ?? {}
+  const { name, schema } = trigger ?? {}
 
   const { mutate: deleteDatabaseTrigger, isLoading } = useDatabaseTriggerDeleteMutation()
 
   async function handleDelete() {
     if (!project) return console.error('Project is required')
-    if (!(name && schema && table)) return console.error('Trigger ID is required')
+    if (!trigger) return console.error('Trigger ID is required')
 
     deleteDatabaseTrigger(
       {
         projectRef: project.ref,
         connectionString: project.connectionString,
-        id: { name, schema, table },
+        trigger,
       },
       {
         onSuccess: () => {

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -133,11 +133,7 @@ export const TriggerSheet = ({ selectedTrigger, open, setOpen }: TriggerSheetPro
       updateDatabaseTrigger({
         projectRef: project?.ref,
         connectionString: project?.connectionString,
-        id: {
-          name: selectedTrigger.name,
-          schema: selectedTrigger.schema,
-          table: selectedTrigger.table,
-        },
+        originalTrigger: selectedTrigger,
         payload: { name: payload.name, enabled_mode: payload.enabled_mode },
       })
     } else {

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -133,7 +133,11 @@ export const TriggerSheet = ({ selectedTrigger, open, setOpen }: TriggerSheetPro
       updateDatabaseTrigger({
         projectRef: project?.ref,
         connectionString: project?.connectionString,
-        id: selectedTrigger.id,
+        id: {
+          name: selectedTrigger.name,
+          schema: selectedTrigger.schema,
+          table: selectedTrigger.table,
+        },
         payload: { name: payload.name, enabled_mode: payload.enabled_mode },
       })
     } else {

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -50,9 +50,9 @@ const FormSchema = z.object({
     .regex(/^\S+$/, 'Name should not contain spaces or whitespaces'),
   schema: z.string(),
   table: z.string(),
-  activation: z.string(),
-  enabled_mode: z.string(),
-  orientation: z.string(),
+  activation: z.enum(['BEFORE', 'AFTER', 'INSTEAD OF']),
+  enabled_mode: z.enum(['ORIGIN', 'REPLICA', 'ALWAYS', 'DISABLED']),
+  orientation: z.enum(['ROW', 'STATEMENT']),
   function_name: z.string(),
   function_schema: z.string(),
   events: z.array(z.string()).min(1, 'Please select at least one event'),
@@ -61,7 +61,7 @@ const FormSchema = z.object({
   tableId: z.string().optional(),
 })
 
-const defaultValues = {
+const defaultValues: z.infer<typeof FormSchema> = {
   name: '',
   schema: '',
   table: '',

--- a/apps/studio/data/database-triggers/database-trigger-create-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-create-mutation.ts
@@ -1,14 +1,15 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-
-import { handleError, post } from 'data/fetchers'
+import pgMeta from '@supabase/pg-meta'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
+import { executeSql } from 'data/sql/execute-sql-query'
+import { PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 export type DatabaseTriggerCreateVariables = {
   projectRef: string
   connectionString?: string | null
-  payload: any
+  payload: PGTriggerCreate
 }
 
 export async function createDatabaseTrigger({
@@ -16,20 +17,16 @@ export async function createDatabaseTrigger({
   connectionString,
   payload,
 }: DatabaseTriggerCreateVariables) {
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
+  const { sql } = pgMeta.triggers.create(payload)
 
-  const { data, error } = await post('/platform/pg-meta/{ref}/triggers', {
-    params: {
-      header: { 'x-connection-encrypted': connectionString! },
-      path: { ref: projectRef },
-    },
-    body: payload,
-    headers,
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['trigger', 'create'],
   })
 
-  if (error) handleError(error)
-  return data
+  return result
 }
 
 type DatabaseTriggerCreateData = Awaited<ReturnType<typeof createDatabaseTrigger>>

--- a/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
@@ -2,13 +2,12 @@ import type { PostgresTrigger } from '@supabase/postgres-meta'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import pgMeta from '@supabase/pg-meta'
-import { del, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 
 export type DatabaseTriggerDeleteVariables = {
-  id: number
+  id: { name: string; schema: string; table: string }
   projectRef: string
   connectionString?: string | null
 }
@@ -20,7 +19,7 @@ export async function deleteDatabaseTrigger({
   projectRef,
   connectionString,
 }: DatabaseTriggerDeleteVariables) {
-  const { sql } = pgMeta.triggers.remove({ id })
+  const { sql } = pgMeta.triggers.remove(id)
 
   const { result } = await executeSql({
     projectRef,

--- a/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
@@ -7,25 +7,28 @@ import { databaseTriggerKeys } from './keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 
 export type DatabaseTriggerDeleteVariables = {
-  id: { name: string; schema: string; table: string }
+  trigger: {
+    id: number
+    name: string
+    schema: string
+    table: string
+  }
   projectRef: string
   connectionString?: string | null
 }
 
-type DeleteDatabaseTriggerResponse = PostgresTrigger & { error?: any }
-
 export async function deleteDatabaseTrigger({
-  id,
+  trigger,
   projectRef,
   connectionString,
 }: DatabaseTriggerDeleteVariables) {
-  const { sql } = pgMeta.triggers.remove(id)
+  const { sql } = pgMeta.triggers.remove(trigger)
 
   const { result } = await executeSql({
     projectRef,
     connectionString,
     sql,
-    queryKey: ['trigger', 'delete'],
+    queryKey: ['trigger', 'delete', trigger.id],
   })
 
   return result

--- a/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
@@ -4,30 +4,33 @@ import pgMeta from '@supabase/pg-meta'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
 import { executeSql } from 'data/sql/execute-sql-query'
+import { PGTriggerUpdate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 export type DatabaseTriggerUpdateVariables = {
-  id: { name: string; schema: string; table: string }
+  originalTrigger: {
+    id: number
+    name: string
+    schema: string
+    table: string
+  }
   projectRef: string
   connectionString?: string | null
-  payload: {
-    name?: string
-    enabled_mode?: 'ORIGIN' | 'REPLICA' | 'ALWAYS' | 'DISABLED'
-  }
+  payload: PGTriggerUpdate
 }
 
 export async function updateDatabaseTrigger({
-  id,
+  originalTrigger,
   projectRef,
   connectionString,
   payload,
 }: DatabaseTriggerUpdateVariables) {
-  const { sql } = pgMeta.triggers.update(id, payload)
+  const { sql } = pgMeta.triggers.update(originalTrigger, payload)
 
   const { result } = await executeSql({
     projectRef,
     connectionString,
     sql,
-    queryKey: ['trigger', 'update'],
+    queryKey: ['trigger', 'update', originalTrigger.id],
   })
 
   return result

--- a/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
@@ -6,7 +6,7 @@ import { databaseTriggerKeys } from './keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 
 export type DatabaseTriggerUpdateVariables = {
-  id: number
+  id: { name: string; schema: string; table: string }
   projectRef: string
   connectionString?: string | null
   payload: {
@@ -21,7 +21,7 @@ export async function updateDatabaseTrigger({
   connectionString,
   payload,
 }: DatabaseTriggerUpdateVariables) {
-  const { sql } = pgMeta.triggers.update({ id }, payload)
+  const { sql } = pgMeta.triggers.update(id, payload)
 
   const { result } = await executeSql({
     projectRef,

--- a/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
@@ -6,7 +6,7 @@ import { quoteLiteral } from 'lib/pg-format'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
 import { PostgresTrigger } from '@supabase/postgres-meta'
-import { PGTriggerCreate, PGTriggerUpdate } from '@supabase/pg-meta/src/pg-meta-triggers'
+import { PGTrigger, PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 // [Joshen] Writing this query within FE as the PATCH endpoint from pg-meta only supports updating
 // trigger name and enabled mode. So we'll delete and create the trigger, within a single transaction
@@ -16,7 +16,7 @@ export type DatabaseTriggerUpdateVariables = {
   projectRef: string
   connectionString?: string | null
   originalTrigger: PostgresTrigger
-  updatedTrigger: PGTriggerCreate & { enabled_mode: PGTriggerUpdate['enabled_mode'] }
+  updatedTrigger: PGTriggerCreate & Pick<PGTrigger, 'enabled_mode'>
 }
 
 export function getDatabaseTriggerUpdateSQL({
@@ -42,7 +42,12 @@ export async function updateDatabaseTrigger({
   updatedTrigger,
 }: DatabaseTriggerUpdateVariables) {
   const sql = getDatabaseTriggerUpdateSQL({ originalTrigger, updatedTrigger })
-  await executeSql({ projectRef, connectionString, sql, queryKey: ['trigger', 'update'] })
+  await executeSql({
+    projectRef,
+    connectionString,
+    sql,
+    queryKey: ['trigger', 'update', originalTrigger.id],
+  })
   return updatedTrigger
 }
 

--- a/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
@@ -42,7 +42,7 @@ export async function updateDatabaseTrigger({
   updatedTrigger,
 }: DatabaseTriggerUpdateVariables) {
   const sql = getDatabaseTriggerUpdateSQL({ originalTrigger, updatedTrigger })
-  await executeSql({ projectRef, connectionString, sql })
+  await executeSql({ projectRef, connectionString, sql, queryKey: ['trigger', 'update'] })
   return updatedTrigger
 }
 

--- a/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
@@ -5,6 +5,8 @@ import { executeSql } from 'data/sql/execute-sql-query'
 import { quoteLiteral } from 'lib/pg-format'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
+import { PostgresTrigger } from '@supabase/postgres-meta'
+import { PGTriggerCreate, PGTriggerUpdate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 // [Joshen] Writing this query within FE as the PATCH endpoint from pg-meta only supports updating
 // trigger name and enabled mode. So we'll delete and create the trigger, within a single transaction
@@ -13,8 +15,8 @@ import { databaseTriggerKeys } from './keys'
 export type DatabaseTriggerUpdateVariables = {
   projectRef: string
   connectionString?: string | null
-  originalTrigger: any
-  updatedTrigger: any
+  originalTrigger: PostgresTrigger
+  updatedTrigger: PGTriggerCreate & { enabled_mode: PGTriggerUpdate['enabled_mode'] }
 }
 
 export function getDatabaseTriggerUpdateSQL({

--- a/packages/pg-meta/src/pg-meta-triggers.ts
+++ b/packages/pg-meta/src/pg-meta-triggers.ts
@@ -121,14 +121,14 @@ export function create({
 } {
   const qualifiedTableName = `${ident(schema)}.${ident(table)}`
   const qualifiedFunctionName = `${ident(function_schema)}.${ident(function_name)}`
-  const triggerEvents = events.join(' OR ')
-  const triggerOrientation = orientation ? `FOR EACH ${orientation}` : ''
-  const triggerCondition = condition ? `WHEN (${condition})` : ''
+  const triggerEvents = events.join(' or ')
+  const triggerOrientation = orientation ? `for each ${orientation}` : ''
+  const triggerCondition = condition ? `when (${condition})` : ''
   const functionArgsStr = function_args.map(literal).join(',')
 
-  const sql = `CREATE TRIGGER ${ident(
+  const sql = `create trigger ${ident(
     name
-  )} ${activation} ${triggerEvents} ON ${qualifiedTableName} ${triggerOrientation} ${triggerCondition} EXECUTE FUNCTION ${qualifiedFunctionName}(${functionArgsStr});`
+  )} ${activation} ${triggerEvents} on ${qualifiedTableName} ${triggerOrientation} ${triggerCondition} execute function ${qualifiedFunctionName}(${functionArgsStr});`
 
   return {
     sql,
@@ -144,51 +144,37 @@ export const pgTriggerUpdateZod = z.object({
 export type PGTriggerUpdate = z.infer<typeof pgTriggerUpdateZod>
 
 export function update(
-  identifier: TriggerIdentifier,
+  id: { name: string; schema: string; table: string },
   params: PGTriggerUpdate
 ): {
   sql: string
 } {
-  const whereIdentifierCondition = getIdentifierWhereClause(identifier)
+  const qualifiedTableName = `${ident(id.schema)}.${ident(id.table)}`
 
-  const sql = `
-do $$
-declare
-  old record;
-begin
-  with triggers as (${TRIGGERS_SQL})
-  select * into old from triggers where ${whereIdentifierCondition};
-  
-  if old is null then
-    raise exception 'Cannot find trigger: %', ${literal(whereIdentifierCondition)};
-  end if;
+  let enabledModeSql = ''
 
-  ${
-    params.enabled_mode
-      ? `
-  execute(format('alter table %I.%I ${
-    params.enabled_mode === 'DISABLED'
-      ? 'DISABLE'
-      : 'ENABLE' +
-        (params.enabled_mode === 'ALWAYS' || params.enabled_mode === 'REPLICA'
-          ? ' ' + params.enabled_mode
-          : '')
-  } TRIGGER %I', 
-    old.schema, old.table, old.name));`
-      : ''
+  switch (params.enabled_mode) {
+    case 'ORIGIN':
+      enabledModeSql = `alter table ${qualifiedTableName} enable trigger ${ident(id.name)};`
+      break
+    case 'DISABLED':
+      enabledModeSql = `alter table ${qualifiedTableName} disable trigger ${ident(id.name)};`
+      break
+    case 'REPLICA':
+    case 'ALWAYS':
+      enabledModeSql = `alter table ${qualifiedTableName} enable ${params.enabled_mode} trigger ${ident(id.name)};`
+      break
+    default:
+      break
   }
 
-  ${
-    params.name
-      ? `
-    -- Using the same name in the rename clause gives an error, so only do it if the new name is different.
-  if ${literal(params.name)} != old.name then
-    execute(format('alter trigger %I on %I.%I rename to %I;', old.name, old.schema, old.table, ${literal(params.name)}));
-  end if;`
+  const updateNameSql =
+    params.name && params.name !== id.name
+      ? `alter trigger ${ident(id.name)} on ${qualifiedTableName} rename to ${ident(params.name)};`
       : ''
-  }
-end
-$$;`
+
+  // updateNameSql must be last
+  const sql = `begin; ${enabledModeSql}; ${updateNameSql}; commit;`
 
   return {
     sql,
@@ -196,30 +182,15 @@ $$;`
 }
 
 export function remove(
-  identifier: TriggerIdentifier,
+  id: { name: string; schema: string; table: string },
   { cascade = false } = {}
 ): {
   sql: string
   zod: z.ZodType<void>
 } {
-  const whereIdentifierCondition = getIdentifierWhereClause(identifier)
+  const qualifiedTableName = `${ident(id.schema)}.${ident(id.table)}`
 
-  const sql = `
-do $$
-declare
-  old record;
-begin
-  with triggers as (${TRIGGERS_SQL})
-  select * into old from triggers where ${whereIdentifierCondition};
-  
-  if old is null then
-    raise exception 'Cannot find trigger';
-  end if;
-
-  execute(format('DROP TRIGGER %I ON %I.%I ${cascade ? 'CASCADE' : ''}',
-    old.name, old.schema, old.table));
-end
-$$;`
+  const sql = `drop trigger ${ident(id.name)} on ${qualifiedTableName} ${cascade ? 'cascade' : ''};`
 
   return {
     sql,

--- a/packages/pg-meta/src/pg-meta-triggers.ts
+++ b/packages/pg-meta/src/pg-meta-triggers.ts
@@ -148,6 +148,7 @@ export function update(
   params: PGTriggerUpdate
 ): {
   sql: string
+  zod: z.ZodType<void>
 } {
   const qualifiedTableName = `${ident(id.schema)}.${ident(id.table)}`
 
@@ -178,6 +179,7 @@ export function update(
 
   return {
     sql,
+    zod: z.void(),
   }
 }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the database trigger management system by enhancing type safety, aligning with the `pg-meta` library's API, and replacing REST-based operations with SQL execution for trigger creation, deletion, and updates. These changes improve maintainability, reduce reliance on REST endpoints, and ensure stricter type validation.

### Enhancements to Type Safety and Validation:
* Updated `EditHookPanel` and `TriggerSheet` components to use the `PGTriggerCreate` type from `pg-meta`, replacing generic `any` types, and added stricter validation schemas using `zod` enums for fields like `activation`, `enabled_mode`, and `orientation`. [[1]](diffhunk://#diff-73425bc27fef574f507e70c4f43d05125f879b0eb17c2f33ba62c5acd59a9378L234-L242) [[2]](diffhunk://#diff-f7e0563d1b9ebb2ec5cec9879bd0aa1bc0023efb0a13aa5ae9b238ceb69fb62cL53-R55) [[3]](diffhunk://#diff-f7e0563d1b9ebb2ec5cec9879bd0aa1bc0023efb0a13aa5ae9b238ceb69fb62cL64-R64)

### Transition to SQL Execution for Triggers:
* Replaced REST-based operations (`post`, `patch`, and `del`) with SQL-based execution using the `pg-meta` library for creating, updating, and deleting database triggers. This includes generating SQL queries via `pgMeta.triggers` methods and executing them with `executeSql`. [[1]](diffhunk://#diff-4916357949739d3d7a3f1c60c198c6e2026730ffc22fa75e7f862ff12931ceb9L3-R29) [[2]](diffhunk://#diff-ee23f69cd6de55291a3ce79f288cd0423324e09f817c5acca9d43d7575f0c999L22-R32) [[3]](diffhunk://#diff-ce6230a69787893ea89a518ff0e7811024410d2a9c8b779d304a6a3867140bc8L21-R33)

### Refactoring and Cleanup:
* Removed redundant imports and unused fields (e.g., `table_id` and `enabled_mode` in `EditHookPanel`) to streamline the code. [[1]](diffhunk://#diff-73425bc27fef574f507e70c4f43d05125f879b0eb17c2f33ba62c5acd59a9378L17-R22) [[2]](diffhunk://#diff-73425bc27fef574f507e70c4f43d05125f879b0eb17c2f33ba62c5acd59a9378L265-R264)
* Refactored the `DatabaseTriggerUpdateTransaction` mutation to use stricter types (`PostgresTrigger`, `PGTriggerCreate`, and `PGTriggerUpdate`) for `originalTrigger` and `updatedTrigger`. [[1]](diffhunk://#diff-f77d1e8641c0281a2016b9d5a93175a53d6945cb1d7ad0744b5d5329b343f5c0R8-R9) [[2]](diffhunk://#diff-f77d1e8641c0281a2016b9d5a93175a53d6945cb1d7ad0744b5d5329b343f5c0L16-R19) [[3]](diffhunk://#diff-f77d1e8641c0281a2016b9d5a93175a53d6945cb1d7ad0744b5d5329b343f5c0L43-R45)