### PR TITLE
Add custom link component to assistant message block

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -5,10 +5,17 @@ import ReactMarkdown from 'react-markdown'
 import { Components } from 'react-markdown/lib/ast-to-react'
 import remarkGfm from 'remark-gfm'
 
-import { AiIconAnimation, cn, markdownComponents, WarningIcon } from 'ui'
+import { cn, markdownComponents, WarningIcon } from 'ui'
 import { EdgeFunctionBlock } from '../EdgeFunctionBlock/EdgeFunctionBlock'
 import { DisplayBlockRenderer } from './DisplayBlockRenderer'
-import { Heading3, InlineCode, ListItem, MarkdownPre, OrderedList } from './MessageMarkdown'
+import {
+  Heading3,
+  Hyperlink,
+  InlineCode,
+  ListItem,
+  MarkdownPre,
+  OrderedList,
+} from './MessageMarkdown'
 
 interface MessageContextType {
   isLoading: boolean
@@ -21,6 +28,7 @@ const baseMarkdownComponents: Partial<Components> = {
   li: ListItem,
   h3: Heading3,
   code: InlineCode,
+  a: Hyperlink,
   img: ({ src }) => <span className="text-foreground-light font-mono">[Image: {src}]</span>,
 }
 

--- a/apps/studio/components/ui/AIAssistantPanel/Message.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.utils.ts
@@ -34,3 +34,27 @@ export const findResultForManualId = (
   }
   return undefined
 }
+
+// [Joshen] From https://github.com/remarkjs/react-markdown/blob/fda7fa560bec901a6103e195f9b1979dab543b17/lib/index.js#L425
+export function defaultUrlTransform(value: string) {
+  const safeProtocol = /^(https?|ircs?|mailto|xmpp)$/i
+  const colon = value.indexOf(':')
+  const questionMark = value.indexOf('?')
+  const numberSign = value.indexOf('#')
+  const slash = value.indexOf('/')
+
+  if (
+    // If there is no protocol, it’s relative.
+    colon === -1 ||
+    // If the first colon is after a `?`, `#`, or `/`, it’s not a protocol.
+    (slash !== -1 && colon > slash) ||
+    (questionMark !== -1 && colon > questionMark) ||
+    (numberSign !== -1 && colon > numberSign) ||
+    // It is a protocol, it should be allowed.
+    safeProtocol.test(value.slice(0, colon))
+  ) {
+    return value
+  }
+
+  return ''
+}

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -1,3 +1,4 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useRouter } from 'next/router'
 import {
   DragEvent,
@@ -10,7 +11,6 @@ import {
   useRef,
 } from 'react'
 
-import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -19,7 +19,21 @@ import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useProfile } from 'lib/profile'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { Dashboards } from 'types'
-import { Badge, cn, CodeBlock, CodeBlockLang } from 'ui'
+import {
+  Badge,
+  Button,
+  cn,
+  CodeBlock,
+  CodeBlockLang,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
 import { DebouncedComponent } from '../DebouncedComponent'
 import { EdgeFunctionBlock } from '../EdgeFunctionBlock/EdgeFunctionBlock'
 import { QueryBlock } from '../QueryBlock/QueryBlock'
@@ -49,6 +63,58 @@ export const InlineCode = memo(
   )
 )
 InlineCode.displayName = 'InlineCode'
