### PR TITLE
docs: update Node.js version in DEVELOPERS.md to match .nvmrc

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -35,7 +35,7 @@ To ensure a positive and inclusive environment, please read our [code of conduct
 You will need to install and configure the following dependencies on your machine to build [Supabase](https://supabase.com):
 
 - [Git](https://git-scm.com/)
-- [Node.js v20.x (LTS)](https://nodejs.org)
+- [Node.js v22.x or higher](https://nodejs.org)
 - [pnpm](https://pnpm.io/) version 9.x.x or higher
 - [make](https://www.gnu.org/software/make/) or the equivalent to `build-essentials` for your OS
 - [Docker](https://docs.docker.com/get-docker/) (to run studio locally)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

`package.json` and `.nvmrc` both specify `"engines.node": ">=22"`, but [DEVELOPERS.md](https://github.com/supabase/supabase/blob/master/DEVELOPERS.md) still says `v20.x`. 

Following this guidance led to `pnpm install` errors due to an unsupported Node version.

## What is the new behavior?

Update the DEVELOPERS.md documentation to specify Node.js v22.x or higher to reflect actual project requirements and prevent install errors.

## Additional context

We could also clarify the docs with a note like:

> (Use .nvmrc for auto-switching with nvm)

...to smooth over future mismatches. But might be overkill.