### PR TITLE
fix(privacy settings): toReversed use

### DIFF
--- a/packages/ui-patterns/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/PrivacySettings/index.tsx
@@ -64,15 +64,16 @@ export const PrivacySettings = ({
         size="medium"
       >
         <div className="pt-3 divide-y divide-border">
-          {categories
-            ?.toReversed()
-            .map((category) => (
-              <Category
-                key={category.slug}
-                category={category}
-                handleServicesChange={handleServicesChange}
-              />
-            ))}
+          {categories &&
+            [...categories]
+              .reverse()
+              .map((category) => (
+                <Category
+                  key={category.slug}
+                  category={category}
+                  handleServicesChange={handleServicesChange}
+                />
+              ))}
         </div>
       </Modal>
     </>


### PR DESCRIPTION
Some portion of our user base is using browsers too old to support toReversed (at least it keeps showing up in docs Sentry errors). The legacy version is a simple enough change, so let's use that instead.