### PR TITLE
Fixing The unnecessacity of calling auth.getUser inside an edge function.(Issue : #35777)

### DIFF
--- a/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
+++ b/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
@@ -1,6 +1,7 @@
 // Follow this setup guide to integrate the Deno language server with your editor:
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
+
 import {decode} from "jsr:@zaubrik/djwt"
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'


### PR DESCRIPTION
In the Page : "supabase.com/docs/guides/functions/auth":
""
 it's suggested that you call auth.getUser with the JWT in order to get the user object. This will do a network request to the auth server to verify the JWT then return the decoded User object. However, unless verify_jwt is set to false for the edge function, the JWT signature is already verified. There's no need to do a network request to check it again. You can simply decode the JWT to get the user object.
""
## Solution : 

Decoded the JWT ,and directly provided the user. Without the unnecessarily need of network request to check again.

Before :
![sss](https://github.com/user-attachments/assets/0a624ff8-1b0e-460b-8326-ec8b0289f28a)
 

After :  
![ss](https://github.com/user-attachments/assets/33c2a594-d1b6-4408-ba12-1b5c30b77df3)

