### PR TITLE
chore: respect retry-after header for rate-limiting

### DIFF
--- a/apps/studio/types/base.ts
+++ b/apps/studio/types/base.ts
@@ -99,11 +99,13 @@ export type SupaResponse<T> = T | ResponseFailure
 export class ResponseError extends Error {
   code?: number
   requestId?: string
+  retryAfter?: number
 
-  constructor(message: string | undefined, code?: number, requestId?: string) {
+  constructor(message: string | undefined, code?: number, requestId?: string, retryAfter?: number) {
     super(message || 'API error happened while trying to communicate with the server.')
     this.code = code
     this.requestId = requestId
+    this.retryAfter = retryAfter
   }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Enables retries for `429` (rate limited) error codes
- Only retry after the `retry-after` duration