### PR TITLE
Add regex guard for edge functions test endpoint

### DIFF
--- a/apps/studio/lib/api/edgeFunctions.test.ts
+++ b/apps/studio/lib/api/edgeFunctions.test.ts
@@ -1,0 +1,31 @@
+import { expect, describe, it } from 'vitest'
+import { isValidEdgeFunctionURL } from './edgeFunctions'
+
+describe('isValidEdgeFunctionURL', () => {
+  const validEdgeFunctionUrls = [
+    'https://projectref.supabase.co/functions/v1/hello-world',
+    'https://projectref.supabase.red/functions/v1/hello-world',
+    'https://projectref.supabase.red/functions/v3/hello-world',
+    'https://projectref.supabase.red/functions/v3/hello-world',
+  ]
+
+  const invalidEdgeFunctionUrls = [
+    'https://notsupabase.com/functions/v1/test',
+    'https://projectref.notsupabase.com/functions/v1/test',
+    'https://localhost?https://aaaa.supabase.co/functions/v1/xxx',
+    'https://localhost:3000/?https://aaaa.supabase.co/functions/v1/xxx',
+    'http://localhost:3000/?https://aaaa.supabase.co/functions/v1/xxx',
+  ]
+
+  it('should match valid edge function URLs', () => {
+    for (const url of validEdgeFunctionUrls) {
+      expect(isValidEdgeFunctionURL(url), `Expected ${url} to be valid`).toBe(true)
+    }
+  })
+
+  it('should not match invalid edge function URLs', () => {
+    for (const url of invalidEdgeFunctionUrls) {
+      expect(isValidEdgeFunctionURL(url), `Expected ${url} to be invalid`).toBe(false)
+    }
+  })
+})

--- a/apps/studio/lib/api/edgeFunctions.ts
+++ b/apps/studio/lib/api/edgeFunctions.ts
@@ -1,0 +1,7 @@
+export const isValidEdgeFunctionURL = (url: string) => {
+  const regexValidEdgeFunctionURL = new RegExp(
+    '^https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/.*$'
+  )
+
+  return regexValidEdgeFunctionURL.test(url)
+}

--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -19,7 +19,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   try {
+    console.log('post', req.body)
     const { url, method, body: requestBody, headers: customHeaders } = req.body
+
+    const regexValidEdgeFunctionURL = new RegExp(
+      'https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/S*',
+      'g'
+    )
+    const validEdgeFunctionURL = regexValidEdgeFunctionURL.test(url)
+
+    if (!validEdgeFunctionURL) {
+      return res.status(400).json({
+        status: 400,
+        error: { message: 'Provided URL is not a valid Supabase edge function URL' },
+      })
+    }
 
     // Remove any undefined or null values from custom headers
     const sanitizedCustomHeaders = Object.entries(customHeaders || {}).reduce(

--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -1,3 +1,4 @@
+import { isValidEdgeFunctionURL } from 'lib/api/edgeFunctions'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -21,13 +22,9 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { url, method, body: requestBody, headers: customHeaders } = req.body
 
-    const regexValidEdgeFunctionURL = new RegExp(
-      'https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/S*',
-      'g'
-    )
-    const validEdgeFunctionURL = regexValidEdgeFunctionURL.test(url)
+    const validEdgeFnUrl = isValidEdgeFunctionURL(url)
 
-    if (!validEdgeFunctionURL) {
+    if (!validEdgeFnUrl) {
       return res.status(400).json({
         status: 400,
         error: { message: 'Provided URL is not a valid Supabase edge function URL' },

--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -19,7 +19,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   try {
-    console.log('post', req.body)
     const { url, method, body: requestBody, headers: customHeaders } = req.body
 
     const regexValidEdgeFunctionURL = new RegExp(


### PR DESCRIPTION
Fixes SEC-365

- moves edge fn validation outside the api for testing
- adds tests