### PR TITLE
feat: add api key, role details to api gateway logs

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -15,6 +15,7 @@ import {
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import DefaultPreviewSelectionRenderer from './LogSelectionRenderers/DefaultPreviewSelectionRenderer'
 import type { LogData, QueryType } from './Logs.types'
+import { jwtAPIKey, apiKey, role as extractRole } from './Logs.utils'
 
 export interface LogSelectionProps {
   log?: LogData
@@ -48,6 +49,9 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
         const path = log?.metadata?.[0]?.request?.[0]?.path
         const user_agent = log?.metadata?.[0]?.request?.[0]?.headers[0].user_agent
         const error_code = log?.metadata?.[0]?.response?.[0]?.headers?.[0]?.x_sb_error_code
+        const apikey = jwtAPIKey(log?.metadata) ?? apiKey(log?.metadata)
+        const role = extractRole(log?.metadata)
+
         const { id, metadata, timestamp, event_message, ...rest } = log
 
         const apiLog = {
@@ -59,7 +63,9 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
           timestamp,
           event_message,
           metadata,
+          ...(apikey ? { apikey } : null),
           ...(error_code ? { error_code } : null),
+          ...(role ? { role } : null),
           ...rest,
         }
 

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -630,3 +630,61 @@ function getWarningCondition(table: LogsTableName): string {
       return 'false'
   }
 }
+
+export function jwtAPIKey(metadata: any) {
+  const apikeyHeader = metadata?.[0]?.request?.[0]?.sb?.[0]?.jwt?.[0]?.apikey?.[0]
+  if (!apikeyHeader) {
+    return undefined
+  }
+
+  if (apikeyHeader.invalid) {
+    return '<invalid>'
+  }
+
+  const payload = apikeyHeader?.payload?.[0]
+  if (!payload) {
+    return '<unrecognized>'
+  }
+
+  if (
+    payload.algorithm === 'HS256' &&
+    payload.issuer === 'supabase' &&
+    ['anon', 'service_role'].includes(payload.role) &&
+    !payload.subject
+  ) {
+    return payload.role
+  }
+
+  return '<unrecognized>'
+}
+
+export function apiKey(metadata: any) {
+  const apikeyHeader = metadata?.[0]?.request?.[0]?.sb?.[0]?.apikey?.[0]?.apikey?.[0]
+  if (!apikeyHeader) {
+    return undefined
+  }
+
+  if (apikeyHeader.error) {
+    return `${apikeyHeader.prefix}... <invalid: ${apikeyHeader.error}>`
+  }
+
+  return `${apikeyHeader.prefix}...`
+}
+
+export function role(metadata: any) {
+  const authorizationHeader = metadata?.[0]?.request?.[0]?.sb?.[0]?.jwt?.[0]?.authorization?.[0]
+  if (!authorizationHeader) {
+    return undefined
+  }
+
+  if (authorizationHeader.invalid) {
+    return undefined
+  }
+
+  const payload = authorizationHeader?.payload?.[0]
+  if (!payload || !payload.role) {
+    return undefined
+  }
+
+  return payload.role
+}


### PR DESCRIPTION
Makes it easier to see what API key and Role were used with a specific API call.

<img width="485" alt="image" src="https://github.com/user-attachments/assets/13ec186b-26c3-4ff5-ac7a-dfdd3e288bc9" />

<img width="485" alt="image" src="https://github.com/user-attachments/assets/a2fe8173-edb6-4b80-89f5-8d5912793a05" />
