### PR TITLE
fix: webhook delete dialog spacing and typo

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
@@ -53,9 +53,8 @@ const DeleteHookModal = ({ selectedHook, visible, onClose }: DeleteHookModalProp
       confirmString={name || ''}
       text={
         <>
-          This will delete the webhook{' '}
-          <span className="text-bold text-foreground">{name}</span>{' '}from the schema{' '}
-          <span className="text-bold text-foreground">{schema}</span>
+          This will delete the webhook <span className="text-bold text-foreground">{name}</span>{' '}
+          from the schema <span className="text-bold text-foreground">{schema}</span>
         </>
       }
       alert={{ title: 'You cannot recover this webhook once deleted.' }}

--- a/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
@@ -53,8 +53,8 @@ const DeleteHookModal = ({ selectedHook, visible, onClose }: DeleteHookModalProp
       confirmString={name || ''}
       text={
         <>
-          This will delete the webhook
-          <span className="text-bold text-foreground">{name}</span> rom the schema
+          This will delete the webhook{' '}
+          <span className="text-bold text-foreground">{name}</span>{' '}from the schema{' '}
           <span className="text-bold text-foreground">{schema}</span>
         </>
       }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Typo fix in dialog

## What is the current behavior?

![Screenshot 2025-06-16 at 11 32 34 AM](https://github.com/user-attachments/assets/4ed5db42-0d19-4973-b7e6-c46e0406d348)

## What is the new behavior?

Added space to the text and fix the typo so it would be for example:

"This will delete the webhook test from the schema auth"
