### PR TITLE
chore(docs): loosen overly strict sentry filter

### DIFF
--- a/apps/docs/instrumentation-client.ts
+++ b/apps/docs/instrumentation-client.ts
@@ -22,8 +22,11 @@ if (!IS_DEV) {
     beforeSend(event) {
       const frames = event.exception?.values?.[0].stacktrace?.frames || []
 
-      // Drop errors originating from user apps or extensions as unactionable
-      if (frames.some((frame) => frame.filename && frame.filename.startsWith('app:///'))) {
+      // Drop errors not originating from docs app static files as unactionable
+      if (
+        frames &&
+        !frames.some((frame) => frame.filename && frame.filename.startsWith('app:///_next'))
+      ) {
         return null
       }
 


### PR DESCRIPTION
Should've double-checked this before applying the filter 😓 but apparently filtering out `app:///` also filters out legitimate events, since those files are prefixed by `app:///` as well.

Instead let's keep only `app:///_next` since that should include all our static JS assets.