### PR TITLE
feat: add support to select api keys in storage explorer

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1741,19 +1741,13 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
     if (!isPaused && hasDataReady && isDifferentProject && serviceKey) {
       const clientEndpoint = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}`
       const supabaseClient = createClient(clientEndpoint, serviceKey.api_key, {
-        auth: {
-          persistSession: false,
-          autoRefreshToken: false,
-          detectSessionInUrl: false,
-          storage: {
-            getItem: (key) => {
-              return null
-            },
-            setItem: (key, value) => {},
-            removeItem: (key) => {},
-          },
+        accessToken: async () => {
+          return serviceKey.api_key
         },
       })
+
+      // when using this inside a proxied object it fails due to accessing client.auth.Symbol()
+      ;(supabaseClient as any).auth = null
 
       setState(
         createStorageExplorerState({


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
