### PR TITLE
Chore/fix index delete

### DIFF
--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -77,6 +77,7 @@ const Indexes = () => {
       projectRef: project.ref,
       connectionString: project.connectionString,
       name: index.name,
+      schema: selectedSchema,
     })
   }
 

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -9,14 +9,16 @@ export type DatabaseIndexDeleteVariables = {
   projectRef: string
   connectionString?: string | null
   name: string
+  schema: string
 }
 
 export async function deleteDatabaseIndex({
   projectRef,
   connectionString,
   name,
+  schema,
 }: DatabaseIndexDeleteVariables) {
-  const sql = `drop index if exists "${name}"`
+  const sql = `drop index if exists "${schema}"."${name}"`
 
   const { result } = await executeSql({
     projectRef,


### PR DESCRIPTION
Pass the schema to delete index action. 

To reproduce: 
- create a custom schema
- create a table with an index in this schema
- delete the index via the ui 
- you'll get a success toast, but it won't delete successfully 