### PR TITLE
feat: remove central eu from default region selection

### DIFF
--- a/apps/studio/data/misc/get-default-region-query.ts
+++ b/apps/studio/data/misc/get-default-region-query.ts
@@ -14,7 +14,6 @@ import { miscKeys } from './keys'
 
 const RESTRICTED_POOL = [
   'EAST_US_2',
-  'CENTRAL_EU',
   'NORTH_EU',
   'WEST_EU',
   'WEST_EU_2',

--- a/apps/studio/data/misc/get-default-region-query.ts
+++ b/apps/studio/data/misc/get-default-region-query.ts
@@ -12,13 +12,7 @@ import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
 import type { ResponseError } from 'types'
 import { miscKeys } from './keys'
 
-const RESTRICTED_POOL = [
-  'EAST_US_2',
-  'NORTH_EU',
-  'WEST_EU',
-  'WEST_EU_2',
-  'SOUTHEAST_ASIA',
-]
+const RESTRICTED_POOL = ['EAST_US_2', 'NORTH_EU', 'WEST_EU', 'WEST_EU_2', 'SOUTHEAST_ASIA']
 
 export type DefaultRegionVariables = {
   cloudProvider?: CloudProvider


### PR DESCRIPTION
It is still available in region selection, just removed from the default.
