### PR TITLE
fix: warning message on upgrade guards

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -193,6 +193,7 @@ const InfrastructureInfo = () => {
                         </AlertDescription_Shadcn_>
                       </Alert_Shadcn_>
                     )}
+                    {/* TODO(bobbie): once extension_dependent_objects is removed on the backend, remove this block and the ts-ignores below */}
                     {!data?.eligible && (data?.extension_dependent_objects || []).length > 0 && (
                       <Alert_Shadcn_
                         variant="warning"
@@ -222,7 +223,96 @@ const InfrastructureInfo = () => {
                               ? 'These extensions are not supported in newer versions of Supabase Postgres. If you are not using them, it is safe to remove them.'
                               : 'Check the docs for which ones might need to be removed.'}
                           </p>
+                          <div>
+                            <Button size="tiny" type="default" asChild>
+                              <a
+                                href="https://supabase.com/docs/guides/platform/upgrading#extensions"
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                View docs
+                              </a>
+                            </Button>
+                          </div>
+                        </AlertDescription_Shadcn_>
+                      </Alert_Shadcn_>
+                    )}
+                    {!data?.eligible && (
+                      // @ts-ignore
+                      data?.objects_to_be_dropped || []
+                    ).length > 0 && (
+                      <Alert_Shadcn_
+                        variant="warning"
+                        title="A new version of Postgres is available for your project"
+                      >
+                        <AlertTitle_Shadcn_>
+                          A new version of Postgres is available
+                        </AlertTitle_Shadcn_>
+                        <AlertDescription_Shadcn_ className="flex flex-col gap-3">
+                          <div>
+                            <p className="mb-1">
+                              You'll need to remove the following objects before upgrading:
+                            </p>
 
+                            <ul className="pl-4">
+                              {(
+                                // @ts-ignore
+                                data?.objects_to_be_dropped || []
+                              ).map((obj: string) => (
+                                <li className="list-disc" key={obj}>
+                                  {obj}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                          <p>
+                            Check the docs for which objects need to be removed.
+                          </p>
+                          <div>
+                            <Button size="tiny" type="default" asChild>
+                              <a
+                                href="https://supabase.com/docs/guides/platform/upgrading#extensions"
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                View docs
+                              </a>
+                            </Button>
+                          </div>
+                        </AlertDescription_Shadcn_>
+                      </Alert_Shadcn_>
+                    )}
+                    {!data?.eligible && (
+                      // @ts-ignore
+                      data?.unsupported_extensions || []
+                    ).length > 0 && (
+                      <Alert_Shadcn_
+                        variant="warning"
+                        title="A new version of Postgres is available for your project"
+                      >
+                        <AlertTitle_Shadcn_>
+                          A new version of Postgres is available
+                        </AlertTitle_Shadcn_>
+                        <AlertDescription_Shadcn_ className="flex flex-col gap-3">
+                          <div>
+                            <p className="mb-1">
+                              You'll need to remove the following extensions before upgrading:
+                            </p>
+
+                            <ul className="pl-4">
+                              {(
+                                // @ts-ignore
+                                data?.unsupported_extensions || []
+                              ).map((obj: string) => (
+                                <li className="list-disc" key={obj}>
+                                  {obj}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                          <p>
+                            These extensions are not supported in newer versions of Supabase Postgres. If you are not using them, it is safe to remove them.
+                          </p>
                           <div>
                             <Button size="tiny" type="default" asChild>
                               <a

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -237,96 +237,93 @@ const InfrastructureInfo = () => {
                         </AlertDescription_Shadcn_>
                       </Alert_Shadcn_>
                     )}
-                    {!data?.eligible && (
+                    {!data?.eligible &&
                       // @ts-ignore
-                      data?.objects_to_be_dropped || []
-                    ).length > 0 && (
-                      <Alert_Shadcn_
-                        variant="warning"
-                        title="A new version of Postgres is available for your project"
-                      >
-                        <AlertTitle_Shadcn_>
-                          A new version of Postgres is available
-                        </AlertTitle_Shadcn_>
-                        <AlertDescription_Shadcn_ className="flex flex-col gap-3">
-                          <div>
-                            <p className="mb-1">
-                              You'll need to remove the following objects before upgrading:
-                            </p>
+                      (data?.objects_to_be_dropped || []).length > 0 && (
+                        <Alert_Shadcn_
+                          variant="warning"
+                          title="A new version of Postgres is available for your project"
+                        >
+                          <AlertTitle_Shadcn_>
+                            A new version of Postgres is available
+                          </AlertTitle_Shadcn_>
+                          <AlertDescription_Shadcn_ className="flex flex-col gap-3">
+                            <div>
+                              <p className="mb-1">
+                                You'll need to remove the following objects before upgrading:
+                              </p>
 
-                            <ul className="pl-4">
-                              {(
-                                // @ts-ignore
-                                data?.objects_to_be_dropped || []
-                              ).map((obj: string) => (
-                                <li className="list-disc" key={obj}>
-                                  {obj}
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                          <p>
-                            Check the docs for which objects need to be removed.
-                          </p>
-                          <div>
-                            <Button size="tiny" type="default" asChild>
-                              <a
-                                href="https://supabase.com/docs/guides/platform/upgrading#extensions"
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                View docs
-                              </a>
-                            </Button>
-                          </div>
-                        </AlertDescription_Shadcn_>
-                      </Alert_Shadcn_>
-                    )}
-                    {!data?.eligible && (
+                              <ul className="pl-4">
+                                {
+                                  // @ts-ignore
+                                  (data?.objects_to_be_dropped || []).map((obj: string) => (
+                                    <li className="list-disc" key={obj}>
+                                      {obj}
+                                    </li>
+                                  ))
+                                }
+                              </ul>
+                            </div>
+                            <p>Check the docs for which objects need to be removed.</p>
+                            <div>
+                              <Button size="tiny" type="default" asChild>
+                                <a
+                                  href="https://supabase.com/docs/guides/platform/upgrading#extensions"
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  View docs
+                                </a>
+                              </Button>
+                            </div>
+                          </AlertDescription_Shadcn_>
+                        </Alert_Shadcn_>
+                      )}
+                    {!data?.eligible &&
                       // @ts-ignore
-                      data?.unsupported_extensions || []
-                    ).length > 0 && (
-                      <Alert_Shadcn_
-                        variant="warning"
-                        title="A new version of Postgres is available for your project"
-                      >
-                        <AlertTitle_Shadcn_>
-                          A new version of Postgres is available
-                        </AlertTitle_Shadcn_>
-                        <AlertDescription_Shadcn_ className="flex flex-col gap-3">
-                          <div>
-                            <p className="mb-1">
-                              You'll need to remove the following extensions before upgrading:
-                            </p>
+                      (data?.unsupported_extensions || []).length > 0 && (
+                        <Alert_Shadcn_
+                          variant="warning"
+                          title="A new version of Postgres is available for your project"
+                        >
+                          <AlertTitle_Shadcn_>
+                            A new version of Postgres is available
+                          </AlertTitle_Shadcn_>
+                          <AlertDescription_Shadcn_ className="flex flex-col gap-3">
+                            <div>
+                              <p className="mb-1">
+                                You'll need to remove the following extensions before upgrading:
+                              </p>
 
-                            <ul className="pl-4">
-                              {(
-                                // @ts-ignore
-                                data?.unsupported_extensions || []
-                              ).map((obj: string) => (
-                                <li className="list-disc" key={obj}>
-                                  {obj}
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                          <p>
-                            These extensions are not supported in newer versions of Supabase Postgres. If you are not using them, it is safe to remove them.
-                          </p>
-                          <div>
-                            <Button size="tiny" type="default" asChild>
-                              <a
-                                href="https://supabase.com/docs/guides/platform/upgrading#extensions"
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                View docs
-                              </a>
-                            </Button>
-                          </div>
-                        </AlertDescription_Shadcn_>
-                      </Alert_Shadcn_>
-                    )}
+                              <ul className="pl-4">
+                                {
+                                  // @ts-ignore
+                                  (data?.unsupported_extensions || []).map((obj: string) => (
+                                    <li className="list-disc" key={obj}>
+                                      {obj}
+                                    </li>
+                                  ))
+                                }
+                              </ul>
+                            </div>
+                            <p>
+                              These extensions are not supported in newer versions of Supabase
+                              Postgres. If you are not using them, it is safe to remove them.
+                            </p>
+                            <div>
+                              <Button size="tiny" type="default" asChild>
+                                <a
+                                  href="https://supabase.com/docs/guides/platform/upgrading#extensions"
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  View docs
+                                </a>
+                              </Button>
+                            </div>
+                          </AlertDescription_Shadcn_>
+                        </Alert_Shadcn_>
+                      )}
                   </>
                 )}
               </>

--- a/packages/ai-commands/src/docs.ts
+++ b/packages/ai-commands/src/docs.ts
@@ -63,7 +63,7 @@ export async function clippy(
 
   const [{ embedding }] = embeddingResponse.data
 
-  const { error: matchError, data: pageSections } = await supabaseClient
+  const { error: matchError, data: pageSections } = (await supabaseClient
     .rpc('match_page_sections_v2', {
       embedding,
       match_threshold: 0.78,
@@ -71,7 +71,7 @@ export async function clippy(
     })
     .neq('rag_ignore', true)
     .select('content,page!inner(path),rag_ignore')
-    .limit(10) as { error: any; data: PageSection[] | null }
+    .limit(10)) as { error: any; data: PageSection[] | null }
 
   if (matchError || !pageSections) {
     throw new ApplicationError('Failed to match page sections', matchError)
@@ -93,10 +93,10 @@ export async function clippy(
     }
 
     const pagePath = pageSection.page.path
-    
+
     // Include source reference with each section
     contextText += `[Source ${sourceIndex}: ${pagePath}]\n${content.trim()}\n---\n`
-    
+
     // Track sources for later reference
     if (!sourcesMap.has(pagePath)) {
       sourcesMap.set(pagePath, content)

--- a/packages/ui-patterns/src/CommandMenu/prepackaged/ai/utils.ts
+++ b/packages/ui-patterns/src/CommandMenu/prepackaged/ai/utils.ts
@@ -49,7 +49,12 @@ interface FinalizeWithSourcesAction {
   index: number
 }
 
-type MessageAction = NewMessageAction | UpdateMessageAction | AppendContentAction | ResetAction | FinalizeWithSourcesAction
+type MessageAction =
+  | NewMessageAction
+  | UpdateMessageAction
+  | AppendContentAction
+  | ResetAction
+  | FinalizeWithSourcesAction
 
 export { MessageRole, MessageStatus }
 export type { Message, MessageAction, SourceLink }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When users are blocked from an upgrade because they have objects that need to be dropped, the message in the warning is incorrect. It asks users to "drop these extensions". But they're not extensions, they're user-defined tables, foreign keys, etc. This will cause confusion.

<img width="600" alt="Screenshot 2025-06-20 at 4 36 32 PM" src="https://github.com/user-attachments/assets/fa8d4486-3540-47b9-b930-9abf2c5fc9f1" />

## What is the new behavior?

Here we use a different messaging when users need to drop their objects.

<img width="598" alt="Screenshot 2025-06-25 at 12 42 17 PM" src="https://github.com/user-attachments/assets/f3e24a2c-6787-4373-977e-94df6b262877" />

## Additional context

Backend changes are on https://github.com/supabase/infrastructure/pull/23802; this PR needs to be deployed first