### PR TITLE
fix: remove trailing comma in SQL example in queues blog post

### DIFF
--- a/apps/www/_blog/2024-12-05-supabase-queues.mdx
+++ b/apps/www/_blog/2024-12-05-supabase-queues.mdx
@@ -140,7 +140,7 @@ If you're [connecting](/docs/guides/database/connecting-to-postgres) to your Pos
 ```sql
 select * from pgmq.send(
   queue_name  => 'foo',
-  msg         => '{ "hello": "world" }',
+  msg         => '{ "hello": "world" }'
 );
 ```
 


### PR DESCRIPTION
Fixes #35460 - removes syntax error causing comma in pgmq.send() function call.
