### PR TITLE
fix(docker): use postgres instead of supabase_admin as current user

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -309,7 +309,7 @@ services:
       PG_META_DB_HOST: ${POSTGRES_HOST}
       PG_META_DB_PORT: ${POSTGRES_PORT}
       PG_META_DB_NAME: ${POSTGRES_DB}
-      PG_META_DB_USER: supabase_admin
+      PG_META_DB_USER: postgres
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
 
   functions:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (sorry, had to recreate PR as I accidentally made changes on main branch and messed up the fork)

studio connects to the database via pgmeta which previously used supabase_admin user to authenticate to db in self-hosted instance. Any resources which were created from dashboard were owned by supabase_admin, leading to permission issues if a user decided to migrate to managed instances.


## What is the current behavior?

Fixes #36973 

## What is the new behavior?

Now pgmeta uses postgres user and any resources which are created via dashboard are owned by postgres user.
