### PR TITLE
fix default enable state for auth hooks to be true

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -240,7 +240,7 @@ export const CreateHookSheet = ({
 
         form.reset({
           hookType: definition.title,
-          enabled: authConfig?.[definition.enabledKey] || false,
+          enabled: authConfig?.[definition.enabledKey] || true,
           selectedType: values.type,
           httpsValues: {
             url: (values.type === 'https' && values.url) || '',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[Auth hooks](https://supabase.com/dashboard/project/_/auth/hooks) default to be disabled on auth hook creation

<img width="977" alt="Screenshot 2025-05-26 at 1 38 10 PM" src="https://github.com/user-attachments/assets/4d5e06be-7008-41a2-93e2-913d97a7e177" />

## What is the new behavior?

Make it be enabled by default
<img width="977" alt="Screenshot 2025-05-26 at 1 39 02 PM" src="https://github.com/user-attachments/assets/dad055a1-6a6a-4c0d-be5b-40ee9d7b244b" />

## Additional context

