### PR TITLE
Fix/topology search path issue

### DIFF
--- a/apps/cms/supabase/config.toml
+++ b/apps/cms/supabase/config.toml
@@ -12,7 +12,7 @@ port = 54321
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
-extra_search_path = ["public", "extensions"]
+extra_search_path = ["public", "extensions", "topology"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000

--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -50,9 +50,9 @@ drop extension if exists postgis;
 
 ## Examples
 
-Now that we are ready to get started with PostGIS, let's create a table and see how we can utilize PostGIS for some typical use cases. Let's imagine we are creating a simple restaurant-searching app.
+Now that we are ready to get started with PostGIS, let’s create a table and see how we can utilize PostGIS for some typical use cases. Let’s imagine we are creating a simple restaurant-searching app.
 
-Let's create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
+Let’s create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
 
 ```sql
 create table if not exists public.restaurants (

--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -50,9 +50,9 @@ drop extension if exists postgis;
 
 ## Examples
 
-Now that we are ready to get started with PostGIS, let’s create a table and see how we can utilize PostGIS for some typical use cases. Let’s imagine we are creating a simple restaurant-searching app.
+Now that we are ready to get started with PostGIS, let's create a table and see how we can utilize PostGIS for some typical use cases. Let's imagine we are creating a simple restaurant-searching app.
 
-Let’s create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
+Let's create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
 
 ```sql
 create table if not exists public.restaurants (
@@ -327,7 +327,7 @@ val data = supabase.postgrest.rpc(
 
 ![Searching within a bounding box of a map](/docs/img/guides/database/extensions/postgis/map.png)
 
-When you are working on a map-based application where the user scrolls through your map, you might want to load the data that lies within the bounding box of the map every time your users scroll. PostGIS can return the rows that are within the bounding box just by supplying the bottom left and the top right coordinates. Let’s look at what the function would look like:
+When you are working on a map-based application where the user scrolls through your map, you might want to load the data that lies within the bounding box of the map every time your users scroll. PostGIS can return the rows that are within the bounding box just by supplying the bottom left and the top right coordinates. Let's look at what the function would look like:
 
 ```sql
 create or replace function restaurants_in_view(min_lat float, min_long float, max_lat float, max_long float)
@@ -433,6 +433,48 @@ val data = supabase.postgrest.rpc(
 
 </TabPanel>
 </Tabs>
+
+## Topology Extension
+
+The PostGIS Topology extension provides functionality for creating and managing topology data structures. When enabled, it creates a `topology` schema that contains functions and types for working with topological data.
+
+### Enabling Topology
+
+To enable the topology extension, you can use SQL:
+
+```sql
+-- Enable the topology extension
+CREATE EXTENSION postgis_topology;
+```
+
+The topology extension automatically creates a `topology` schema containing functions like:
+- `CreateTopology()` - Creates a new topology
+- `AddTopoGeometryColumn()` - Adds a topological geometry column
+- `TopoGeo_AddPoint()` - Adds a point to a topology
+
+### Search Path Configuration
+
+The topology schema is automatically included in Supabase's search path, allowing you to use topology functions without schema qualification:
+
+```sql
+-- You can use topology functions directly
+SELECT CreateTopology('my_topology', 4326);
+
+-- Instead of requiring schema qualification
+SELECT topology.CreateTopology('my_topology', 4326);
+```
+
+This configuration is set in your `config.toml`:
+
+```toml
+extra_search_path = ["public", "extensions", "topology"]
+```
+
+<Admonition type="note">
+
+If you're upgrading from an older Supabase project, you may need to update your `config.toml` to include `"topology"` in the `extra_search_path` array to access topology functions without schema qualification.
+
+</Admonition>
 
 ## Troubleshooting
 

--- a/examples/todo-list/nextjs-todo-list/supabase/config.toml
+++ b/examples/todo-list/nextjs-todo-list/supabase/config.toml
@@ -10,7 +10,7 @@ port = 54321
 # endpoints. `public` and `graphql_public` are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
-extra_search_path = ["public", "extensions"]
+extra_search_path = ["public", "extensions", "topology"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000

--- a/examples/user-management/flutter-user-management/supabase/config.toml
+++ b/examples/user-management/flutter-user-management/supabase/config.toml
@@ -10,7 +10,7 @@ port = 54321
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
-extra_search_path = ["public", "extensions"]
+extra_search_path = ["public", "extensions", "topology"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000

--- a/examples/user-management/nextjs-user-management/supabase/config.toml
+++ b/examples/user-management/nextjs-user-management/supabase/config.toml
@@ -10,7 +10,7 @@ port = 54321
 # endpoints. `public` and `graphql_public` are included by default.
 schemas = ["public"]
 # Extra schemas to add to the search_path of every request.
-extra_search_path = ["public", "extensions"]
+extra_search_path = ["public", "extensions", "topology"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000

--- a/packages/shared-data/extensions.json
+++ b/packages/shared-data/extensions.json
@@ -479,6 +479,15 @@
     "product_url": null
   },
   {
+    "name": "postgis_topology",
+    "comment": "PostGIS topology spatial types and functions",
+    "tags": ["Geo"],
+    "link": "/guides/database/extensions/postgis",
+    "github_url": null,
+    "product": null,
+    "product_url": null
+  },
+  {
     "name": "postgres_fdw",
     "comment": "foreign-data wrapper for remote PostgreSQL servers",
     "tags": ["Admin"],

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -12,7 +12,7 @@ port = 54321
 # endpoints. public and storage are always included.
 schemas = ["public", "content", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
-extra_search_path = ["public", "extensions"]
+extra_search_path = ["public", "extensions", "topology"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the PostGIS topology extension is enabled, it creates a `topology` schema, but this schema is not included in the default search path. This means users must manually qualify all topology function calls (e.g., `topology.CreateTopology()` instead of just `CreateTopology()`), which breaks the expected PostGIS behavior and creates a poor developer experience.

Please link any relevant issues here: #36505

## What is the new behavior?

The topology schema is now automatically included in Supabase's search path configuration. Users can use topology functions without schema qualification:

```sql
-- Now works without schema qualification
SELECT CreateTopology('my_topology', 4326);

-- Instead of requiring 
SELECT topology.CreateTopology('my_topology', 4326);
```

**Changes made:**
- Added `"topology"` to `extra_search_path` in all config.toml files
- Updated PostGIS documentation with topology extension section
- Added `postgis_topology` to shared extensions data
- Ensured consistency across all example projects

## Additional context

This fix addresses a breaking change where topology functionality moved from PostGIS but wasn't properly integrated into Supabase's search path configuration. The topology extension is commonly used for advanced geospatial operations, and this change ensures it works seamlessly like other PostGIS functions.

The fix maintains backward compatibility while providing the expected developer experience for topology functions.