### PR TITLE
Update background-tasks.mdx with lint errors fix

### DIFF
--- a/apps/docs/content/guides/functions/background-tasks.mdx
+++ b/apps/docs/content/guides/functions/background-tasks.mdx
@@ -19,7 +19,9 @@ You can listen to the `beforeunload` event handler to be notified when Function 
 
 Here's an example of using `EdgeRuntime.waitUntil` to run a background task and using `beforeunload` event to be notified when the instance is about to be shut down.
 
-```ts
+```ts 
+/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />
+
 async function longRunningTask() {
   // do work here
 }
@@ -42,11 +44,18 @@ Deno.serve(async (req) => {
 })
 ```
 
+**Note:**
+To prevent linting errors, make sure add the following line at the top of your Edge Function file:
+
+`/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />`
+
 ### Starting a background task in the request handler
 
 You can call `EdgeRuntime.waitUntil` in the request handler too. This will not block the request.
 
 ```ts
+/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />
+
 async function fetchAndLog(url: string) {
   const response = await fetch(url)
   console.log(response)


### PR DESCRIPTION
I added a triple-slash directive (/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />) instruction. This makes the TypeScript compiler aware of the EdgeRuntime type without creating a runtime dependency.

`/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />`

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

Users get a lint error when adding EdgeRuntime.waitUntil() since the IDE does not know of its existence.

## What is the new behavior?

Added a note to add the reference types line above their function.
