### PR TITLE
docs: fix Claude Code MCP installation command syntax

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -117,7 +117,7 @@ You can also add the Supabase MCP server as a locally-scoped server, which will 
 1. Run the following command in your terminal:
 
    ```bash
-   claude mcp add supabase -s local -e SUPABASE_ACCESS_TOKEN=your_token_here npx -y @supabase/mcp-server-supabase@latest
+   claude mcp add supabase -s local -e SUPABASE_ACCESS_TOKEN=your_token_here -- npx -y @supabase/mcp-server-supabase@latest
    ```
 
 Locally-scoped servers take precedence over project-scoped servers with the same name and are stored in your project-specific user settings.


### PR DESCRIPTION
## Problem
The current Claude Code MCP installation command in the documentation is missing the required `--` separator, causing installation failures.

## Solution
Add the missing `--` separator between environment variables and the command.

## Testing
Tested locally - the fixed command works correctly:
```bash
claude mcp add supabase -s local -e SUPABASE_ACCESS_TOKEN=token -- npx -y @supabase/mcp-server-supabase@latest
```

Without the `--`, users get: `Invalid environment variable format: npx -y @supabase/mcp-server-supabase@latest`

## Impact
This fix will prevent users from encountering installation failures when following the MCP setup documentation.