### PR TITLE
Add type param update log drain mutation

### DIFF
--- a/apps/studio/data/log-drains/update-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/update-log-drain-mutation.ts
@@ -25,6 +25,7 @@ export async function updateLogDrain(payload: LogDrainUpdateVariables) {
     body: {
       name: payload.name,
       description: payload.description,
+      type: payload.type,
       config: payload.config as any,
     },
   })


### PR DESCRIPTION
Related infrastructure PR: https://github.com/supabase/infrastructure/pull/23615

## Changes involved
- Mainly adds the `type` param to the PUT body of `update-log-drain-mutation`
- Verified locally that creating + updating log drain works okay

## To test
- [ ] Can create log drain
- [ ] Can update log drain