### PR TITLE
docs: clarify that migrations must be applied manually after starting local DB

### DIFF
--- a/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
+++ b/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
@@ -74,7 +74,7 @@ supabase db diff -f create_employees_table
 
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Start the local database and apply migrations">
-      Start the local database and then apply the migration file to see your schema changes in the local Dashboard.
+      Start the local database first. Then, apply the migration manually to see your schema changes in the local Dashboard.
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
@@ -82,7 +82,8 @@ supabase db diff -f create_employees_table
 <$CodeTabs>
 
 ```bash name=Terminal
-supabase start && supabase migration up
+supabase start
+supabase migration up
 ```
 
 </$CodeTabs>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The documentation under the "Start the local database and apply migrations" step implies that running `supabase start && supabase migration up` will automatically apply migrations when the local database starts.

This could mislead users into thinking that migrations run automatically, which is not the case.

Related issue: https://github.com/supabase/supabase/issues/35078

## What is the new behavior?

Updated the documentation to:
- Clarify that `supabase migration up` must be run **after** the database is started
- Split the command into two separate lines for better visibility
- Updated the instructional text to reflect this behavior

```bash
supabase start
supabase migration up
