### PR TITLE
feat: list allowed symbols for password security

### DIFF
--- a/apps/docs/content/guides/auth/password-security.mdx
+++ b/apps/docs/content/guides/auth/password-security.mdx
@@ -23,7 +23,7 @@ There are hundreds of millions (and growing!) known passwords out there. Malicio
 To help protect your users, Supabase Auth allows you fine-grained control over the strength of the passwords used on your project. You can configure these in your project's [Auth settings](/dashboard/project/_/auth/providers?provider=Email):
 
 - Set a large minimum password length. Anything less than 8 characters is not recommended.
-- Set the required characters that must appear at least once in a user's password. Use the strongest option of requiring digits, lowercase and uppercase letters, and symbols. The allowed symbols are: ```!@#$%^&*()_+-=[]{};'\:"|<>?,./`~```
+- Set the required characters that must appear at least once in a user's password. Use the strongest option of requiring digits, lowercase and uppercase letters, and symbols. The allowed symbols are: ``!@#$%^&*()_+-=[]{};'\:"|<>?,./`~``
 - Prevent the use of leaked passwords. Supabase Auth uses the open-source [HaveIBeenPwned.org Pwned Passwords API](https://haveibeenpwned.com/Passwords) to reject passwords that have been leaked and are known by malicious actors.
 
 <Admonition type="note">

--- a/apps/docs/content/guides/auth/password-security.mdx
+++ b/apps/docs/content/guides/auth/password-security.mdx
@@ -23,7 +23,7 @@ There are hundreds of millions (and growing!) known passwords out there. Malicio
 To help protect your users, Supabase Auth allows you fine-grained control over the strength of the passwords used on your project. You can configure these in your project's [Auth settings](/dashboard/project/_/auth/providers?provider=Email):
 
 - Set a large minimum password length. Anything less than 8 characters is not recommended.
-- Set the required characters that must appear at least once in a user's password. Use the strongest option of requiring digits, lowercase and uppercase letters, and symbols.
+- Set the required characters that must appear at least once in a user's password. Use the strongest option of requiring digits, lowercase and uppercase letters, and symbols. The allowed symbols are: ```!@#$%^&*()_+-=[]{};'\:"|<>?,./`~```
 - Prevent the use of leaked passwords. Supabase Auth uses the open-source [HaveIBeenPwned.org Pwned Passwords API](https://haveibeenpwned.com/Passwords) to reject passwords that have been leaked and are known by malicious actors.
 
 <Admonition type="note">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to list the allowed characters for password security
