### PR TITLE
Fix broken link to replication guide

### DIFF
--- a/apps/docs/content/guides/database/replication/setting-up-replication.mdx
+++ b/apps/docs/content/guides/database/replication/setting-up-replication.mdx
@@ -12,7 +12,7 @@ To set up replication, the following is recommended:
 - Instance size of XL or greater
 - [IPv4 add-on](/guides/platform/ipv4-address) enabled
 
-To create a replication slot, you will need to use the `postgres` user and follow the instructions in our [guide](/guides/database/postgres/setup-replication-external).
+To create a replication slot, you will need to use the `postgres` user and follow the instructions in our [guide](/docs/guides/database/postgres/setup-replication-external).
 
 <Admonition type="note">
   If you are running Postgres 17 or higher, you can create a new user and grant them replication


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Link to external replication guide is broken

## What is the new behavior?

It is now unbroken

## Additional context

Thanks to a friendly customer for reporting this!
