### PR TITLE
Changed -an List- to -a List-

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -3167,7 +3167,7 @@ functions:
       - name: values
         isOptional: false
         type: Map<String, dynamic> or List<Map<String, dynamic>>
-        description: The values to upsert with. Pass a Map to upsert a single row or a List to upsert multiple rows.
+        description: The values to upsert with. Pass a Map to upsert a single row or an array to upsert multiple rows.
       - name: onConflict
         isOptional: true
         type: String

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -3167,7 +3167,7 @@ functions:
       - name: values
         isOptional: false
         type: Map<String, dynamic> or List<Map<String, dynamic>>
-        description: The values to upsert with. Pass a Map to upsert a single row or an List to upsert multiple rows.
+        description: The values to upsert with. Pass a Map to upsert a single row or a List to upsert multiple rows.
       - name: onConflict
         isOptional: true
         type: String


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?
A spelling mistake 

Please link any relevant issues here.

## What is the new behavior?
Corrected the spelling from "an List" to "a List"
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
