### PR TITLE
chore: exclude common fetchers

### DIFF
--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -34,7 +34,12 @@ export default defineConfig({
     reporters: [['default']],
     coverage: {
       reporter: ['lcov'],
-      exclude: ['**/*.test.ts', '**/*.test.tsx', 'lib/common/fetch/**'],
+      exclude: [
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        // 👇 Excluded because it will be deprecated.
+        'lib/common/fetch/**',
+      ],
       include: ['lib/**/*.ts'],
     },
   },

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     reporters: [['default']],
     coverage: {
       reporter: ['lcov'],
-      exclude: ['**/*.test.ts', '**/*.test.tsx'],
+      exclude: ['**/*.test.ts', '**/*.test.tsx', 'lib/common/fetch/**'],
       include: ['lib/**/*.ts'],
     },
   },


### PR DESCRIPTION
- gonna get deprecated so we can ignore it from tests.