### PR TITLE
fix infinite loop in api keys

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.utils.ts
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.utils.ts
@@ -1,13 +1,15 @@
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import { useRef } from 'react'
 
 import useLogsQuery from 'hooks/analytics/useLogsQuery'
 
 dayjs.extend(duration)
 dayjs.extend(relativeTime)
 
-export function useLastUsedAPIKeysLogQuery(projectRef: string, now: Date = new Date()) {
+export function useLastUsedAPIKeysLogQuery(projectRef: string) {
+  const now = useRef(new Date()).current
   return useLogsQuery(projectRef, {
     iso_timestamp_start: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(),
     iso_timestamp_end: now.toISOString(),


### PR DESCRIPTION
### Problem. 

- The code used new Date() as a default argument in a hook, which created a new value on every render.
- This caused the query parameters to change every time the component rendered.
- React Query saw the parameters as different and kept refetching data.
- This led to an infinite loop of fetching and re-rendering.
---
### fix:
- Makes sure the "now" timestamp used for fetching API key usage logs is stable and does not change on every render.
- Uses useRef(new Date()).current so the query only uses the time from when the component first mounts.