### PR TITLE
tooltip animation from far-left fixed

### DIFF
--- a/packages/ui-patterns/src/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/src/LogsBarChart/index.tsx
@@ -67,7 +67,6 @@ export const LogsBarChart = ({
               setFocusDataIndex(e.activeTooltipIndex)
             }
           }}
-          onMouseLeave={() => setFocusDataIndex(null)}
           onClick={(tooltipData) => {
             const datum = tooltipData?.activePayload?.[0]?.payload
             if (onBarClick) onBarClick(datum, tooltipData)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

removed onMouseLeave function that makes the value of hovered bar null, which makes it animate from extreme left

## What is the current behavior?

hovering a bar in Dashboard Logs & Analytics, makes the tooltip come from extreme left

## What is the new behavior?

hovering a bar in Dashboard Logs & Analytics, makes the tooltip come from the prevously hovered bar

## Additional context

fixed #36360 
