### PR TITLE
Fix: Copy selected text instead of entire cell in table editor

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -218,9 +218,19 @@ export const handleCopyCell = (
   event: CellKeyboardEvent
 ) => {
   if (event.code === 'KeyC' && (event.metaKey || event.ctrlKey)) {
-    const colKey = column.key
-    const cellValue = row[colKey] ?? ''
-    const value = formatClipboardValue(cellValue)
-    copyToClipboard(value)
+    // Check if there's a text selection
+    const selection = window.getSelection()
+    const selectedText = selection?.toString().trim()
+    
+    if (selectedText && selectedText.length > 0) {
+      // Copy only the selected text
+      copyToClipboard(selectedText)
+    } else {
+      // Fall back to copying entire cell value
+      const colKey = column.key
+      const cellValue = row[colKey] ?? ''
+      const value = formatClipboardValue(cellValue)
+      copyToClipboard(value)
+    }
   }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[#37298](https://github.com/supabase/supabase/issues/37298).

## What is the new behavior?

- Modified `handleCopyCell` function to check for text selection
- If text is selected, copies only the selected portion
- Falls back to copying entire cell if no text is selected
- Maintains backward compatibility

## Testing
- ✅ Select part of long text → Ctrl+C → Copies only selected text
- ✅ Click in cell without selection → Ctrl+C → Copies entire cell
- ✅ Works with different data types (JSON, text, numbers)
