### PR TITLE
fix(project switcher page): stuck in loading state

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
@@ -19,6 +19,7 @@ import ProjectCard from './ProjectCard'
 import ShimmeringCard from './ShimmeringCard'
 
 export interface ProjectListProps {
+  forOrganization?: Organization
   rewriteHref?: (projectRef: string) => string
   search?: string
   filterStatus?: string[]
@@ -27,12 +28,13 @@ export interface ProjectListProps {
 
 const ProjectList = ({
   search = '',
+  forOrganization,
   rewriteHref,
   filterStatus,
   resetFilterStatus,
 }: ProjectListProps) => {
   const { slug } = useParams()
-  const organization = useSelectedOrganization()
+  const organization = useSelectedOrganization() ?? forOrganization
 
   const {
     data: allProjects = [],
@@ -48,7 +50,9 @@ const ProjectList = ({
   } = usePermissionsQuery()
   const { data: resourceWarnings } = useResourceWarningsQuery()
 
-  const orgProjects = allProjects.filter((x) => x.organization_slug === slug)
+  const orgProjects = allProjects.filter(
+    (x) => x.organization_slug === slug || x.organization_slug === organization?.slug
+  )
   const isLoadingPermissions = IS_PLATFORM ? _isLoadingPermissions : false
 
   const hasFilterStatusApplied = filterStatus !== undefined && filterStatus.length !== 2


### PR DESCRIPTION
# Before

On project switcher pages (those with underscore URLs), the project list is forever stuck in the loading state because it wants to filter by selected organization, but there is no selected organization.

![image](https://github.com/user-attachments/assets/0e53651e-c855-4e15-b64e-bf456265aab7)

# After

Not stuck in loading state. Shows all projects sorted by organization.

![image](https://github.com/user-attachments/assets/e20cad3e-8ca2-4f6b-902a-dc9b58aae7ac)
