### PR TITLE
style: add comma to the Applied to target roles

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -78,10 +78,10 @@ const PolicyRow = ({
               <div className="text-foreground-lighter text-sm">
                 Applied to:{' '}
                 {policy.roles.slice(0, 3).map((role, i) => (
-                  <code key={`policy-${role}-${i}`} className="text-foreground-light text-xs">
-                    {role}
-                    {policy.roles.length > 1 ? '' : ' '}
-                  </code>
+                  <span key={`policy-${role}-${i}`}>
+                    <code className="text-foreground-light text-xs">{role}</code>
+                    {i < Math.min(policy.roles.length, 3) - 1 && ', '}
+                  </span>
                 ))}
                 {policy.roles.length > 1 ? 'roles' : 'role'}
               </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Issue Link : #36068 

## What kind of change does this PR introduce?

Style changes

## What is the current behavior?
<img width="966" alt="Screenshot 2025-05-31 at 1 31 44 PM" src="https://github.com/user-attachments/assets/f47c242c-19d8-4b7e-940d-73d292d32b5f" />

The target roles do not have any space in between them, making it difficult to read
## What is the new behavior?
<img width="670" alt="image" src="https://github.com/user-attachments/assets/b7c808e9-c5b8-4759-8e4d-08513510c562" />

