### PR TITLE
docs: update documentation for issue #36705

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -895,14 +895,14 @@ parameters:
       - name: 'Auth Server configuration'
         link: 'https://supabase.com/docs/reference/auth'
 
-  - id: 'auth.email.otp_exp'
-    title: 'auth.email.otp_exp'
+  - id: 'auth.email.otp_expiry'
+    title: 'auth.email.otp_expiry'
     tags: ['auth']
     required: false
-    default: '300'
+    default: '3600'
     description: |
       The expiry time for an OTP code in seconds.
-      Default is 300 seconds (5 minutes).
+      Default is 3600 seconds (1 hour).
     links:
       - name: 'Auth Server configuration'
         link: 'https://supabase.com/docs/reference/auth'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The current [config.toml](https://github.com/supabase/cli/blob/2e8672d925496be4a438bc086ed2ab990a603349/pkg/config/templates/config.toml#L169) file has the key `otp_expiry`
```toml
otp_expiry = 3600
```
but the [docs](https://supabase.com/docs/guides/local-development/cli/config#auth.email.otp_exp) points the key `otp_exp`


## What is the new behavior?

Update the docs to reference the correct key.

## Additional context

Add any other context or screenshots.

[Supabase CLI #3760](https://github.com/supabase/cli/issues/3760)
Closes #36705 