### PR TITLE
Fix edge functions headers span

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -42,6 +42,18 @@ const EdgeFunctionSecrets = () => {
         []
       : data ?? []
 
+  const headers = [
+    <Table.th key="secret-name">Name</Table.th>,
+    <Table.th key="secret-value" className="flex items-center gap-x-2">
+      Digest{' '}
+      <Badge color="scale" className="font-mono">
+        SHA256
+      </Badge>
+    </Table.th>,
+    <Table.th key="secret-updated-at">Updated at</Table.th>,
+    <Table.th key="actions" />,
+  ]
+
   return (
     <>
       {isLoading && <GenericSkeletonLoader />}
@@ -73,17 +85,7 @@ const EdgeFunctionSecrets = () => {
 
               <div className="w-full overflow-hidden overflow-x-auto">
                 <Table
-                  head={[
-                    <Table.th key="secret-name">Name</Table.th>,
-                    <Table.th key="secret-value" className="flex items-center gap-x-2">
-                      Digest{' '}
-                      <Badge color="scale" className="font-mono">
-                        SHA256
-                      </Badge>
-                    </Table.th>,
-                    <Table.th key="secret-updated-at">Updated at</Table.th>,
-                    <Table.th key="actions" />,
-                  ]}
+                  head={headers}
                   body={
                     secrets.length > 0 ? (
                       secrets.map((secret) => (
@@ -95,7 +97,7 @@ const EdgeFunctionSecrets = () => {
                       ))
                     ) : secrets.length === 0 && searchString.length > 0 ? (
                       <Table.tr>
-                        <Table.td colSpan={3}>
+                        <Table.td colSpan={headers.length}>
                           <p className="text-sm text-foreground">No results found</p>
                           <p className="text-sm text-foreground-light">
                             Your search for "{searchString}" did not return any results
@@ -104,7 +106,7 @@ const EdgeFunctionSecrets = () => {
                       </Table.tr>
                     ) : (
                       <Table.tr>
-                        <Table.td colSpan={3}>
+                        <Table.td colSpan={headers.length}>
                           <p className="text-sm text-foreground">No secrets created</p>
                           <p className="text-sm text-foreground-light">
                             There are no secrets associated with your project yet


### PR DESCRIPTION
Addresses a tiny misalignment issue in edge functions secrets page
![image](https://github.com/user-attachments/assets/ab112ca1-eac3-472f-8a9c-1a6f38e38723)
