### PR TITLE
chore: move HIPAA checks from org to project level

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -11,6 +11,7 @@ import {
 import { Snippet } from 'data/content/sql-folders-query'
 import type { SqlSnippet } from 'data/content/sql-snippets-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { createTabId, useTabsStateSnapshot } from 'state/tabs'
@@ -42,9 +43,10 @@ const RenameQueryModal = ({
   )
   const isSQLSnippet = snippet.type === 'sql'
   const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
 
   // Customers on HIPAA plans should not have access to Supabase AI
-  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
+  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
 
   const { id, name, description } = snippet
 

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -143,14 +143,9 @@ export const SQLEditor = () => {
   useAddDefinitions(id, monacoRef.current)
 
   /** React query data fetching  */
-  // only need to check subscription settings if org is opted into AI
-  let hasHipaaAddon: boolean = false
-  if (isOptedInToAI) {
-    const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: org?.slug })
-    const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
-    hasHipaaAddon =
-      subscriptionHasHipaaAddon(subscription) && (projectSettings?.is_sensitive || false)
-  }
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: org?.slug })
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
+  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
 
   const { data: databases, isSuccess: isSuccessReadReplicas } = useReadReplicasQuery(
     {

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -17,11 +17,9 @@ import { constructHeaders, isValidConnString } from 'data/fetchers'
 import { lintKeys } from 'data/lint/keys'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
-import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { isError } from 'data/utils/error-check'
-import { useOrgOptedIntoAi } from 'hooks/misc/useOrgOptedIntoAi'
+import { useOrgOptedIntoAiAndHippaProject } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSchemasForAi } from 'hooks/misc/useSchemasForAi'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
@@ -54,7 +52,6 @@ import {
   cn,
 } from 'ui'
 import { useIsSQLEditorTabsEnabled } from '../App/FeaturePreview/FeaturePreviewContext'
-import { subscriptionHasHipaaAddon } from '../Billing/Subscription/Subscription.utils'
 import { useSqlEditorDiff, useSqlEditorPrompt } from './hooks'
 import { RunQueryWarningModal } from './RunQueryWarningModal'
 import {
@@ -95,9 +92,9 @@ export const SQLEditor = () => {
   const snapV2 = useSqlEditorV2StateSnapshot()
   const getImpersonatedRoleState = useGetImpersonatedRoleState()
   const databaseSelectorState = useDatabaseSelectorStateSnapshot()
-  const isOptedInToAI = useOrgOptedIntoAi()
+  const { isOptedInToAI, isHipaaProjectDisallowed } = useOrgOptedIntoAiAndHippaProject()
   const [selectedSchemas] = useSchemasForAi(project?.ref!)
-  const includeSchemaMetadata = isOptedInToAI || !IS_PLATFORM
+  const includeSchemaMetadata = (isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM
   const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
   const {
@@ -141,11 +138,6 @@ export const SQLEditor = () => {
   const isLoading = urlId === 'new' ? false : snippetIsLoading
 
   useAddDefinitions(id, monacoRef.current)
-
-  /** React query data fetching  */
-  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: org?.slug })
-  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
-  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
 
   const { data: databases, isSuccess: isSuccessReadReplicas } = useReadReplicasQuery(
     {
@@ -297,7 +289,7 @@ export const SQLEditor = () => {
           return
         }
 
-        if (!hasHipaaAddon && snippet?.snippet.name === untitledSnippetTitle) {
+        if (!isHipaaProjectDisallowed && snippet?.snippet.name === untitledSnippetTitle) {
           // Intentionally don't await title gen (lazy)
           setAiTitle(id, sql)
         }
@@ -342,7 +334,7 @@ export const SQLEditor = () => {
       id,
       isExecuting,
       project,
-      hasHipaaAddon,
+      isHipaaProjectDisallowed,
       execute,
       getImpersonatedRoleState,
       setAiTitle,

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -7,6 +7,7 @@ import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscri
 import CopyButton from 'components/ui/CopyButton'
 import { InlineLink, InlineLinkClassName } from 'components/ui/InlineLink'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
@@ -33,7 +34,8 @@ const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
     const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
 
     // Customers on HIPAA plans should not have access to Supabase AI
-    const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
+    const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
+    const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
 
     const isTimeout =
       result?.error?.message?.includes('canceling statement due to statement timeout') ||

--- a/apps/studio/components/interfaces/SqlGenerator/SqlGeneratorImpl.tsx
+++ b/apps/studio/components/interfaces/SqlGenerator/SqlGeneratorImpl.tsx
@@ -4,7 +4,7 @@ import { useEffectOnce } from 'react-use'
 
 import { IS_PLATFORM } from 'common'
 import { useEntityDefinitionsQuery } from 'data/database/entity-definitions-query'
-import { useOrgOptedIntoAi } from 'hooks/misc/useOrgOptedIntoAi'
+import { useOrgOptedIntoAiAndHippaProject } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSchemasForAi } from 'hooks/misc/useSchemasForAi'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { formatSql } from 'lib/formatSql'
@@ -45,11 +45,14 @@ import { SAMPLE_QUERIES, generatePrompt } from './SqlGenerator.utils'
 import { SQLOutputActions } from './SqlOutputActions'
 
 function useSchemaMetadataForAi() {
-  const isOptedInToAI = useOrgOptedIntoAi()
+  const { isOptedInToAI, isHipaaProjectDisallowed } = useOrgOptedIntoAiAndHippaProject()
   const project = useSelectedProject()
 
   const [schemas] = useSchemasForAi(project?.ref!)
-  const includeMetadata = (isOptedInToAI || !IS_PLATFORM) && schemas.length > 0 && !!project
+  const includeMetadata =
+    ((isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM) &&
+    schemas.length > 0 &&
+    !!project
 
   const metadataSkipReason: AiMetadataSkipReason = !project ? 'no_project' : 'forbidden'
 

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -15,6 +15,7 @@ import OptInToOpenAIToggle from 'components/interfaces/Organization/GeneralSetti
 import { SQL_TEMPLATES } from 'components/interfaces/SQLEditor/SQLEditor.queries'
 import { useCheckOpenAIKeyQuery } from 'data/ai/check-api-key-query'
 import { constructHeaders } from 'data/fetchers'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useOrganizationUpdateMutation } from 'data/organizations/organization-update-mutation'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useTablesQuery } from 'data/tables/tables-query'
@@ -91,7 +92,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   const project = useSelectedProject()
   const isOptedInToAI = useOrgOptedIntoAi()
   const selectedOrganization = useSelectedOrganization()
-  const { id: entityId } = useParams()
+  const { ref: ref, id: entityId } = useParams()
   const searchParams = useSearchParamsShallow()
   const includeSchemaMetadata = isOptedInToAI || !IS_PLATFORM
 
@@ -116,7 +117,8 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   const snippetContent = snippet?.snippet?.content?.sql
 
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: selectedOrganization?.slug })
-  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: project?.ref || ref })
+  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
 
   const { data: tables, isLoading: isLoadingTables } = useTablesQuery(
     {
@@ -131,8 +133,6 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   const currentSchema = searchParams?.get('schema') ?? 'public'
   const currentChat = snap.activeChat?.name
 
-  const { ref } = useParams()
-  const org = useSelectedOrganization()
   const { mutate: sendEvent } = useSendEventMutation()
 
   const handleError = useCallback((error: Error) => {
@@ -237,12 +237,18 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     if (content.includes('Help me to debug')) {
       sendEvent({
         action: 'assistant_debug_submitted',
-        groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+        groups: {
+          project: ref ?? 'Unknown',
+          organization: selectedOrganization?.slug ?? 'Unknown',
+        },
       })
     } else {
       sendEvent({
         action: 'assistant_prompt_submitted',
-        groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+        groups: {
+          project: ref ?? 'Unknown',
+          organization: selectedOrganization?.slug ?? 'Unknown',
+        },
       })
     }
   }
@@ -364,7 +370,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
                 title="Project metadata is not shared"
                 description={
                   hasHipaaAddon
-                    ? 'Your organization has the HIPAA addon and will not send any project metadata with your prompts.'
+                    ? 'Your organization has the HIPAA addon and will not send project metadata with your prompts for projects marked as HIPAA.'
                     : 'The Assistant can improve the quality of the answers if you send project metadata along with your prompts. Opt into sending anonymous data to share your schema and table definitions.'
                 }
                 className="border-0 border-b rounded-none bg-background"

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -12,7 +12,7 @@ import Results from 'components/interfaces/SQLEditor/UtilityPanel/Results'
 import { SqlRunButton } from 'components/interfaces/SQLEditor/UtilityPanel/RunButton'
 import { useSqlTitleGenerateMutation } from 'data/ai/sql-title-mutation'
 import { QueryResponseError, useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
-import { useOrgOptedIntoAi } from 'hooks/misc/useOrgOptedIntoAi'
+import { useOrgOptedIntoAiAndHippaProject } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
 import { uuidv4 } from 'lib/helpers'
@@ -55,8 +55,8 @@ export const EditorPanel = ({ onChange }: EditorPanelProps) => {
   const { profile } = useProfile()
   const snapV2 = useSqlEditorV2StateSnapshot()
   const { mutateAsync: generateSqlTitle } = useSqlTitleGenerateMutation()
-  const isOptedInToAI = useOrgOptedIntoAi()
-  const includeSchemaMetadata = isOptedInToAI || !IS_PLATFORM
+  const { isOptedInToAI, isHipaaProjectDisallowed } = useOrgOptedIntoAiAndHippaProject()
+  const includeSchemaMetadata = (isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM
 
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<QueryResponseError>()

--- a/apps/studio/hooks/misc/useDisallowHipaa.ts
+++ b/apps/studio/hooks/misc/useDisallowHipaa.ts
@@ -1,19 +1,23 @@
 import { useCallback } from 'react'
 
 import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscription/Subscription.utils'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 
 export function useDisallowHipaa() {
   const selectedOrganization = useSelectedOrganization()
+  const project = useSelectedProject()
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: selectedOrganization?.slug })
   const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: project?.ref })
 
   const disallowHipaa = useCallback(
     (allowed: boolean) => {
-      return hasHipaaAddon ? false : allowed
+      return hasHipaaAddon && projectSettings?.is_sensitive ? false : allowed
     },
-    [hasHipaaAddon]
+    [hasHipaaAddon, projectSettings]
   )
 
   return disallowHipaa

--- a/apps/studio/hooks/misc/useOrgOptedIntoAi.ts
+++ b/apps/studio/hooks/misc/useOrgOptedIntoAi.ts
@@ -1,4 +1,5 @@
 import { useDisallowHipaa } from 'hooks/misc/useDisallowHipaa'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { OPT_IN_TAGS } from 'lib/constants'
 
@@ -9,9 +10,26 @@ import { OPT_IN_TAGS } from 'lib/constants'
  */
 export function useOrgOptedIntoAi() {
   const selectedOrganization = useSelectedOrganization()
+  const selectedProject = useSelectedProject()
   const optInTags = selectedOrganization?.opt_in_tags
   const isOptedIntoAI = optInTags?.includes(OPT_IN_TAGS.AI_SQL) ?? false
 
   const disallowHipaa = useDisallowHipaa()
-  return disallowHipaa(isOptedIntoAI)
+  /* if we are in a project context and this has been called,
+   * ensure that we aren't letting HIPAA projects activate AI
+   * returns true if optedIntoAI and no project selected
+   * returns true if optedIntoAI and we are in a project and not HIPAA project
+   * returns false if opted out of AI
+   * returns false if optedIntoAI and we are in a HIPAA project
+   */
+  return isOptedIntoAI && (!selectedProject || disallowHipaa(isOptedIntoAI))
+}
+
+export function useOrgOptedIntoAiAndHippaProject() {
+  const selectedOrganization = useSelectedOrganization()
+  const optInTags = selectedOrganization?.opt_in_tags
+  const isOptedIntoAI = optInTags?.includes(OPT_IN_TAGS.AI_SQL) ?? false
+
+  const disallowHipaa = useDisallowHipaa()
+  return { isOptedInToAI: isOptedIntoAI, isHipaaProjectDisallowed: disallowHipaa(isOptedIntoAI) }
 }

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
@@ -15,7 +15,7 @@ import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'
 import { useEdgeFunctionDeployMutation } from 'data/edge-functions/edge-functions-deploy-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useOrgOptedIntoAi } from 'hooks/misc/useOrgOptedIntoAi'
+import { useOrgOptedIntoAiAndHippaProject } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
@@ -24,8 +24,8 @@ import { LogoLoader } from 'ui'
 const CodePage = () => {
   const { ref, functionSlug } = useParams()
   const project = useSelectedProject()
-  const isOptedInToAI = useOrgOptedIntoAi()
-  const includeSchemaMetadata = isOptedInToAI || !IS_PLATFORM
+  const { isOptedInToAI, isHipaaProjectDisallowed } = useOrgOptedIntoAiAndHippaProject()
+  const includeSchemaMetadata = (isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM
   const { mutate: sendEvent } = useSendEventMutation()
   const org = useSelectedOrganization()
   const [showDeployWarning, setShowDeployWarning] = useState(false)

--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -14,7 +14,7 @@ import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import FileExplorerAndEditor from 'components/ui/FileExplorerAndEditor/FileExplorerAndEditor'
 import { useEdgeFunctionDeployMutation } from 'data/edge-functions/edge-functions-deploy-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
-import { useOrgOptedIntoAi } from 'hooks/misc/useOrgOptedIntoAi'
+import { useOrgOptedIntoAiAndHippaProject } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
@@ -100,8 +100,8 @@ const NewFunctionPage = () => {
   const router = useRouter()
   const { ref, template } = useParams()
   const project = useSelectedProject()
-  const isOptedInToAI = useOrgOptedIntoAi()
-  const includeSchemaMetadata = isOptedInToAI || !IS_PLATFORM
+  const { isOptedInToAI, isHipaaProjectDisallowed } = useOrgOptedIntoAiAndHippaProject()
+  const includeSchemaMetadata = (isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM
   const snap = useAiAssistantStateSnapshot()
   const { mutate: sendEvent } = useSendEventMutation()
   const org = useSelectedOrganization()


### PR DESCRIPTION
HIPAA orgs can mark specific projects as sensitive. Those projects will have HIPAA restrictions applied to them. This opens non-HIPAA projects in the same Organization up to use previously disabled features.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature update

## What is the current behavior?

HIPAA restrictions apply at the Org level for some features, but at the project level for others.

## What is the new behavior?

HIPAA restrictions are now at the project level

## Additional context

https://supabase.com/docs/guides/platform/hipaa-projects
