### PR TITLE
Fix padding empty state

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/EmptyStates.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/EmptyStates.tsx
@@ -130,9 +130,9 @@ export const PreviewBranchesEmptyState = ({
   onSelectCreateBranch: () => void
 }) => {
   return (
-    <div className="flex items-center flex-col justify-center w-full py-10">
+    <div className="flex items-center flex-col justify-center w-full p-10 text-center">
       <p>Create your first preview branch</p>
-      <p className="text-foreground-light mb-4">
+      <p className="text-foreground-light mb-4 text-center">
         Preview branches are used to experiment with changes to your database schema in a safe,
         non-destructive environment.
       </p>


### PR DESCRIPTION

<img width="535" height="281" alt="image" src="https://github.com/user-attachments/assets/43a00ddc-542b-4ec9-837d-5ccd2e238f62" />


Fixes an issue where empty branching state had no padding and misaligned.