### PR TITLE
chore(docs): allow partners fetch to be revalidated by tag

### DIFF
--- a/apps/docs/app/guides/integrations/layout.tsx
+++ b/apps/docs/app/guides/integrations/layout.tsx
@@ -1,7 +1,7 @@
 import { IS_PLATFORM } from 'common'
 import { unstable_cache } from 'next/cache'
-
 import { type NavMenuSection } from '~/components/Navigation/Navigation.types'
+import { REVALIDATION_TAGS } from '~/features/helpers.fetch'
 import Layout from '~/layouts/guides'
 import { supabaseMisc } from '~/lib/supabaseMisc'
 
@@ -13,7 +13,9 @@ export default async function IntegrationsLayout({ children }: { children: React
 
 // Will need to turn on revalidation later, just turning it off for now so we
 // can slowly turn things back on while monitoring usage
-const getPartners = unstable_cache(getPartnersImpl, [], { revalidate: false })
+const getPartners = unstable_cache(getPartnersImpl, [], {
+  tags: [REVALIDATION_TAGS.PARTNERS],
+})
 async function getPartnersImpl() {
   if (!IS_PLATFORM) return []
 

--- a/apps/docs/features/helpers.fetch.ts
+++ b/apps/docs/features/helpers.fetch.ts
@@ -10,6 +10,7 @@ import { ONE_DAY_IN_SECONDS } from './helpers.time'
 
 export const REVALIDATION_TAGS = {
   GRAPHQL: 'graphql',
+  PARTNERS: 'partners',
   WRAPPERS: 'wrappers',
 } as const
 // Casting to avoid problems with using this as a Zod enum, TypeScript does
@@ -33,4 +34,4 @@ const fetchRevalidatePerDay = fetchWithNextOptions({
   next: { revalidate: ONE_DAY_IN_SECONDS },
 })
 
-export { fetchWithNextOptions, fetchRevalidatePerDay }
+export { fetchRevalidatePerDay, fetchWithNextOptions }


### PR DESCRIPTION
## Before

Partners fetch is showing stale data from a few months ago

## After

Partners fetch can be revalidated by tag. The revalidation will be triggered by a DB function when the partners table is changed.

Towards DOCS-3