### PR TITLE
Fix organization card link

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -41,7 +41,9 @@ export const OrgNotFound = ({ slug }: { slug?: string }) => {
           <AlertError error={organizationsError} subject="Failed to load organizations" />
         )}
         {isOrganizationsSuccess &&
-          organizations?.map((org) => <OrganizationCard key={org.slug} organization={org} />)}
+          organizations?.map((org) => (
+            <OrganizationCard key={org.slug} organization={org} href={`/new/${org.slug}`} />
+          ))}
       </div>
     </>
   )

--- a/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
@@ -5,12 +5,18 @@ import { ActionCard } from 'components/ui/ActionCard'
 import { useProjectsQuery } from 'data/projects/projects-query'
 import { Organization } from 'types'
 
-export const OrganizationCard = ({ organization }: { organization: Organization }) => {
+export const OrganizationCard = ({
+  organization,
+  href,
+}: {
+  organization: Organization
+  href?: string
+}) => {
   const { data: allProjects = [] } = useProjectsQuery()
   const numProjects = allProjects.filter((x) => x.organization_slug === organization.slug).length
 
   return (
-    <Link href={`/new/${organization.slug}`}>
+    <Link href={href ?? `/org/${organization.slug}`}>
       <ActionCard
         bgColor="bg border"
         className="[&>div]:items-center"


### PR DESCRIPTION
## Context

We updated the OrganizationCard's link in this [PR](https://github.com/supabase/supabase/pull/36349) to be `/new/[slug]` but this should've been specific to just in `OrgNotFound.tsx`.

## Changes involved

- `OrganizationCard.tsx` to accept an optional `href` param, and revert link to default to `/org/[slug]`
- `OrgNotFound.tsx` to pass in `href` param when rendering `OrganizationCard`
