### PR TITLE
Remove review button

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -20,7 +20,7 @@ export const BranchManagementSection = ({
   children,
 }: PropsWithChildren<BranchManagementSectionProps>) => {
   return (
-    <div className="border rounded-lg">
+    <div className="border rounded-lg overflow-hidden">
       <div className="bg-surface-100 shadow-sm flex justify-between items-center px-4 py-3 rounded-t-lg text-xs font-mono uppercase">
         {typeof header === 'string' ? <span>{header}</span> : header}
       </div>
@@ -75,6 +75,7 @@ export const BranchRow = ({
   rowActions,
 }: BranchRowProps) => {
   const router = useRouter()
+  const page = router.pathname.split('/').pop()
 
   const daysFromNow = dayjs().diff(dayjs(branch.updated_at), 'day')
   const formattedTimeFromNow = dayjs(branch.updated_at).fromNow()
@@ -115,7 +116,12 @@ export const BranchRow = ({
               {label || branch.name}
             </div>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Switch to branch</TooltipContent>
+          {((page === 'branches' && !branch.is_default) || page === 'merge-requests') && (
+            <TooltipContent side="bottom">
+              {page === 'branches' && !branch.is_default && 'Switch to branch'}
+              {page === 'merge-requests' && 'View merge request'}
+            </TooltipContent>
+          )}
         </Tooltip>
       </div>
       <div className="flex items-center gap-x-4">

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -361,9 +361,6 @@ const MergePage: NextPageWithLayout = () => {
   const isMergeDisabled =
     !combinedHasChanges || isCombinedDiffLoading || isBranchOutOfDateOverall || isWorkflowRunning
 
-  const isReadyForReview = !!currentBranch?.review_requested_at
-
-  // Update primary actions - remove push button if branch is out of date (it will be in the notice)
   const primaryActions = (
     <div className="flex items-end gap-2">
       <ReviewWithAI
@@ -373,16 +370,7 @@ const MergePage: NextPageWithLayout = () => {
         diffContent={diffContent}
         disabled={!currentBranch || !mainBranch || isCombinedDiffLoading}
       />
-      {!isReadyForReview ? (
-        <Button
-          type="primary"
-          onClick={handleReadyForReview}
-          disabled={!combinedHasChanges || isCombinedDiffLoading}
-          icon={<Shield size={16} strokeWidth={1.5} className="text-brand" />}
-        >
-          Mark as ready for review
-        </Button>
-      ) : isMergeDisabled ? (
+      {isMergeDisabled ? (
         <ButtonTooltip
           tooltip={{
             content: {


### PR DESCRIPTION
We previously had a button to mark a branch as ready for review, but repositioning as merge requests so removing this button for now. A user could technically access the merge page and merge without a merge request, but requires a direct link.