### PR TITLE
fix: Fix link pointing to new API keys

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -13,6 +13,7 @@ import { useFlag } from 'hooks/ui/useFlag'
 import { Input } from 'ui'
 import { getLastUsedAPIKeys, useLastUsedAPIKeysLogQuery } from './DisplayApiSettings.utils'
 import { ToggleLegacyApiKeysPanel } from './ToggleLegacyApiKeys'
+import Link from 'next/link'
 
 export const DisplayApiSettings = ({
   showTitle = true,
@@ -172,12 +173,12 @@ export const DisplayApiSettings = ({
                       {showLegacyText && (
                         <span>
                           Prefer using{' '}
-                          <a
+                          <Link
                             href={`/project/${projectRef}/settings/api-keys/new`}
                             className="text-link underline"
                           >
                             Secret API keys
-                          </a>{' '}
+                          </Link>{' '}
                           instead.
                         </span>
                       )}
@@ -189,12 +190,12 @@ export const DisplayApiSettings = ({
                       {showLegacyText && (
                         <span>
                           Prefer using{' '}
-                          <a
+                          <Link
                             href={`/project/${projectRef}/settings/api-keys/new`}
                             className="text-link underline"
                           >
                             Publishable API keys
-                          </a>{' '}
+                          </Link>{' '}
                           instead.
                         </span>
                       )}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes a link that 404s by changing an `<a>` tag to a Next.js `<Link>`. I think the problem is that the `<a>` tag doesn't pick up the basePath that is configured in the Next.js config and doesn't prefix the link with `/dashboard`.
