### PR TITLE
feat: add client-side PostHog telemetry tracking

### DIFF
--- a/apps/studio/csp.js
+++ b/apps/studio/csp.js
@@ -26,6 +26,11 @@ const SUPABASE_CONTENT_API_URL = process.env.NEXT_PUBLIC_CONTENT_API_URL
   ? new URL(process.env.NEXT_PUBLIC_CONTENT_API_URL).origin
   : ''
 
+const isDevOrStaging =
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ||
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+
 const SUPABASE_STAGING_PROJECTS_URL = 'https://*.supabase.red'
 const SUPABASE_STAGING_PROJECTS_URL_WS = 'wss://*.supabase.red'
 const SUPABASE_COM_URL = 'https://supabase.com'
@@ -58,6 +63,7 @@ const SUPABASE_ASSETS_URL =
   process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
     ? 'https://frontend-assets.supabase.green'
     : 'https://frontend-assets.supabase.com'
+const POSTHOG_URL = isDevOrStaging ? 'https://ph.supabase.green' : 'https://ph.supabase.com'
 
 const USERCENTRICS_URLS = 'https://*.usercentrics.eu'
 const USERCENTRICS_APP_URL = 'https://app.usercentrics.eu'
@@ -89,6 +95,7 @@ module.exports.getCSP = function getCSP() {
     USERCENTRICS_URLS,
     STAPE_URL,
     GOOGLE_MAPS_API_URL,
+    POSTHOG_URL,
   ]
   const SCRIPT_SRC_URLS = [
     CLOUDFLARE_CDN_URL,
@@ -96,6 +103,7 @@ module.exports.getCSP = function getCSP() {
     STRIPE_JS_URL,
     SUPABASE_ASSETS_URL,
     STAPE_URL,
+    POSTHOG_URL,
   ]
   const FRAME_SRC_URLS = [HCAPTCHA_ASSET_URL, STRIPE_JS_URL, STAPE_URL]
   const IMG_SRC_URLS = [
@@ -110,11 +118,6 @@ module.exports.getCSP = function getCSP() {
   ]
   const STYLE_SRC_URLS = [CLOUDFLARE_CDN_URL, SUPABASE_ASSETS_URL]
   const FONT_SRC_URLS = [CLOUDFLARE_CDN_URL, SUPABASE_ASSETS_URL]
-
-  const isDevOrStaging =
-    process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ||
-    process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
-    process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
 
   const defaultSrcDirective = [
     `default-src 'self'`,

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -37,6 +37,12 @@ export const GOTRUE_ERRORS = {
 export const STRIPE_PUBLIC_KEY =
   process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY || 'pk_test_XVwg5IZH3I9Gti98hZw6KRzd00v5858heG'
 
+export const POSTHOG_URL =
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging' ||
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'local'
+    ? 'https://ph.supabase.green'
+    : 'https://ph.supabase.com'
+
 export const USAGE_APPROACHING_THRESHOLD = 0.75
 
 export const OPT_IN_TAGS = {

--- a/apps/studio/lib/telemetry.tsx
+++ b/apps/studio/lib/telemetry.tsx
@@ -1,7 +1,7 @@
 import { PageTelemetry } from 'common'
-import GroupsTelemetry from 'components/ui/GroupsTelemetry'
 import { API_URL, IS_PLATFORM } from 'lib/constants'
 import { useConsentToast } from 'ui-patterns/consent'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 
 export function Telemetry() {
   // Although this is "technically" breaking the rules of hooks
@@ -9,14 +9,16 @@ export function Telemetry() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { hasAcceptedConsent } = IS_PLATFORM ? useConsentToast() : { hasAcceptedConsent: true }
 
+  // Get org from selected organization query because it's not
+  // always available in the URL params
+  const { data: organization } = useSelectedOrganizationQuery()
+
   return (
-    <>
-      <PageTelemetry
-        API_URL={API_URL}
-        hasAcceptedConsent={hasAcceptedConsent}
-        enabled={IS_PLATFORM}
-      />
-      <GroupsTelemetry hasAcceptedConsent={hasAcceptedConsent} />
-    </>
+    <PageTelemetry
+      API_URL={API_URL}
+      hasAcceptedConsent={hasAcceptedConsent}
+      enabled={IS_PLATFORM}
+      organizationSlug={organization?.slug}
+    />
   )
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,12 +13,13 @@
   "dependencies": {
     "@types/dat.gui": "^0.7.12",
     "@usercentrics/cmp-browser-sdk": "^4.42.0",
-    "flags": "^4.0.0",
     "api-types": "workspace:*",
     "config": "workspace:*",
     "dat.gui": "^0.7.9",
+    "flags": "^4.0.0",
     "lodash": "^4.17.21",
     "next-themes": "^0.3.0",
+    "posthog-js": "^1.257.2",
     "react-use": "^17.4.0",
     "valtio": "catalog:"
   },

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -1,0 +1,65 @@
+import posthog from 'posthog-js'
+import { PostHogConfig } from 'posthog-js'
+
+interface PostHogClientConfig {
+  apiKey?: string
+  apiHost?: string
+}
+
+class PostHogClient {
+  private initialized = false
+  private pendingGroups: Record<string, string> = {}
+  private config: PostHogClientConfig
+
+  constructor(config: PostHogClientConfig = {}) {
+    this.config = {
+      apiKey: config.apiKey || process.env.NEXT_PUBLIC_POSTHOG_KEY,
+      apiHost:
+        config.apiHost || process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://ph.supabase.green',
+    }
+  }
+
+  init(hasConsent: boolean = true) {
+    if (this.initialized || typeof window === 'undefined' || !hasConsent) return
+
+    if (!this.config.apiKey) {
+      console.warn('PostHog API key not found. Skipping initialization.')
+      return
+    }
+
+    const config: Partial<PostHogConfig> = {
+      api_host: this.config.apiHost,
+      autocapture: false, // We'll manually track events
+      capture_pageview: false, // We'll manually track pageviews
+      capture_pageleave: false, // We'll manually track page leaves
+      loaded: (posthog) => {
+        // Apply any pending groups
+        Object.entries(this.pendingGroups).forEach(([type, id]) => {
+          posthog.group(type, id)
+        })
+        this.pendingGroups = {}
+      },
+    }
+
+    posthog.init(this.config.apiKey, config)
+    this.initialized = true
+  }
+
+  capturePageView(properties: Record<string, any>, hasConsent: boolean = true) {
+    if (!hasConsent || !this.initialized) return
+    posthog.capture('$pageview', properties)
+  }
+
+  capturePageLeave(properties: Record<string, any>, hasConsent: boolean = true) {
+    if (!hasConsent || !this.initialized) return
+    posthog.capture('$pageleave', properties)
+  }
+
+  identify(userId: string, properties?: Record<string, any>, hasConsent: boolean = true) {
+    if (!hasConsent || !this.initialized) return
+
+    posthog.identify(userId, properties)
+  }
+}
+
+export const posthogClient = new PostHogClient()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1850,6 +1850,9 @@ importers:
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      posthog-js:
+        specifier: ^1.257.2
+        version: 1.257.2
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -10272,6 +10275,9 @@ packages:
   core-js@3.35.0:
     resolution: {integrity: sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==}
 
+  core-js@3.44.0:
+    resolution: {integrity: sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -11313,7 +11319,6 @@ packages:
     resolution: {integrity: sha512-t0q23FIpvHDTtnORW+bDJziGsal5uh9RJTJ1fyH8drd4lICOoXhJ5pLMUZ5C0VQei6dNmwTzzoTRgMkO9JgHEQ==}
     peerDependencies:
       eslint: '>= 5'
-    bundledDependencies: []
 
   eslint-plugin-import@2.31.0:
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
@@ -11670,6 +11675,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
@@ -15206,6 +15214,20 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  posthog-js@1.257.2:
+    resolution: {integrity: sha512-E+8wI/ahaiUGrmkilOtAB9aTFL+oELwOEsH1eO/2NyXB5WWcSUk6Rm1loixq8/lC4f3oR+Qqp9rHyXTSYbBDRQ==}
+    peerDependencies:
+      '@rrweb/types': 2.0.0-alpha.17
+      rrweb-snapshot: 2.0.0-alpha.17
+    peerDependenciesMeta:
+      '@rrweb/types':
+        optional: true
+      rrweb-snapshot:
+        optional: true
+
+  preact@10.26.9:
+    resolution: {integrity: sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -18070,6 +18092,9 @@ packages:
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
+
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -29528,6 +29553,8 @@ snapshots:
 
   core-js@3.35.0: {}
 
+  core-js@3.44.0: {}
+
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
@@ -31037,6 +31064,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.2.1
+
+  fflate@0.4.8: {}
 
   fflate@0.7.4: {}
 
@@ -35710,6 +35739,15 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  posthog-js@1.257.2:
+    dependencies:
+      core-js: 3.44.0
+      fflate: 0.4.8
+      preact: 10.26.9
+      web-vitals: 4.2.4
+
+  preact@10.26.9: {}
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.0.3
@@ -39360,6 +39398,8 @@ snapshots:
   web-streams-polyfill@3.2.1: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
+
+  web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## What does this PR do?

Adds client-side PostHog tracking to run in parallel with server-side telemetry across `studio`, `docs`, and `www`. This enables session replays and resolves a race condition where page views arrive before group assignments resulting in attribution errors.

Resolves GROWTH-438
Resolves GROWTH-271

## Changes

- Created PostHog client wrapper with consent-aware initialization in common package
- Integrated PostHog client calls into existing telemetry functions to send events to both PostHog (client) and backend (server)
- Updated CSP to allow connections to PostHog endpoints
- Added environment variable support for all apps

## Implementation Details

- PostHog client accepts consent as a parameter and respects user preferences
- Events can be distinguished in PostHog by `$lib` property (`posthog-js` vs `posthog-node`)
- PostHog URL configured based on environment (staging/local uses `ph.supabase.green`)
- Maintains full backward compatibility with existing telemetry system

During this migration, we should be seeing both client and server-side events in posthog logged across `studio`, `docs`, and `www`:
<img width="1217" height="1143" alt="CleanShot 2025-07-31 at 16 26 50" src="https://github.com/user-attachments/assets/1cf3bb69-0f1a-4796-b6ad-a6f72e35d5f7" />

Client-side events are now correctly grouped by org only if they have an `orgSlug` or a corresponding `projectRef` in the URL (some `posthog-node` PVs are still being incorrectly bucketed but these events are effectively deprecated with this change and will be removed in an upcoming PR):
<img width="1353" height="1049" alt="CleanShot 2025-07-31 at 16 47 45" src="https://github.com/user-attachments/assets/30c416f9-471e-4deb-a718-eb6f8a17fead" />

Client-side page views that aren't grouped to a specific project or org are still being tracked, but they no longer clutter the org-specific event feed:
<img width="1358" height="1052" alt="CleanShot 2025-07-31 at 16 50 53" src="https://github.com/user-attachments/assets/683a0261-842f-4611-81a5-e4a863d0339f" />


## Local Development Setup

To test this locally, add the following environment variables to each app's `.env.local` file:

```
NEXT_PUBLIC_IS_PLATFORM="true"
NEXT_PUBLIC_ENVIRONMENT="local"
NEXT_PUBLIC_POSTHOG_KEY="phc_ihjC3EeB2wXCt87yccX5idgIgeZsub7WG0XR5hGFhJz"
```

Note: `studio` already has the first two variables configured, so only `NEXT_PUBLIC_POSTHOG_KEY` needs to be added there.

## Production/Staging Deployment

The following has already been done in separate PRs/tasks:
- `NEXT_PUBLIC_POSTHOG_KEY` configured in all Vercel environments
- PostHog reverse proxy (ph.supabase.green and ph.supabase.com) configured to accept client-side requests

This should work in production and staging environments. Testing will be needed after merge to confirm.

## Next Steps

1. Test in staging/production environments after merge
2. Monitor both event streams during migration period
3. Eventually deprecate server-side page tracking

## Testing Instructions

1. **Run the Studio app locally.**
2. **In PostHog**, switch to the **staging environment**.
3. Navigate to **People → Organizations**, choose one of your local organizations, and open the **Events** tab.
4. In a separate browser tab, visit an **organization-specific page** (e.g., `/org/[orgSlug]` or `/project/[projectRef]`).
5. **Refresh the events list** in PostHog:

   * You should see events from both the **`web` library** (frontend) and **`posthog-node`** (backend).
   * It can take a few minutes for events to appear.
6. Visit an **unassociated page** (e.g., `/organizations` or `/new`):

   * **Expected:** No `web` library page view events.
   * **Note:** Some `posthog-node` events may still appear due to client-server race conditions.
7. **Optional:** Run `docs` and `www` locally:

   * Page views from these apps should **not** appear in the **organization-specific** event list.
   * However, if you click your **user ID** and view the **user-specific events** list, you should see **all** page views (including `docs` and `www`).