### PR TITLE
fix(common): prevent errors when accessing local storage in certain browser setups

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -9,17 +9,28 @@ export const AUTH_NAVIGATOR_LOCK_DISABLED_KEY =
   process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY ||
   'supabase.dashboard.auth.navigatorLock.disabled'
 
+/**
+ * Catches errors thrown when accessing localStorage. Safari with certain
+ * security settings throws when localStorage is accessed.
+ */
+function safeGetLocalStorage(key: string) {
+  try {
+    return globalThis?.localStorage?.getItem(key)
+  } catch {
+    return null
+  }
+}
+
 const debug =
-  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  globalThis?.localStorage?.getItem(AUTH_DEBUG_KEY) === 'true'
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && safeGetLocalStorage(AUTH_DEBUG_KEY) === 'true'
 
 const persistedDebug =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  globalThis?.localStorage?.getItem(AUTH_DEBUG_PERSISTED_KEY) === 'true'
+  safeGetLocalStorage(AUTH_DEBUG_PERSISTED_KEY) === 'true'
 
 const shouldEnableNavigatorLock =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  !(globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_DISABLED_KEY) === 'true')
+  !(safeGetLocalStorage(AUTH_NAVIGATOR_LOCK_DISABLED_KEY) === 'true')
 
 const shouldDetectSessionInUrl = process.env.NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_URL
   ? process.env.NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_URL === 'true'


### PR DESCRIPTION
Got many reports of errors from accessing localStorage on Safari, probably due to certain user security settings that cause the browser to throw an error on storage access.