### PR TITLE
[FE-1648] fix: privacy settings failed to load state

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
@@ -1,9 +1,9 @@
-import { Toggle } from 'ui'
+import { toast } from 'sonner'
 
 import { useConsentState } from 'common'
 import Panel from 'components/ui/Panel'
 import { useSendResetMutation } from 'data/telemetry/send-reset-mutation'
-import { toast } from 'sonner'
+import { Toggle } from 'ui'
 
 export const AnalyticsSettings = () => {
   const { hasAccepted, acceptAll, denyAll, categories } = useConsentState()

--- a/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
@@ -3,12 +3,22 @@ import { Toggle } from 'ui'
 import { useConsentState } from 'common'
 import Panel from 'components/ui/Panel'
 import { useSendResetMutation } from 'data/telemetry/send-reset-mutation'
+import { toast } from 'sonner'
 
 export const AnalyticsSettings = () => {
-  const { hasAccepted, acceptAll, denyAll } = useConsentState()
+  const { hasAccepted, acceptAll, denyAll, categories } = useConsentState()
+  const hasLoaded = categories !== null
+
   const { mutate: sendReset } = useSendResetMutation()
 
   const onToggleOptIn = () => {
+    if (!hasLoaded) {
+      toast.error(
+        "We couldn't load the privacy settings due to an ad blocker or network error. Please disable any ad blockers and try again. If the problem persists, please contact support."
+      )
+      return
+    }
+
     if (hasAccepted) {
       denyAll()
       sendReset()

--- a/packages/ui-patterns/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/PrivacySettings/index.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useConsentState } from 'common'
 import Link from 'next/link'
 import { PropsWithChildren, useState } from 'react'
+
+import { useConsentState } from 'common'
 import { Modal, Toggle } from 'ui'
 import { Admonition } from '../admonition'
 

--- a/packages/ui-patterns/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/PrivacySettings/index.tsx
@@ -4,6 +4,7 @@ import { useConsentState } from 'common'
 import Link from 'next/link'
 import { PropsWithChildren, useState } from 'react'
 import { Modal, Toggle } from 'ui'
+import { Admonition } from '../admonition'
 
 interface PrivacySettingsProps {
   className?: string
@@ -64,15 +65,34 @@ export const PrivacySettings = ({
         size="medium"
       >
         <div className="pt-3 divide-y divide-border">
-          {categories
-            ?.toReversed()
-            .map((category) => (
-              <Category
-                key={category.slug}
-                category={category}
-                handleServicesChange={handleServicesChange}
+          {categories === null ? (
+            <Modal.Content>
+              <Admonition
+                type="warning"
+                title="Unable to Load Privacy Settings"
+                description={
+                  <>
+                    We couldn't load the privacy settings due to an ad blocker or network error.
+                    Please disable any ad blockers and try again. If the problem persists, please{' '}
+                    <Link href="https://supabase.com/dashboard/support/new" className="underline">
+                      contact support
+                    </Link>
+                    .
+                  </>
+                }
               />
-            ))}
+            </Modal.Content>
+          ) : (
+            categories
+              .toReversed()
+              .map((category) => (
+                <Category
+                  key={category.slug}
+                  category={category}
+                  handleServicesChange={handleServicesChange}
+                />
+              ))
+          )}
         </div>
       </Modal>
     </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Settings Modal:
<img width="613" alt="Screenshot 2025-05-23 at 17 15 15" src="https://github.com/user-attachments/assets/3fbd82b4-0a7e-4b19-ae99-1fca9e957408" />

On dashboard toggle:
<img width="386" alt="Screenshot 2025-05-23 at 17 20 40" src="https://github.com/user-attachments/assets/d63fd8b2-3e58-4144-a8e0-a6395623a6ae" />
