### PR TITLE
Reinstate pnpm command for running studio in non hosted mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ gcloud.json
 
 # Sentry CLI config
 **/.sentryclirc
+
+keys.json

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "turbo run dev --parallel",
     "dev:cms": "turbo run dev --filter=cms --parallel",
     "dev:studio": "turbo run dev --filter=studio --parallel",
-    "dev:studio-local": "pnpm run --dir tests/studio-tests codegen:setup",
+    "dev:studio-local": "pnpm setup:cli && NODE_ENV=test pnpm --prefix ./apps/studio dev",
     "dev:docs": "turbo run dev --filter=docs --parallel",
     "dev:www": "turbo run dev --filter=www --parallel",
     "dev:design-system": "turbo run dev --filter=design-system --parallel",
@@ -42,6 +42,7 @@
 
     "perf:kong": "ab -t 5 -c 20 -T application/json http://localhost:8000/",
     "perf:meta": "ab -t 5 -c 20 -T application/json http://localhost:5555/tables",
+    "setup:cli": "supabase start -x studio && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
     "generate:types": "supabase gen types typescript --local > ./supabase/functions/common/database-types.ts",
     "api:codegen": "cd packages/api-types && pnpm run codegen",
     "knip": "pnpx knip@~5.50.0"

--- a/scripts/generateLocalEnv.js
+++ b/scripts/generateLocalEnv.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+const generatedEnv = require('../keys.json')
+
+/**
+ * This script takes the API keys from the local environment, merges them with some predefined variables and saves them
+ * to a env.test file in the studio app. This is needed to prepare the studio so that it can be run with the local
+ * environment as the backend.
+ */
+
+const defaultEnv = {
+  // POSTGRES_PASSWORD: 'postgres',
+  // NEXT_ANALYTICS_BACKEND_PROVIDER: 'postgres',
+  // SUPABASE_REST_URL: 'http://127.0.0.1:54321/rest/v1/',
+  // NEXT_PUBLIC_ENABLE_LOGS: 'false',
+  // NEXT_PUBLIC_IS_PLATFORM: 'false',
+  SUPABASE_ANON_KEY: '$ANON_KEY',
+  SUPABASE_SERVICE_KEY: '$SERVICE_ROLE_KEY',
+  SUPABASE_URL: '$API_URL',
+  STUDIO_PG_META_URL: '$API_URL/pg',
+  SUPABASE_PUBLIC_URL: '$API_URL',
+  SENTRY_IGNORE_API_RESOLUTION_ERROR: '1',
+  LOGFLARE_URL: 'http://localhost:54329',
+  LOGFLARE_API_KEY: 'api-key',
+  NEXT_PUBLIC_SITE_URL: 'http://localhost:8082',
+  NEXT_PUBLIC_GOTRUE_URL: '$SUPABASE_PUBLIC_URL/auth/v1',
+  NEXT_PUBLIC_HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',
+  NEXT_PUBLIC_NODE_ENV: 'test',
+}
+
+const environment = { ...generatedEnv, ...defaultEnv }
+
+fs.writeFileSync(
+  './apps/studio/.env.test',
+  Object.keys(environment)
+    .map((key) => `${key}=${environment[key]}`)
+    .join('\n')
+)


### PR DESCRIPTION
For convenience - we previously had a command that would allow us to run the dashboard in local / self-hosted set up using a local supabase project as the BE. This PR adds that back in