### PR TITLE
Add portal to PopoverContent in TimezoneSelection.tsx

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/PITR/TimezoneSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/TimezoneSelection.tsx
@@ -48,7 +48,7 @@ export const TimezoneSelection = ({
               : 'Select timezone...'}
           </Button>
         </PopoverTrigger_Shadcn_>
-        <PopoverContent_Shadcn_ className="w-[350px] p-0">
+        <PopoverContent_Shadcn_ portal className="w-[350px] p-0">
           <Command_Shadcn_>
             <CommandInput_Shadcn_ placeholder="Search timezone..." className="h-9" />
             <CommandList_Shadcn_>


### PR DESCRIPTION
Fixes FE-1716
Fixes the PopoverContent not aligning with the Trigger

## Before
<img src="https://github.com/user-attachments/assets/a0e11209-b62f-4b1a-88d4-a123ce31ba0f" width="500" />

## After
<img width="510" alt="image" src="https://github.com/user-attachments/assets/8a33a0a5-b1d9-4d4f-931d-7e64b09a8c98" />