### PR TITLE
fix: Make the database.new redirect work

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -15,17 +15,19 @@ export const OrgNotFound = ({ slug }: { slug?: string }) => {
 
   return (
     <>
-      <Admonition type="danger">
-        The selected organization does not exist or you don't have permission to access it.{' '}
-        {slug ? (
-          <>
-            Contact the owner or administrator to create a new project in the <code>{slug}</code>{' '}
-            organization.
-          </>
-        ) : (
-          <>Contact the owner or administrator to create a new project.</>
-        )}
-      </Admonition>
+      {slug !== '_' && (
+        <Admonition type="danger">
+          The selected organization does not exist or you don't have permission to access it.{' '}
+          {slug ? (
+            <>
+              Contact the owner or administrator to create a new project in the <code>{slug}</code>{' '}
+              organization.
+            </>
+          ) : (
+            <>Contact the owner or administrator to create a new project.</>
+          )}
+        </Admonition>
+      )}
 
       <h3 className="text-sm">Select an organization to create your new project from</h3>
 

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -148,7 +148,11 @@ const Wizard: NextPageWithLayout = () => {
 
   // This is to make the database.new redirect work correctly. The database.new redirect should be set to supabase.com/dashboard/new/last-visited-org
   if (slug === 'last-visited-org') {
-    router.replace(`/new/${lastVisitedOrganization}`, undefined, { shallow: true })
+    if (lastVisitedOrganization) {
+      router.replace(`/new/${lastVisitedOrganization}`, undefined, { shallow: true })
+    } else {
+      router.replace(`/new/_`, undefined, { shallow: true })
+    }
   }
 
   const { mutate: sendEvent } = useSendEventMutation()

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -165,7 +165,10 @@ const Wizard: NextPageWithLayout = () => {
     { enabled: isFreePlan }
   )
 
-  const { data: approvedOAuthApps } = useAuthorizedAppsQuery({ slug }, { enabled: !isFreePlan })
+  const { data: approvedOAuthApps } = useAuthorizedAppsQuery(
+    { slug },
+    { enabled: !isFreePlan && slug !== '_' }
+  )
 
   const hasOAuthApps = approvedOAuthApps && approvedOAuthApps.length > 0
 
@@ -632,7 +635,9 @@ const Wizard: NextPageWithLayout = () => {
                     />
                   )}
 
-                  {!isAdmin && !orgNotFound && <NotOrganizationOwnerWarning slug={slug} />}
+                  {isOrganizationsSuccess && !isAdmin && !orgNotFound && (
+                    <NotOrganizationOwnerWarning slug={slug} />
+                  )}
                   {orgNotFound && <OrgNotFound slug={slug} />}
                 </Panel.Content>
 

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -146,6 +146,11 @@ const Wizard: NextPageWithLayout = () => {
     ''
   )
 
+  // This is to make the database.new redirect work correctly. The database.new redirect should be set to supabase.com/dashboard/new/last-visited-org
+  if (slug === 'last-visited-org') {
+    router.replace(`/new/${lastVisitedOrganization}`, undefined, { shallow: true })
+  }
+
   const { mutate: sendEvent } = useSendEventMutation()
 
   const projectCreationDisabled = useFlag('disableProjectCreationAndUpdate')


### PR DESCRIPTION
This PR adds a special case for the `/new/last-visited-org` URL which will redirect the user to create a project in the last visited org.