### PR TITLE
add Sean Oliver to humans.txt as part of onboarding

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -91,6 +91,7 @@ Rodrigo Mansueli
 Ronan Lehane
 Rory Wilding
 Sam Rose
+Sean Oliver
 Sergio Cioban Filho
 Sreyas Udayavarman
 Stanislav M


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Docs: Add Sean Oliver to `humans.txt` as part of new employee onboarding.

## What is the current behavior?

Sean is not in the list.

## What is the new behavior?

Sean is in the list!

## Additional context

n/a
