### PR TITLE
fix(api-settings): correct API keys description text with link

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -165,12 +165,45 @@ export const DisplayApiSettings = ({
                 }
                 onChange={() => {}}
                 descriptionText={
-                  x.tags === 'service_role'
-                    ? 'This key has the ability to bypass Row Level Security. Never share it publicly. If leaked, generate a new JWT secret immediately. ' +
-                      (showLegacyText ? 'Prefer using Publishable API keys instead.' : '')
-                    : 'This key is safe to use in a browser if you have enabled Row Level Security for your tables and configured policies. ' +
-                      (showLegacyText ? 'Prefer using Secret API keys instead.' : '')
+                  x.tags === 'service_role' ? (
+                    <>
+                      This key has the ability to bypass Row Level Security. Never share it publicly. If leaked, generate a new JWT secret immediately.{' '}
+                      {showLegacyText && (
+                        <span>
+                          Prefer using{' '}
+                          <a
+                            href={`/project/${projectRef}/settings/api-keys/new`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-link underline"
+                          >
+                            Secret API keys
+                          </a>{' '}
+                          instead.
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      This key is safe to use in a browser if you have enabled Row Level Security for your tables and configured policies.{' '}
+                      {showLegacyText && (
+                        <span>
+                          Prefer using{' '}
+                          <a
+                            href={`/project/${projectRef}/settings/api-keys/new`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-link underline"
+                          >
+                            Publishable API keys
+                          </a>{' '}
+                          instead.
+                        </span>
+                      )}
+                    </>
+                  )
                 }
+
               />
 
               <div

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -167,7 +167,8 @@ export const DisplayApiSettings = ({
                 descriptionText={
                   x.tags === 'service_role' ? (
                     <>
-                      This key has the ability to bypass Row Level Security. Never share it publicly. If leaked, generate a new JWT secret immediately.{' '}
+                      This key has the ability to bypass Row Level Security. Never share it
+                      publicly. If leaked, generate a new JWT secret immediately.{' '}
                       {showLegacyText && (
                         <span>
                           Prefer using{' '}
@@ -183,7 +184,8 @@ export const DisplayApiSettings = ({
                     </>
                   ) : (
                     <>
-                      This key is safe to use in a browser if you have enabled Row Level Security for your tables and configured policies.{' '}
+                      This key is safe to use in a browser if you have enabled Row Level Security
+                      for your tables and configured policies.{' '}
                       {showLegacyText && (
                         <span>
                           Prefer using{' '}
@@ -199,7 +201,6 @@ export const DisplayApiSettings = ({
                     </>
                   )
                 }
-
               />
 
               <div

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -173,8 +173,6 @@ export const DisplayApiSettings = ({
                           Prefer using{' '}
                           <a
                             href={`/project/${projectRef}/settings/api-keys/new`}
-                            target="_blank"
-                            rel="noopener noreferrer"
                             className="text-link underline"
                           >
                             Secret API keys
@@ -191,8 +189,6 @@ export const DisplayApiSettings = ({
                           Prefer using{' '}
                           <a
                             href={`/project/${projectRef}/settings/api-keys/new`}
-                            target="_blank"
-                            rel="noopener noreferrer"
                             className="text-link underline"
                           >
                             Publishable API keys


### PR DESCRIPTION
The legacy guidance text had "Secret" and "Publishable" API keys swapped for `anon` and `service_role` keys. This fix corrects the text and adds contextual links to the new API keys page to guide users appropriately.