### PR TITLE
Gate unified logs to team and above

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 
 import { FeatureFlagContext, LOCAL_STORAGE_KEYS } from 'common'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useFlag, useIsRealtimeSettingsFFEnabled } from 'hooks/ui/useFlag'
 import { EMPTY_OBJ } from 'lib/void'
 import { FEATURE_PREVIEWS } from './FeaturePreview.constants'
@@ -91,8 +92,12 @@ export const useIsInlineEditorEnabled = () => {
 }
 
 export const useUnifiedLogsPreview = () => {
+  const organization = useSelectedOrganization()
   const { flags, onUpdateFlag } = useFeaturePreviewContext()
-  const isEnabled = flags[LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS]
+
+  const isTeamsOrEnterprise = ['team', 'enterprise'].includes(organization?.plan.id ?? '')
+  const isEnabled = isTeamsOrEnterprise && flags[LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS]
+
   const enable = () => onUpdateFlag(LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS, true)
   const disable = () => onUpdateFlag(LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS, false)
   return { isEnabled, enable, disable }

--- a/apps/studio/components/interfaces/App/FeaturePreview/UnifiedLogsPreview.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/UnifiedLogsPreview.tsx
@@ -19,6 +19,9 @@ export const UnifiedLogsPreview = () => {
         Experience our enhanced logs interface with improved filtering, real-time updates, and a
         unified view across all your services. Built for better performance and easier debugging.
       </p>
+      <p className="text-foreground-light text-sm mb-4">
+        This interface will only be available for organizations on the Team plan or above.
+      </p>
       <div className="space-y-2 !mt-4">
         <p className="text-sm">Enabling this preview will:</p>
         <ul className="list-disc pl-6 text-sm text-foreground-light space-y-1">

--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -91,7 +91,7 @@ export function LogsSidebarMenuV2() {
   const { ref } = useParams() as { ref: string }
 
   const warehouseEnabled = useFlag('warehouse')
-  const isUnifiedLogsPreviewAvailable = useFlag('unifiedLogs')
+  const unifiedLogsFlagEnabled = useFlag('unifiedLogs')
   const { selectFeaturePreview } = useFeaturePreviewModal()
   const { enable: enableUnifiedLogs } = useUnifiedLogsPreview()
 
@@ -114,6 +114,11 @@ export function LogsSidebarMenuV2() {
 
   const { plan: orgPlan, isLoading: isOrgPlanLoading } = useCurrentOrgPlan()
   const isFreePlan = !isOrgPlanLoading && orgPlan?.id === 'free'
+
+  const isUnifiedLogsPreviewAvailable =
+    unifiedLogsFlagEnabled &&
+    !isOrgPlanLoading &&
+    ['team', 'enterprise'].includes(orgPlan?.id ?? '')
 
   const { data: savedQueriesRes, isLoading: savedQueriesLoading } = useContentQuery({
     projectRef: ref,


### PR DESCRIPTION
## Changes involved

- Update unified logs feature preview content to state that its only for team and above
- Fix old logs explorer interface for orgs not on team and above
- Hide callout for unified logs interface for orgs not on team and above

## To test
- [ ] Projects in free/pro org cannot see new logs interface even if the logs interface feature preview is enabled
- [ ] Projects in team/enterprise can see new logs interface if logs interface feature preview is enabled
- [ ] Projects in free/pro org cannot see the new logs interface call out