### PR TITLE
Add edge functions empty state for local/self-host

### DIFF
--- a/apps/studio/components/interfaces/EdgeFunctions/DeployEdgeFunctionButton.tsx
+++ b/apps/studio/components/interfaces/EdgeFunctions/DeployEdgeFunctionButton.tsx
@@ -1,0 +1,118 @@
+import { ChevronDown, Code, Terminal } from 'lucide-react'
+import { useRouter } from 'next/router'
+
+import { useParams } from 'common'
+import { TerminalInstructions } from 'components/interfaces/Functions/TerminalInstructions'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
+import {
+  AiIconAnimation,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogSection,
+  DialogTitle,
+  DialogTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'ui'
+
+export const DeployEdgeFunctionButton = () => {
+  const router = useRouter()
+  const { ref } = useParams()
+  const org = useSelectedOrganization()
+  const snap = useAiAssistantStateSnapshot()
+
+  const { mutate: sendEvent } = useSendEventMutation()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="primary" iconRight={<ChevronDown className="w-4 h-4" strokeWidth={1.5} />}>
+          Deploy a new function
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80">
+        <DropdownMenuItem
+          onSelect={() => {
+            router.push(`/project/${ref}/functions/new`)
+            sendEvent({
+              action: 'edge_function_via_editor_button_clicked',
+              properties: { origin: 'secondary_action' },
+              groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+            })
+          }}
+          className="gap-4"
+        >
+          <Code className="shrink-0" size={16} strokeWidth={1.5} />
+          <div>
+            <span className="text-foreground">Via Editor</span>
+            <p>Write and deploy in the browser</p>
+          </div>
+        </DropdownMenuItem>
+        <Dialog>
+          <DialogTrigger asChild>
+            <DropdownMenuItem
+              className="gap-4"
+              onSelect={(e) => {
+                e.preventDefault()
+                sendEvent({
+                  action: 'edge_function_via_cli_button_clicked',
+                  properties: { origin: 'secondary_action' },
+                  groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+                })
+              }}
+            >
+              <Terminal className="shrink-0" size={16} strokeWidth={1.5} />
+              <div>
+                <span className="text-foreground">Via CLI</span>
+                <p>Write locally, deploy with the CLI</p>
+              </div>
+            </DropdownMenuItem>
+          </DialogTrigger>
+          <DialogContent size="large">
+            <DialogTitle className="sr-only">
+              Create your first Edge Function via the CLI
+            </DialogTitle>
+            <DialogSection padding="small">
+              <TerminalInstructions />
+            </DialogSection>
+          </DialogContent>
+        </Dialog>
+        <DropdownMenuItem
+          className="gap-4"
+          onSelect={() => {
+            snap.newChat({
+              name: 'Create new edge function',
+              open: true,
+              initialInput: `Create a new edge function that ...`,
+              suggestions: {
+                title:
+                  'I can help you create a new edge function. Here are a few example prompts to get you started:',
+                prompts: [
+                  'Create a new edge function that processes payments with Stripe',
+                  'Create a new edge function that sends emails with Resend',
+                  'Create a new edge function that generates PDFs from HTML templates',
+                ],
+              },
+            })
+            sendEvent({
+              action: 'edge_function_ai_assistant_button_clicked',
+              properties: { origin: 'secondary_action' },
+              groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+            })
+          }}
+        >
+          <AiIconAnimation className="shrink-0" size={16} />
+          <div>
+            <span className="text-foreground">Via AI Assistant</span>
+            <p>Let the Assistant write and deploy for you</p>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -189,9 +189,8 @@ export const FunctionsEmptyStateLocal = () => {
                 <Code size={20} />
                 <h4 className="text-base text-foreground">Create an Edge Function</h4>
               </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4">
-                Create a new edge function called{' '}
-                <code className="text-foreground">hello-world</code> in your project via the
+              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full">
+                Create a new edge function called <code>hello-world</code> in your project via the
                 Supabase CLI.
               </p>
               <div className="mb-4">
@@ -212,9 +211,8 @@ export const FunctionsEmptyStateLocal = () => {
                 <Play size={20} />
                 <h4 className="text-base text-foreground">Run Edge Functions locally</h4>
               </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4">
-                You can run your Edge Function locally using{' '}
-                <code className="text-foreground">supabase functions serve</code>.
+              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full">
+                You can run your Edge Function locally using <code>supabase functions serve</code>.
               </p>
               <div className="mb-4">
                 <CodeBlock
@@ -342,17 +340,13 @@ export const FunctionsSecretsEmptyStateLocal = () => {
               ways
             </p>
             <ul className="list-disc pl-6">
-              <li>
-                Through an <code className="text-foreground">.env</code> file placed at{' '}
-                <code className="text-foreground">supabase/functions/.env</code>, which is
-                automatically loaded on <code className="text-foreground">supabase start</code>
+              <li className="prose [&>code]:text-xs text-sm max-w-full">
+                Through an <code>.env</code> file placed at <code>supabase/functions/.env</code>,
+                which is automatically loaded on <code>supabase start</code>
               </li>
-              <li>
-                Through the <code className="text-foreground">--env-file</code> option for{' '}
-                <code className="text-foreground">supabase functions serve</code>, for example: s
-                <code className="text-foreground">
-                  upabase functions serve --env-file ./path/to/.env-file
-                </code>
+              <li className="prose [&>code]:text-xs text-sm max-w-full">
+                Through the <code>--env-file</code> option for <code>supabase functions serve</code>
+                , for example: <code>supabase functions serve --env-file ./path/to/.env-file</code>
               </li>
             </ul>
           </div>

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -1,12 +1,14 @@
+import { Code, Github, Play, Server, Terminal } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
 import { useParams } from 'common'
 import { ScaffoldSectionTitle } from 'components/layouts/Scaffold'
+import { DocsButton } from 'components/ui/DocsButton'
 import { ResourceItem } from 'components/ui/Resource/ResourceItem'
 import { ResourceList } from 'components/ui/Resource/ResourceList'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { Code, Terminal } from 'lucide-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import {
   AiIconAnimation,
@@ -15,11 +17,18 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  cn,
+  CodeBlock,
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogHeader,
   DialogSection,
+  DialogTitle,
   DialogTrigger,
+  Separator,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { EDGE_FUNCTION_TEMPLATES } from './Functions.templates'
 import { TerminalInstructions } from './TerminalInstructions'
 
@@ -157,6 +166,156 @@ export const FunctionsEmptyState = () => {
           </ResourceItem>
         ))}
       </ResourceList>
+    </>
+  )
+}
+
+export const FunctionsEmptyStateLocal = () => {
+  return (
+    <>
+      <div className="flex flex-col gap-y-4">
+        <Admonition
+          className="mb-0"
+          type="note"
+          title="Management of Edge Functions is currently not supported via Studio for CLI or self-host"
+          description="You can still develop and test edge functions locally, or explore self-hosting the Supabase Edge Runtime."
+        />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Developing Edge Functions locally</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+            <div className="p-8">
+              <div className="flex items-center gap-2">
+                <Code size={20} />
+                <h4 className="text-base text-foreground">Create an Edge Function</h4>
+              </div>
+              <p className="text-sm text-foreground-light mt-1 mb-4">
+                Create a new edge function called{' '}
+                <code className="text-foreground">hello-world</code> in your project via the
+                Supabase CLI.
+              </p>
+              <div className="mb-4">
+                <CodeBlock
+                  language="bash"
+                  hideLineNumbers={true}
+                  className={cn('px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 min-h-28')}
+                  value="supabase functions new hello-world"
+                />
+              </div>
+              <DocsButton href="https://supabase.com/docs/guides/functions/local-quickstart#create-an-edge-function" />
+            </div>
+
+            <div className="p-8">
+              <div className="flex items-center gap-2">
+                <Play size={20} />
+                <h4 className="text-base text-foreground">Run Edge Functions locally</h4>
+              </div>
+              <p className="text-sm text-foreground-light mt-1 mb-4">
+                You can run your Edge Function locally using{' '}
+                <code className="text-foreground">supabase functions serve</code>.
+              </p>
+              <div className="mb-4">
+                <CodeBlock
+                  language="bash"
+                  hideLineNumbers={true}
+                  className={cn('px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 min-h-28')}
+                  value={`
+supabase start # start the supabase stack
+supabase functions serve # start the Functions watcher`.trim()}
+                />
+              </div>
+              <DocsButton href="https://supabase.com/docs/guides/functions/local-quickstart#running-edge-functions-locally" />
+            </div>
+
+            <div className="p-8">
+              <div className="flex items-center gap-2">
+                <Terminal strokeWidth={1.5} size={20} />
+                <h4 className="text-base text-foreground">Invoke Edge Functions locally</h4>
+              </div>
+              <p className="text-sm text-foreground-light mt-1 mb-4">
+                While serving your local Edge Functions, you can invoke it using cURL or one of the
+                client libraries.
+              </p>
+              <div className="mb-4">
+                <CodeBlock
+                  language="bash"
+                  hideLineNumbers={true}
+                  className={cn('px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 min-h-28')}
+                  value={`
+curl --request POST 'http://localhost:54321/functions/v1/hello-world' \\
+  --header 'Authorization: Bearer SUPABASE_ANON_KEY' \\
+  --header 'Content-Type: application/json' \\
+  --data '{ "name":"Functions" }'`.trim()}
+                />
+              </div>
+              <DocsButton href="https://supabase.com/docs/guides/functions/local-quickstart#invoking-edge-functions-locally" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Self-hosting Edge Functions</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+            <div className="p-8">
+              <div className="flex items-center gap-2">
+                <Server size={20} />
+                <h4 className="text-base text-foreground">Self-hosting Edge Functions</h4>
+              </div>
+              <p className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+                Supabase Edge Runtime consists of a web server based on the Deno runtime, capable of
+                running Javascript, Typescript, and WASM services. You may self-host edge functions
+                on providers like Fly.io, Digital Ocean, or AWS.
+              </p>
+              <div className="flex items-center gap-x-2">
+                <DocsButton href="https://supabase.com/docs/reference/self-hosting-functions/introduction" />
+                <Button asChild type="default" icon={<Github />}>
+                  <a href="https://github.com/supabase/edge-runtime/">GitHub</a>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <ScaffoldSectionTitle className="text-xl mt-12">Explore our templates</ScaffoldSectionTitle>
+        <ResourceList>
+          {EDGE_FUNCTION_TEMPLATES.map((template) => (
+            <Dialog>
+              <DialogTrigger asChild>
+                <ResourceItem
+                  key={template.name}
+                  media={<Code strokeWidth={1.5} size={16} className="-translate-y-[9px]" />}
+                >
+                  <div>
+                    <p>{template.name}</p>
+                    <p className="text-sm text-foreground-lighter">{template.description}</p>
+                  </div>
+                </ResourceItem>
+              </DialogTrigger>
+              <DialogContent size="large">
+                <DialogHeader>
+                  <DialogTitle>{template.name}</DialogTitle>
+                  <DialogDescription>{template.description}</DialogDescription>
+                </DialogHeader>
+                <Separator />
+                <DialogSection className="!p-0">
+                  <CodeBlock
+                    language="ts"
+                    hideLineNumbers={true}
+                    className={cn(
+                      'border-0 rounded-none px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 max-h-[420px]'
+                    )}
+                    value={template.content}
+                  />
+                </DialogSection>
+              </DialogContent>
+            </Dialog>
+          ))}
+        </ResourceList>
+      </div>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -1,4 +1,4 @@
-import { Code, Github, Play, Server, Terminal } from 'lucide-react'
+import { Code, Github, Lock, Play, Server, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
@@ -28,7 +28,6 @@ import {
   DialogTrigger,
   Separator,
 } from 'ui'
-import { Admonition } from 'ui-patterns'
 import { EDGE_FUNCTION_TEMPLATES } from './Functions.templates'
 import { TerminalInstructions } from './TerminalInstructions'
 
@@ -174,18 +173,17 @@ export const FunctionsEmptyStateLocal = () => {
   return (
     <>
       <div className="flex flex-col gap-y-4">
-        <Admonition
-          className="mb-0"
-          type="note"
-          title="Management of Edge Functions is currently not supported via Studio for CLI or self-host"
-          description="You can still develop and test edge functions locally, or explore self-hosting the Supabase Edge Runtime."
-        />
-
         <Card>
           <CardHeader>
             <CardTitle>Developing Edge Functions locally</CardTitle>
           </CardHeader>
-          <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+          <CardContent
+            className={cn(
+              'p-0 flex flex-col',
+              '2xl:grid 2xl:grid-cols-[repeat(auto-fit,minmax(240px,1fr))] 2xl:divide-y-0 2xl:divide-x',
+              'divide-y divide-default items-stretch'
+            )}
+          >
             <div className="p-8">
               <div className="flex items-center gap-2">
                 <Code size={20} />
@@ -200,7 +198,9 @@ export const FunctionsEmptyStateLocal = () => {
                 <CodeBlock
                   language="bash"
                   hideLineNumbers={true}
-                  className={cn('px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 min-h-28')}
+                  className={cn(
+                    'px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 2xl:min-h-28'
+                  )}
                   value="supabase functions new hello-world"
                 />
               </div>
@@ -220,7 +220,9 @@ export const FunctionsEmptyStateLocal = () => {
                 <CodeBlock
                   language="bash"
                   hideLineNumbers={true}
-                  className={cn('px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 min-h-28')}
+                  className={cn(
+                    'px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 2xl:min-h-28'
+                  )}
                   value={`
 supabase start # start the supabase stack
 supabase functions serve # start the Functions watcher`.trim()}
@@ -242,7 +244,9 @@ supabase functions serve # start the Functions watcher`.trim()}
                 <CodeBlock
                   language="bash"
                   hideLineNumbers={true}
-                  className={cn('px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 min-h-28')}
+                  className={cn(
+                    'px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 2xl:min-h-28'
+                  )}
                   value={`
 curl --request POST 'http://localhost:54321/functions/v1/hello-world' \\
   --header 'Authorization: Bearer SUPABASE_ANON_KEY' \\
@@ -317,5 +321,44 @@ curl --request POST 'http://localhost:54321/functions/v1/hello-world' \\
         </ResourceList>
       </div>
     </>
+  )
+}
+
+export const FunctionsSecretsEmptyStateLocal = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Managing secrets and environment variables locally</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+        <div className="p-8">
+          <div className="flex items-center gap-2">
+            <Lock size={20} />
+            <h4 className="text-base text-foreground">Managing secrets</h4>
+          </div>
+          <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+            <p>
+              Local secrets and environment variables can be loaded in either of the following two
+              ways
+            </p>
+            <ul className="list-disc pl-6">
+              <li>
+                Through an <code className="text-foreground">.env</code> file placed at{' '}
+                <code className="text-foreground">supabase/functions/.env</code>, which is
+                automatically loaded on <code className="text-foreground">supabase start</code>
+              </li>
+              <li>
+                Through the <code className="text-foreground">--env-file</code> option for{' '}
+                <code className="text-foreground">supabase functions serve</code>, for example: s
+                <code className="text-foreground">
+                  upabase functions serve --env-file ./path/to/.env-file
+                </code>
+              </li>
+            </ul>
+          </div>
+          <DocsButton href="https://supabase.com/docs/guides/functions/secrets#using-the-cli" />
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout.tsx
@@ -4,7 +4,6 @@ import { PropsWithChildren } from 'react'
 import { useParams } from 'common'
 import { ProductMenu } from 'components/ui/ProductMenu'
 import { withAuth } from 'hooks/misc/withAuth'
-import { IS_PLATFORM } from 'lib/constants'
 import ProjectLayout from '../ProjectLayout/ProjectLayout'
 
 const EdgeFunctionsProductMenu = () => {
@@ -23,16 +22,12 @@ const EdgeFunctionsProductMenu = () => {
           url: `/project/${projectRef}/functions`,
           items: [],
         },
-        ...(IS_PLATFORM
-          ? [
-              {
-                name: 'Secrets',
-                key: 'secrets',
-                url: `/project/${projectRef}/functions/secrets`,
-                items: [],
-              },
-            ]
-          : []),
+        {
+          name: 'Secrets',
+          key: 'secrets',
+          url: `/project/${projectRef}/functions/secrets`,
+          items: [],
+        },
       ],
     },
   ]

--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react'
 import { useParams } from 'common'
 import { ProductMenu } from 'components/ui/ProductMenu'
 import { withAuth } from 'hooks/misc/withAuth'
+import { IS_PLATFORM } from 'lib/constants'
 import ProjectLayout from '../ProjectLayout/ProjectLayout'
 
 const EdgeFunctionsProductMenu = () => {
@@ -22,12 +23,16 @@ const EdgeFunctionsProductMenu = () => {
           url: `/project/${projectRef}/functions`,
           items: [],
         },
-        {
-          name: 'Secrets',
-          key: 'secrets',
-          url: `/project/${projectRef}/functions/secrets`,
-          items: [],
-        },
+        ...(IS_PLATFORM
+          ? [
+              {
+                name: 'Secrets',
+                key: 'secrets',
+                url: `/project/${projectRef}/functions/secrets`,
+                items: [],
+              },
+            ]
+          : []),
       ],
     },
   ]

--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -99,7 +99,7 @@ export const generateProductRoutes = (
           },
         ]
       : []),
-    ...(IS_PLATFORM && edgeFunctionsEnabled
+    ...(edgeFunctionsEnabled
       ? [
           {
             key: 'functions',

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -1,10 +1,13 @@
-import { ChevronDown, Code, ExternalLink, Terminal } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import { useRouter } from 'next/router'
 
 import { useParams } from 'common'
+import { DeployEdgeFunctionButton } from 'components/interfaces/EdgeFunctions/DeployEdgeFunctionButton'
 import { EdgeFunctionsListItem } from 'components/interfaces/Functions/EdgeFunctionsListItem'
-import { FunctionsEmptyState } from 'components/interfaces/Functions/FunctionsEmptyState'
-import { TerminalInstructions } from 'components/interfaces/Functions/TerminalInstructions'
+import {
+  FunctionsEmptyState,
+  FunctionsEmptyStateLocal,
+} from 'components/interfaces/Functions/FunctionsEmptyState'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import EdgeFunctionsLayout from 'components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
@@ -16,21 +19,10 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useEdgeFunctionsQuery } from 'data/edge-functions/edge-functions-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { IS_PLATFORM } from 'lib/constants'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import type { NextPageWithLayout } from 'types'
-import {
-  AiIconAnimation,
-  Button,
-  Dialog,
-  DialogContent,
-  DialogSection,
-  DialogTitle,
-  DialogTrigger,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from 'ui'
+import { Button } from 'ui'
 
 const EdgeFunctionsPage: NextPageWithLayout = () => {
   const { ref } = useParams()
@@ -47,94 +39,6 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
   const org = useSelectedOrganization()
 
   const hasFunctions = (functions ?? []).length > 0
-
-  const deployButton = (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button type="primary" iconRight={<ChevronDown className="w-4 h-4" strokeWidth={1.5} />}>
-          Deploy a new function
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-80">
-        <DropdownMenuItem
-          onSelect={() => {
-            router.push(`/project/${ref}/functions/new`)
-            sendEvent({
-              action: 'edge_function_via_editor_button_clicked',
-              properties: { origin: 'secondary_action' },
-              groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
-            })
-          }}
-          className="gap-4"
-        >
-          <Code className="shrink-0" size={16} strokeWidth={1.5} />
-          <div>
-            <span className="text-foreground">Via Editor</span>
-            <p>Write and deploy in the browser</p>
-          </div>
-        </DropdownMenuItem>
-        <Dialog>
-          <DialogTrigger asChild>
-            <DropdownMenuItem
-              className="gap-4"
-              onSelect={(e) => {
-                e.preventDefault()
-                sendEvent({
-                  action: 'edge_function_via_cli_button_clicked',
-                  properties: { origin: 'secondary_action' },
-                  groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
-                })
-              }}
-            >
-              <Terminal className="shrink-0" size={16} strokeWidth={1.5} />
-              <div>
-                <span className="text-foreground">Via CLI</span>
-                <p>Write locally, deploy with the CLI</p>
-              </div>
-            </DropdownMenuItem>
-          </DialogTrigger>
-          <DialogContent size="large">
-            <DialogTitle className="sr-only">
-              Create your first Edge Function via the CLI
-            </DialogTitle>
-            <DialogSection padding="small">
-              <TerminalInstructions />
-            </DialogSection>
-          </DialogContent>
-        </Dialog>
-        <DropdownMenuItem
-          className="gap-4"
-          onSelect={() => {
-            snap.newChat({
-              name: 'Create new edge function',
-              open: true,
-              initialInput: `Create a new edge function that ...`,
-              suggestions: {
-                title:
-                  'I can help you create a new edge function. Here are a few example prompts to get you started:',
-                prompts: [
-                  'Create a new edge function that processes payments with Stripe',
-                  'Create a new edge function that sends emails with Resend',
-                  'Create a new edge function that generates PDFs from HTML templates',
-                ],
-              },
-            })
-            sendEvent({
-              action: 'edge_function_ai_assistant_button_clicked',
-              properties: { origin: 'secondary_action' },
-              groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
-            })
-          }}
-        >
-          <AiIconAnimation className="shrink-0" size={16} />
-          <div>
-            <span className="text-foreground">Via AI Assistant</span>
-            <p>Let the Assistant write and deploy for you</p>
-          </div>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
 
   const secondaryActions = [
     <DocsButton key="docs" href="https://supabase.com/docs/guides/functions" />,
@@ -154,41 +58,45 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
       size="large"
       title="Edge Functions"
       subtitle="Deploy edge functions to handle complex business logic"
-      primaryActions={deployButton}
+      primaryActions={IS_PLATFORM ? <DeployEdgeFunctionButton /> : undefined}
       secondaryActions={secondaryActions}
     >
       <ScaffoldContainer size="large">
         <ScaffoldSection isFullWidth>
-          {isLoading && <GenericSkeletonLoader />}
-
-          {isError && <AlertError error={error} subject="Failed to retrieve edge functions" />}
-
-          {isSuccess && (
+          {IS_PLATFORM ? (
             <>
-              {hasFunctions ? (
-                <Table
-                  head={
-                    <>
-                      <Table.th>Name</Table.th>
-                      <Table.th>URL</Table.th>
-                      <Table.th className="hidden 2xl:table-cell">Created</Table.th>
-                      <Table.th className="lg:table-cell">Last updated</Table.th>
-                      <Table.th className="lg:table-cell">Deployments</Table.th>
-                    </>
-                  }
-                  body={
-                    <>
-                      {functions.length > 0 &&
-                        functions.map((item) => (
-                          <EdgeFunctionsListItem key={item.id} function={item} />
-                        ))}
-                    </>
-                  }
-                />
-              ) : (
-                <FunctionsEmptyState />
+              {isLoading && <GenericSkeletonLoader />}
+              {isError && <AlertError error={error} subject="Failed to retrieve edge functions" />}
+              {isSuccess && (
+                <>
+                  {hasFunctions ? (
+                    <Table
+                      head={
+                        <>
+                          <Table.th>Name</Table.th>
+                          <Table.th>URL</Table.th>
+                          <Table.th className="hidden 2xl:table-cell">Created</Table.th>
+                          <Table.th className="lg:table-cell">Last updated</Table.th>
+                          <Table.th className="lg:table-cell">Deployments</Table.th>
+                        </>
+                      }
+                      body={
+                        <>
+                          {functions.length > 0 &&
+                            functions.map((item) => (
+                              <EdgeFunctionsListItem key={item.id} function={item} />
+                            ))}
+                        </>
+                      }
+                    />
+                  ) : (
+                    <FunctionsEmptyState />
+                  )}
+                </>
               )}
             </>
+          ) : (
+            <FunctionsEmptyStateLocal />
           )}
         </ScaffoldSection>
       </ScaffoldContainer>

--- a/apps/studio/pages/project/[ref]/functions/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/functions/secrets.tsx
@@ -1,14 +1,16 @@
 import EdgeFunctionSecrets from 'components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets'
+import { FunctionsSecretsEmptyStateLocal } from 'components/interfaces/Functions/FunctionsEmptyState'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import EdgeFunctionsLayout from 'components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer } from 'components/layouts/Scaffold'
+import { IS_PLATFORM } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
 
 const SecretsPage: NextPageWithLayout = () => {
   return (
     <ScaffoldContainer size="large" className="pt-6">
-      <EdgeFunctionSecrets />
+      {IS_PLATFORM ? <EdgeFunctionSecrets /> : <FunctionsSecretsEmptyStateLocal />}
     </ScaffoldContainer>
   )
 }

--- a/apps/studio/pages/project/[ref]/functions/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/functions/secrets.tsx
@@ -22,7 +22,7 @@ SecretsPage.getLayout = (page) => {
         <PageLayout
           size="large"
           title="Edge Function Secrets"
-          subtitle="Manage the secrets for your project's edge functions"
+          subtitle="Manage the secrets for your project's Edge Functions"
         >
           {page}
         </PageLayout>

--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -126,21 +126,23 @@ const Home: NextPageWithLayout = () => {
                     </p>
                   </div>
 
-                  <div className="flex flex-col gap-y-1">
-                    <Link
-                      href={`/project/${ref}/functions`}
-                      className="transition text-foreground-light hover:text-foreground text-sm"
-                    >
-                      Functions
-                    </Link>
-                    <p className="text-2xl tabular-nums">
-                      {isLoadingFunctions ? (
-                        <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
-                      ) : (
-                        functionsCount
-                      )}
-                    </p>
-                  </div>
+                  {IS_PLATFORM && (
+                    <div className="flex flex-col gap-y-1">
+                      <Link
+                        href={`/project/${ref}/functions`}
+                        className="transition text-foreground-light hover:text-foreground text-sm"
+                      >
+                        Functions
+                      </Link>
+                      <p className="text-2xl tabular-nums">
+                        {isLoadingFunctions ? (
+                          <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
+                        ) : (
+                          functionsCount
+                        )}
+                      </p>
+                    </div>
+                  )}
 
                   {IS_PLATFORM && (
                     <div className="flex flex-col gap-y-1">


### PR DESCRIPTION
## Context

Management of edge functions in the dashboard for local CLI or self-host is currently not available and we hide the Edge Functions button in the side bar navigation in those environments.

However, this has led to some confusions about the parity difference between the hosted and non-hosted "versions" of the dashboard, so we're bridging this gap a little by minimally not hiding the Edge Functions button + adding an empty state UI for managing edge functions with local CLI or self-host

![image](https://github.com/user-attachments/assets/b3ab416c-fd2c-422e-a643-2141d05d4398)
![image](https://github.com/user-attachments/assets/52ec7609-196b-42eb-b9ec-6296777e7a2d)


Templates are still available for reference and clicking on them will open the template snippet in a modal
![image](https://github.com/user-attachments/assets/f0e62995-dcf5-466c-b542-137c28199ada)
![image](https://github.com/user-attachments/assets/5f20c0b1-3dad-4a26-9b16-7388049cdece)

## What to test / verify

- [ ] Content for the added empty state makes sense from a dev's POV and are factually correct
- [ ] Changes should not affect the hosted dashboard's Edge Functions pages