### PR TITLE
Add context menu to Tabs Interface for closing tabs

### DIFF
--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -15,14 +15,23 @@ import { useParams } from 'common'
 import { TabsUpdateTooltip } from 'components/interfaces/App/FeaturePreview/TableEditorTabs'
 import { useAppStateSnapshot } from 'state/app-state'
 import { editorEntityTypes, useTabsStateSnapshot, type Tab } from 'state/tabs'
-import { cn, Tabs_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
+import {
+  cn,
+  ContextMenu_Shadcn_,
+  ContextMenuContent_Shadcn_,
+  ContextMenuItem_Shadcn_,
+  ContextMenuTrigger_Shadcn_,
+  Tabs_Shadcn_,
+  TabsList_Shadcn_,
+  TabsTrigger_Shadcn_,
+} from 'ui'
 import { useEditorType } from '../editors/EditorsLayout.hooks'
 import { CollapseButton } from './CollapseButton'
 import { SortableTab } from './SortableTab'
 import { TabPreview } from './TabPreview'
 
 export const EditorTabs = () => {
-  const { ref } = useParams()
+  const { ref, id } = useParams()
   const router = useRouter()
   const appSnap = useAppStateSnapshot()
 
@@ -59,13 +68,56 @@ export const EditorTabs = () => {
     }
   }
 
-  const handleClose = (id: string) => {
-    const onClearDashboardHistory = () => {
-      if (ref && editor) {
-        appSnap.setDashboardHistory(ref, editor === 'table' ? 'editor' : editor, undefined)
+  const onClearDashboardHistory = () => {
+    if (ref && editor) {
+      appSnap.setDashboardHistory(ref, editor === 'table' ? 'editor' : editor, undefined)
+    }
+  }
+
+  const handleClose = (tabId: string) => {
+    tabs.handleTabClose({ id: tabId, router, editor, onClearDashboardHistory })
+  }
+
+  const handleCloseAll = () => {
+    if (editor) {
+      const tabsToClose =
+        editor === 'table'
+          ? tabs.openTabs.filter((x) => !x.startsWith('sql'))
+          : tabs.openTabs.filter((x) => x.startsWith('sql'))
+
+      tabs.removeTabs(tabsToClose)
+      onClearDashboardHistory()
+      router.push(`/project/${ref}/${editor === 'table' ? 'editor' : 'sql'}`)
+    }
+  }
+
+  const handleCloseOthers = (tabId: string) => {
+    if (editor) {
+      const tabsToClose =
+        editor === 'table'
+          ? tabs.openTabs.filter((x) => !x.startsWith('sql') && x !== tabId)
+          : tabs.openTabs.filter((x) => x.startsWith('sql') && x !== tabId)
+
+      tabs.removeTabs(tabsToClose)
+      onClearDashboardHistory()
+
+      const entityId = editor === 'table' ? tabId.split('-')[1] : tabId.split('sql-')[1]
+      if (id !== entityId) {
+        router.push(`/project/${ref}/${editor === 'table' ? 'editor' : 'sql'}/${entityId}`)
       }
     }
-    tabs.handleTabClose({ id, router, editor, onClearDashboardHistory })
+  }
+
+  const handleCloseRight = (tabId: string) => {
+    if (editor) {
+      const openedTabs =
+        editor === 'table'
+          ? tabs.openTabs.filter((x) => !x.startsWith('sql'))
+          : tabs.openTabs.filter((x) => x.startsWith('sql'))
+      const tabIdx = openedTabs.indexOf(tabId)
+      const tabsToClose = openedTabs.slice(tabIdx + 1)
+      tabs.removeTabs(tabsToClose)
+    }
   }
 
   const handleTabChange = (id: string) => {
@@ -80,19 +132,42 @@ export const EditorTabs = () => {
         onValueChange={handleTabChange}
       >
         <CollapseButton hideTabs={false} />
-        <TabsList_Shadcn_ className="bg-surface-200 dark:bg-alternative rounded-b-none gap-0 h-10 flex items-center w-full z-[1] border-none overflow-clip overflow-x-auto ">
+        <TabsList_Shadcn_
+          className={cn(
+            'rounded-b-none gap-0 h-10 flex items-center w-full z-[1]',
+            'bg-surface-200 dark:bg-alternative border-none overflow-clip overflow-x-auto'
+          )}
+        >
           <SortableContext
             items={editorTabs.map((tab) => tab.id)}
             strategy={horizontalListSortingStrategy}
           >
             {editorTabs.map((tab, index) => (
-              <SortableTab
-                key={tab.id}
-                tab={tab}
-                index={index}
-                openTabs={openTabs}
-                onClose={() => handleClose(tab.id)}
-              />
+              <ContextMenu_Shadcn_>
+                <ContextMenuTrigger_Shadcn_>
+                  <SortableTab
+                    key={tab.id}
+                    tab={tab}
+                    index={index}
+                    openTabs={openTabs}
+                    onClose={() => handleClose(tab.id)}
+                  />
+                </ContextMenuTrigger_Shadcn_>
+                <ContextMenuContent_Shadcn_>
+                  <ContextMenuItem_Shadcn_ onClick={() => handleClose(tab.id)}>
+                    Close
+                  </ContextMenuItem_Shadcn_>
+                  <ContextMenuItem_Shadcn_ onClick={() => handleCloseOthers(tab.id)}>
+                    Close Others
+                  </ContextMenuItem_Shadcn_>
+                  <ContextMenuItem_Shadcn_ onClick={() => handleCloseRight(tab.id)}>
+                    Close to the Right
+                  </ContextMenuItem_Shadcn_>
+                  <ContextMenuItem_Shadcn_ onClick={handleCloseAll}>
+                    Close All
+                  </ContextMenuItem_Shadcn_>
+                </ContextMenuContent_Shadcn_>
+              </ContextMenu_Shadcn_>
             ))}
           </SortableContext>
 

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -353,6 +353,23 @@ function createTabsState(projectRef: string) {
 
       onClose?.(id)
     },
+    handleTabCloseAll: ({
+      editor,
+      router,
+      onClearDashboardHistory,
+    }: {
+      editor: 'sql' | 'table'
+      router: NextRouter
+      onClearDashboardHistory: () => void
+    }) => {
+      const tabsToClose =
+        editor === 'table'
+          ? store.openTabs.filter((x) => !x.startsWith('sql'))
+          : store.openTabs.filter((x) => x.startsWith('sql'))
+      store.removeTabs(tabsToClose)
+      onClearDashboardHistory()
+      router.push(`/project/${router.query.ref}/${editor === 'table' ? 'editor' : 'sql'}`)
+    },
     handleTabDragEnd: (oldIndex: number, newIndex: number, tabId: string, router: any) => {
       // Make permanent if needed
       const draggedTab = store.tabsMap[tabId]


### PR DESCRIPTION
As per suggestion from Tabs Interface GH Discussion [here](https://github.com/orgs/supabase/discussions/35636#discussioncomment-13351469): 
Adds a context menu to the tabs interface to support a few tab closing actions
![image](https://github.com/user-attachments/assets/09ae48ad-19ee-4282-ad2d-fd06d4984f2f)

## Things to test
- Each context menu action works as expected, in particular the post-closing behaviour
  - e.g close all -> should redirect to base page
  - e.g close others -> should redirect to the tab which you hit close others on, if not currently on that tab
- Each context menu action is isolated to just the editor (e.g Hitting "Close to the right" in the table editor, should not affect any tabs in the SQL editor)
