### PR TITLE
Docs/self hosted jwt setup

### DIFF
--- a/apps/docs/content/guides/auth/jwts.mdx
+++ b/apps/docs/content/guides/auth/jwts.mdx
@@ -192,15 +192,18 @@ Your tokens should include the following claims:
   "role": "authenticated"
 }
 
-Explanation of claims:
-- `aud`: Audience – typically set to `"authenticated"` for Supabase projects
-- `sub`: Subject – the user's unique ID
-- `iss`: Issuer – identifies who created the token (your app name)
-- `exp`: Expiration time in UNIX timestamp
-- `email`: Optional – used for user identification
-- `role`: Supabase uses this for role-based access
-
 ```
+
+**Explanation of claims:**
+
+- `aud`: Audience – typically set to `"authenticated"` for Supabase projects  
+- `sub`: Subject – the user's unique ID  
+- `iss`: Issuer – identifies who created the token (your app name)  
+- `exp`: Expiration time in UNIX timestamp  
+- `email`: Optional – used for user identification  
+- `role`: Supabase uses this for role-based access  
+
+
 
 
 To make Supabase validate your tokens correctly, ensure your `.env` or environment config includes:

--- a/apps/docs/content/guides/auth/jwts.mdx
+++ b/apps/docs/content/guides/auth/jwts.mdx
@@ -174,6 +174,51 @@ curl "$YOUR_PROJECT_URL/rest/v1/colors?select=name" \
 
 Now that you understand what JWTs are and where they're used in Supabase, you can explore how to use them in combination with Row Level Security to start restricting access to certain tables, rows, and columns in your Postgres database.
 
+### Configuring JWTs for Self-Hosted Supabase
+
+If you're hosting Supabase yourself (using Docker, Railway, Render, or your own VPS), you'll need to configure JWTs manually to ensure authentication and authorization work as expected.
+
+Supabase services rely on a shared secret (`JWT_SECRET`) to validate tokens. If this is misconfigured, users may receive "JWT verification failed" errors or fail to access protected resources.
+
+Your tokens should include the following claims:
+
+```json
+{
+  "aud": "authenticated",
+  "sub": "user-id",
+  "iss": "your-app",
+  "exp": 1712345678,
+  "email": "user@example.com",
+  "role": "authenticated"
+}
+
+Explanation of claims:
+- `aud`: Audience – typically set to `"authenticated"` for Supabase projects
+- `sub`: Subject – the user's unique ID
+- `iss`: Issuer – identifies who created the token (your app name)
+- `exp`: Expiration time in UNIX timestamp
+- `email`: Optional – used for user identification
+- `role`: Supabase uses this for role-based access
+
+```
+
+
+To make Supabase validate your tokens correctly, ensure your `.env` or environment config includes:
+
+```bash
+JWT_SECRET=your-very-secure-secret
+
+```
+
+This secret is used to **sign** the JWT and also by Supabase to **verify** the token's validity.
+
+You can create and debug your tokens at [https://jwt.io](https://jwt.io).  
+Make sure to match the claims and signing secret exactly.
+
+This setup is essential for using Supabase Auth securely when you're managing your own infrastructure instead of using the official Supabase Cloud.
+
+
+
 ## Resources
 
 - JWT debugger: https://jwt.io/


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update – clarifies JWT configuration steps for self-hosted Supabase environments.

## What is the current behavior?

Docs mention JWTs but lack complete explanation for self-hosted setups, which can lead to confusion or token verification failures.

## What is the new behavior?

This PR:
- Adds a dedicated section explaining required JWT claims (`aud`, `sub`, `exp`, etc.)
- Includes `.env` configuration (`JWT_SECRET`)
- Provides developer-friendly context and helpful links (e.g., [jwt.io](https://jwt.io))

## Additional context


Fixes a common issue seen by self-hosting users getting "JWT verification failed" errors.

File updated: `apps/docs/pages/docs/guides/auth/auth-jwts.mdx`
