### PR TITLE
docs: update the message for users with deprecated extensions

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -219,8 +219,8 @@ const InfrastructureInfo = () => {
                             {projectUpgradeEligibilityData?.potential_breaking_changes?.includes(
                               'pg17_upgrade_unsupported_extensions'
                             )
-                              ? 'These extensions are not supported in newer versions of Supabase Postgres.'
-                              : 'You can add them back after the upgrade is done. Check the docs for which ones might need to be removed.'}
+                              ? 'These extensions are not supported in newer versions of Supabase Postgres. If you are not using them, it is safe to remove them.'
+                              : 'Check the docs for which ones might need to be removed.'}
                           </p>
 
                           <div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The previous message shown to users was found to be confusing. Updating to do the following:

1. Make it clear that if you were not using them, they can be removed
2. Not suggesting to turn them back on after upgrade, as they are deprecated. 