+
+export const Hyperlink = memo(({ href, children }: { href?: string; children: ReactNode }) => {
+  const isExternalURL = !href?.startsWith('https://supabase.com/dashboard')
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <span
+          className={cn(
+            '!m-0 text-foreground cursor-pointer transition',
+            'underline underline-offset-2 decoration-foreground-muted hover:decoration-foreground-lighter'
+          )}
+        >
+          {children}
+        </span>
+      </DialogTrigger>
+      <DialogContent size="small">
+        <DialogHeader className="border-b">
+          <DialogTitle>Verify the link before navigating</DialogTitle>
+        </DialogHeader>
+
+        <DialogSection className="flex flex-col">
+          <p className="text-sm text-foreground-light">
+            This link will take you to the following URL:
+          </p>
+          <p className="text-sm text-foreground">{href}</p>
+          <p className="text-sm text-foreground-light mt-2">Are you sure you want to head there?</p>
+        </DialogSection>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="default" className="opacity-100">
+              Cancel
+            </Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button asChild type="primary" className="opacity-100">
+              <a
+                href={href}
+                target={isExternalURL ? '_blank' : '_self'}
+                rel={isExternalURL ? 'noreferrer noopener' : undefined}
+              >
+                Head to link
+              </a>
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+})
+Hyperlink.displayName = 'Hyperlink'
 
 const MemoizedQueryBlock = memo(
   ({

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -71,6 +71,10 @@ export const Hyperlink = memo(({ href, children }: { href?: string; children: Re
   const safeUrl = defaultUrlTransform(href ?? '')
   const isSafeUrl = safeUrl.length > 0
 
+  if (!isSafeUrl) {
+    return <span className="text-foreground">{children}</span>
+  }
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -85,33 +89,16 @@ export const Hyperlink = memo(({ href, children }: { href?: string; children: Re
       </DialogTrigger>
       <DialogContent size="small">
         <DialogHeader className="border-b">
-          <DialogTitle>
-            {isSafeUrl ? 'Verify the link before navigating' : 'Unsafe URL detected'}
-          </DialogTitle>
+          <DialogTitle>Verify the link before navigating</DialogTitle>
         </DialogHeader>
 
-        {isSafeUrl ? (
-          <DialogSection className="flex flex-col">
-            <p className="text-sm text-foreground-light">
-              This link will take you to the following URL:
-            </p>
-            <p className="text-sm text-foreground">{safeUrl}</p>
-            <p className="text-sm text-foreground-light mt-2">
-              Are you sure you want to head there?
-            </p>
-          </DialogSection>
-        ) : (
-          <DialogSection className="flex flex-col">
-            <p className="text-sm text-foreground-light">
-              We have detected that the following URL is unsafe:
-            </p>
-            <p className="text-sm text-foreground">{href}</p>
-            <p className="text-sm text-foreground-light mt-2">
-              If you'd still like to proceed, you may copy the URL to open it directly in your
-              browser.
-            </p>
-          </DialogSection>
-        )}
+        <DialogSection className="flex flex-col">
+          <p className="text-sm text-foreground-light">
+            This link will take you to the following URL:
+          </p>
+          <p className="text-sm text-foreground">{safeUrl}</p>
+          <p className="text-sm text-foreground-light mt-2">Are you sure you want to head there?</p>
+        </DialogSection>
 
         <DialogFooter>
           <DialogClose asChild>
@@ -119,19 +106,17 @@ export const Hyperlink = memo(({ href, children }: { href?: string; children: Re
               Cancel
             </Button>
           </DialogClose>
-          {isSafeUrl && (
-            <DialogClose asChild>
-              <Button asChild type="primary" className="opacity-100">
-                {isExternalURL ? (
-                  <a href={safeUrl} target="_blank" rel="noreferrer noopener">
-                    Head to link
-                  </a>
-                ) : (
-                  <Link href={safeUrl}>Head to link</Link>
-                )}
-              </Button>
-            </DialogClose>
-          )}
+          <DialogClose asChild>
+            <Button asChild type="primary" className="opacity-100">
+              {isExternalURL ? (
+                <a href={safeUrl} target="_blank" rel="noreferrer noopener">
+                  Head to link
+                </a>
+              ) : (
+                <Link href={safeUrl}>Head to link</Link>
+              )}
+            </Button>
+          </DialogClose>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Context

In efforts to mitigate any potential risks in the hyperlinks that the AI Assistant generates, we're adding a custom `a` component that'll render in the Assistant's messages, such that clicking on any hyperlinks will open a confirmation dialog before navigating to the actual link

![image](https://github.com/user-attachments/assets/1f4d91a8-2121-498b-91cf-abcea1dbe1ef)

## To test

Can be tested with the following prompt which should get the assistant to generate some links:
```hey there, can you give me links to supabase docs?```

- [ ] Verify that rendered links open a confirmation dialog instead of directly opening the links