### PR TITLE
backup-restore.mdx: Fix storage migration

### DIFF
--- a/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
@@ -234,9 +234,7 @@ const NEW_PROJECT_SERVICE_KEY = 'new-project-service-key-yyy'
 
 ;(async () => {
   const oldSupabaseRestClient = createClient(OLD_PROJECT_URL, OLD_PROJECT_SERVICE_KEY, {
-    db: {
-      schema: 'storage',
-    },
+    schema: 'storage',
   })
   const oldSupabaseClient = createClient(OLD_PROJECT_URL, OLD_PROJECT_SERVICE_KEY)
   const newSupabaseClient = createClient(NEW_PROJECT_URL, NEW_PROJECT_SERVICE_KEY)


### PR DESCRIPTION
The specification of the `storage` schema seems to have been outdated.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix documentation

## What is the current behavior?

Running the migration script fails with:
```
> node move_storage.js 
error getting objects from old bucket
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".] {
  code: 'ERR_UNHANDLED_REJECTION'
}

Node.js v20.12.2
```

## What is the new behavior?
Migration succeeds:
```
> node move_storage.js 
moving 48195ca5-8c7f-4035-9584-22c0348ec210
moving 32eb9410-bfb9-4be0-8c4c-6b8394306f8a
moving 75cdb668-3e91-4755-8bca-90c518018c25
moving c98635da-7d85-4885-a2bf-e2ce21286327
...
```

