### PR TITLE
Update Postgres MCP server reference link

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -130,7 +130,7 @@ For a full list of tools available, see the [GitHub README](https://github.com/s
 
 ## MCP for local Supabase instances
 
-The Supabase MCP server connects directly to the cloud platform to access your database. If you are running a local instance of Supabase, you can instead use the [Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect to your local database. This MCP server runs all queries as read-only transactions.
+The Supabase MCP server connects directly to the cloud platform to access your database. If you are running a local instance of Supabase, you can instead use the [Postgres MCP server](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/postgres) to connect to your local database. This MCP server runs all queries as read-only transactions.
 
 ### Step 1: Find your database connection string
 


### PR DESCRIPTION
The resource has been moved from the `modelcontextprotocol/servers` repo to an archived repo named `modelcontextprotocol/servers-archived`.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

docs update to fix broken link.

## What is the current behavior?

Link to Postgres MCP server resource is broken since the resource has been moved.

## What is the new behavior?

Link directs to the resource in the new repo where it was moved.

## Additional context
