### PR TITLE
fix: reset loading state after deleting users in auth management UI

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -220,6 +220,7 @@ export const UsersV2 = () => {
         `Successfully deleted the selected ${selectedUsers.size} user${selectedUsers.size > 1 ? 's' : ''}`
       )
       setShowDeleteModal(false)
+      setIsDeletingUsers(false)
       setSelectedUsers(new Set([]))
 
       if (userIds.includes(selectedUser)) setSelectedUser(undefined)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the current behavior?

https://github.com/supabase/supabase/issues/36096

## What is the new behavior?

Delete user confirmation is not stuck in the isDeleting state. It is reset post deletion, so that next delete the modal starts with `isDeleting = false`
