### PR TITLE
docs(edge-functions): update file structure docs for consistency

### DIFF
--- a/apps/docs/content/_partials/edge_functions_file_structure.mdx
+++ b/apps/docs/content/_partials/edge_functions_file_structure.mdx
@@ -1,0 +1,35 @@
+Each function should have its own `deno.json` file to manage dependencies and configure Deno-specific settings. This ensures proper isolation between functions and is the recommended approach for deployment. For a complete list of supported options, see the [official Deno configuration documentation](https://docs.deno.com/runtime/manual/getting_started/configuration_file).
+
+```json supabase/functions/my-function/deno.json
+{
+  "imports": {
+    "lodash": "https://cdn.skypack.dev/lodash"
+  }
+}
+```
+
+The recommended file structure for deployment:
+
+```bash
+└── supabase
+    ├── functions
+    │   ├── _shared
+    │   │   ├── supabaseAdmin.ts # Supabase client with SERVICE_ROLE key.
+    │   │   └── supabaseClient.ts # Supabase client with ANON key.
+    │   │   └── cors.ts # Reusable CORS headers.
+    │   ├── function-one
+    │   │   ├── index.ts
+    │   │   ├─- deno.json    # Function-specific Deno configuration
+    │   │   └── .npmrc       # Function-specific npm configuration (if needed)
+    │   └── function-two
+    │       ├── index.ts
+    │       ├─- deno.json    # Function-specific Deno configuration
+    │       └── .npmrc       # Function-specific npm configuration (if needed)
+    └── config.toml
+```
+
+<Admonition type="caution">
+  While it's possible to use a global `deno.json` in the `/supabase/functions` directory for local
+  development, this approach is not recommended for deployment. Each function should maintain its
+  own configuration to ensure proper isolation and dependency management.
+</Admonition>

--- a/apps/docs/content/guides/functions/dependencies.mdx
+++ b/apps/docs/content/guides/functions/dependencies.mdx
@@ -57,43 +57,15 @@ There are two ways to manage your dependencies in Supabase Edge Functions:
 
 ### Using deno.json (recommended)
 
+
 <Admonition type="note">
 
 This feature requires Supabase CLI version 1.215.0 or higher.
 
 </Admonition>
 
-Each function should have its own `deno.json` file to manage dependencies and configure Deno-specific settings. This ensures proper isolation between functions and is the recommended approach for deployment. For a complete list of supported options, see the [official Deno configuration documentation](https://docs.deno.com/runtime/manual/getting_started/configuration_file).
 
-```json supabase/functions/my-function/deno.json
-{
-  "imports": {
-    "lodash": "https://cdn.skypack.dev/lodash"
-  }
-}
-```
-
-The recommended file structure for deployment:
-
-```bash
-└── supabase
-    ├── functions
-    │   ├── function-one
-    │   │   ├── index.ts
-    │   │   ├─- deno.json    # Function-specific Deno configuration
-    │   │   └── .npmrc       # Function-specific npm configuration (if needed)
-    │   └── function-two
-    │       ├── index.ts
-    │       ├─- deno.json    # Function-specific Deno configuration
-    │       └── .npmrc       # Function-specific npm configuration (if needed)
-    └── config.toml
-```
-
-<Admonition type="caution">
-  While it's possible to use a global `deno.json` in the `/supabase/functions` directory for local
-  development, this approach is not recommended for deployment. Each function should maintain its
-  own configuration to ensure proper isolation and dependency management.
-</Admonition>
+<$Partial path="edge_functions_file_structure.mdx" />
 
 ### Using import maps (legacy)
 

--- a/apps/docs/content/guides/functions/dependencies.mdx
+++ b/apps/docs/content/guides/functions/dependencies.mdx
@@ -57,13 +57,11 @@ There are two ways to manage your dependencies in Supabase Edge Functions:
 
 ### Using deno.json (recommended)
 
-
 <Admonition type="note">
 
 This feature requires Supabase CLI version 1.215.0 or higher.
 
 </Admonition>
-
 
 <$Partial path="edge_functions_file_structure.mdx" />
 

--- a/apps/docs/content/guides/functions/development-tips.mdx
+++ b/apps/docs/content/guides/functions/development-tips.mdx
@@ -34,35 +34,16 @@ We recommend using hyphens to name functions because hyphens are the most URL-fr
 ### Organizing your Edge Functions
 
 We recommend developing "fat functions". This means that you should develop few large functions, rather than many small functions. One common pattern when developing Functions is that you need to share code between two or more Functions. To do this, you can store any shared code in a folder prefixed with an underscore (`_`). We also recommend a separate folder for [Unit Tests](/docs/guides/functions/unit-test) including the name of the function followed by a `-test` suffix.
-We recommend this folder structure:
 
-```bash
-└── supabase
-    ├── functions
-    │   ├── import_map.json # A top-level import map to use across functions.
-    │   ├── _shared
-    │   │   ├── supabaseAdmin.ts # Supabase client with SERVICE_ROLE key.
-    │   │   └── supabaseClient.ts # Supabase client with ANON key.
-    │   │   └── cors.ts # Reusable CORS headers.
-    │   ├── function-one # Use hyphens to name functions.
-    │   │   └── index.ts
-    │   └── function-two
-    │   │   └── index.ts
-    │   └── tests
-    │       └── function-one-test.ts
-    │       └── function-two-test.ts
-    ├── migrations
-    └── config.toml
-```
+<$Partial path="edge_functions_file_structure.mdx" />
 
 ### Using config.toml
 
-Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/guides/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) can be set via the `config.toml` file.
 
 ```toml supabase/config.toml
 [functions.hello-world]
 verify_jwt = false
-import_map = './import_map.json'
 ```
 
 ### Not using TypeScript


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The **development tips** docs have an example of using `import_maps.json` whilst the **manage dependencies** docs shows `deno.json` as the recommended way for managing dependencies.

## What is the new behavior?

The **development tips** and **manage dependencies** docs both show `deno.json` as the recommended way for managing dependencies.

## Additional context

Fixes #36303
