### PR TITLE
fix: delete row loading spinner

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/DeleteConfirmationDialogs.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/DeleteConfirmationDialogs.tsx
@@ -69,7 +69,7 @@ const DeleteConfirmationDialogs = ({
     },
   })
 
-  const { mutate: deleteRows } = useTableRowDeleteMutation({
+  const { mutate: deleteRows, isLoading: isDeletingRows } = useTableRowDeleteMutation({
     onSuccess: () => {
       if (snap.confirmationDialog?.type === 'row') {
         snap.confirmationDialog.callback?.()
@@ -81,7 +81,7 @@ const DeleteConfirmationDialogs = ({
     },
   })
 
-  const { mutate: deleteAllRows } = useTableRowDeleteAllMutation({
+  const { mutate: deleteAllRows, isLoading: isDeletingAllRows } = useTableRowDeleteAllMutation({
     onSuccess: () => {
       if (snap.confirmationDialog?.type === 'row') {
         snap.confirmationDialog.callback?.()
@@ -96,7 +96,7 @@ const DeleteConfirmationDialogs = ({
     },
   })
 
-  const { mutate: truncateRows } = useTableRowTruncateMutation({
+  const { mutate: truncateRows, isLoading: isTruncatingRows } = useTableRowTruncateMutation({
     onSuccess: () => {
       if (snap.confirmationDialog?.type === 'row') {
         snap.confirmationDialog.callback?.()
@@ -310,6 +310,7 @@ const DeleteConfirmationDialogs = ({
         confirmLabelLoading="Deleting"
         onCancel={() => snap.closeConfirmationDialog()}
         onConfirm={() => onConfirmDeleteRow()}
+        loading={isTruncatingRows || isDeletingRows || isDeletingAllRows}
       >
         <div className="space-y-4">
           <p className="text-sm text-foreground-light">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix; when deleting a row, no loading spinner is shown. This PR fixes that.



<img width="417" alt="Screenshot 2025-06-02 at 17 31 32" src="https://github.com/user-attachments/assets/a42e6748-b1ae-40b0-bf58-997126679ef9" />
