### PR TITLE
[docs] Fix Postgresql install link destination

### DIFF
--- a/apps/docs/content/_partials/postgres_installation.mdx
+++ b/apps/docs/content/_partials/postgres_installation.mdx
@@ -13,7 +13,7 @@
 
     <StepHikeCompact.Details title="Install Postgres" fullWidth>
 
-    Download and run the installation file for the latest version from the [Postgres installer download page](https://www.postgresql.org/download/windows/).
+    Download and run the installation file for the latest version from the [Postgres installer download page](https://www.postgresql.org/download/).
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
makes the link to install Postgres point to the general Download page rather than the Windows-specific one

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

https://github.com/supabase/supabase/issues/37221

The link to install Postgres goes to the Windows downloads page rather than the general installation downloads page.

## What is the new behavior?

The link goes to the overall downloads page.

