### PR TITLE
Tiny patch table editor

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -131,14 +131,14 @@ export const TableGridEditor = ({
                   >
                     Close tab
                   </Button>
-                ) : tabs.openTabs.length > 0 ? (
+                ) : openTabs.length > 0 ? (
                   <Button
                     asChild
                     type="default"
                     className="mt-2"
                     onClick={() => appSnap.setDashboardHistory(projectRef, 'editor', undefined)}
                   >
-                    <Link href={`/project/${projectRef}/editor/${tabs.openTabs[0].split('-')[1]}`}>
+                    <Link href={`/project/${projectRef}/editor/${openTabs[0].split('-')[1]}`}>
                       Close tab
                     </Link>
                   </Button>


### PR DESCRIPTION
Mistake in TableGridEditor where we're checking through _all_ open tabs for the CTA when landing on a table ID that doesn't exist - resulting in an incorrect URL if there were opened SQL tabs as well

We already had declared `openedTabs` that filters out SQL Editor tabs, just that we weren't using it 😓 