### PR TITLE
ci(docs): scheduled linter

### DIFF
--- a/.github/workflows/docs-lint-v2-scheduled.yml
+++ b/.github/workflows/docs-lint-v2-scheduled.yml
@@ -45,18 +45,15 @@ jobs:
             git config --global user.email 'github-docs-bot@supabase.com'
             BRANCH_NAME="bot/docs-lint-fixes"
             EXISTING_BRANCH=$(git ls-remote --heads origin $BRANCH_NAME)
-            if [ -n "$EXISTING_BRANCH" ]; then
-              git checkout $BRANCH_NAME
-            else
-              git checkout -b $BRANCH_NAME
+            if [[ -n "$EXISTING_BRANCH" ]]; then
+                git push origin --delete $BRANCH_NAME
             fi
+            git checkout -b $BRANCH_NAME
             supa-mdx-lint apps/docs/content --fix || FIX_FAILED=1
             git add .
             git commit -m '[bot] fix lint errors' || true
             git push origin $BRANCH_NAME
-            if [ -z "$EXISTING_BRANCH" ]; then
-              gh pr create --title '[bot] fix lint errors' --body 'This PR fixes lint errors in the documentation.' --head $BRANCH_NAME
-            fi
+            gh pr create --title '[bot] fix lint errors' --body 'This PR fixes lint errors in the documentation.' --head $BRANCH_NAME
             if [ "${FIX_FAILED:-0}" -eq 1 ]; then
               echo "Fix did not correct all errors."
               exit 1

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -35,6 +35,7 @@ allow_list = [
     "[Cc]onfigs?",
     "[Cc]onsecutiveness",
     "[Cc]ooldowns?",
+    "[Cc]oroutines?",
     "[Cc]ron",
     "[Dd]atasets?",
     "[Dd]atasources?",


### PR DESCRIPTION
1. Fix lint errors showing up in the scheduled linting run.
2. Found a bug with the scheduled linting run workflow: if the bot branch already exists, we check it out and try to run lint fix on it. But this branch is never synced with the current state of master, which is the one we actually want to run lint fix on. Instead we should delete and recreate it from latest master if it already exists..