### PR TITLE
chore: redirect after reset password

### DIFF
--- a/apps/studio/components/interfaces/SignIn/ForgotPasswordWizard.tsx
+++ b/apps/studio/components/interfaces/SignIn/ForgotPasswordWizard.tsx
@@ -60,10 +60,13 @@ const ConfirmResetCodeForm = ({ email }: { email: string }) => {
       if (user?.factors?.length) {
         await router.push({
           pathname: '/forgot-password-mfa',
-          query: { returnTo: '/reset-password' },
+          query: router.query,
         })
       } else {
-        await router.push('reset-password')
+        await router.push({
+          pathname: '/reset-password',
+          query: router.query,
+        })
       }
     }
   }

--- a/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
@@ -7,7 +7,7 @@ import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
-import { auth } from 'lib/gotrue'
+import { auth, getReturnToPath } from 'lib/gotrue'
 import {
   Button,
   Form_Shadcn_,
@@ -67,7 +67,7 @@ const ResetPasswordForm = () => {
 
       // logout all other sessions after changing password
       await auth.signOut({ scope: 'others' })
-      await router.push('/organizations')
+      await router.push(getReturnToPath('/organizations'))
     } else {
       toast.error(`Failed to save password: ${error.message}`, { id: toastId })
       if (!WHITELIST_ERRORS.some((e) => error.message.includes(e))) {

--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -18,7 +18,11 @@ const signInSchema = object({
   code: string().required('MFA Code is required'),
 })
 
-const SignInMfaForm = () => {
+interface SignInMfaFormProps {
+  context?: 'forgot-password' | 'sign-in'
+}
+
+const SignInMfaForm = ({ context = 'sign-in' }: SignInMfaFormProps) => {
   const router = useRouter()
   const signOut = useSignOut()
   const queryClient = useQueryClient()
@@ -38,7 +42,15 @@ const SignInMfaForm = () => {
   } = useMfaChallengeAndVerifyMutation({
     onSuccess: async () => {
       await queryClient.resetQueries()
-      router.push(getReturnToPath())
+
+      if (context === 'forgot-password') {
+        router.push({
+          pathname: '/reset-password',
+          query: router.query,
+        })
+      } else {
+        router.push(getReturnToPath())
+      }
     },
   })
 

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -73,6 +73,11 @@ export const buildPathWithParams = (pathname: string) => {
 }
 
 export const getReturnToPath = (fallback = DEFAULT_FALLBACK_PATH) => {
+  // If we're in a server environment, return the fallback
+  if (typeof location === 'undefined') {
+    return fallback
+  }
+
   const searchParams = new URLSearchParams(location.search)
 
   let returnTo = searchParams.get('returnTo') ?? fallback

--- a/apps/studio/pages/forgot-password-mfa.tsx
+++ b/apps/studio/pages/forgot-password-mfa.tsx
@@ -86,7 +86,7 @@ const ForgotPasswordMfa: NextPageWithLayout = () => {
       heading="Complete two-factor authentication"
       subheading="Enter the authentication code from your two-factor authentication app before changing your password"
     >
-      <SignInMfaForm />
+      <SignInMfaForm context="forgot-password" />
     </ForgotPasswordLayout>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR adds support for preserving query parameters throughout the Forgot Password flow, including the MFA screen, and enabling a final redirect to the `?returnTo=...` URL once the user resets their password.

## What is the current behavior?

Navigating to `forgot-password` from the `sign-in` page loses context of the URL parameters, including the `returnTo` parameter, causing us to default to navigating to the `organizations` page once the user finishes resetting their password.

## What is the new behavior?
- The `Forgot Password` link in the `sign-in` now includes the encoded `returnTo` parameter, as in: `http://localhost:8082/forgot-password?returnTo=%2Faccount%2Fme%3Fbuyer_id%3Dbyr_123`
- The `ResetPasswordForm` now navigates to the `returnToPath` after the user successfully resets their password, instead of always navigating to `organizations`
- The `SignInMfaForm` component has a new `context: 'forgot-password' | 'sign-in'` prop, enabling us to navigate to `reset-password` in the `forgot-password` context without relying on the `returnTo` parameter to do so, freeing the parameter for the final navigation to the user's original intended URL.
- For users without MFA, the `ForgotPasswordWizard` now navigates to the `reset-password` page, preserving the `returnTo` parameter.
- For users with MFA, the `ForgotPasswordWizard` now redirects to the `forgot-password-mfa` page, preserving the original `returnTo` parameter instead of replacing it with `/reset-password`


## Testing

### Account without MFA
- Open up a private window or log out of your account
- Navigate to `http://localhost:8082/account/me?param1=value1&param2=value`
- Click on the Forgot Password link in the `sign-in` page
- Assert that the `forgot-password` url contains the `returnTo` parameter
- Type in the email of an account without MFA and click on `Send reset code`
- Type the reset code from the email you've received and click on `Confirm reset code`
- Assert that you have navigated to the `reset-password` page and that the URL contains the `returnTo` parameter
- Choose a new password and click on `Save new password`
- Assert that you have been redirected to `http://localhost:8082/account/me?param1=value1&param2=value` (note the intended `account/me` URL and both `param1` and `param2`)

For extra safety, you can repeat the steps above, starting from the `http://localhost:8082/sign-in` page. At the final step you should be redirected to the `organizations` page (the default)

### Account with MFA
- Open up a private window or log out of your account
- Navigate to `http://localhost:8082/account/me?param1=value1&param2=value`
- Click on the Forgot Password link in the `sign-in` page
- Assert that the `forgot-password` URL contains the `returnTo` parameter
- Type in the email of an account without MFA and click on `Send reset code`
- Type the reset code from the email you've received and click on `Confirm reset code`
- Assert that you have navigated to the `forgot-password-mfa` page and that the URL contains the `returnTo` parameter.
- Enter your MFA code and click on `Verify`
- Assert that you have navigated to the `reset-password` page and that the URL contains the `returnTo` parameter
- Choose a new password and click on `Save new password`
- Assert that you have been redirected to `http://localhost:8082/account/me?param1=value1&param2=value` (note the intended `account/me` URL and both `param1` and `param2`)

For extra safety, you can repeat the steps above, starting from the `http://localhost:8082/sign-in` page. At the final step you should be redirected to the `organizations` page (the default)