### PR TITLE
chore: hint for compute costs in upgrade screen

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -1,7 +1,6 @@
 import { Check, InfoIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useRef, useState } from 'react'
-import tweets from 'shared-data/tweets'
 import { toast } from 'sonner'
 
 import {
@@ -32,12 +31,6 @@ import { getStripeElementsAppearanceOptions } from 'components/interfaces/Billin
 import { plans as subscriptionsPlans } from 'shared-data/plans'
 
 const stripePromise = loadStripe(STRIPE_PUBLIC_KEY)
-
-const getRandomTweet = () => {
-  const filteredTweets = tweets.filter((it) => it.text.length < 180)
-  const randomIndex = Math.floor(Math.random() * filteredTweets.length)
-  return filteredTweets[randomIndex]
-}
 
 const PLAN_HEADINGS = {
   tier_pro:
@@ -100,8 +93,6 @@ export const SubscriptionPlanUpdateDialog = ({
       appearance: getStripeElementsAppearanceOptions(resolvedTheme),
     } as StripeElementsOptions
   }, [paymentIntentSecret, resolvedTheme])
-
-  const testimonialTweet = useMemo(() => getRandomTweet(), [])
 
   const changeType = useMemo(() => {
     return getPlanChangeType(subscription?.plan?.id, planMeta?.id)
@@ -340,8 +331,8 @@ export const SubscriptionPlanUpdateDialog = ({
                           <div className="w-[520px] p-6">
                             <h3 className="text-base font-medium mb-2">Your new monthly invoice</h3>
                             <p className="prose text-xs mb-2">
-                              Each paid project runs on a dedicated 24/7 server. First project uses
-                              Compute Credits; additional ones cost <span translate="no">$10+</span>
+                              Paid projects run 24/7 without pausing. First project uses Compute
+                              Credits; additional projects start at <span translate="no">$10</span>
                               /month regardless of usage.{' '}
                               <Link
                                 href={'/docs/guides/platform/manage-your-usage/compute'}
@@ -601,6 +592,31 @@ export const SubscriptionPlanUpdateDialog = ({
                   </div>
                 )}
 
+              {projects.filter(
+                (it) =>
+                  it.status === PROJECT_STATUS.ACTIVE_HEALTHY ||
+                  it.status === PROJECT_STATUS.COMING_UP
+              ).length === 1 &&
+                subscriptionPlanMeta?.planId === 'pro' &&
+                changeType === 'upgrade' && (
+                  <div className="pb-2">
+                    <Admonition type="note">
+                      <div className="text-sm prose">
+                        Paid projects run 24/7 without pausing. First project uses Compute Credits;
+                        additional projects cost <span translate="no">$10+</span>
+                        /month regardless of usage.{' '}
+                      </div>
+                      <Link
+                        href={'/docs/guides/platform/manage-your-usage/compute'}
+                        target="_blank"
+                        className="underline"
+                      >
+                        Learn more
+                      </Link>
+                    </Admonition>
+                  </div>
+                )}
+
               <div className="flex space-x-2">
                 <Button type="default" size="medium" onClick={onClose} className="flex-1">
                   Cancel
@@ -669,14 +685,6 @@ export const SubscriptionPlanUpdateDialog = ({
                     </div>
                   </div>
                 )}
-            {changeType !== 'downgrade' && (
-              <div className="border-t pt-6">
-                <blockquote className="text-sm text-foreground-light italic">
-                  {testimonialTweet.text}
-                  <div className="mt-2 text-foreground">— @{testimonialTweet.handle}</div>
-                </blockquote>
-              </div>
-            )}
           </div>
         </div>
 


### PR DESCRIPTION
- Remove random tweet to focus the user on what's important in the upgrade modal (already lots of info)
- Add compute cost hint if upgrading to Pro Plan with one project (common refund scenario)

<img width="760" height="617" alt="Screenshot 2025-07-14 at 13 53 06" src="https://github.com/user-attachments/assets/a56c8d03-b11c-4cc0-8b68-094401b8145d" />

