### PR TITLE
Update auth-send-email-hook-react-email-resend.mdx - typo

### DIFF
--- a/apps/docs/content/guides/functions/examples/auth-send-email-hook-react-email-resend.mdx
+++ b/apps/docs/content/guides/functions/examples/auth-send-email-hook-react-email-resend.mdx
@@ -294,7 +294,7 @@ Set the secrets from the `.env` file:
 supabase secrets set --env-file supabase/functions/.env
 ```
 
-Now your Supabase Edge Function will be triggered anytime an Auth Email needs to be send to the user!
+Now your Supabase Edge Function will be triggered anytime an Auth Email needs to be sent to the user!
 
 ## More resources
 


### PR DESCRIPTION
Fix: Typo in Auth Email trigger message from '...needs to be send' to '...needs to be sent'

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
Typo: "...needs to be send"

## What is the new behavior?
Corrected: "...needs to be sent"

## Additional context
N/A