### PR TITLE
Chore/add instructions for psql export table editor

### DIFF
--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -68,10 +68,9 @@ pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${snap.
 
         <DialogSection className="flex flex-col gap-y-4">
           <p className="text-sm">
-            We highly recommend using the CLI to export your table data via{' '}
-            <code>{selectedTab === 'csv' ? 'psql' : 'pg_dump'}</code>, in particular if your table
-            is relatively large. This can be done via the following command that you can run in your
-            terminal:
+            We highly recommend using <code>{selectedTab === 'csv' ? 'psql' : 'pg_dump'}</code> to
+            export your table data, in particular if your table is relatively large. This can be
+            done via the following command that you can run in your terminal:
           </p>
 
           <Tabs_Shadcn_ value={selectedTab} onValueChange={setSelectedTab}>

--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -99,7 +99,7 @@ pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${snap.
           </Tabs_Shadcn_>
 
           <p className="text-sm">
-            You will be prompted with your database password, and the output file{' '}
+            You will be prompted for your database password, and the output file{' '}
             <code>
               {outputName}.{selectedTab}
             </code>{' '}

--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -68,7 +68,8 @@ pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${snap.
 
         <DialogSection className="flex flex-col gap-y-4">
           <p className="text-sm">
-            We highly recommend using the CLI to export your table data, in particular if your table
+            We highly recommend using the CLI to export your table data via{' '}
+            <code>{selectedTab === 'csv' ? 'psql' : 'pg_dump'}</code>, in particular if your table
             is relatively large. This can be done via the following command that you can run in your
             terminal:
           </p>
@@ -106,7 +107,17 @@ pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${snap.
             will be saved in the current directory that your terminal is in.
           </p>
 
-          <Admonition type="note" title="You may need to upgrade your version of pg_dump" />
+          {selectedTab === 'sql' && (
+            <Admonition
+              type="note"
+              title="The pg_dump version needs to match your Postgres version"
+            >
+              <p className="!leading-normal">
+                If you run into a server version mismatch error, you will need to update{' '}
+                <code>pg_dump</code> before running the command.
+              </p>
+            </Admonition>
+          )}
         </DialogSection>
         <DialogFooter>
           <Button type="default" onClick={() => onOpenChange(false)}>

--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -1,0 +1,76 @@
+import { useParams } from 'common'
+import { getConnectionStrings } from 'components/interfaces/Connect/DatabaseSettings.utils'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { pluckObjectFields } from 'lib/helpers'
+import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
+import {
+  cn,
+  CodeBlock,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+} from 'ui'
+
+interface ExportDialogProps {
+  format?: 'csv' | 'sql'
+  onOpenChange: (open: boolean) => void
+}
+
+export const ExportDialog = ({ format, onOpenChange }: ExportDialogProps) => {
+  const { ref: projectRef } = useParams()
+  const snap = useTableEditorTableStateSnapshot()
+  console.log(snap.table)
+
+  const { data: databases } = useReadReplicasQuery({ projectRef })
+  const primaryDatabase = (databases ?? []).find((db) => db.identifier === projectRef)
+  const DB_FIELDS = ['db_host', 'db_name', 'db_port', 'db_user', 'inserted_at']
+  const emptyState = { db_user: '', db_host: '', db_port: '', db_name: '' }
+  const connectionInfo = pluckObjectFields(primaryDatabase || emptyState, DB_FIELDS)
+
+  const connectionStrings = getConnectionStrings({
+    connectionInfo,
+    metadata: { projectRef },
+    // [Joshen] We don't need any pooler details for this context, we only want direct
+    poolingInfo: { connectionString: '', db_host: '', db_name: '', db_port: 0, db_user: '' },
+  })
+
+  const csvExportCommand = `
+${connectionStrings.direct.psql} -c "COPY (SELECT * FROM "${snap.table.schema}"."${snap.table.name}") TO STDOUT WITH CSV HEADER DELIMITER ',';" > test.csv
+`.trim()
+
+  return (
+    <Dialog open={!!format} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Export table data to {format?.toUpperCase()} via <code>psql</code>
+          </DialogTitle>
+          <DialogDescription>World</DialogDescription>
+        </DialogHeader>
+
+        <DialogSectionSeparator />
+
+        <DialogSection className="flex flex-col gap-y-4">
+          <p className="text-sm">
+            We highly recommend using <code>psql</code> to export your table data, in particular if
+            your table is relatively large. This can be done via the following command that you can
+            run in your terminal:
+          </p>
+
+          <CodeBlock
+            wrapperClassName={cn('[&_pre]:px-4 [&_pre]:py-3')}
+            language="bash"
+            value={format === 'csv' ? csvExportCommand : 'hello'}
+            className="[&_code]:text-[12px] [&_code]:text-foreground"
+            hideLineNumbers
+            onCopyCallback={() => {}}
+          />
+        </DialogSection>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -2,34 +2,43 @@ import { useParams } from 'common'
 import { getConnectionStrings } from 'components/interfaces/Connect/DatabaseSettings.utils'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { pluckObjectFields } from 'lib/helpers'
+import { useState } from 'react'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import {
+  Button,
   cn,
   CodeBlock,
   Dialog,
   DialogContent,
-  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
+  Tabs_Shadcn_,
+  TabsContent_Shadcn_,
+  TabsList_Shadcn_,
+  TabsTrigger_Shadcn_,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 interface ExportDialogProps {
-  format?: 'csv' | 'sql'
+  open: boolean
   onOpenChange: (open: boolean) => void
 }
 
-export const ExportDialog = ({ format, onOpenChange }: ExportDialogProps) => {
+export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
   const { ref: projectRef } = useParams()
   const snap = useTableEditorTableStateSnapshot()
-  console.log(snap.table)
+  const [selectedTab, setSelectedTab] = useState<string>('csv')
 
   const { data: databases } = useReadReplicasQuery({ projectRef })
   const primaryDatabase = (databases ?? []).find((db) => db.identifier === projectRef)
   const DB_FIELDS = ['db_host', 'db_name', 'db_port', 'db_user', 'inserted_at']
   const emptyState = { db_user: '', db_host: '', db_port: '', db_name: '' }
+
   const connectionInfo = pluckObjectFields(primaryDatabase || emptyState, DB_FIELDS)
+  const { db_host, db_port, db_user, db_name } = connectionInfo
 
   const connectionStrings = getConnectionStrings({
     connectionInfo,
@@ -38,38 +47,72 @@ export const ExportDialog = ({ format, onOpenChange }: ExportDialogProps) => {
     poolingInfo: { connectionString: '', db_host: '', db_name: '', db_port: 0, db_user: '' },
   })
 
+  const outputName = `${snap.table.name}_rows`
+
   const csvExportCommand = `
-${connectionStrings.direct.psql} -c "COPY (SELECT * FROM "${snap.table.schema}"."${snap.table.name}") TO STDOUT WITH CSV HEADER DELIMITER ',';" > test.csv
+${connectionStrings.direct.psql} -c "COPY (SELECT * FROM "${snap.table.schema}"."${snap.table.name}") TO STDOUT WITH CSV HEADER DELIMITER ',';" > ${outputName}.csv
 `.trim()
 
+  const sqlExportCommand = `
+pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${snap.table.schema}.${snap.table.name}" --data-only --column-inserts > ${outputName}.sql
+  `.trim()
+
   return (
-    <Dialog open={!!format} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>
-            Export table data to {format?.toUpperCase()} via <code>psql</code>
-          </DialogTitle>
-          <DialogDescription>World</DialogDescription>
+          <DialogTitle>Export table data via CLI</DialogTitle>
         </DialogHeader>
 
         <DialogSectionSeparator />
 
         <DialogSection className="flex flex-col gap-y-4">
           <p className="text-sm">
-            We highly recommend using <code>psql</code> to export your table data, in particular if
-            your table is relatively large. This can be done via the following command that you can
-            run in your terminal:
+            We highly recommend using the CLI to export your table data, in particular if your table
+            is relatively large. This can be done via the following command that you can run in your
+            terminal:
           </p>
 
-          <CodeBlock
-            wrapperClassName={cn('[&_pre]:px-4 [&_pre]:py-3')}
-            language="bash"
-            value={format === 'csv' ? csvExportCommand : 'hello'}
-            className="[&_code]:text-[12px] [&_code]:text-foreground"
-            hideLineNumbers
-            onCopyCallback={() => {}}
-          />
+          <Tabs_Shadcn_ value={selectedTab} onValueChange={setSelectedTab}>
+            <TabsList_Shadcn_ className="gap-x-3">
+              <TabsTrigger_Shadcn_ value="csv">As CSV</TabsTrigger_Shadcn_>
+              <TabsTrigger_Shadcn_ value="sql">As SQL</TabsTrigger_Shadcn_>
+            </TabsList_Shadcn_>
+            <TabsContent_Shadcn_ value="csv">
+              <CodeBlock
+                hideLineNumbers
+                wrapperClassName={cn('[&_pre]:px-4 [&_pre]:py-3')}
+                language="bash"
+                value={csvExportCommand}
+                className="[&_code]:text-[12px] [&_code]:text-foreground"
+              />
+            </TabsContent_Shadcn_>
+            <TabsContent_Shadcn_ value="sql">
+              <CodeBlock
+                hideLineNumbers
+                wrapperClassName={cn('[&_pre]:px-4 [&_pre]:py-3')}
+                language="bash"
+                value={sqlExportCommand}
+                className="[&_code]:text-[12px] [&_code]:text-foreground"
+              />
+            </TabsContent_Shadcn_>
+          </Tabs_Shadcn_>
+
+          <p className="text-sm">
+            You will be prompted with your database password, and the output file{' '}
+            <code>
+              {outputName}.{selectedTab}
+            </code>{' '}
+            will be saved in the current directory that your terminal is in.
+          </p>
+
+          <Admonition type="note" title="You may need to upgrade your version of pg_dump" />
         </DialogSection>
+        <DialogFooter>
+          <Button type="default" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -484,6 +484,8 @@ const RowHeader = () => {
           <DropdownMenuContent className={snap.allRowsSelected ? 'w-52' : 'w-40'}>
             <DropdownMenuItem onClick={onRowsExportCSV}>Export as CSV</DropdownMenuItem>
             <DropdownMenuItem onClick={onRowsExportSQL}>Export as SQL</DropdownMenuItem>
+            {/* [Joshen] Should make this available for all cases, but that'll involve updating
+            the Dialog's SQL output to be dynamic based on any filters applied */}
             {snap.allRowsSelected && (
               <DropdownMenuItem className="group" onClick={() => setShowExportModal(true)}>
                 <div>

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -31,10 +31,14 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Separator,
   SonnerProgress,
 } from 'ui'
+import { ExportDialog } from './ExportDialog'
 import { FilterPopover } from './filter/FilterPopover'
 import { SortPopover } from './sort/SortPopover'
 // [Joshen] CSV exports require this guard as a fail-safe if the table is
@@ -230,6 +234,7 @@ const RowHeader = () => {
   const { sorts } = useTableSort()
 
   const [isExporting, setIsExporting] = useState(false)
+  const [showExportModal, setShowExportModal] = useState<'csv' | 'sql'>()
 
   const { data } = useTableRowsQuery({
     projectRef: project?.ref,
@@ -441,61 +446,79 @@ const RowHeader = () => {
   })
 
   return (
-    <div className="flex items-center gap-x-2">
-      {snap.editable && (
-        <ButtonTooltip
-          type="default"
-          size="tiny"
-          icon={<Trash />}
-          onClick={onRowsDelete}
-          disabled={snap.allRowsSelected && isImpersonatingRole}
-          tooltip={{
-            content: {
-              side: 'bottom',
-              text:
-                snap.allRowsSelected && isImpersonatingRole
-                  ? 'Table truncation is not supported when impersonating a role'
-                  : undefined,
-            },
-          }}
-        >
-          {snap.allRowsSelected
-            ? `Delete all rows in table`
-            : snap.selectedRows.size > 1
-              ? `Delete ${snap.selectedRows.size} rows`
-              : `Delete ${snap.selectedRows.size} row`}
-        </ButtonTooltip>
-      )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
+    <>
+      <div className="flex items-center gap-x-2">
+        {snap.editable && (
+          <ButtonTooltip
             type="default"
             size="tiny"
-            iconRight={<ChevronDown />}
-            loading={isExporting}
-            disabled={isExporting}
+            icon={<Trash />}
+            onClick={onRowsDelete}
+            disabled={snap.allRowsSelected && isImpersonatingRole}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text:
+                  snap.allRowsSelected && isImpersonatingRole
+                    ? 'Table truncation is not supported when impersonating a role'
+                    : undefined,
+              },
+            }}
           >
-            Export
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-40">
-          <DropdownMenuItem onClick={onRowsExportCSV}>
-            <span className="text-foreground-light">Export to CSV</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onRowsExportSQL}>Export to SQL</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+            {snap.allRowsSelected
+              ? `Delete all rows in table`
+              : snap.selectedRows.size > 1
+                ? `Delete ${snap.selectedRows.size} rows`
+                : `Delete ${snap.selectedRows.size} row`}
+          </ButtonTooltip>
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="default"
+              size="tiny"
+              iconRight={<ChevronDown />}
+              loading={isExporting}
+              disabled={isExporting}
+            >
+              Export
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-60">
+            <DropdownMenuItem onClick={onRowsExportCSV}>Export as CSV</DropdownMenuItem>
+            <DropdownMenuItem onClick={onRowsExportSQL}>Export as SQL</DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="group">
+                <div>
+                  <p className="group-hover:text-foreground">Export via psql</p>
+                  <p className="text-foreground-lighter">Recommended for large tables</p>
+                </div>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem onClick={() => setShowExportModal('csv')}>
+                  As CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setShowExportModal('sql')}>
+                  As SQL
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-      {!snap.allRowsSelected && totalRows > allRows.length && (
-        <>
-          <div className="h-6 ml-0.5">
-            <Separator orientation="vertical" />
-          </div>
-          <Button type="text" onClick={() => onSelectAllRows()}>
-            Select all rows in table
-          </Button>
-        </>
-      )}
-    </div>
+        {!snap.allRowsSelected && totalRows > allRows.length && (
+          <>
+            <div className="h-6 ml-0.5">
+              <Separator orientation="vertical" />
+            </div>
+            <Button type="text" onClick={() => onSelectAllRows()}>
+              Select all rows in table
+            </Button>
+          </>
+        )}
+      </div>
+
+      <ExportDialog format={showExportModal} onOpenChange={() => setShowExportModal(undefined)} />
+    </>
   )
 }

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -31,9 +31,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Separator,
   SonnerProgress,
@@ -234,7 +231,7 @@ const RowHeader = () => {
   const { sorts } = useTableSort()
 
   const [isExporting, setIsExporting] = useState(false)
-  const [showExportModal, setShowExportModal] = useState<'csv' | 'sql'>()
+  const [showExportModal, setShowExportModal] = useState(false)
 
   const { data } = useTableRowsQuery({
     projectRef: project?.ref,
@@ -484,25 +481,17 @@ const RowHeader = () => {
               Export
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-60">
+          <DropdownMenuContent className={snap.allRowsSelected ? 'w-52' : 'w-40'}>
             <DropdownMenuItem onClick={onRowsExportCSV}>Export as CSV</DropdownMenuItem>
             <DropdownMenuItem onClick={onRowsExportSQL}>Export as SQL</DropdownMenuItem>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger className="group">
+            {snap.allRowsSelected && (
+              <DropdownMenuItem className="group" onClick={() => setShowExportModal(true)}>
                 <div>
-                  <p className="group-hover:text-foreground">Export via psql</p>
+                  <p className="group-hover:text-foreground">Export via CLI</p>
                   <p className="text-foreground-lighter">Recommended for large tables</p>
                 </div>
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                <DropdownMenuItem onClick={() => setShowExportModal('csv')}>
-                  As CSV
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setShowExportModal('sql')}>
-                  As SQL
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
 
@@ -518,7 +507,7 @@ const RowHeader = () => {
         )}
       </div>
 
-      <ExportDialog format={showExportModal} onOpenChange={() => setShowExportModal(undefined)} />
+      <ExportDialog open={showExportModal} onOpenChange={() => setShowExportModal(false)} />
     </>
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -12,10 +12,7 @@ import {
   isTableLike,
   isView,
 } from 'data/table-editor/table-editor-types'
-import { useGetTables } from 'data/tables/tables-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
-import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { PROTECTED_SCHEMAS } from 'lib/constants/schemas'
 import { useAppStateSnapshot } from 'state/app-state'
@@ -37,12 +34,10 @@ export const TableGridEditor = ({
   selectedTable,
 }: TableGridEditorProps) => {
   const router = useRouter()
-  const project = useSelectedProject()
   const appSnap = useAppStateSnapshot()
   const { ref: projectRef, id } = useParams()
 
   const tabs = useTabsStateSnapshot()
-  const { selectedSchema } = useQuerySchemaState()
 
   useLoadTableEditorStateFromLocalStorageIntoUrl({
     projectRef,
@@ -56,11 +51,6 @@ export const TableGridEditor = ({
   const isReadOnly = !canEditTables && !canEditColumns
   const tabId = !!id ? tabs.openTabs.find((x) => x.endsWith(id)) : undefined
   const openTabs = tabs.openTabs.filter((x) => !x.startsWith('sql'))
-
-  const getTables = useGetTables({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
 
   const onClearDashboardHistory = useCallback(() => {
     if (projectRef) appSnap.setDashboardHistory(projectRef, 'editor', undefined)


### PR DESCRIPTION
## Context
2 problems that this is trying to address
- We've had issues of users trying to figure out the best way to export their table data. While the dashboard does currently provide a way to export as CSV / SQL, its not really the best way as it involves paginating via limit and offset with `pg-meta` and involves several calls to `pg-meta` (we fetch 500 rows per page, so it could involve hundreds of calls if the table has > 100k rows). Not to mention this involves heavy load on the browser as we're storing all the rows in memory before downloading it
- There's been some inconsistencies with exporting all rows via this method as well, most commonly reported issue is with duplicated rows in the results. Likely related to the limit offset logic.

Reckon the best solution here is to export rows via the CLI and using either psql or pg_dump export data from the database directly, so this PR tries to make it easier for users to do so by having the necessary commands easily copyable

## Changes involved
- Add "Export via CLI" dropdown option under Export in Table Editor if _all_ rows are selected
<img width="392" height="200" alt="image" src="https://github.com/user-attachments/assets/83572e09-d3a4-4fc0-9f52-c99e7c4df999" />

- Add instructions for exporting table data to CSV via psql (tested command locally)
<img width="549" height="436" alt="image" src="https://github.com/user-attachments/assets/6cc23b91-9d15-44f6-93ce-424330f948b1" />

- Add instructions for exporting table data to SQL via pg_dump (tested command locally)
<img width="532" height="551" alt="image" src="https://github.com/user-attachments/assets/4d88bf55-889a-40d7-9747-c3686b3cabc5" />

## To test
- [ ] Verify the UX, if it makes sense from a user's POV
- [ ] Test that the command to export to CSV works
- [ ] Test that the command to export to SQL works