### PR TITLE
docs: update required Node.js version to v22 LTS 

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -35,7 +35,7 @@ To ensure a positive and inclusive environment, please read our [code of conduct
 You will need to install and configure the following dependencies on your machine to build [Supabase](https://supabase.com):
 
 - [Git](https://git-scm.com/)
-- [Node.js v20.x (LTS)](https://nodejs.org)
+- [Node.js v22.x (LTS)](https://nodejs.org)
 - [pnpm](https://pnpm.io/) version 9.x.x or higher
 - [make](https://www.gnu.org/software/make/) or the equivalent to `build-essentials` for your OS
 - [Docker](https://docs.docker.com/get-docker/) (to run studio locally)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The DEVELOPERS.md mentions Node.js v20 (LTS), but the .nvmrc file and dependencies (`@types/node@22`) expect Node.js v22 (LTS), causing confusion and installation errors (`ERR_PNPM_UNSUPPORTED_ENGINE`).

## What is the new behavior?

Updated the DEVELOPERS.md to state Node.js v22 (LTS) as the required version, aligning the documentation with the actual project setup.

## Additional context

The Node version was bumped to v22 in commit https://github.com/supabase/supabase/commit/7322007. This change should be reflected in the DEVELOPERS.md for clarity.

