### PR TITLE
fix(db): remove failing statement in migration

### DIFF
--- a/supabase/migrations/20250423133137_improve_vector_search.sql
+++ b/supabase/migrations/20250423133137_improve_vector_search.sql
@@ -1,8 +1,3 @@
-create index if not exists
-idx_page_section_embedding
-on public.page_section
-using hnsw (embedding vector_ip_ops);
-
 create or replace function match_embedding(
   embedding vector(1536),
   match_threshold float default 0.78,


### PR DESCRIPTION
Create index with HNSW fails on prod because it has a version of pgvector < 0.5.0. Removing for now because the index isn't critical (we're not using any at the moment and we have few enough rows that it works fine).