### PR TITLE
Fix storage store init when switching projects

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -3,7 +3,7 @@ import { createContext, PropsWithChildren, useContext, useEffect, useState } fro
 import { useLatest } from 'react-use'
 import { toast } from 'sonner'
 import * as tus from 'tus-js-client'
-import { proxy, snapshot, useSnapshot } from 'valtio'
+import { proxy, useSnapshot } from 'valtio'
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
@@ -1744,6 +1744,7 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
   const { serviceKey } = getKeys(apiKeys)
   const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
+  const resumableUploadUrl = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}/storage/v1/upload/resumable`
 
   // [Joshen] JFYI opting with the useEffect here as the storage explorer state was being loaded
   // before the project details were ready, hence the store kept returning project ref as undefined
@@ -1751,16 +1752,10 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
   // So the useEffect here is to make sure that the project ref is loaded into the state properly
   // Although I'd be keen to re-investigate this to see if we can remove this
   useEffect(() => {
-    const snap = snapshot(stateRef.current)
     const hasDataReady = !!project?.ref
-    const resumableUploadUrl = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}/storage/v1/upload/resumable`
-
-    const isDifferentProject = snap.projectRef !== project?.ref
-    const isDifferentResumableUploadUrl = snap.resumableUploadUrl !== resumableUploadUrl
-
     const serviceApiKey = serviceKey?.api_key ?? 'unknown'
 
-    if (!isPaused && hasDataReady && (isDifferentProject || isDifferentResumableUploadUrl)) {
+    if (!isPaused && hasDataReady) {
       const clientEndpoint = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}`
       const supabaseClient = createClient(clientEndpoint, serviceApiKey, {
         auth: {
@@ -1786,7 +1781,15 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
         })
       )
     }
-  }, [project?.ref, stateRef, serviceKey?.api_key, isPaused, protocol, endpoint])
+  }, [
+    project?.ref,
+    stateRef,
+    serviceKey?.api_key,
+    isPaused,
+    resumableUploadUrl,
+    protocol,
+    endpoint,
+  ])
 
   return (
     <StorageExplorerStateContext.Provider value={state}>


### PR DESCRIPTION
## Context

Storage explorer store initialization `setState` within the useEffect was not getting called as it didn't seem to enter the `if` block. 

This is happening due to the check for `isDifferentProject` - because the service key comes later after the request for `api-keys` is completed, once its ready the `setState` doesn't trigger as we're technically still on the same project. Issue causes uploads to fail

## Changes involved

- Remove check for `isDifferentProject || isDifferentResumableUploadUrl`
  - We're still checking for changes to `project.ref` in the useEffect dependency array so the storage store will reset when switching projects