### PR TITLE
fix(docs): correct parameter type for getUserById function

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -2462,7 +2462,9 @@ functions:
         isSpotlight: true
         code: |
           ```js
-          const { data, error } = await supabase.auth.admin.getUserById(1)
+          const { data, error } = await supabase.auth.admin.getUserById(
+            '715ed5db-f090-4b8c-a067-640ecee36aa0'
+          )
           ```
         response: |
           ```json


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Docs call getUserById with the incorrect type number

## What is the new behavior?

Now they call the function with the correct type string

## Additional context

empty
