### PR TITLE
Restore spaces

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -80,7 +80,7 @@ const PolicyRow = ({
                 {policy.roles.slice(0, 3).map((role, i) => (
                   <span key={`policy-${role}-${i}`}>
                     <code className="text-foreground-light text-xs">{role}</code>
-                    {i < Math.min(policy.roles.length, 3) - 1 && ', '}
+                    {i < Math.min(policy.roles.length, 3) - 1 ? ', ' : ' '}
                   </span>
                 ))}
                 {policy.roles.length > 1 ? 'roles' : 'role'}


### PR DESCRIPTION
fixes spacing issue added in https://github.com/supabase/supabase/pull/36067/files


Before: 

![screenshot-2025-06-11-at-14 53 20](https://github.com/user-attachments/assets/91d5fbb0-22bb-4ca4-af4e-ce5eaa596627)


After: 
![screenshot-2025-06-11-at-14 52 00](https://github.com/user-attachments/assets/95f32fdf-58ee-441f-9625-542b00e2fa9b)


Imo the tooltip if roles > 3 isn't really necessary here