### PR TITLE
Update row-level-security.mdx | correct example

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -104,7 +104,7 @@ Let's say you have a table called `profiles` in the public schema and you want t
 -- 1. Create table
 create table profiles (
   id uuid primary key,
-  user_id references auth.users,
+  user_id uuid references auth.users,
   avatar_url text
 );
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Example uses incorrect SQL:

```sql
create table profiles (
  id uuid primary key,
  user_id references auth.users, --<-----missing a data type
  avatar_url text
);
```

## What is the new behavior?

updated sql

```sql
create table profiles (
  id uuid primary key,
  user_id uuid references auth.users, --<-----added data type
  avatar_url text
);
```