### PR TITLE
fixed breaking of replication link in doc

### DIFF
--- a/apps/docs/content/guides/database/replication/setting-up-replication.mdx
+++ b/apps/docs/content/guides/database/replication/setting-up-replication.mdx
@@ -10,9 +10,9 @@ sidebar_label: 'Setting up replication and CDC'
 To set up replication, the following is recommended:
 
 - Instance size of XL or greater
-- [IPv4 add-on](/guides/platform/ipv4-address) enabled
+- [IPv4 add-on](/docs/guides/platform/ipv4-address) enabled
 
-To create a replication slot, you will need to use the `postgres` user and follow the instructions in our [guide](/guides/database/postgres/setup-replication-external).
+To create a replication slot, you will need to use the `postgres` user and follow the instructions in our [guide](/docs/guides/database/postgres/setup-replication-external).
 
 <Admonition type="note">
   If you are running Postgres 17 or higher, you can create a new user and grant them replication


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?
Bug fix: Fixed the breaking of links in https://supabase.com/docs/guides/database/replication/setting-up-replication


## What is the current behavior?
The links are redirecting to https://supabase.com/guides/database/postgres/setup-replication-external and https://supabase.com/guides/platform/ipv4-address

Please link any relevant issues here.
Fix #36089 
## What is the new behavior?
