### PR TITLE
fix: studio create buckets

### DIFF
--- a/apps/docs/content/guides/storage/buckets/creating-buckets.mdx
+++ b/apps/docs/content/guides/storage/buckets/creating-buckets.mdx
@@ -93,6 +93,17 @@ supabase.storage.create_bucket(
 </TabPanel>
 </Tabs>
 
+<details>
+<summary>Show/Hide allowed bucket naming rules</summary>
+
+| `Allowed Characters` | `Examples`                                                                 |
+| -------------------- | -------------------------------------------------------------------------- |
+| `Letters`            | `A-Z`,`a-z`                                                                |
+| `Numbers`            | `0-9`                                                                      |
+| `Special Characters` | `!`, `.`, `*`, `'`, `()`, `&`, `$`, `@`, `=`, `;`, `:`, `+`, `,`, `?`, ` ` |
+
+</details>
+
 ## Restricting uploads
 
 When creating a bucket you can add additional configurations to restrict the type or size of files you want this bucket to contain.

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -58,9 +58,8 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
       errors.name = 'Please provide a name for your bucket'
     }
 
-    if (values.name && !/^[a-z0-9.-]+$/.test(values.name)) {
-      errors.name =
-        'The name of the bucket must only container lowercase letters, numbers, dots, and hyphens'
+    if (values.name && !/^(\w|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/.test(values.name)) {
+      errors.name = 'The name of the bucket has invalid characters.'
     }
 
     if (values.name && values.name.endsWith(' ')) {
@@ -126,8 +125,19 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
                   layout="vertical"
                   label="Name of bucket"
                   labelOptional="Buckets cannot be renamed once created."
-                  descriptionText="Only lowercase letters, numbers, dots, and hyphens"
                 />
+                <div className="space-y-2 mt-3">
+                  <Link
+                    href="https://supabase.com/docs/guides/storage/buckets/creating-buckets"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <div className="flex items-center space-x-2 opacity-50 hover:opacity-100 transition">
+                      <p className="text-sm m-0">View allowed characters for bucket names</p>
+                      <ExternalLink size={16} strokeWidth={1.5} />
+                    </div>
+                  </Link>
+                </div>
                 <div className="space-y-2 mt-6">
                   <Toggle
                     id="public"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Storage > Create Bucket

## What is the current behavior?

The check for bucket names does not match the api check.

## What is the new behavior?

Bucket naming rule matches api rules and also docs update:


https://github.com/user-attachments/assets/b167956a-5f27-4f95-9c7e-8a8b083b79a2


https://github.com/user-attachments/assets/590c7b1c-5f92-4bc0-b3ea-320e0b59b99a



## Additional context

Closes #34470 
