### PR TITLE
Update Auth hooks docs reference link

### DIFF
--- a/apps/studio/pages/project/[ref]/auth/hooks.tsx
+++ b/apps/studio/pages/project/[ref]/auth/hooks.tsx
@@ -25,7 +25,7 @@ const Hooks: NextPageWithLayout = () => {
   )
 }
 const secondaryActions = [
-  <DocsButton key="docs" href="https://supabase.com/docs/guides/functions" />,
+  <DocsButton key="docs" href="https://supabase.com/docs/guides/auth/auth-hooks" />,
 ]
 
 Hooks.getLayout = (page) => (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

"Docs" button redirects user to https://supabase.com/docs/guides/functions

<img width="1104" height="481" alt="Screenshot 2025-07-21 at 6 09 50 pm" src="https://github.com/user-attachments/assets/5715db03-8bc0-4ada-8d30-78a36960ba20" />

## What is the new behavior?

"Docs" button redirects user to https://supabase.com/docs/guides/auth/auth-hooks

## Additional context

Rather than sending users to an unrelated Edge Functions section, direct them to the Auth Hooks guide: https://supabase.com/docs/guides/auth/auth-hooks.
