### PR TITLE
chore(docs linter): bump version

### DIFF
--- a/.github/workflows/docs-lint-v2-scheduled.yml
+++ b/.github/workflows/docs-lint-v2-scheduled.yml
@@ -31,10 +31,10 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: b848086c298be920a40aa9b26c65c7575ae8deca
+          key: 3186b58a532c98d7f470f2b887c2b74a086d5f2e
       - name: install linter
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: cargo install --locked --git https://github.com/supabase-community/supa-mdx-lint --rev b848086c298be920a40aa9b26c65c7575ae8deca
+        run: cargo install --locked --git https://github.com/supabase-community/supa-mdx-lint --rev 3186b58a532c98d7f470f2b887c2b74a086d5f2e
       - name: run linter
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-lint-v2.yml
+++ b/.github/workflows/docs-lint-v2.yml
@@ -53,10 +53,10 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: b848086c298be920a40aa9b26c65c7575ae8deca
+          key: 3186b58a532c98d7f470f2b887c2b74a086d5f2e
       - name: install linter
         if: steps.filter.outputs.docs == 'true' && steps.cache-cargo.outputs.cache-hit != 'true'
-        run: cargo install --locked --git https://github.com/supabase-community/supa-mdx-lint --rev b848086c298be920a40aa9b26c65c7575ae8deca
+        run: cargo install --locked --git https://github.com/supabase-community/supa-mdx-lint --rev 3186b58a532c98d7f470f2b887c2b74a086d5f2e
       - name: install reviewdog
         if: steps.filter.outputs.docs == 'true'
         uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0

--- a/apps/docs/content/guides/auth/auth-helpers.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers.mdx
@@ -6,6 +6,7 @@ sidebar_label: 'Overview'
 ---
 
 <Admonition type="caution">
+
 The Auth helpers package is deprecated. Use the new `@supabase/ssr` package for Server Side Authentication. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>

--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -136,7 +136,9 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
     4. Register the Services ID you created to your project's [Apple provider configuration in the Supabase dashboard](https://supabase.com/dashboard/project/_/auth/providers) under _Client IDs_.
 
     <Admonition type="note">
+
       If you're using Sign in with Apple JS you do not need to configure the OAuth settings.
+
     </Admonition>
 
   </TabPanel>

