### PR TITLE
Emphasize resource limit issues

### DIFF
--- a/apps/docs/content/guides/functions/examples/image-manipulation.mdx
+++ b/apps/docs/content/guides/functions/examples/image-manipulation.mdx
@@ -4,7 +4,15 @@ description: 'How to optimize and transform images using Edge Functions.'
 ---
 
 Supabase Storage has [out-of-the-box support](https://supabase.com/docs/guides/storage/serving/image-transformations?queryGroups=language&language=js) for the most common image transformations and optimizations you need.
-If you need to do anything custom beyond what Supabase Storage provides, you can use Edge Functions to write custom image manipulation scripts.
+If you need to do anything custom beyond what Supabase Storage provides, you can use Edge Functions to write custom image manipulation scripts for images less than about 5MB. Attempting to process images greater than 5MB will most likely cause a resource limit exceeded error.
+
+<Admonition type="caution">
+
+Hosted Edge Functions have [limits](https://supabase.com/docs/guides/functions/limits) on memory and CPU usage.
+
+If you try to perform complex image processing or handle large images (> 5MB) your function may return a resource limit exceeded error.
+
+</Admonition>
 
 In this example, we will use [`magick-wasm`](https://github.com/dlemstra/magick-wasm) to perform image manipulations. `magick-wasm` is the WebAssembly port of the popular ImageMagick library and supports processing over 100 file formats.
 
@@ -69,10 +77,3 @@ supabase functions deploy image-blur
 
 ```
 
-<Admonition type="caution">
-
-Hosted Edge Functions have [limits](https://supabase.com/docs/guides/functions/limits) on memory and CPU usage.
-
-If you try to perform complex image processing or handle large images (> 5MB) your function may return a resource limit exceeded error.
-
-</Admonition>


### PR DESCRIPTION
Moved the caution on resource limit exceeded issues to the top of the document. Also added a little text to the introductory paragraph to call this out as a limitation.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update docs

## What is the current behavior?

Current behavior de-emphasizes resource limit exceeded issues by mentioning them at the bottom of the document, mostly as an afterthought.

## What is the new behavior?

The new behavior emphasizes resource limit exceeded issues by moving the caution to the top of the document. I feel this is needed because if you are turning to this sort of solution it is most likely because you can't use the existing Supabase transformation features and it's likely you'll be working on images larger than 5MB or will be consuming sufficient resources so as to trigger the limits. Thus, it seems reasonable that the warning should be up front and not at the bottom (where most people will disregard it as "not applicable to me" because it seems like an afterthought).
