### PR TITLE
Update auth-google.mdx to reflect the new Auth object

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -694,7 +694,7 @@ val supabaseClient = createSupabaseClient(
     supabaseUrl = "SUPABASE_URL",
     supabaseKey = "SUPABASE_KEY"
 ) {
-    install(GoTrue)
+    install(Auth)
     install(ComposeAuth) {
         nativeGoogleLogin("WEB_GOOGLE_CLIENT_ID") //Use the Web Client ID, not the Android one!
     }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## Context
The `GoTrue` was replaced by `Auth` in [this commit](https://github.com/supabase-community/supabase-kt/commit/45af76c01a92dae0413814ba2b3f33ba7555e190) ([PR](https://github.com/supabase-community/supabase-kt/pull/732)). But the doc is still using `GoTrue`

<img width="500" alt="image" src="https://github.com/user-attachments/assets/667ea634-b41d-4342-a436-b7732f258894" />

