### PR TITLE
fix(SQLEditor): disable transactional mode for manual queries

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -316,6 +316,7 @@ export const SQLEditor = () => {
           sql: wrapWithRoleImpersonation(formattedSql, impersonatedRoleState),
           autoLimit: appendAutoLimit ? limit : undefined,
           isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRoleState.role),
+          isStatementTimeoutDisabled: true,
           contextualInvalidation: true,
           handleError: (error) => {
             throw error

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -17,6 +17,7 @@ export type ExecuteSqlVariables = {
   queryKey?: QueryKey
   handleError?: (error: ResponseError) => { result: any }
   isRoleImpersonationEnabled?: boolean
+  isStatementTimeoutDisabled?: boolean
   autoLimit?: number
   contextualInvalidation?: boolean
 }
@@ -29,6 +30,7 @@ export async function executeSql<T = any>(
     queryKey,
     handleError,
     isRoleImpersonationEnabled = false,
+    isStatementTimeoutDisabled = false,
   }: Pick<
     ExecuteSqlVariables,
     | 'projectRef'
@@ -37,6 +39,7 @@ export async function executeSql<T = any>(
     | 'queryKey'
     | 'handleError'
     | 'isRoleImpersonationEnabled'
+    | 'isStatementTimeoutDisabled'
   >,
   signal?: AbortSignal,
   headersInit?: HeadersInit,
@@ -80,7 +83,7 @@ export async function executeSql<T = any>(
               .join('-') ?? '',
         },
       },
-      body: { query: sql },
+      body: { query: sql, disable_statement_timeout: isStatementTimeoutDisabled },
       headers,
     })
 

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -7224,6 +7224,7 @@ export interface components {
     }
     RunQueryBody: {
       query: string
+      disable_statement_timeout?: boolean
     }
     SearchProfileBody: {
       keywords: string


### PR DESCRIPTION
Statement timeout implicitely create a transaction which can cause issue while running some queries (eg: `CREATE INDEX CONCURENTLY`).

While we want this to be enabled to ensure we don't run long running queries over the database by mistake, in the case of SQLEditor, it's an user manually ran query, we want to allow anything to run.