### PR TITLE
Remove unnecessary includeSystemSchemas, stay consistent with hosted — fixes custom schema enums

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -53,7 +53,7 @@ const FormSchema = z.object({
   activation: z.string(),
   enabled_mode: z.string(),
   orientation: z.string(),
-  function_name: z.string(),
+  function_name: z.string().min(1, 'Please select a database function for your trigger to call'),
   function_schema: z.string(),
   events: z.array(z.string()).min(1, 'Please select at least one event'),
 
@@ -413,6 +413,17 @@ export const TriggerSheet = ({ selectedTrigger, open, setOpen }: TriggerSheetPro
                         </Button>
                       </div>
                     )}
+
+                    {/* [Joshen] Just for form to handle errors for function_name, since this parameter is handled outside of a form component */}
+                    <FormField_Shadcn_
+                      name="function_name"
+                      control={form.control}
+                      render={() => (
+                        <FormItemLayout layout="vertical">
+                          <FormControl_Shadcn_ />
+                        </FormItemLayout>
+                      )}
+                    />
                   </div>
                 </>
               )}

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -374,57 +374,62 @@ export const TriggerSheet = ({ selectedTrigger, open, setOpen }: TriggerSheetPro
 
                   <Separator />
 
-                  <div className="px-5 flex flex-col gap-y-2">
-                    <p className="text-smn">Function to trigger</p>
-                    {function_name.length === 0 ? (
-                      <button
-                        type="button"
-                        className={cn(
-                          'relative w-full rounded border border-default',
-                          'bg-surface-200 px-5 py-1 shadow-sm transition-all',
-                          'hover:border-strong hover:bg-overlay-hover'
-                        )}
-                        onClick={() => setShowFunctionSelector(true)}
-                      >
-                        <FormBoxEmpty
-                          icon={<Terminal size={14} strokeWidth={2} />}
-                          text="Choose a function to trigger"
-                        />
-                      </button>
-                    ) : (
-                      <div
-                        className={cn(
-                          'relative w-full flex items-center justify-between',
-                          'space-x-3 px-5 py-4 border border-default',
-                          'rounded shadow-sm transition-shadow'
-                        )}
-                      >
-                        <div className="flex items-center gap-2">
-                          <div className="flex h-6 w-6 items-center justify-center rounded bg-foreground text-background focus-within:bg-opacity-10">
-                            <Terminal size="18" strokeWidth={2} width={14} />
+                  <FormField_Shadcn_
+                    name="function_name"
+                    control={form.control}
+                    render={() => (
+                      <FormItemLayout layout="vertical" className="px-5">
+                        <FormControl_Shadcn_>
+                          <div className="flex flex-col gap-y-2">
+                            <p className="text-smn">Function to trigger</p>
+                            {function_name.length === 0 ? (
+                              <button
+                                type="button"
+                                className={cn(
+                                  'relative w-full rounded border border-default',
+                                  'bg-surface-200 px-5 py-1 shadow-sm transition-all',
+                                  'hover:border-strong hover:bg-overlay-hover'
+                                )}
+                                onClick={() => setShowFunctionSelector(true)}
+                              >
+                                <FormBoxEmpty
+                                  icon={<Terminal size={14} strokeWidth={2} />}
+                                  text="Choose a function to trigger"
+                                />
+                              </button>
+                            ) : (
+                              <div
+                                className={cn(
+                                  'relative w-full flex items-center justify-between',
+                                  'space-x-3 px-5 py-4 border border-default',
+                                  'rounded shadow-sm transition-shadow'
+                                )}
+                              >
+                                <div className="flex items-center gap-2">
+                                  <div className="flex h-6 w-6 items-center justify-center rounded bg-foreground text-background focus-within:bg-opacity-10">
+                                    <Terminal size="18" strokeWidth={2} width={14} />
+                                  </div>
+                                  <p>
+                                    <span className="text-sm text-foreground-light">
+                                      {function_schema}
+                                    </span>
+                                    .
+                                    <span className="text-sm text-foreground">{function_name}</span>
+                                  </p>
+                                </div>
+                                <Button
+                                  type="default"
+                                  onClick={() => setShowFunctionSelector(true)}
+                                >
+                                  Change function
+                                </Button>
+                              </div>
+                            )}
                           </div>
-                          <p>
-                            <span className="text-sm text-foreground-light">{function_schema}</span>
-                            .<span className="text-sm text-foreground">{function_name}</span>
-                          </p>
-                        </div>
-                        <Button type="default" onClick={() => setShowFunctionSelector(true)}>
-                          Change function
-                        </Button>
-                      </div>
+                        </FormControl_Shadcn_>
+                      </FormItemLayout>
                     )}
-
-                    {/* [Joshen] Just for form to handle errors for function_name, since this parameter is handled outside of a form component */}
-                    <FormField_Shadcn_
-                      name="function_name"
-                      control={form.control}
-                      render={() => (
-                        <FormItemLayout layout="vertical">
-                          <FormControl_Shadcn_ />
-                        </FormItemLayout>
-                      )}
-                    />
-                  </div>
+                  />
                 </>
               )}
             </form>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -293,7 +293,7 @@ export const ForeignKeySelector = ({
                   Select columns from{' '}
                   <code className="text-xs">
                     {fk.schema}.{fk.table}
-                  </code>
+                  </code>{' '}
                   to reference to
                 </label>
                 <div className="grid grid-cols-10 gap-y-2">

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/types.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/types.ts
@@ -1,8 +1,8 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-import { PG_META_URL } from 'lib/constants'
-import apiWrapper from 'lib/api/apiWrapper'
 import { constructHeaders } from 'lib/api/apiHelpers'
+import apiWrapper from 'lib/api/apiWrapper'
 import { get } from 'lib/common/fetch'
+import { PG_META_URL } from 'lib/constants'
+import { NextApiRequest, NextApiResponse } from 'next'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>
   apiWrapper(req, res, handler, { withAuth: true })
@@ -23,15 +23,8 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   const headers = constructHeaders(req.headers)
   const response = await get(`${PG_META_URL}/types`, { headers })
 
-  const includeSystemSchemas = req.query['include_system_schemas'] === 'true'
-
   if (response.error) {
     return res.status(400).json({ error: response.error })
-  }
-
-  if (!includeSystemSchemas) {
-    const types = response?.filter((x: any) => x.schema === 'public')
-    return res.status(200).json(types)
   }
 
   return res.status(200).json(response)


### PR DESCRIPTION
Just needed removing `includeSystemSchemas` from the local API endpoint, this part was added 3 years ago hahaha
Removing it to stay consistent with the hosted, which we don't use `includeSystemSchemas` anywhere anymore

## To test (Must be tested via self-host/local)
- Create enum type in custom schema
- Can view enum in database/enums
- Can view enum in table editor when creating a column -> column type
- (Unrelated) Adds error handling for database trigger sheet when a function is not selected

Fixes FE-1643
