### PR TITLE
docs(python): add params to the update_user method

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -1218,7 +1218,38 @@ functions:
       - In order to use the `update_user()` method, the user needs to be signed in first.
       - By default, email updates sends a confirmation link to both the user's current and new email.
       To only send a confirmation link to the user's new email, disable **Secure email change** in your project's [email auth provider settings](/dashboard/project/_/auth/providers).
-
+    params:
+      - name: attributes
+        isOptional: false
+        type: UserAttributes
+        subContent: 
+          - name: data
+            isOptional: true
+            type: object
+            description: A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
+          - name: email
+            isOptional: true
+            type: string
+            description: The user's email.
+          - name: nonce
+            isOptional: true
+            type: string
+            description: The nonce sent for reauthentication if the user's password is to be updated.
+          - name: password
+            isOptional: true
+            type: string
+            description: The user's password.
+          - name: phone
+            isOptional: true
+            type: string
+            description: The user's phone.
+      - name: options
+        isOptional: true
+        type: object
+        subContent:
+          - name: email_redirect_to
+            isOptional: true
+            type: string
     examples:
       - id: update-the-email-for-an-authenticated-user
         name: Update the email for an authenticated user


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update: add missing params to the `update_user` method of the Python reference docs.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
