### PR TITLE
realtime: Limit access to settings based on project

### DIFF
--- a/apps/studio/components/layouts/RealtimeLayout/RealtimeLayout.tsx
+++ b/apps/studio/components/layouts/RealtimeLayout/RealtimeLayout.tsx
@@ -14,7 +14,14 @@ export interface RealtimeLayoutProps {
 
 const RealtimeLayout = ({ title, children }: PropsWithChildren<RealtimeLayoutProps>) => {
   const project = useSelectedProject()
-  const enableRealtimeSettings = useFlag('enableRealtimeSettings')
+  const enableRealtimeSettingsFlag = useFlag<string>('enableRealtimeSettings')
+  const enableRealtimeSettings =
+    project?.ref &&
+    enableRealtimeSettingsFlag &&
+    enableRealtimeSettingsFlag
+      .split(',')
+      .map((it) => it.trim())
+      .includes(project.ref)
 
   const router = useRouter()
   const page = router.pathname.split('/')[4]

--- a/apps/studio/components/layouts/RealtimeLayout/RealtimeLayout.tsx
+++ b/apps/studio/components/layouts/RealtimeLayout/RealtimeLayout.tsx
@@ -14,15 +14,18 @@ export interface RealtimeLayoutProps {
 
 const RealtimeLayout = ({ title, children }: PropsWithChildren<RealtimeLayoutProps>) => {
   const project = useSelectedProject()
-  const enableRealtimeSettingsFlag = useFlag<string>('enableRealtimeSettings')
-  const enableRealtimeSettings = !!(
-    project?.ref &&
-    enableRealtimeSettingsFlag &&
-    enableRealtimeSettingsFlag
+  // the flag is used to enable/disable the realtime settings for all projects
+  const enableRealtimeSettingsFlag = useFlag('enableRealtimeSettings')
+  // the flag is used to enable/disable the realtime settings for specific projects. Will be overridden by the enableRealtimeSettingsFlag if it is enabled.
+  const approvedProjects = useFlag<string>('isRealtimeSettingsEnabledOnProjects')
+
+  const isEnabledOnProject =
+    !!project?.ref &&
+    typeof approvedProjects === 'string' &&
+    (approvedProjects ?? '')
       .split(',')
       .map((it) => it.trim())
-      .includes(project.ref)
-  )
+      .includes(project?.ref)
 
   const router = useRouter()
   const page = router.pathname.split('/')[4]
@@ -34,7 +37,9 @@ const RealtimeLayout = ({ title, children }: PropsWithChildren<RealtimeLayoutPro
       productMenu={
         <ProductMenu
           page={page}
-          menu={generateRealtimeMenu(project!, { enableRealtimeSettings })}
+          menu={generateRealtimeMenu(project!, {
+            enableRealtimeSettings: enableRealtimeSettingsFlag || isEnabledOnProject,
+          })}
         />
       }
     >

--- a/apps/studio/components/layouts/RealtimeLayout/RealtimeLayout.tsx
+++ b/apps/studio/components/layouts/RealtimeLayout/RealtimeLayout.tsx
@@ -15,13 +15,14 @@ export interface RealtimeLayoutProps {
 const RealtimeLayout = ({ title, children }: PropsWithChildren<RealtimeLayoutProps>) => {
   const project = useSelectedProject()
   const enableRealtimeSettingsFlag = useFlag<string>('enableRealtimeSettings')
-  const enableRealtimeSettings =
+  const enableRealtimeSettings = !!(
     project?.ref &&
     enableRealtimeSettingsFlag &&
     enableRealtimeSettingsFlag
       .split(',')
       .map((it) => it.trim())
       .includes(project.ref)
+  )
 
   const router = useRouter()
   const page = router.pathname.split('/')[4]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Limit access to Realtime Settings based on feature flag configuration