### PR TITLE
fix: reverts local storage

### DIFF
--- a/apps/studio/hooks/misc/useLocalStorage.ts
+++ b/apps/studio/hooks/misc/useLocalStorage.ts
@@ -71,26 +71,19 @@ export function useLocalStorageQuery<T>(key: string, initialValue: T) {
     isSuccess,
     isLoading,
     isError,
-  } = useQuery(
-    queryKey,
-    () => {
-      if (typeof window === 'undefined') {
-        return initialValue
-      }
-
-      const item = window.localStorage.getItem(key)
-
-      if (!item) {
-        return initialValue
-      }
-
-      return JSON.parse(item) as T
-    },
-    {
-      enabled: isClient, // Only run query on client side
-      staleTime: Infinity, // Prevent unnecessary refetches
+  } = useQuery(queryKey, () => {
+    if (typeof window === 'undefined') {
+      return initialValue
     }
-  )
+
+    const item = window.localStorage.getItem(key)
+
+    if (!item) {
+      return initialValue
+    }
+
+    return JSON.parse(item) as T
+  })
 
   const setValue: Dispatch<SetStateAction<T>> = (value) => {
     const valueToStore = value instanceof Function ? value(storedValue) : value
@@ -103,8 +96,5 @@ export function useLocalStorageQuery<T>(key: string, initialValue: T) {
     queryClient.invalidateQueries(queryKey)
   }
 
-  // Return initial value during SSR, actual value on client
-  const finalValue = isClient ? storedValue : initialValue
-
-  return [finalValue, setValue, { isSuccess, isLoading, isError, error }] as const
+  return [storedValue, setValue, { isSuccess, isLoading, isError, error }] as const
 }

--- a/apps/studio/hooks/misc/useLocalStorage.ts
+++ b/apps/studio/hooks/misc/useLocalStorage.ts
@@ -1,7 +1,7 @@
 // Reference: https://usehooks.com/useLocalStorage/
 
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { Dispatch, SetStateAction, useCallback, useState, useEffect } from 'react'
+import { Dispatch, SetStateAction, useCallback, useState } from 'react'
 
 export function useLocalStorage<T>(key: string, initialValue: T) {
   // State to store our value
@@ -57,13 +57,6 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
 export function useLocalStorageQuery<T>(key: string, initialValue: T) {
   const queryClient = useQueryClient()
   const queryKey = ['localStorage', key]
-
-  // During SSR, return initial value immediately to prevent hydration mismatch
-  const [isClient, setIsClient] = useState(false)
-
-  useEffect(() => {
-    setIsClient(true)
-  }, [])
 
   const {
     error,


### PR DESCRIPTION
Recent PR has mistakenly had changes to [useLocalStorage](https://github.com/supabase/supabase/pull/36298/files#diff-9532503062ae7dcdc01cfd846494f2b145996ad25bfad81c2a67e9606ba1caf5).ts
This PR reverts the changes.

