### PR TITLE
fix: Add admonition about pitr to new project for vercel marketplace

### DIFF
--- a/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
@@ -188,6 +188,16 @@ const RestoreToNewProject = () => {
     }
   }
 
+  if (organization?.managed_by === 'vercel-marketplace') {
+    return (
+      <Admonition
+        type="default"
+        title="Restore to new project is not available for Vercel Marketplace organizations"
+        description="Restoring project backups to a new project created via Vercel Marketplace is not supported yet."
+      />
+    )
+  }
+
   if (isFreePlan) {
     return (
       <UpgradeToPro


### PR DESCRIPTION
This is currently not available and once someone does restore it like that, they get locked out of possibility to remove the project, as it's treated as managed by Vercel.