### PR TITLE
Update hooks.tsx, change docs link

### DIFF
--- a/apps/studio/pages/project/[ref]/auth/hooks.tsx
+++ b/apps/studio/pages/project/[ref]/auth/hooks.tsx
@@ -25,7 +25,7 @@ const Hooks: NextPageWithLayout = () => {
   )
 }
 const secondaryActions = [
-  <DocsButton key="docs" href="https://supabase.com/docs/guides/functions" />,
+  <DocsButton key="docs" href="https://supabase.com/docs/guides/auth/auth-hooks" />,
 ]
 
 Hooks.getLayout = (page) => (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updating the link to docs

## What is the current behavior?

The docs link in Auth hooks in studio links to [functions](https://supabase.com/docs/guides/functions)

## What is the new behavior?

The docs link in Auth hooks in studio links to [auth hooks](https://supabase.com/docs/guides/auth/auth-hooks)

## Additional context

