### PR TITLE
fix: disable usercentrics for local dev

### DIFF
--- a/packages/common/consent-state.ts
+++ b/packages/common/consent-state.ts
@@ -1,7 +1,7 @@
 import type Usercentrics from '@usercentrics/cmp-browser-sdk'
 import type { BaseCategory, UserDecision } from '@usercentrics/cmp-browser-sdk'
 import { proxy, snapshot, useSnapshot } from 'valtio'
-import { LOCAL_STORAGE_KEYS, IS_PLATFORM } from './constants'
+import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from './constants'
 
 export const consentState = proxy({
   // Usercentrics state
@@ -59,8 +59,15 @@ export const consentState = proxy({
 })
 
 async function initUserCentrics() {
-  if (process.env.NODE_ENV === 'test') return
-  if (!IS_PLATFORM) return
+  if (process.env.NODE_ENV === 'test' || !IS_PLATFORM) return
+
+  // [Alaister] For local development, we accept all consent by default.
+  // If you need to test usercentrics locally, comment out the
+  // NEXT_PUBLIC_ENVIRONMENT check and add an ngrok domain to usercentrics
+  if (process.env.NEXT_PUBLIC_ENVIRONMENT === 'local') {
+    consentState.hasConsented = true
+    return
+  }
 
   const { default: Usercentrics } = await import('@usercentrics/cmp-browser-sdk')
 


### PR DESCRIPTION
In local dev there's a giant error caused by usercentrics being unable to load on local host. This PR treats consent as accepted while in local development.