### PR TITLE
docs: add individual developer setup for Kakao OAuth

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -70,17 +70,17 @@ If you're an individual developer (not business-verified), you may encounter err
 
 To resolve this issue:
 
-1. Go to **App Settings** > **Business** in your Kakao Developer Console
-2. Click **"Register business information"**
-3. Select **"Register as Individual"** option
-4. Agree to the terms of use (this may redirect you to your KakaoTalk mobile app)
-5. Reload the developer portal page in your browser
+1. Go to **App Settings** > **App** > **General** in your Kakao Developer Console
+2. Upload an **App Icon** if you haven't already (required for business app conversion)
+3. In the **Business Information** section, click **"개인 개발자 비즈 앱 전환"** (Individual Developer Business App Conversion)
+4. Complete personal verification and agree to Kakao Business integrated service terms
+5. After conversion, your app will show "비즈 앱" status and you can set `account_email` as a required consent item under **제품 설정** (Product Settings) > **카카오 로그인** (Kakao Login) > **동의항목** (Consent Items)
 
-After completing these steps, you'll have access to the `account_email` scope without requiring full business verification. This allows individual developers to use Kakao OAuth with email access in their applications.
+This allows individual developers to use Kakao OAuth with email access without requiring a business license.
 
 <Admonition type="note">
 
-You may also need to upload an app icon if you haven't already done so, as this can be a requirement for enabling certain features.
+The app icon upload is a prerequisite for business app conversion. Without an app icon, the conversion option will not be available.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -64,6 +64,26 @@ This will serve as the `client_id` when you make API calls to authenticate the u
 
 ![Consent items needs to be set.](/docs/img/guides/auth-kakao/kakao-developers-consent-items-set.png)
 
+### For Individual Developers
+
+If you're an individual developer (not business-verified), you may encounter error `KOE205` when using the `account_email` scope. This error occurs because the `account_email` scope is restricted to business-verified applications by default.
+
+To resolve this issue:
+
+1. Go to **App Settings** > **Business** in your Kakao Developer Console
+2. Click **"Register business information"**
+3. Select **"Register as Individual"** option
+4. Agree to the terms of use (this may redirect you to your KakaoTalk mobile app)
+5. Reload the developer portal page in your browser
+
+After completing these steps, you'll have access to the `account_email` scope without requiring full business verification. This allows individual developers to use Kakao OAuth with email access in their applications.
+
+<Admonition type="note">
+
+You may also need to upload an app icon if you haven't already done so, as this can be a requirement for enabling certain features.
+
+</Admonition>
+
 ## Add your OAuth credentials to Supabase
 
 <$Partial path="social_provider_settings_supabase.mdx" variables={{ "provider": "Kakao" }} />


### PR DESCRIPTION
Add 'Register as Individual' instructions to resolve KOE205 error when using account_email scope for individual developers.

Fixes #36878

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Individual developers encounter KOE205 error when setting up Kakao OAuth because the documentation doesn't mention the "Register as Individual" workaround. This causes many developers to abandon Kakao OAuth implementation, thinking business verification is required.

Issue: #36878

## What is the new behavior?

Added a new "For Individual Developers" section that provides step-by-step instructions for the "Register as Individual" workaround. This allows individual developers to access the account_email scope without full business verification.

## Additional context

This solution was previously discovered by @woodwardryan in issue #29917 but was never documented. The documentation gap has been causing confusion for many developers trying to implement Kakao OAuth.
