### PR TITLE
[FE-1722] fix: race condition in permissions hooks

### DIFF
--- a/apps/studio/hooks/misc/useSelectedOrganization.ts
+++ b/apps/studio/hooks/misc/useSelectedOrganization.ts
@@ -2,8 +2,20 @@ import { useIsLoggedIn, useParams } from 'common'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useMemo } from 'react'
 
-import { useProjectByRef } from './useSelectedProject'
+import { useProjectByRef, useProjectByRefQuery } from './useSelectedProject'
 
+/**
+ * @deprecated Use useSelectedOrganizationQuery instead for access to loading states etc
+ *
+ * Example migration:
+ * ```
+ * // Old:
+ * const organization = useSelectedOrganization(ref)
+ *
+ * // New:
+ * const { data: organization } = useSelectedOrganizationQuery(ref)
+ * ```
+ */
 export function useSelectedOrganization({ enabled = true } = {}) {
   const isLoggedIn = useIsLoggedIn()
 
@@ -19,4 +31,22 @@ export function useSelectedOrganization({ enabled = true } = {}) {
       return undefined
     })
   }, [data, selectedProject, slug])
+}
+
+export function useSelectedOrganizationQuery({ enabled = true } = {}) {
+  const isLoggedIn = useIsLoggedIn()
+
+  const { ref, slug } = useParams()
+  const { data: selectedProject } = useProjectByRefQuery(ref)
+
+  return useOrganizationsQuery({
+    enabled: isLoggedIn && enabled,
+    select: (data) => {
+      return data.find((org) => {
+        if (slug !== undefined) return org.slug === slug
+        if (selectedProject !== undefined) return org.id === selectedProject.organization_id
+        return undefined
+      })
+    },
+  })
 }


### PR DESCRIPTION
Fixes this state:
<img width="866" height="150" alt="Screenshot 2025-07-14 at 12 11 12" src="https://github.com/user-attachments/assets/8f477cae-a456-4e31-bc47-0060e7890bd2" />

This is caused by `useGetProjectPermissions` not accounting for all the data being loaded before it runs the permissions check

**Changes:** 

refactors the permission hooks to use new query methods:

- Replaced `useSelectedOrganization` and `useSelectedProject` with their respective query counterparts for improved loading state management
- Added loading and success states for organization and project queries in `useGetProjectPermissions`
- Introduced `useSelectedOrganizationQuery` and `useSelectedProjectQuery` for better data handling and deprecated old methods