### PR TITLE
chore: external svg scripts

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -30,7 +30,7 @@ const nextConfig = {
   // swcMinify: true,
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || '/docs',
   images: {
-    dangerouslyAllowSVG: true,
+    dangerouslyAllowSVG: false,
     // @ts-ignore
     remotePatterns,
   },

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -446,7 +446,7 @@ const nextConfig = {
   },
   images: {
     // to make Vercel avatars work without issue. Vercel uses SVGs for users who don't have set avatars.
-    dangerouslyAllowSVG: true,
+    dangerouslyAllowSVG: false,
     remotePatterns: [
       {
         protocol: 'https',

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -61,7 +61,7 @@ const nextConfig = {
   },
   reactStrictMode: true,
   images: {
-    dangerouslyAllowSVG: true,
+    dangerouslyAllowSVG: false,
     remotePatterns,
   },
   async headers() {


### PR DESCRIPTION
Addressing an issue where remote svgs can be downloaded with potential scripts in them.
This setting does not affect the preview panel in the Storage UI
Fixes SEC-436