### PR TITLE
fix(docs): update oauth guides to show example redirect per framework

### DIFF
--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -31,13 +31,16 @@ await supabase.auth.signInWithOAuth({
 
 In the server, you need to handle the redirect to the OAuth provider's authentication endpoint. The `signInWithOAuth` method returns the endpoint URL, which you can redirect to.
 
-```js
-import { createClient, type Provider } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
-const provider = 'provider' as Provider
-const redirect = (url: string) => {}
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="nextjs"
+  queryGroup="framework"
+>
+<TabPanel id="nextjs" label="Next.js">
 
-// ---cut---
+```js
 const { data, error } = await supabase.auth.signInWithOAuth({
   provider,
   options: {
@@ -46,9 +49,80 @@ const { data, error } = await supabase.auth.signInWithOAuth({
 })
 
 if (data.url) {
-  redirect(data.url) // use the redirect API for your server framework
+  redirect(data.url)
 }
 ```
+
+</TabPanel>
+
+<TabPanel id="sveltekit" label="SvelteKit">
+
+```js
+const { data, error } = await supabase.auth.signInWithOAuth({
+  provider,
+  options: {
+    redirectTo: 'http://example.com/auth/callback',
+  },
+})
+
+if (data.url) {
+  redirect(303, data.url)
+}
+```
+
+</TabPanel>
+
+<TabPanel id="astro" label="Astro">
+
+```js
+const { data, error } = await supabase.auth.signInWithOAuth({
+  provider,
+  options: {
+    redirectTo: 'http://example.com/auth/callback',
+  },
+})
+
+if (data.url) {
+  redirect(data.url)
+}
+```
+
+</TabPanel>
+
+<TabPanel id="remix" label="Remix">
+
+```js
+const { data, error } = await supabase.auth.signInWithOAuth({
+  provider,
+  options: {
+    redirectTo: 'http://example.com/auth/callback',
+  },
+})
+
+if (data.url) {
+  redirect(data.url, { headers })
+}
+```
+
+</TabPanel>
+
+<TabPanel id="express" label="Express">
+
+```js
+const { data, error } = await supabase.auth.signInWithOAuth({
+  provider,
+  options: {
+    redirectTo: 'http://example.com/auth/callback',
+  },
+})
+
+if (data.url) {
+  res.redirect(303, data.url)
+}
+```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The OAuth guides show a generic redirect with comment about checking how your framework handles this, but this has caused confusion for some Remix users.

## What is the new behavior?

The OAuth guides shows a framework specific redirect.

## Additional context

Fixes #30900 