### PR TITLE
fix: edge function auto refetching

### DIFF
--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
@@ -1,7 +1,6 @@
 import { common, dirname, relative } from '@std/path/posix'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { AlertCircle, CornerDownLeft, Loader2 } from 'lucide-react'
-import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -23,7 +22,6 @@ import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
 import { LogoLoader } from 'ui'
 
 const CodePage = () => {
-  const router = useRouter()
   const { ref, functionSlug } = useParams()
   const project = useSelectedProject()
   const isOptedInToAI = useOrgOptedIntoAi()
@@ -47,9 +45,16 @@ const CodePage = () => {
       slug: functionSlug,
     },
     {
+      // [Alaister]: These parameters prevent the function files
+      // from being refetched when the user is editing the code
       retry: false,
-      refetchOnWindowFocus: false,
       retryOnMount: false,
+      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchInterval: false,
+      refetchIntervalInBackground: false,
     }
   )
   const [files, setFiles] = useState<


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

- Prevents `useEdgeFunctionBodyQuery()` from refetching data while the user is editing a function