### PR TITLE
docs(troubleshooting): make docs on server-side admin clearer

### DIFF
--- a/apps/docs/content/troubleshooting/performing-administration-tasks-on-the-server-side-with-the-servicerole-secret-BYM4Fa.mdx
+++ b/apps/docs/content/troubleshooting/performing-administration-tasks-on-the-server-side-with-the-servicerole-secret-BYM4Fa.mdx
@@ -9,7 +9,7 @@ database_id = "0d3389c0-5e75-473c-a18b-0699d0911fb2"
 
 By default, the auth-helpers/ssr do not permit the use of the `service_role` `secret`. This restriction is in place to prevent the accidental exposure of your `service_role` `secret` to the public. Since the auth-helpers/ssr function on both the server and client side, it becomes challenging to separate the key specifically for client-side usage.
 
-However, there is a solution. You can create a separate Supabase client using the `createClient` method from `@supabase/supabase-js` and provide it with the `service_role` `secret`. In a server environment, you will also need to disable certain properties to ensure proper functionality.
+However, there is a solution. You can create a separate Supabase client using the `createClient` method from `@supabase/supabase-js` and provide it with the `service_role` `secret`. In a server environment, you will also need to disable certain properties to ensure proper functionality. See the example code below for the required settings.
 
 By implementing this approach, you can safely utilize the `service_role` `secret` without compromising security or exposing sensitive information to the public.
 


### PR DESCRIPTION
The "required properties" that need to be disabled are actually listed in the code block, but it's not entirely clear from the way that it's written that it's the case, leading to user confusion. Added a line to make that explicit.

Fixes DOCS-233