### PR TITLE
fix: api docs with new api keys

### DIFF
--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -63,6 +63,9 @@ export const useProjectSettingsV2Query = <TData = ProjectSettingsData>(
   )
 }
 
+/**
+ * @deprecated Use api-keys-query instead!
+ */
 export const getAPIKeys = (settings?: ProjectSettings) => {
   const anonKey = (settings?.service_api_keys ?? []).find((x) => x.tags === 'anon')
   const serviceKey = (settings?.service_api_keys ?? []).find((x) => x.tags === 'service_role')

--- a/apps/studio/pages/project/[ref]/api/index.tsx
+++ b/apps/studio/pages/project/[ref]/api/index.tsx
@@ -3,13 +3,13 @@ import { useState } from 'react'
 
 import { GeneralContent, ResourceContent, RpcContent } from 'components/interfaces/Docs'
 import LangSelector from 'components/interfaces/Docs/LangSelector'
+import DefaultLayout from 'components/layouts/DefaultLayout'
 import DocsLayout from 'components/layouts/DocsLayout/DocsLayout'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useProjectJsonSchemaQuery } from 'data/docs/project-json-schema-query'
 import { snakeToCamel } from 'lib/helpers'
 import type { NextPageWithLayout } from 'types'
-import DefaultLayout from 'components/layouts/DefaultLayout'
 
 const PageConfig: NextPageWithLayout = () => {
   return <DocView />
@@ -29,7 +29,7 @@ const DocView = () => {
 
   const { ref: projectRef, page, resource, rpc } = useParams()
   const [selectedLang, setSelectedLang] = useState<any>('js')
-  const [showApiKey, setShowApiKey] = useState<any>(DEFAULT_KEY)
+  const [selectedApikey, setSelectedApiKey] = useState<any>(DEFAULT_KEY)
 
   const { data: settings, error: settingsError } = useProjectSettingsV2Query({ projectRef })
   const {
@@ -112,9 +112,9 @@ const DocView = () => {
         <div className="sticky top-0 z-40 flex flex-row-reverse w-full ">
           <LangSelector
             selectedLang={selectedLang}
-            showApiKey={showApiKey}
+            selectedApiKey={selectedApikey}
             setSelectedLang={setSelectedLang}
-            setShowApiKey={setShowApiKey}
+            setSelectedApiKey={setSelectedApiKey}
           />
         </div>
         <div>
@@ -124,7 +124,7 @@ const DocView = () => {
               selectedLang={selectedLang}
               resourceId={resource}
               resources={resources}
-              showApiKey={showApiKey.key}
+              showApiKey={selectedApikey.key}
               refreshDocs={refreshDocs}
             />
           ) : rpc ? (
@@ -133,11 +133,15 @@ const DocView = () => {
               rpcId={rpc}
               paths={paths}
               rpcs={rpcs}
-              showApiKey={showApiKey.key}
+              showApiKey={selectedApikey.key}
               refreshDocs={refreshDocs}
             />
           ) : (
-            <GeneralContent selectedLang={selectedLang} showApiKey={showApiKey.key} page={page} />
+            <GeneralContent
+              selectedLang={selectedLang}
+              showApiKey={selectedApikey.key}
+              page={page}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
Allows users to select all the types of API keys on the API Docs page.

<img width="304" alt="image" src="https://github.com/user-attachments/assets/fb34b1e0-1ad7-4ba6-9bcb-ef915082878b" />
