### PR TITLE
fix: update docs link for auth hooks configuration page

### DIFF
--- a/apps/studio/pages/project/[ref]/auth/hooks.tsx
+++ b/apps/studio/pages/project/[ref]/auth/hooks.tsx
@@ -25,7 +25,7 @@ const Hooks: NextPageWithLayout = () => {
   )
 }
 const secondaryActions = [
-  <DocsButton key="docs" href="https://supabase.com/docs/guides/functions" />,
+  <DocsButton key="docs" href="https://supabase.com/docs/guides/auth/auth-hooks" />,
 ]
 
 Hooks.getLayout = (page) => (


### PR DESCRIPTION
This fixes an incorrect docs link introduced in https://github.com/supabase/supabase/pull/36567