### PR TITLE
Fix missing x axis labels in reports

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import dayjs from 'dayjs'
+import { formatBytes } from 'lib/helpers'
 import { useTheme } from 'next-themes'
 import { ComponentProps, useEffect, useState } from 'react'
 import {
   Area,
   Bar,
   CartesianGrid,
+  Label,
   Line,
   ComposedChart as RechartComposedChart,
   ReferenceArea,
@@ -14,7 +16,6 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-  Label,
 } from 'recharts'
 import { CategoricalChartState } from 'recharts/types/chart/types'
 import { cn } from 'ui'
@@ -28,11 +29,14 @@ import {
 } from './Charts.constants'
 import { CommonChartProps, Datum } from './Charts.types'
 import { numberFormatter, useChartSize } from './Charts.utils'
-import { calculateTotalChartAggregate, CustomLabel, CustomTooltip } from './ComposedChart.utils'
+import {
+  calculateTotalChartAggregate,
+  CustomLabel,
+  CustomTooltip,
+  MultiAttribute,
+} from './ComposedChart.utils'
 import NoDataPlaceholder from './NoDataPlaceholder'
-import { MultiAttribute } from './ComposedChart.utils'
 import { ChartHighlight } from './useChartHighlight'
-import { formatBytes } from 'lib/helpers'
 
 export interface ComposedChartProps<D = Datum> extends CommonChartProps<D> {
   attributes: MultiAttribute[]

--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -200,9 +200,10 @@ const ComposedChartHandler = ({
           point[attr] = value
         })
 
-        const formattedDataPoint: DataPoint = !('period_start' in point)
-          ? { ...point, period_start: dayjs.utc(point.timestamp).unix() * 1000 }
-          : point
+        const formattedDataPoint: DataPoint =
+          !('period_start' in point) && 'timestamp' in point
+            ? { ...point, period_start: dayjs.utc(point.timestamp).unix() * 1000 }
+            : point
 
         return formattedDataPoint
       })

--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -1,21 +1,22 @@
-import React, { PropsWithChildren, useState, useMemo, useEffect, useRef } from 'react'
-import { useRouter } from 'next/router'
 import { Loader2 } from 'lucide-react'
+import { useRouter } from 'next/router'
+import React, { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react'
 import { cn, WarningIcon } from 'ui'
 
 import Panel from 'components/ui/Panel'
 import ComposedChart from './ComposedChart'
 
 import { AnalyticsInterval, DataPoint } from 'data/analytics/constants'
-import { InfraMonitoringAttribute } from 'data/analytics/infra-monitoring-query'
 import { useInfraMonitoringQueries } from 'data/analytics/infra-monitoring-queries'
-import { ProjectDailyStatsAttribute } from 'data/analytics/project-daily-stats-query'
+import { InfraMonitoringAttribute } from 'data/analytics/infra-monitoring-query'
 import { useProjectDailyStatsQueries } from 'data/analytics/project-daily-stats-queries'
+import { ProjectDailyStatsAttribute } from 'data/analytics/project-daily-stats-query'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { useChartHighlight } from './useChartHighlight'
 
-import type { ChartData } from './Charts.types'
+import dayjs from 'dayjs'
 import type { UpdateDateRange } from 'pages/project/[ref]/reports/database'
+import type { ChartData } from './Charts.types'
 import { MultiAttribute } from './ComposedChart.utils'
 
 export interface ComposedChartHandlerProps {
@@ -199,7 +200,11 @@ const ComposedChartHandler = ({
           point[attr] = value
         })
 
-        return point as DataPoint
+        const formattedDataPoint: DataPoint = !('period_start' in point)
+          ? { ...point, period_start: dayjs.utc(point.timestamp).unix() * 1000 }
+          : point
+
+        return formattedDataPoint
       })
 
     return combined as DataPoint[]
@@ -275,6 +280,7 @@ const ComposedChartHandler = ({
           attributes={attributes}
           data={combinedData as DataPoint[]}
           format={format}
+          // [Joshen] This is where it's messing up
           xAxisKey="period_start"
           yAxisKey={attributes[0].attribute}
           highlightedValue={_highlightedValue}


### PR DESCRIPTION
## Context

X axis labels in our reports (e.g database reports) are missing timestamps:
<img width="1057" height="279" alt="image" src="https://github.com/user-attachments/assets/e71966a7-a54e-405e-a4e4-ab5742dd42cb" />

Realised that the `ComposedChartHandler` is sending `xAxisKey` as `period_start` ([ref](https://github.com/supabase/supabase/blob/master/apps/studio/components/ui/Charts/ComposedChartHandler.tsx#L278)), but the data being returned doesn't have that property:
<img width="390" height="112" alt="image" src="https://github.com/user-attachments/assets/f0f3904a-0107-4afb-9ad9-aa0c3cbded33" />

## Changes involved:
- Updated `combinedData` in `ComposedChartHandler` to include a `period_start` property if it doesn't exist, which is just converting `timestamp` to unix
  - Since this is a reusable component, I didn't want to just change the `xAxisKey` directly in case it causes a break somewhere else

<img width="1056" height="296" alt="image" src="https://github.com/user-attachments/assets/cd27b409-cdb2-4d5e-8ad1-2852eaab85ac" />

