### PR TITLE
fix: Typo in architecture.mdx

### DIFF
--- a/apps/docs/content/guides/getting-started/architecture.mdx
+++ b/apps/docs/content/guides/getting-started/architecture.mdx
@@ -29,7 +29,7 @@ Each Supabase project consists of several tools:
 
 ### Postgres (database)
 
-Postgres is the core of Supabase. We do not abstract the Postgres database—you can access it and use it with full privileges. We provide tools which makes Postgres as easy to use as Firebase.
+Postgres is the core of Supabase. We do not abstract the Postgres database—you can access it and use it with full privileges. We provide tools which make Postgres as easy to use as Firebase.
 
 - Official Docs: [postgresql.org/docs](https://www.postgresql.org/docs/current/index.html)
 - Source code: [github.com/postgres/postgres](https://github.com/postgres/postgres) (mirror)


### PR DESCRIPTION
"We provide tools which make**s** Postgres as easy to use as Firebase."

Remove superfluous **s**

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update: Fix for typo.

## What is the current behavior?

"We provide tools which make**s** Postgres as easy to use as Firebase."

## What is the new behavior?

Remove superfluous **s**


