### PR TITLE
feat: use enablePgReplicate feature flag

### DIFF
--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
@@ -30,6 +30,7 @@ const DatabaseProductMenu = () => {
   const pgNetExtensionExists = (data ?? []).find((ext) => ext.name === 'pg_net') !== undefined
   const pitrEnabled = addons?.selected_addons.find((addon) => addon.type === 'pitr') !== undefined
   const columnLevelPrivileges = useIsColumnLevelPrivilegesEnabled()
+  const enablePgReplicate = useFlag('enablePgReplicate')
 
   return (
     <>
@@ -39,6 +40,7 @@ const DatabaseProductMenu = () => {
           pgNetExtensionExists,
           pitrEnabled,
           columnLevelPrivileges,
+          enablePgReplicate,
         })}
       />
     </>

--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
@@ -9,10 +9,12 @@ export const generateDatabaseMenu = (
     pgNetExtensionExists: boolean
     pitrEnabled: boolean
     columnLevelPrivileges: boolean
+    enablePgReplicate: boolean
   }
 ): ProductMenuGroup[] => {
   const ref = project?.ref ?? 'default'
-  const { pgNetExtensionExists, pitrEnabled, columnLevelPrivileges } = flags || {}
+  const { pgNetExtensionExists, pitrEnabled, columnLevelPrivileges, enablePgReplicate } =
+    flags || {}
 
   return [
     {
@@ -62,13 +64,24 @@ export const generateDatabaseMenu = (
           url: `/project/${ref}/database/publications`,
           items: [],
         },
-        {
-          name: 'Replication',
-          key: 'replication',
-          url: `/project/${ref}/database/replication`,
-          label: 'Coming Soon',
-          items: [],
-        },
+        ...(enablePgReplicate
+          ? [
+              {
+                name: 'Replication',
+                key: 'replication',
+                url: `/project/${ref}/database/replication`,
+                items: [],
+              },
+            ]
+          : [
+              {
+                name: 'Replication',
+                key: 'replication',
+                url: `/project/${ref}/database/replication`,
+                label: 'Coming Soon',
+                items: [],
+              },
+            ]),
       ],
     },
     {

--- a/apps/studio/pages/project/[ref]/database/replication.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication.tsx
@@ -1,4 +1,5 @@
 import ReplicationComingSoon from 'components/interfaces/Database/Replication/ComingSoon'
+import Destinations from 'components/interfaces/Database/Replication/Destinations'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import {
@@ -8,16 +9,25 @@ import {
   ScaffoldSection,
   ScaffoldTitle,
 } from 'components/layouts/Scaffold'
+import { useFlag } from 'hooks/ui/useFlag'
 import type { NextPageWithLayout } from 'types'
 import { Admonition } from 'ui-patterns'
 
 const DatabaseReplicationPage: NextPageWithLayout = () => {
-  //const enablePgReplicate = useFlag('enablePgReplicate')
-  const enablePgReplicate = true
+  const enablePgReplicate = useFlag('enablePgReplicate')
 
   return (
     <>
       {enablePgReplicate ? (
+        <>
+          <ScaffoldContainer>
+            <ScaffoldHeader>
+              <ScaffoldTitle>Replication</ScaffoldTitle>
+              <Destinations />
+            </ScaffoldHeader>
+          </ScaffoldContainer>
+        </>
+      ) : (
         <>
           <ScaffoldContainer>
             <ScaffoldHeader>
@@ -27,14 +37,6 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
           </ScaffoldContainer>
           <ReplicationComingSoon />
         </>
-      ) : (
-        <ScaffoldContainer>
-          <ScaffoldSection isFullWidth>
-            <Admonition type="default" title="Coming soon">
-              <p className="!mb-0">Replication is not yet available for your project</p>
-            </Admonition>
-          </ScaffoldSection>
-        </ScaffoldContainer>
       )}
     </>
   )


### PR DESCRIPTION
This PR enables the etl (formerly pg_replicate) UI elements when the `enablePgReplicate` feature flag is enabled and will show the coming soon placeholder page if disabled. This will help in local testing of the feature.