### PR TITLE
docs: Add JSON type support for generated typescript types

### DIFF
--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -141,11 +141,11 @@ To use `MergeDeep`, set `compilerOptions.strictNullChecks` to `true` in your `ts
 
 </Admonition>
 
-## Enhanced Type Inference for JSON Fields
+## Enhanced type inference for JSON fields
 
 Starting from [supabase-js v2.48.0](https://github.com/supabase/supabase-js/releases/tag/v2.48.0), you can define custom types for JSON fields and get enhanced type inference when using JSON selectors with the `->` and `->>` operators. This makes your code more type-safe and intuitive when working with JSON/JSONB columns.
 
-### Defining Custom JSON Types
+### Defining custom JSON types
 
 You can extend your generated database types to include custom JSON schemas using `MergeDeep`:
 
@@ -190,7 +190,7 @@ export type Database = MergeDeep<
 >
 ```
 
-### Type-Safe JSON Querying
+### Type-safe JSON querying
 
 Once you've defined your custom JSON types, TypeScript will automatically infer the correct types when using JSON selectors:
 

--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -141,6 +141,85 @@ To use `MergeDeep`, set `compilerOptions.strictNullChecks` to `true` in your `ts
 
 </Admonition>
 
+## Enhanced Type Inference for JSON Fields
+
+Starting from [supabase-js v2.48.0](https://github.com/supabase/supabase-js/releases/tag/v2.48.0), you can define custom types for JSON fields and get enhanced type inference when using JSON selectors with the `->` and `->>` operators. This makes your code more type-safe and intuitive when working with JSON/JSONB columns.
+
+### Defining Custom JSON Types
+
+You can extend your generated database types to include custom JSON schemas using `MergeDeep`:
+
+```ts ./database.types.ts
+import { MergeDeep } from 'type-fest'
+import { Database as DatabaseGenerated } from './database-generated.types'
+
+// Define your custom JSON type
+type CustomJsonType = {
+  foo: string;
+  bar: { baz: number };
+  en: 'ONE' | 'TWO' | 'THREE';
+};
+
+export type Database = MergeDeep<
+  DatabaseGenerated,
+  {
+    public: {
+      Tables: {
+        your_table: {
+          Row: {
+            data: CustomJsonType | null;
+          };
+          // Optional: Use if you want type-checking for inserts and updates
+          // Insert: {
+          //   data?: CustomJsonType | null;
+          // };
+          // Update: {
+          //   data?: CustomJsonType | null;
+          // };
+        }
+      }
+      Views: {
+        your_view: {
+          Row: {
+            data: CustomJsonType | null;
+          };
+        }
+      }
+    }
+  }
+>
+```
+
+### Type-Safe JSON Querying
+
+Once you've defined your custom JSON types, TypeScript will automatically infer the correct types when using JSON selectors:
+
+```ts
+const res = await client
+  .from('your_table')
+  .select('data->bar->baz, data->en, data->bar');
+
+if (res.data) {
+  console.log(res.data);
+  // TypeScript infers the shape of your JSON data:
+  // [
+  //   {
+  //     baz: number;
+  //     en: 'ONE' | 'TWO' | 'THREE';
+  //     bar: { baz: number };
+  //   }
+  // ]
+}
+```
+
+This feature works with:
+- Single-level JSON access: `data->foo`
+- Nested JSON access: `data->bar->baz`  
+- Text extraction: `data->>foo` (returns string)
+- Mixed selections combining multiple JSON paths
+
+The type inference automatically handles the difference between `->` (returns JSON) and `->>` (returns text) operators, ensuring your TypeScript types match the actual runtime behavior.
+
 You can also override the type of an individual successful response if needed:
 
 ```ts

--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -155,10 +155,10 @@ import { Database as DatabaseGenerated } from './database-generated.types'
 
 // Define your custom JSON type
 type CustomJsonType = {
-  foo: string;
-  bar: { baz: number };
-  en: 'ONE' | 'TWO' | 'THREE';
-};
+  foo: string
+  bar: { baz: number }
+  en: 'ONE' | 'TWO' | 'THREE'
+}
 
 export type Database = MergeDeep<
   DatabaseGenerated,
@@ -167,8 +167,8 @@ export type Database = MergeDeep<
       Tables: {
         your_table: {
           Row: {
-            data: CustomJsonType | null;
-          };
+            data: CustomJsonType | null
+          }
           // Optional: Use if you want type-checking for inserts and updates
           // Insert: {
           //   data?: CustomJsonType | null;
@@ -181,8 +181,8 @@ export type Database = MergeDeep<
       Views: {
         your_view: {
           Row: {
-            data: CustomJsonType | null;
-          };
+            data: CustomJsonType | null
+          }
         }
       }
     }
@@ -195,12 +195,10 @@ export type Database = MergeDeep<
 Once you've defined your custom JSON types, TypeScript will automatically infer the correct types when using JSON selectors:
 
 ```ts
-const res = await client
-  .from('your_table')
-  .select('data->bar->baz, data->en, data->bar');
+const res = await client.from('your_table').select('data->bar->baz, data->en, data->bar')
 
 if (res.data) {
-  console.log(res.data);
+  console.log(res.data)
   // TypeScript infers the shape of your JSON data:
   // [
   //   {
@@ -213,8 +211,9 @@ if (res.data) {
 ```
 
 This feature works with:
+
 - Single-level JSON access: `data->foo`
-- Nested JSON access: `data->bar->baz`  
+- Nested JSON access: `data->bar->baz`
 - Text extraction: `data->>foo` (returns string)
 - Mixed selections combining multiple JSON paths
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds docs about JSON support on TypeScript types. 
https://github.com/orgs/supabase/discussions/32925