### PR TITLE
doc typo nextjs.config.js -> next.config.js

### DIFF
--- a/apps/docs/content/guides/storage/serving/image-transformations.mdx
+++ b/apps/docs/content/guides/storage/serving/image-transformations.mdx
@@ -377,7 +377,7 @@ export default function supabaseLoader({ src, width, quality }) {
 }
 ```
 
-In your `nextjs.config.js` file add the following configuration to instruct Next.js to use our custom loader
+In your `next.config.js` file add the following configuration to instruct Next.js to use our custom loader
 
 ```js
 module.exports = {


### PR DESCRIPTION
Minor typo:

```diff
-nextjs.config.js
+next.config.js
```

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## Additional context

Minor typo
