### PR TITLE
add Danny White to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -28,6 +28,7 @@ Chris Copplestone
 Chris Gwilliams
 Chris Stockton
 Craig Cannon
+Danny White
 Darren Cunningham
 Dave Wilson
 David A. Ventimiglia


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

docs/update: adding my name to the humans.txt file as part of onboarding

## What is the current behavior?

My name not in humans.txt

## What is the new behavior?

My name is in humans.txt
