### PR TITLE
Fix delete button in users management

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -211,6 +211,7 @@ export const UsersV2 = () => {
       if (userIds.includes(selectedUser)) setSelectedUser(undefined)
     } catch (error: any) {
       toast.error(`Failed to delete selected users: ${error.message}`)
+    } finally {
       setIsDeletingUsers(false)
     }
   }


### PR DESCRIPTION
Fixes FE-1663

## Context

In the auth/users page, if you delete a user by selecting its checkbox, then hitting "Delete", and you do it again once more for another user, the "Delete user" button in the confirmation modal stays disabled in a loading state. Just missing a `setIsDeletingUsers` when the `handleDeleteUsers` is completed

## To test

- [ ] In the auth/users page, select a user via checkbox and delete the user
- [ ] Do that again for another user, verify that the confirmation modal is not stuck in a loading state