### PR TITLE
chore/unified-logs-fixes-04b

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -14,6 +14,7 @@ import { useSelectedLog } from 'hooks/analytics/useSelectedLog'
 import useSingleLog from 'hooks/analytics/useSingleLog'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useUpgradePrompt } from 'hooks/misc/useUpgradePrompt'
+import { useFlag } from 'hooks/ui/useFlag'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { Button } from 'ui'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
@@ -27,9 +28,8 @@ import {
 } from './Logs.constants'
 import type { Filters, LogSearchCallback, LogTemplate, QueryType } from './Logs.types'
 import { maybeShowUpgradePrompt } from './Logs.utils'
-import UpgradePrompt from './UpgradePrompt'
-import { useFlag } from 'hooks/ui/useFlag'
 import { PreviewFilterPanelWithUniversal } from './PreviewFilterPanelWithUniversal'
+import UpgradePrompt from './UpgradePrompt'
 
 /**
  * Acts as a container component for the entire log display

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanelWithUniversal.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanelWithUniversal.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useParams } from 'common'
-// import CSVButton from 'components/ui/CSVButton'
 import DatabaseSelector from 'components/ui/DatabaseSelector'
 import { useLoadBalancersQuery } from 'data/read-replicas/load-balancers-query'
 import { IS_PLATFORM } from 'lib/constants'
@@ -20,11 +19,6 @@ import { FilterBar } from 'ui-patterns/FilterBar'
 import { DatePickerValue } from './Logs.DatePickers'
 import { FILTER_OPTIONS, LOG_ROUTES_WITH_REPLICA_SUPPORT, LogsTableName } from './Logs.constants'
 import type { Filters, LogSearchCallback, LogTemplate } from './Logs.types'
-
-interface CustomDateRangePickerProps {
-  value?: { from: Date; to?: Date }
-  onChange: (range: { from: Date; to?: Date } | undefined) => void
-}
 
 function CustomDateRangePicker({ onChange, onCancel }: CustomOptionProps) {
   const [dateRange, setDateRange] = useState<any | undefined>()

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -297,7 +297,7 @@ export const UnifiedLogs = () => {
     >
       <DataTableSideBarLayout topBarHeight={topBarHeight}>
         <ResizablePanelGroup direction="horizontal" autoSaveId="logs-layout">
-          <FilterSideBar />
+          <FilterSideBar dateRangeDisabled={{ after: new Date() }} />
           <ResizableHandle
             withHandle
             // disabled={resizableSidebar ? false : true}

--- a/apps/studio/components/ui/DataTable/DataTable.types.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.types.ts
@@ -30,10 +30,13 @@ export type Slider = {
   options?: Option[]
 }
 
+export type DateRangeDisabled = { before?: Date; after?: Date }
+
 export type Timerange = {
   type: 'timerange'
   options?: Option[] // required for TS
   presets?: DatePreset[]
+  dateRangeDisabled?: DateRangeDisabled
 }
 
 export type Base<TData> = {

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCommand.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCommand.tsx
@@ -62,6 +62,10 @@ export function DataTableFilterCommand({
 
   const trimmedInputValue = inputValue.trim()
 
+  const queryFields = filterFields.filter(
+    (x) => typeof x.value === 'string' && currentWord.includes(`${x.value}:`)
+  )
+
   // [Joshen] Temporarily disabling as this conflicts with our current CMD K behaviour
   // useHotKey(() => setOpen((open) => !open), 'k')
 
@@ -80,18 +84,6 @@ export function DataTableFilterCommand({
       const field = _filterFields?.find((field) => field.value === filter.id)
       return !field?.commandDisabled
     })
-    const currentDisabledFilters = currentFilters.filter((filter) => {
-      const field = _filterFields?.find((field) => field.value === filter.id)
-      return field?.commandDisabled
-    })
-
-    const commandDisabledFilterKeys = currentDisabledFilters.reduce(
-      (prev, curr) => {
-        prev[curr.id] = curr.value
-        return prev
-      },
-      {} as Record<string, unknown>
-    )
 
     for (const key of Object.keys(searchParams)) {
       const value = searchParams[key as keyof typeof searchParams]
@@ -198,6 +190,7 @@ export function DataTableFilterCommand({
           <div className="absolute top-2 z-50 w-full overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-md outline-none animate-in">
             {/* default height is 300px but in case of more, we'd like to tease the user */}
             <CommandList className="max-h-[310px] bg-surface-100">
