### PR TITLE
fix: Sandbox email preview frame

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -340,6 +340,7 @@ const TemplateEditor = ({ template }: TemplateEditorProps) => {
                     className="!mb-0 mt-0 overflow-hidden h-96 w-full"
                     title={id}
                     srcDoc={bodyValue}
+                    sandbox="allow-scripts allow-forms"
                   />
                   <Admonition
                     type="default"


### PR DESCRIPTION
This change will allow scripts to continue running in the Preview pane of the Email Template view, but will run as a cross origin context, namely calls and scripts will not inherit the users cookies.

Could not be tested locally, but have POC'ed this iframe config
<img width="822" alt="image" src="https://github.com/user-attachments/assets/dd4f2062-1ef4-4cf1-bb80-e8f36b5cf7cf" />
Can add additional sandbox attributes as needed (just not allow-same-origin)

Fixes SEC-348