### PR TITLE
Update new project flow to add a warning before redirecting

### DIFF
--- a/apps/studio/components/interfaces/Organization/NewProject/NotOrganizationOwnerWarning.tsx
+++ b/apps/studio/components/interfaces/Organization/NewProject/NotOrganizationOwnerWarning.tsx
@@ -1,19 +1,30 @@
 import InformationBox from 'components/ui/InformationBox'
 import { AlertCircle } from 'lucide-react'
 
+interface NotOrganizationOwnerWarningProps {
+  slug?: string
+}
+
 // [Joshen] This can just use NoPermission component i think
-const NotOrganizationOwnerWarning = () => {
+const NotOrganizationOwnerWarning = ({ slug }: NotOrganizationOwnerWarningProps) => {
   return (
     <div className="mt-4">
       <InformationBox
-        icon={<AlertCircle className="text-white" size="20" strokeWidth={1.5} />}
+        icon={<AlertCircle size="20" strokeWidth={1.5} />}
         defaultVisibility={true}
         hideCollapse
         title="You do not have permission to create a project"
         description={
           <div className="space-y-3">
             <p className="text-sm leading-normal">
-              Contact your organization owner or administrator to create a new project.
+              {slug ? (
+                <>
+                  Contact the owner or administrator to create a new project in the{' '}
+                  <code>{slug}</code> organization.
+                </>
+              ) : (
+                <>Contact the owner or administrator to create a new project.</>
+              )}
             </p>
           </div>
         }

--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -1,9 +1,10 @@
 import AlertError from 'components/ui/AlertError'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { Skeleton } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 import { OrganizationCard } from './OrganizationCard'
 
-export const OrgNotFound = () => {
+export const OrgNotFound = ({ slug }: { slug?: string }) => {
   const {
     data: organizations,
     isSuccess: isOrganizationsSuccess,
@@ -14,6 +15,18 @@ export const OrgNotFound = () => {
 
   return (
     <>
+      <Admonition type="danger">
+        The selected organization does not exist or you don't have permissions to access it.{' '}
+        {slug ? (
+          <>
+            Contact the owner or administrator to create a new project in the <code>{slug}</code>{' '}
+            organization.
+          </>
+        ) : (
+          <>Contact the owner or administrator to create a new project.</>
+        )}
+      </Admonition>
+
       <h3 className="text-sm">Select an organization to create your new project from</h3>
 
       <div className="grid gap-2 grid-cols-2">

--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -16,7 +16,7 @@ export const OrgNotFound = ({ slug }: { slug?: string }) => {
   return (
     <>
       <Admonition type="danger">
-        The selected organization does not exist or you don't have permissions to access it.{' '}
+        The selected organization does not exist or you don't have permission to access it.{' '}
         {slug ? (
           <>
             Contact the owner or administrator to create a new project in the <code>{slug}</code>{' '}

--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -1,0 +1,35 @@
+import AlertError from 'components/ui/AlertError'
+import { useOrganizationsQuery } from 'data/organizations/organizations-query'
+import { Skeleton } from 'ui'
+import { OrganizationCard } from './OrganizationCard'
+
+export const OrgNotFound = () => {
+  const {
+    data: organizations,
+    isSuccess: isOrganizationsSuccess,
+    isLoading: isOrganizationsLoading,
+    isError: isOrganizationsError,
+    error: organizationsError,
+  } = useOrganizationsQuery()
+
+  return (
+    <>
+      <h3 className="text-sm">Select an organization to create your new project from</h3>
+
+      <div className="grid gap-2 grid-cols-2">
+        {isOrganizationsLoading && (
+          <>
+            <Skeleton className="h-[62px] rounded-md" />
+            <Skeleton className="h-[62px] rounded-md" />
+            <Skeleton className="h-[62px] rounded-md" />
+          </>
+        )}
+        {isOrganizationsError && (
+          <AlertError error={organizationsError} subject="Failed to load organizations" />
+        )}
+        {isOrganizationsSuccess &&
+          organizations?.map((org) => <OrganizationCard key={org.slug} organization={org} />)}
+      </div>
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
@@ -1,0 +1,23 @@
+import { Boxes } from 'lucide-react'
+import Link from 'next/link'
+
+import { ActionCard } from 'components/ui/ActionCard'
+import { useProjectsQuery } from 'data/projects/projects-query'
+import { Organization } from 'types'
+
+export const OrganizationCard = ({ organization }: { organization: Organization }) => {
+  const { data: allProjects = [] } = useProjectsQuery()
+  const numProjects = allProjects.filter((x) => x.organization_slug === organization.slug).length
+
+  return (
+    <Link href={`/new/${organization.slug}`}>
+      <ActionCard
+        bgColor="bg border"
+        className="[&>div]:items-center"
+        icon={<Boxes size={18} strokeWidth={1} className="text-foreground" />}
+        title={organization.name}
+        description={`${organization.plan.name} Plan${numProjects > 0 ? `${'  '}•${'  '}${numProjects} project${numProjects > 1 ? 's' : ''}` : ''}`}
+      />
+    </Link>
+  )
+}

--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -45,7 +45,10 @@ export const OrganizationDropdown = () => {
 
   return (
     <>
-      <Link href={`/org/${slug}`} className="flex items-center gap-2 flex-shrink-0 text-sm">
+      <Link
+        href={slug ? `/org/${slug}` : '/organizations'}
+        className="flex items-center gap-2 flex-shrink-0 text-sm"
+      >
         <Boxes size={14} strokeWidth={1.5} className="text-foreground-lighter" />
         <span
           className={cn(

--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -47,10 +47,17 @@ export const OrganizationDropdown = () => {
     <>
       <Link href={`/org/${slug}`} className="flex items-center gap-2 flex-shrink-0 text-sm">
         <Boxes size={14} strokeWidth={1.5} className="text-foreground-lighter" />
-        <span className="text-foreground max-w-32 lg:max-w-none truncate hidden md:block">
-          {orgName}
+        <span
+          className={cn(
+            'max-w-32 lg:max-w-none truncate hidden md:block',
+            !!selectedOrganization ? 'text-foreground' : 'text-foreground-lighter'
+          )}
+        >
+          {orgName ?? 'Select an organization'}
         </span>
-        <Badge variant="default">{selectedOrganization?.plan.name}</Badge>
+        {!!selectedOrganization && (
+          <Badge variant="default">{selectedOrganization?.plan.name}</Badge>
+        )}
       </Link>
       <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
         <PopoverTrigger_Shadcn_ asChild>

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { debounce } from 'lodash'
-import { Boxes, ExternalLink } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react'
@@ -16,6 +16,7 @@ import {
   FreeProjectLimitWarning,
   NotOrganizationOwnerWarning,
 } from 'components/interfaces/Organization/NewProject'
+import { OrgNotFound } from 'components/interfaces/Organization/OrgNotFound'
 import { AdvancedConfiguration } from 'components/interfaces/ProjectCreation/AdvancedConfiguration'
 import {
   extractPostgresVersionDetails,
@@ -27,8 +28,6 @@ import { SecurityOptions } from 'components/interfaces/ProjectCreation/SecurityO
 import { SpecialSymbolsCallout } from 'components/interfaces/ProjectCreation/SpecialSymbolsCallout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { WizardLayoutWithoutAuth } from 'components/layouts/WizardLayout'
-import { ActionCard } from 'components/ui/ActionCard'
-import AlertError from 'components/ui/AlertError'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
 import { InlineLink } from 'components/ui/InlineLink'
 import Panel from 'components/ui/Panel'
@@ -78,7 +77,6 @@ import {
   SelectItem_Shadcn_,
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
-  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -540,7 +538,6 @@ const Wizard: NextPageWithLayout = () => {
                                   Total Monthly Compute Costs
                                   {/**
                                    * API currently doesnt output replica information on the projects list endpoint. Until then, we cannot correctly calculate the costs including RRs.
-                                   *
                                    * Will be adjusted in the future [kevin]
                                    */}
                                   {organizationProjects.length > 0 && (
@@ -632,54 +629,8 @@ const Wizard: NextPageWithLayout = () => {
                     />
                   )}
 
-                  {!isAdmin && <NotOrganizationOwnerWarning slug={slug} />}
-                  {/* If the org is not found, list all orgs and let the user select one */}
-                  {orgNotFound && (
-                    <>
-                      <div className="grid gap-2">
-                        <h2 className="mt-6">Your organizations</h2>
-                        <h3 className="text-sm  ">Create a new project in your organization</h3>
-                      </div>
-
-                      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                        {isOrganizationsLoading && (
-                          <>
-                            <Skeleton className="h-[62px] rounded-md" />
-                            <Skeleton className="h-[62px] rounded-md" />
-                            <Skeleton className="h-[62px] rounded-md" />
-                          </>
-                        )}
-                        {isOrganizationsError && (
-                          <AlertError
-                            error={organizationsError}
-                            subject="Failed to load organizations"
-                          />
-                        )}
-                        {isOrganizationsSuccess &&
-                          organizations?.map((organization) => {
-                            const numProjects = allProjects?.filter(
-                              (x) => x.organization_slug === organization.slug
-                            ).length
-
-                            if (!numProjects) return null
-
-                            return (
-                              <ActionCard
-                                bgColor="bg border"
-                                className="[&>div]:items-center"
-                                key={organization.id}
-                                icon={
-                                  <Boxes size={18} strokeWidth={1} className="text-foreground" />
-                                }
-                                title={organization.name}
-                                description={`${organization.plan.name} Plan${numProjects > 0 ? `${'  '}•${'  '}${numProjects} project${numProjects > 1 ? 's' : ''}` : ''}`}
-                                onClick={() => router.push(`/new/${organization.slug}`)}
-                              />
-                            )
-                          })}
-                      </div>
-                    </>
-                  )}
+                  {!isAdmin && !orgNotFound && <NotOrganizationOwnerWarning slug={slug} />}
+                  {orgNotFound && <OrgNotFound />}
                 </Panel.Content>
 
                 {canCreateProject && (

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -166,13 +166,7 @@ const Wizard: NextPageWithLayout = () => {
   const [isComputeCostsConfirmationModalVisible, setIsComputeCostsConfirmationModalVisible] =
     useState(false)
 
-  const {
-    data: organizations,
-    isSuccess: isOrganizationsSuccess,
-    isLoading: isOrganizationsLoading,
-    isError: isOrganizationsError,
-    error: organizationsError,
-  } = useOrganizationsQuery()
+  const { data: organizations, isSuccess: isOrganizationsSuccess } = useOrganizationsQuery()
 
   const isNotOnTeamOrEnterprisePlan = useMemo(
     () => !['team', 'enterprise'].includes(currentOrg?.plan.id ?? ''),
@@ -630,7 +624,7 @@ const Wizard: NextPageWithLayout = () => {
                   )}
 
                   {!isAdmin && !orgNotFound && <NotOrganizationOwnerWarning slug={slug} />}
-                  {orgNotFound && <OrgNotFound />}
+                  {orgNotFound && <OrgNotFound slug={slug} />}
                 </Panel.Content>
 
                 {canCreateProject && (

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -1,17 +1,16 @@
-import { Boxes, Search } from 'lucide-react'
+import { Search } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
 import { useParams } from 'common'
+import { OrganizationCard } from 'components/interfaces/Organization/OrganizationCard'
 import AppLayout from 'components/layouts/AppLayout/AppLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainerLegacy, ScaffoldTitle } from 'components/layouts/Scaffold'
-import { ActionCard } from 'components/ui/ActionCard'
 import AlertError from 'components/ui/AlertError'
 import NoSearchResults from 'components/ui/NoSearchResults'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
-import { useProjectsQuery } from 'data/projects/projects-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { withAuth } from 'hooks/misc/withAuth'
 import { NextPageWithLayout } from 'types'
@@ -31,7 +30,6 @@ const OrganizationsPage: NextPageWithLayout = () => {
   const { error: orgNotFoundError, org: orgSlug } = useParams()
   const orgNotFound = orgNotFoundError === 'org_not_found'
 
-  const { data: projects = [] } = useProjectsQuery()
   const { data: organizations = [], error, isLoading, isError, isSuccess } = useOrganizationsQuery()
 
   const organizationCreationEnabled = useIsFeatureEnabled('organizations:create')
@@ -105,23 +103,7 @@ const OrganizationsPage: NextPageWithLayout = () => {
         )}
         {isError && <AlertError error={error} subject="Failed to load organizations" />}
         {isSuccess &&
-          filteredOrganizations.map((organization) => {
-            const numProjects = projects.filter(
-              (x) => x.organization_slug === organization.slug
-            ).length
-
-            return (
-              <ActionCard
-                bgColor="bg border"
-                className="[&>div]:items-center"
-                key={organization.id}
-                icon={<Boxes size={18} strokeWidth={1} className="text-foreground" />}
-                title={organization.name}
-                description={`${organization.plan.name} Plan${numProjects > 0 ? `${'  '}•${'  '}${numProjects} project${numProjects > 1 ? 's' : ''}` : ''}`}
-                onClick={() => router.push(`/org/${organization.slug}`)}
-              />
-            )
-          })}
+          filteredOrganizations.map((org) => <OrganizationCard key={org.id} organization={org} />)}
       </div>
     </ScaffoldContainerLegacy>
   )


### PR DESCRIPTION
Issue:

- users land at supabase.com/new/abc
- if they don't have access to that org, they get automatically redirected to organizations[0].slug
- it isn't obvious that this has happened, and users end up creating projects in the wrong org 

This PR make is explicit: they're shown that they don't have access to their referring org and given a list of orgs that they are part of. 

![screenshot-2025-06-11-at-23 08 37](https://github.com/user-attachments/assets/0056bbfc-a9ad-4099-b1a1-b9fc169eb620)

