### PR TITLE
chore: fix failing sql-editor playwright test

### DIFF
--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -25,6 +25,7 @@ test.describe('SQL Editor', () => {
     await expect(page.getByText('Running...')).not.toBeVisible()
 
     // remove stuff from the editor
+    await editor.click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.press('Backspace')
 

--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -7,10 +7,10 @@ test.describe('SQL Editor', () => {
   test('should check if SQL editor can run simple commands', async ({ page }) => {
     await page.goto(toUrl(`/project/${getProjectRef()}/sql`))
 
-    //
     const editor = page.getByRole('code').nth(0)
 
     // write some sql in the editor
+    // This has to be done since the editor is not editable (input, textarea, etc.)
     await editor.click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.type(`select 'hello world';`)
@@ -24,7 +24,7 @@ test.describe('SQL Editor', () => {
     // Wait until Running... is not visible
     await expect(page.getByText('Running...')).not.toBeVisible()
 
-    // remove stuff from the editor
+    // clear the editor
     await editor.click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.press('Backspace')


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Fix failures with e2e test when running all tests. 
The root issue is the cursor is not in the correct browser when running in parallel. Added a `editor.click()` to make sure that the cursor is in the right place when we do `ControlOrMeta+KeyA` + `Backspace`. 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
