### PR TITLE
Log Explorer improvements

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import { ReactNode, useState } from 'react'
 
-import { Popover, PopoverContent, PopoverTrigger } from '@ui/components/shadcn/ui/popover'
 import { IS_PLATFORM } from 'common'
 import Table from 'components/to-be-cleaned/Table'
 import dayjs from 'dayjs'
@@ -234,31 +233,32 @@ const LogsQueryPanel = ({
               />
             )}
 
-            <div className="overflow-hidden">
-              <div
-                data-testid="log-explorer-warnings"
-                className={` transition-all duration-300 ${
-                  warnings.length > 0 ? 'opacity-100' : 'invisible h-0 w-0 opacity-0'
-                }`}
-              >
-                <Popover>
-                  <PopoverTrigger>
-                    <Badge variant="warning">
-                      {warnings.length} {warnings.length > 1 ? 'warnings' : 'warning'}
-                    </Badge>
-                    <PopoverContent className="p-0 divide-y">
-                      {warnings.map((warning, index) => (
-                        <p key={index} className="p-3 text-xs text-foreground-light text-left">
-                          {warning.text}{' '}
-                          {warning.link && (
-                            <Link href={warning.link}>{warning.linkText || 'View'}</Link>
-                          )}
-                        </p>
-                      ))}
-                    </PopoverContent>
-                  </PopoverTrigger>
-                </Popover>
-              </div>
+            <div
+              data-testid="log-explorer-warnings"
+              className={`transition-all duration-300 h-full ${
+                warnings.length > 0 ? 'opacity-100' : 'invisible h-0 w-0 opacity-0'
+              }`}
+            >
+              <Tooltip>
+                <TooltipTrigger className="flex items-start">
+                  <Badge variant="warning">
+                    {warnings.length} {warnings.length > 1 ? 'warnings' : 'warning'}
+                  </Badge>
+                  <TooltipContent className="p-0 divide-y max-w-xs" side="bottom">
+                    {warnings.map((warning, index) => (
+                      <p
+                        key={index}
+                        className="px-3 py-1.5 text-xs text-foreground-light text-left"
+                      >
+                        {warning.text}{' '}
+                        {warning.link && (
+                          <Link href={warning.link}>{warning.linkText || 'View'}</Link>
+                        )}
+                      </p>
+                    ))}
+                  </TooltipContent>
+                </TooltipTrigger>
+              </Tooltip>
             </div>
           </div>
           {dataSource === 'logs' && (

--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -218,22 +218,24 @@ export function LogsSidebarMenuV2() {
             onChange={(e) => setSearchText(e.target.value)}
           ></InnerSideBarFilterSearchInput>
         </InnerSideBarFilters>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="default"
-              icon={<Plus className="text-foreground" />}
-              className="w-[26px]"
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuItem className="gap-x-2" asChild>
-              <Link href={`/project/${ref}/logs/explorer`}>
-                <FilePlus size={14} />
-                Create query
-              </Link>
-            </DropdownMenuItem>
-            {warehouseEnabled && (
+
+        {warehouseEnabled ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="default"
+                icon={<Plus className="text-foreground" />}
+                className="w-[26px]"
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem className="gap-x-2" asChild>
+                <Link href={`/project/${ref}/logs/explorer`}>
+                  <FilePlus size={14} />
+                  Create query
+                </Link>
+              </DropdownMenuItem>
+
               <Tooltip>
                 <TooltipTrigger asChild>
                   <DropdownMenuItem className="gap-x-2" asChild>
@@ -253,9 +255,17 @@ export function LogsSidebarMenuV2() {
                   </TooltipContent>
                 )}
               </Tooltip>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <Button
+            type="default"
+            icon={<Plus className="text-foreground" />}
+            className="w-[26px]"
+            onClick={() => router.push(`/project/${ref}/logs/explorer`)}
+          />
+        )}
+
         <CreateWarehouseCollectionModal
           open={createCollectionOpen}
           onOpenChange={setCreateCollectionOpen}

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { Dispatch, SetStateAction, useState } from 'react'
+import { Dispatch, SetStateAction, useState, useEffect } from 'react'
 
 import { IS_PLATFORM } from 'common'
 import {
@@ -45,6 +45,22 @@ const useLogsQuery = (
       ? initialParams.iso_timestamp_end
       : defaultHelper.calcTo(),
   })
+
+  useEffect(() => {
+    setParams((prev) => ({
+      ...prev,
+      ...initialParams,
+      project: projectRef,
+      sql: initialParams?.sql ?? prev.sql,
+      iso_timestamp_start: initialParams.iso_timestamp_start ?? prev.iso_timestamp_start,
+      iso_timestamp_end: initialParams.iso_timestamp_end ?? prev.iso_timestamp_end,
+    }))
+  }, [
+    projectRef,
+    initialParams.sql,
+    initialParams.iso_timestamp_start,
+    initialParams.iso_timestamp_end,
+  ])
 
   const _enabled = enabled && typeof projectRef !== 'undefined' && Boolean(params.sql)
 

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -338,7 +338,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         text: 'Querying large date ranges can be slow. Consider selecting a smaller date range.',
       })
     }
-    if (editorValue && !editorValue.includes('limit')) {
+    if (editorValue && !editorValue.toLowerCase().includes('limit')) {
       newWarnings.push({ text: 'When querying large date ranges, include a LIMIT clause.' })
     }
     setWarnings(newWarnings)


### PR DESCRIPTION
- make warnings tooltip instead of popover so it doesnt have to be clicked
- improve spacing, padding
- fix LIMIT warning not being caught when written in uppercase
- fix bug where log explorer doenst send query with correct time range

## To test:  
- write a query in log explorer
`select
 COUNT(path),
 path
from edge_logs
cross join unnest(metadata) as metadata
cross join unnest(response) AS response
cross join unnest(request) AS request
where
  regexp_contains(path, '^/rest/v1/')
group by path` 

- set date range to 7 days
- you should see 2 warnings

![CleanShot 2025-06-03 at 12 27 18@2x](https://github.com/user-attachments/assets/99554297-9385-4d9f-a271-7ef702b4fac2)
