### PR TITLE
Fix unnecessary GET content request when writing a new SQL query

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -68,6 +68,7 @@ export const createSqlSnippetSkeletonV2 = ({
       content_id: id ?? '',
       sql: sql ?? '',
     } as any,
+    isNotSavedInDatabaseYet: true,
   }
 }
 

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -23,6 +23,7 @@ const SqlEditor: NextPageWithLayout = () => {
   const tabs = useTabsStateSnapshot()
 
   const allSnippets = useSnippets(ref!)
+  const snippet = allSnippets.find((x) => x.id === id)
 
   // [Refactor] There's an unnecessary request getting triggered when we start typing while on /new
   // the URL ID gets updated and we attempt to fetch content for a snippet that's not been created yet
@@ -32,7 +33,9 @@ const SqlEditor: NextPageWithLayout = () => {
       // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
       // the snapV2 valtio store for some reason hence why the added typeof check here
       retry: false,
-      enabled: Boolean(id !== 'new' && typeof snapV2.addSnippet === 'function'),
+      enabled: Boolean(
+        id !== 'new' && typeof snapV2.addSnippet === 'function' && !snippet?.isNotSavedInDatabaseYet
+      ),
     }
   )
 

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -6,28 +6,36 @@ import { useIsSQLEditorTabsEnabled } from 'components/interfaces/App/FeaturePrev
 import { SQLEditor } from 'components/interfaces/SQLEditor/SQLEditor'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { EditorBaseLayout } from 'components/layouts/editors/EditorBaseLayout'
+import { useEditorType } from 'components/layouts/editors/EditorsLayout.hooks'
 import SQLEditorLayout from 'components/layouts/SQLEditorLayout/SQLEditorLayout'
 import { SQLEditorMenu } from 'components/layouts/SQLEditorLayout/SQLEditorMenu'
 import { useContentIdQuery } from 'data/content/content-id-query'
+import Link from 'next/link'
 import { useAppStateSnapshot } from 'state/app-state'
 import { SnippetWithContent, useSnippets, useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { createTabId, useTabsStateSnapshot } from 'state/tabs'
 import type { NextPageWithLayout } from 'types'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 const SqlEditor: NextPageWithLayout = () => {
   const router = useRouter()
   const { id, ref, content, skip } = useParams()
 
+  const editor = useEditorType()
+  const tabs = useTabsStateSnapshot()
   const appSnap = useAppStateSnapshot()
   const snapV2 = useSqlEditorV2StateSnapshot()
-  const tabs = useTabsStateSnapshot()
+  const isSqlEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
   const allSnippets = useSnippets(ref!)
   const snippet = allSnippets.find((x) => x.id === id)
 
+  const tabId = !!id ? tabs.openTabs.find((x) => x.endsWith(id)) : undefined
+
   // [Refactor] There's an unnecessary request getting triggered when we start typing while on /new
   // the URL ID gets updated and we attempt to fetch content for a snippet that's not been created yet
-  const { data } = useContentIdQuery(
+  const { data, error, isError } = useContentIdQuery(
     { projectRef: ref, id },
     {
       // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
@@ -38,6 +46,9 @@ const SqlEditor: NextPageWithLayout = () => {
       ),
     }
   )
+  const snippetMissing =
+    isError && error.code === 404 && error.message.includes('Content not found')
+  const invalidId = isError && error.code === 400 && error.message.includes('Invalid uuid')
 
   useEffect(() => {
     if (ref && data) {
@@ -59,8 +70,6 @@ const SqlEditor: NextPageWithLayout = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, allSnippets, content])
 
-  const isSqlEditorTabsEnabled = useIsSQLEditorTabsEnabled()
-
   // Watch for route changes
   useEffect(() => {
     if (isSqlEditorTabsEnabled) {
@@ -80,6 +89,47 @@ const SqlEditor: NextPageWithLayout = () => {
       })
     }
   }, [router.isReady, id, isSqlEditorTabsEnabled])
+
+  if (snippetMissing || invalidId) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="w-[400px]">
+          <Admonition
+            type="default"
+            title={`Unable to find snippet with ID ${id}`}
+            description="This snippet doesn't exist in your project"
+          >
+            {isSqlEditorTabsEnabled && (
+              <>
+                {!!tabId ? (
+                  <Button
+                    type="default"
+                    className="mt-2"
+                    onClick={() => {
+                      tabs.handleTabClose({
+                        id: tabId,
+                        router,
+                        editor,
+                        onClearDashboardHistory: () => {
+                          if (ref) appSnap.setDashboardHistory(ref, 'sql', undefined)
+                        },
+                      })
+                    }}
+                  >
+                    Close tab
+                  </Button>
+                ) : (
+                  <Button asChild type="default" className="mt-2">
+                    <Link href={`/project/${ref}/sql`}>Head back</Link>
+                  </Button>
+                )}
+              </>
+            )}
+          </Admonition>
+        </div>
+      </div>
+    )
+  }
 
   return <SQLEditor />
 }

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -22,6 +22,7 @@ export type StateSnippetFolder = {
 // [Joshen] API codegen is somehow missing the content property
 export interface SnippetWithContent extends Snippet {
   content?: SqlSnippets.Content
+  isNotSavedInDatabaseYet?: boolean
 }
 
 export type StateSnippet = {
@@ -304,6 +305,8 @@ async function upsertSnippet(
       ])
     }
 
+    let snippet = sqlEditorState.snippets[id]?.snippet
+    if (snippet?.content) snippet.isNotSavedInDatabaseYet = false
     sqlEditorState.savingStates[id] = 'IDLE'
   } catch (error) {
     sqlEditorState.savingStates[id] = 'UPDATING_FAILED'


### PR DESCRIPTION
Fixes FE-1646

## Context

I noticed that whenever we're typing a new query in the SQL Editor on the `/sql/new` route (e.g clicking on the new snippet button), we'd make an unnecessary GET content request which naturally results in a 404 as the snippet is not created just yet

- Upon typing in the code editor in `/sql/new`, we'd redirect to `/sql/[id]` immediately ([ref](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx#L174))
- Thereafter, once landing on `/sql/[id]`, the `useContentIdQuery` gets called [here](https://github.com/supabase/supabase/blob/master/apps/studio/pages/project/%5Bref%5D/sql/%5Bid%5D.tsx#L35) which results in the 404

## Changes involved

- Adding a new flag `isNotSavedInDatabaseYet` that defaults to false unless specified otherwise
  - This is specifically set to `true` within `createSqlSnippetSkeletonV2` and will be set to false after the content is saved in `sql-editor-v2` -> `upsertSnippet`
- Pass this flag into the `enabled` param of `useContentIdQuery`
- I've also added some better error handling that's similar to the Table Editor when landing on a snippet ID that doesn't exist
![image](https://github.com/user-attachments/assets/c54cdf61-cc91-4758-8155-73b1e15600ac)


## To test

- First verify on staging/prod that there's an unnecessary 404 request once you type in something while on `/sql/new`
- Then verify on this preview that it no longer happens + doesn't have any unintended side effects