### PR TITLE
ci(docs lint): fix workflow_run condition

### DIFF
--- a/.github/workflows/docs-lint-v2-comment.yml
+++ b/.github/workflows/docs-lint-v2-comment.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   comment_on_pr:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
     steps:
       - id: download_artifact
         name: 'Download artifact'


### PR DESCRIPTION
The originating workflow was changed so that lint failures fail the workflow, so now we should be running the target workflow on failure, not on success.