### PR TITLE
docs(flutter): update the verifyOtp to mention deprecated types

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -859,7 +859,7 @@ functions:
   - id: verify-otp
     title: 'verifyOtp()'
     notes: |
-      - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `signup`, `magiclink`, `recovery`, `invite` or `email_change`.
+      - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `email`, `recovery`, `invite` or `email_change` (`signup` and `magiclink` types are deprecated).
       - The verification type used should be determined based on the corresponding auth method called before `verifyOtp` to sign up or sign in a user.
     params:
       - name: token


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The `verifyOtp` docs mention `signup` and `magiclink` as types, but these have been deprecated for more than a year now and `email` type should be mentioned instead.

## What is the new behavior?

The `verifyOtp` docs mention `signup` and `magiclink` types as deprecated and `email` type as the replacement instead.

## Additional context

Add any other context or screenshots.
