### PR TITLE
Adjust open new tab SQL Editor CTA

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { IS_PLATFORM } from 'common'
 import { useParams } from 'common/hooks/useParams'
+import { useIsSQLEditorTabsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useSQLSnippetFolderContentsQuery } from 'data/content/sql-folder-contents-query'
 import { Snippet } from 'data/content/sql-folders-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -82,6 +83,7 @@ export const SQLEditorTreeViewItem = ({
   const { profile } = useProfile()
   const { className, onClick } = getNodeProps()
   const snapV2 = useSqlEditorV2StateSnapshot()
+  const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
   const isOwner = profile?.id === element?.metadata.owner_id
   const isSharedSnippet = element.metadata.visibility === 'project'
@@ -265,7 +267,7 @@ export const SQLEditorTreeViewItem = ({
               >
                 <Link
                   href={`/project/${projectRef}/sql/${element.id}`}
-                  target="_blank"
+                  target={isSQLEditorTabsEnabled ? '_self' : '_blank'}
                   rel="noreferrer"
                 >
                   <ExternalLink size={14} />


### PR DESCRIPTION
"Open in new tab" button here opens the new in a new _browser_ tab which doesn't really make sense if the Tabs Interface is enabled. This was brought up in the GH discussion [here](https://github.com/orgs/supabase/discussions/35636#discussioncomment-13235674), so updating the button to just open a new tab in the tabs interface, instead of browser tab if the tabs interface feature preview is enabled

![image](https://github.com/user-attachments/assets/8a6a9387-6592-4371-945c-7a44fcc9351d)
