### PR TITLE
Improve `supabase link` documentation

### DIFF
--- a/apps/docs/spec/cli_v1_commands.yaml
+++ b/apps/docs/spec/cli_v1_commands.yaml
@@ -1678,6 +1678,8 @@ commands:
       > If you do not want to be prompted for the database password, such as in a CI environment, you may specify it explicitly via the `SUPABASE_DB_PASSWORD` environment variable.
 
       Some commands like `db dump`, `db push`, and `db pull` require your project to be linked first.
+
+      The selected project ref is stored in `supabase/.temp/project_ref`.
     examples:
       - id: basic-usage
         name: Basic usage


### PR DESCRIPTION
Show that its setting is persisted in the filesystem at `supabase/.temp/project_ref`, so developers have a way of seeing what project is currently linked. 

This appears to be otherwise undocumented, and only mentioned in one Github issue and one Reddit comment as far as I can tell.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES 🙌

## What kind of change does this PR introduce?

docs update
