### PR TITLE
Add missing permissions text for AI opt in modal

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIOptInModal.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOptInModal.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 
 import { AIOptInLevelSelector } from 'components/interfaces/Organization/GeneralSettings/AIOptInLevelSelector'
 import { useAIOptInForm } from 'hooks/forms/useAIOptInForm'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useFlag } from 'hooks/ui/useFlag'
 import {
   Button,

--- a/apps/studio/components/ui/AIAssistantPanel/AIOptInModal.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOptInModal.tsx
@@ -3,10 +3,10 @@ import { useEffect } from 'react'
 
 import { AIOptInLevelSelector } from 'components/interfaces/Organization/GeneralSettings/AIOptInLevelSelector'
 import { useAIOptInForm } from 'hooks/forms/useAIOptInForm'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useFlag } from 'hooks/ui/useFlag'
 import {
   Button,
+  cn,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -57,19 +57,29 @@ export const AIOptInModal = ({ visible, onCancel }: AIOptInModalProps) => {
               />
             </DialogSection>
 
-            <DialogFooter padding="small">
-              <Button type="default" disabled={isUpdating} onClick={onCancel}>
-                Cancel
-              </Button>
-              <Button
-                type="primary"
-                htmlType="submit"
-                form="ai-opt-in-form"
-                loading={isUpdating}
-                disabled={isUpdating || !canUpdateOrganization || !form.formState.isDirty}
-              >
-                Confirm
-              </Button>
+            <DialogFooter
+              padding="small"
+              className={cn(!canUpdateOrganization && '!justify-between')}
+            >
+              {!canUpdateOrganization && (
+                <p className="text-sm text-foreground-lighter">
+                  You need additional permissions to update the opt-in level
+                </p>
+              )}
+              <div className="flex items-center gap-x-2">
+                <Button type="default" disabled={isUpdating} onClick={onCancel}>
+                  Cancel
+                </Button>
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  form="ai-opt-in-form"
+                  loading={isUpdating}
+                  disabled={isUpdating || !canUpdateOrganization || !form.formState.isDirty}
+                >
+                  Confirm
+                </Button>
+              </div>
             </DialogFooter>
           </form>
         </Form_Shadcn_>


### PR DESCRIPTION
## Context

Realized that for the AI Opt-in modal specifically that's toggled from the SQL Editor, there's no helper text indicating while the options are disabled if the user doesn't have the necessary permissions for it (based on the role that the user has in the organization)

## Changes involved

- Add missing helper text to indicate disabled reason
<img width="647" alt="image" src="https://github.com/user-attachments/assets/03bec603-c634-42ee-944c-a4171c473bdd" />
 