### PR TITLE
Make check-cname endpoint GET, and improve middleware checking

### DIFF
--- a/apps/studio/data/custom-domains/check-cname-mutation.ts
+++ b/apps/studio/data/custom-domains/check-cname-mutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
-import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
+import { fetchHandler, handleError } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
 import { toast } from 'sonner'
 
@@ -24,12 +24,9 @@ export type CheckCNAMERecordResponse = {
 // [Joshen] Should tally with https://github.com/supabase/cli/blob/63790a1bd43bee06f82c4f510e709925526a4daa/internal/utils/api.go#L98
 export async function checkCNAMERecord({ domain }: CheckCNAMERecordVariables) {
   try {
-    const headers = await constructHeaders({ 'Content-Type': 'application/json' })
-    const res: CheckCNAMERecordResponse = await fetchHandler(`${BASE_PATH}/api/check-cname`, {
-      headers,
-      method: 'POST',
-      body: JSON.stringify({ domain }),
-    }).then((res) => res.json())
+    const res: CheckCNAMERecordResponse = await fetchHandler(
+      `${BASE_PATH}/api/check-cname?domain=${domain}`
+    ).then((res) => res.json())
 
     if (res.Answer === undefined) {
       throw new Error(

--- a/apps/studio/middleware.ts
+++ b/apps/studio/middleware.ts
@@ -30,7 +30,10 @@ const HOSTED_SUPPORTED_API_URLS = [
 ]
 
 export function middleware(request: NextRequest) {
-  if (IS_PLATFORM && !HOSTED_SUPPORTED_API_URLS.some((url) => request.url.endsWith(url))) {
+  if (
+    IS_PLATFORM &&
+    !HOSTED_SUPPORTED_API_URLS.some((url) => request.nextUrl.pathname.endsWith(url))
+  ) {
     return Response.json(
       { success: false, message: 'Endpoint not supported on hosted' },
       { status: 404 }

--- a/apps/studio/pages/api/check-cname.ts
+++ b/apps/studio/pages/api/check-cname.ts
@@ -2,7 +2,7 @@ import { CheckCNAMERecordResponse } from 'data/custom-domains/check-cname-mutati
 import { NextApiRequest, NextApiResponse } from 'next'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { domain } = req.body
+  const { domain } = req.query
 
   try {
     const result: CheckCNAMERecordResponse = await fetch(


### PR DESCRIPTION
## Context

Addresses the feedback from this [PR](https://github.com/supabase/supabase/pull/37210#discussion_r2210771013) RE calling the new `check-cname` endpoint with a GET request instead. Requires a change in the middleware checking to support this.

## Changes involved
- `check-cname-mutation` now calls `check-cname` with GET instead of POST
  - Removes the need to send headers and body, just append `domain` as a query param
- `middleware.ts` checks for pathname instead of the whole url

## To test
- [ ] Verify again that a custom domain can be added