### PR TITLE
Adding note to broadcast_changes that is uses a private channel.

### DIFF
--- a/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
+++ b/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
@@ -13,7 +13,7 @@ You can use Supabase to subscribe to real-time database changes. There are two o
 
 ## Using Broadcast
 
-To automatically send messages when a record is created, updated, or deleted, we can attach a [Postgres trigger](/docs/guides/database/postgres/triggers) to any table. Supabase Realtime provides a `realtime.broadcast_changes()` function which we can use in conjunction with a trigger. This function will use a private channel and needs broadcast authorization RLS policies met.
+To automatically send messages when a record is created, updated, or deleted, we can attach a [Postgres trigger](/docs/guides/database/postgres/triggers) to any table. Supabase Realtime provides a `realtime.broadcast_changes()` function which we can use in conjunction with a trigger. This function will use a private channel and needs broadcast authorization RLS policies to be met.
 
 ### Broadcast authorization
 

--- a/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
+++ b/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
@@ -13,7 +13,7 @@ You can use Supabase to subscribe to real-time database changes. There are two o
 
 ## Using Broadcast
 
-To automatically send messages when a record is created, updated, or deleted, we can attach a [Postgres trigger](/docs/guides/database/postgres/triggers) to any table. Supabase Realtime provides a `realtime.broadcast_changes()` function which we can use in conjunction with a trigger.
+To automatically send messages when a record is created, updated, or deleted, we can attach a [Postgres trigger](/docs/guides/database/postgres/triggers) to any table. Supabase Realtime provides a `realtime.broadcast_changes()` function which we can use in conjunction with a trigger. This function will use a private channel and needs broadcast authorization RLS policies met.
 
 ### Broadcast authorization
 


### PR DESCRIPTION
2 customers confused so far on need for RLS and private flag set to use this function.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

Unclear that broadcast changes use a private channel to some  users.

## What is the new behavior?

Add a specific note about it, versus just the separate section below it saying Broadcast Authorization required for Broadcast messages.

## Additional context
https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#using-broadcast