### PR TITLE
feat: add billing information to the leave org modal

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/LeaveTeamButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/LeaveTeamButton.tsx
@@ -37,8 +37,13 @@ export const LeaveTeamButton = () => {
   const { data: members } = useOrganizationMembersQuery({ slug })
   const { data: allRoles } = useOrganizationRolesV2Query({ slug })
 
-  const isOwner = selectedOrganization?.is_owner
   const roles = allRoles?.org_scoped_roles ?? []
+  const currentUserMember = members?.find((member) => member.gotrue_id === profile?.gotrue_id)
+  const currentUserRoleId = currentUserMember?.role_ids?.[0]
+  const currentUserRole = roles.find((role) => role.id === currentUserRoleId)
+  const isAdmin = currentUserRole?.name === 'Administrator'
+  const isOwner = selectedOrganization?.is_owner
+
   const canLeave = !isOwner || (isOwner && hasMultipleOwners(members, roles))
 
   const { mutate: deleteMember } = useOrganizationMemberDeleteMutation({
@@ -106,6 +111,22 @@ export const LeaveTeamButton = () => {
                 <li>Custom reports</li>
                 <li>Log Explorer queries</li>
               </ul>
+              {(isOwner || isAdmin) && (
+                <div className="mt-2">
+                  <p>
+                    <span className="text-foreground">
+                      Leaving won't remove your payment method or stop payments.
+                    </span>
+                  </p>
+                  <ul className="list-disc pl-4">
+                    <li>
+                      The current payment method will remain active and may still be charged after
+                      you leave.
+                    </li>
+                    <li>The billing address will remain unchanged.</li>
+                  </ul>
+                </div>
+              )}
             </div>
           ),
         }}


### PR DESCRIPTION
This PR improves the confirmation modal shown when an Owner or Admin leaves an organization.
The existing modal warns about the deletion of user content but does not clearly explain that the user’s credit card may remain active or continue to be charged.

### Why
This aims to reduce billing-related support tickets from users who assume that leaving an organization removes their credit card or stops charges. It will also hopefully protects users from surprise charges when they no longer have access to the org.


### Changes
- Added a role check for the Administrator role to only show the billing information to Owners and Administrators.
- Added the relevant information to the confirmation modal.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2025-07-03 at 3 35 05 PM](https://github.com/user-attachments/assets/9ab5acb3-7335-4295-81ed-021fa39cac28)  | ![Screenshot 2025-07-03 at 3 34 30 PM](https://github.com/user-attachments/assets/60c3c403-faba-42fd-a6dc-70fc0038b0e2) |


### Testing
- Head over to `http://localhost:8082/org/_/team`
- Pick an org with two or more users
- With an user with the `Owner` or `Admin` role, click on `Leave team`
- You should see the new billing information in the confirmation modal
- Repeat the same process with a user with the `Developer` role
- You should **not** see the billing information in the confirmation modal