### PR TITLE
fix mcp tools and parse data

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -214,7 +214,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   const hasMessages = chatMessages.length > 0
 
   const sendMessageToAssistant = (content: string) => {
-    const payload = { role: 'user', createdAt: new Date(), content } as MessageType
+    const payload = { role: 'user', createdAt: new Date(), content, id: uuidv4() } as MessageType
     snap.clearSqlSnippets()
 
     // Store the user message in the ref before appending

--- a/apps/studio/components/ui/AIAssistantPanel/Message.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.utils.ts
@@ -2,6 +2,20 @@ import { Message } from 'ai/react'
 
 type MessagePart = NonNullable<Message['parts']>[number]
 
+const extractDataFromSafetyMessage = (text: string): string | null => {
+  const openingTags = [...text.matchAll(/<untrusted-data-[a-z0-9-]+>/gi)]
+  if (openingTags.length < 2) return null
+
+  const closingTagMatch = text.match(/<\/untrusted-data-[a-z0-9-]+>/i)
+  if (!closingTagMatch) return null
+
+  const secondOpeningEnd = openingTags[1].index! + openingTags[1][0].length
+  const closingStart = text.indexOf(closingTagMatch[0])
+  const content = text.substring(secondOpeningEnd, closingStart)
+
+  return content.replace(/\\n/g, '').replace(/\\"/g, '"').replace(/\n/g, '').trim()
+}
+
 // Helper function to find result data directly from parts array
 export const findResultForManualId = (
   parts: Readonly<MessagePart[]> | undefined,
@@ -25,7 +39,11 @@ export const findResultForManualId = (
     invocationPart.toolInvocation.result?.content?.[0]?.text
   ) {
     try {
-      const parsedData = JSON.parse(invocationPart.toolInvocation.result.content[0].text)
+      const rawText = invocationPart.toolInvocation.result.content[0].text
+
+      const extractedData = extractDataFromSafetyMessage(rawText) || rawText
+
+      let parsedData = JSON.parse(extractedData.trim())
       return Array.isArray(parsedData) ? parsedData : undefined
     } catch (error) {
       console.error('Failed to parse tool invocation result data for manualId:', manualId, error)

--- a/apps/studio/pages/api/ai/sql/supabase-mcp.ts
+++ b/apps/studio/pages/api/ai/sql/supabase-mcp.ts
@@ -1,4 +1,4 @@
-import { createSupabaseMcpServer } from '@supabase/mcp-server-supabase'
+import { createSupabaseApiPlatform, createSupabaseMcpServer } from '@supabase/mcp-server-supabase'
 import { StreamTransport } from '@supabase/mcp-utils'
 import {
   experimental_createMCPClient as createMCPClient,
@@ -27,10 +27,10 @@ export async function createSupabaseMCPClient({
   // Instantiate the MCP server and connect to its transport
   const apiUrl = API_URL?.replace('/platform', '')
   const server = createSupabaseMcpServer({
-    platform: {
+    platform: createSupabaseApiPlatform({
       accessToken,
       apiUrl,
-    },
+    }),
     projectId,
     readOnly: true,
   })


### PR DESCRIPTION
Fixes issues with recent MCP update.
- We now have to parse execute_sql results to get the actual data
- We have to use `createSupabaseApiPlatform` 
- Re-added id generation to user messages to save correctly