### PR TITLE
docs: enhance verifyOtp() method description with detailed verification types explanation

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1095,9 +1095,17 @@ functions:
     title: 'verifyOtp()'
     $ref: '@supabase/auth-js.GoTrueClient.verifyOtp'
     notes: |
-      - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `email`, `recovery`, `invite` or `email_change` (`signup` and `magiclink` types are deprecated).
+      - The `verifyOtp` method takes in different verification types.
+      - If a phone number is used, the type can either be:
+        1. `sms` – Used when verifying a one-time password (OTP) sent via SMS during sign-up or sign-in.
+        2. `phone_change` – Used when verifying an OTP sent to a new phone number during a phone number update process.
+      - If an email address is used, the type can be one of the following (note: `signup` and `magiclink` types are deprecated):
+        1. `email` – Used when verifying an OTP sent to the user's email during sign-up or sign-in.
+        2. `recovery` – Used when verifying an OTP sent for account recovery, typically after a password reset request.
+        3. `invite` – Used when verifying an OTP sent as part of an invitation to join a project or organization.
+        4. `email_change` – Used when verifying an OTP sent to a new email address during an email update process.
       - The verification type used should be determined based on the corresponding auth method called before `verifyOtp` to sign up / sign-in a user.
-      - The `TokenHash` is contained in the [email templates](/docs/guides/auth/auth-email-templates) and can be used to sign in. You may wish to use the hash with Magic Links for the PKCE flow for Server Side Auth. See [this guide](/docs/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr) for more details.
+      - The `TokenHash` is contained in the email templates and can be used to sign in. You may wish to use the hash with Magic Links for the PKCE flow for Server Side Auth. See this guide for more details.
     examples:
       - id: verify-signup-one-time-password(otp)
         name: Verify Signup One-Time Password (OTP)
@@ -1653,7 +1661,7 @@ functions:
       - Resends a signup confirmation, email change or phone change email to the user.
       - Passwordless sign-ins can be resent by calling the `signInWithOtp()` method again.
       - Password recovery emails can be resent by calling the `resetPasswordForEmail()` method again.
-      - This method will only resend an email or phone OTP to the user if there was an initial signup, email change or phone change request being made.
+      - This method will only resend an email or phone OTP to the user if there was an initial signup, email change or phone change request being made(note: For existing users signing in with OTP, you should use `signInWithOtp()` again to resend the OTP).
       - You can specify a redirect url when you resend an email link using the `emailRedirectTo` option.
     examples:
       - id: resend-email-signup-confirmation


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

As mentioned in #20007 , There is no proper explanation/difference provided in the docs for auth-verifyotp verification types (sms and email verification types). Additionally, in auth-resend, a clear note stating that the function `resend()` should not be used for sign-in of existing users, but rather should use `signInWithOtp()`. The lack of explanation confuses new supabase users. The below images reference to the issue:

<img width="722" height="638" alt="image" src="https://github.com/user-attachments/assets/2a292880-0c56-4130-968e-b19d3a1061ec" />
<img width="721" height="618" alt="image" src="https://github.com/user-attachments/assets/4fb8e358-6f93-4144-b465-1487bbe4f6cf" />

## What is the new behavior?

Updated the docs to show the clear difference between the different verification types as shown below:

<img width="766" height="795" alt="image" src="https://github.com/user-attachments/assets/12e3ded0-470e-4cbf-ae20-2fb056e208e7" />
<img width="755" height="705" alt="image" src="https://github.com/user-attachments/assets/eec85908-7b3b-4329-9741-f94941ab25e4" />

## Additional context

Note: I have updated the docs for javascript examples of version 2 supabase. The same fix has to be applied to other languages as well. I will be happy to do it, if the current PR is approved. I will subsequently create new PR's for each language. Thank you.
