### PR TITLE
fix: attempt to stringify request body before parsing

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -159,7 +159,7 @@ export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTester
 
     // Validate that the body is valid JSON
     try {
-      JSON.parse(values.body)
+      JSON.parse(JSON.stringify(values.body))
     } catch (e) {
       form.setError('body', { message: 'Must be a valid JSON string' })
       return


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

In the Test Edge Function dialog, stringify request body before parsing.

## What is the current behavior?

![test-function-json-before](https://github.com/user-attachments/assets/a2b61b1a-22d5-47d8-9a5f-bbee89d32351)

## What is the new behavior?

![test-function-json-after](https://github.com/user-attachments/assets/fdad7df4-6e2c-43c1-83fc-34e015b482e7)

## Additional context

NA