### PR TITLE
fix: don't refetch settings on inactive projects

### DIFF
--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -51,9 +51,11 @@ export const useProjectSettingsV2Query = <TData = ProjectSettingsData>(
     ({ signal }) => getProjectSettings({ projectRef }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      refetchInterval(data) {
-        const apiKeys = (data as ProjectSettings)?.service_api_keys ?? []
-        const interval = canReadAPIKeys && apiKeys.length === 0 ? 2000 : 0
+      refetchInterval(_data) {
+        const data = _data as ProjectSettings | undefined
+        const apiKeys = data?.service_api_keys ?? []
+        const interval =
+          canReadAPIKeys && data?.status !== 'INACTIVE' && apiKeys.length === 0 ? 2000 : 0
         return interval
       },
       ...options,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

- `service_api_keys` will be `undefined` on inactive projects, causing the refetch to continually trigger endlessly