### PR TITLE
fix: fix clipboard copy not working on Safari due to async issue

### DIFF
--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -44,9 +44,9 @@ const CopyButton = ({
   return (
     <Button
       onClick={async (e) => {
-        const textToCopy = asyncText ? await asyncText() : text
+        const valueToCopy = asyncText ? asyncText() : Promise.resolve(text)
+        await copyToClipboard(valueToCopy)
         setShowCopied(true)
-        await copyToClipboard(textToCopy!)
         onClick?.(e)
       }}
       {...props}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

![before](https://github.com/user-attachments/assets/1dcf0a1e-2d5f-4154-b590-e3f67b323088)

The text copy function intermittently fails to work on the Safari browser.

## What is the new behavior?

![after](https://github.com/user-attachments/assets/7ad82fc8-a960-430c-9e98-56ad5adaaf1e)

Tested on a local server, and the copy function works on the Safari browser.

## Additional context

The currently deployed version works fine on Chrome, but not on Safari, so I made this fix as a Safari user.
