### PR TITLE
chore: Use npm specifier instead of jsr for supabase-js imports

### DIFF
--- a/apps/docs/content/guides/ai/examples/huggingface-image-captioning.mdx
+++ b/apps/docs/content/guides/ai/examples/huggingface-image-captioning.mdx
@@ -41,7 +41,7 @@ Find the complete code on [GitHub](https://github.com/supabase/supabase/tree/mas
 ```ts
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { HfInference } from 'https://esm.sh/@huggingface/inference@2.3.2'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 import { Database } from './types.ts'
 
 console.log('Hello from `huggingface-image-captioning` function!')

--- a/apps/docs/content/guides/ai/hybrid-search.mdx
+++ b/apps/docs/content/guides/ai/hybrid-search.mdx
@@ -166,7 +166,7 @@ from
 In practice, you will likely be calling this from the [Supabase client](/docs/reference/javascript/introduction) or through a custom backend layer. Here is a quick example of how you might call this from an [Edge Function](/docs/guides/functions) using JavaScript:
 
 ```tsx
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 import OpenAI from 'npm:openai'
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL')!

--- a/apps/docs/content/guides/functions/auth.mdx
+++ b/apps/docs/content/guides/functions/auth.mdx
@@ -12,7 +12,7 @@ Edge Functions work seamlessly with [Supabase Auth](/docs/guides/auth).
 When a user makes a request to an Edge Function, you can use the Authorization header to set the Auth context in the Supabase client:
 
 ```js
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 
 Deno.serve(async (req: Request) => {
 
@@ -41,7 +41,7 @@ Importantly, this is done _inside_ the `Deno.serve()` callback argument, so that
 After initializing a Supabase client with the Auth context, you can use `getUser()` to fetch the user object, and run queries in the context of the user with [Row Level Security (RLS)](/docs/guides/database/postgres/row-level-security) policies enforced.
 
 ```js
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 
 Deno.serve(async (req: Request) => {
 
@@ -74,7 +74,7 @@ Deno.serve(async (req: Request) => {
 After initializing a Supabase client with the Auth context, all queries will be executed with the context of the user. For database queries, this means [Row Level Security](/docs/guides/database/postgres/row-level-security) will be enforced.
 
 ```js
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 
 Deno.serve(async (req: Request) => {
 

--- a/apps/docs/content/guides/functions/connect-to-postgres.mdx
+++ b/apps/docs/content/guides/functions/connect-to-postgres.mdx
@@ -14,7 +14,7 @@ You can also use other Postgres clients like [Deno Postgres](https://deno.land/x
 The `supabase-js` client is a great option for connecting to your Supabase database since it handles authorization with Row Level Security, and it automatically formats your response as JSON.
 
 ```ts index.ts
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 
 Deno.serve(async (req) => {
   try {

--- a/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
@@ -98,7 +98,7 @@ In your newly created `supabase/functions/text-to-speech/index.ts` file, add the
 ```ts supabase/functions/text-to-speech/index.ts
 // Setup type definitions for built-in Supabase Runtime APIs
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 import { ElevenLabsClient } from 'npm:elevenlabs@1.52.0'
 import * as hash from 'npm:object-hash'
 

--- a/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
@@ -108,7 +108,7 @@ In your newly created `scribe-bot/index.ts` file, add the following code:
 ```ts supabase/functions/scribe-bot/index.ts
 import { Bot, webhookCallback } from 'https://deno.land/x/grammy@v1.34.0/mod.ts'
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js@2'
 import { ElevenLabsClient } from 'npm:elevenlabs@1.50.5'
 
 console.log(`Function "elevenlabs-scribe-bot" up and running!`)

--- a/apps/docs/content/guides/functions/examples/push-notifications.mdx
+++ b/apps/docs/content/guides/functions/examples/push-notifications.mdx
@@ -53,7 +53,7 @@ Push notifications are an important part of any mobile app. They allow you to se
     1. `supabase secrets set --env-file .env.local`
 
     ```ts supabase/functions/push/index.ts
-    import { createClient } from 'jsr:@supabase/supabase-js@2'
+    import { createClient } from 'npm:@supabase/supabase-js@2'
 
     console.log('Hello from Functions!')
 

--- a/apps/docs/content/guides/functions/unit-test.mdx
+++ b/apps/docs/content/guides/functions/unit-test.mdx
@@ -35,7 +35,7 @@ The following script is a good example to get started with testing your Edge Fun
 ```typescript function-one-test.ts
 // Import required libraries and modules
 import { assert, assertEquals } from 'jsr:@std/assert@1'
-import { createClient, SupabaseClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient, SupabaseClient } from 'npm:@supabase/supabase-js@2'
 
 // Will load the .env file to Deno.env
 import 'jsr:@std/dotenv/load'

--- a/apps/docs/content/guides/functions/websockets.mdx
+++ b/apps/docs/content/guides/functions/websockets.mdx
@@ -123,7 +123,7 @@ To authenticate the user making WebSocket requests, you can pass the JWT in URL 
 >
 <TabPanel id="query" label="Using query params">
 ```ts
-  import { createClient } from "jsr:@supabase/supabase-js@2";
+  import { createClient } from "npm:@supabase/supabase-js@2";
 
 const supabase = createClient(
 Deno.env.get("SUPABASE_URL"),
@@ -173,7 +173,7 @@ return new Response("User is not authenticated", { status: 403 });
 </TabPanel>
 <TabPanel id="protocol" label="Using custom protocol">
 ```ts
-  import { createClient } from "jsr:@supabase/supabase-js@2";
+  import { createClient } from "npm:@supabase/supabase-js@2";
 
 const supabase = createClient(
 Deno.env.get("SUPABASE_URL"),

--- a/apps/docs/content/guides/telemetry/log-drains.mdx
+++ b/apps/docs/content/guides/telemetry/log-drains.mdx
@@ -51,7 +51,7 @@ supabase functions new hello-world
 You can use this example snippet as an illustration of how the received request will be like.
 
 ```ts
-import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import 'npm:@supabase/functions-js/edge-runtime.d.ts'
 
 Deno.serve(async (req) => {
   const data = await req.json()

--- a/apps/docs/docs/ref/javascript/installing.mdx
+++ b/apps/docs/docs/ref/javascript/installing.mdx
@@ -80,7 +80,7 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
   <RefSubLayout.Examples>
 
     ```ts
-      import { createClient } from 'jsr:@supabase/supabase-js@2'
+      import { createClient } from 'npm:@supabase/supabase-js@2'
     ```
 
   </RefSubLayout.Examples>

--- a/examples/edge-functions/supabase/functions/background-upload-storage/index.ts
+++ b/examples/edge-functions/supabase/functions/background-upload-storage/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'jsr:@supabase/supabase-js@2.45.6'
+import { createClient } from 'npm:supabase-js@2'
 import OpenAI from 'https://deno.land/x/openai@v4.68.2/mod.ts'
 
 const client = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY')! })

--- a/examples/edge-functions/supabase/functions/elevenlabs-speech-to-text/index.ts
+++ b/examples/edge-functions/supabase/functions/elevenlabs-speech-to-text/index.ts
@@ -4,7 +4,7 @@
 
 // Setup type definitions for built-in Supabase Runtime APIs
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient } from "npm:supabase-js@2";
 
 console.log(`Function "elevenlabs-scribe-bot" up and running!`);
 

--- a/examples/edge-functions/supabase/functions/elevenlabs-text-to-speech/index.ts
+++ b/examples/edge-functions/supabase/functions/elevenlabs-text-to-speech/index.ts
@@ -1,6 +1,6 @@
 // Setup type definitions for built-in Supabase Runtime APIs
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient } from "npm:supabase-js@2";
 import { ElevenLabsClient } from "npm:elevenlabs@1.52.0";
 import * as hash from "npm:object-hash";
 

--- a/examples/edge-functions/supabase/functions/file-upload-storage/index.ts
+++ b/examples/edge-functions/supabase/functions/file-upload-storage/index.ts
@@ -2,7 +2,7 @@
 // and write files to Supabase Storage and other fields to a database table.
 
 import { Application } from 'https://deno.land/x/oak@v11.1.0/mod.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 
 const MB = 1024 * 1024
 

--- a/examples/edge-functions/supabase/functions/get-tshirt-competition/index.ts
+++ b/examples/edge-functions/supabase/functions/get-tshirt-competition/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 
 console.log(`Function "get-tshirt-competition" up and running!`)

--- a/examples/edge-functions/supabase/functions/huggingface-image-captioning/index.ts
+++ b/examples/edge-functions/supabase/functions/huggingface-image-captioning/index.ts
@@ -1,5 +1,5 @@
 import { HfInference } from 'https://esm.sh/@huggingface/inference@2.3.2'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 import { Database } from './types.ts'
 
 console.log('Hello from `huggingface-image-captioning` function!')

--- a/examples/edge-functions/supabase/functions/openai-image-generation/index.ts
+++ b/examples/edge-functions/supabase/functions/openai-image-generation/index.ts
@@ -2,7 +2,7 @@
 // - `generated-images` bucket already created.
 // - `OPENAI_API_KEY` environment variable set.
 
-import { createClient } from "npm:@supabase/supabase-js@2.49.4";
+import { createClient } from "npm:supabase-js@2";
 import OpenAI, { toFile } from "jsr:@openai/openai@4.96.2";
 
 // Configure COS headers for the function

--- a/examples/edge-functions/supabase/functions/read-storage/index.ts
+++ b/examples/edge-functions/supabase/functions/read-storage/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/examples/edge-functions/supabase/functions/restful-tasks/index.ts
+++ b/examples/edge-functions/supabase/functions/restful-tasks/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient, SupabaseClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient, SupabaseClient } from 'npm:supabase-js@2'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
+++ b/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 
 console.log(`Function "select-from-table-with-auth-rls" up and running!`)

--- a/examples/edge-functions/supabase/functions/sentry/index.ts
+++ b/examples/edge-functions/supabase/functions/sentry/index.ts
@@ -4,7 +4,7 @@
 
 console.log('Hello from the Sentry Functions Challenge!')
 
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 import * as Sentry from 'https://deno.land/x/sentry@7.102.0/index.mjs'
 
 const supabase = createClient(

--- a/examples/edge-functions/supabase/functions/upstash-redis-ratelimit/index.ts
+++ b/examples/edge-functions/supabase/functions/upstash-redis-ratelimit/index.ts
@@ -1,6 +1,6 @@
 import { Redis } from 'https://deno.land/x/upstash_redis@v1.19.3/mod.ts'
 import { Ratelimit } from 'https://cdn.skypack.dev/@upstash/ratelimit@0.4.4'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'npm:supabase-js@2'
 
 console.log(`Function "upstash-redis-counter" up and running!`)
 


### PR DESCRIPTION
There was a [recent incident](https://status.supabase.com/incidents/1v26qpnczmrg) due to JSR registry not correctly updating after a supabase-js release. To prevent such issues in future, updating all examples to use `npm:` specifier for supabase-js instead of `jsr`.