### PR TITLE
Update Magic Link Button

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -7,7 +7,7 @@ const CONFIRMATION: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'CONFIRMATION',
   type: 'object',
-  title: 'Confirm signup',
+  title: 'Confirm Signup',
   properties: {
     MAILER_SUBJECTS_CONFIRMATION: {
       title: 'Subject heading',
@@ -42,7 +42,7 @@ const INVITE: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'INVITE',
   type: 'object',
-  title: 'Invite user',
+  title: 'Invite User',
   properties: {
     MAILER_SUBJECTS_INVITE: {
       title: 'Subject heading',

--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -96,10 +96,11 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
   const { mutate: sendMagicLink, isLoading: isSendingMagicLink } = useUserSendMagicLinkMutation({
     onSuccess: (_, vars) => {
       setSuccessAction('send_magic_link')
-      toast.success(`Sent magic link to ${vars.user.email}`)
+      const isConfirmed = vars.user.confirmed_at
+      toast.success(`Sent ${isConfirmed ? 'magic link' : 'confirmation link'} to ${vars.user.email}`)
     },
     onError: (err) => {
-      toast.error(`Failed to send magic link: ${err.message}`)
+      toast.error(`Failed to send ${user.confirmed_at ? 'magic link' : 'confirmation link'}: ${err.message}`)
     },
   })
   const { mutate: sendOTP, isLoading: isSendingOTP } = useUserSendOTPMutation({
@@ -278,11 +279,11 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
                 }
               />
               <RowAction
-                title="Send magic link"
-                description="Passwordless login via email for the user"
+                title={user.confirmed_at ? "Send magic link" : "Send confirmation link"}
+                description={user.confirmed_at ? "Passwordless login via email for the user" : "Send email confirmation link for user signup"}
                 button={{
                   icon: <Mail />,
-                  text: 'Send magic link',
+                  text: user.confirmed_at ? 'Send magic link' : 'Confirm sign up link',
                   isLoading: isSendingMagicLink,
                   disabled: !canSendMagicLink,
                   onClick: () => {
@@ -292,7 +293,7 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
                 success={
                   successAction === 'send_magic_link'
                     ? {
-                        title: 'Magic link sent',
+                        title: user.confirmed_at ? 'Magic link sent' : 'Confirmation link sent',
                         description: `The link in the email is valid for ${formattedExpiry}`,
                       }
                     : undefined

--- a/apps/studio/data/auth/user-send-confirmation-mutation.ts
+++ b/apps/studio/data/auth/user-send-confirmation-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import type { User } from './users-infinite-query'
 
@@ -10,25 +11,14 @@ export type UserSendConfirmationVariables = {
 }
 
 export async function sendConfirmation({ projectRef, user }: UserSendConfirmationVariables) {
-  if (!user.email) {
-    throw new Error('User email is required')
-  }
-
-  const url = `/platform/auth/${projectRef}/confirmation`
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email: user.email }),
+  const { data, error } = await post('/platform/auth/{ref}/confirmation' as any, {
+    params: { path: { ref: projectRef } },
+    body: { email: user.email },
   })
 
-  if (!response.ok) {
-    const error = await response.json()
-    throw new Error(error.message || 'Failed to send confirmation email')
-  }
+  if (error) handleError(error)
 
-  return await response.json()
+  return data
 }
 
 type UserSendConfirmationData = Awaited<ReturnType<typeof sendConfirmation>>

--- a/apps/studio/data/auth/user-send-confirmation-mutation.ts
+++ b/apps/studio/data/auth/user-send-confirmation-mutation.ts
@@ -1,0 +1,60 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { ResponseError } from 'types'
+import type { User } from './users-infinite-query'
+
+export type UserSendConfirmationVariables = {
+  projectRef: string
+  user: User
+}
+
+export async function sendConfirmation({ projectRef, user }: UserSendConfirmationVariables) {
+  if (!user.email) {
+    throw new Error('User email is required')
+  }
+
+  const url = `/platform/auth/${projectRef}/confirmation`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email: user.email }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.message || 'Failed to send confirmation email')
+  }
+
+  return await response.json()
+}
+
+type UserSendConfirmationData = Awaited<ReturnType<typeof sendConfirmation>>
+
+export const useUserSendConfirmationMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<UserSendConfirmationData, ResponseError, UserSendConfirmationVariables>,
+  'mutationFn'
+> = {}) => {
+  return useMutation<UserSendConfirmationData, ResponseError, UserSendConfirmationVariables>(
+    (vars) => sendConfirmation(vars),
+    {
+      async onSuccess(data, variables, context) {
+        await onSuccess?.(data, variables, context)
+      },
+      async onError(data, variables, context) {
+        if (onError === undefined) {
+          toast.error(`Failed to send confirmation email: ${data.message}`)
+        } else {
+          onError(data, variables, context)
+        }
+      },
+      ...options,
+    }
+  )
+}

--- a/apps/studio/pages/api/platform/auth/[ref]/confirmation.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/confirmation.ts
@@ -1,0 +1,33 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import apiWrapper from 'lib/api/apiWrapper'
+import { constructHeaders } from 'lib/api/apiHelpers'
+import { post } from 'lib/common/fetch'
+
+export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+
+  switch (method) {
+    case 'POST':
+      return handlePost(req, res)
+    default:
+      res.setHeader('Allow', ['POST'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders({
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    Authorization: `Bearer ${process.env.SUPABASE_SERVICE_KEY}`,
+  })
+  
+  // Use the invite endpoint to send confirmation emails with the confirmation template
+  // The invite endpoint sends the proper confirmation email for unconfirmed users
+  const url = `${process.env.SUPABASE_URL}/auth/v1/invite`
+  const payload = { email: req.body.email }
+  const response = await post(url, payload, { headers })
+  return res.status(200).json(response)
+}

--- a/apps/studio/pages/api/platform/auth/[ref]/confirmation.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/confirmation.ts
@@ -23,9 +23,6 @@ const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
     Accept: 'application/json',
     Authorization: `Bearer ${process.env.SUPABASE_SERVICE_KEY}`,
   })
-  
-  // Use the invite endpoint to send confirmation emails with the confirmation template
-  // The invite endpoint sends the proper confirmation email for unconfirmed users
   const url = `${process.env.SUPABASE_URL}/auth/v1/invite`
   const payload = { email: req.body.email }
   const response = await post(url, payload, { headers })

--- a/apps/studio/tests/components/Auth/Users/UserOverview.test.tsx
+++ b/apps/studio/tests/components/Auth/Users/UserOverview.test.tsx
@@ -26,6 +26,17 @@ vi.mock('data/auth/user-send-magic-link-mutation', () => ({
   })),
 }))
 
