### PR TITLE
Table editor cast column type to text if filtering with like based filter

### DIFF
--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -1,5 +1,5 @@
-import { ident, literal, format } from '../pg-format'
-import type { Filter, QueryPagination, QueryTable, Sort, Dictionary } from './types'
+import { format, ident, literal } from '../pg-format'
+import type { Dictionary, Filter, QueryPagination, QueryTable, Sort } from './types'
 
 export function countQuery(
   table: QueryTable,
@@ -171,6 +171,11 @@ function applyFilters(query: string, filters: Filter[]) {
           return inFilterSql(filter)
         case 'is':
           return isFilterSql(filter)
+        case '~~':
+        case '~~*':
+        case '!~~':
+        case '!~~*':
+          return castColumnToText(filter)
         default:
           return `${ident(filter.column)} ${filter.operator} ${filterLiteral(filter.value)}`
       }
@@ -201,6 +206,10 @@ function isFilterSql(filter: Filter) {
     default:
       return `${ident(filter.column)} ${filter.operator} ${filterLiteral(filter.value)}`
   }
+}
+
+function castColumnToText(filter: Filter) {
+  return `${ident(filter.column)}::text ${filter.operator} ${filterLiteral(filter.value)}`
 }
 
 function filterLiteral(value: any) {

--- a/packages/pg-meta/test/query/advanced-query.test.ts
+++ b/packages/pg-meta/test/query/advanced-query.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, describe, afterAll } from 'vitest'
+import { afterAll, describe, expect, test } from 'vitest'
 import { Query } from '../../src/query/Query'
-import { createTestDatabase, cleanupRoot } from '../db/utils'
+import { cleanupRoot, createTestDatabase } from '../db/utils'
 
 type TestDb = Awaited<ReturnType<typeof createTestDatabase>>
 
@@ -343,7 +343,7 @@ describe('Advanced Query Tests', () => {
           .toSql()
 
         expect(sql).toMatchInlineSnapshot(
-          `"select id, name from public.normal_table where id > 10 and name ~~ '%John%' order by normal_table.name asc nulls last limit 10 offset 0;"`
+          `"select id, name from public.normal_table where id > 10 and name::text ~~ '%John%' order by normal_table.name asc nulls last limit 10 offset 0;"`
         )
 
         const result = await validateSql(db, sql)
@@ -444,7 +444,7 @@ describe('Advanced Query Tests', () => {
         .toSql()
 
       expect(sql).toMatchInlineSnapshot(
-        '"select count(*) from public.normal_table where name ~~ \'%John%\';"'
+        '"select count(*) from public.normal_table where name::text ~~ \'%John%\';"'
       )
 
       const result = await validateSql(db, sql)

--- a/packages/pg-meta/test/query/query.test.ts
+++ b/packages/pg-meta/test/query/query.test.ts
@@ -1,10 +1,10 @@
-import { expect, test, describe } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { Query } from '../../src/query/Query'
+import * as QueryUtils from '../../src/query/Query.utils'
 import { QueryAction } from '../../src/query/QueryAction'
 import { QueryFilter } from '../../src/query/QueryFilter'
 import { QueryModifier } from '../../src/query/QueryModifier'
-import * as QueryUtils from '../../src/query/Query.utils'
-import type { QueryTable, Filter, Sort } from '../../src/query/types'
+import type { Filter, QueryTable, Sort } from '../../src/query/types'
 
 describe('Query', () => {
   test('from() should create a QueryAction with the correct table', () => {
@@ -515,7 +515,9 @@ describe('End-to-end query chaining', () => {
       .filter('name', '~~', '%John%')
       .toSql()
 
-    expect(sql).toBe("select id, name, email from public.users where id > 10 and name ~~ '%John%';")
+    expect(sql).toBe(
+      "select id, name, email from public.users where id > 10 and name::text ~~ '%John%';"
+    )
   })
 
   test('should correctly build a select query with match criteria', () => {

--- a/packages/pg-meta/test/query/table-row-query.test.ts
+++ b/packages/pg-meta/test/query/table-row-query.test.ts
@@ -1,8 +1,8 @@
-import { expect, test, describe, afterAll, beforeAll } from 'vitest'
-import { createTestDatabase, cleanupRoot } from '../db/utils'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import pgMeta from '../../src/index'
+import { Filter, Sort } from '../../src/query'
 import { getDefaultOrderByColumns, getTableRowsSql } from '../../src/query/table-row-query'
-import { Sort, Filter } from '../../src/query'
+import { cleanupRoot, createTestDatabase } from '../db/utils'
 
 beforeAll(async () => {
   // Any global setup if needed
@@ -1098,7 +1098,7 @@ describe('Table Row Query', () => {
       // Verify SQL generation with snapshot
       expect(sql).toMatchInlineSnapshot(
         `
-        "with _base_query as (select * from public.test_sql_filter where name ~~ 'Test%' and category = 'A' order by test_sql_filter.id asc nulls last limit 10 offset 0)
+        "with _base_query as (select * from public.test_sql_filter where name::text ~~ 'Test%' and category = 'A' order by test_sql_filter.id asc nulls last limit 10 offset 0)
           select id,case
                 when octet_length(name::text) > 10240 
                 then left(name::text, 10240) || '...'


### PR DESCRIPTION
## Context

Currently if you try to filter via `LIKE` on a column that's not a string type (e.g UUID), you get this Postgres error:
<img width="651" height="150" alt="image" src="https://github.com/user-attachments/assets/fc1bcb37-230a-4f89-8c21-2041da309112" />

While it's technically correct, we could make this UX a little better by type casting the column to text whenever filtering using a LIKE, or ILIKE filter

## Changes involved
- Cast column to text when filtering on LIKE or ILIKE filter in table editor

## To test
- [ ] Can filter by LIKE or ILIKE on a UUID column (or any non text column)