### PR TITLE
refactor: update watch repo gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
 
 Watch "releases" of this repo to get notified of major updates.
 
-<kbd><img src="https://raw.githubusercontent.com/supabase/supabase/d5f7f413ab356dc1a92075cb3cee4e40a957d5b1/web/static/watch-repo.gif" alt="Watch this repo"/></kbd>
+<kbd>
+  <img src="https://github.com/user-attachments/assets/b6e5c132-6a6e-4472-8e4b-616f50db6df2" alt="Watch this repo" width="500"/>
+</kbd>
 
 ## Documentation
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Docs update**

## What is the current behavior?

The README contains an outdated GIF showing how to "Watch" the repository for updates. The previous visual was based on an older version of the GitHub UI, which might be confusing for new users.

## What is the new behavior?

The GIF in the README has been updated to reflect the current GitHub UI, making it clearer and more accurate for users who want to follow the repository:


**Before**
![image](https://github.com/user-attachments/assets/9e1573c1-3999-4ed4-8d08-e039d0c408e8)

**After**
![image](https://github.com/user-attachments/assets/daf9e848-dffe-4091-9b9b-7475ecbf77a9)

## Additional context

This small documentation improvement helps keep the onboarding experience smooth and visually consistent with GitHub’s latest design. No functional changes were made—only an updated visual asset.

