### PR TITLE
Merge complete loop

### DIFF
--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -142,7 +142,14 @@ const MergePage: NextPageWithLayout = () => {
         })
       }
     },
-    [refetchDiff, clearDiffsOptimistically, parentProjectRef, currentBranch?.id, updateBranch]
+    [
+      refetchDiff,
+      clearDiffsOptimistically,
+      parentProjectRef,
+      currentBranch?.id,
+      updateBranch,
+      currentBranch?.review_requested_at,
+    ]
   )
 
   const { currentWorkflowRun: currentBranchWorkflow, workflowRunLogs: currentBranchLogs } =

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -103,39 +103,60 @@ const MergePage: NextPageWithLayout = () => {
     currentBranchCreatedAt: currentBranch?.created_at,
   })
 
+  const { mutate: updateBranch } = useBranchUpdateMutation({
+    onSuccess: () => {
+      toast.success('Branch updated successfully')
+    },
+    onError: (error) => {
+      toast.error(`Failed to update branch: ${error.message}`)
+    },
+  })
+
+  const clearDiffsOptimistically = edgeFunctionsDiff.clearDiffsOptimistically
+
   const currentWorkflowRunId = router.query.workflow_run_id as string | undefined
 
   useEffect(() => {
     setWorkflowFinalStatus(null)
   }, [currentWorkflowRunId])
 
+  const handleCurrentBranchWorkflowComplete = useCallback(
+    (status: string) => {
+      setWorkflowFinalStatus(status)
+      refetchDiff()
+      clearDiffsOptimistically()
+    },
+    [refetchDiff, clearDiffsOptimistically]
+  )
+
+  const handleParentBranchWorkflowComplete = useCallback(
+    (status: string) => {
+      setWorkflowFinalStatus(status)
+      refetchDiff()
+      clearDiffsOptimistically()
+      if (parentProjectRef && currentBranch?.id && currentBranch.review_requested_at) {
+        updateBranch({
+          id: currentBranch.id,
+          projectRef: parentProjectRef,
+          requestReview: false,
+        })
+      }
+    },
+    [refetchDiff, clearDiffsOptimistically, parentProjectRef, currentBranch?.id, updateBranch]
+  )
+
   const { currentWorkflowRun: currentBranchWorkflow, workflowRunLogs: currentBranchLogs } =
     useWorkflowManagement({
       workflowRunId: currentWorkflowRunId,
       projectRef: ref,
-      onWorkflowComplete: (status) => {
-        setWorkflowFinalStatus(status)
-        refetchDiff()
-        edgeFunctionsDiff.clearDiffsOptimistically()
-      },
+      onWorkflowComplete: handleCurrentBranchWorkflowComplete,
     })
 
   const { currentWorkflowRun: parentBranchWorkflow, workflowRunLogs: parentBranchLogs } =
     useWorkflowManagement({
       workflowRunId: currentWorkflowRunId,
       projectRef: parentProjectRef,
-      onWorkflowComplete: (status) => {
-        setWorkflowFinalStatus(status)
-        refetchDiff()
-        edgeFunctionsDiff.clearDiffsOptimistically()
-        if (parentProjectRef && currentBranch?.id) {
-          updateBranch({
-            id: currentBranch.id,
-            projectRef: parentProjectRef,
-            requestReview: false,
-          })
-        }
-      },
+      onWorkflowComplete: handleParentBranchWorkflowComplete,
     })
 
   const currentWorkflowRun = currentBranchWorkflow || parentBranchWorkflow
@@ -207,15 +228,6 @@ const MergePage: NextPageWithLayout = () => {
     },
     onError: (error) => {
       toast.error(`Failed to close branch: ${error.message}`)
-    },
-  })
-
-  const { mutate: updateBranch } = useBranchUpdateMutation({
-    onSuccess: () => {
-      toast.success('Branch updated successfully')
-    },
-    onError: (error) => {
-      toast.error(`Failed to update branch: ${error.message}`)
     },
   })
 


### PR DESCRIPTION
Currently when a branch merge completes we update the branch and set the `review_requested_at` field to null via `requestReview`. This causes re-renders which recreates callback and creates a loop. This change uses useCallback and adds review_requested_at check before updating branch.

To test:
1. Make sure gitlessBranching flag is enabled
2. Create branch
3. Make a change on branch
4. Create a branch review and visit /merge
5. Click merge and see workflow logs
6. Wait until completion and check if can see completion state without error