### PR TITLE
feat(docs): add error code filtering to GraphQL errors endpoint

### DIFF
--- a/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
+++ b/apps/docs/app/api/graphql/__snapshots__/route.test.ts.snap
@@ -151,6 +151,9 @@ type RootQueryType {
 
     """Filter errors by a specific Supabase service"""
     service: Service
+
+    """Filter errors by a specific error code"""
+    code: String
   ): ErrorCollection
 }
 

--- a/apps/docs/resources/error/errorResolver.ts
+++ b/apps/docs/resources/error/errorResolver.ts
@@ -61,18 +61,25 @@ async function resolveErrors(
   return (
     await Result.tryCatchFlat(
       async (...args) => {
-        const fetch: CollectionFetch<ErrorModel, { service?: Service }, ApiError>['fetch'] = async (
-          fetchArgs
-        ) => {
+        const fetch: CollectionFetch<
+          ErrorModel,
+          { service?: Service; code?: string },
+          ApiError
+        >['fetch'] = async (fetchArgs) => {
           const result = await ErrorModel.loadErrors({
             ...fetchArgs,
             additionalArgs: {
               service: args[0].service ?? undefined,
+              code: args[0].code ?? undefined,
             },
           })
           return result.mapError((error) => new ApiError('Failed to resolve error codes', error))
         }
-        return await GraphQLCollectionBuilder.create<ErrorModel, { service?: Service }, ApiError>({
+        return await GraphQLCollectionBuilder.create<
+          ErrorModel,
+          { service?: Service; code?: string },
+          ApiError
+        >({
           fetch,
           args: {
             ...args[0],
@@ -121,6 +128,10 @@ export const errorsRoot = {
       service: {
         type: GraphQLEnumTypeService,
         description: 'Filter errors by a specific Supabase service',
+      },
+      code: {
+        type: GraphQLString,
+        description: 'Filter errors by a specific error code',
       },
     },
     type: createCollectionType(GraphQLObjectTypeError),


### PR DESCRIPTION
- Add support for filtering errors by specific error codes
- Implement `errors` query that accepts array of error code IDs
- Add tests for error code filtering functionality
- Update GraphQL schema with new error filtering capabilities

## Example

Query:
```graphql
query {
    errors(code: "mfa_web_authn_verify_not_enabled") {
        nodes {
            service
            message
            httpStatusCode
        }
    }
}
```

Response:
```json
{
    "data": {
        "errors": {
            "nodes": [
                {
                    "service": "AUTH",
                    "message": "Login via WebAuthn factors and verification of new WebAuthn factors is disabled.",
                    "httpStatusCode": null
                }
            ]
        }
    }
}
```