### PR TITLE
seo(docs): canonical links for reference pages

### DIFF
--- a/apps/docs/app/api/crawlers/route.ts
+++ b/apps/docs/app/api/crawlers/route.ts
@@ -85,7 +85,6 @@ function htmlShell(
     `<meta name="og:image" content="https://supabase.com/docs/img/supabase-og-image.png">` +
     `<meta name="twitter:image" content="https://supabase.com/docs/img/supabase-og-image.png">` +
     `<link rel="canonical" href="https://supabase.com/docs/reference/${lib}` +
-    (version ? '/' + version : '') +
     (slug ? '/' + slug : '') +
     `">` +
     '</head>' +

--- a/apps/docs/features/docs/Reference.utils.ts
+++ b/apps/docs/features/docs/Reference.utils.ts
@@ -1,6 +1,6 @@
 import { fromMarkdown } from 'mdast-util-from-markdown'
-import { toMarkdown } from 'mdast-util-to-markdown'
 import { mdxFromMarkdown, mdxToMarkdown } from 'mdast-util-mdx'
+import { toMarkdown } from 'mdast-util-to-markdown'
 import { mdxjs } from 'micromark-extension-mdxjs'
 import type { Metadata, ResolvingMetadata } from 'next'
 import { redirect } from 'next/navigation'
@@ -131,7 +131,7 @@ export async function generateReferenceMetadata(
   const isApiReference = parsedPath.__type === 'api'
   const isSelfHostingReference = parsedPath.__type === 'self-hosting'
   if (isClientSdkReference) {
-    const { sdkId, maybeVersion } = parsedPath
+    const { sdkId, maybeVersion, path } = parsedPath
     const version = maybeVersion ?? REFERENCES[sdkId].versions[0]
 
     const flattenedSections = await getFlattenedSections(sdkId, version)
@@ -141,7 +141,7 @@ export async function generateReferenceMetadata(
       slug.length > 0
         ? flattenedSections.find((section) => section.slug === slug[0])?.title
         : undefined
-    const url = [BASE_PATH, 'reference', sdkId, maybeVersion, slug[0]].filter(Boolean).join('/')
+    const url = [BASE_PATH, 'reference', sdkId, path[0]].filter(Boolean).join('/')
 
     const images = generateOpenGraphImageMeta({
       type: 'API Reference',


### PR DESCRIPTION
To avoid content duplication warnings, direct all canonical links for reference pages to the newest library version.