### PR TITLE
docs: fix wrappers assets (images)

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -96,6 +96,10 @@ async function getLatestRelease(after: string | null = null) {
   }
 }
 
+function rewriteAssetUrls(mdContent: string, baseUrl: string): string {
+  return mdContent.replace(/(\.\.\/)+assets\//g, baseUrl)
+}
+
 // Each external docs page is mapped to a local page
 const pageMap = [
   {
@@ -278,7 +282,14 @@ const getContent = async (params: Params) => {
     })
     const rawContent = await response.text()
 
-    const { content: contentWithoutFrontmatter } = matter(rawContent)
+    // Build assets base URL dynamically
+    const baseUrl = `https://raw.githubusercontent.com/${org}/${repo}/${tag}/docs/assets/`
+
+    // Rewrite asset URLs in the content
+    const rewrittenContent = rewriteAssetUrls(rawContent, baseUrl)
+
+    // Use rewritten content with proper external asset URLs
+    const { content: contentWithoutFrontmatter } = matter(rewrittenContent)
     content = removeRedundantH1(contentWithoutFrontmatter)
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This adds a small function that updates the assets urls imported by the wrappers md files to use proper external urls from the wrappers repo (just like we load the md files).

## What is the current behavior?

The images are not loading in the supabase/docs/wrappers pages because they are referenced as local resources, but they are actually external resources.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/c6b73910-50db-497d-87ff-52b82fb9fe1d" />

## What is the new behavior?

With this fix, now they load properly:

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/63a350d3-7186-44c4-892b-d15a61275bc8" />


## Additional context

None.
