### PR TITLE
fix: ensure magic link endpoint uses correct template instead of signup confirmation

### DIFF
--- a/apps/studio/pages/api/platform/auth/[ref]/magiclink.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/magiclink.ts
@@ -26,8 +26,14 @@ const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
     Accept: 'application/json',
     Authorization: `Bearer ${process.env.SUPABASE_SERVICE_KEY}`,
   })
-  const url = `${process.env.SUPABASE_URL}/auth/v1/magiclink`
-  const payload = { email: req.body.email }
+  const url = `${process.env.SUPABASE_URL}/auth/v1/otp`
+  const payload = { 
+    email: req.body.email,
+    type: 'magiclink',
+    options: {
+      data: { type: 'magiclink' }
+    }
+  }
   const response = await post(url, payload, { headers })
   return res.status(200).json(response)
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where clicking "Send magic link" in the user menu sends the "Confirm signup" template instead of the "Magic Link" template.

## Changes
- Updated the magic link endpoint (`/api/platform/auth/[ref]/magiclink.ts`) to use the correct OTP endpoint with explicit magic link type
- Changed payload to include `type: 'magiclink'` to ensure correct template selection
- Added `options.data.type` for additional context in template selection

## Testing
1. Go to Auth > Users in the dashboard
2. Select a user and click "Send magic link" in their menu
3. Verify that the received email uses the Magic Link template instead of the Confirm Signup template

## Additional Context
This fixes the confusion reported in [Discussion #27425](https://github.com/orgs/supabase/discussions/27425) where users were receiving incorrect email templates when using the magic link feature.

## Screenshots
Before: User receives "Confirm signup" template
After: User receives correct "Magic Link" template