### PR TITLE
Update React quickstart guide with recommended alternatives to create-react-app

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -27,22 +27,35 @@ hideToc: true
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={2}>
+  <StepHikeCompact.Details title="Create a React app">
 
-    <StepHikeCompact.Details title="Create a React app">
+    Create a React app using one of the following recommended tools:
 
-    Create a React app using the `create-react-app` command.
+    - [Next.js](https://nextjs.org/)
+    - [React Router](https://reactrouter.com/)
+    - [Expo](https://expo.dev/)
 
-    </StepHikeCompact.Details>
+    *NOTE: The React team has officially deprecated `create-react-app` as of February 2025.
+    For more info, see the React team's announcement: [Sunsetting Create React App](https://react.dev/blog/2025/02/14/sunsetting-create-react-app).*
 
-    <StepHikeCompact.Code>
+  </StepHikeCompact.Details>
 
-      ```bash name=Terminal
-      npx create-react-app my-app
-      ```
+  <StepHikeCompact.Code>
 
-    </StepHikeCompact.Code>
+    ```bash name=Terminal
+    # Next.js app
+    npx create-next-app@latest my-next-app
 
-  </StepHikeCompact.Step>
+    # React Router app
+    npx create-react-router@latest my-react-router-app
+
+    # Expo app (React Native)
+    npx create-expo-app@latest my-expo-app
+    ```
+
+  </StepHikeCompact.Code>
+</StepHikeCompact.Step>
+
 
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Install the Supabase client library">

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -29,33 +29,19 @@ hideToc: true
   <StepHikeCompact.Step step={2}>
   <StepHikeCompact.Details title="Create a React app">
 
-    Create a React app using one of the following recommended tools:
-
-    - [Next.js](https://nextjs.org/)
-    - [React Router](https://reactrouter.com/)
-    - [Expo](https://expo.dev/)
-
-    *NOTE: The React team has officially deprecated `create-react-app` as of February 2025.
-    For more info, see the React team's announcement: [Sunsetting Create React App](https://react.dev/blog/2025/02/14/sunsetting-create-react-app).*
+    Create a React app using [Vite](https://vitejs.dev/).
 
   </StepHikeCompact.Details>
 
   <StepHikeCompact.Code>
 
     ```bash name=Terminal
-    # Next.js app
-    npx create-next-app@latest my-next-app
+    npm create vite@latest my-app -- --template react
 
-    # React Router app
-    npx create-react-router@latest my-react-router-app
-
-    # Expo app (React Native)
-    npx create-expo-app@latest my-expo-app
     ```
 
   </StepHikeCompact.Code>
 </StepHikeCompact.Step>
-
 
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Install the Supabase client library">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce? 
Docs Update

## What is the current behavior? 
https://github.com/supabase/supabase/issues/34388

## What is the new behavior? 

- Removed `create-react-app` setup
- Added Vite as recommended tools

Feel free to include screenshots if it includes visual changes.

<img width="1348" height="200" alt="Screenshot 2025-07-17 at 2 35 31 PM" src="https://github.com/user-attachments/assets/91e20749-8ea2-4810-ae15-a9e31eddfe0e" />


## Additional context

Add any other context or screenshots.

Closes #34388
