### PR TITLE
docs(#36820): correct title and grammar in RedwoodJS quickstart guide

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
@@ -223,10 +223,10 @@ hideToc: true
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={12}>
-    <StepHikeCompact.Details title="View Books UI">
-      Click on `/instruments` to visit http://localhost:8910/instruments where should see the list of instruments.
+    <StepHikeCompact.Details title="View Instruments UI">
+      Click on `/instruments` to visit http://localhost:8910/instruments where you should see the list of instruments.
 
-      You may now edit, delete, and add new books using the scaffolded UI.
+      You may now edit, delete, and add new instruments using the scaffolded UI.
     </StepHikeCompact.Details>
 
   </StepHikeCompact.Step>


### PR DESCRIPTION
# Pull Request: Fix RedwoodJS Quickstart Documentation

## Changes Made
- Change 'View Books UI' to 'View Instruments UI' for consistency
- Fix grammar: add 'you' in 'where you should see the list'

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update - fixing typos and inconsistencies in documentation

## What is the current behavior?

The RedwoodJS quickstart guide has inconsistent terminology and a grammar error:
- Step 12 title says "View Books UI" but the entire guide is about instruments
- Missing word "you" in the sentence "where should see the list of instruments"

File: apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
Lines: 221-225

## What is the new behavior?

- Step 12 title now correctly says "View Instruments UI" to match the guide's content
- Grammar is fixed to read "where you should see the list of instruments"
- Documentation is now consistent throughout the entire quickstart guide

## Additional context

This is a minor documentation fix that improves readability and consistency. The guide walks users through creating an "Instrument" model and scaffolding, so all references should use "instruments" terminology rather than "books".

No visual changes - this is a text-only documentation update.