### PR TITLE
fix: include primary database identifier in API report filtering

### DIFF
--- a/apps/studio/data/reports/api-report-query.ts
+++ b/apps/studio/data/reports/api-report-query.ts
@@ -65,7 +65,7 @@ export const useApiReport = () => {
   // [Joshen] Keeping database selector separate from filter state, and merging them here for simplicity
   const formattedFilters: ReportFilterItem[] = [
     ...filters,
-    ...(identifier !== undefined && identifier !== project?.ref
+    ...(identifier !== undefined
       ? [{ key: 'identifier', value: `'${identifier}'`, compare: 'is' } as ReportFilterItem]
       : []),
   ]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
API reports are filtering by secondary identifiers but are missing the primary database identifier in the filter criteria. This means the primary database identifier is not being included when generating filtered reports, creating inconsistent filtering behavior across different identifier types.

## What is the new behavior?
API reports now include the primary database identifier in the filtering logic alongside the existing secondary identifiers. This ensures consistent and complete filtering behavior across all identifier types.