### PR TITLE
Add Amp to MCP getting started page

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -153,8 +153,8 @@ You can add the Supabase MCP server to Amp in two ways:
 
    Replace `project-ref` and `personal-access-token` with your project ref and personal access token.
 
-1. Save the configuration file.
-1. Restart VS Code to apply the new configuration.
+3. Save the configuration file.
+4. Restart VS Code to apply the new configuration.
 
 #### Option 2: Amp CLI
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -14,6 +14,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP)
 - [Cline](#cline) (VS Code extension)
 - [Claude desktop](#claude-desktop)
 - [Claude code](#claude-code)
+- [Amp](#amp)
 
 Once connected, your AI assistants can interact with and query your Supabase projects on your behalf.
 
@@ -121,6 +122,63 @@ You can also add the Supabase MCP server as a locally-scoped server, which will 
    ```
 
 Locally-scoped servers take precedence over project-scoped servers with the same name and are stored in your project-specific user settings.
+
+### Amp
+
+You can add the Supabase MCP server to Amp in two ways:
+
+#### Option 1: VS Code settings.json
+
+1. Open "Preferences: Open User Settings (JSON)"
+2. Add the following configuration:
+
+```json
+{
+  "amp.mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--read-only",
+        "--project-ref=<project-ref>"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "<personal-access-token>"
+      }
+    }
+  }
+}
+```
+1. Save the configuration file.
+1. Restart VS Code to apply the new configuration.
+
+#### Option 2: Amp CLI
+
+1. Edit `~/.config/amp/settings.json`
+1. Add the following configuration:
+
+```json
+{
+  "amp.mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--read-only",
+        "--project-ref=<project-ref>"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "<personal-access-token>"
+      }
+    }
+  }
+}
+```
+
+1. Save the configuration file.
+1. Restart Amp to apply the new configuration.
 
 ### Next steps
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -127,7 +127,7 @@ Locally-scoped servers take precedence over project-scoped servers with the same
 
 You can add the Supabase MCP server to Amp in two ways:
 
-#### Option 1: VS Code settings.json
+#### Option 1: VSCode settings.json
 
 1. Open "Preferences: Open User Settings (JSON)"
 2. Add the following configuration:

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -132,24 +132,26 @@ You can add the Supabase MCP server to Amp in two ways:
 1. Open "Preferences: Open User Settings (JSON)"
 2. Add the following configuration:
 
-```json
-{
-  "amp.mcpServers": {
-    "supabase": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@supabase/mcp-server-supabase@latest",
-        "--read-only",
-        "--project-ref=<project-ref>"
-      ],
-      "env": {
-        "SUPABASE_ACCESS_TOKEN": "<personal-access-token>"
-      }
-    }
-  }
-}
-```
+   ```json
+   {
+     "amp.mcpServers": {
+       "supabase": {
+         "command": "npx",
+         "args": [
+           "-y",
+           "@supabase/mcp-server-supabase@latest",
+           "--read-only",
+           "--project-ref=<project-ref>"
+         ],
+         "env": {
+           "SUPABASE_ACCESS_TOKEN": "<personal-access-token>"
+         }
+       }
+     }
+   }
+   ```
+
+   Replace `project-ref` and `personal-access-token` with your project ref and personal access token.
 
 1. Save the configuration file.
 1. Restart VS Code to apply the new configuration.
@@ -159,24 +161,26 @@ You can add the Supabase MCP server to Amp in two ways:
 1. Edit `~/.config/amp/settings.json`
 1. Add the following configuration:
 
-```json
-{
-  "amp.mcpServers": {
-    "supabase": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@supabase/mcp-server-supabase@latest",
-        "--read-only",
-        "--project-ref=<project-ref>"
-      ],
-      "env": {
-        "SUPABASE_ACCESS_TOKEN": "<personal-access-token>"
-      }
-    }
-  }
-}
-```
+   ```json
+   {
+     "amp.mcpServers": {
+       "supabase": {
+         "command": "npx",
+         "args": [
+           "-y",
+           "@supabase/mcp-server-supabase@latest",
+           "--read-only",
+           "--project-ref=<project-ref>"
+         ],
+         "env": {
+           "SUPABASE_ACCESS_TOKEN": "<personal-access-token>"
+         }
+       }
+     }
+   }
+   ```
+
+   Replace `project-ref` and `personal-access-token` with your project ref and personal access token.
 
 1. Save the configuration file.
 1. Restart Amp to apply the new configuration.

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -150,6 +150,7 @@ You can add the Supabase MCP server to Amp in two ways:
   }
 }
 ```
+
 1. Save the configuration file.
 1. Restart VS Code to apply the new configuration.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

MIssing instructions for using Supabase's MCP with Amp

## What is the new behavior?

![CleanShot 2025-06-24 at 22 54 01@2x](https://github.com/user-attachments/assets/8322af28-e32a-4d79-a34a-f4bdb5b9a6a6)


## Additional context

Unfortunately, I couldn't reuse `<$Partial path="mcp_supabase_config.mdx" variables={{ "app": "Claude code" }} />` since our property/key is `amp.mcpServers` not `mcpServers` which is breaking the numbered lists.

If you want, I can create `mcp_amp_supabase_config.mdx`.

![CleanShot 2025-06-24 at 22 55 16@2x](https://github.com/user-attachments/assets/4644c926-1e21-4922-90f8-c6deee08ffba)

