### PR TITLE
revalidate careers page w/ISR

### DIFF
--- a/apps/www/data/career.json
+++ b/apps/www/data/career.json
@@ -1,7 +1,7 @@
 {
   "company": [
     {
-      "number": "90+",
+      "number": "120+",
       "text": "team members\n\nin 25+ countries"
     },
     {
@@ -9,15 +9,15 @@
       "text": "languages spoken"
     },
     {
-      "number": "$196M",
+      "number": "$396M",
       "text": "in funding"
     },
     {
-      "number": "250,000+",
+      "number": "350,000+",
       "text": "community members"
     },
     {
-      "number": "5,000+",
+      "number": "10,000+",
       "text": "memes posted\n\n(and counting)"
     }
   ],

--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -79,6 +79,7 @@ export async function getStaticProps() {
       placeholderJob: placeholderJob ?? null,
       contributors: contributors,
     },
+    revalidate: 60 * 5, // 5 minutes,
   }
 }
 


### PR DESCRIPTION
- Revalidate careers page every 5 minutes to sync with Ashby without needing new deployment.
- update stats