+vi.mock('data/auth/user-send-confirmation-mutation', () => ({
+  useUserSendConfirmationMutation: vi.fn((options) => ({
+    mutate: vi.fn((vars) => {
+      if (options?.onSuccess) {
+        options.onSuccess(null, vars)
+      }
+    }),
+    isLoading: false,
+  })),
+}))
+
 vi.mock('data/auth/user-reset-password-mutation', () => ({
   useUserResetPasswordMutation: vi.fn(() => ({
     mutate: vi.fn(),
@@ -74,14 +85,14 @@ describe('UserOverview Magic Link Context-Aware Functionality', () => {
   const createMockUser = (confirmed: boolean): User => ({
     id: 'test-user-id',
     email: 'test@example.com',
-    phone: null,
+    phone: undefined,
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
-    confirmed_at: confirmed ? '2023-01-01T01:00:00Z' : null,
-    last_sign_in_at: null,
-    invited_at: null,
-    confirmation_sent_at: null,
-    banned_until: null,
+    confirmed_at: confirmed ? '2023-01-01T01:00:00Z' : undefined,
+    last_sign_in_at: undefined,
+    invited_at: undefined,
+    confirmation_sent_at: undefined,
+    banned_until: undefined,
     is_sso_user: false,
     raw_app_meta_data: {
       providers: ['email'],
@@ -175,7 +186,20 @@ describe('UserOverview Magic Link Context-Aware Functionality', () => {
       vi.mocked(useUserSendMagicLinkMutation).mockReturnValue({
         mutate: mockMutate,
         isLoading: false,
-      })
+        isError: false,
+        isSuccess: false,
+        isIdle: true,
+        data: undefined,
+        error: null,
+        status: 'idle',
+        variables: undefined,
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isPaused: false,
+        mutateAsync: vi.fn(),
+        reset: vi.fn(),
+      } as any)
 
       const confirmedUser = createMockUser(true)
       
@@ -190,14 +214,27 @@ describe('UserOverview Magic Link Context-Aware Functionality', () => {
       })
     })
 
-    test('calls sendMagicLink mutation when button is clicked for unconfirmed user', async () => {
+    test('calls sendConfirmation mutation when button is clicked for unconfirmed user', async () => {
       const mockMutate = vi.fn()
-      const { useUserSendMagicLinkMutation } = await import('data/auth/user-send-magic-link-mutation')
+      const { useUserSendConfirmationMutation } = await import('data/auth/user-send-confirmation-mutation')
       
-      vi.mocked(useUserSendMagicLinkMutation).mockReturnValue({
+      vi.mocked(useUserSendConfirmationMutation).mockReturnValue({
         mutate: mockMutate,
         isLoading: false,
-      })
+        isError: false,
+        isSuccess: false,
+        isIdle: true,
+        data: undefined,
+        error: null,
+        status: 'idle',
+        variables: undefined,
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isPaused: false,
+        mutateAsync: vi.fn(),
+        reset: vi.fn(),
+      } as any)
 
       const unconfirmedUser = createMockUser(false)
       

--- a/apps/studio/tests/components/Auth/Users/UserOverview.test.tsx
+++ b/apps/studio/tests/components/Auth/Users/UserOverview.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { expect, test, describe, vi, beforeEach } from 'vitest'
 

--- a/apps/studio/tests/components/Auth/Users/UserOverview.test.tsx
+++ b/apps/studio/tests/components/Auth/Users/UserOverview.test.tsx
@@ -1,0 +1,271 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { expect, test, describe, vi, beforeEach } from 'vitest'
+
+import { UserOverview } from 'components/interfaces/Auth/Users/UserOverview'
+import { User } from 'data/auth/users-infinite-query'
+import { render } from 'tests/helpers'
+
+// Mock the hooks used by UserOverview
+vi.mock('data/auth/auth-config-query', () => ({
+  useAuthConfigQuery: vi.fn(() => ({
+    data: {
+      MAILER_OTP_EXP: 3600, // 1 hour
+    },
+  })),
+}))
+
+vi.mock('data/auth/user-send-magic-link-mutation', () => ({
+  useUserSendMagicLinkMutation: vi.fn((options) => ({
+    mutate: vi.fn((vars) => {
+      if (options?.onSuccess) {
+        options.onSuccess(null, vars)
+      }
+    }),
+    isLoading: false,
+  })),
+}))
+
+vi.mock('data/auth/user-reset-password-mutation', () => ({
+  useUserResetPasswordMutation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isLoading: false,
+  })),
+}))
+
+vi.mock('data/auth/user-send-otp-mutation', () => ({
+  useUserSendOTPMutation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isLoading: false,
+  })),
+}))
+
+vi.mock('data/auth/user-delete-mfa-factors-mutation', () => ({
+  useUserDeleteMFAFactorsMutation: vi.fn(() => ({
+    mutate: vi.fn(),
+  })),
+}))
+
+vi.mock('data/auth/user-update-mutation', () => ({
+  useUserUpdateMutation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isLoading: false,
+  })),
+}))
+
+vi.mock('hooks/misc/useCheckPermissions', () => ({
+  useCheckPermissions: vi.fn(() => true), // Allow all permissions for tests
+}))
+
+vi.mock('common', () => ({
+  useParams: vi.fn(() => ({ ref: 'test-project-ref' })),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('UserOverview Magic Link Context-Aware Functionality', () => {
+  const mockOnDeleteSuccess = vi.fn()
+
+  const createMockUser = (confirmed: boolean): User => ({
+    id: 'test-user-id',
+    email: 'test@example.com',
+    phone: null,
+    created_at: '2023-01-01T00:00:00Z',
+    updated_at: '2023-01-01T00:00:00Z',
+    confirmed_at: confirmed ? '2023-01-01T01:00:00Z' : null,
+    last_sign_in_at: null,
+    invited_at: null,
+    confirmation_sent_at: null,
+    banned_until: null,
+    is_sso_user: false,
+    raw_app_meta_data: {
+      providers: ['email'],
+    },
+    providers: ['email'],
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Confirmed User (user.confirmed_at is truthy)', () => {
+    test('shows "Send magic link" button text for confirmed user', () => {
+      const confirmedUser = createMockUser(true)
+      
+      render(<UserOverview user={confirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      expect(screen.getByRole('button', { name: /send magic link/i })).toBeInTheDocument()
+      expect(screen.getByText('Passwordless login via email for the user')).toBeInTheDocument()
+    })
+
+    test('shows "Send magic link" button with correct title', () => {
+      const confirmedUser = createMockUser(true)
+      
+      render(<UserOverview user={confirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /send magic link/i })
+      expect(button).toBeInTheDocument()
+    })
+
+    test('displays success message "Magic link sent" for confirmed user', async () => {
+      const confirmedUser = createMockUser(true)
+      
+      render(<UserOverview user={confirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /send magic link/i })
+      await userEvent.click(button)
+      
+      await waitFor(() => {
+        expect(screen.getByText('Magic link sent')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Unconfirmed User (user.confirmed_at is null)', () => {
+    test('shows "Confirm sign up link" button text for unconfirmed user', () => {
+      const unconfirmedUser = createMockUser(false)
+      
+      render(<UserOverview user={unconfirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      expect(screen.getByText('Confirm sign up link')).toBeInTheDocument()
+      expect(screen.getByText('Send email confirmation link for user signup')).toBeInTheDocument()
+    })
+
+    test('shows "Send confirmation link" title for unconfirmed user', () => {
+      const unconfirmedUser = createMockUser(false)
+      
+      render(<UserOverview user={unconfirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      expect(screen.getByText('Send confirmation link')).toBeInTheDocument()
+    })
+
+    test('shows "Confirm sign up link" button with correct text', () => {
+      const unconfirmedUser = createMockUser(false)
+      
+      render(<UserOverview user={unconfirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /confirm sign up link/i })
+      expect(button).toBeInTheDocument()
+    })
+
+    test('displays success message "Confirmation link sent" for unconfirmed user', async () => {
+      const unconfirmedUser = createMockUser(false)
+      
+      render(<UserOverview user={unconfirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /confirm sign up link/i })
+      await userEvent.click(button)
+      
+      await waitFor(() => {
+        expect(screen.getByText('Confirmation link sent')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Button Functionality', () => {
+    test('calls sendMagicLink mutation when button is clicked for confirmed user', async () => {
+      const mockMutate = vi.fn()
+      const { useUserSendMagicLinkMutation } = await import('data/auth/user-send-magic-link-mutation')
+      
+      vi.mocked(useUserSendMagicLinkMutation).mockReturnValue({
+        mutate: mockMutate,
+        isLoading: false,
+      })
+
+      const confirmedUser = createMockUser(true)
+      
+      render(<UserOverview user={confirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /send magic link/i })
+      await userEvent.click(button)
+      
+      expect(mockMutate).toHaveBeenCalledWith({
+        projectRef: 'test-project-ref',
+        user: confirmedUser,
+      })
+    })
+
+    test('calls sendMagicLink mutation when button is clicked for unconfirmed user', async () => {
+      const mockMutate = vi.fn()
+      const { useUserSendMagicLinkMutation } = await import('data/auth/user-send-magic-link-mutation')
+      
+      vi.mocked(useUserSendMagicLinkMutation).mockReturnValue({
+        mutate: mockMutate,
+        isLoading: false,
+      })
+
+      const unconfirmedUser = createMockUser(false)
+      
+      render(<UserOverview user={unconfirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /confirm sign up link/i })
+      await userEvent.click(button)
+      
+      expect(mockMutate).toHaveBeenCalledWith({
+        projectRef: 'test-project-ref',
+        user: unconfirmedUser,
+      })
+    })
+  })
+
+  describe('Toast Messages', () => {
+    test('shows correct success toast for confirmed user', async () => {
+      const { toast } = await import('sonner')
+      const confirmedUser = createMockUser(true)
+      
+      render(<UserOverview user={confirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /send magic link/i })
+      await userEvent.click(button)
+      
+      expect(toast.success).toHaveBeenCalledWith('Sent magic link to test@example.com')
+    })
+
+    test('shows correct success toast for unconfirmed user', async () => {
+      const { toast } = await import('sonner')
+      const unconfirmedUser = createMockUser(false)
+      
+      render(<UserOverview user={unconfirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /confirm sign up link/i })
+      await userEvent.click(button)
+      
+      expect(toast.success).toHaveBeenCalledWith('Sent confirmation link to test@example.com')
+    })
+  })
+
+  describe('Success State Behavior', () => {
+    test('shows success state after button click', async () => {
+      const confirmedUser = createMockUser(true)
+      
+      render(<UserOverview user={confirmedUser} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      const button = screen.getByRole('button', { name: /send magic link/i })
+      await userEvent.click(button)
+      
+      // Should show success state
+      await waitFor(() => {
+        expect(screen.getByText('Magic link sent')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('User without email', () => {
+    test('does not show magic link section for user without email', () => {
+      const userWithoutEmail: User = {
+        ...createMockUser(true),
+        email: null as any, // Allow null for test
+      }
+      
+      render(<UserOverview user={userWithoutEmail} onDeleteSuccess={mockOnDeleteSuccess} />)
+      
+      expect(screen.queryByRole('button', { name: /send magic link/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /confirm sign up link/i })).not.toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Magic Link tab is shown even though user is not confirmed.

Please link any relevant issues here.
https://github.com/supabase/supabase/issues/27475

## What is the new behavior?

For unconfirmed users the Magic link was shown.

<img width="707" height="160" alt="Screenshot 2025-07-24 at 2 06 15 PM" src="https://github.com/user-attachments/assets/c4fdc100-64f8-4ef1-9fdb-665111e8c87a" />

Now for unconfirmed user, it shows Confirm user instead.

<img width="707" height="160" alt="Screenshot 2025-07-24 at 2 06 09 PM" src="https://github.com/user-attachments/assets/60fb95e7-eefe-4487-8346-ffc9372c3b41" />


## Additional context

Add any other context or screenshots.

Closes https://github.com/supabase/supabase/issues/27475

