### PR TITLE
docs: credit top ups pay outstanding invoices

### DIFF
--- a/apps/docs/content/guides/platform/credits.mdx
+++ b/apps/docs/content/guides/platform/credits.mdx
@@ -29,6 +29,8 @@ As an example, if you start a Pro Plan subscription on January 1 and downgrade t
 
 You can top up credits at any time, with a maximum of <Price price="999" /> per top-up. These credits do not expire and are non-refundable.
 
+If you have any outstanding invoices, we’ll automatically use your credits to pay them off. Any remaining credits will be applied to future invoices.
+
 You may want to consider this option to avoid issues with recurring payments, gain more control over how often your credit card is charged, and potentially make things easier for your accounting department.
 
 <Admonition type="note">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -227,8 +227,8 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
             <DialogTitle>Top Up Credits</DialogTitle>
             <DialogDescription>
               On successful payment, an invoice will be issued and you'll be granted credits.
-              Credits will be applied to future invoices only and are not refundable. The topped up
-              credits do not expire.
+              Credits will be applied to outstanding and future invoices and are not refundable. The
+              topped up credits do not expire.
             </DialogDescription>
           </DialogHeader>
 


### PR DESCRIPTION
This PR adds docs about how we can now pay outstanding invoices when a credit top-up is made.