### PR TITLE
docs: clarify local dev dependency on docker

### DIFF
--- a/apps/docs/content/guides/local-development.mdx
+++ b/apps/docs/content/guides/local-development.mdx
@@ -18,7 +18,7 @@ Develop locally while running the Supabase stack on your machine.
     </TabPanel><TabPanel id="yarn" label="yarn">
 
     ```sh
-    yarn add supabase --dev
+    NODE_OPTIONS=--no-experimental-fetch yarn add supabase --dev
     ```
 
     </TabPanel><TabPanel id="pnpm" label="pnpm">
@@ -94,6 +94,17 @@ Develop locally while running the Supabase stack on your machine.
     </TabPanel>
 
     </Tabs>
+
+    <Admonition type="note">
+
+    As a prerequisite, you must install one of the container tools that's compatible with Docker APIs.
+
+    - [Docker Desktop](https://docs.docker.com/desktop/) (macOS, Windows, Linux)
+    - [Rancher Desktop](https://rancherdesktop.io/) (macOS, Windows, Linux)
+    - [Podman](https://podman.io/) (macOS, Windows, Linux)
+    - [OrbStack](https://orbstack.dev/) (macOS)
+
+    </Admonition>
 
 4.  View your local Supabase instance at [http://localhost:54323](http://localhost:54323).
 

--- a/apps/docs/content/guides/local-development.mdx
+++ b/apps/docs/content/guides/local-development.mdx
@@ -97,7 +97,7 @@ Develop locally while running the Supabase stack on your machine.
 
     <Admonition type="note">
 
-    As a prerequisite, you must install one of the container tools that's compatible with Docker APIs.
+    As a prerequisite, you must install a container runtime compatible with Docker APIs.
 
     - [Docker Desktop](https://docs.docker.com/desktop/) (macOS, Windows, Linux)
     - [Rancher Desktop](https://rancherdesktop.io/) (macOS, Windows, Linux)


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Currently cli prints a warning about missing docker engine. Show the same warning in docs as well.

## Additional context

Add any other context or screenshots.
