### PR TITLE
chore(docs): remove unnecessary toml package

### DIFF
--- a/apps/docs/features/docs/Troubleshooting.script.mjs
+++ b/apps/docs/features/docs/Troubleshooting.script.mjs
@@ -19,8 +19,7 @@ import { toMarkdown } from 'mdast-util-to-markdown'
 import { gfm } from 'micromark-extension-gfm'
 import { mdxjs } from 'micromark-extension-mdxjs'
 import { readFile, writeFile } from 'node:fs/promises'
-import { stringify } from 'smol-toml'
-import toml from 'toml'
+import { parse, stringify } from 'smol-toml'
 
 import {
   getAllTroubleshootingEntriesInternal as getAllTroubleshootingEntries,
@@ -173,7 +172,7 @@ function calculateChecksum(content) {
 
   const { data, content: body } = matter(bodyNormalized, {
     language: 'toml',
-    engines: { toml: toml.parse.bind(toml) },
+    engines: { toml: parse },
   })
   const newFrontmatter = stringify(data)
   const normalized = `---\n${newFrontmatter}\n---\n${body}`
@@ -442,7 +441,7 @@ async function updateFileId(entry, id) {
   const fileContents = await readFile(entry.filePath, 'utf-8')
   const { data, content } = matter(fileContents, {
     language: 'toml',
-    engines: { toml: toml.parse.bind(toml) },
+    engines: { toml: parse },
   })
   data.database_id = id
 

--- a/apps/docs/features/docs/Troubleshooting.utils.common.mjs
+++ b/apps/docs/features/docs/Troubleshooting.utils.common.mjs
@@ -17,7 +17,7 @@ import { gfm } from 'micromark-extension-gfm'
 import { mdxjs } from 'micromark-extension-mdxjs'
 import { readdir, readFile, stat } from 'node:fs/promises'
 import { join, sep } from 'node:path'
-import toml from 'toml'
+import { parse } from 'smol-toml'
 import { visit } from 'unist-util-visit'
 import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
@@ -123,7 +123,7 @@ export async function getAllTroubleshootingEntriesInternal() {
     const fileContents = await readFile(filePath, 'utf-8')
     const { content, data: frontmatter } = matter(fileContents, {
       language: 'toml',
-      engines: { toml: toml.parse.bind(toml) },
+      engines: { toml: parse },
     })
 
     const parseResult = validateTroubleshootingMetadata(frontmatter)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -146,7 +146,6 @@
     "simple-git": "^3.24.0",
     "slugify": "^1.6.6",
     "smol-toml": "^1.3.1",
-    "toml": "^3.0.0",
     "tsconfig": "workspace:*",
     "tsx": "^4.19.3",
     "twoslash": "^0.3.1",

--- a/apps/docs/scripts/last-changed.ts
+++ b/apps/docs/scripts/last-changed.ts
@@ -21,9 +21,8 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { parseArgs } from 'node:util'
 import { SimpleGit, simpleGit } from 'simple-git'
-import toml from 'toml'
-
-import { Section } from './helpers.mdx'
+import { parse } from 'smol-toml'
+import { type Section } from './helpers.mdx'
 
 interface Options {
   reset: boolean
@@ -164,7 +163,7 @@ function processMdx(rawContent: string): Array<SectionWithChecksum> {
   } catch (err) {
     content = matter(rawContent, {
       language: 'toml',
-      engines: { toml: toml.parse.bind(toml) },
+      engines: { toml: parse },
     }).content
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,9 +544,6 @@ importers:
       smol-toml:
         specifier: ^1.3.1
         version: 1.3.1
-      toml:
-        specifier: ^3.0.0
-        version: 3.0.0
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION
We have two packages for handling toml, which is a bit unnecessary. Settle on smol-toml as it is under more active maintenance.