+              <CommandEmpty>No results found.</CommandEmpty>
               <CommandGroup heading="Filter">
                 {filterFields.map((field) => {
                   if (typeof field.value !== 'string') return null
@@ -227,106 +220,113 @@ export function DataTableFilterCommand({
                       }}
                       className="group"
                     >
-                      {field.value}
+                      {field.label}
                       <CommandItemSuggestions field={field} />
                     </CommandItem>
                   )
                 })}
               </CommandGroup>
+
               <CommandSeparator />
-              <CommandGroup heading="Query">
-                {filterFields?.map((field) => {
-                  if (typeof field.value !== 'string') return null
-                  if (!currentWord.includes(`${field.value}:`)) return null
 
-                  const column = table.getColumn(field.value)
-                  const facetedValue =
-                    getFacetedUniqueValues?.(table, field.value) || column?.getFacetedUniqueValues()
+              {queryFields.length > 0 && (
+                <>
+                  <CommandGroup heading="Query">
+                    {queryFields.map((field) => {
+                      const column = table.getColumn(field.value)
+                      const facetedValue =
+                        getFacetedUniqueValues?.(table, field.value) ||
+                        column?.getFacetedUniqueValues()
 
-                  const options = getFieldOptions({ field })
+                      const options = getFieldOptions({ field })
 
-                  return options.map((optionValue) => {
-                    return (
-                      <CommandItem
-                        key={`${String(field.value)}:${optionValue}`}
-                        value={`${String(field.value)}:${optionValue}`}
-                        onMouseDown={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                        }}
-                        onSelect={(value) => {
-                          setInputValue((prev) =>
-                            replaceInputByFieldType({
-                              prev,
-                              currentWord,
-                              optionValue,
-                              value,
-                              field,
-                            })
-                          )
-                          setCurrentWord('')
-                        }}
-                      >
-                        {`${optionValue}`}
-                        {facetedValue?.has(optionValue) ? (
-                          <span className="ml-auto font-mono text-muted-foreground">
-                            {formatCompactNumber(facetedValue.get(optionValue) || 0)}
-                          </span>
-                        ) : null}
-                      </CommandItem>
-                    )
-                  })
-                })}
-              </CommandGroup>
-              <CommandSeparator />
-              <CommandGroup heading="Suggestions">
-                {lastSearches
-                  ?.sort((a, b) => b.timestamp - a.timestamp)
-                  .slice(0, 5)
-                  .map((item) => {
-                    return (
-                      <CommandItem
-                        key={`suggestion:${item.search}`}
-                        value={`suggestion:${item.search}`}
-                        onMouseDown={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                        }}
-                        onSelect={(value) => {
-                          const search = value.replace('suggestion:', '')
-                          setInputValue(`${search} `)
-                          setCurrentWord('')
-                        }}
-                        className="group"
-                      >
-                        {item.search}
-                        <span className="ml-auto truncate text-muted-foreground/80 group-aria-[selected=true]:block">
-                          {formatDistanceToNow(item.timestamp, {
-                            addSuffix: true,
-                          })}
-                        </span>
-                        <button
-                          type="button"
+                      return options.map((optionValue) => {
+                        return (
+                          <CommandItem
+                            key={`${String(field.value)}:${optionValue}`}
+                            value={`${String(field.value)}:${optionValue}`}
+                            onMouseDown={(e) => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                            }}
+                            onSelect={(value) => {
+                              setInputValue((prev) =>
+                                replaceInputByFieldType({
+                                  prev,
+                                  currentWord,
+                                  optionValue,
+                                  value,
+                                  field,
+                                })
+                              )
+                              setCurrentWord('')
+                            }}
+                          >
+                            {`${optionValue}`}
+                            {facetedValue?.has(optionValue) ? (
+                              <span className="ml-auto font-mono text-muted-foreground">
+                                {formatCompactNumber(facetedValue.get(optionValue) || 0)}
+                              </span>
+                            ) : null}
+                          </CommandItem>
+                        )
+                      })
+                    })}
+                  </CommandGroup>
+                  <CommandSeparator />
+                </>
+              )}
+
+              {lastSearches.length > 0 && (
+                <CommandGroup heading="Suggestions">
+                  {lastSearches
+                    .sort((a, b) => b.timestamp - a.timestamp)
+                    .slice(0, 5)
+                    .map((item) => {
+                      return (
+                        <CommandItem
+                          key={`suggestion:${item.search}`}
+                          value={`suggestion:${item.search}`}
                           onMouseDown={(e) => {
                             e.preventDefault()
                             e.stopPropagation()
                           }}
-                          onClick={(e) => {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            // TODO: extract into function
-                            setLastSearches(lastSearches.filter((i) => i.search !== item.search))
+                          onSelect={(value) => {
+                            const search = value.replace('suggestion:', '')
+                            setInputValue(`${search} `)
+                            setCurrentWord('')
                           }}
-                          className="ml-1 hidden rounded-md p-0.5 hover:bg-background group-aria-[selected=true]:block"
+                          className="group"
                         >
-                          <X className="h-4 w-4" />
-                        </button>
-                      </CommandItem>
-                    )
-                  })}
-              </CommandGroup>
-              <CommandEmpty>No results found.</CommandEmpty>
+                          {item.search}
+                          <span className="ml-auto truncate text-muted-foreground/80 group-aria-[selected=true]:block">
+                            {formatDistanceToNow(item.timestamp, {
+                              addSuffix: true,
+                            })}
+                          </span>
+                          <button
+                            type="button"
+                            onMouseDown={(e) => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                            }}
+                            onClick={(e) => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              // TODO: extract into function
+                              setLastSearches(lastSearches.filter((i) => i.search !== item.search))
+                            }}
+                            className="ml-1 hidden rounded-md p-0.5 hover:bg-background group-aria-[selected=true]:block"
+                          >
+                            <X className="h-4 w-4" />
+                          </button>
+                        </CommandItem>
+                      )
+                    })}
+                </CommandGroup>
+              )}
             </CommandList>
