### PR TITLE
Fix Table Editor non-existing table state

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -134,6 +134,17 @@ export const TableGridEditor = ({
                   >
                     Close tab
                   </Button>
+                ) : tabs.openTabs.length > 0 ? (
+                  <Button
+                    asChild
+                    type="default"
+                    className="mt-2"
+                    onClick={() => appSnap.setDashboardHistory(projectRef, 'editor', undefined)}
+                  >
+                    <Link href={`/project/${projectRef}/editor/${tabs.openTabs[0].split('-')[1]}`}>
+                      Close tab
+                    </Link>
+                  </Button>
                 ) : (
                   <Button
                     asChild

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -19,6 +19,7 @@ import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { PROTECTED_SCHEMAS } from 'lib/constants/schemas'
+import Link from 'next/link'
 import { useAppStateSnapshot } from 'state/app-state'
 import { TableEditorTableStateContextProvider } from 'state/table-editor-table'
 import { createTabId, useTabsStateSnapshot } from 'state/tabs'
@@ -117,22 +118,33 @@ export const TableGridEditor = ({
             description="This table doesn't exist in your database"
           >
             {isTableEditorTabsEnabled && (
-              <Button
-                type="default"
-                className="mt-2"
-                onClick={() => {
-                  if (tabId) {
-                    tabs.handleTabClose({
-                      id: tabId,
-                      router,
-                      editor,
-                      onClearDashboardHistory,
-                    })
-                  }
-                }}
-              >
-                Close tab
-              </Button>
+              <>
+                {!!tabId ? (
+                  <Button
+                    type="default"
+                    className="mt-2"
+                    onClick={() => {
+                      tabs.handleTabClose({
+                        id: tabId,
+                        router,
+                        editor,
+                        onClearDashboardHistory,
+                      })
+                    }}
+                  >
+                    Close tab
+                  </Button>
+                ) : (
+                  <Button
+                    asChild
+                    type="default"
+                    className="mt-2"
+                    onClick={() => appSnap.setDashboardHistory(projectRef, 'editor', undefined)}
+                  >
+                    <Link href={`/project/${projectRef}/editor`}>Head back</Link>
+                  </Button>
+                )}
+              </>
             )}
           </Admonition>
         </div>

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -60,6 +60,7 @@ export const TableGridEditor = ({
   const canEditColumns = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'columns')
   const isReadOnly = !canEditTables && !canEditColumns
   const tabId = !!id ? tabs.openTabs.find((x) => x.endsWith(id)) : undefined
+  const openTabs = tabs.openTabs.filter((x) => !x.startsWith('sql'))
 
   const getTables = useGetTables({
     projectRef: project?.ref,
@@ -134,14 +135,14 @@ export const TableGridEditor = ({
                   >
                     Close tab
                   </Button>
-                ) : tabs.openTabs.length > 0 ? (
+                ) : openTabs.length > 0 ? (
                   <Button
                     asChild
                     type="default"
                     className="mt-2"
                     onClick={() => appSnap.setDashboardHistory(projectRef, 'editor', undefined)}
                   >
-                    <Link href={`/project/${projectRef}/editor/${tabs.openTabs[0].split('-')[1]}`}>
+                    <Link href={`/project/${projectRef}/editor/${openTabs[0].split('-')[1]}`}>
                       Close tab
                     </Link>
                   </Button>

--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -11,9 +11,8 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Plus, X } from 'lucide-react'
 import { useRouter } from 'next/router'
 
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { useParams } from 'common'
 import { TabsUpdateTooltip } from 'components/interfaces/App/FeaturePreview/TableEditorTabs'
-import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useAppStateSnapshot } from 'state/app-state'
 import { editorEntityTypes, useTabsStateSnapshot, type Tab } from 'state/tabs'
 import { cn, Tabs_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
@@ -35,11 +34,6 @@ export const EditorTabs = () => {
         distance: 1, // Start with a very small distance
       },
     })
-  )
-
-  const [tabsInterfaceAcknowledge, setTabsInterfaceAcknowledge] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.TABS_INTERFACE_ACKNOWLEDGED,
-    false
   )
 
   const openTabs = tabs.openTabs

--- a/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
+++ b/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
@@ -32,14 +32,10 @@ export const EditorBaseLayout = ({ children, title, product, ...props }: Explore
   const tableEditorTabsEnabled = editor === 'table' && isTableEditorTabsEnabled
   const sqlEditorTabsEnabled = editor === 'sql' && isSQLEditorTabsEnabled
 
-  const openTabs =
-    editor === 'sql'
-      ? tabs.openTabs.filter((x) => x.startsWith('sql'))
-      : tabs.openTabs.filter((x) => !x.startsWith('sql'))
+  const hasNoOpenTabs =
+    editor === 'table' ? tabs.openTabs.filter((x) => !x.startsWith('sql')).length === 0 : false
   const hideTabs =
-    pathname === `/project/${ref}/editor` ||
-    pathname === `/project/${ref}/sql` ||
-    openTabs.length === 0
+    pathname === `/project/${ref}/editor` || pathname === `/project/${ref}/sql` || hasNoOpenTabs
 
   return (
     <ProjectLayoutWithAuth resizableSidebar title={title} product={product} {...props}>

--- a/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
+++ b/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
@@ -6,6 +6,7 @@ import {
   useIsSQLEditorTabsEnabled,
   useIsTableEditorTabsEnabled,
 } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { useTabsStateSnapshot } from 'state/tabs'
 import { cn } from 'ui'
 import { ProjectLayoutWithAuth } from '../ProjectLayout/ProjectLayout'
 import { CollapseButton } from '../Tabs/CollapseButton'
@@ -23,16 +24,25 @@ export const EditorBaseLayout = ({ children, title, product, ...props }: Explore
   const { ref } = useParams()
   const pathname = usePathname()
   const editor = useEditorType()
+  const tabs = useTabsStateSnapshot()
 
   const isTableEditorTabsEnabled = useIsTableEditorTabsEnabled()
   const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
   const tableEditorTabsEnabled = editor === 'table' && isTableEditorTabsEnabled
   const sqlEditorTabsEnabled = editor === 'sql' && isSQLEditorTabsEnabled
-  const hideTabs = pathname === `/project/${ref}/editor` || pathname === `/project/${ref}/sql`
+
+  const openTabs =
+    editor === 'sql'
+      ? tabs.openTabs.filter((x) => x.startsWith('sql'))
+      : tabs.openTabs.filter((x) => !x.startsWith('sql'))
+  const hideTabs =
+    pathname === `/project/${ref}/editor` ||
+    pathname === `/project/${ref}/sql` ||
+    openTabs.length === 0
 
   return (
-    <ProjectLayoutWithAuth resizableSidebar={true} title={title} product={product} {...props}>
+    <ProjectLayoutWithAuth resizableSidebar title={title} product={product} {...props}>
       <div className="flex flex-col h-full">
         {tableEditorTabsEnabled || sqlEditorTabsEnabled ? (
           <div


### PR DESCRIPTION
Fixes FE-1645

## Context

A couple of quirks when opening the table editor with an ID that doesn't exist in the database (e.g if deleting the table via the SQL editor from another browser session)

- In the event whereby you have no other tables in the database + schema, clicking "Close tab" does nothing and hitting
- Clicking the "+" new tab opens the new tab state, but if you close it, it leads to a 404

## Changes involved

- For a non-existent table, CTA button to handle other scenarios
  - If no other tables, the button will just redirect to `/editor` instead
  - If there are other tabs opened, the button will redirect to the first opened tab
- Don't show tabs UI if there's no opened tabs for table editor
  - Similar handling as per landing on `/editor`

![image](https://github.com/user-attachments/assets/e9839cb4-0456-42c2-9fa5-5880bc89138b)
