### PR TITLE
docs: mark pgjwt extension as deprecated in upgrade guide

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -124,6 +124,14 @@ In-place upgrades do not currently support upgrading of databases using extensio
 
 To upgrade to a newer version of Postgres, you will need to drop the extensions before the upgrade, and recreate them after the upgrade.
 
+### Deprecated Extensions
+
+Some extensions are no longer supported or recommended.
+
+- `pgjwt`: This extension is deprecated.
+
+To check if your project uses `pgjwt`, search for the use of `sign()` or `verify()` functions in your SQL or RPC code.
+
 #### Authentication method changes - deprecating md5 in favor of scram-sha-256
 
 The md5 hashing method has [known weaknesses](https://en.wikipedia.org/wiki/MD5#Security) that make it unsuitable for cryptography.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update – improving instructions related to detecting and removing the `pgjwt` extension.

## What is the current behavior?

The [Upgrade Guide](https://supabase.com/docs/guides/platform/upgrading) does not mention that the pgjwt extension is deprecated. This can be confusing, especially since the Supabase dashboard and other docs reference its deprecation.

Closes: [supabase/supabase#<#36403>]

## What is the new behavior?

This PR adds pgjwt to the list of deprecated extensions in the upgrade guide, providing clarity to users who may be relying on it.

## Additional context

<img width="1496" alt="Screenshot 2025-06-16 at 4 44 04 PM" src="https://github.com/user-attachments/assets/daf01b4e-ec77-4ea7-ae45-6ec381ffe0ea" />
