### PR TITLE
chore: remove unnecessary $ in usage page

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -195,7 +195,7 @@ const Usage = () => {
             title="Usage filtered by project"
             description={
               <div>
-                You are currently viewing usage for the "$
+                You are currently viewing usage for the "
                 {selectedProject?.name || selectedProjectRef}" project. Supabase uses{' '}
                 <Link
                   href="/docs/guides/platform/billing-on-supabase#organization-based-billing"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Typo in the usage page
I don't think it was intended, looks like a string template syntax 

## What is the current behavior?

![Screenshot 2025-06-04 at 21 16 08](https://github.com/user-attachments/assets/bf10efd7-d351-43ee-b91d-e436eefeda9c)

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
