### PR TITLE
chore: add katerina to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -64,6 +64,7 @@ Kamil Ogórek
 Kang Ming Tay
 Karan S
 Karlo Ison
+Katerina Skroumpelou
 Kevin Brolly
 Kevin Grüneberg
 Lakshan Perera


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adding myself to `humans.txt` as part of my onboarding! Excited to be here!

## What is the current behavior?

Katerina does not exist in `humans.txt`

## What is the new behavior?

Katerina exists in `humans.txt`
