### PR TITLE
Remove stop database admonition when performing db diff

### DIFF
--- a/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
+++ b/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
@@ -42,12 +42,6 @@ create table "employees" (
   </StepHikeCompact.Step>
 </StepHikeCompact>
 
-<Admonition type="note">
-
-Make sure your local database is stopped before diffing your schema.
-
-</Admonition>
-
 <StepHikeCompact>
 
   <StepHikeCompact.Step step={2}>


### PR DESCRIPTION
Docs currently admonish the user to stop their local db instance before performing db diff. This is no longer necessary, see https://github.com/supabase/cli/pull/3829

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

n/a

## What is the new behavior?

n/a

## Additional context

Add any other context or screenshots.
