### PR TITLE
fix: bedrock region

### DIFF
--- a/apps/studio/lib/ai/bedrock.ts
+++ b/apps/studio/lib/ai/bedrock.ts
@@ -14,7 +14,10 @@ const credentialProvider = createCredentialChain(
   })
 )
 
-export const bedrock = createAmazonBedrock({ credentialProvider })
+export const bedrock = createAmazonBedrock({
+  credentialProvider,
+  region: process.env.AWS_BEDROCK_REGION,
+})
 
 export async function checkAwsCredentials() {
   try {


### PR DESCRIPTION
Explicitly tells the AWS Bedrock model to use the region defined in `AWS_BEDROCK_REGION`.