### PR TITLE
fix logs datepickers state not refreshing on page load

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -74,6 +74,18 @@ export const LogsPreviewer = ({
 
   const { search, setSearch, timestampStart, timestampEnd, setTimeRange, filters, setFilters } =
     useLogsUrlState()
+
+  useEffect(() => {
+    if (timestampStart && timestampEnd) {
+      setSelectedDatePickerValue({
+        to: timestampEnd,
+        from: timestampStart,
+        text: `${dayjs(timestampStart).format('DD MMM, HH:mm')} - ${dayjs(timestampEnd).format('DD MMM, HH:mm')}`,
+        isHelper: false,
+      })
+    }
+  }, [timestampStart, timestampEnd])
+
   const [selectedLogId, setSelectedLogId] = useSelectedLog()
   const { data: databases, isSuccess } = useReadReplicasQuery({ projectRef })
 


### PR DESCRIPTION
# Problem. 
In logs, when filtering by date range, if you reload the page (or someone shares a link with you) the datepicker component will show with the default value instead of the current filter.

## How to test. 
In prod:
- Go to logs
- Filter by date range
- Reload
- Shows "Last hour" even tho it's filtering by a date range

In the preview: 
- Go to logs
- Filter by date range
- Reload
- Should show the current filter

## Caveat
- If the user picked a helper (Last 30 mins, Last hour...) and reloads, the dates used for that helper will be shown instead of the helper text. I plan on making some changes to the state to fix this in different PRs.
