### PR TITLE
Change path to pathname in storage unified logs query

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -460,7 +460,7 @@ const getSupabaseStorageLogsQuery = () => {
           WHEN edge_logs_response.status_code >= 500 THEN 'error'
           ELSE 'success'
       END as level,
-      edge_logs_request.path as path,
+      edge_logs_request.path as pathname,
       edge_logs_request.host as host,
       null as event_message,
       edge_logs_request.method as method,

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -346,7 +346,7 @@ const getEdgeFunctionLogsQuery = () => {
           WHEN fel_response.status_code >= 500 THEN 'error'
           ELSE 'success'
       END as level,
-      fel_request.url as pathname,
+      fel_request.path as pathname,
       fel_request.host as host,
       COALESCE(function_logs_agg.last_event_message, '') as event_message,
       fel_request.method as method,


### PR DESCRIPTION
## Context

I've recently updated all `path` properties for the Unified Logs queries to `pathname` for consistency + fixes searching pathname through the DataTableFilterSheet back in this [PR](https://github.com/supabase/supabase/pull/36710). This PR just updates `path` to `pathname` for the newly added storage logs query 

## To test

- [ ] Verify that storage logs can still be viewed and can be searched via the Unified Logs interface
  - I'm not exactly sure how to generate storage logs though, might need to check with Jonny for this. Although can probably try doing some stuff in the storage explorer, see if that generates anything