### PR TITLE
Add org_not_found param to detect if landing on a proper org

### DIFF
--- a/apps/studio/components/interfaces/App/RouteValidationWrapper.tsx
+++ b/apps/studio/components/interfaces/App/RouteValidationWrapper.tsx
@@ -69,8 +69,8 @@ const RouteValidationWrapper = ({ children }: PropsWithChildren<{}>) => {
       const isValidOrg = organizations.some((org) => org.slug === slug)
 
       if (!isValidOrg) {
-        toast.error('This organization does not exist')
-        router.push(DEFAULT_HOME)
+        toast.error("We couldn't find that organization")
+        router.push(`${DEFAULT_HOME}?error=org_not_found&org=${slug}`)
         return
       }
     }

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
+import { useParams } from 'common'
 import AppLayout from 'components/layouts/AppLayout/AppLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainerLegacy, ScaffoldTitle } from 'components/layouts/Scaffold'
@@ -14,12 +15,21 @@ import { useProjectsQuery } from 'data/projects/projects-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { withAuth } from 'hooks/misc/withAuth'
 import { NextPageWithLayout } from 'types'
-import { Button, Skeleton } from 'ui'
+import {
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Alert_Shadcn_,
+  Button,
+  CriticalIcon,
+  Skeleton,
+} from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
 const OrganizationsPage: NextPageWithLayout = () => {
   const router = useRouter()
   const [search, setSearch] = useState('')
+  const { error: orgNotFoundError, org: orgSlug } = useParams()
+  const orgNotFound = orgNotFoundError === 'org_not_found'
 
   const { data: projects = [] } = useProjectsQuery()
   const { data: organizations = [], error, isLoading, isError, isSuccess } = useOrganizationsQuery()
@@ -34,14 +44,33 @@ const OrganizationsPage: NextPageWithLayout = () => {
 
   useEffect(() => {
     // If there are no organizations, force the user to create one
-    if (isSuccess && organizations.length <= 0) {
+    // unless the user is on the not found page
+    if (isSuccess && organizations.length <= 0 && !orgNotFound) {
       router.push('/new')
     }
   }, [isSuccess, organizations])
 
   return (
     <ScaffoldContainerLegacy>
+      {orgNotFound && (
+        <Alert_Shadcn_ variant="destructive">
+          <CriticalIcon />
+          <AlertTitle_Shadcn_>Organization not found</AlertTitle_Shadcn_>
+          <AlertDescription_Shadcn_>
+            That organization (<code>{orgSlug}</code>) does not exist or you don't have access to
+            it.
+          </AlertDescription_Shadcn_>
+          <AlertDescription_Shadcn_ className="mt-3">
+            If you think this is an error, please reach out to the org owner to get access.
+          </AlertDescription_Shadcn_>
+        </Alert_Shadcn_>
+      )}
+
       <ScaffoldTitle>Your Organizations</ScaffoldTitle>
+
+      {organizations.length === 0 && orgNotFound && (
+        <p className="-mt-4">You don't have any organizations yet. Create one to get started.</p>
+      )}
 
       <div className="flex items-center gap-x-2 md:gap-x-3">
         {organizationCreationEnabled && (
@@ -49,14 +78,17 @@ const OrganizationsPage: NextPageWithLayout = () => {
             <Link href={`/new`}>New organization</Link>
           </Button>
         )}
-        <Input
-          size="tiny"
-          placeholder="Search for an organization"
-          icon={<Search size={16} />}
-          className="w-full flex-1 md:w-64 [&>div>div>div>input]:!pl-7 [&>div>div>div>div]:!pl-2"
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-        />
+
+        {organizations.length > 0 && (
+          <Input
+            size="tiny"
+            placeholder="Search for an organization"
+            icon={<Search size={16} />}
+            className="w-full flex-1 md:w-64 [&>div>div>div>input]:!pl-7 [&>div>div>div>div]:!pl-2"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        )}
       </div>
 
       {search.length > 0 && filteredOrganizations.length === 0 && (


### PR DESCRIPTION
Issue: 
- users land at supabase.com/org/abc 
- if they don't have access to that org, they get automatically redirected to `/organizations`

It isn't transparent to them what's happening there.  
We want to make it explicit that they don't have access and let them choose what to do next (try again, ask the org owner, create a new org, etc) 

PR adds:
- a new param (org_not_found) to org links so users don't get automatically redirected
- an alert if org_not_found is present 
- a change in the redirect if the user doesn't yet have an org

![screenshot-2025-06-11-at-16 39 50](https://github.com/user-attachments/assets/6ac09990-bb05-43a3-8136-2a88d10c5ad0)
