### PR TITLE
fix: studio extensions flex wrap

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -111,7 +111,7 @@ const ExtensionCard = ({ extension }: ExtensionCardProps) => {
 
         <div className={cn('flex h-full flex-col gap-y-3 py-3', X_PADDING)}>
           <p className="text-sm text-foreground-light capitalize-sentence">{extension.comment}</p>
-          <div className="flex items-center gap-x-2">
+          <div className="flex flex-wrap items-center gap-2">
             {extensionMeta?.github_url && (
               <Button asChild type="default" icon={<Github />} className="rounded-full">
                 <a


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio - [Database > Extensions](https://supabase.com/dashboard/project/_/database/extensions)

## What is the current behavior?

Footer does not wrap on the cards:

<img width="1465" alt="Screenshot 2025-06-23 at 20 50 57" src="https://github.com/user-attachments/assets/93b8c666-9511-42cf-a0eb-cb87e8bee468" />


## What is the new behavior?

Footer now wraps:

<img width="1465" alt="Screenshot 2025-06-23 at 20 51 15" src="https://github.com/user-attachments/assets/8a1bcdf5-3a25-4cf0-b4e4-5f99b73fb1ad" />


