### PR TITLE
chore(docs): refine sentry filter

### DIFF
--- a/apps/docs/instrumentation-client.ts
+++ b/apps/docs/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
+import { hasConsented, IS_PLATFORM } from 'common'
 import { IS_DEV } from './lib/constants'
 
 if (!IS_DEV) {
@@ -20,18 +21,37 @@ if (!IS_DEV) {
     ],
 
     beforeSend(event) {
-      const frames = event.exception?.values?.[0].stacktrace?.frames || []
+      if (!IS_PLATFORM || !hasConsented()) {
+        return null
+      }
 
-      // Drop errors not originating from docs app static files as unactionable
-      if (
-        frames &&
-        !frames.some((frame) => frame.filename && frame.filename.startsWith('app:///_next'))
-      ) {
+      const frames = event.exception?.values?.[0].stacktrace?.frames || []
+      if (isThirdPartyError(frames)) {
         return null
       }
 
       return event
     },
+  })
+}
+
+// We want to ignore errors not originating from docs app static files
+// (such as errors from browser extensions). Those errors come from files
+// not starting with 'app:///_next'.
+//
+// However, there is a complication because the Sentry code that sends
+// the error shows up in the stack trace, and that _does_ start with
+// 'app:///_next'. It is always the first frame in the stack trace,
+// and has a specific pre_context comment that we can use for filtering.
+function isThirdPartyError(frames: Sentry.StackFrame[] | undefined) {
+  if (!frames) return false
+
+  function isSentryFrame(frame: Sentry.StackFrame, index: number) {
+    return index === 0 && frame.pre_context?.[0]?.includes('sentry.javascript')
+  }
+
+  return !frames.some((frame, index) => {
+    frame.abs_path?.startsWith('app:///_next') && !isSentryFrame(frame, index)
   })
 }
 


### PR DESCRIPTION
Right now we're filtering out third-party extensions by looking for stack traces that don't touch 'app:///_next'. However, third-party stack traces do include the Sentry code that sends the error, and that originates in 'app:///_next'. We need to filter out any events that do not have 'app:///_next' events beyond that one Sentry frame.