### PR TITLE
Fix planet return example

### DIFF
--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -207,7 +207,7 @@ create or replace function get_planets()
 returns setof planets
 language sql
 as $$
-  select * from planets;
+  return query select * from planets;
 $$;
 ```
 


### PR DESCRIPTION
The example provided does not work. 
It ends up with a `ERROR:  query has no destination for result data`, because we need to return the actual set and mark it as a query.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs example fix

## What is the current behavior?
N/A

## What is the new behavior?
N/A

