### PR TITLE
Add regex guard for edge functions test endpoint

### DIFF
--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -19,7 +19,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   try {
+    console.log('post', req.body)
     const { url, method, body: requestBody, headers: customHeaders } = req.body
+
+    const regexValidEdgeFunctionURL = new RegExp(
+      'https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/S*',
+      'g'
+    )
+    const validEdgeFunctionURL = regexValidEdgeFunctionURL.test(url)
+
+    if (!validEdgeFunctionURL) {
+      return res.status(400).json({
+        status: 400,
+        error: { message: 'Provided URL is not a valid Supabase edge function URL' },
+      })
+    }
 
     // Remove any undefined or null values from custom headers
     const sanitizedCustomHeaders = Object.entries(customHeaders || {}).reduce(

--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -22,7 +22,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     const { url, method, body: requestBody, headers: customHeaders } = req.body
 
     const regexValidEdgeFunctionURL = new RegExp(
-      'https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/S*',
+      '^https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/\S*$',
       'g'
     )
     const validEdgeFunctionURL = regexValidEdgeFunctionURL.test(url)

--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -19,7 +19,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   try {
-    console.log('post', req.body)
     const { url, method, body: requestBody, headers: customHeaders } = req.body
 
     const regexValidEdgeFunctionURL = new RegExp(


### PR DESCRIPTION
Fixes SEC-365

Validates that provided URL parameter is only a Supabase edge function URL

- Tested working normally on the dashboard edge functions page
- Tested curling directly with an invalid URL returns a 400