### PR TITLE
Add feature flag for opt in tags

### DIFF
--- a/apps/studio/components/interfaces/Organization/GeneralSettings/AIOptInLevelSelector.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/AIOptInLevelSelector.tsx
@@ -2,7 +2,9 @@ import { ReactNode } from 'react'
 import { Control } from 'react-hook-form'
 
 import { AIOptInFormValues } from 'hooks/forms/useAIOptInForm'
+import { useFlag } from 'hooks/ui/useFlag'
 import { FormField_Shadcn_, RadioGroup_Shadcn_, RadioGroupItem_Shadcn_ } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { OptInToOpenAIToggle } from './OptInToOpenAIToggle'
 
@@ -46,11 +48,20 @@ export const AIOptInLevelSelector = ({
   label,
   layout = 'vertical',
 }: AIOptInLevelSelectorProps) => {
+  const newOrgAiOptIn = useFlag('newOrgAiOptIn')
+
   return (
     <FormItemLayout
       label={label}
       description={
         <div className="flex flex-col gap-y-4 my-4 max-w-xl">
+          {!newOrgAiOptIn && (
+            <Admonition
+              type="note"
+              title="Assistant Opt-in is temporarily disabled"
+              description="We will re-enable opting in to the assistant shortly!"
+            />
+          )}
           <p>
             Supabase AI can provide more relevant answers if you choose to share different levels of
             data. This feature is powered by Amazon Bedrock which does not store or log your prompts

--- a/apps/studio/components/interfaces/Organization/GeneralSettings/DataPrivacyForm.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/DataPrivacyForm.tsx
@@ -4,10 +4,12 @@ import { useEffect } from 'react'
 import { FormActions } from 'components/ui/Forms/FormActions'
 import { useAIOptInForm } from 'hooks/forms/useAIOptInForm'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useFlag } from 'hooks/ui/useFlag'
 import { Card, CardContent, CardFooter, Form_Shadcn_ } from 'ui'
 import { AIOptInLevelSelector } from './AIOptInLevelSelector'
 
 export const DataPrivacyForm = () => {
+  const newOrgAiOptIn = useFlag('newOrgAiOptIn')
   const { form, onSubmit, isUpdating, currentOptInLevel } = useAIOptInForm()
   const canUpdateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
 
@@ -26,7 +28,7 @@ export const DataPrivacyForm = () => {
           <CardContent className="pt-6">
             <AIOptInLevelSelector
               control={form.control}
-              disabled={!canUpdateOrganization || isUpdating}
+              disabled={!canUpdateOrganization || !newOrgAiOptIn || isUpdating}
               layout="flex-row-reverse"
               label="Supabase Assistant Opt-in Level"
             />

--- a/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
@@ -9,7 +9,6 @@ import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import OrganizationDeletePanel from './OrganizationDeletePanel'
 
-// Import the new form components
 import { DataPrivacyForm } from './DataPrivacyForm'
 import { OrganizationDetailsForm } from './OrganizationDetailsForm'
 

--- a/apps/studio/components/ui/AIAssistantPanel/AIOptInModal.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOptInModal.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { AIOptInLevelSelector } from 'components/interfaces/Organization/GeneralSettings/AIOptInLevelSelector'
 import { useAIOptInForm } from 'hooks/forms/useAIOptInForm'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useFlag } from 'hooks/ui/useFlag'
 import {
   Button,
   Dialog,
@@ -22,6 +23,7 @@ interface AIOptInModalProps {
 }
 
 export const AIOptInModal = ({ visible, onCancel }: AIOptInModalProps) => {
+  const newOrgAiOptIn = useFlag('newOrgAiOptIn')
   const { form, onSubmit, isUpdating, currentOptInLevel } = useAIOptInForm(onCancel)
   const canUpdateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
 
@@ -49,7 +51,7 @@ export const AIOptInModal = ({ visible, onCancel }: AIOptInModalProps) => {
             <DialogSection className="space-y-4" padding="small">
               <AIOptInLevelSelector
                 control={form.control}
-                disabled={!canUpdateOrganization || isUpdating}
+                disabled={!canUpdateOrganization || !newOrgAiOptIn || isUpdating}
               />
             </DialogSection>
             <DialogSectionSeparator />

--- a/apps/studio/hooks/forms/useAIOptInForm.ts
+++ b/apps/studio/hooks/forms/useAIOptInForm.ts
@@ -10,6 +10,7 @@ import { invalidateOrganizationsQuery } from 'data/organizations/organizations-q
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { getAiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useFlag } from 'hooks/ui/useFlag'
 import { OPT_IN_TAGS } from 'lib/constants'
 import type { ResponseError } from 'types'
 
@@ -30,6 +31,11 @@ export const useAIOptInForm = (onSuccessCallback?: () => void) => {
   const queryClient = useQueryClient()
   const selectedOrganization = useSelectedOrganization()
   const canUpdateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
+
+  // [Joshen] This is to prevent users from changing their opt in levels until the migration
+  // to clean up the existing opt in tags are completed. Once toggled on, users can then change their
+  // opt in levels again and we can clean this feature flag up
+  const newOrgAiOptIn = useFlag('newOrgAiOptIn')
 
   const { mutate: updateOrganization, isLoading: isUpdating } = useOrganizationUpdateMutation()
 
@@ -95,6 +101,8 @@ export const useAIOptInForm = (onSuccessCallback?: () => void) => {
     form,
     onSubmit,
     isUpdating,
-    currentOptInLevel: getAiOptInLevel(selectedOrganization?.opt_in_tags),
+    currentOptInLevel: !newOrgAiOptIn
+      ? 'disabled'
+      : getAiOptInLevel(selectedOrganization?.opt_in_tags),
   }
 }

--- a/apps/studio/hooks/misc/useOrgOptedIntoAi.ts
+++ b/apps/studio/hooks/misc/useOrgOptedIntoAi.ts
@@ -5,6 +5,7 @@ import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { useFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM, OPT_IN_TAGS } from 'lib/constants'
 
 export const aiOptInLevelSchema = z.enum([
@@ -53,9 +54,12 @@ export function useOrgAiOptInLevel(): {
 } {
   const selectedProject = useSelectedProject()
   const selectedOrganization = useSelectedOrganization()
+  const newOrgAiOptIn = useFlag('newOrgAiOptIn')
 
+  // [Joshen] Default to disabled until migration to clean up existing opt in tags are completed
+  // Once toggled on, then we can default to their set opt in level and clean up feature flag
   const optInTags = selectedOrganization?.opt_in_tags
-  const level = getAiOptInLevel(optInTags)
+  const level = !newOrgAiOptIn ? 'disabled' : getAiOptInLevel(optInTags)
   const isOptedIntoAI = level !== 'disabled'
 
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: selectedOrganization?.slug })


### PR DESCRIPTION
## Context

Prior to the release of the new Assistant MCP, we're going to have to reset our users' opt in preference for the AI Assistant through a migration on the BE. While the migration is going on, we'll be defaulting the opt in level for all users to `disabled` and also preventing users from changing their opt in levels, in which these 2 behaviours will be controlled by a feature flag

![image](https://github.com/user-attachments/assets/b9eca632-c2d1-4d9b-8311-b3d82071c0e8)
![image](https://github.com/user-attachments/assets/7e727b0e-85a7-4774-9ba9-9e08cb67962b)

Once the migration is completed, we can then toggle the feature flag to be on, in which users can thereafter change their opt in levels again, and their opt in levels will be respected in `useOrgAiOptInLevel`

## Changes involved

While feature flag is OFF
- Users will not be able to update their Assistant Opt In levels (via org settings or opt in modal)
- Assistant Opt In levels will be defaulted to `disabled`