### PR TITLE
Show credit balance also for partner billed organizations

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
@@ -82,7 +82,7 @@ export const BillingSettings = () => {
         </>
       )}
 
-      {isBillingCreditsEnabledOnProfileLevel && isNotOrgWithPartnerBilling && (
+      {isBillingCreditsEnabledOnProfileLevel && (
         <>
           <ScaffoldDivider />
 


### PR DESCRIPTION
When an organization that is billed through Vercel is downgraded in the middle of the billing cycle, the organization gets credits (same behavior as with Supabase platform billing). To make that more obvious/reduce confusion, we show the credit balance on the organization's biling page. That becomes more relevant now that we automatically sync the Vercel invoice when an invoice gets voided or a credit note gets issued, resulting in fewer refunds to the credit card.

Shows the balance for all partner billed organizations. That's fine for now. Will have to do some adjustments to the Dashboard in the context of the AWS Marketplace revamp anyway.