### PR TITLE
format data to ms in execution time - edge fn report

### DIFF
--- a/apps/studio/components/ui/Charts/Charts.utils.tsx
+++ b/apps/studio/components/ui/Charts/Charts.utils.tsx
@@ -36,6 +36,9 @@ export const isFloat = (num: number) => String(num).includes('.')
  * precisionFormatter(123.123, 2)   // "123.12"
  */
 export const precisionFormatter = (num: number, precision: number): string => {
+  if (precision === 0) {
+    return String(Math.round(num))
+  }
   if (isFloat(num)) {
     const [head, tail] = String(num).split('.')
     return Number(head).toLocaleString() + '.' + tail.slice(0, precision)

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -346,6 +346,7 @@ export default function ComposedChart({
               showTooltip ? (
                 <CustomTooltip
                   {...props}
+                  format={format}
                   isPercentage={isPercentage}
                   label={resolvedHighlightedLabel}
                   attributes={attributes}

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -105,6 +105,7 @@ interface TooltipProps {
   label?: string | number
   attributes?: MultiAttribute[]
   isPercentage?: boolean
+  format?: 'ms'
   valuePrecision?: number
   showMaxValue?: boolean
   showTotal?: boolean
@@ -131,6 +132,7 @@ const CustomTooltip = ({
   payload,
   attributes,
   isPercentage,
+  format,
   valuePrecision,
   showTotal,
   isActiveHoveredChart,
@@ -183,6 +185,7 @@ const CustomTooltip = ({
               ? formatBytes(isNetworkChart ? Math.abs(entry.value) : entry.value, valuePrecision)
               : numberFormatter(entry.value, valuePrecision)}
             {isPercentage ? '%' : ''}
+            {format === 'ms' ? 'ms' : ''}
 
             {/* Show percentage if max value is set */}
             {!!maxValueData && !isMax && !isPercentage && (
@@ -220,6 +223,7 @@ const CustomTooltip = ({
                       )
                     : numberFormatter(total as number, valuePrecision)}
                   {isPercentage ? '%' : ''}
+                  {format === 'ms' ? 'ms' : ''}
                 </span>
                 {maxValueAttribute &&
                   !isPercentage &&

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -9,6 +9,7 @@ import { formatBytes } from 'lib/helpers'
 
 export interface ReportAttributes {
   id?: string
+  titleTooltip?: string
   label: string
   attributes?: (MultiAttribute | false)[]
   defaultChartStyle?: 'bar' | 'line' | 'stackedAreaLine'

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -105,7 +105,7 @@ interface TooltipProps {
   label?: string | number
   attributes?: MultiAttribute[]
   isPercentage?: boolean
-  format?: 'ms'
+  format?: string | ((value: unknown) => string)
   valuePrecision?: number
   showMaxValue?: boolean
   showTotal?: boolean

--- a/apps/studio/data/reports/edgefn-charts.ts
+++ b/apps/studio/data/reports/edgefn-charts.ts
@@ -1,4 +1,6 @@
-export const getEdgeFunctionReportAttributes = () => [
+import { ReportAttributes } from 'components/ui/Charts/ComposedChart.utils'
+
+export const getEdgeFunctionReportAttributes = (): ReportAttributes[] => [
   {
     id: 'invocations',
     label: 'Edge Function Invocations',
@@ -60,7 +62,7 @@ export const getEdgeFunctionReportAttributes = () => [
   {
     id: 'execution-time',
     label: 'Edge Function Execution Time',
-    valuePrecision: 2,
+    valuePrecision: 0,
     hide: false,
     showTooltip: true,
     showLegend: true,
@@ -68,6 +70,11 @@ export const getEdgeFunctionReportAttributes = () => [
     hideChartType: false,
     defaultChartStyle: 'line',
     titleTooltip: 'Average execution time for edge functions.',
+    format: 'ms',
+    YAxisProps: {
+      width: 50,
+      tickFormatter: (value: number) => `${value}ms`,
+    },
     attributes: [
       {
         attribute: 'ExecutionTime',


### PR DESCRIPTION
## To test
- go to edge functions report
- go to execution time
- hover the chart
- shows numbers as ms (ex: 320ms)