### PR TITLE
Fix storage mime type not getting set on create

### DIFF
--- a/apps/studio/data/storage/bucket-create-mutation.ts
+++ b/apps/studio/data/storage/bucket-create-mutation.ts
@@ -28,7 +28,7 @@ export async function createBucket({
 
   const payload: Partial<CreateStorageBucketBody> = { id, public: isPublic }
   if (file_size_limit) payload.file_size_limit = file_size_limit
-  if (allowed_mime_types) payload.allowed_mime_types
+  if (allowed_mime_types) payload.allowed_mime_types = allowed_mime_types
 
   const { data, error } = await post('/platform/storage/{ref}/buckets', {
     params: { path: { ref: projectRef } },


### PR DESCRIPTION
Mime type doesn't get saved on bucket create (works on bucket update)
![screenshot-2025-05-29-at-10 39 07](https://github.com/user-attachments/assets/9ba5c0b2-16f9-493d-a972-70cc433b3d40)
