### PR TITLE
ci: Change permissions for api docs update CI action

### DIFF
--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
 
 jobs:
   update-docs:


### PR DESCRIPTION
per: https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#token 
broken runs: https://github.com/supabase/supabase/actions/workflows/docs-mgmt-api-update.yml
broken due to this PR change: https://github.com/supabase/supabase/pull/34648