### PR TITLE
Add guard in storage explorer to not render store if api key is undefined

### DIFF
--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -1,11 +1,14 @@
 import { Transition } from '@headlessui/react'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { get, noop, sum } from 'lodash'
 import { Upload } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useContextMenu } from 'react-contexify'
+import { toast } from 'sonner'
 
 import InfiniteList from 'components/ui/InfiniteList'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { BASE_PATH } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
@@ -82,6 +85,7 @@ const FileExplorerColumn = ({
   const fileExplorerColumnRef = useRef<any>(null)
 
   const snap = useStorageExplorerStateSnapshot()
+  const canUpdateStorage = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   useEffect(() => {
     if (fileExplorerColumnRef) {
@@ -126,7 +130,12 @@ const FileExplorerColumn = ({
 
   const onDrop = (event: any) => {
     onDragOver(event)
-    onFilesUpload(event, index)
+
+    if (!canUpdateStorage) {
+      toast('You need additional permissions to upload files to this project')
+    } else {
+      onFilesUpload(event, index)
+    }
   }
 
   const SelectAllCheckbox = () => (

--- a/apps/studio/pages/project/[ref]/storage/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/buckets/[bucketId].tsx
@@ -16,6 +16,7 @@ const PageLayout: NextPageWithLayout = () => {
   const { projectRef } = useStorageExplorerStateSnapshot()
   const { bucket, error, isSuccess, isError } = useSelectedBucket()
 
+  // [Joshen] Checking against projectRef from storage explorer to check if the store has initialized
   if (!project || !projectRef) return null
 
   return (

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1758,14 +1758,11 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
     const isDifferentProject = snap.projectRef !== project?.ref
     const isDifferentResumableUploadUrl = snap.resumableUploadUrl !== resumableUploadUrl
 
-    if (
-      !isPaused &&
-      hasDataReady &&
-      (isDifferentProject || isDifferentResumableUploadUrl) &&
-      serviceKey?.api_key
-    ) {
+    const serviceApiKey = serviceKey?.api_key ?? 'unknown'
+
+    if (!isPaused && hasDataReady && (isDifferentProject || isDifferentResumableUploadUrl)) {
       const clientEndpoint = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}`
-      const supabaseClient = createClient(clientEndpoint, serviceKey.api_key, {
+      const supabaseClient = createClient(clientEndpoint, serviceApiKey, {
         auth: {
           persistSession: false,
           autoRefreshToken: false,
@@ -1785,7 +1782,7 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
           projectRef: project?.ref ?? '',
           supabaseClient,
           resumableUploadUrl,
-          serviceKey: serviceKey.api_key,
+          serviceKey: serviceApiKey,
         })
       )
     }

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1762,7 +1762,7 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
       !isPaused &&
       hasDataReady &&
       (isDifferentProject || isDifferentResumableUploadUrl) &&
-      serviceKey
+      serviceKey?.api_key
     ) {
       const clientEndpoint = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}`
       const supabaseClient = createClient(clientEndpoint, serviceKey.api_key, {
@@ -1789,7 +1789,7 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
         })
       )
     }
-  }, [project?.ref, stateRef, serviceKey, isPaused, protocol, endpoint])
+  }, [project?.ref, stateRef, serviceKey?.api_key, isPaused, protocol, endpoint])
 
   return (
     <StorageExplorerStateContext.Provider value={state}>


### PR DESCRIPTION
As per PR title - we've received a couple of tickets about `supabaseKey is required` which implies that a declaration of `createClient` somewhere is causing this. Narrowed down to `storage-explorer.tsx` since this file is rendered at the app level.

I think what's happening is that the user doesn't have the necessary perms based on the role in the org, so unable to retrieve any keys, hence why resulting in this error as the api_key will be undefined

[edit]

Also addresses a separate issue whereby users who do not have the necessary perms will not see the storage explorer rendered at all when opening a bucket (e.g read only user)
- updated to init the storage explorer store irregardless of the service api key (by falling back to a default value)
  - this will render the storage explorer UI properly for read only users to view
  - most of the storage explorer functionality is using the mgmt API endpoint, only upload uses the client library
  - we already have the necessary perm checks to prevent uploading of files so it wouldnt matter if the supabase client here is initialized with an incorrect key