### PR TITLE
ref: Use organization_slug instead of org_id for project creation

### DIFF
--- a/apps/studio/data/projects/project-create-mutation.ts
+++ b/apps/studio/data/projects/project-create-mutation.ts
@@ -21,7 +21,7 @@ const WHITELIST_ERRORS = [
 
 export type ProjectCreateVariables = {
   name: string
-  organizationId: number
+  organizationSlug: string
   dbPass: string
   dbRegion: string
   dbSql?: string
@@ -38,7 +38,7 @@ export type ProjectCreateVariables = {
 
 export async function createProject({
   name,
-  organizationId,
+  organizationSlug,
   dbPass,
   dbRegion,
   dbSql,
@@ -53,7 +53,7 @@ export async function createProject({
 }: ProjectCreateVariables) {
   const body: components['schemas']['CreateProjectBody'] = {
     cloud_provider: cloudProvider,
-    org_id: organizationId,
+    organization_slug: organizationSlug,
     name,
     db_pass: dbPass,
     db_region: dbRegion,

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -137,8 +137,8 @@ const CreateProject = () => {
   async function onCreateProject() {
     if (!organizationIntegration) return console.error('No organization installation details found')
     if (!organizationIntegration?.id) return console.error('No organization installation ID found')
-    if (!foreignProjectId) return console.error('No foreignProjectId ID set')
-    if (!organization) return console.error('No organization ID set')
+    if (!foreignProjectId) return console.error('No foreignProjectId set')
+    if (!organization) return console.error('No organization set')
 
     snapshot.setLoading(true)
 
@@ -150,7 +150,7 @@ const CreateProject = () => {
     }
 
     createProject({
-      organizationId: organization.id,
+      organizationSlug: organization.slug,
       name: projectName,
       dbPass,
       dbRegion,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -368,7 +368,7 @@ const Wizard: NextPageWithLayout = () => {
 
     const data: ProjectCreateVariables = {
       cloudProvider: cloudProvider,
-      organizationId: currentOrg.id,
+      organizationSlug: currentOrg.slug,
       name: projectName,
       dbPass: dbPass,
       dbRegion: dbRegion,


### PR DESCRIPTION
It's been due for almost a year now since Hieu updated the endpoint. It was never followed up on the FE side. Tested locally by creating new project.