### PR TITLE
fix: use gotrue_id for member search and partition

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -88,7 +88,7 @@ export const MemberRow = ({ member }: MemberRowProps) => {
           />
           <div className="flex item-center gap-x-2">
             <p className="text-foreground-light truncate">{member.primary_email}</p>
-            {member.primary_email === profile?.primary_email && <Badge color="scale">You</Badge>}
+            {member.gotrue_id === profile?.gotrue_id && <Badge color="scale">You</Badge>}
           </div>
 
           {(member.metadata as any)?.origin && (

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -54,13 +54,13 @@ const MembersView = ({ searchString }: MembersViewProps) => {
 
   const [[user], otherMembers] = partition(
     filteredMembers,
-    (m) => m.primary_email === profile?.primary_email
+    (m) => m.gotrue_id === profile?.gotrue_id
   )
   const sortedMembers = otherMembers.sort((a, b) =>
     (a.primary_email ?? '').localeCompare(b.primary_email ?? '')
   )
 
-  const userMember = members.find((m) => m.primary_email === profile?.primary_email)
+  const userMember = members.find((m) => m.gotrue_id === profile?.gotrue_id)
   const orgScopedRoleIds = (roles?.org_scoped_roles ?? []).map((r) => r.id)
   const isOrgScopedRole = orgScopedRoleIds.includes(userMember?.role_ids?.[0] ?? -1)
 


### PR DESCRIPTION
It is possible to have multiple emails from different providers, a common example being SSO users. The user flow being:

1) Sign up with email using name@company.local
2) Upgrade to teams or enterprise
3) Enable SSO for the Org using domain company.local
4) Sign in with name@company.local
5) The SSO provider now handles the login, assigning new gotrue_id but uses the same primary_email
6) View the teams members and one will be omitted

This change fixes the case above so that both users are displayed. It also uses the gotrue_id to ensure that the "You" badge displays the correct user.
