### PR TITLE
fix: managed by header

### DIFF
--- a/apps/studio/data/organizations/organization-create-mutation.ts
+++ b/apps/studio/data/organizations/organization-create-mutation.ts
@@ -6,6 +6,7 @@ import { handleError, post } from 'data/fetchers'
 import { permissionKeys } from 'data/permissions/keys'
 import type { ResponseError } from 'types'
 import { organizationKeys } from './keys'
+import { castOrganizationResponseToOrganization } from './organizations-query'
 
 export type OrganizationCreateVariables = {
   name: string
@@ -71,7 +72,7 @@ export const useOrganizationCreateMutation = ({
           },
           (prev: any) => {
             if (!prev) return prev
-            return [...prev, data]
+            return [...prev, castOrganizationResponseToOrganization(data)]
           }
         )
 

--- a/apps/studio/data/organizations/organizations-query.ts
+++ b/apps/studio/data/organizations/organizations-query.ts
@@ -6,7 +6,7 @@ import { useProfile } from 'lib/profile'
 import type { Organization, ResponseError } from 'types'
 import { organizationKeys } from './keys'
 
-function castOrganizationResponseToOrganization(
+export function castOrganizationResponseToOrganization(
   org: components['schemas']['OrganizationResponse']
 ): Organization {
   return {


### PR DESCRIPTION
When pushing the org into the org list, there is a banner showing "managed by ", because the "managed_by" property is missing, which is only set when retrieving data on organization listing.
