### PR TITLE
Feat/add mfa and wrapper tracking

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateIcebergWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateIcebergWrapperSheet.tsx
@@ -8,6 +8,7 @@ import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui
 import SchemaSelector from 'components/ui/SchemaSelector'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useFDWCreateMutation } from 'data/fdw/fdw-create-mutation'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import {
   Button,
   Form,
@@ -24,6 +25,7 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { CreateWrapperSheetProps } from './CreateWrapperSheet'
 import InputField from './InputField'
 import { makeValidateRequired } from './Wrappers.utils'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 
 const FORM_ID = 'create-wrapper-form'
 
@@ -63,6 +65,8 @@ export const CreateIcebergWrapperSheet = ({
   onClose,
 }: CreateWrapperSheetProps) => {
   const { project } = useProjectContext()
+  const org = useSelectedOrganization()
+  const { mutate: sendEvent } = useSendEventMutation()
 
   const [createSchemaSheetOpen, setCreateSchemaSheetOpen] = useState(false)
   const [selectedTarget, setSelectedTarget] = useState<Target>('S3Tables')
@@ -130,6 +134,17 @@ export const CreateIcebergWrapperSheet = ({
       tables: [],
       sourceSchema: values.source_schema,
       targetSchema: values.target_schema,
+    })
+
+    sendEvent({
+      action: 'foreign_data_wrapper_created',
+      properties: {
+        wrapperType: wrapperMeta.label,
+      },
+      groups: {
+        project: project?.ref ?? 'Unknown',
+        organization: org?.slug ?? 'Unknown',
+      },
     })
   }
 

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -11,6 +11,7 @@ import SchemaSelector from 'components/ui/SchemaSelector'
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import { invalidateSchemasQuery, useSchemasQuery } from 'data/database/schemas-query'
 import { useFDWCreateMutation } from 'data/fdw/fdw-create-mutation'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import {
   Button,
   Form,
@@ -29,6 +30,7 @@ import InputField from './InputField'
 import { WrapperMeta } from './Wrappers.types'
 import { makeValidateRequired } from './Wrappers.utils'
 import WrapperTableEditor from './WrapperTableEditor'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 
 export interface CreateWrapperSheetProps {
   isClosing: boolean
@@ -47,6 +49,8 @@ export const CreateWrapperSheet = ({
 }: CreateWrapperSheetProps) => {
   const queryClient = useQueryClient()
   const { project } = useProjectContext()
+  const org = useSelectedOrganization()
+  const { mutate: sendEvent } = useSendEventMutation()
 
   const [newTables, setNewTables] = useState<any[]>([])
   const [isEditingTable, setIsEditingTable] = useState(false)
@@ -134,6 +138,17 @@ export const CreateWrapperSheet = ({
       tables: newTables,
       sourceSchema: values.source_schema,
       targetSchema: values.target_schema,
+    })
+
+    sendEvent({
+      action: 'foreign_data_wrapper_created',
+      properties: {
+        wrapperType: wrapperMeta.label,
+      },
+      groups: {
+        project: project?.ref ?? 'Unknown',
+        organization: org?.slug ?? 'Unknown',
+      },
     })
   }
 

--- a/apps/studio/components/interfaces/Organization/SecuritySettings/SecuritySettings.tsx
+++ b/apps/studio/components/interfaces/Organization/SecuritySettings/SecuritySettings.tsx
@@ -15,6 +15,7 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useOrganizationMembersQuery } from 'data/organizations/organization-members-query'
 import { useOrganizationMfaToggleMutation } from 'data/organizations/organization-mfa-mutation'
 import { useOrganizationMfaQuery } from 'data/organizations/organization-mfa-query'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useProfile } from 'lib/profile'
@@ -48,6 +49,7 @@ const SecuritySettings = () => {
   const { data: members } = useOrganizationMembersQuery({ slug })
   const canReadMfaConfig = useCheckPermissions(PermissionAction.READ, 'organizations')
   const canUpdateMfaConfig = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
+  const { mutate: sendEvent } = useSendEventMutation()
 
   const isPaidPlan = selectedOrganization?.plan.id !== 'free'
 
@@ -66,6 +68,15 @@ const SecuritySettings = () => {
     },
     onSuccess: (data) => {
       toast.success('Successfully updated organization MFA settings')
+      sendEvent({
+        action: 'organization_mfa_enforcement_updated',
+        properties: {
+          mfaEnforced: data.enforced,
+        },
+        groups: {
+          organization: slug ?? 'Unknown',
+        },
+      })
     },
   })
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -666,7 +666,7 @@ export interface CustomReportAddSQLBlockClicked {
  * @source studio
  * @page /dashboard/project/{ref}/reports/{id}
  */
-export interface CustomReportAssistantSQLBlockAdded {
+export interface CustomReportAssistantSQLBlockAddedEvent {
   action: 'custom_report_assistant_sql_block_added'
   groups: {
     project: string
@@ -1343,6 +1343,27 @@ export interface OrganizationMfaEnforcementUpdated {
 }
 
 /**
+ * Triggered when a new foreign data wrapper is created in a project.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/database/integrations
+ */
+export interface ForeignDataWrapperCreatedEvent {
+  action: 'foreign_data_wrapper_created'
+  properties: {
+    /**
+     * The type of the foreign data wrapper, e.g. postgres_fdw, mysql_fdw, etc.
+     */
+    wrapperType: string
+  }
+  groups: {
+    project: string
+    organization: string
+  }
+}
+
+/**
  * @hidden
  */
 export type TelemetryEvent =
@@ -1392,7 +1413,7 @@ export type TelemetryEvent =
   | HomepageCustomerStoryCardClickedEvent
   | HomepageProjectTemplateCardClickedEvent
   | CustomReportAddSQLBlockClicked
-  | CustomReportAssistantSQLBlockAdded
+  | CustomReportAssistantSQLBlockAddedEvent
   | OpenSourceRepoCardClickedEvent
   | StartProjectButtonClickedEvent
   | SeeDocumentationButtonClickedEvent
@@ -1421,3 +1442,4 @@ export type TelemetryEvent =
   | SupportTicketSubmittedEvent
   | AiAssistantInSupportFormClickedEvent
   | OrganizationMfaEnforcementUpdated
+  | ForeignDataWrapperCreatedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1326,6 +1326,23 @@ export interface SupabaseUiCommandCopyButtonClickedEvent {
 }
 
 /**
+ * Triggered when the organization MFA enforcement setting is updated.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/org/{slug}/security
+ */
+export interface OrganizationMfaEnforcementUpdated {
+  action: 'organization_mfa_enforcement_updated'
+  properties: {
+    mfaEnforced: boolean
+  }
+  groups: {
+    organization: string
+  }
+}
+
+/**
  * @hidden
  */
 export type TelemetryEvent =
@@ -1403,3 +1420,4 @@ export type TelemetryEvent =
   | SupabaseUiCommandCopyButtonClickedEvent
   | SupportTicketSubmittedEvent
   | AiAssistantInSupportFormClickedEvent
+  | OrganizationMfaEnforcementUpdated


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- track org mfa enforcement and fdw created events 
- resolves GROWTH-418, GROWTH-419
- tested locally and on preview actually doing said events on studio that the events show up on posthog