### PR TITLE
docs: Make the broadcast from database functions security definer

### DIFF
--- a/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
+++ b/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
@@ -36,6 +36,7 @@ Let's create a function that we can call any time a record is created, updated, 
 ```sql
 create or replace function public.your_table_changes()
 returns trigger
+security definer
 language plpgsql
 as $$
 begin

--- a/apps/www/_blog/2025-04-02-realtime-broadcast-from-database.mdx
+++ b/apps/www/_blog/2025-04-02-realtime-broadcast-from-database.mdx
@@ -83,6 +83,8 @@ Then, set up the function that will be called whenever a Database change is dete
 ```sql
 create or replace function public.your_table_changes()
 returns trigger
+security definer
+language plpgsql
 as $$
 begin
     perform realtime.broadcast_changes(
@@ -96,7 +98,7 @@ begin
 		);
     return null;
 end;
-$$ language plpgsql;
+$$;
 ```
 
 Then, set up the trigger conditions under which you will execute the function:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Currently, the example Postgres functions that we have for broadcast from database are not set to Security Definer, but in most realistic cases, these functions need to be a security_definer because it inserts a role on the realtime schema on behalf of an authenticated user. This pull request updates the sample code so that the functions are defined as security_definer.

## What is the current behavior?

Example functions are not set to security_definer

## What is the new behavior?

Example functions are set to security_definer