### PR TITLE
fix: pooler connect to POSTGRES_HOST

### DIFF
--- a/docker/volumes/pooler/pooler.exs
+++ b/docker/volumes/pooler/pooler.exs
@@ -8,7 +8,7 @@
 
 params = %{
   "external_id" => System.get_env("POOLER_TENANT_ID"),
-  "db_host" => "db",
+  "db_host" => System.get_env("POSTGRES_HOST"),
   "db_port" => System.get_env("POSTGRES_PORT"),
   "db_database" => System.get_env("POSTGRES_DB"),
   "require_user" => false,


### PR DESCRIPTION
In my previous PR, I changed hard-code `db` to `${POSTGRES_HOST}` in docker/docker-compose.yml . 

According to https://github.com/supabase/supabase/pull/36572#issuecomment-3025883723 this reply, I should also fix the same problem in pooler.exs .

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
