### PR TITLE
docs: clarify backup restore for paused project

### DIFF
--- a/apps/docs/content/guides/local-development/restoring-downloaded-backup.mdx
+++ b/apps/docs/content/guides/local-development/restoring-downloaded-backup.mdx
@@ -3,7 +3,7 @@ title: Restoring a downloaded backup locally
 subtitle: Restore a backup of a remote database on a local instance to inspect and extract data
 ---
 
-You can restore a downloaded backup to a local Supabase instance. This might be useful if your paused project has exceeded its [restoring time limit](/docs/guides/platform/upgrading#time-limits). You can download the latest backup, then load it locally to inspect and extract your data.
+If your paused project has exceeded its [restoring time limit](/docs/guides/platform/upgrading#time-limits), you can download a backup from the dashboard and restore it to your local development environment. This might be useful for inspecting and extracting data from your paused project.
 
 <Admonition type="caution">
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Mention that local backup restore is only meant for paused free projects.

## Additional context

Add any other context or screenshots.
