### PR TITLE
fix: deleting state not updated in authentication page

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -225,6 +225,8 @@ export const UsersV2 = () => {
       if (userIds.includes(selectedUser)) setSelectedUser(undefined)
     } catch (error: any) {
       toast.error(`Failed to delete selected users: ${error.message}`)
+    }
+    finally {
       setIsDeletingUsers(false)
     }
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When deleting users the "IsDeletingUsers" state remains true even after the process is done and the button is disabled next time

## What is the new behavior?

The "setIsDeletingUsers" is set to false and the delete button works fine

## Additional context
