### PR TITLE
Docs: clarify how to enable column level privileges

### DIFF
--- a/apps/docs/content/guides/database/postgres/column-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/column-level-security.mdx
@@ -82,6 +82,12 @@ This time, we are revoking the column-level `UPDATE` privilege of the `title` co
 
 ## Manage column privileges in the Dashboard
 
+<Admonition type="caution">
+
+Column-level privileges are a powerful tool, but they're also quite advanced and in many cases, not the best fit for common access control needs. For that reason, we've intentionally moved the UI for this feature under the Feature Preview section in the dashboard.
+
+</Admonition>
+
 You can view and edit the privileges in the [Supabase Studio](https://supabase.com/dashboard/project/_/database/column-privileges).
 
 ![Column level privileges](/docs/img/guides/privileges/column-level-privileges-2.png)


### PR DESCRIPTION
This pull request adds a cautionary note to mention that the UI for this feature has been placed under the Feature Preview section in the Supabase dashboard.

<img width="814" alt="image" src="https://github.com/user-attachments/assets/de2646be-eb64-430c-9ddb-09db83834371" />

Documentation update:

* [`apps/docs/content/guides/database/postgres/column-level-security.mdx`](diffhunk://#diff-9a770f7986d0b3192e6bdda7a21f16e9da9b6bb364ad93a23b3dfdddef835722R85-R90).