### PR TITLE
chore(docs): add redirect for functions local-quickstart URL

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1542,6 +1542,11 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/docs/guides/functions/local-quickstart',
+    destination: '/docs/guides/functions/quickstart',
+  },
+  {
+    permanent: true,
     source: '/projects',
     destination: 'https://supabase.com/dashboard/projects',
   },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Redirect `https://supabase.com/docs/guides/functions/local-quickstart` to `https://supabase.com/docs/guides/functions/quickstart`.

(I know it's nitpick, sorry!)

## What is the current behavior?

User clicks Google result for Supabase functions "quickstart" and gets 404 if they click the "Local development" link. This was introduced during some updates on the edge function docs.

## What is the new behavior?

User clicks the "Local development" link from Google and is redirected to the new link correctly.

- Redirects old `local-quickstart` path to current `quickstart` guide
- Fixes 404 error from outdated documentation link
- Maintains backward compatibility for existing bookmarks

## Additional context

Old result is still indexed so users may be directed to 404.

<img width="705" height="476" alt="Screenshot 2025-07-18 at 5 50 35 PM" src="https://github.com/user-attachments/assets/025767b5-182e-438b-aeac-a6e34b4bf645" />

