### PR TITLE
backup-restore.mdx: Better fix

### DIFF
--- a/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
@@ -223,7 +223,7 @@ supabase db diff --linked --schema auth,storage > changes.sql
 The new project has the old project's Storage buckets, but the Storage objects need to be migrated manually. Use this script to move storage objects from one project to another.
 
 ```js
-// npm install @supabase/supabase-js@1
+// npm install @supabase/supabase-js@2
 const { createClient } = require('@supabase/supabase-js')
 
 const OLD_PROJECT_URL = 'https://xxx.supabase.co'
@@ -234,7 +234,9 @@ const NEW_PROJECT_SERVICE_KEY = 'new-project-service-key-yyy'
 
 ;(async () => {
   const oldSupabaseRestClient = createClient(OLD_PROJECT_URL, OLD_PROJECT_SERVICE_KEY, {
-    schema: 'storage',
+    db: {
+      schema: 'storage',
+    },
   })
   const oldSupabaseClient = createClient(OLD_PROJECT_URL, OLD_PROJECT_SERVICE_KEY)
   const newSupabaseClient = createClient(NEW_PROJECT_URL, NEW_PROJECT_SERVICE_KEY)


### PR DESCRIPTION
The argument, I previously fixed, was actually correct for version @2 but the header said to use @1, so better change that and use the newer argument style.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

It's OK but uses the older version of supabase-js.

## What is the new behavior?

It uses supabase-js@2.