+
             <div className="bg-surface-100 flex flex-wrap justify-between gap-3 border-t bg-accent/50 px-2 py-1.5 text-sm text-accent-foreground">
               <div className="flex flex-wrap gap-3">
                 <span>
@@ -370,10 +370,12 @@ export function DataTableFilterCommand({
 function CommandItemSuggestions<TData>({ field }: { field: DataTableFilterField<TData> }) {
   const { table, getFacetedMinMaxValues, getFacetedUniqueValues } = useDataTable()
   const value = field.value as string
+  const className = 'ml-2 hidden truncate text-foreground-lighter group-aria-[selected=true]:block'
+
   switch (field.type) {
     case 'checkbox': {
       return (
-        <span className="ml-1 hidden truncate text-muted-foreground/80 group-aria-[selected=true]:block">
+        <span className={cn(className)}>
           {getFacetedUniqueValues
             ? Array.from(getFacetedUniqueValues(table, value)?.keys() || [])
                 .map((value) => `[${value}]`)
@@ -385,17 +387,13 @@ function CommandItemSuggestions<TData>({ field }: { field: DataTableFilterField<
     case 'slider': {
       const [min, max] = getFacetedMinMaxValues?.(table, value) || [field.min, field.max]
       return (
-        <span className="ml-1 hidden truncate text-muted-foreground/80 group-aria-[selected=true]:block">
+        <span className={cn(className)}>
           [{min} - {max}]
         </span>
       )
     }
     case 'input': {
-      return (
-        <span className="ml-1 hidden truncate text-muted-foreground/80 group-aria-[selected=true]:block">
-          [{`${String(field.value)}`} input]
-        </span>
-      )
+      return <span className={cn(className)}>[{`${String(field.value)}`} input]</span>
     }
     default: {
       return null

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterControls.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterControls.tsx
@@ -11,6 +11,7 @@ import { DataTableFilterResetButton } from './DataTableFilterResetButton'
 import { DataTableFilterSlider } from './DataTableFilterSlider'
 import { DataTableFilterTimerange } from './DataTableFilterTimerange'
 
+import { DateRangeDisabled } from '../DataTable.types'
 import { useDataTable } from '../providers/DataTableProvider'
 
 // FIXME: use @container (especially for the slider element) to restructure elements
@@ -18,7 +19,11 @@ import { useDataTable } from '../providers/DataTableProvider'
 // TODO: only pass the columns to generate the filters!
 // https://tanstack.com/table/v8/docs/framework/react/examples/filters
 
-export function DataTableFilterControls() {
+interface DataTableFilterControls {
+  dateRangeDisabled?: DateRangeDisabled
+}
+
+export function DataTableFilterControls({ dateRangeDisabled }: DataTableFilterControls) {
   const { filterFields } = useDataTable()
   return (
     <Accordion
@@ -55,7 +60,12 @@ export function DataTableFilterControls() {
                       return <DataTableFilterInput {...field} />
                     }
                     case 'timerange': {
-                      return <DataTableFilterTimerange {...field} />
+                      return (
+                        <DataTableFilterTimerange
+                          dateRangeDisabled={dateRangeDisabled}
+                          {...field}
+                        />
+                      )
                     }
                   }
                 })()}

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterTimerange.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterTimerange.tsx
@@ -9,6 +9,7 @@ import { useDataTable } from '../providers/DataTableProvider'
 export function DataTableFilterTimerange<TData>({
   value: _value,
   presets,
+  dateRangeDisabled,
 }: DataTableTimerangeFilterField<TData>) {
   const value = _value as string
   const { table, columnFilters } = useDataTable()
@@ -35,5 +36,7 @@ export function DataTableFilterTimerange<TData>({
     }
   }
 
-  return <DatePickerWithRange {...{ date, setDate, presets }} />
+  return (
+    <DatePickerWithRange dateRangeDisabled={dateRangeDisabled} {...{ date, setDate, presets }} />
+  )
 }

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilters.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilters.utils.ts
@@ -218,13 +218,10 @@ export function columnFiltersParser<TData>({
       const regex = /(\w+):([^]*?)(?=\s+\w+:|$)/g
       let match
 
-      console.log('DataTableFilterCommand parsing input:', inputValue)
-
       while ((match = regex.exec(inputValue)) !== null) {
         const [_, fieldName, fieldValue] = match
         if (fieldName && fieldValue) {
           filterPairs[fieldName] = fieldValue.trim()
-          console.log(`Parsed filter pair: ${fieldName} = ${fieldValue.trim()}`)
         }
       }
 

--- a/apps/studio/components/ui/DataTable/DatePickerWithRange.tsx
+++ b/apps/studio/components/ui/DataTable/DatePickerWithRange.tsx
@@ -22,7 +22,7 @@ import {
   SelectValue_Shadcn_ as SelectValue,
 } from 'ui'
 import { presets as defaultPresets } from './DataTable.constants'
-import type { DatePreset } from './DataTable.types'
+import type { DatePreset, DateRangeDisabled } from './DataTable.types'
 import { useDebounce } from './hooks/useDebounce'
 import { kdbClassName } from './primitives/Kbd'
 
@@ -30,6 +30,7 @@ interface DatePickerWithRangeProps extends HTMLAttributes<HTMLDivElement> {
   date: DateRange | undefined
   setDate: (date: DateRange | undefined) => void
   presets?: DatePreset[]
+  dateRangeDisabled?: DateRangeDisabled
 }
 
 // [Joshen] This might be better placed in ui instead of DataTable since it could be reusable
@@ -38,6 +39,7 @@ export function DatePickerWithRange({
   date,
   setDate,
   presets = defaultPresets,
+  dateRangeDisabled,
 }: DatePickerWithRangeProps) {
   const [open, setOpen] = useState(false)
 
@@ -98,6 +100,8 @@ export function DatePickerWithRange({
               selected={date}
               onSelect={setDate}
               numberOfMonths={1}
+              // @ts-ignore
+              disabled={dateRangeDisabled}
             />
           </div>
           <PopoverSeparator />

--- a/apps/studio/components/ui/DataTable/FilterSideBar.tsx
+++ b/apps/studio/components/ui/DataTable/FilterSideBar.tsx
@@ -1,9 +1,14 @@
 import { cn, ResizablePanel } from 'ui'
+import { DateRangeDisabled } from './DataTable.types'
 import { DataTableFilterControls } from './DataTableFilters/DataTableFilterControls'
 import { DataTableResetButton } from './DataTableResetButton'
 import { useDataTable } from './providers/DataTableProvider'
 
-export function FilterSideBar() {
+interface FilterSideBarProps {
+  dateRangeDisabled?: DateRangeDisabled
+}
+
+export function FilterSideBar({ dateRangeDisabled }: FilterSideBarProps) {
   const { table } = useDataTable()
 
   return (
@@ -26,7 +31,7 @@ export function FilterSideBar() {
         </div>
       </div>
       <div className="flex-1 p-2 sm:overflow-y-scroll">
-        <DataTableFilterControls />
+        <DataTableFilterControls dateRangeDisabled={dateRangeDisabled} />
       </div>
     </ResizablePanel>
   )

--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
@@ -1,5 +1,5 @@
-import { NextApiRequest, NextApiResponse } from 'next'
 import apiWrapper from 'lib/api/apiWrapper'
+import { NextApiRequest, NextApiResponse } from 'next'
 import { PROJECT_ANALYTICS_URL } from 'pages/api/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
@@ -9,6 +9,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
+    case 'POST':
       const missingEnvVars = [
         process.env.LOGFLARE_PRIVATE_ACCESS_TOKEN ? null : 'LOGFLARE_PRIVATE_ACCESS_TOKEN',
         process.env.LOGFLARE_URL ? null : 'LOGFLARE_URL',
@@ -23,15 +24,26 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }
 
     default:
-      res.setHeader('Allow', ['GET'])
+      res.setHeader('Allow', ['GET', 'POST'])
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
   }
 }
 
 const proxyRequest = async (req: NextApiRequest) => {
   const { name, ...toForward } = req.query
-  const payload = { ...toForward, project_tier: 'ENTERPRISE' }
-  const search = '?' + new URLSearchParams(payload as any).toString()
+  const project_tier = 'ENTERPRISE'
+
+  if (req.method === 'GET') {
+    const payload = { ...toForward, project_tier }
+    return retrieveAnalyticsData(name as string, payload)
+  } else if (req.method === 'POST') {
+    const payload = { ...req.body, project_tier }
+    return retrieveAnalyticsData(name as string, payload)
+  }
+}
+
+const retrieveAnalyticsData = async (name: string, payload: any) => {
+  const search = '?' + new URLSearchParams(payload).toString()
   const apiKey = process.env.LOGFLARE_PRIVATE_ACCESS_TOKEN
   const url = `${PROJECT_ANALYTICS_URL}endpoints/query/${name}${search}`
   const result = await fetch(url, {

--- a/packages/ui/src/components/shadcn/ui/calendar.tsx
+++ b/packages/ui/src/components/shadcn/ui/calendar.tsx
@@ -10,6 +10,11 @@ import { buttonVariants } from './button'
 export type CalendarProps = React.ComponentProps<typeof DayPicker>
 
 function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  // [Joshen] Wondering if this is a bug with react-day-picker v8 whereby a single selected date
+  // has styles applied for both day_range_start and day_range_end
+  const fullDateRangeSelected =
+    props.mode === 'range' && !!props.selected?.from && !!props.selected?.to
+
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
@@ -30,23 +35,27 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         head_row: 'flex',
         head_cell: 'text-foreground-muted rounded-md w-9 font-normal text-[0.8rem]',
         row: 'flex w-full mt-2',
-        cell: 'text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+        cell: cn(
+          'text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md',
+          'last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20'
+        ),
         day: cn(
           buttonVariants({ variant: 'ghost' }),
           'h-9 w-9 p-0 font-normal aria-selected:opacity-100'
         ),
-        day_selected:
-          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+        day_selected: 'bg-brand-500 text-foreground text-foreground',
         day_today: 'bg-accent text-accent-foreground',
         day_outside: 'text-foreground-muted opacity-50',
         day_disabled: 'text-foreground-muted opacity-50',
-        day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
+        day_range_start: cn(fullDateRangeSelected && 'bg-brand-500 rounded-r-none'),
+        day_range_middle: 'aria-selected:bg-brand-400 rounded-none',
+        day_range_end: cn(fullDateRangeSelected && 'bg-brand-500 rounded-l-none'),
         day_hidden: 'invisible',
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/packages/ui/src/components/shadcn/ui/calendar.tsx
+++ b/packages/ui/src/components/shadcn/ui/calendar.tsx
@@ -11,7 +11,8 @@ export type CalendarProps = React.ComponentProps<typeof DayPicker>
 
 function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
   // [Joshen] Wondering if this is a bug with react-day-picker v8 whereby a single selected date
-  // has styles applied for both day_range_start and day_range_end
+  // has styles applied for both day_range_start and day_range_end. This might be fixed with the latest
+  // version of react-day-picker, but in case we can opt for a pure tailwind solution instead of JS
   const fullDateRangeSelected =
     props.mode === 'range' && !!props.selected?.from && !!props.selected?.to
 


### PR DESCRIPTION
Shifting changes over from [here](https://github.com/supabase/supabase/pull/36762) cause I messed up that PR 🥲 
Just copy pasting the PR description over since its the same, and also have addressed the feedback from that PR too

## Context

Couple more fixes from testing for Unified Logs interface, this round testing the following:

- Filter by Time range
- Filter Command Bar
- Self-hosted
  - JFYI UI is controlled via feature flag which means that it won't be available on self-hosted just yet until we clean up the feature flag
- RE Auth users: I'm unable to test this on my end as I'm not sure how to generate logs that'll include auth users

## Changes involved

- Fix missing colors for calendar component when a range is selected (Fixes FE-1694)
![image](https://github.com/user-attachments/assets/02415caf-7042-4d49-b3a2-6689b258dbc3)
- Prevent selecting future dates from current date in unified logs date picker (Fixes FE-1695)
  - e.g Current date is 30th June, all dates in July are disabled
![image](https://github.com/user-attachments/assets/728481a5-85bc-486a-bc33-973e6f177595)
- Small cleanups for DataTableFilterCommand
  - Only show "Query" section if there are any queries
  - Only show "Suggestions" section if there are any suggestions
![image](https://github.com/user-attachments/assets/43e5b5ab-0713-4a9a-aba4-08baa72dc0c2)
- Add missing POST method to dashboard analytics API to support Unified Logs for self-hosted (Fixes FE-1696)
  - I'm not able to test this locally by the way, running into this error for any pings to the logs pages for self-hosted run via `pnpm run dev:studio-local`
![image](https://github.com/user-attachments/assets/fb703105-5e79-4eed-a88e-9ac70aeeacb0)
