### PR TITLE
Remove project parameter for all calls to logs.all endpoint

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -20,7 +20,6 @@ export interface LogsWarning {
   linkText?: string
 }
 export interface LogsEndpointParams {
-  project: string // project ref
   iso_timestamp_start?: string
   iso_timestamp_end?: string
   sql?: string

--- a/apps/studio/hooks/analytics/useLogsPreview.tsx
+++ b/apps/studio/hooks/analytics/useLogsPreview.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
-import { useMemo, useState, useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import {
   LogsTableName,
@@ -22,8 +22,8 @@ import {
   genDefaultQuery,
 } from 'components/interfaces/Settings/Logs/Logs.utils'
 import { get } from 'data/fetchers'
-import { useLogsUrlState } from './useLogsUrlState'
 import { useFillTimeseriesSorted } from './useFillTimeseriesSorted'
+import { useLogsUrlState } from './useLogsUrlState'
 import useTimeseriesUnixToIso from './useTimeseriesUnixToIso'
 
 interface LogsPreviewHook {
@@ -83,12 +83,11 @@ function useLogsPreview({
   const params: LogsEndpointParams = useMemo(() => {
     const currentSql = genDefaultQuery(table, mergedFilters, limit)
     return {
-      project: projectRef,
       iso_timestamp_start: timestampStart,
       iso_timestamp_end: timestampEnd,
       sql: currentSql,
     }
-  }, [projectRef, timestampStart, timestampEnd, table, mergedFilters, limit])
+  }, [timestampStart, timestampEnd, table, mergedFilters, limit])
 
   const queryKey = useMemo(() => ['projects', projectRef, 'logs', params], [projectRef, params])
 
@@ -177,7 +176,6 @@ function useLogsPreview({
         params: {
           path: { ref: projectRef },
           query: {
-            project: projectRef,
             sql: countQuerySql,
             iso_timestamp_start: latestRefresh,
             iso_timestamp_end: timestampEnd,
@@ -228,7 +226,6 @@ function useLogsPreview({
           query: {
             iso_timestamp_start: timestampStart,
             iso_timestamp_end: timestampEnd,
-            project: projectRef,
             sql: chartQuery,
           },
         },

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { Dispatch, SetStateAction, useState, useEffect } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
 import { IS_PLATFORM } from 'common'
 import {
@@ -37,7 +37,6 @@ const useLogsQuery = (
   const defaultHelper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
   const [params, setParams] = useState<LogsEndpointParams>({
     sql: initialParams?.sql || '',
-    project: projectRef,
     iso_timestamp_start: initialParams.iso_timestamp_start
       ? initialParams.iso_timestamp_start
       : defaultHelper.calcFrom(),

--- a/apps/studio/hooks/analytics/useSingleLog.tsx
+++ b/apps/studio/hooks/analytics/useSingleLog.tsx
@@ -31,7 +31,7 @@ function useSingleLog({
   const table = queryType ? LOGS_TABLES[queryType] : undefined
   const sql = id && table ? genSingleLogQuery(table, id) : ''
 
-  const params: LogsEndpointParams = { ...paramsToMerge, project: projectRef, sql }
+  const params: LogsEndpointParams = { ...paramsToMerge, sql }
 
   const isWarehouseQuery = queryType === 'warehouse'
   // Warehouse queries are handled differently


### PR DESCRIPTION
## Context

With reference to this line in our infrastructure repo [here](https://github.com/supabase/infrastructure/blob/develop/api/apps/mgmt-api/src/routes/platform/projects/ref/analytics/endpoints/logs.dto.ts#L12), the `project` parameter is unused and needs to be cleaned up prior to removing it from the BE. Kamil's requesting it in this comment [here](https://github.com/supabase/infrastructure/pull/23013#discussion_r2161055111)

## Changes involved

- Remove `project` parameter for all calls to the `logs.all` endpoint in `useLogsPreview`, `useLogsQuery` and `useSingleLog`
  - Have omitted `QueryOptions` as we're in the midst of deprecating it in this [PR](https://github.com/supabase/supabase/pull/36598)

## To test

- [ ] Verify that logs explorer pages are working