### PR TITLE
ci(docs lint): fix workflow for external lints

### DIFF
--- a/.github/workflows/docs-lint-v2-comment.yml
+++ b/.github/workflows/docs-lint-v2-comment.yml
@@ -1,4 +1,4 @@
-name: Comment on external PRs with linter results
+name: docs_lint_comment_external
 
 # This is a continuation of ./docs-lint-v2.yml, to write comments on external
 # PRs.
@@ -11,7 +11,7 @@ name: Comment on external PRs with linter results
 
 on:
   workflow_run:
-    workflows: ['[Docs] Lint v2']
+    workflows: [docs_lint]
     types:
       - completed
 

--- a/.github/workflows/docs-lint-v2.yml
+++ b/.github/workflows/docs-lint-v2.yml
@@ -1,4 +1,4 @@
-name: '[Docs] Lint v2'
+name: docs_lint
 
 # Runs the docs linter on PRs that edit docs content.
 # There are two branches of this workflow for internal and external PRs, due
@@ -102,3 +102,6 @@ jobs:
         with:
           name: lint_results
           path: __github_actions__pr/
+      - name: fail if linter fails (external)
+        if: steps.filter.outputs.docs == 'true' && github.event.pull_request.head.repo.full_name != github.repository && steps.external_lint.outputs.LINT_EXIT_CODE != 0
+        run: exit 1


### PR DESCRIPTION
Workflow for external lints still not working quite right.

1. The lint workflow should fail if linting fails, to block merge. Right now the exit status of the linter is ignored; added a step to fix that.
2. The workflow_run event is not triggered by completion of the first workflow. Couldn't find an obvious problem with the two, but saw online that some people had problems with a quoted workflow name, so tried renaming the workflows to avoid having to quote the names.