### PR TITLE
fix: edgeFunctions test should not follow redirects

### DIFF
--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -69,6 +69,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       method,
       headers: requestHeaders,
       body: finalBody,
+      redirect: 'manual', // don't follow the redirect and return response as is
     })
 
     // Handle non-JSON responses


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Follows a redirect sent by the edge function

## What is the new behavior?

Return the edge function response without following any redirects.

