### PR TITLE
Reinstate inline editor and assistant for local CLI and self host

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -206,6 +206,16 @@ const LayoutHeader = ({
           ) : (
             <>
               <LocalVersionPopover />
+              <div className="overflow-hidden flex items-center rounded-full border">
+                <AnimatePresence initial={false}>
+                  {!!projectRef && (
+                    <>
+                      <InlineEditorButton />
+                      <AssistantButton />
+                    </>
+                  )}
+                </AnimatePresence>
+              </div>
               <LocalDropdown />
             </>
           )}


### PR DESCRIPTION
Inline Editor and Assistant were accidentally removed for local CLI / self-host in this PR [here](https://github.com/supabase/supabase/pull/36269), so reinstating them

![image](https://github.com/user-attachments/assets/88191520-3534-42e9-b026-9fbc61d2b74d)
