### PR TITLE
feat(graphql): add paginated errors collection query

### DIFF
--- a/.cursor/rules/docs-graphql.mdc
+++ b/.cursor/rules/docs-graphql.mdc
@@ -211,7 +211,7 @@ export const rootGraphQLSchema = new GraphQLSchema({
 ### 6. Update TypeScript Types
 Run the GraphQL codegen to update TypeScript types:
 ```bash
-pnpm run generate:types
+pnpm run -F docs codegen:graphql
 ```
 
 ## Best Practices

--- a/.cursor/rules/docs-graphql.mdc
+++ b/.cursor/rules/docs-graphql.mdc
@@ -1,0 +1,267 @@
+---
+description: Docs GraphQL Architecture
+globs: apps/docs/resources/**/*.ts
+alwaysApply: false
+---
+
+# Docs GraphQL Architecture
+
+## Overview
+
+The `/apps/docs/resources` folder contains the GraphQL endpoint architecture for the docs GraphQL endpoint at `/api/graphql`. It follows a modular pattern where each top-level query is organized into its own folder with consistent file structure.
+
+## Architecture Pattern
+
+Each GraphQL query follows this structure:
+
+```
+resources/
+├── queryObject/
+│   ├── queryObjectModel.ts      # Data models and business logic
+│   ├── queryObjectSchema.ts     # GraphQL type definitions
+│   ├── queryObjectResolver.ts   # Query resolver and arguments
+│   ├── queryObjectTypes.ts      # TypeScript interfaces (optional)
+│   └── queryObjectSync.ts       # Functions for syncing repo content to the database (optional)
+├── utils/
+│   ├── connections.ts         # GraphQL connection/pagination utilities
+│   └── fields.ts              # GraphQL field selection utilities
+├── rootSchema.ts              # Main GraphQL schema with all queries
+└── rootSync.ts                # Root sync script for syncing to database
+```
+
+## Example queries
+
+1. **searchDocs** (`globalSearch/`) - Vector-based search across all docs content
+2. **error** (`error/`) - Error code lookup for Supabase services  
+3. **schema** - GraphQL schema introspection
+
+## Key Files
+
+### `rootSchema.ts`
+- Main GraphQL schema definition
+- Imports all resolvers and combines them into the root query
+- Defines the `RootQueryType` with all top-level fields
+
+### `utils/connections.ts`
+- Provides `createCollectionType()` for paginated collections
+- `GraphQLCollectionBuilder` for building collection responses
+- Standard pagination arguments and edge/node patterns
+
+### `utils/fields.ts`
+- `graphQLFields()` utility to analyze requested fields in resolvers
+- Used for optimizing data fetching based on what fields are actually requested
+
+## Creating a New Top-Level Query
+
+To add a new GraphQL query, follow these steps:
+
+### 1. Create Query Folder Structure
+```bash
+mkdir resources/newQuery
+touch resources/newQuery/newQueryModel.ts
+touch resources/newQuery/newQuerySchema.ts  
+touch resources/newQuery/newQueryResolver.ts
+```
+
+### 2. Define GraphQL Schema (`newQuerySchema.ts`)
+```typescript
+import { GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const GRAPHQL_FIELD_NEW_QUERY = 'newQuery' as const
+
+export const GraphQLObjectTypeNewQuery = new GraphQLObjectType({
+  name: 'NewQuery',
+  description: 'Description of what this query returns',
+  fields: {
+    id: {
+      type: GraphQLString,
+      description: 'Unique identifier',
+    },
+    // Add other fields...
+  },
+})
+```
+
+### 3. Create Data Model (`newQueryModel.ts`)
+
+> [!NOTE]
+> The data model should be agnostic to GraphQL. It may import argument types
+> from `~/__generated__/graphql`, but otherwise all functions and classes
+> should be unaware of whether they are called for GraphQL resolution.
+
+> [!TIP]
+> The types in `~/__generated__/graphql` for a new endpoint will not exist
+> until the code generation is run in the next step.
+
+```typescript
+import { type RootQueryTypeNewQueryArgs } from '~/__generated__/graphql'
+import { convertPostgrestToApiError, type ApiErrorGeneric } from '~/app/api/utils'
+import { Result } from '~/features/helpers.fn'
+import { supabase } from '~/lib/supabase'
+
+export class NewQueryModel {
+  constructor(public readonly data: {
+    id: string
+    // other properties...
+  }) {}
+
+  static async loadData(
+    args: RootQueryTypeNewQueryArgs,
+    requestedFields: Array<string>
+  ): Promise<Result<NewQueryModel[], ApiErrorGeneric>> {
+    // Implement data fetching logic
+    const result = new Result(
+      await supabase()
+        .from('your_table')
+        .select('*')
+        // Add filters based on args
+    )
+    .map((data) => data.map((item) => new NewQueryModel(item)))
+    .mapError(convertPostgrestToApiError)
+
+    return result
+  }
+}
+```
+
+### 4. Create Resolver (`newQueryResolver.ts`)
+```typescript
+import { GraphQLError, GraphQLNonNull, GraphQLString, type GraphQLResolveInfo } from 'graphql'
+import { type RootQueryTypeNewQueryArgs } from '~/__generated__/graphql'
+import { convertUnknownToApiError } from '~/app/api/utils'
+import { Result } from '~/features/helpers.fn'
+import { graphQLFields } from '../utils/fields'
+import { NewQueryModel } from './newQueryModel'
+import { GRAPHQL_FIELD_NEW_QUERY, GraphQLObjectTypeNewQuery } from './newQuerySchema'
+
+async function resolveNewQuery(
+  _parent: unknown,
+  args: RootQueryTypeNewQueryArgs,
+  _context: unknown,
+  info: GraphQLResolveInfo
+): Promise<NewQueryModel[] | GraphQLError> {
+  return (
+    await Result.tryCatchFlat(
+      resolveNewQueryImpl,
+      convertUnknownToApiError,
+      args,
+      info
+    )
+  ).match(
+    (data) => data,
+    (error) => {
+      console.error(`Error resolving ${GRAPHQL_FIELD_NEW_QUERY}:`, error)
+      return new GraphQLError(error.isPrivate() ? 'Internal Server Error' : error.message)
+    }
+  )
+}
+
+async function resolveNewQueryImpl(
+  args: RootQueryTypeNewQueryArgs,
+  info: GraphQLResolveInfo
+): Promise<Result<NewQueryModel[], ApiErrorGeneric>> {
+  const fieldsInfo = graphQLFields(info)
+  const requestedFields = Object.keys(fieldsInfo)
+  return await NewQueryModel.loadData(args, requestedFields)
+}
+
+export const newQueryRoot = {
+  [GRAPHQL_FIELD_NEW_QUERY]: {
+    description: 'Description of what this query does',
+    args: {
+      id: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: 'Required argument description',
+      },
+      // Add other arguments...
+    },
+    type: GraphQLObjectTypeNewQuery, // or createCollectionType() for lists
+    resolve: resolveNewQuery,
+  },
+}
+```
+
+### 5. Register in Root Schema
+In `rootSchema.ts`, add your resolver:
+
+```typescript
+// Import your resolver
+import { newQueryRoot } from './newQuery/newQueryResolver'
+
+// Add to the query fields
+export const rootGraphQLSchema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'RootQueryType',
+    fields: {
+      ...introspectRoot,
+      ...searchRoot,
+      ...errorRoot,
+      ...newQueryRoot, // Add this line
+    },
+  }),
+  types: [
+    GraphQLObjectTypeGuide,
+    GraphQLObjectTypeReferenceCLICommand,
+    GraphQLObjectTypeReferenceSDKFunction,
+    GraphQLObjectTypeTroubleshooting,
+  ],
+})
+```
+
+### 6. Update TypeScript Types
+Run the GraphQL codegen to update TypeScript types:
+```bash
+pnpm run generate:types
+```
+
+## Best Practices
+
+1. **Error Handling**: Error handling always uses the Result class, defined in apps/docs/features/helpers.fn.ts
+2. **Field Optimization**: Use `graphQLFields()` to only fetch requested data
+3. **Collections**: Use `createCollectionType()` for paginated lists
+4. **Naming**: Use `GRAPHQL_FIELD_*` constants for field names
+5. **Documentation**: Add GraphQL descriptions to all fields and types
+6. **Database**: Use `supabase()` client for database operations with `convertPostgrestToApiError`
+
+## Testing
+
+Tests are located in apps/docs/app/api/graphql/tests. Each top-level query
+should have its own test file, located at <queryName>.test.ts.
+
+### Test data
+
+Test data uses a local database, seeded with the file at supabase/seed.sql. Add
+any data required for running your new query.
+
+### Integration tests
+
+Integration tests import the POST function defined in
+apps/docs/api/graphql/route.ts, then make a request to this function.
+
+For example:
+
+```ts
+import { POST } from '../route'
+
+it('test name', async () => {
+  const query = `
+    query {
+      ...
+    }
+  `
+  const request = new Request('http://localhost/api/graphql', {
+    method: 'POST',
+    body: JSON.stringify({ query }),
+  })
+
+  const result = await POST(request)
+})
+```
+
+Include at least the following tests:
+
+1. A test that requests all fields (including nested fields) on the new query
+   object, and asserts that there are no errors, and the requested fields are
+   properly returned.
+2. A test that triggers and error, and asserts that a GraphQL error is properly
+   returned.

--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -148,6 +148,9 @@ type RootQueryType {
 
     """Returns elements that come before the specified cursor"""
     before: String
+
+    """Filter errors by a specific Supabase service"""
+    service: Service
   ): ErrorCollection
 }
 

--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -134,6 +134,21 @@ type RootQueryType {
 
   """Get the details of an error code returned from a Supabase service"""
   error(code: String!, service: Service!): Error
+
+  """Get error codes that can potentially be returned by Supabase services"""
+  errors(
+    """Returns the first n elements from the list"""
+    first: Int
+
+    """Returns elements that come after the specified cursor"""
+    after: String
+
+    """Returns the last n elements from the list"""
+    last: Int
+
+    """Returns elements that come before the specified cursor"""
+    before: String
+  ): ErrorCollection
 }
 
 """A collection of search results containing content from Supabase docs"""
@@ -177,5 +192,44 @@ enum Service {
   AUTH
   REALTIME
   STORAGE
+}
+
+"""A collection of Errors"""
+type ErrorCollection {
+  """A list of edges containing nodes in this collection"""
+  edges: [ErrorEdge!]!
+
+  """The nodes in this collection, directly accessible"""
+  nodes: [Error!]!
+
+  """Pagination information"""
+  pageInfo: PageInfo!
+
+  """The total count of items available in this collection"""
+  totalCount: Int!
+}
+
+"""An edge in a collection of Errors"""
+type ErrorEdge {
+  """The Error at the end of the edge"""
+  node: Error!
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Pagination information for a collection"""
+type PageInfo {
+  """Whether there are more items after the current page"""
+  hasNextPage: Boolean!
+
+  """Whether there are more items before the current page"""
+  hasPreviousPage: Boolean!
+
+  """Cursor pointing to the start of the current page"""
+  startCursor: String
+
+  """Cursor pointing to the end of the current page"""
+  endCursor: String
 }"
 `;

--- a/apps/docs/app/api/graphql/tests/errors.collection.test.ts
+++ b/apps/docs/app/api/graphql/tests/errors.collection.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest'
+import { supabase } from '~/lib/supabase'
+import { POST } from '../route'
+
+describe('/api/graphql errors collection', () => {
+  it('returns a list of errors with pagination info', async () => {
+    // Get the expected order of errors from the database
+    const { data: dbErrors } = await supabase()
+      .schema('content')
+      .from('error')
+      .select('id, code, ...service(service:name), httpStatusCode:http_status_code, message')
+      .is('deleted_at', null)
+      .order('id', { ascending: true })
+
+    const errorsQuery = `
+      query {
+        errors(first: 2) {
+          totalCount
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              code
+              service
+              httpStatusCode
+              message
+            }
+          }
+          nodes {
+            code
+            service
+            httpStatusCode
+            message
+          }
+        }
+      }
+    `
+    const request = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: errorsQuery }),
+    })
+
+    const result = await POST(request)
+    const {
+      data: { errors },
+      errors: queryErrors,
+    } = await result.json()
+
+    expect(queryErrors).toBeUndefined()
+    expect(errors.totalCount).toBe(3)
+    expect(errors.edges).toHaveLength(2)
+    expect(errors.nodes).toHaveLength(2)
+    expect(errors.pageInfo.hasNextPage).toBe(true)
+    expect(errors.pageInfo.hasPreviousPage).toBe(false)
+    expect(errors.pageInfo.startCursor).toBeDefined()
+    expect(errors.pageInfo.endCursor).toBeDefined()
+
+    // Compare against the first error from the database
+    expect(dbErrors).not.toBe(null)
+    const firstDbError = dbErrors![0]
+    const firstError = errors.nodes[0]
+    expect(firstError.code).toBe(firstDbError.code)
+    expect(firstError.service).toBe(firstDbError.service)
+    expect(firstError.httpStatusCode).toBe(firstDbError.httpStatusCode)
+    expect(firstError.message).toBe(firstDbError.message)
+
+    const firstEdge = errors.edges[0]
+    expect(firstEdge.cursor).toBeDefined()
+    expect(firstEdge.node).toEqual(firstError)
+  })
+
+  it('supports cursor-based pagination', async () => {
+    const firstPageQuery = `
+      query {
+        errors(first: 1) {
+          edges {
+            cursor
+            node {
+              code
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+        }
+      }
+    `
+    const firstRequest = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: firstPageQuery }),
+    })
+
+    const firstResult = await POST(firstRequest)
+    const firstJson = await firstResult.json()
+    expect(firstJson.errors).toBeUndefined()
+    expect(firstJson.data.errors.edges).toHaveLength(1)
+    expect(firstJson.data.errors.pageInfo.hasNextPage).toBe(true)
+    expect(firstJson.data.errors.pageInfo.hasPreviousPage).toBe(false)
+
+    const firstCursor = firstJson.data.errors.edges[0].cursor
+
+    const secondPageQuery = `
+      query {
+        errors(first: 1, after: "${firstCursor}") {
+          edges {
+            cursor
+            node {
+              code
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+        }
+      }
+    `
+    const secondRequest = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: secondPageQuery }),
+    })
+
+    const secondResult = await POST(secondRequest)
+    const secondJson = await secondResult.json()
+    expect(secondJson.errors).toBeUndefined()
+    expect(secondJson.data.errors.edges).toHaveLength(1)
+    expect(secondJson.data.errors.pageInfo.hasPreviousPage).toBe(true)
+
+    expect(firstJson.data.errors.edges[0].node.code).not.toBe(
+      secondJson.data.errors.edges[0].node.code
+    )
+  })
+
+  it('returns empty list when paginating past available results', async () => {
+    const query = `
+      query {
+        errors(first: 1, after: "ffffffff-ffff-ffff-ffff-ffffffffffff") {
+          edges {
+            cursor
+            node {
+              code
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+        }
+      }
+    `
+    const request = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query }),
+    })
+
+    const result = await POST(request)
+    const json = await result.json()
+    expect(json.errors).toBeUndefined()
+    expect(json.data.errors.edges).toHaveLength(0)
+    expect(json.data.errors.pageInfo.hasNextPage).toBe(false)
+    expect(json.data.errors.pageInfo.hasPreviousPage).toBe(true)
+  })
+
+  it('supports backward pagination with last', async () => {
+    const lastPageQuery = `
+      query {
+        errors(last: 1) {
+          edges {
+            cursor
+            node {
+              code
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+        }
+      }
+    `
+    const lastRequest = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: lastPageQuery }),
+    })
+
+    const lastResult = await POST(lastRequest)
+    const lastJson = await lastResult.json()
+    expect(lastJson.errors).toBeUndefined()
+    expect(lastJson.data.errors.edges).toHaveLength(1)
+    expect(lastJson.data.errors.pageInfo.hasNextPage).toBe(false)
+    expect(lastJson.data.errors.pageInfo.hasPreviousPage).toBe(true)
+    const lastCursor = lastJson.data.errors.edges[0].cursor
+
+    const beforeLastQuery = `
+      query {
+        errors(last: 1, before: "${lastCursor}") {
+          edges {
+            cursor
+            node {
+              code
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+        }
+      }
+    `
+    const beforeLastRequest = new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: beforeLastQuery }),
+    })
+    const beforeLastResult = await POST(beforeLastRequest)
+
+    const beforeLastJson = await beforeLastResult.json()
+    expect(beforeLastJson.errors).toBeUndefined()
+    expect(beforeLastJson.data.errors.edges).toHaveLength(1)
+    expect(beforeLastJson.data.errors.pageInfo.hasNextPage).toBe(true)
+    expect(beforeLastJson.data.errors.edges[0].node.code).not.toBe(
+      lastJson.data.errors.edges[0].node.code
+    )
+  })
+})

--- a/apps/docs/app/api/graphql/tests/errors.collection.test.ts
+++ b/apps/docs/app/api/graphql/tests/errors.collection.test.ts
@@ -142,9 +142,13 @@ describe('/api/graphql errors collection', () => {
   })
 
   it('returns empty list when paginating past available results', async () => {
+    // Base64 encode the UUID that's guaranteed to be after any real data
+    const afterCursor = Buffer.from('ffffffff-ffff-ffff-ffff-ffffffffffff', 'utf8').toString(
+      'base64'
+    )
     const query = `
       query {
-        errors(first: 1, after: "ffffffff-ffff-ffff-ffff-ffffffffffff") {
+        errors(first: 1, after: "${afterCursor}") {
           edges {
             cursor
             node {

--- a/apps/docs/app/api/utils.ts
+++ b/apps/docs/app/api/utils.ts
@@ -84,6 +84,30 @@ export class MultiError<ErrorType = unknown, Details extends ObjectOrNever = nev
   }
 }
 
+export class CollectionQueryError extends Error {
+  constructor(
+    message: string,
+    public readonly queryErrors: {
+      count?: PostgrestError
+      data?: PostgrestError
+    }
+  ) {
+    super(message)
+  }
+
+  public static fromErrors(
+    countError: PostgrestError | undefined,
+    dataError: PostgrestError | undefined
+  ): CollectionQueryError {
+    const fetchFailedFor =
+      countError && dataError ? 'count and collection' : countError ? 'count' : 'collection'
+    return new CollectionQueryError(`Failed to fetch ${fetchFailedFor}`, {
+      count: countError,
+      data: dataError,
+    })
+  }
+}
+
 export function convertUnknownToApiError(error: unknown): ApiError {
   return new ApiError('Unknown error', error)
 }

--- a/apps/docs/features/helpers.fn.ts
+++ b/apps/docs/features/helpers.fn.ts
@@ -137,4 +137,24 @@ export class Result<Ok, Error> {
     if (this.isOk()) return onOk(this.internal.data!)
     return onError(this.internal.error!)
   }
+
+  unwrap(): Ok {
+    if (!this.isOk()) {
+      throw new Error(`Unwrap called on Err: ${this.internal.error}`, {
+        cause: this.internal.error,
+      })
+    }
+    return this.internal.data!
+  }
+
+  join<OtherOk, OtherError>(
+    other: Result<OtherOk, OtherError>
+  ): Result<[Ok, OtherOk], [Error, OtherError]> {
+    if (!this.isOk() || !other.isOk())
+      return Result.error([this.internal.error, other.internal.error]) as Result<
+        [Ok, OtherOk],
+        [Error, OtherError]
+      >
+    return Result.ok([this.internal.data!, other.internal.data!])
+  }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -33,6 +33,7 @@
     "sync": "tsx --conditions=react-server ./resources/rootSync.ts",
     "test": "pnpm supabase start && pnpm run test:local && pnpm supabase stop",
     "test:local": "vitest --exclude \"**/*.smoke.test.ts\"",
+    "test:local:unwatch": "vitest --exclude \"**/*.smoke.test.ts\" --run",
     "test:smoke": "pnpm run codegen:references && vitest -t \"prod smoke test\"",
     "troubleshooting:sync": "node features/docs/Troubleshooting.script.mjs",
     "typecheck": "tsc --noEmit"

--- a/apps/docs/resources/error/errorModel.ts
+++ b/apps/docs/resources/error/errorModel.ts
@@ -1,6 +1,13 @@
-import { ApiErrorGeneric, convertPostgrestToApiError, NoDataError } from '~/app/api/utils'
+import { type PostgrestError } from '@supabase/supabase-js'
+import {
+  ApiErrorGeneric,
+  CollectionQueryError,
+  convertPostgrestToApiError,
+  NoDataError,
+} from '~/app/api/utils'
 import { Result } from '~/features/helpers.fn'
 import { supabase } from '~/lib/supabase'
+import { type CollectionFetch } from '../utils/connections'
 
 export const SERVICES = {
   AUTH: {
@@ -15,24 +22,29 @@ export const SERVICES = {
 } as const
 
 type Service = keyof typeof SERVICES
+type ErrorCollectionFetch = CollectionFetch<ErrorModel, never>['fetch']
 
 export class ErrorModel {
+  public id: string
   public code: string
   public service: Service
   public httpStatusCode?: number
   public message?: string
 
   constructor({
+    id,
     code,
     service,
-    httpStatusCode: httpStatusCode,
+    httpStatusCode,
     message,
   }: {
+    id: string
     code: string
     service: Service
     httpStatusCode?: number
     message?: string
   }) {
+    this.id = id
     this.code = code
     this.service = service
     this.httpStatusCode = httpStatusCode
@@ -50,19 +62,25 @@ export class ErrorModel {
       await supabase()
         .schema('content')
         .from('error')
-        .select('code, ...service(service:name), httpStatusCode:http_status_code, message')
+        .select('id, code, service(name), httpStatusCode:http_status_code, message')
         .eq('code', code)
         .eq('service.name', service)
         .is('deleted_at', null)
         .single<{
+          id: string
           code: string
-          service: Service
+          service: {
+            name: Service
+          }
           httpStatusCode?: number
           message?: string
         }>()
     )
       .map((data) => {
-        return new ErrorModel(data)
+        return new ErrorModel({
+          ...data,
+          service: data.service.name,
+        })
       })
       .mapError((error) => {
         if (error.code === 'PGRST116') {
@@ -71,4 +89,94 @@ export class ErrorModel {
         return convertPostgrestToApiError(error)
       })
   }
+
+  static async loadErrors(
+    args: Parameters<ErrorCollectionFetch>[0]
+  ): ReturnType<ErrorCollectionFetch> {
+    const PAGE_SIZE = 20
+    const limit = args?.first ?? args?.last ?? PAGE_SIZE
+
+    const [countResult, errorCodesResult] = await Promise.all([
+      fetchTotalErrorCount(),
+      fetchErrorDescriptions({
+        after: args?.after ?? undefined,
+        before: args?.before ?? undefined,
+        reverse: !!args?.last,
+        limit: limit + 1,
+      }),
+    ])
+
+    return countResult
+      .join(errorCodesResult)
+      .map(([count, errorCodes]) => {
+        const hasMoreItems = errorCodes.length > limit
+        const items = args?.last ? errorCodes.slice(1) : errorCodes.slice(0, limit)
+
+        return {
+          items: items.map((errorCode) => new ErrorModel(errorCode)),
+          totalCount: count,
+          hasNextPage: args?.last ? !!args?.before : hasMoreItems,
+          hasPreviousPage: args?.last ? hasMoreItems : !!args?.after,
+        }
+      })
+      .mapError(([countError, errorCodeError]) => {
+        return CollectionQueryError.fromErrors(countError, errorCodeError)
+      })
+  }
+}
+
+async function fetchTotalErrorCount(): Promise<Result<number, PostgrestError>> {
+  const { count, error } = await supabase()
+    .schema('content')
+    .from('error')
+    .select('id', { count: 'exact', head: true })
+    .is('deleted_at', null)
+  if (error) {
+    return Result.error(error)
+  }
+  return Result.ok(count ?? 0)
+}
+
+type ErrorDescription = {
+  id: string
+  code: string
+  service: Service
+  httpStatusCode?: number
+  message?: string
+}
+
+async function fetchErrorDescriptions({
+  after,
+  before,
+  reverse,
+  limit,
+}: {
+  after?: string
+  before?: string
+  reverse: boolean
+  limit: number
+}): Promise<Result<ErrorDescription[], PostgrestError>> {
+  const query = supabase()
+    .schema('content')
+    .from('error')
+    .select('id, code, service(name), httpStatusCode: http_status_code, message')
+    .is('deleted_at', null)
+    .order('id', { ascending: reverse ? false : true })
+
+  if (after != undefined) {
+    query.gt('id', after)
+  }
+  if (before != undefined) {
+    query.lt('id', before)
+  }
+  query.limit(limit)
+
+  const result = await query
+  return new Result(result).map((results) => {
+    const transformedResults = (reverse ? results.toReversed() : results).map((error) => ({
+      ...error,
+      service: error.service.name,
+    }))
+    return transformedResults as ErrorDescription[]
+  })
 }

--- a/apps/docs/resources/error/errorResolver.ts
+++ b/apps/docs/resources/error/errorResolver.ts
@@ -1,10 +1,21 @@
 import { GraphQLError, GraphQLNonNull, GraphQLResolveInfo, GraphQLString } from 'graphql'
-import { type RootQueryTypeErrorArgs } from '~/__generated__/graphql'
-import { convertUnknownToApiError } from '~/app/api/utils'
+import type {
+  ErrorCollection,
+  RootQueryTypeErrorArgs,
+  RootQueryTypeErrorsArgs,
+} from '~/__generated__/graphql'
+import { ApiError, convertUnknownToApiError } from '~/app/api/utils'
 import { Result } from '~/features/helpers.fn'
+import {
+  createCollectionType,
+  GraphQLCollectionBuilder,
+  paginationArgs,
+  type CollectionFetch,
+} from '../utils/connections'
 import { ErrorModel } from './errorModel'
 import {
   GRAPHQL_FIELD_ERROR_GLOBAL,
+  GRAPHQL_FIELD_ERRORS_GLOBAL,
   GraphQLEnumTypeService,
   GraphQLObjectTypeError,
 } from './errorSchema'
@@ -26,6 +37,39 @@ async function resolveSingleError(
   )
 }
 
+async function resolveErrors(
+  _parent: unknown,
+  args: RootQueryTypeErrorsArgs,
+  _context: unknown,
+  _info: GraphQLResolveInfo
+): Promise<ErrorCollection | GraphQLError> {
+  return (
+    await Result.tryCatchFlat(
+      async (...args) => {
+        const fetch: CollectionFetch<ErrorModel, never, ApiError>['fetch'] = async (fetchArgs) => {
+          const result = await ErrorModel.loadErrors(fetchArgs ?? {})
+          return result.mapError((error) => new ApiError('Failed to resolve error codes', error))
+        }
+        return await GraphQLCollectionBuilder.create<ErrorModel, never, ApiError>({
+          fetch,
+          args: args[0],
+          getCursor: (item) => item.id,
+        })
+      },
+      convertUnknownToApiError,
+      args
+    )
+  ).match(
+    (data) => data as ErrorCollection,
+    (error) => {
+      console.error(`Error resolving ${GRAPHQL_FIELD_ERRORS_GLOBAL}:`, error)
+      return error instanceof GraphQLError
+        ? error
+        : new GraphQLError(error.isPrivate() ? 'Internal Server Error' : error.message)
+    }
+  )
+}
+
 export const errorRoot = {
   [GRAPHQL_FIELD_ERROR_GLOBAL]: {
     description: 'Get the details of an error code returned from a Supabase service',
@@ -39,5 +83,14 @@ export const errorRoot = {
     },
     type: GraphQLObjectTypeError,
     resolve: resolveSingleError,
+  },
+}
+
+export const errorsRoot = {
+  [GRAPHQL_FIELD_ERRORS_GLOBAL]: {
+    description: 'Get error codes that can potentially be returned by Supabase services',
+    args: paginationArgs,
+    type: createCollectionType(GraphQLObjectTypeError),
+    resolve: resolveErrors,
   },
 }

--- a/apps/docs/resources/error/errorSchema.ts
+++ b/apps/docs/resources/error/errorSchema.ts
@@ -8,6 +8,7 @@ import {
 import { SERVICES } from './errorModel'
 
 export const GRAPHQL_FIELD_ERROR_GLOBAL = 'error' as const
+export const GRAPHQL_FIELD_ERRORS_GLOBAL = 'errors' as const
 
 export const GraphQLEnumTypeService = new GraphQLEnumType({
   name: 'Service',

--- a/apps/docs/resources/globalSearch/globalSearchResolver.ts
+++ b/apps/docs/resources/globalSearch/globalSearchResolver.ts
@@ -32,7 +32,8 @@ async function resolveSearch(
       info
     )
   ).match(
-    (data) => GraphQLCollectionBuilder.create({ items: data }),
+    // Building a collection from an array is infallible
+    async (data) => (await GraphQLCollectionBuilder.create({ items: data })).unwrap(),
     (error) => {
       console.error(`Error resolving ${GRAPHQL_FIELD_SEARCH_GLOBAL}:`, error)
       return new GraphQLError(error.isPrivate() ? 'Internal Server Error' : error.message)

--- a/apps/docs/resources/guide/guideSchema.ts
+++ b/apps/docs/resources/guide/guideSchema.ts
@@ -50,7 +50,8 @@ export const GraphQLObjectTypeGuide = new GraphQLObjectType({
       }),
       description:
         'The subsections of the document. If the document is returned from a search match, only matching content chunks are returned. For the full content of the original document, use the content field in the parent Guide.',
-      resolve: (node: GuideModel) => GraphQLCollectionBuilder.create({ items: node.subsections }),
+      resolve: async (node: GuideModel) =>
+        (await GraphQLCollectionBuilder.create({ items: node.subsections })).unwrap(),
     },
   },
 })

--- a/apps/docs/resources/rootSchema.ts
+++ b/apps/docs/resources/rootSchema.ts
@@ -6,7 +6,7 @@ import {
   printSchema,
 } from 'graphql'
 import { RootQueryTypeResolvers } from '~/__generated__/graphql'
-import { errorRoot } from './error/errorResolver'
+import { errorRoot, errorsRoot } from './error/errorResolver'
 import { searchRoot } from './globalSearch/globalSearchResolver'
 import { GraphQLObjectTypeGuide } from './guide/guideSchema'
 import { GraphQLObjectTypeReferenceCLICommand } from './reference/referenceCLISchema'
@@ -37,6 +37,7 @@ export const rootGraphQLSchema = new GraphQLSchema({
       ...introspectRoot,
       ...searchRoot,
       ...errorRoot,
+      ...errorsRoot,
     },
   }),
   types: [

--- a/packages/common/database-types.ts
+++ b/packages/common/database-types.ts
@@ -9,6 +9,7 @@ export type Database = {
           created_at: string | null
           deleted_at: string | null
           http_status_code: number | null
+          id: string
           message: string | null
           metadata: Json | null
           service: string
@@ -19,6 +20,7 @@ export type Database = {
           created_at?: string | null
           deleted_at?: string | null
           http_status_code?: number | null
+          id?: string
           message?: string | null
           metadata?: Json | null
           service: string
@@ -29,6 +31,7 @@ export type Database = {
           created_at?: string | null
           deleted_at?: string | null
           http_status_code?: number | null
+          id?: string
           message?: string | null
           metadata?: Json | null
           service?: string

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -15,4 +15,11 @@ values
     (select id from content.service where name = 'AUTH'),
     500,
     'This is a test error message'
+  ),
+  ('test_code2', (select id from content.service where name = 'AUTH'), 429, 'Too many requests'),
+  (
+    'test_code3',
+    (select id from content.service where name = 'REALTIME'),
+    500,
+    'A realtime error message'
   );


### PR DESCRIPTION
Add a new top-level query field `errors` to get all documented errors generated by Supabase services:

```
  """Get error codes that can potentially be returned by Supabase services"""
  errors(
    """Returns the first n elements from the list"""
    first: Int

    """Returns elements that come after the specified cursor"""
    after: String

    """Returns the last n elements from the list"""
    last: Int

    """Returns elements that come before the specified cursor"""
    before: String

    """Filter errors by a specific Supabase service"""
    service: Service
  ): ErrorCollection

```

- Add new GraphQL query field 'errors' with cursor-based pagination
- Implement error collection resolver with forward/backward pagination
- Add comprehensive test suite for pagination functionality
- Update database types and schema to support new error collection
- Add utility functions for handling collection queries and errors
- Add seed data for testing pagination scenarios

This change allows clients to efficiently paginate through error codes using cursor-based pagination, supporting both forward and backward traversal.

## Example

Query:

```
{
    errors(first: 1, service: AUTH) {
        edges {
            node {
                code
                message
            }
        }
    }
}
```

```response
{
    "data": {
        "errors": {
            "edges": [
                {
                    "node": {
                        "code": "mfa_web_authn_verify_not_enabled",
                        "message": "Login via WebAuthn factors and verification of new WebAuthn factors is disabled."
                    }
                }
            ]
        }
    }
}
```

Resolves DOCS-251