### PR TITLE
Refactor custom domain verification

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
@@ -33,7 +33,7 @@ const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainActivate
   const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation({
     onSuccess: () => {
       toast.success(
-        'Cancelled setting up custom domain. It may take a few seconds before your custom domain is fully removed, hence you may need to refresh your browser.'
+        'Custom domain setup cancelled successfully. It may take a few seconds before your custom domain is fully removed, so you may need to refresh your browser.'
       )
     },
   })

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
@@ -30,7 +30,13 @@ const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainActivate
       },
     }
   )
-  const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation()
+  const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation({
+    onSuccess: () => {
+      toast.success(
+        'Cancelled setting up custom domain. It may take a few seconds before your custom domain is fully removed, hence you may need to refresh your browser.'
+      )
+    },
+  })
 
   const endpoint = settings?.app_config?.endpoint
 

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -27,10 +27,10 @@ const CustomDomainConfig = () => {
   const hasCustomDomainAddon = !!addons?.selected_addons.find((x) => x.type === 'custom_domain')
 
   const {
+    data: customDomainData,
     isLoading: isCustomDomainsLoading,
     isError,
     isSuccess,
-    data,
   } = useCustomDomainsQuery(
     { projectRef: ref },
     {
@@ -44,6 +44,8 @@ const CustomDomainConfig = () => {
       },
     }
   )
+
+  const { status, customDomain } = customDomainData || {}
 
   return (
     <section id="custom-domains">
@@ -94,24 +96,25 @@ const CustomDomainConfig = () => {
             </div>
           </Panel.Content>
         </Panel>
-      ) : data?.status === '0_no_hostname_configured' ? (
+      ) : status === '0_no_hostname_configured' ? (
         <CustomDomainsConfigureHostname />
       ) : (
         <Panel>
           {isSuccess && (
             <div className="flex flex-col">
-              {(data.status === '1_not_started' ||
-                data.status === '2_initiated' ||
-                data.status === '3_challenge_verified') && (
-                <CustomDomainVerify customDomain={data.customDomain} />
+              {(status === '1_not_started' ||
+                status === '2_initiated' ||
+                status === '3_challenge_verified') && <CustomDomainVerify />}
+
+              {customDomainData.status === '4_origin_setup_completed' && (
+                <CustomDomainActivate
+                  projectRef={ref}
+                  customDomain={customDomainData.customDomain}
+                />
               )}
 
-              {data.status === '4_origin_setup_completed' && (
-                <CustomDomainActivate projectRef={ref} customDomain={data.customDomain} />
-              )}
-
-              {data.status === '5_services_reconfigured' && (
-                <CustomDomainDelete projectRef={ref} customDomain={data.customDomain} />
+              {customDomainData.status === '5_services_reconfigured' && (
+                <CustomDomainDelete projectRef={ref} customDomain={customDomainData.customDomain} />
               )}
             </div>
           )}

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainDelete.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainDelete.tsx
@@ -18,7 +18,9 @@ const CustomDomainDelete = ({ projectRef, customDomain }: CustomDomainDeleteProp
   const [isDeleteConfirmModalVisible, setIsDeleteConfirmModalVisible] = useState(false)
   const { mutate: deleteCustomDomain } = useCustomDomainDeleteMutation({
     onSuccess: () => {
-      toast.success(`Successfully deleted custom domain`)
+      toast.success(
+        `Successfully deleted custom domain. It may take a few seconds before your custom domain is fully removed, hence you may need to refresh your browser.`
+      )
       setIsDeleteConfirmModalVisible(false)
     },
   })

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -7,7 +7,7 @@ import { DocsButton } from 'components/ui/DocsButton'
 import Panel from 'components/ui/Panel'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainDeleteMutation } from 'data/custom-domains/custom-domains-delete-mutation'
-import type { CustomDomainResponse } from 'data/custom-domains/custom-domains-query'
+import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useCustomDomainReverifyMutation } from 'data/custom-domains/custom-domains-reverify-mutation'
 import { useInterval } from 'hooks/misc/useInterval'
 import {
@@ -20,15 +20,16 @@ import {
 import DNSRecord from './DNSRecord'
 import { DNSTableHeaders } from './DNSTableHeaders'
 
-export type CustomDomainVerifyProps = {
-  customDomain: CustomDomainResponse
-}
-
-const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
+const CustomDomainVerify = () => {
   const { ref: projectRef } = useParams()
   const [isNotVerifiedYet, setIsNotVerifiedYet] = useState(false)
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
+
+  const { data: customDomainData } = useCustomDomainsQuery({ projectRef })
+  const customDomain = customDomainData?.customDomain
+  const isSSLCertificateDeploying =
+    customDomain?.ssl.status !== undefined && customDomain.ssl.txt_name === undefined
 
   const { mutate: reverifyCustomDomain, isLoading: isReverifyLoading } =
     useCustomDomainReverifyMutation({
@@ -39,11 +40,11 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
 
   const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation()
 
-  const hasCAAErrors = customDomain.ssl.validation_errors?.reduce(
+  const hasCAAErrors = customDomain?.ssl.validation_errors?.reduce(
     (acc, error) => acc || error.message.includes('caa_error'),
     false
   )
-  const isValidating = (customDomain.ssl.txt_name ?? '') === ''
+  const isValidating = (customDomain?.ssl.txt_name ?? '') === ''
 
   const onReverifyCustomDomain = () => {
     if (!projectRef) return console.error('Project ref is required')
@@ -53,7 +54,7 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
   useInterval(
     onReverifyCustomDomain,
     // Poll every 5 seconds if the SSL certificate is being deployed
-    customDomain.ssl.status !== undefined && customDomain.ssl.txt_name === undefined ? 5000 : false
+    isSSLCertificateDeploying && !isDeleting ? 5000 : false
   )
 
   const onCancelCustomDomain = async () => {
@@ -67,7 +68,7 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
         <div>
           <h4 className="text-foreground mb-2">
             Configure TXT verification for your custom domain{' '}
-            <code className="text-sm">{customDomain.hostname}</code>
+            <code className="text-sm">{customDomain?.hostname}</code>
           </h4>
           <p className="text-sm text-foreground-light">
             Set the following TXT record(s) in your DNS provider, then click verify to confirm your
@@ -102,7 +103,7 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
                       <Link
                         target="_blank"
                         rel="noreferrer"
-                        href={`https://whatsmydns.net/#TXT/${customDomain.hostname}`}
+                        href={`https://whatsmydns.net/#TXT/${customDomain?.hostname}`}
                         className="text-brand"
                       >
                         here
@@ -131,13 +132,13 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
             </AlertTitle_Shadcn_>
             <AlertDescription_Shadcn_>
               Please add a CAA record allowing "digicert.com" to issue certificates for{' '}
-              <code className="text-xs">{customDomain.hostname}</code>. For example:{' '}
+              <code className="text-xs">{customDomain?.hostname}</code>. For example:{' '}
               <code className="text-xs">0 issue "digicert.com"</code>
             </AlertDescription_Shadcn_>
           </Alert_Shadcn_>
         )}
 
-        {customDomain.ssl.status === 'validation_timed_out' ? (
+        {customDomain?.ssl.status === 'validation_timed_out' ? (
           <Alert_Shadcn_>
             <WarningIcon />
             <AlertTitle_Shadcn_>Validation timed out</AlertTitle_Shadcn_>
@@ -147,27 +148,27 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
           </Alert_Shadcn_>
         ) : (
           <div className="space-y-2">
-            <DNSTableHeaders display={customDomain.ssl.txt_name ?? ''} />
+            <DNSTableHeaders display={customDomain?.ssl.txt_name ?? ''} />
 
-            {customDomain.verification_errors?.includes(
+            {customDomain?.verification_errors?.includes(
               'custom hostname does not CNAME to this zone.'
             ) && (
               <DNSRecord
                 type="CNAME"
-                name={customDomain.hostname}
+                name={customDomain?.hostname}
                 value={settings?.app_config?.endpoint ?? 'Loading...'}
               />
             )}
 
-            {!isValidating && customDomain.ssl.status === 'pending_validation' && (
+            {!isValidating && customDomain?.ssl.status === 'pending_validation' && (
               <DNSRecord
                 type="TXT"
-                name={customDomain.ssl.txt_name ?? 'Loading...'}
-                value={customDomain.ssl.txt_value ?? 'Loading...'}
+                name={customDomain?.ssl.txt_name ?? 'Loading...'}
+                value={customDomain?.ssl.txt_value ?? 'Loading...'}
               />
             )}
 
-            {customDomain.ssl.status === 'pending_deployment' && (
+            {customDomain?.ssl.status === 'pending_deployment' && (
               <div className="flex items-center justify-center space-x-2 py-8">
                 <AlertCircle size={16} strokeWidth={1.5} />
                 <p className="text-sm text-foreground-light">

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, HelpCircle, RefreshCw } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
+import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import { DocsButton } from 'components/ui/DocsButton'
@@ -38,7 +39,13 @@ const CustomDomainVerify = () => {
       },
     })
 
-  const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation()
+  const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation({
+    onSuccess: () => {
+      toast.success(
+        'Cancelled setting up custom domain. It may take a few seconds before your custom domain is fully removed, hence you may need to refresh your browser.'
+      )
+    },
+  })
 
   const hasCAAErrors = customDomain?.ssl.validation_errors?.reduce(
     (acc, error) => acc || error.message.includes('caa_error'),

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -42,7 +42,7 @@ const CustomDomainVerify = () => {
   const { mutate: deleteCustomDomain, isLoading: isDeleting } = useCustomDomainDeleteMutation({
     onSuccess: () => {
       toast.success(
-        'Cancelled setting up custom domain. It may take a few seconds before your custom domain is fully removed, hence you may need to refresh your browser.'
+        'Custom domain setup cancelled successfully. It may take a few seconds before your custom domain is fully removed, so you may need to refresh your browser.'
       )
     },
   })

--- a/apps/studio/hooks/misc/useInterval.ts
+++ b/apps/studio/hooks/misc/useInterval.ts
@@ -20,4 +20,6 @@ export function useInterval(callback: () => void, delay: number | false) {
       clearInterval(id)
     }
   }, [delay])
+
+  return {}
 }

--- a/apps/studio/hooks/misc/useInterval.ts
+++ b/apps/studio/hooks/misc/useInterval.ts
@@ -20,6 +20,4 @@ export function useInterval(callback: () => void, delay: number | false) {
       clearInterval(id)
     }
   }, [delay])
-
-  return {}
 }


### PR DESCRIPTION
## Context

We've seen a couple of tickets whereby users hit "Cancel" on the 2nd step of setting up custom domains seems to trigger an odd unrelated error as such:
<img width="251" height="81" alt="image" src="https://github.com/user-attachments/assets/0f88a3ab-0655-4f7b-b48c-3f6e19214dfc" />

2 observations here:
- There's a `useInterval` in `CustomDomainVerify.tsx` [here](https://github.com/supabase/supabase/blob/dbb413beebcb07532d5d0ebbf4fbd837652293b4/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx#L53), in which the polling doesn't get cancelled if the user has clicked to delete the custom domain. Hence there's a chance that the /reverify request subsequently errors out, leading to a seemingly random error message
- Deleting a custom domain, based on the API implementation, is an async process that depends on a queue. As such the custom domain of a project may not be immediately updated upon clicking delete.

## Changes involved
- [ ] Set the delay for the `useInterval` in `CustomDomainVerify.tsx` to be false if user is deleting custom domain
- [ ] Add + Update toast messages for deleting custom domain that it may take a few seconds before changes are reflected
- [ ] Also small refactor to `CustomDomainVerify` to just use the custom domain RQ, instead depending on a prop from parent

## To test
- [ ] Test that you can configure a custom domain from start to end