### PR TITLE
fix: trim confirmation input and comparison

### DIFF
--- a/apps/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
@@ -37,7 +37,7 @@ export const DeleteOrganizationButton = () => {
     if (!values.orgName) {
       errors.orgName = 'Enter the name of the organization.'
     }
-    if (values.orgName !== orgSlug) {
+    if (values.orgName.trim() !== orgSlug?.trim()) {
       errors.orgName = 'Value entered does not match the value above.'
     }
     return errors

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -80,9 +80,12 @@ const TextConfirmModal = forwardRef<
     ref
   ) => {
     const formSchema = z.object({
-      confirmValue: z.literal(confirmString, {
-        required_error: 'Value entered does not match.',
-      }),
+      confirmValue: z.preprocess(
+        (val) => (typeof val === 'string' ? val.trim() : val),
+        z.literal(confirmString.trim(), {
+          required_error: 'Value entered does not match.',
+        })
+      ),
     })
 
     // 1. Define your form.


### PR DESCRIPTION
We regularly have customer support tickets that cannot confirm because of a mismatching space at the end (and they cannot for the life of them figure this one out).

Trimming both input and comparison string will prevent unnecessary support tickets and still guarantees enough safety.