### PR TITLE
fix: delete button in wrong position

### DIFF
--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.tsx
@@ -258,24 +258,24 @@ const PreviewPane = () => {
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}
+              <ButtonTooltip
+                type="outline"
+                disabled={!canUpdateFiles}
+                size="tiny"
+                icon={<Trash2 strokeWidth={2} />}
+                onClick={() => setSelectedItemsToDelete([file])}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: !canUpdateFiles
+                      ? 'You need additional permissions to delete this file'
+                      : undefined,
+                  },
+                }}
+              >
+                Delete file
+              </ButtonTooltip>
             </div>
-            <ButtonTooltip
-              type="outline"
-              disabled={!canUpdateFiles}
-              size="tiny"
-              icon={<Trash2 strokeWidth={2} />}
-              onClick={() => setSelectedItemsToDelete([file])}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text: !canUpdateFiles
-                    ? 'You need additional permissions to delete this file'
-                    : undefined,
-                },
-              }}
-            >
-              Delete file
-            </ButtonTooltip>
           </div>
         </div>
       </Transition>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Delete button is in wrong position on the storage page

## What is the new behavior?

Delete button is at the right position on the storage page

## Additional context