### PR TITLE
Shift pipeline status page to its own route

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -1,4 +1,3 @@
-import { noop } from 'lodash'
 import { Plus, Search } from 'lucide-react'
 import { useState } from 'react'
 
@@ -14,11 +13,7 @@ import NewDestinationPanel from './DestinationPanel'
 import { DestinationRow } from './DestinationRow'
 import { PIPELINE_ERROR_MESSAGES } from './Pipeline.utils'
 
-interface DestinationsProps {
-  onSelectPipeline?: (pipelineId: number, destinationName: string) => void
-}
-
-export const Destinations = ({ onSelectPipeline = noop }: DestinationsProps) => {
+export const Destinations = () => {
   const [showNewDestinationPanel, setShowNewDestinationPanel] = useState(false)
   const [filterString, setFilterString] = useState<string>('')
   const { ref: projectRef } = useParams()
@@ -122,7 +117,6 @@ export const Destinations = ({ onSelectPipeline = noop }: DestinationsProps) => 
                   isLoading={isPipelinesLoading}
                   isError={isPipelinesError}
                   isSuccess={isPipelinesSuccess}
-                  onSelectPipeline={onSelectPipeline}
                 />
               )
             })}

--- a/apps/studio/components/interfaces/Database/Replication/Replication.constants.ts
+++ b/apps/studio/components/interfaces/Database/Replication/Replication.constants.ts
@@ -1,0 +1,1 @@
+export const STATUS_REFRESH_FREQUENCY_MS: number = 5000

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -136,7 +136,7 @@ export const ReplicationPipelineStatus = () => {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-x-3">
           <Button asChild type="outline" icon={<ChevronLeft />} style={{ padding: '5px' }}>
-            <a href={`/project/${projectRef}/database/replication`} />
+            <Link href={`/project/${projectRef}/database/replication`} />
           </Button>
           <div>
             <div className="flex items-center gap-x-3">

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -20,23 +20,15 @@ import { Badge, Button, cn, copyToClipboard, Input_Shadcn_ } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
 import { getStatusName, PIPELINE_ERROR_MESSAGES } from './Pipeline.utils'
 import { PipelineStatus } from './PipelineStatus'
+import { STATUS_REFRESH_FREQUENCY_MS } from './Replication.constants'
 import { TableState } from './ReplicationPipelineStatus.types'
 import { getDisabledStateConfig, getStatusConfig } from './ReplicationPipelineStatus.utils'
 
-interface ReplicationPipelineStatusProps {
-  pipelineId: number
-  destinationName?: string
-  onSelectBack: () => void
-}
-
-export const ReplicationPipelineStatus = ({
-  pipelineId,
-  destinationName,
-  onSelectBack,
-}: ReplicationPipelineStatusProps) => {
-  const { ref: projectRef } = useParams()
+export const ReplicationPipelineStatus = () => {
+  const { ref: projectRef, pipelineId: _pipelineId } = useParams()
   const [filterString, setFilterString] = useState<string>('')
 
+  const pipelineId = Number(_pipelineId)
   const { getRequestStatus, updatePipelineStatus, setRequestStatus } = usePipelineRequestStatus()
   const requestStatus = getRequestStatus(pipelineId)
 
@@ -60,7 +52,7 @@ export const ReplicationPipelineStatus = ({
     { projectRef, pipelineId },
     {
       enabled: !!pipelineId,
-      refetchInterval: 2000, // Poll every 2 seconds
+      refetchInterval: STATUS_REFRESH_FREQUENCY_MS,
     }
   )
 
@@ -73,13 +65,14 @@ export const ReplicationPipelineStatus = ({
     { projectRef, pipelineId },
     {
       enabled: !!pipelineId,
-      refetchInterval: 2000, // Poll every 2 seconds
+      refetchInterval: STATUS_REFRESH_FREQUENCY_MS,
     }
   )
 
   const { mutateAsync: startPipeline, isLoading: isStartingPipeline } = useStartPipelineMutation()
   const { mutateAsync: stopPipeline, isLoading: isStoppingPipeline } = useStopPipelineMutation()
 
+  const destinationName = pipeline?.destination_name
   const statusName = getStatusName(pipelineStatusData?.status)
   const config = getDisabledStateConfig({ requestStatus, statusName })
 
@@ -138,36 +131,13 @@ export const ReplicationPipelineStatus = ({
     updatePipelineStatus(pipelineId, statusName)
   }, [pipelineId, statusName, updatePipelineStatus])
 
-  if (isPipelineError) {
-    return (
-      <div className="flex flex-col gap-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-x-3">
-            <Button
-              type="outline"
-              onClick={onSelectBack}
-              icon={<ChevronLeft />}
-              style={{ padding: '5px' }}
-            />
-            <h3 className="text-xl font-semibold">Pipeline Status</h3>
-          </div>
-        </div>
-        <AlertError error={pipelineError} subject={PIPELINE_ERROR_MESSAGES.RETRIEVE_PIPELINE} />
-      </div>
-    )
-  }
-
   return (
     <div className="space-y-4">
-      {/* Header with back button and filters */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-x-3">
-          <Button
-            type="outline"
-            onClick={onSelectBack}
-            icon={<ChevronLeft />}
-            style={{ padding: '5px' }}
-          />
+          <Button asChild type="outline" icon={<ChevronLeft />} style={{ padding: '5px' }}>
+            <a href={`/project/${projectRef}/database/replication`} />
+          </Button>
           <div>
             <div className="flex items-center gap-x-3">
               <h3 className="text-xl font-semibold">{destinationName || 'Pipeline'}</h3>
@@ -192,13 +162,14 @@ export const ReplicationPipelineStatus = ({
               className="pl-7 h-[26px] text-xs"
               placeholder="Search for tables"
               value={filterString}
+              disabled={isPipelineError}
               onChange={(e) => setFilterString(e.target.value)}
             />
           </div>
           <Button
             type={statusName === 'stopped' ? 'primary' : 'default'}
             onClick={() => onTogglePipeline()}
-            loading={isStartingPipeline || isStoppingPipeline}
+            loading={isPipelineError || isStartingPipeline || isStoppingPipeline}
             disabled={!['failed', 'started', 'stopped'].includes(statusName ?? '')}
           >
             {statusName === 'stopped' ? 'Enable' : 'Disable'} pipeline
@@ -207,6 +178,10 @@ export const ReplicationPipelineStatus = ({
       </div>
 
       {(isPipelineLoading || isStatusLoading) && <GenericSkeletonLoader />}
+
+      {isPipelineError && (
+        <AlertError error={pipelineError} subject={PIPELINE_ERROR_MESSAGES.RETRIEVE_PIPELINE} />
+      )}
 
       {isStatusError && (
         <AlertError

--- a/apps/studio/components/interfaces/Database/Replication/RowMenu.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/RowMenu.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
+import { Pipeline } from 'data/replication/pipelines-query'
 import { useStartPipelineMutation } from 'data/replication/start-pipeline-mutation'
 import { useStopPipelineMutation } from 'data/replication/stop-pipeline-mutation'
 import {
@@ -19,7 +20,6 @@ import {
   DropdownMenuTrigger,
 } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
-import { Pipeline } from './DestinationRow'
 import { PIPELINE_ERROR_MESSAGES } from './Pipeline.utils'
 import { PipelineStatusName } from './PipelineStatus'
 
@@ -103,55 +103,26 @@ export const RowMenu = ({
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button
-            type="default"
-            className="px-1.5"
-            icon={<MoreVertical />}
-            onClick={(e) => e.stopPropagation()}
-          />
+          <Button type="default" className="px-1.5" icon={<MoreVertical />} />
         </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="end" className="w-52">
           {pipelineEnabled ? (
-            <DropdownMenuItem
-              className="space-x-2"
-              onClick={(e) => {
-                e.stopPropagation()
-                onDisablePipeline()
-              }}
-            >
+            <DropdownMenuItem className="space-x-2" onClick={onDisablePipeline}>
               <Pause size={14} />
               <p>Disable pipeline</p>
             </DropdownMenuItem>
           ) : (
-            <DropdownMenuItem
-              className="space-x-2"
-              onClick={(e) => {
-                e.stopPropagation()
-                onEnablePipeline()
-              }}
-            >
+            <DropdownMenuItem className="space-x-2" onClick={onEnablePipeline}>
               <Play size={14} />
               <p>Enable pipeline</p>
             </DropdownMenuItem>
           )}
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className="space-x-2"
-            onClick={(e) => {
-              e.stopPropagation()
-              onEditClick()
-            }}
-          >
+          <DropdownMenuItem className="space-x-2" onClick={onEditClick}>
             <Edit size={14} />
             <p>Edit destination</p>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            className="space-x-2"
-            onClick={(e) => {
-              e.stopPropagation()
-              onDeleteClick()
-            }}
-          >
+          <DropdownMenuItem className="space-x-2" onClick={onDeleteClick}>
             <Trash stroke="red" size={14} />
             <p>Delete destination</p>
           </DropdownMenuItem>

--- a/apps/studio/data/replication/pipelines-query.ts
+++ b/apps/studio/data/replication/pipelines-query.ts
@@ -24,6 +24,7 @@ async function fetchReplicationPipelines(
 }
 
 export type ReplicationPipelinesData = Awaited<ReturnType<typeof fetchReplicationPipelines>>
+export type Pipeline = ReplicationPipelinesData['pipelines'][0]
 
 export const useReplicationPipelinesQuery = <TData = ReplicationPipelinesData>(
   { projectRef }: ReplicationPipelinesParams,

--- a/apps/studio/pages/project/[ref]/database/replication/[pipelineId].tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/[pipelineId].tsx
@@ -1,5 +1,8 @@
-import { ReplicationComingSoon } from 'components/interfaces/Database/Replication/ComingSoon'
-import { Destinations } from 'components/interfaces/Database/Replication/Destinations'
+import { useRouter } from 'next/router'
+import { useContext, useEffect } from 'react'
+
+import { FeatureFlagContext, useParams } from 'common'
+import { ReplicationPipelineStatus } from 'components/interfaces/Database/Replication/ReplicationPipelineStatus'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
@@ -9,32 +12,30 @@ import { PipelineRequestStatusProvider } from 'state/replication-pipeline-reques
 import type { NextPageWithLayout } from 'types'
 
 const DatabaseReplicationPage: NextPageWithLayout = () => {
+  const router = useRouter()
+  const { ref } = useParams()
+  const { hasLoaded } = useContext(FeatureFlagContext)
   const enablePgReplicate = useFlag('enablePgReplicate')
+
+  useEffect(() => {
+    if (hasLoaded && !enablePgReplicate) {
+      router.replace(`/project/${ref}/database/replication}`)
+    }
+  }, [router, hasLoaded, ref, enablePgReplicate])
 
   return (
     <>
-      {enablePgReplicate ? (
+      {enablePgReplicate && (
         <PipelineRequestStatusProvider>
           <ScaffoldContainer>
             <ScaffoldSection>
               <div className="col-span-12">
                 <FormHeader title="Replication" />
-                <Destinations />
+                <ReplicationPipelineStatus />
               </div>
             </ScaffoldSection>
           </ScaffoldContainer>
         </PipelineRequestStatusProvider>
-      ) : (
-        <>
-          <ScaffoldContainer>
-            <ScaffoldSection>
-              <div className="col-span-12">
-                <FormHeader title="Replication" description="Send data to other destinations" />
-              </div>
-            </ScaffoldSection>
-          </ScaffoldContainer>
-          <ReplicationComingSoon />
-        </>
       )}
     </>
   )


### PR DESCRIPTION
## Context

This is related to the Database Replication page, previous PR was [here](https://github.com/supabase/supabase/pull/37376) which was to introduce a new pipeline status page from the database replication page. But the navigation between replications to pipeline status page (and vice versa) was all controlled via state.

So this PR changes that to have pipeline status page on its own route

## Changes involved

- Shift pipeline status page to its own route and refactor page navigation UI logic accordingly
- Reverted clicking on row to navigate to pipeline status page - realised this was inconsistent, so following how we do it with database/tables by reinstantiating a button to navigate "View status"
  <img width="1046" height="135" alt="image" src="https://github.com/user-attachments/assets/23fed4f1-64e5-4196-8bd2-6c4198ccb9b5" />
- Updated long poll frequency for replication + pipeline status from 2s to 5s, think 2s is a bit too frequent esp if at scale, mgmt API server might be hammered