### PR TITLE
Limit tools based on extensions

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -117,7 +117,7 @@ export const DisplayBlockRenderer = ({
         showRunButtonIfNotReadOnly={true}
         isLoading={isLoading}
         draggable={isDraggableToReports}
-        runQuery={initialArgs.runQuery === true && !displayData && !manualId}
+        runQuery={false}
         tooltip={
           isDraggableToReports ? (
             <div className="flex items-center gap-x-2">

--- a/apps/studio/data/database-extensions/database-extensions-query.ts
+++ b/apps/studio/data/database-extensions/database-extensions-query.ts
@@ -15,11 +15,12 @@ export type DatabaseExtensionsVariables = {
 
 export async function getDatabaseExtensions(
   { projectRef, connectionString }: DatabaseExtensionsVariables,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  headersInit?: HeadersInit
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers()
+  let headers = new Headers(headersInit)
   if (connectionString) headers.set('x-connection-encrypted', connectionString)
 
   const { data, error } = await get('/platform/pg-meta/{ref}/extensions', {

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -123,6 +123,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     )
   } catch (error) {
     console.error('Failed to fetch database extensions:', error)
+    effectiveAiOptInLevel = 'disabled'
   }
 
   const { model, error: modelError } = await getModel(projectRef) // use project ref as routing key

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -15,12 +15,14 @@ import apiWrapper from 'lib/api/apiWrapper'
 import { queryPgMetaSelfHosted } from 'lib/self-hosted'
 import { getUnifiedLogsChart } from 'data/logs/unified-logs-chart-query'
 import { getUnifiedLogs } from 'data/logs/unified-logs-infinite-query'
+import { getDatabaseExtensions } from 'data/database-extensions/database-extensions-query'
 import { QuerySearchParamsType } from 'components/interfaces/UnifiedLogs/UnifiedLogs.types'
 import { createSupabaseMCPClient } from 'lib/ai/supabase-mcp'
 import {
   filterToolsByOptInLevel,
   toolSetValidationSchema,
   transformToolResult,
+  checkNetworkExtensionsAndAdjustOptInLevel,
 } from 'lib/ai/tool-filter'
 import { getTools } from './tools'
 
@@ -101,6 +103,27 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const aiOptInLevel = getAiOptInLevel(selectedOrg?.opt_in_tags)
+
+  // Check enabled database extensions to potentially restrict data access
+  let effectiveAiOptInLevel = aiOptInLevel
+
+  try {
+    let headers = new Headers()
+    if (authorization) headers.set('Authorization', authorization)
+
+    const dbExtensions = await getDatabaseExtensions(
+      { projectRef, connectionString },
+      undefined,
+      headers
+    )
+
+    effectiveAiOptInLevel = checkNetworkExtensionsAndAdjustOptInLevel(
+      dbExtensions,
+      effectiveAiOptInLevel
+    )
+  } catch (error) {
+    console.error('Failed to fetch database extensions:', error)
+  }
 
   const { model, error: modelError } = await getModel(projectRef) // use project ref as routing key
 
@@ -399,8 +422,8 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       })
 
       const availableMcpTools = await mcpClient.tools()
-      // Filter tools based on the AI opt-in level
-      const allowedMcpTools = filterToolsByOptInLevel(availableMcpTools, aiOptInLevel)
+      // Filter tools based on the (potentially modified) AI opt-in level
+      const allowedMcpTools = filterToolsByOptInLevel(availableMcpTools, effectiveAiOptInLevel)
 
       // Validate that only known tools are provided
       const { data: validatedTools, error: validationError } =
@@ -435,8 +458,8 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       }
     }
 
-    // Filter local tools based on the AI opt-in level
-    const filteredLocalTools = filterToolsByOptInLevel(localTools, aiOptInLevel)
+    // Filter local tools based on the (potentially modified) AI opt-in level
+    const filteredLocalTools = filterToolsByOptInLevel(localTools, effectiveAiOptInLevel)
 
     // Combine MCP tools with filtered local tools
     const tools: ToolSet = {


### PR DESCRIPTION
This PR limits opt in level based on installed extensions for additional security measures. It also disables the auto running of read only queries on client-side.