### PR TITLE
Chore/refactor derivate more types from queries

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -1,4 +1,4 @@
-import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
+import type { PostgresColumn } from '@supabase/postgres-meta'
 import { isEqual, isNull } from 'lodash'
 import type { Dictionary } from 'types'
 
@@ -11,6 +11,7 @@ import {
   ExtendedPostgresRelationship,
   UpdateColumnPayload,
 } from '../SidePanelEditor.types'
+import type { RetrievedTableColumn, RetrieveTableResult } from 'data/tables/table-retrieve-query'
 
 const isSQLExpression = (input: string) => {
   if (['CURRENT_DATE'].includes(input)) return true
@@ -54,7 +55,7 @@ export const generateColumnField = (field: any = {}): ColumnField => {
 
 export const generateColumnFieldFromPostgresColumn = (
   column: PostgresColumn,
-  table: PostgresTable,
+  table: RetrieveTableResult,
   foreignKeys: ForeignKeyConstraint[]
 ): ColumnField => {
   const { primary_keys } = table
@@ -84,7 +85,7 @@ export const generateColumnFieldFromPostgresColumn = (
 }
 
 export const generateCreateColumnPayload = (
-  table: PostgresTable,
+  table: RetrieveTableResult,
   field: ColumnField
 ): CreateColumnPayload => {
   const isIdentity = field.format.includes('int') ? field.isIdentity : false
@@ -114,8 +115,8 @@ export const generateCreateColumnPayload = (
 }
 
 export const generateUpdateColumnPayload = (
-  originalColumn: PostgresColumn,
-  table: PostgresTable,
+  originalColumn: RetrievedTableColumn,
+  table: RetrieveTableResult,
   field: ColumnField
 ): Partial<UpdateColumnPayload> => {
   const primaryKeyColumns = table.primary_keys.map((key) => key.name)
@@ -206,7 +207,7 @@ export const getForeignKeyUIState = (
 
 export const getColumnForeignKey = (
   column: PostgresColumn,
-  table: PostgresTable,
+  table: RetrieveTableResult,
   foreignKeys: ForeignKeyConstraint[]
 ) => {
   const { relationships } = table

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -50,6 +50,7 @@ import {
 import SpreadsheetImport from './SpreadsheetImport/SpreadsheetImport'
 import TableEditor from './TableEditor/TableEditor'
 import type { ImportContent } from './TableEditor/TableEditor.types'
+import { RetrieveTableResult } from 'data/tables/table-retrieve-query'
 
 export interface SidePanelEditorProps {
   editable?: boolean
@@ -58,7 +59,7 @@ export interface SidePanelEditorProps {
 
   // Because the panel is shared between grid editor and database pages
   // Both require different responses upon success of these events
-  onTableCreated?: (table: PostgresTable) => void
+  onTableCreated?: (table: RetrieveTableResult) => void
 }
 
 const SidePanelEditor = ({
@@ -229,7 +230,7 @@ const SidePanelEditor = ({
     resolve: any
   ) => {
     const selectedColumnToEdit = snap.sidePanel?.type === 'column' && snap.sidePanel.column
-    const { columnId, primaryKey, foreignKeyRelations, existingForeignKeyRelations } = configuration
+    const { primaryKey, foreignKeyRelations, existingForeignKeyRelations } = configuration
 
     if (!project || selectedTable === undefined) {
       return console.error('no project or table selected')
@@ -313,7 +314,7 @@ const SidePanelEditor = ({
     })
   }
 
-  const updateTableRealtime = async (table: PostgresTable, enabled: boolean) => {
+  const updateTableRealtime = async (table: RetrieveTableResult, enabled: boolean) => {
     if (!project) return console.error('Project is required')
     const realtimePublication = publications?.find((pub) => pub.name === 'supabase_realtime')
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -1,4 +1,4 @@
-import type { PostgresColumn, PostgresPrimaryKey, PostgresTable } from '@supabase/postgres-meta'
+import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
 import { chunk, find, isEmpty, isEqual } from 'lodash'
 import Papa from 'papaparse'
 import { toast } from 'sonner'
@@ -27,7 +27,11 @@ import {
   updateTable as updateTableMutation,
 } from 'data/tables/table-update-mutation'
 import { getTables } from 'data/tables/tables-query'
-import { getTable } from 'data/tables/table-retrieve-query'
+import {
+  getTable,
+  RetrievedTableColumn,
+  RetrieveTableResult,
+} from 'data/tables/table-retrieve-query'
 import { timeout, tryParseJson } from 'lib/helpers'
 import {
   generateCreateColumnPayload,
@@ -224,7 +228,7 @@ export const createColumn = async ({
   projectRef: string
   connectionString?: string | null
   payload: CreateColumnPayload
-  selectedTable: PostgresTable
+  selectedTable: RetrieveTableResult
   primaryKey?: Constraint
   foreignKeyRelations?: ForeignKey[]
   skipSuccessMessage?: boolean
@@ -300,9 +304,9 @@ export const updateColumn = async ({
 }: {
   projectRef: string
   connectionString?: string | null
-  originalColumn: PostgresColumn
+  originalColumn: RetrievedTableColumn
   payload: UpdateColumnPayload
-  selectedTable: PostgresTable
+  selectedTable: RetrieveTableResult
   primaryKey?: Constraint
   foreignKeyRelations?: ForeignKey[]
   existingForeignKeyRelations?: ForeignKeyConstraint[]
@@ -370,7 +374,7 @@ export const duplicateTable = async (
   connectionString: string | undefined | null,
   payload: { name: string; comment?: string },
   metadata: {
-    duplicateTable: PostgresTable
+    duplicateTable: RetrieveTableResult
     isRLSEnabled: boolean
     isDuplicateRows: boolean
     foreignKeyRelations: ForeignKey[]
@@ -661,7 +665,7 @@ export const updateTable = async ({
   projectRef: string
   connectionString?: string | null
   toastId: string | number
-  table: PostgresTable
+  table: RetrieveTableResult
   payload: UpdateTableBody
   columns: ColumnField[]
   foreignKeyRelations: ForeignKey[]
@@ -821,7 +825,7 @@ export const insertRowsViaSpreadsheet = async (
   projectRef: string,
   connectionString: string | undefined | null,
   file: any,
-  table: PostgresTable,
+  table: RetrieveTableResult,
   selectedHeaders: string[],
   onProgressUpdate: (progress: number) => void
 ) => {
@@ -882,7 +886,7 @@ export const insertRowsViaSpreadsheet = async (
 export const insertTableRows = async (
   projectRef: string,
   connectionString: string | undefined | null,
-  table: PostgresTable,
+  table: RetrieveTableResult,
   rows: any,
   selectedHeaders: string[],
   onProgressUpdate: (progress: number) => void

--- a/apps/studio/data/database-columns/database-column-delete-mutation.ts
+++ b/apps/studio/data/database-columns/database-column-delete-mutation.ts
@@ -26,7 +26,7 @@ export async function deleteDatabaseColumn({
 }: DatabaseColumnDeleteVariables) {
   const { sql } = pgMeta.columns.remove(column, { cascade })
 
-  const { result } = await executeSql({
+  const { result } = await executeSql<void>({
     projectRef,
     connectionString,
     sql,

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -21,7 +21,7 @@ export type ExecuteSqlVariables = {
   contextualInvalidation?: boolean
 }
 
-export async function executeSql(
+export async function executeSql<T = any>(
   {
     projectRef,
     connectionString,
@@ -40,7 +40,7 @@ export async function executeSql(
   >,
   signal?: AbortSignal,
   headersInit?: HeadersInit
-): Promise<{ result: any }> {
+): Promise<{ result: T }> {
   if (!projectRef) throw new Error('projectRef is required')
 
   const sqlSize = new Blob([sql]).size
@@ -107,10 +107,10 @@ export async function executeSql(
     Array.isArray(data) &&
     data?.[0]?.[ROLE_IMPERSONATION_NO_RESULTS] === 1
   ) {
-    return { result: [] }
+    return { result: [] as T }
   }
 
-  return { result: data }
+  return { result: data as T }
 }
 
 export type ExecuteSqlData = Awaited<ReturnType<typeof executeSql>>

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -113,7 +113,7 @@ export async function executeSql<T = any>(
   return { result: data as T }
 }
 
-export type ExecuteSqlData = Awaited<ReturnType<typeof executeSql>>
+export type ExecuteSqlData = Awaited<ReturnType<typeof executeSql<any[]>>>
 export type ExecuteSqlError = ResponseError
 
 /**

--- a/apps/studio/data/tables/table-create-mutation.ts
+++ b/apps/studio/data/tables/table-create-mutation.ts
@@ -19,7 +19,7 @@ export type TableCreateVariables = {
 export async function createTable({ projectRef, connectionString, payload }: TableCreateVariables) {
   const { sql } = pgMeta.tables.create(payload)
 
-  const { result } = await executeSql({
+  const { result } = await executeSql<void>({
     projectRef,
     connectionString,
     sql,

--- a/apps/studio/data/tables/table-delete-mutation.ts
+++ b/apps/studio/data/tables/table-delete-mutation.ts
@@ -28,7 +28,7 @@ export async function deleteTable({
 }: TableDeleteVariables) {
   const { sql } = pgMeta.tables.remove({ name, schema }, { cascade })
 
-  const { result } = await executeSql({
+  const { result } = await executeSql<void>({
     projectRef,
     connectionString,
     sql,

--- a/apps/studio/data/tables/table-update-mutation.ts
+++ b/apps/studio/data/tables/table-update-mutation.ts
@@ -30,7 +30,7 @@ export async function updateTable({
 }: TableUpdateVariables) {
   const { sql } = pgMeta.tables.update({ id, name, schema }, payload)
 
-  const { result } = await executeSql({
+  const { result } = await executeSql<void>({
     projectRef,
     connectionString,
     sql,

--- a/packages/pg-meta/src/pg-meta-tables.ts
+++ b/packages/pg-meta/src/pg-meta-tables.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { coalesceRowsToArray, exceptionIdentifierNotFound, filterByList } from './helpers'
+import { coalesceRowsToArray, filterByList } from './helpers'
 import { TABLES_SQL } from './sql/tables'
 import { COLUMNS_SQL } from './sql/columns'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
@@ -107,14 +107,14 @@ function list<T extends boolean | undefined = true>(
 
 function retrieve(identifier: TableIdentifier): {
   sql: string
-  zod: z.ZodType<PGTable | undefined>
+  zod: z.ZodType<TableWithColumns>
 } {
   let whereClause = getIdentifierWhereClause(identifier)
 
   const sql = `${generateEnrichedTablesSql({ includeColumns: true })} where ${whereClause};`
   return {
     sql,
-    zod: pgTableZod.optional(),
+    zod: pgTableZod,
   }
 }
 


### PR DESCRIPTION
- It allows to decouple more the frontend logic and the pg-meta/sql-query logic allowing to reduce the number of cast
and get closer types between what we do fetch and what we expect in our components

The idea is to "cast" and "parse / validate" the result of the 3rd party (pg-meta call) in a single point into the frontend app (after the fetching). Then, all the frontend types within component should be derivated from this function fetcher call. It will allows to reduce casting, get closer match between data retrieved and data expected in components, and will show what exactly will be in error within the frontend if the result type of the query fetch were to be changed.

Basically:

3rd parties (sql queries) -> React app fetching (parse/validate result type) -> ResultType - | -> Frontend-components