### PR TITLE
chore: add e2e test for sql editor snippets

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -80,6 +80,7 @@ const UtilityActions = ({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
+            data-testId="sql-editor-utility-actions"
             type="default"
             className={cn('px-1', isAiOpen ? 'block 2xl:hidden' : 'hidden')}
             icon={<MoreVertical className="text-foreground-light" />}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -134,6 +134,7 @@ export const SQLEditorMenu = () => {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
+                data-testId="sql-editor-new-query-button"
                 type="default"
                 icon={<Plus className="text-foreground" />}
                 className="w-[26px]"

--- a/e2e/studio/features/home.spec.ts
+++ b/e2e/studio/features/home.spec.ts
@@ -4,9 +4,8 @@ import { toUrl } from '../utils/to-url'
 
 test.describe('Project', async () => {
   test('Can navigate to project home page', async ({ page, ref }) => {
-    console.log(page.url())
     await page.goto(toUrl(`/project/${ref}`))
 
-    await expect(page.getByRole('button', { name: 'Project Status' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Tables' })).toBeVisible()
   })
 })

--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -36,7 +36,7 @@ test.describe('SQL Editor', () => {
 })
 
 test.describe('SQL Snippets', () => {
-  test.only('should create and load a new snippet', async ({ page }) => {
+  test('should create and load a new snippet', async ({ page }) => {
     await page.goto(toUrl(`/project/${env.PROJECT_REF}/sql`))
 
     const addButton = page.getByTestId('sql-editor-new-query-button')
@@ -58,43 +58,44 @@ test.describe('SQL Snippets', () => {
     await runButton.click()
 
     // snippet exists
-    const sqlSnippet = page.getByText('Untitled query', { exact: true })
-    await expect(sqlSnippet).toBeVisible()
+    const privateSnippet = page.getByLabel('private-snippets')
+    await expect(privateSnippet).toContainText('Untitled query')
 
     // favourite snippets
     await page.getByTestId('sql-editor-utility-actions').click()
     await page.getByRole('menuitem', { name: 'Add to favorites', exact: true }).click()
-    await expect(page.getByText('Untitled query', { exact: true })).toHaveCount(2)
+    const favouriteSnippetsSection = page.getByLabel('favorite-snippets')
+    await expect(favouriteSnippetsSection).toContainText('Untitled query')
 
     // unfavorite snippets
     await page.waitForTimeout(500)
     await page.getByTestId('sql-editor-utility-actions').click()
     await page.getByRole('menuitem', { name: 'Remove from favorites' }).click()
+    await expect(favouriteSnippetsSection).not.toBeVisible()
 
     // rename snippet
-    await sqlSnippet.click({ button: 'right' })
+    await privateSnippet.getByText('Untitled query').click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Rename query', exact: true }).click()
     await expect(page.getByRole('heading', { name: 'Rename' })).toBeVisible()
     await page.getByRole('textbox', { name: 'Name' }).fill('test snippet')
     await page.getByRole('button', { name: 'Rename query', exact: true }).click()
 
-    const sqlSnippet2 = page.getByText('test snippet', { exact: true })
-    await expect(sqlSnippet2).toBeVisible()
+    const privateSnippet2 = privateSnippet.getByText('test snippet', { exact: true })
+    await expect(privateSnippet2).toBeVisible()
 
     // share with a team
-    await sqlSnippet2.click({ button: 'right' })
+    await privateSnippet2.click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Share query with team' }).click()
     await expect(page.getByRole('heading', { name: 'Confirm to share query: test' })).toBeVisible()
     await page.getByRole('button', { name: 'Share query', exact: true }).click()
-    await expect(page.getByText('test snippet')).toHaveCount(2)
+    const sharedSnippet = await page.getByLabel('project-level-snippets')
+    await expect(sharedSnippet).toContainText('test snippet')
 
     // unshare a snippet
-    const sqlSnippetshared = page.getByText('test snippet', { exact: true })
-    await sqlSnippetshared.click({ button: 'right' })
+    await sharedSnippet.getByText('test snippet').click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Unshare query with team' }).click()
-
     await expect(page.getByRole('heading', { name: 'Confirm to unshare query:' })).toBeVisible()
     await page.getByRole('button', { name: 'Unshare query', exact: true }).click()
-    await expect(page.getByText('test snippet', { exact: true })).toHaveCount(1)
+    await expect(sharedSnippet).not.toBeVisible()
   })
 })

--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -34,3 +34,67 @@ test.describe('SQL Editor', () => {
     await expect(result).toBeVisible()
   })
 })
+
+test.describe('SQL Snippets', () => {
+  test.only('should create and load a new snippet', async ({ page }) => {
+    await page.goto(toUrl(`/project/${env.PROJECT_REF}/sql`))
+
+    const addButton = page.getByTestId('sql-editor-new-query-button')
+    const runButton = page.getByTestId('sql-run-button')
+    await page.getByRole('button', { name: 'Favorites' }).click()
+    await page.getByRole('button', { name: 'Shared' }).click()
+    await expect(page.getByText('No shared queries')).toBeVisible()
+    await expect(page.getByText('No favorite queries')).toBeVisible()
+
+    // write some sql in the editor
+    await addButton.click()
+    await page.getByRole('menuitem', { name: 'Create a new snippet' }).click()
+
+    const editor = page.getByRole('code').nth(0)
+    await page.waitForTimeout(1000)
+    await editor.click()
+    await page.keyboard.type(`select 'hello world';`)
+    await expect(page.getByText("select 'hello world';")).toBeVisible()
+    await runButton.click()
+
+    // snippet exists
+    const sqlSnippet = page.getByText('Untitled query', { exact: true })
+    await expect(sqlSnippet).toBeVisible()
+
+    // favourite snippets
+    await page.getByTestId('sql-editor-utility-actions').click()
+    await page.getByRole('menuitem', { name: 'Add to favorites', exact: true }).click()
+    await expect(page.getByText('Untitled query', { exact: true })).toHaveCount(2)
+
+    // unfavorite snippets
+    await page.waitForTimeout(500)
+    await page.getByTestId('sql-editor-utility-actions').click()
+    await page.getByRole('menuitem', { name: 'Remove from favorites' }).click()
+
+    // rename snippet
+    await sqlSnippet.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename query', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Rename' })).toBeVisible()
+    await page.getByRole('textbox', { name: 'Name' }).fill('test snippet')
+    await page.getByRole('button', { name: 'Rename query', exact: true }).click()
+
+    const sqlSnippet2 = page.getByText('test snippet', { exact: true })
+    await expect(sqlSnippet2).toBeVisible()
+
+    // share with a team
+    await sqlSnippet2.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Share query with team' }).click()
+    await expect(page.getByRole('heading', { name: 'Confirm to share query: test' })).toBeVisible()
+    await page.getByRole('button', { name: 'Share query', exact: true }).click()
+    await expect(page.getByText('test snippet')).toHaveCount(2)
+
+    // unshare a snippet
+    const sqlSnippetshared = page.getByText('test snippet', { exact: true })
+    await sqlSnippetshared.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Unshare query with team' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Confirm to unshare query:' })).toBeVisible()
+    await page.getByRole('button', { name: 'Unshare query', exact: true }).click()
+    await expect(page.getByText('test snippet', { exact: true })).toHaveCount(1)
+  })
+})

--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   forbidOnly: IS_CI,
-  retries: 3,
+  retries: IS_CI ? 3 : 1,
   use: {
     baseURL: env.STUDIO_URL,
     screenshot: 'off',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- Add e2e test for sql snippet according to Studio testing notion doc

![image](https://github.com/user-attachments/assets/c659f989-d71e-46c5-ac51-ff18c79da1a2)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