--- a/apps/docs/content/guides/database/dbeaver.mdx
+++ b/apps/docs/content/guides/database/dbeaver.mdx
@@ -38,7 +38,9 @@ If you do not have DBeaver, you can download it from its [website](https://dbeav
 
       You will also need your database's password. If you forgot it, you can generate a new one in the settings.
       <Admonition type="note">
+
         If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
       </Admonition>
 
     </StepHikeCompact.Details>

--- a/apps/docs/content/guides/database/extensions/wrappers/overview.mdx
+++ b/apps/docs/content/guides/database/extensions/wrappers/overview.mdx
@@ -192,9 +192,9 @@ As an example, go to [SQL Editor](https://supabase.com/dashboard/project/_/sql/n
 
    <Admonition type="danger">
 
-     By default, the function created can be executed by any roles like `anon`, that means the
-     foreign table is public accessible. Always limit the function execution permission to
-     appropriate roles.
+   By default, the function created can be executed by any roles like `anon`, that means the
+   foreign table is public accessible. Always limit the function execution permission to
+   appropriate roles.
 
    </Admonition>
 

--- a/apps/docs/content/guides/database/extensions/wrappers/overview.mdx
+++ b/apps/docs/content/guides/database/extensions/wrappers/overview.mdx
@@ -191,9 +191,11 @@ As an example, go to [SQL Editor](https://supabase.com/dashboard/project/_/sql/n
 3. Restrict the function execution to a specific role only, for example, the authenticated users:
 
    <Admonition type="danger">
+
      By default, the function created can be executed by any roles like `anon`, that means the
      foreign table is public accessible. Always limit the function execution permission to
      appropriate roles.
+
    </Admonition>
 
    ```sql

--- a/apps/docs/content/guides/database/import-data.mdx
+++ b/apps/docs/content/guides/database/import-data.mdx
@@ -75,6 +75,7 @@ Read more about [Bulk data loading.](/docs/guides/database/tables#bulk-data-load
 The Supabase API allows you to programmatically import data into your tables. You can use various client libraries to interact with the API and perform data import operations. This approach is useful when you need to automate data imports, and it gives you fine-grained control over the process. Refer to our [API guide](/docs/guides/api) for more details.
 
 <Admonition type="note">
+
 When importing data via the Supabase API, it's advisable to refrain from bulk imports. This helps ensure a smooth data transfer process and prevents any potential disruptions.
 
 Read more about [Rate Limiting, Resource Allocation, & Abuse Prevention.](/docs/guides/platform/going-into-prod#rate-limiting-resource-allocation--abuse-prevention)

--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -71,7 +71,8 @@ alter role example_role set statement_timeout = '10min'; -- could also use secon
 ```
 
 <Admonition type="tip">
-  If you are changing the timeout for the Supabase Client API calls, you will need to reload PostgREST to reflect the timeout changes by running the following script:
+
+If you are changing the timeout for the Supabase Client API calls, you will need to reload PostgREST to reflect the timeout changes by running the following script:
 
 ```sql
 NOTIFY pgrst, 'reload config';

--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -125,7 +125,9 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
     - On your project dashboard, click [Connect](https://supabase.com/dashboard/project/_?showConnect=true)
     - Find your Supavisor Session pooler string. It should end with 5432. It will be used in your `.env` file.
     <Admonition type="note">
+
       If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
     </Admonition>
 
     - If you plan on deploying Prisma to a serverless or auto-scaling environment, you'll also need your Supavisor transaction mode string.
@@ -282,7 +284,9 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="tip" label="conflict management">
+
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
+
             </Admonition>
 
             ```bash
@@ -308,7 +312,9 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="note" label="conflict management">
+
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
+
             </Admonition>
 
             ```bash
@@ -334,7 +340,9 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="note" label="conflict management">
+
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
+
             </Admonition>
 
             ```bash
@@ -360,7 +368,9 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="note" label="conflict management">
+
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma-troubleshooting) for more details
+
             </Admonition>
 
             ```bash

--- a/apps/docs/content/guides/database/replication/setting-up-replication.mdx
+++ b/apps/docs/content/guides/database/replication/setting-up-replication.mdx
@@ -15,9 +15,9 @@ To set up replication, the following is recommended:
 To create a replication slot, you will need to use the `postgres` user and follow the instructions in our [guide](/docs/guides/database/postgres/setup-replication-external).
 
 <Admonition type="note">
-  If you are running Postgres 17 or higher, you can create a new user and grant them replication
-  permissions with the `postgres` user. For versions below 17, you will need to use the `postgres`
-  user.
+
+If you are running Postgres 17 or higher, you can create a new user and grant them replication permissions with the `postgres` user. For versions below 17, you will need to use the `postgres` user.
+
 </Admonition>
 
 If you are replicating to an external system and using any of the tools below, check their documentation first and we have added additional information where the setup with Supabase can vary.

--- a/apps/docs/content/guides/deployment/branching.mdx
+++ b/apps/docs/content/guides/deployment/branching.mdx
@@ -115,7 +115,9 @@ You can use the [Supabase CLI](/docs/guides/cli) to manage changes inside a loca
             # postgres://postgres.xxxx:password@xxxx.pooler.supabase.com:6543/postgres
             ```
         <Admonition type="note">
+
           If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
         </Admonition>
 
         </StepHikeCompact.Details>
@@ -593,8 +595,9 @@ password = "env(SMTP_PASSWORD)"
 ```
 
 <Admonition type="note" label="Secrets are branch-specific">
-  Secrets set for one branch are not automatically available in other branches. You'll need to set
-  them separately for each branch that needs them.
+
+Secrets set for one branch are not automatically available in other branches. You'll need to set them separately for each branch that needs them.
+
 </Admonition>
 
 #### Using dotenvx for git-based workflow
@@ -649,10 +652,9 @@ secret = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET)"
 ```
 
 <Admonition type="note" label="Secret fields">
-  The `encrypted:` syntax only works for designated "secret" fields in the configuration (like
-  `secret` in auth providers). Using encrypted values in other fields will not be automatically
-  decrypted and may cause issues. For non-secret fields, use environment variables with the `env()`
-  syntax instead.
+
+The `encrypted:` syntax only works for designated "secret" fields in the configuration (like `secret` in auth providers). Using encrypted values in other fields will not be automatically decrypted and may cause issues. For non-secret fields, use environment variables with the `env()` syntax instead.
+
 </Admonition>
 
 ##### Using with preview branches

--- a/apps/docs/content/guides/functions/dependencies.mdx
+++ b/apps/docs/content/guides/functions/dependencies.mdx
@@ -125,9 +125,9 @@ The recommended file structure:
 
 <Admonition type="caution">
 
-  While it's possible to use a global `import_map.json` in the `/supabase/functions` directory for
-  local development, this approach is not recommended for deployment. Each function should maintain
-  its own import map to ensure proper isolation.
+While it's possible to use a global `import_map.json` in the `/supabase/functions` directory for
+local development, this approach is not recommended for deployment. Each function should maintain
+its own import map to ensure proper isolation.
 
 </Admonition>
 

--- a/apps/docs/content/guides/functions/dependencies.mdx
+++ b/apps/docs/content/guides/functions/dependencies.mdx
@@ -90,9 +90,9 @@ The recommended file structure for deployment:
 ```
 
 <Admonition type="caution">
-  While it's possible to use a global `deno.json` in the `/supabase/functions` directory for local
-  development, this approach is not recommended for deployment. Each function should maintain its
-  own configuration to ensure proper isolation and dependency management.
+
+While it's possible to use a global `deno.json` in the `/supabase/functions` directory for local development, this approach is not recommended for deployment. Each function should maintain its own configuration to ensure proper isolation and dependency management.
+
 </Admonition>
 
 ### Using import maps (legacy)
@@ -124,9 +124,11 @@ The recommended file structure:
 ```
 
 <Admonition type="caution">
+
   While it's possible to use a global `import_map.json` in the `/supabase/functions` directory for
   local development, this approach is not recommended for deployment. Each function should maintain
   its own import map to ensure proper isolation.
+
 </Admonition>
 
 If using import maps with VSCode, update your `.vscode/settings.json` to point to your function-specific import map:
@@ -173,9 +175,9 @@ Add your registry details in the `.npmrc` file. Follow [this guide](https://docs
 ```
 
 <Admonition type="caution">
-  While it's possible to use a global `.npmrc` in the `/supabase/functions` directory for local
-  development, we recommend using function-specific `.npmrc` files for deployment to maintain proper
-  isolation.
+
+While it's possible to use a global `.npmrc` in the `/supabase/functions` directory for local development, we recommend using function-specific `.npmrc` files for deployment to maintain proper isolation.
+
 </Admonition>
 
 After configuring your `.npmrc`, you can import the private package in your function code:

--- a/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
@@ -9,8 +9,9 @@ tocVideo: '4Roog4PAmZ8'
 In this tutorial you will learn how to build an edge API to generate, stream, store, and cache speech using Supabase Edge Functions, Supabase Storage, and [ElevenLabs text to speech API](https://elevenlabs.io/text-to-speech).
 
 <Admonition type="tip">
-  Find the [example project on
-  GitHub](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/text-to-speech/supabase/stream-and-cache-storage).
+
+Find the [example project on GitHub](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/text-to-speech/supabase/stream-and-cache-storage).
+
 </Admonition>
 
 ## Requirements
@@ -43,9 +44,9 @@ objects_path = "./audio"
 ```
 
 <Admonition type="tip">
-  Upon running `supabase start` this will create a new storage bucket in your local Supabase
-  project. Should you want to push this to your hosted Supabase project, you can run `supabase seed
-  buckets --linked`.
+
+Upon running `supabase start` this will create a new storage bucket in your local Supabase project. Should you want to push this to your hosted Supabase project, you can run `supabase seed buckets --linked`.
+
 </Admonition>
 
 ### Configure background tasks for Supabase Edge Functions
@@ -58,8 +59,9 @@ policy = "per_worker"
 ```
 
 <Admonition type="tip">
-  When running with `per_worker` policy, Function won't auto-reload on edits. You will need to
-  manually restart it by running `supabase functions serve`.
+
+When running with `per_worker` policy, Function won't auto-reload on edits. You will need to manually restart it by running `supabase functions serve`.
+
 </Admonition>
 
 ### Create a Supabase Edge Function for speech generation

--- a/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
@@ -11,8 +11,9 @@ In this tutorial you will learn how to build a Telegram bot that transcribes aud
 To check out what the end result will look like, you can test out the [t.me/ElevenLabsScribeBot](https://t.me/ElevenLabsScribeBot)
 
 <Admonition type="tip">
-  Find the [example project on
-  GitHub](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/speech-to-text/telegram-transcription-bot).
+
+Find the [example project on GitHub](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/speech-to-text/telegram-transcription-bot).
+
 </Admonition>
 
 ## Requirements

--- a/apps/docs/content/guides/functions/logging.mdx
+++ b/apps/docs/content/guides/functions/logging.mdx
@@ -29,8 +29,9 @@ When [developing locally](/docs/guides/functions/local-development) you will see
 - **Boot and Shutdown Logs**: The Logs tool extends its coverage to include logs for the boot and shutdown of functions.
 
 <Admonition type="note">
-  A custom log message can contain up to 10,000 characters. A function can log up to 100 events
-  within a 10 second period.
+
+A custom log message can contain up to 10,000 characters. A function can log up to 100 events within a 10 second period.
+
 </Admonition>
 
 Here is an example of how to use custom logs events in your function:

--- a/apps/docs/content/guides/functions/troubleshooting.mdx
+++ b/apps/docs/content/guides/functions/troubleshooting.mdx
@@ -59,9 +59,9 @@ To determine how much memory and CPU your Edge Function consumes, follow these s
 - View the resource usage **Metrics** on the charts provided.
 
 <Admonition type="note">
-  Edge Functions have limited resources (CPU, memory, and execution time) compared to traditional
-  servers. Make sure your functions are optimized for performance and don't exceed the allocated
-  resources.
+
+Edge Functions have limited resources (CPU, memory, and execution time) compared to traditional servers. Make sure your functions are optimized for performance and don't exceed the allocated resources.
+
 </Admonition>
 
 ### Understanding CPU soft and hard limits

--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -63,8 +63,9 @@ meta="index.ts"
 />
 
 <Admonition type="note">
-  Supabase Edge Functions currently use Deno 1.46. From [Deno 2.1, importing Wasm
-  modules](https://deno.com/blog/v2.1) will require even less boilerplate code.
+
+Supabase Edge Functions currently use Deno 1.46. From [Deno 2.1, importing Wasm modules](https://deno.com/blog/v2.1) will require even less boilerplate code.
+
 </Admonition>
 
 ### Bundle and deploy the Edge Function
@@ -72,7 +73,9 @@ meta="index.ts"
 Before deploying the Edge Function, we need to ensure it bundles the Wasm module with it. We can do this by defining it in the `static_files` for the function in `superbase/config.toml`.
 
 <Admonition type="note">
+
   You will need update Supabase CLI to 2.7.0 or higher for the `static_files` support.
+
 </Admonition>
 
 ```toml

--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -74,7 +74,7 @@ Before deploying the Edge Function, we need to ensure it bundles the Wasm module
 
 <Admonition type="note">
 
-  You will need update Supabase CLI to 2.7.0 or higher for the `static_files` support.
+You will need update Supabase CLI to 2.7.0 or higher for the `static_files` support.
 
 </Admonition>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
@@ -54,7 +54,9 @@ hideToc: true
     Look for the Session Pooler connection string and copy the string. You will need to replace the Password with your saved database password. You can reset your database password in your [database settings](https://supabase.com/dashboard/project/_/settings/database) if you do not have it.
 
       <Admonition type="note">
+
         If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
       </Admonition>
 
     </StepHikeCompact.Details>

--- a/apps/docs/content/guides/getting-started/quickstarts/ruby-on-rails.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/ruby-on-rails.mdx
@@ -36,7 +36,9 @@ hideToc: true
     Look for the Session Pooler connection string and copy the string. You will need to replace the Password with your saved database password. You can reset your database password in your [database settings](https://supabase.com/dashboard/project/_/settings/database) if you do not have it.
 
       <Admonition type="note">
+
         If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
       </Admonition>
 
     </StepHikeCompact.Details>

--- a/apps/docs/content/guides/platform/cost-control.mdx
+++ b/apps/docs/content/guides/platform/cost-control.mdx
@@ -15,7 +15,7 @@ After exceeding the quota for a usage item, further usage of that item is disall
 
 <Admonition type="note">
 
-  Note that only certain usage items are covered by the Spend Cap.
+Note that only certain usage items are covered by the Spend Cap.
 
 </Admonition>
 
@@ -25,7 +25,7 @@ Your projects will continue to operate after exceeding the quota for a usage ite
 
 <Admonition type="note">
 
-  When the Spend Cap is off, we recommend monitoring your usage and costs on the [organization's usage page](https://supabase.com/dashboard/org/_/usage).
+When the Spend Cap is off, we recommend monitoring your usage and costs on the [organization's usage page](https://supabase.com/dashboard/org/_/usage).
 
 </Admonition>
 

--- a/apps/docs/content/guides/platform/cost-control.mdx
+++ b/apps/docs/content/guides/platform/cost-control.mdx
@@ -14,7 +14,9 @@ This feature is available only with the Pro Plan. However, you will not be charg
 After exceeding the quota for a usage item, further usage of that item is disallowed until the next billing cycle. You don't get charged for over-usage but your services will be restricted according to our [Fair Use Policy](/docs/guides/platform/billing-faq#fair-use-policy) if you consistently exceed the quota.
 
 <Admonition type="note">
+
   Note that only certain usage items are covered by the Spend Cap.
+
 </Admonition>
 
 ### What happens when the Spend Cap is off?
@@ -22,8 +24,9 @@ After exceeding the quota for a usage item, further usage of that item is disall
 Your projects will continue to operate after exceeding the quota for a usage item. Any additional usage will be charged based on the item's cost per unit, as outlined on the [pricing page](https://supabase.com/pricing).
 
 <Admonition type="note">
-  When the Spend Cap is off, we recommend monitoring your usage and costs on the [organization's
-  usage page](https://supabase.com/dashboard/org/_/usage).
+
+  When the Spend Cap is off, we recommend monitoring your usage and costs on the [organization's usage page](https://supabase.com/dashboard/org/_/usage).
+
 </Admonition>
 
 ### Usage items covered by the Spend Cap

--- a/apps/docs/content/guides/platform/ipv4-address.mdx
+++ b/apps/docs/content/guides/platform/ipv4-address.mdx
@@ -53,8 +53,9 @@ curl -X DELETE "https://api.supabase.com/v1/projects/$PROJECT_REF/billing/addons
 ```
 
 <Admonition type="caution">
-  Note that direct database connections can experience a short amount of downtime when toggling the
-  add-on due to DNS reconfiguration and propagation. Generally, this should be less than a minute.
+
+Note that direct database connections can experience a short amount of downtime when toggling the add-on due to DNS reconfiguration and propagation. Generally, this should be less than a minute.
+
 </Admonition>
 
 ## Read replicas and IPv4 add-on

--- a/apps/docs/content/guides/platform/migrating-to-supabase/postgres.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/postgres.mdx
@@ -29,8 +29,9 @@ Example:
 1. Under Session pooler, Copy the connection string and replace the password placeholder with your database password.
 
    <Admonition type="note">
-     If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have
-     the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
+   If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
    </Admonition>
 
 ![Finding Supabase host address](/docs/img/guides/resources/migrating-to-supabase/postgres/database-settings-host.png)

--- a/apps/docs/content/guides/platform/migrating-to-supabase/render.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/render.mdx
@@ -33,8 +33,9 @@ Example:
 1. Under Session pooler, Copy the connection string and replace the password placeholder with your database password.
 
    <Admonition type="note">
-     If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have
-     the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
+   If you're in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, you can use the direct connection string instead of Supavisor in Session mode.
+
    </Admonition>
 
 ## Migrate the database

--- a/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
@@ -24,7 +24,9 @@ breadcrumb: 'Migrations'
       On your project dashboard, click [Connect](https://supabase.com/dashboard/project/_?showConnect=true).
 
       <Admonition type="note">
+
         Use the Session pooler connection string by default. If your ISP supports IPv6 or you have the IPv4 add-on enabled, use the direct connection string.
+
       </Admonition>
 
       Session pooler connection string:
@@ -112,7 +114,9 @@ breadcrumb: 'Migrations'
         Go to the [project page](/dashboard/project/_/) and click the "**Connect**" button at the top of the page for the connection string.
 
       <Admonition type="note">
+
         Use the Session pooler connection string by default. If your ISP supports IPv6, use the direct connection string.
+
       </Admonition>
 
         Session pooler connection string:

--- a/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
@@ -67,7 +67,9 @@ Here are some things that are not stored directly in your database and will requ
       On your project dashboard, click [Connect](https://supabase.com/dashboard/project/_?showConnect=true).
 
       <Admonition type="note">
+
         Use the Session pooler connection string by default. If your ISP supports IPv6 or you have the IPv4 add-on enabled, use the direct connection string.
+
       </Admonition>
 
       Session pooler connection string:
@@ -85,7 +87,9 @@ Here are some things that are not stored directly in your database and will requ
 <StepHikeCompact.Step step={2}>
   <StepHikeCompact.Details title="Get the database password" fullWidth>
     <Admonition type="caution">
+
       It can take a few minutes for the database password reset to take effect. Especially if multiple password resets are done.
+
     </Admonition>
     Reset the password in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database).
 

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -136,6 +136,7 @@ To call a read-only Postgres function on Read Replicas through the REST API, use
 If you remove all Read Replicas from your project, the load balancer and its endpoint are removed as well. Make sure to redirect requests back to your Primary database before removal.
 
 <Admonition type="note">
+
 Starting on April 4th, 2025, we will be changing the routing behavior for eligible Data API requests:
 
 - Old behavior: Round-Robin distribution among all databases (all read replicas + primary) of your project, regardless of location

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -23,8 +23,9 @@ The Migrating and Upgrading guide has been divided into two sections. To migrate
 ## In-place upgrades
 
 <Admonition type="note">
-  For security purposes, passwords for custom roles are not backed up and, following a restore, they
-  would need to be reset. See [here](/docs/guides/platform/backups#daily-backups) for more details
+
+For security purposes, passwords for custom roles are not backed up and, following a restore, they would need to be reset. See [here](/docs/guides/platform/backups#daily-backups) for more details
+
 </Admonition>
 
 In-place upgrades uses `pg_upgrade`. For projects larger than 1GB, this method is generally faster than a pause and restore cycle, and the speed advantage grows with the size of the database.

--- a/apps/docs/content/guides/storage/debugging/error-codes.mdx
+++ b/apps/docs/content/guides/storage/debugging/error-codes.mdx
@@ -9,8 +9,9 @@ sidebar_label: 'Debugging'
 ## Storage error codes
 
 <Admonition type="note">
-  We are transitioning to a new error code system. For backwards compatibility you'll still be able
-  to see the old error codes
+
+We are transitioning to a new error code system. For backwards compatibility you'll still be able to see the old error codes
+
 </Admonition>
 
 Error codes in Storage are returned as part of the response body. They are useful for debugging and understanding what went wrong with your request.

--- a/apps/docs/content/guides/storage/schema/design.mdx
+++ b/apps/docs/content/guides/storage/schema/design.mdx
@@ -9,6 +9,7 @@ sidebar_label: 'Schema'
 Storage uses Postgres to store metadata regarding your buckets and objects. Users can use RLS (Row-Level Security) policies for access control. This data is stored in a dedicated schema within your project called `storage`.
 
 <Admonition type="note">
+
 When working with SQL, it's crucial to consider all records in Storage tables as read-only. All operations, including uploading, copying, moving, and deleting, should **exclusively go through the API**.
 
 This is important because the storage schema only stores the metadata and the actual objects are stored in a provider like S3. Deleting the metadata doesn't remove the object in the underlying storage provider. This results in your object being inaccessible, but you'll still be billed for it.

--- a/apps/docs/content/guides/telemetry/log-drains.mdx
+++ b/apps/docs/content/guides/telemetry/log-drains.mdx
@@ -28,7 +28,9 @@ Custom headers can optionally be configured for all requests.
 Note that requests are **unsigned**.
 
 <Admonition type="note">
+
   Unsigned requests to HTTP endpoints are temporary and all requests will signed in the near future.
+
 </Admonition>
 
 <Accordion

--- a/apps/docs/content/guides/telemetry/log-drains.mdx
+++ b/apps/docs/content/guides/telemetry/log-drains.mdx
@@ -29,7 +29,7 @@ Note that requests are **unsigned**.
 
 <Admonition type="note">
 
-  Unsigned requests to HTTP endpoints are temporary and all requests will signed in the near future.
+Unsigned requests to HTTP endpoints are temporary and all requests will signed in the near future.
 
 </Admonition>
 

--- a/apps/docs/content/guides/telemetry/metrics.mdx
+++ b/apps/docs/content/guides/telemetry/metrics.mdx
@@ -130,6 +130,6 @@ You can configure alerts from Prometheus or Grafana. The `supabase-grafana` repo
 <Admonition type="caution">
 
 Grafana Cloud has an unofficial integration for scraping Supabase metrics. See their [docs](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-supabase/) for instructions on how to configure it but note that it is not full-featured nor is it supported
-  by Supabase.
+by Supabase.
 
 </Admonition>

--- a/apps/docs/content/guides/telemetry/metrics.mdx
+++ b/apps/docs/content/guides/telemetry/metrics.mdx
@@ -128,8 +128,8 @@ Click `Load` and the dashboard will load from the project specified in your Prom
 You can configure alerts from Prometheus or Grafana. The `supabase-grafana` repository has a selection of [example alerts](https://github.com/supabase/supabase-grafana/blob/main/docs/example-alerts.md) that can be configured.
 
 <Admonition type="caution">
-  Grafana Cloud has an unofficial integration for scraping Supabase metrics. See their
-  [docs](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-supabase/)
-  for instructions on how to configure it but note that it is not full-featured nor is it supported
+
+Grafana Cloud has an unofficial integration for scraping Supabase metrics. See their [docs](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-supabase/) for instructions on how to configure it but note that it is not full-featured nor is it supported
   by Supabase.
+
 </Admonition>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -124,7 +124,7 @@
     "@graphql-codegen/cli": "5.0.5",
     "@graphql-codegen/typescript": "4.1.6",
     "@graphql-codegen/typescript-resolvers": "4.5.0",
-    "@supabase/supa-mdx-lint": "0.2.9-alpha",
+    "@supabase/supa-mdx-lint": "0.3.0-alpha",
     "@types/common-tags": "^1.8.4",
     "@types/estree": "1.0.5",
     "@types/graphql-validation-complexity": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,8 +544,8 @@ importers:
         specifier: 4.5.0
         version: 4.5.0(encoding@0.1.13)(graphql-sock@1.0.1(graphql@16.10.0))(graphql@16.10.0)
       '@supabase/supa-mdx-lint':
-        specifier: 0.2.9-alpha
-        version: 0.2.9-alpha
+        specifier: 0.3.0-alpha
+        version: 0.3.0-alpha
       '@types/common-tags':
         specifier: ^1.8.4
         version: 1.8.4
@@ -7914,8 +7914,8 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
-  '@supabase/supa-mdx-lint-darwin@0.2.9-alpha':
-    resolution: {integrity: sha512-o2Yy7VdfGvzgy9jwDUt90u0ZWms9OECyC/BG+elZN3ShSsIUrK/Z/OMZVYrGnbGLfoFmYPcAuawIsqGvhc/iCg==}
+  '@supabase/supa-mdx-lint-darwin@0.3.0-alpha':
+    resolution: {integrity: sha512-gz8qGrigRIoU3JAAygmxUxTm+0RoNy3fbIW7jo5eLxY9V3aMmLqwAUMsV8afNJjtjP7MpnpN8poIFsSSAi9A7w==}
     engines: {node: '>=10'}
     os: [darwin]
 
@@ -7925,8 +7925,8 @@ packages:
     cpu: [arm64]
     os: [linux, freebsd]
 
-  '@supabase/supa-mdx-lint-linux-arm64@0.2.9-alpha':
-    resolution: {integrity: sha512-62spvawezXAr3u0tTVi+NfQEMXL6WG3+fZHh5y6ftIRb74m3AIBfnstltf4zf3PQ2U4mxIBbFK6FV5hXF8pRcA==}
+  '@supabase/supa-mdx-lint-linux-arm64@0.3.0-alpha':
+    resolution: {integrity: sha512-zr3wBIsKltCFpb4yJ9vmCehFcMTihSdGwfFi9p1cZEUs0n+Kug6MncFpk5PsSsahNHk76IvdxnyLxkD0NV+YZA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux, freebsd]
@@ -7937,8 +7937,8 @@ packages:
     cpu: [arm]
     os: [linux, freebsd]
 
-  '@supabase/supa-mdx-lint-linux-arm@0.2.9-alpha':
-    resolution: {integrity: sha512-AhrT5bYc/N46Dmn/4pgTYAQE2aPhVA5+XKAWYVFAxPjEw9x64Cf9Y4oGwt9i4gFrhxEBckNVuH7a8UWfg6legw==}
+  '@supabase/supa-mdx-lint-linux-arm@0.3.0-alpha':
+    resolution: {integrity: sha512-azoxkiqEv4AJfjaWxp0qoL/KFuKXSG2Ex8DgwVwkpbB3oWXhVuuTxMSyJYB2l49seRXBprIrDlXDpzC6BH4leQ==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux, freebsd]
@@ -7949,8 +7949,8 @@ packages:
     cpu: [x86, ia32]
     os: [linux, freebsd]
 
-  '@supabase/supa-mdx-lint-linux-i686@0.2.9-alpha':
-    resolution: {integrity: sha512-WGZksF2EFZqK5EJBQj7myvlZvKuw56DVxg+TWe8dvgPJFsy60NooUJJX/0Gij8i10bSGnP9hcrIUUinSBFrnKA==}
+  '@supabase/supa-mdx-lint-linux-i686@0.3.0-alpha':
+    resolution: {integrity: sha512-QjIL+qwfCO+pbQR+VnLpPryp/Hm8FoPufWl31/v8Yo2GGJdwYYgt8NU/iDzDjbzLCXdnfRLO68BPh5g5DmG7wQ==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [linux, freebsd]
@@ -7961,8 +7961,8 @@ packages:
     cpu: [x64]
     os: [linux, freebsd]
 
-  '@supabase/supa-mdx-lint-linux-x64@0.2.9-alpha':
-    resolution: {integrity: sha512-jN8G4D7T5zxq8/5sfriMO6PSxXmXTZxQKwUS2cX/+PV24Biln3STzdszxwA4ix6D3rrSaYc+AZ/rVkmZGLL9qg==}
+  '@supabase/supa-mdx-lint-linux-x64@0.3.0-alpha':
+    resolution: {integrity: sha512-7v+vWGHhamTJJuMXzS9VZ6XvIgMMLFQxd8df4P/RppdEFTSWDZO/MWMhfhjz3opRrkYA+hGCTgUk+CWN8ggbig==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux, freebsd]
@@ -7973,8 +7973,8 @@ packages:
     cpu: [x86, ia32]
     os: [win32]
 
-  '@supabase/supa-mdx-lint-win32-i686@0.2.9-alpha':
-    resolution: {integrity: sha512-uZ7orThD7stUGuenpNGCMUuIpmpJ6p7+D99aCWBqF9YfJX3jFX212Jaj3k0qxDaUFmMzX6MEbjHT+57ix1/0YA==}
+  '@supabase/supa-mdx-lint-win32-i686@0.3.0-alpha':
+    resolution: {integrity: sha512-KX/tVNJSYyCUb9VSxDqbpsMZUjvH4NOMTy5f/+fHXOzD4XxdzH+mImUBVpcrwyQrbV4YtwL4kQBUj9pVETuKSQ==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [win32]
@@ -7985,8 +7985,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@supabase/supa-mdx-lint-win32-x64@0.2.9-alpha':
-    resolution: {integrity: sha512-RWaywt2IzYUDXbAvqhwxN8Q7sAQMKCpZY8wVd5mBpmMBDtPp7FTYIjZV0erSYB+huUp9rc/hmN7HgI6GEZdviw==}
+  '@supabase/supa-mdx-lint-win32-x64@0.3.0-alpha':
+    resolution: {integrity: sha512-SFRAOaG/3fK4dFODuqI6XgAV+MBx/vjP6N6mt6eDvlUKMT54iuKUQSfDf52Q3nyDKRkaasxl51CQDO5gPMXItQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -7995,8 +7995,8 @@ packages:
     resolution: {integrity: sha512-rfp+xsnTaQ/UB5LNNZEh6w00JxxkZMoZnjjIgb/TBvqr/E1DbWyLHSyWwMD8sBoC+LX8q20ym75GRAXhvxIONA==}
     hasBin: true
 
-  '@supabase/supa-mdx-lint@0.2.9-alpha':
-    resolution: {integrity: sha512-+zQQkqjau6Mw1pRrqma5amniRNjp54oNq1S+8A/UcvwEuq2xBZk44qD8VYG79GaM6sX1LE1kTmeelC2MK5hMNA==}
+  '@supabase/supa-mdx-lint@0.3.0-alpha':
+    resolution: {integrity: sha512-7ndeL31NIiMcS+0Unv99GN9n1NG4ZwZuE6o0LbpFZzXatxn6noYiAwWtwgzipxjDGI7CGYxRPQQN048Wn9oJ4Q==}
     hasBin: true
 
   '@supabase/supabase-js@2.49.3':
@@ -26674,43 +26674,43 @@ snapshots:
   '@supabase/supa-mdx-lint-darwin@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-darwin@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-darwin@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint-linux-arm64@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-linux-arm64@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-linux-arm64@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint-linux-arm@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-linux-arm@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-linux-arm@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint-linux-i686@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-linux-i686@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-linux-i686@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint-linux-x64@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-linux-x64@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-linux-x64@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint-win32-i686@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-win32-i686@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-win32-i686@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint-win32-x64@0.2.6-alpha':
     optional: true
 
-  '@supabase/supa-mdx-lint-win32-x64@0.2.9-alpha':
+  '@supabase/supa-mdx-lint-win32-x64@0.3.0-alpha':
     optional: true
 
   '@supabase/supa-mdx-lint@0.2.6-alpha':
@@ -26724,15 +26724,15 @@ snapshots:
       '@supabase/supa-mdx-lint-win32-x64': 0.2.6-alpha
       node-pty: 1.0.0
 
-  '@supabase/supa-mdx-lint@0.2.9-alpha':
+  '@supabase/supa-mdx-lint@0.3.0-alpha':
     optionalDependencies:
-      '@supabase/supa-mdx-lint-darwin': 0.2.9-alpha
-      '@supabase/supa-mdx-lint-linux-arm': 0.2.9-alpha
-      '@supabase/supa-mdx-lint-linux-arm64': 0.2.9-alpha
-      '@supabase/supa-mdx-lint-linux-i686': 0.2.9-alpha
-      '@supabase/supa-mdx-lint-linux-x64': 0.2.9-alpha
-      '@supabase/supa-mdx-lint-win32-i686': 0.2.9-alpha
-      '@supabase/supa-mdx-lint-win32-x64': 0.2.9-alpha
+      '@supabase/supa-mdx-lint-darwin': 0.3.0-alpha
+      '@supabase/supa-mdx-lint-linux-arm': 0.3.0-alpha
+      '@supabase/supa-mdx-lint-linux-arm64': 0.3.0-alpha
+      '@supabase/supa-mdx-lint-linux-i686': 0.3.0-alpha
+      '@supabase/supa-mdx-lint-linux-x64': 0.3.0-alpha
+      '@supabase/supa-mdx-lint-win32-i686': 0.3.0-alpha
+      '@supabase/supa-mdx-lint-win32-x64': 0.3.0-alpha
       node-pty: 1.0.0
 
   '@supabase/supabase-js@2.49.3':


### PR DESCRIPTION
new:
- admonition tags must be separated from content by blank line (otherwise prettier puts in line breaks that break formatting in the final page)
- fix to interactive fix mode to prevent it eating newlines in some cases