### PR TITLE
chore: add Francis to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -38,6 +38,7 @@ Eleftheria Trivyzaki
 Etienne Stalmans
 Fabrizio Fenoglio
 Francesco Sansalvadore
+Francis L
 Greg P
 Greg Richardson
 Guilherme Souza


### PR DESCRIPTION
Onboarding instructions did not specify a Reviewer and the previous commits were not consistent. For anyone who looks at these changes, can you please review?

-----

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update `humans.txt` per Onboarding

## What is the current behavior?


## What is the new behavior?


## Additional context

