### PR TITLE
Fix incorrect logic for isHipaaProjectDisallowed

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -97,6 +97,8 @@ export const SQLEditor = () => {
   const includeSchemaMetadata = (isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM
   const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
+  console.log({ isHipaaProjectDisallowed })
+
   const {
     sourceSqlDiff,
     setSourceSqlDiff,

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -97,8 +97,6 @@ export const SQLEditor = () => {
   const includeSchemaMetadata = (isOptedInToAI && !isHipaaProjectDisallowed) || !IS_PLATFORM
   const isSQLEditorTabsEnabled = useIsSQLEditorTabsEnabled()
 
-  console.log({ isHipaaProjectDisallowed })
-
   const {
     sourceSqlDiff,
     setSourceSqlDiff,

--- a/apps/studio/hooks/misc/useOrgOptedIntoAi.ts
+++ b/apps/studio/hooks/misc/useOrgOptedIntoAi.ts
@@ -1,6 +1,9 @@
+import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscription/Subscription.utils'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useDisallowHipaa } from 'hooks/misc/useDisallowHipaa'
-import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { OPT_IN_TAGS } from 'lib/constants'
 
 /**
@@ -26,10 +29,18 @@ export function useOrgOptedIntoAi() {
 }
 
 export function useOrgOptedIntoAiAndHippaProject() {
+  const selectedProject = useSelectedProject()
   const selectedOrganization = useSelectedOrganization()
   const optInTags = selectedOrganization?.opt_in_tags
   const isOptedIntoAI = optInTags?.includes(OPT_IN_TAGS.AI_SQL) ?? false
 
-  const disallowHipaa = useDisallowHipaa()
-  return { isOptedInToAI: isOptedIntoAI, isHipaaProjectDisallowed: disallowHipaa(isOptedIntoAI) }
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: selectedOrganization?.slug })
+  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
+
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: selectedProject?.ref })
+  const isProjectSensitive = !!projectSettings?.is_sensitive
+
+  const preventProjectFromUsingAI = hasHipaaAddon && isProjectSensitive
+
+  return { isOptedInToAI: isOptedIntoAI, isHipaaProjectDisallowed: preventProjectFromUsingAI }
 }


### PR DESCRIPTION
## Context

We've received some reports of the SQL snippets not automatically renaming by AI, causing a list of "Untitled query" to snowball. Realised that the AI renaming of snippets wasn't getting triggered because of a newly added `isHipaaProjectDisallowed` check that was introduced [here](https://github.com/supabase/supabase/pull/35925).

The `useDisallowHipaa` hook in itself is quite confusing tbh, and we've looked into refactoring the logic in this [PR](https://github.com/supabase/supabase/pull/35318) - so am bringing the changes from that PR out to fix this issue

## To test
- [ ] Verify that running a new query in the SQL editor will rename "Untitled query" into something relevant to the query's contents