### PR TITLE
fix(ui): show confirmLabelLoading in ConfirmationModal when loading is true

### DIFF
--- a/packages/ui-patterns/Dialogs/ConfirmationModal.tsx
+++ b/packages/ui-patterns/Dialogs/ConfirmationModal.tsx
@@ -132,7 +132,7 @@ const ConfirmationModal = forwardRef<
               onClick={onSubmit}
               className="truncate"
             >
-              {confirmLabel}
+              {loading ? confirmLabelLoading ?? confirmLabel : confirmLabel}
             </Button>
           </div>
         </DialogContent>


### PR DESCRIPTION
Previously, the confirm button always rendered `confirmLabel`, even when loading. This change ensures that `confirmLabelLoading` is displayed when loading is true.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The confirm button always shows `confirmLabel`, even when `loading` is `true`. The `confirmLabelLoading` prop was accepted but not used.

## What is the new behavior?

When `loading` is `true`, the confirm button now displays `confirmLabelLoading` if provided.

## Additional context

This improves the UX of destructive actions by aligning the label with the loading state. It also unblocks use cases relying on `confirmLabelLoading`.
