### PR TITLE
Fix: update extension name for Google login in auth-google.mdx

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -696,7 +696,7 @@ val supabaseClient = createSupabaseClient(
 ) {
     install(Auth)
     install(ComposeAuth) {
-        nativeGoogleLogin("WEB_GOOGLE_CLIENT_ID") //Use the Web Client ID, not the Android one!
+        googleNativeLogin("WEB_GOOGLE_CLIENT_ID") //Use the Web Client ID, not the Android one!
     }
 }
 ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Docs update (fix)

## Additional context

The correct name of the extension is `googleNativeLogin` and not `nativeGoogleLogin` as shown in the documentation. We can see it in the master branch of the supabase-kt lib, [here](https://github.com/supabase-community/supabase-kt/blob/50fba64c2fc3b7d926b0f9644f42891c0099e337/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/GoogleLoginConfig.kt#L26). There is no `nativeGoogleLogin` in the code. This extension was introduced in [this PR](https://github.com/supabase-community/supabase-kt/pull/241).
