### PR TITLE
fix: restrict log inspection panel tab focus refetch

### DIFF
--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -182,6 +182,7 @@ export const useUnifiedLogInspectionQuery = <TData = UnifiedLogInspectionData>(
     ({ signal }) => getUnifiedLogInspection({ projectRef, logId, type, search }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
+      refetchOnWindowFocus: false,
       ...options,
     }
   )

--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -11,7 +11,10 @@ import { QuerySearchParamsType } from 'components/interfaces/UnifiedLogs/Unified
 import { handleError, post } from 'data/fetchers'
 import { ResponseError } from 'types'
 import { logsKeys } from './keys'
-import { getUnifiedLogsISOStartEnd } from './unified-logs-infinite-query'
+import {
+  getUnifiedLogsISOStartEnd,
+  UNIFIED_LOGS_QUERY_OPTIONS,
+} from './unified-logs-infinite-query'
 
 // Service flow types - subset of LOG_TYPES that support service flows
 export const SERVICE_FLOW_TYPES = [
@@ -182,7 +185,7 @@ export const useUnifiedLogInspectionQuery = <TData = UnifiedLogInspectionData>(
     ({ signal }) => getUnifiedLogInspection({ projectRef, logId, type, search }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      refetchOnWindowFocus: false,
+      ...UNIFIED_LOGS_QUERY_OPTIONS,
       ...options,
     }
   )


### PR DESCRIPTION
- stops inspection panel running an enrichment query on each tab refocus
  - we don't need this as log data doesn't change over time