### PR TITLE
fix: never create a default branch from modal

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -182,6 +182,7 @@ export const CreateBranchModal = () => {
     createBranch({
       projectRef,
       branchName: data.branchName,
+      is_default: false,
       ...(data.gitBranchName ? { gitBranch: data.gitBranchName } : {}),
     })
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

If you have a github connection but disable deploy to production, the first branch created must explicitly set `is_default: false` to avoid creating the default branch.

## Additional context

Add any other context or screenshots.
