### PR TITLE
docs: fix RPC example for parameterless calls by adding undefined

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4406,7 +4406,7 @@ functions:
         name: Call a read-only Postgres function
         code: |
           ```ts
-          const { data, error } = await supabase.rpc('hello_world', { get: true })
+          const { data, error } = await supabase.rpc('hello_world', undefined, { get: true })
           ```
         data:
           sql: |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The RPC example doesn’t show that `undefined` must be passed as the second argument when using options (`get: true`) for parameterless RPCs. 
From issue **#36713**

## What is the new behavior?

Updated the example to include `undefined` as the second parameter.

```js
// Incorrect
const { data, error } = await supabase.rpc('hello_world', { get: true }); // Will error

// Correct
const { data, error } = await supabase.rpc('hello_world', undefined, { get: true });
```
---
