### PR TITLE
fix(docs): sentry errors do not get sent from vercel edge

### DIFF
--- a/apps/docs/app/api/graphql/route.ts
+++ b/apps/docs/app/api/graphql/route.ts
@@ -89,7 +89,11 @@ function validateGraphQLRequest(query: string, isDevGraphiQL = false): ReadonlyA
 
 export async function POST(request: Request): Promise<NextResponse> {
   try {
-    return await handleGraphQLRequest(request)
+    const result = await handleGraphQLRequest(request)
+    // Do not let Vercel close the process until Sentry has flushed
+    // https://github.com/getsentry/sentry-javascript/issues/9626
+    await Sentry.flush(2000)
+    return result
   } catch (error: unknown) {
     console.error(error)
 
@@ -97,12 +101,18 @@ export async function POST(request: Request): Promise<NextResponse> {
       if (!error.isUserError()) {
         Sentry.captureException(error)
       }
+      // Do not let Vercel close the process until Sentry has flushed
+      // https://github.com/getsentry/sentry-javascript/issues/9626
+      await Sentry.flush(2000)
 
       return NextResponse.json({
         errors: [{ message: error.isPrivate() ? 'Internal Server Error' : error.message }],
       })
     } else {
       Sentry.captureException(error)
+      // Do not let Vercel close the process until Sentry has flushed
+      // https://github.com/getsentry/sentry-javascript/issues/9626
+      await Sentry.flush(2000)
 
       return NextResponse.json({
         errors: [{ message: 'Internal Server Error' }],


### PR DESCRIPTION
Sentry errors captured on routes run on Edge are not getting properly sent. This is apparently a known issue where Vercel closes the process before Sentry can flush, so the exceptions need to be manually flushed:

https://www.github.com/getsentry/sentry-javascript/issues/9626