### PR TITLE
Fix unified logs stuff on self-hosted

### DIFF
--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -229,19 +229,21 @@ export function LogsSidebarMenuV2() {
 
   return (
     <div className="pb-12 relative">
-      <FeaturePreviewSidebarPanel
-        className="mx-4 mt-4"
-        illustration={<Badge variant="default">Coming soon</Badge>}
-        title="New logs"
-        description="Get early access"
-        actions={
-          <Link href="https://forms.supabase.com/unified-logs-signup" target="_blank">
-            <Button type="default" size="tiny">
-              Early access
-            </Button>
-          </Link>
-        }
-      />
+      {IS_PLATFORM && (
+        <FeaturePreviewSidebarPanel
+          className="mx-4 mt-4"
+          illustration={<Badge variant="default">Coming soon</Badge>}
+          title="New logs"
+          description="Get early access"
+          actions={
+            <Link href="https://forms.supabase.com/unified-logs-signup" target="_blank">
+              <Button type="default" size="tiny">
+                Early access
+              </Button>
+            </Link>
+          }
+        />
+      )}
       {isUnifiedLogsPreviewAvailable && (
         <FeaturePreviewSidebarPanel
           className="mx-4 mt-4"

--- a/apps/studio/pages/project/[ref]/logs/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/index.tsx
@@ -9,6 +9,7 @@ import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import ProjectLayout from 'components/layouts/ProjectLayout/ProjectLayout'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { IS_PLATFORM } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
 
 export const LogPage: NextPageWithLayout = () => {
@@ -33,9 +34,9 @@ export const LogPage: NextPageWithLayout = () => {
   // Handle redirects when unified logs preview flag changes
   useEffect(() => {
     // Only handle redirects if we're currently on a logs page
-    if (!router.asPath.includes('/logs') || !hasLoaded) return
+    if (!router.asPath.includes('/logs') || (IS_PLATFORM && !hasLoaded)) return
 
-    if (isUnifiedLogsEnabled) {
+    if (IS_PLATFORM && isUnifiedLogsEnabled) {
       // If unified logs preview is enabled and we're not already on the main logs page
       if (router.asPath !== `/project/${ref}/logs` && router.asPath.includes('/logs/')) {
         router.push(`/project/${ref}/logs`)


### PR DESCRIPTION
For local/self-hosted
- Hides the early access call out
- Fix redirect when landing on /logs to /logs/explorer