### PR TITLE
Update warnings in bucket modals

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -13,7 +13,8 @@ import {
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import { useBucketCreateMutation } from 'data/storage/bucket-create-mutation'
 import { IS_PLATFORM } from 'lib/constants'
-import { Alert, Button, Collapsible, Form, Input, Listbox, Modal, Toggle, cn } from 'ui'
+import { Button, Collapsible, Form, Input, Listbox, Modal, Toggle, cn } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 export interface CreateBucketModalProps {
   visible: boolean
@@ -115,29 +116,36 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
         onSubmit={onSubmit}
       >
         {({ values }: { values: any }) => {
+          const isPublicBucket = values.public
+
           return (
             <>
-              <Modal.Content>
+              <Modal.Content className={cn('!px-0', isPublicBucket && '!pb-0')}>
                 <Input
                   id="name"
                   name="name"
                   type="text"
-                  className="w-full"
+                  className="w-full px-5"
                   layout="vertical"
                   label="Name of bucket"
                   labelOptional="Buckets cannot be renamed once created."
                   descriptionText="Only lowercase letters, numbers, dots, and hyphens"
                 />
-                <div className="space-y-2 mt-6">
+                <div className="flex flex-col gap-y-2 mt-6">
                   <Toggle
                     id="public"
                     name="public"
                     layout="flex"
+                    className="px-5"
                     label="Public bucket"
                     descriptionText="Anyone can read any object without any authorization"
                   />
-                  {values.public && (
-                    <Alert title="Public buckets are not protected" variant="warning" withIcon>
+                  {isPublicBucket && (
+                    <Admonition
+                      type="warning"
+                      className="rounded-none border-x-0 border-b-0 mb-0 [&>div>p]:!leading-normal"
+                      title="Public buckets are not protected"
+                    >
                       <p className="mb-2">
                         Users can read objects in public buckets without any authorization.
                       </p>
@@ -145,7 +153,7 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
                         Row level security (RLS) policies are still required for other operations
                         such as object uploads and deletes.
                       </p>
-                    </Alert>
+                    </Admonition>
                   )}
                 </div>
               </Modal.Content>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -3,16 +3,18 @@ import { ChevronDown } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Alert, Button, Collapsible, Form, Input, Listbox, Modal, Toggle, cn } from 'ui'
+import { Button, Collapsible, Form, Input, Listbox, Modal, Toggle, cn } from 'ui'
 
 import { StorageSizeUnits } from 'components/to-be-cleaned/Storage/StorageSettings/StorageSettings.constants'
 import {
   convertFromBytes,
   convertToBytes,
 } from 'components/to-be-cleaned/Storage/StorageSettings/StorageSettings.utils'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import { useBucketUpdateMutation } from 'data/storage/bucket-update-mutation'
 import { IS_PLATFORM } from 'lib/constants'
+import { Admonition } from 'ui-patterns'
 import type { StorageBucket } from './Storage.types'
 
 export interface EditBucketModalProps {
@@ -84,6 +86,10 @@ const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalProps) => 
     >
       <Form validateOnBlur={false} initialValues={{}} validate={validate} onSubmit={onSubmit}>
         {({ values, resetForm }: { values: any; resetForm: any }) => {
+          const isChangingBucketVisibility = bucket?.public !== values.public
+          const isMakingBucketPrivate = bucket?.public && !values.public
+          const isMakingBucketPublic = !bucket?.public && values.public
+
           // [Alaister] although this "technically" is breaking the rules of React hooks
           // it won't error because the hooks are always rendered in the same order
           // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -106,45 +112,56 @@ const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalProps) => 
 
           return (
             <>
-              <Modal.Content>
+              <Modal.Content className={cn('!px-0', isChangingBucketVisibility && '!pb-0')}>
                 <Input
                   disabled
                   id="name"
                   name="name"
                   type="text"
-                  className="w-full"
+                  className="w-full px-5"
                   layout="vertical"
                   label="Name of bucket"
                   labelOptional="Buckets cannot be renamed once created."
                 />
-                <div className="space-y-2 mt-6">
+                <div className={cn('flex flex-col gap-y-2 mt-6')}>
                   <Toggle
                     id="public"
                     name="public"
                     layout="flex"
                     label="Public bucket"
+                    className="px-5"
                     descriptionText="Anyone can read any object without any authorization"
                   />
-                  {bucket?.public !== values.public && (
-                    <Alert
+                  {isChangingBucketVisibility && (
+                    <Admonition
+                      type="warning"
+                      className="rounded-none border-x-0 border-b-0 mb-0 [&>div>p]:!leading-normal"
                       title={
-                        !bucket?.public && values.public
+                        isMakingBucketPublic
                           ? 'Warning: Making bucket public'
-                          : bucket?.public && !values.public
+                          : isMakingBucketPrivate
                             ? 'Warning: Making bucket private'
                             : ''
                       }
-                      variant="warning"
-                      withIcon
                     >
-                      <p className="mb-2">
-                        {!bucket?.public && values.public
-                          ? `This will make all objects in the bucket "${bucket?.name}" public`
-                          : bucket?.public && !values.public
-                            ? `All objects in "${bucket?.name}" will be made private and will only be accessible via signed URLs or downloaded with the right authorisation headers`
+                      <p>
+                        {isMakingBucketPublic
+                          ? `This will make all objects in your bucket publicly accessible.`
+                          : isMakingBucketPrivate
+                            ? `All objects in your bucket will be private and only accessible via signed URLs, or downloaded with the right authorisation headers.`
                             : ''}
                       </p>
-                    </Alert>
+                      {isMakingBucketPrivate && (
+                        <p>
+                          Assets cached in the CDN may still be publicly accessible. You can
+                          consider{' '}
+                          <InlineLink href="https://supabase.com/docs/guides/storage/cdn/smart-cdn#cache-eviction">
+                            purging the cache
+                          </InlineLink>{' '}
+                          or moving your assets to a new bucket.
+                        </p>
+                      )}
+                    </Admonition>
                   )}
                 </div>
               </Modal.Content>


### PR DESCRIPTION
## Changes involved

- Update Alerts in bucket modals to use Admonition for consistency
![image](https://github.com/user-attachments/assets/be6873dc-a852-45e2-9b79-5f6c44f73564)
![image](https://github.com/user-attachments/assets/909fbd3f-6c63-4652-bde9-cc26efb3a189)

- Update warning copy when toggling a bucket from public to private to add instructions about purging cache
![image](https://github.com/user-attachments/assets/0e62ad73-2876-4419-ad54-331ad82e4abd)

