### PR TITLE
monitoring(docs,content api): send resolver errors to sentry

### DIFF
--- a/apps/docs/resources/globalSearch/globalSearchResolver.ts
+++ b/apps/docs/resources/globalSearch/globalSearchResolver.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs'
 import {
   GraphQLError,
   GraphQLInt,
@@ -36,6 +37,9 @@ async function resolveSearch(
     async (data) => (await GraphQLCollectionBuilder.create({ items: data })).unwrap(),
     (error) => {
       console.error(`Error resolving ${GRAPHQL_FIELD_SEARCH_GLOBAL}:`, error)
+      if (!error.isUserError()) {
+        Sentry.captureException(error)
+      }
       return new GraphQLError(error.isPrivate() ? 'Internal Server Error' : error.message)
     }
   )


### PR DESCRIPTION
Resolver errors currently not being sent to Sentry, should be tracking these.