### PR TITLE
Chore/add e2e test for database

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -184,7 +184,7 @@ const CreateFunction = ({ func, visible, setVisible }: CreateFunctionProps) => {
                       layout="horizontal"
                     >
                       <FormControl_Shadcn_>
-                        <Input_Shadcn_ {...field} />
+                        <Input_Shadcn_ {...field} placeholder="Name of function" />
                       </FormControl_Shadcn_>
                     </FormItemLayout>
                   )}

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -112,7 +112,12 @@ const FunctionList = ({
                   {canUpdateFunctions ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button type="default" className="px-1" icon={<MoreVertical />} />
+                        <Button
+                          aria-label="More options"
+                          type="default"
+                          className="px-1"
+                          icon={<MoreVertical />}
+                        />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent side="left" className="w-52">
                         {isApiDocumentAvailable && (

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -192,6 +192,7 @@ const Indexes = () => {
                               </Button>
                               {!isLocked && (
                                 <Button
+                                  aria-label="Delete index"
                                   type="text"
                                   className="px-1"
                                   icon={<Trash />}

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -229,6 +229,7 @@ export const SchemaGraph = () => {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <ButtonTooltip
+                    aria-label="Download Schema"
                     type="default"
                     loading={isDownloading}
                     className="px-1.5"

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -139,7 +139,12 @@ const TriggerList = ({
                 {canUpdateTriggers ? (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button type="default" className="px-1" icon={<MoreVertical />} />
+                      <Button
+                        aria-label="More options"
+                        type="default"
+                        className="px-1"
+                        icon={<MoreVertical />}
+                      />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="bottom" align="end" className="w-52">
                       <DropdownMenuItem

--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -2,12 +2,15 @@ import { expect, Page } from '@playwright/test'
 import { env } from '../env.config'
 import { test } from '../utils/test'
 import { toUrl } from '../utils/to-url'
+import { waitForApiResponse } from '../utils/wait-for-response'
 
 const databaseTableName = 'pw_database_table'
 const databaseTableNameNew = 'pw_database_table_new'
 const databaseTableNameUpdated = 'pw_database_table_updated'
 const databaseTableNameDuplicate = 'pw_database_table_duplicate'
 const databaseColumnName = 'pw_database_column'
+const databaseColumnName2 = 'pw_database_column_2'
+const databaseColumnName3 = 'pw_database_column_3'
 const databaseIndexName = 'pw_database_index'
 const databaseEnumName = 'pw_database_enum'
 const databaseEnumValue1Name = 'pw_database_value1'
@@ -17,6 +20,7 @@ const databaseTriggerName = 'pw_database_trigger'
 const databaseTriggerNameUpdated = 'pw_database_trigger_updated'
 const databaseFunctionName = 'pw_database_function'
 const databaseFunctionNameUpdated = 'pw_database_function_updated'
+const databaseRoleName = 'pw_database_role'
 
 const createTable = async (page: Page, tableName: string, newColumnName: string) => {
   await page.getByRole('button', { name: 'New table', exact: true }).click()
@@ -45,351 +49,279 @@ const createTable = async (page: Page, tableName: string, newColumnName: string)
   ).toBeVisible()
 }
 
+const deleteTable = async (page: Page, tableName: string) => {
+  await page.getByLabel(`View ${tableName}`, { exact: true }).click()
+  await page.getByLabel(`View ${tableName}`, { exact: true }).getByRole('button').nth(1).click()
+  await page.getByText('Delete table').click()
+  await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).click()
+  await page.getByRole('button', { name: 'Delete' }).click()
+  await expect(
+    page.getByText(`Successfully deleted table "${tableName}"`),
+    'Delete confirmation toast should be visible'
+  ).toBeVisible()
+}
+
 test.describe('Database', () => {
   let page: Page
 
   test.beforeAll(async ({ browser, ref }) => {
     page = await browser.newPage()
     await page.goto(toUrl(`/project/${ref}/editor`))
-    await page.waitForTimeout(2000)
-
-    // delete table name if it exists
-    const exists =
+    await page.waitForTimeout(1000)
+    if (
       (await page.getByRole('button', { name: `View ${databaseTableName}`, exact: true }).count()) >
       0
-
-    if (exists) {
-      await page.getByLabel(`View ${databaseTableName}`, { exact: true }).click()
-      await page
-        .getByLabel(`View ${databaseTableName}`, { exact: true })
-        .getByRole('button')
-        .nth(1)
-        .click()
-      await page.getByText('Delete table').click()
-      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).click()
-      await page.getByRole('button', { name: 'Delete' }).click()
-      await expect(
-        page.getByText(`Successfully deleted table "${databaseTableName}"`),
-        'Delete confirmation toast should be visible'
-      ).toBeVisible()
+    ) {
+      await deleteTable(page, databaseTableName)
     }
 
-    // create database table for indexes
     await createTable(page, databaseTableName, databaseColumnName)
   })
 
   test.afterAll(async ({ ref }) => {
     await page.goto(toUrl(`/project/${ref}/editor`))
     await page.waitForTimeout(1000)
-
-    // delete table name
-    const exists =
+    if (
       (await page.getByRole('button', { name: `View ${databaseTableName}`, exact: true }).count()) >
       0
-
-    if (exists) {
-      await page.getByLabel(`View ${databaseTableName}`, { exact: true }).click()
-      await page
-        .getByLabel(`View ${databaseTableName}`, { exact: true })
-        .getByRole('button')
-        .nth(1)
-        .click()
-      await page.getByText('Delete table').click()
-      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).click()
-      await page.getByRole('button', { name: 'Delete' }).click()
-      await expect(
-        page.getByText(`Successfully deleted table "${databaseTableName}"`),
-        'Delete confirmation toast should be visible'
-      ).toBeVisible()
+    ) {
+      await deleteTable(page, databaseTableName)
     }
   })
 
-  test.describe('Roles', () => {
+  test.describe('Schema Visualizer', () => {
     test('actions works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/roles`))
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schemea=public`))
 
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=database-roles`) ||
-          response.url().includes('pg-meta/default/query?key=database-roles')
-      )
+      // Wait for schema visualizer to load
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
 
-      // filter between active and all roles
-      await page.getByRole('button', { name: 'Active roles' }).click()
-      await expect(page.getByRole('button', { name: 'supabase_admin' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'authenticator' })).toBeVisible()
+      // validates table and column exists
+      await page.waitForTimeout(500)
+      await expect(page.getByText(databaseTableName)).toBeVisible()
+      await expect(page.getByText(databaseColumnName)).toBeVisible()
 
-      // filter by querying
-      await page.getByRole('textbox', { name: 'Search for a role' }).fill('supabase')
-      await expect(page.getByRole('button', { name: 'supabase_admin' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'authenticator' })).not.toBeVisible()
-    })
+      // copies schema definition to clipboard
+      await page.getByRole('button', { name: 'Copy as SQL' }).click()
+      await page.waitForTimeout(500)
+      const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+      expect(clipboardText).toContain(`CREATE TABLE public.pw_database_table (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  created_at timestamp with time zone DEFAULT now(),
+  pw_database_column text,
+  CONSTRAINT pw_database_table_pkey PRIMARY KEY (id)
+);`)
 
-    test('CRUD operations works as expected', async ({ page, ref }) => {
-      const testRoleName = 'pw_test_role'
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/roles`))
+      // downloads schema diagram when export is triggered
+      const downloadPromise = page.waitForEvent('download')
+      await page.getByRole('button', { name: 'Download Schema' }).click()
+      await page.getByRole('menuitem', { name: 'Download as PNG' }).click()
+      const download = await downloadPromise
+      await expect(download.suggestedFilename()).toContain('.png')
 
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=database-roles`) ||
-          response.url().includes('pg-meta/default/query?key=database-roles')
-      )
+      // changing schema -> auth
+      await page.getByTestId('schema-selector').click()
+      await page.getByRole('option', { name: 'auth' }).click()
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=auth')
+      await expect(page.getByText('users')).toBeVisible()
+      await expect(page.getByText('sso_providers')).toBeVisible()
+      await expect(page.getByText('saml_providers')).toBeVisible()
 
-      // delete pw_test_role if exists
-      const exists = (await page.getByRole('button', { name: testRoleName }).count()) > 0
-      if (exists) {
-        await page.getByRole('button', { name: testRoleName }).getByRole('button').click()
-        await page.getByRole('menuitem', { name: 'Delete' }).click()
-        await page.getByRole('button', { name: 'Confirm' }).click()
-        await expect(
-          page.getByText(`Successfully deleted role: ${testRoleName}`),
-          'Delete confirmation toast should be visible'
-        ).toBeVisible({
-          timeout: 50000,
-        })
-      }
-
-      // create new role
-      await page.getByRole('button', { name: 'Add role' }).click()
-      await page.getByRole('textbox', { name: 'Name' }).fill(testRoleName)
-      await page.getByRole('switch').nth(0).click()
-      await page.getByRole('switch').nth(1).click()
-      await page.getByRole('switch').nth(2).click()
-      await page.getByRole('button', { name: 'Save' }).click()
-      await expect(
-        page.getByText(`Successfully created new role: ${testRoleName}`),
-        'Create confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
-
-      // delete a role
-      await page.getByRole('button', { name: testRoleName }).getByRole('button').click()
-      await page.getByRole('menuitem', { name: 'Delete' }).click()
-      await page.getByRole('button', { name: 'Confirm' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=roles-delete`) ||
-          response.url().includes('pg-meta/default/query?key=roles-delete')
-      )
-      await expect(
-        page.getByText(`Successfully deleted role: ${testRoleName}`),
-        'Delete confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
+      // navigate to table editor when icon is clicked
+      const samlProvidersHeader = await page.getByText('saml_providers')
+      await samlProvidersHeader.locator('..').getByRole('link').click()
+      await page.waitForURL(/.*\/editor\/\d+/)
+      await page.getByRole('button', { name: 'View saml_providers', exact: true }).click()
     })
   })
 
-  test.describe('Indexes', () => {
+  test.describe('Tables', () => {
     test('actions works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/indexes?schema=public`))
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
 
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=indexes-public`) ||
-          response.url().includes('pg-meta/default/query?key=indexes-public')
-      )
+      // Wait for database tables to be populated
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
 
-      // create index appears on public schema
-      await expect(page.getByRole('button', { name: 'Create index' })).toBeVisible()
+      // check new table button is present in public schema
+      await expect(page.getByRole('button', { name: 'New table' })).toBeVisible()
 
-      // filter by schema
+      // validates database name is present and has accurate number of columns
+      const tableRow = await page.getByRole('row', { name: databaseTableName })
+      await expect(tableRow).toContainText(databaseTableName)
+      await expect(tableRow).toContainText('3 columns')
+
+      // change schema -> auth
       await page.getByTestId('schema-selector').click()
       await page.getByPlaceholder('Find schema...').fill('auth')
       await page.getByRole('option', { name: 'auth' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=indexes-auth`) ||
-          response.url().includes('pg-meta/default/query?key=indexes-auth')
-      )
-      expect(page.getByText('sso_providers_pkey')).toBeVisible()
-      expect(page.getByText('confirmation_token_idx')).toBeVisible()
-      expect(page.getByRole('button', { name: 'Create index' })).not.toBeVisible()
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=auth')
+      await expect(page.getByText('sso_providers')).toBeVisible()
+      // check new table button is not present in other schemas
+      await expect(page.getByRole('button', { name: 'New table' })).not.toBeVisible()
 
       // filter by querying
-      await page.getByRole('textbox', { name: 'Search for an index' }).fill('users')
+      await page.getByRole('textbox', { name: 'Search for a table' }).fill('mfa')
       await page.waitForTimeout(500)
-      expect(page.getByText('sso_providers_pkey')).not.toBeVisible()
-      expect(page.getByText('confirmation_token_idx')).toBeVisible()
-
-      // check index definition
-      await page.getByRole('row', { name: 'confirmation_token_idx' }).getByRole('button').click()
-      await page.getByText('Index:confirmation_token_idx')
-      await page.waitForTimeout(500) // wait for text content to be visible
-      expect(await page.getByRole('presentation').textContent()).toBe(
-        `CREATE UNIQUE INDEX confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE ((confirmation_token)::text !~ '^[0-9 ]*$'::text)`
-      )
+      await expect(page.getByText('sso_providers')).not.toBeVisible()
+      await expect(page.getByText('mfa_factors')).toBeVisible()
     })
 
-    test('CRUD operations works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/indexes?schema=public`))
+    test('CRUD operations and copy works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
 
-      // Wait for database indexs list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=indexes-public`) ||
-          response.url().includes('pg-meta/default/query?key=indexes-public')
-      )
+      // Wait for database tables to be populated
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
 
-      // delete pw_test_index if exists
-      const exists = (await page.getByRole('button', { name: databaseIndexName }).count()) > 0
-      if (exists) {
-        await page.getByRole('button', { name: databaseIndexName }).getByRole('button').click()
-        await page.getByRole('menuitem', { name: 'Delete' }).click()
-        await page.getByRole('button', { name: 'Confirm' }).click()
-        await expect(
-          page.getByText(`Successfully deleted role: ${databaseIndexName}`),
-          'Delete confirmation toast should be visible'
-        ).toBeVisible({
-          timeout: 50000,
-        })
+      // drop database tables if exists
+      if ((await page.getByText(databaseTableNameNew, { exact: true }).count()) > 0) {
+        await page.getByRole('row', { name: databaseTableNameNew }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete table' }).click()
+        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+        await page.getByRole('button', { name: 'Delete' }).click()
+        await waitForApiResponse(page, ref, 'query?key=table-delete')
       }
 
-      // create new index on pw_test_table
-      await page.getByRole('button', { name: 'Create index' }).click()
-      await page.getByRole('button', { name: 'Choose a table' }).click()
-      await page.getByRole('option', { name: databaseTableName }).click()
-      await page.getByText('Choose which columns to create an index on').click()
-      await page.getByRole('option', { name: databaseColumnName }).click()
-      await page.getByRole('button', { name: 'Create index' }).click()
+      if ((await page.getByText(databaseTableNameUpdated, { exact: true }).count()) > 0) {
+        await page.getByRole('row', { name: databaseTableNameUpdated }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete table' }).click()
+        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+        await page.getByRole('button', { name: 'Delete' }).click()
+        await waitForApiResponse(page, ref, 'query?key=table-delete')
+      }
 
-      await expect(
-        page.getByText(`Successfully created index`),
-        'Index creation confirmation toast should be visible.'
-      ).toBeVisible({ timeout: 50000 })
-      await expect(
-        page.getByText(`${databaseTableName}_${databaseColumnName}_idx`, { exact: true })
-      ).toBeVisible()
-
-      // check index definition
-      const newIndexRow = await page.getByRole('row', {
-        name: `${databaseTableName}_${databaseColumnName}_idx`,
-      })
-
-      await newIndexRow.getByRole('button', { name: 'View definition' }).click()
-      await page.waitForTimeout(500) // wait for text content to be visible
-      expect(await page.getByRole('presentation').textContent()).toBe(
-        `CREATE INDEX ${databaseTableName}_${databaseColumnName}_idx ON public.${databaseTableName} USING btree (${databaseColumnName})`
-      )
-      await page.getByRole('button', { name: 'Cancel' }).click()
-
-      // delete the index
-      await newIndexRow.getByRole('button', { name: 'Delete index' }).click()
-      await page.getByRole('button', { name: 'Confirm delete' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=indexes`) ||
-          response.url().includes('pg-meta/default/query?key=indexes')
-      )
-      await expect(
-        page.getByText('Successfully deleted index'),
-        'Index deletion confirmation toast should be visible'
-      ).toBeVisible({ timeout: 50000 })
-    })
-  })
-
-  test.describe('Enumerated Types', () => {
-    test('actions works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/types?schema=public`))
-
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=schemas`) ||
-          response.url().includes('pg-meta/default/query?key=schemas')
-      )
-
-      // create index appears on public schema
-      await expect(page.getByRole('button', { name: 'Create type' })).toBeVisible()
-
-      // filter by schema
-      await page.getByTestId('schema-selector').click()
-      await page.getByPlaceholder('Find schema...').fill('auth')
-      await page.getByRole('option', { name: 'auth' }).click()
-
-      expect(page.getByText('factor_type')).toBeVisible()
-      expect(page.getByText('code_challenge_method')).toBeVisible()
-      expect(page.getByRole('button', { name: 'Create type' })).not.toBeVisible()
-
-      // filter by querying
-      await page.getByRole('textbox', { name: 'Search for a type' }).fill('code')
-      await page.waitForTimeout(500) // wait for enum types to be loaded
-      expect(page.getByText('factor_type')).not.toBeVisible()
-      expect(page.getByText('code_challenge_method')).toBeVisible()
-    })
-
-    test('CRUD operations works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/types?schema=public`))
-
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=schemas`) ||
-          response.url().includes('pg-meta/default/query?key=schemas')
-      )
-
-      // if exists, delete it.
-      await page.waitForTimeout(500)
-      const exists =
-        (await page.getByRole('cell', { name: databaseEnumName, exact: true }).count()) > 0
-
-      if (exists) {
+      if ((await page.getByText(databaseTableNameDuplicate, { exact: true }).count()) > 0) {
         await page
-          .getByRole('row', { name: `public ${databaseEnumName}` })
+          .getByRole('row', { name: databaseTableNameDuplicate })
           .getByRole('button')
           .click()
-        await page.getByRole('menuitem', { name: 'Delete type' }).click()
-        await page.getByRole('heading', { name: 'Confirm to delete enumerated' }).click()
-        await page.getByRole('button', { name: 'Confirm delete' }).click()
-        await expect(page.getByText(`Successfully deleted "${databaseEnumName}"`)).toBeVisible()
+        await page.getByRole('menuitem', { name: 'Delete table' }).click()
+        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+        await page.getByRole('button', { name: 'Delete' }).click()
+        await waitForApiResponse(page, ref, 'query?key=table-delete')
       }
 
-      // create a new enum
-      await page.getByRole('button', { name: 'Create type' }).click()
-      await page.getByRole('textbox', { name: 'Name' }).fill(databaseEnumName)
-      await page.getByRole('button', { name: 'Create type' }).click()
-      await page.locator('input[name="values.0.value"]').fill(databaseEnumValue1Name)
-      await page.getByRole('button', { name: 'Add value' }).click()
-      await page.locator('input[name="values.1.value"]').fill(databaseEnumValue2Name)
-      await page.getByRole('button', { name: 'Create type' }).click()
+      // create a new table
+      await page.getByRole('button', { name: 'New table' }).click()
+      await page.getByTestId('table-name-input').fill(databaseTableNameNew)
+      await page.getByRole('button', { name: 'Save' }).click()
 
-      // Wait for enum response to be completed
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/types`) ||
-          response.url().includes('pg-meta/default/types')
-      )
+      // validate table creation
+      await waitForApiResponse(page, ref, 'query?key=table-create')
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
+      await expect(page.getByText(databaseTableNameNew, { exact: true })).toBeVisible()
 
-      // verify enum is created
-      const enumRow = page.getByRole('row', { name: `${databaseEnumName}` })
-      await expect(enumRow).toContainText(databaseEnumName)
-      await expect(enumRow).toContainText(`${databaseEnumValue1Name}, ${databaseEnumValue2Name}`)
+      // edit a new table
+      await page.getByRole('row', { name: databaseTableNameNew }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Edit table' }).click()
+      await page.getByTestId('table-name-input').fill(databaseTableNameUpdated)
+      await page.getByRole('button', { name: 'Save' }).click()
 
-      // update enum
-      await enumRow.getByRole('button').click()
-      await page.getByRole('menuitem', { name: 'Update type' }).click()
+      // validate table update
+      await waitForApiResponse(page, ref, 'query?key=table-update')
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
+      await expect(page.getByText(databaseTableNameUpdated, { exact: true })).toBeVisible()
 
-      await page.getByRole('button', { name: 'Add value' }).click()
-      await page.locator('input[name="values.2.updatedValue"]').fill(databaseEnumValue3Name)
-      await page.getByRole('button', { name: 'Update type' }).click()
+      // duplicate table
+      await page.getByRole('row', { name: databaseTableNameUpdated }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Duplicate Table' }).click()
+      await page.getByTestId('table-name-input').fill(databaseTableNameDuplicate)
+      await page.getByRole('textbox', { name: 'Optional' }).fill('')
+      await page.getByRole('button', { name: 'Save' }).click()
 
-      const updatedEnumRow = page.getByRole('row', { name: `${databaseEnumName}` })
-      await expect(updatedEnumRow).toContainText(
-        `${databaseEnumValue1Name}, ${databaseEnumValue2Name}, ${databaseEnumValue3Name}`
-      )
+      // validate table duplicate
+      await waitForApiResponse(page, ref, 'query?key=')
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
+      await expect(page.getByText(databaseTableNameDuplicate, { exact: true })).toBeVisible()
 
-      // delete enum
-      await updatedEnumRow.getByRole('button').click()
-      await page.getByRole('menuitem', { name: 'Delete type' }).click()
-      await page.getByRole('heading', { name: 'Confirm to delete enumerated' }).click()
-      await page.getByRole('button', { name: 'Confirm delete' }).click()
-      await expect(page.getByText(`Successfully deleted "${databaseEnumName}"`)).toBeVisible({
-        timeout: 50000,
-      })
+      // delete tables
+      await page
+        .getByRole('row', { name: `${databaseTableNameDuplicate}` })
+        .getByRole('button')
+        .click()
+      await page.getByRole('menuitem', { name: 'Delete table' }).click()
+      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await waitForApiResponse(page, ref, 'query?key=table-delete')
+
+      await page
+        .getByRole('row', { name: `${databaseTableNameUpdated}` })
+        .getByRole('button')
+        .click()
+      await page.getByRole('menuitem', { name: 'Delete table' }).click()
+      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await waitForApiResponse(page, ref, 'query?key=table-delete')
+
+      // validate navigating to table editor from database table page
+      await page.getByRole('row', { name: databaseTableName }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'View in Table Editor' }).click()
+      await page.waitForTimeout(1000) // wait for the table editor to be loaded
+      expect(page.url().includes('editor')).toBe(true)
+    })
+  })
+
+  test.describe('Tables columns', () => {
+    test('everything works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
+
+      // Wait for database tables to be populated
+      await waitForApiResponse(page, ref, 'tables?include_columns=true&included_schemas=public')
+
+      // navigate to table columns
+      const databaseRow = page.getByRole('row', { name: databaseTableName })
+      await databaseRow.getByRole('link', { name: '3 columns' }).click()
+      await page.waitForURL(/.*\/database\/tables\/\d+/)
+
+      // validate and display everything correctly
+      const columnDatabaseRow = page.getByRole('row', { name: databaseColumnName })
+      await expect(columnDatabaseRow).toContainText(databaseColumnName)
+      await expect(columnDatabaseRow).toContainText('text')
+
+      // create a new table column
+      await page.getByRole('button', { name: 'New column' }).click()
+      await page
+        .getByRole('textbox', { name: 'column_name', exact: true })
+        .fill('pw_database_column_2')
+      await page.getByText('Choose a column type...').click()
+      await page.getByText('numeric', { exact: true }).click()
+      await page.getByRole('button', { name: 'Save' }).click()
+
+      // wait for response + validate
+      await waitForApiResponse(page, ref, 'query?key=column-create')
+      await waitForApiResponse(page, ref, 'query?key=table-editor-')
+      const columnDatabase2Row = page.getByRole('row', { name: databaseColumnName2 })
+      await expect(columnDatabase2Row).toContainText(databaseColumnName2)
+      await expect(columnDatabase2Row).toContainText('numeric')
+
+      // update table column
+      await columnDatabase2Row.getByRole('button').click()
+      await page.getByRole('button', { name: 'Edit column' }).click()
+      await page.getByRole('textbox', { name: 'column_name' }).fill(databaseColumnName3)
+      await page.getByRole('button', { name: 'Save' }).click()
+
+      // wait for response + validate
+      await waitForApiResponse(page, ref, 'query?key=column-update')
+      await waitForApiResponse(page, ref, 'query?key=table-editor-')
+
+      // delete table column
+      const columnDatabase3Row = page.getByRole('row', { name: databaseColumnName3 })
+      await columnDatabase3Row.getByRole('button').click()
+      await page.getByRole('button', { name: 'Delete column' }).click()
+      await page.getByRole('checkbox', { name: 'Drop column with cascade?' }).check()
+      await page.getByRole('button', { name: 'Delete' }).click()
+
+      // wait for response + validate
+      await waitForApiResponse(page, ref, 'query?key=column-delete')
+      await waitForApiResponse(page, ref, 'query?key=table-editor-')
+      await expect(
+        page.getByText(`Successfully deleted column "${databaseColumnName3}"`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible()
+
+      // test filtering columns
+      await page.getByRole('textbox', { name: 'Filter columns' }).fill('id')
+      await expect(page.getByRole('row', { name: 'id' })).toBeVisible()
+      await expect(page.getByRole('row', { name: databaseColumnName })).not.toBeVisible()
     })
   })
 
@@ -397,22 +329,18 @@ test.describe('Database', () => {
     test('actions works as expected', async ({ page, ref }) => {
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/triggers?schema=public`))
 
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/triggers`) ||
-          response.url().includes('pg-meta/default/triggers')
-      )
+      // Wait for database triggers to be populated
+      await waitForApiResponse(page, ref, 'triggers')
 
-      // create index appears on public schema
+      // create new trigger button to exist in public schema
       await expect(page.getByRole('button', { name: 'New trigger' })).toBeVisible()
 
-      // filter by schema
+      // change schema -> realtime
       await page.getByTestId('schema-selector').click()
       await page.getByPlaceholder('Find schema...').fill('realtime')
-      await page.getByRole('option', { name: 'realtime' }).click()
-
+      await page.getByRole('option', { name: 'realtime', exact: true }).click()
       await expect(page.getByText('tr_check_filters')).toBeVisible()
+      // create new trigger button does not exist in other schemas
       await expect(page.getByRole('button', { name: 'New trigger' })).not.toBeVisible()
 
       // filter by querying
@@ -424,16 +352,11 @@ test.describe('Database', () => {
     test('CRUD operations works as expected', async ({ page, ref }) => {
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/triggers?schema=public`))
 
-      // Wait for database indexs list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/triggers`) ||
-          response.url().includes('pg-meta/default/triggers')
-      )
+      // Wait for database triggers to be populated
+      await waitForApiResponse(page, ref, 'triggers')
 
       // delete trigger if exists
-      const exists = (await page.getByRole('button', { name: databaseTriggerName }).count()) > 0
-      if (exists) {
+      if ((await page.getByRole('button', { name: databaseTriggerName }).count()) > 0) {
         const triggerRow = await page.getByRole('row', { name: databaseTriggerName })
         await triggerRow.getByRole('button', { name: 'More options' }).click()
         await page.getByRole('menuitem', { name: 'Delete trigger' }).click()
@@ -444,16 +367,14 @@ test.describe('Database', () => {
         await expect(
           page.getByText(`Successfully removed ${databaseTriggerName}`),
           'Delete confirmation toast should be visible'
-        ).toBeVisible({
-          timeout: 50000,
-        })
+        ).toBeVisible({ timeout: 50000 })
       }
 
-      // create new index on pw_test_table
+      // create new index
       await page.getByRole('button', { name: 'New trigger' }).click()
       await page.getByRole('textbox', { name: 'Name of trigger' }).fill(databaseTriggerName)
       await page.getByRole('combobox').first().click()
-      await page.getByRole('option', { name: 'public.pw_database_table' }).click()
+      await page.getByRole('option', { name: `public.${databaseTableName}` }).click()
       await page.getByRole('checkbox').first().click()
       await page.getByRole('checkbox').nth(1).click()
       await page.getByRole('checkbox').nth(2).click()
@@ -462,11 +383,7 @@ test.describe('Database', () => {
       await page.getByRole('button', { name: 'Create trigger' }).click()
 
       // validate trigger creation
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=trigger-create`) ||
-          response.url().includes('pg-meta/default/query?key=trigger-create')
-      )
+      await waitForApiResponse(page, ref, 'query?key=trigger-create')
       await expect(
         page.getByText(`Successfully created trigger`),
         'Trigger creation confirmation toast should be visible'
@@ -484,11 +401,7 @@ test.describe('Database', () => {
       await page.getByRole('button', { name: 'Create trigger' }).click()
 
       // validate trigger update
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=trigger-update`) ||
-          response.url().includes('pg-meta/default/query?key=trigger-update')
-      )
+      await waitForApiResponse(page, ref, 'query?key=trigger-update')
       await expect(
         page.getByText(`Successfully updated trigger`),
         'Trigger updated confirmation toast should be visible'
@@ -517,407 +430,343 @@ test.describe('Database', () => {
     })
   })
 
-  test.describe('Functions', () => {
+  test.describe('Database Indexes', () => {
     test('actions works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/functions?schema=public`))
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/indexes?schema=public`))
 
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=database-functions`) ||
-          response.url().includes('pg-meta/default/query?key=database-functions')
-      )
+      // Wait for database indexes to be populated
+      await waitForApiResponse(page, ref, 'query?key=indexes-public')
 
-      // create index appears on public schema
-      await expect(page.getByRole('button', { name: 'Create a new function' })).toBeVisible()
+      // create new index button exists in public schema
+      await expect(page.getByRole('button', { name: 'Create index' })).toBeVisible()
 
-      // filter by schema
+      // change schema -> auth
       await page.getByTestId('schema-selector').click()
       await page.getByPlaceholder('Find schema...').fill('auth')
       await page.getByRole('option', { name: 'auth' }).click()
-      await expect(page.getByText('email')).toBeVisible()
-      await expect(page.getByText('jwt')).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Create a new function' })).not.toBeVisible()
+      await waitForApiResponse(page, ref, 'query?key=indexes-auth')
+      expect(page.getByText('sso_providers_pkey')).toBeVisible()
+      expect(page.getByText('confirmation_token_idx')).toBeVisible()
+      // create new index button does not exist in other schemas
+      expect(page.getByRole('button', { name: 'Create index' })).not.toBeVisible()
 
       // filter by querying
-      await page.getByRole('textbox', { name: 'Search for a function' }).fill('email')
-      await page.waitForTimeout(500) // wait for enum types to be loaded
-      await expect(page.getByText('email')).toBeVisible()
-      await expect(page.getByText('jwt')).not.toBeVisible()
+      await page.getByRole('textbox', { name: 'Search for an index' }).fill('users')
+      await page.waitForTimeout(500)
+      expect(page.getByText('sso_providers_pkey')).not.toBeVisible()
+      expect(page.getByText('confirmation_token_idx')).toBeVisible()
+
+      // check index definition
+      await page.getByRole('row', { name: 'confirmation_token_idx' }).getByRole('button').click()
+      await page.getByText('Index:confirmation_token_idx')
+      await page.waitForTimeout(500) // wait for text content to be visible
+      expect(await page.getByRole('presentation').textContent()).toBe(
+        `CREATE UNIQUE INDEX confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE ((confirmation_token)::text !~ '^[0-9 ]*$'::text)`
+      )
     })
 
     test('CRUD operations works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/functions?schema=public`))
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/indexes?schema=public`))
 
-      // Wait for database indexs list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=database-functions`) ||
-          response.url().includes('pg-meta/default/query?key=database-functions')
-      )
+      // Wait for database indexes to be populated
+      await waitForApiResponse(page, ref, 'query?key=indexes-public')
 
-      // delete function if exists
-      const exists = (await page.getByRole('button', { name: databaseFunctionName }).count()) > 0
+      // delete index if exist
+      const exists = (await page.getByRole('button', { name: databaseIndexName }).count()) > 0
       if (exists) {
-        const functionRow = await page.getByRole('row', { name: databaseFunctionName })
-        await functionRow.getByRole('button', { name: 'More options' }).click()
-        await page.getByRole('menuitem', { name: 'Delete function' }).click()
-        await page
-          .getByRole('textbox', { name: `Type ${databaseFunctionName} to confirm.` })
-          .fill(databaseFunctionName)
-        await page.getByRole('button', { name: `Delete function ${databaseFunctionName}` }).click()
+        await page.getByRole('button', { name: databaseIndexName }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete' }).click()
+        await page.getByRole('button', { name: 'Confirm' }).click()
         await expect(
-          page.getByText(`Successfully removed ${databaseFunctionName}`),
+          page.getByText(`Successfully deleted role: ${databaseIndexName}`),
           'Delete confirmation toast should be visible'
-        ).toBeVisible({
-          timeout: 50000,
-        })
+        ).toBeVisible({ timeout: 50000 })
       }
 
-      // create new function
-      await page.getByRole('button', { name: 'Create a new function' }).click()
-      await page.getByRole('textbox', { name: 'Name of function' }).fill(databaseFunctionName)
-      const editor = await page.getByRole('presentation')
-      await editor.click()
-      await page.keyboard.type(`BEGIN
-END;`)
+      // create new index
+      await page.getByRole('button', { name: 'Create index' }).click()
+      await page.getByRole('button', { name: 'Choose a table' }).click()
+      await page.getByRole('option', { name: databaseTableName }).click()
+      await page.getByText('Choose which columns to create an index on').click()
+      await page.getByRole('option', { name: databaseColumnName }).click()
+      await page.getByRole('button', { name: 'Create index' }).click()
+      await expect(
+        page.getByText(`Successfully created index`),
+        'Index creation confirmation toast should be visible.'
+      ).toBeVisible({ timeout: 50000 })
+      await expect(
+        page.getByText(`${databaseTableName}_${databaseColumnName}_idx`, { exact: true })
+      ).toBeVisible()
+
+      // check index definition
+      const newIndexRow = await page.getByRole('row', {
+        name: `${databaseTableName}_${databaseColumnName}_idx`,
+      })
+      await newIndexRow.getByRole('button', { name: 'View definition' }).click()
       await page.waitForTimeout(500) // wait for text content to be visible
-      expect(await page.getByRole('presentation').textContent()).toBe(`BEGINEND;`)
-      await page.getByRole('button', { name: 'Confirm' }).click()
+      expect(await page.getByRole('presentation').textContent()).toBe(
+        `CREATE INDEX ${databaseTableName}_${databaseColumnName}_idx ON public.${databaseTableName} USING btree (${databaseColumnName})`
+      )
+      await page.getByRole('button', { name: 'Cancel' }).click()
 
-      // validate function creation
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=functions-create`) ||
-          response.url().includes('pg-meta/default/query?key=functions-create')
-      )
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=database-functions`) ||
-          response.url().includes('pg-meta/default/query?key=database-functions')
-      )
+      // delete the index
+      await newIndexRow.getByRole('button', { name: 'Delete index' }).click()
+      await page.getByRole('button', { name: 'Confirm delete' }).click()
+      await waitForApiResponse(page, ref, 'query?key=indexes')
       await expect(
-        page.getByText(`Successfully created function`),
-        'Trigger creation confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
-      const functionRow = await page.getByRole('row', { name: databaseFunctionName })
-      expect(functionRow).toContainText(databaseFunctionName)
+        page.getByText('Successfully deleted index'),
+        'Index deletion confirmation toast should be visible'
+      ).toBeVisible({ timeout: 50000 })
+    })
+  })
 
-      // update function
-      await functionRow.getByRole('button', { name: 'More options' }).click()
-      await page.getByRole('menuitem', { name: 'Edit function', exact: true }).click()
+  test.describe('Roles', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/roles`))
+
+      // Wait for database roles list to be populated
+      await waitForApiResponse(page, ref, 'query?key=database-roles')
+
+      // filter between active and all roles
+      await page.getByRole('button', { name: 'Active roles' }).click()
+      await expect(page.getByRole('button', { name: 'supabase_admin' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'authenticator' })).toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a role' }).fill('supabase')
+      await expect(page.getByRole('button', { name: 'supabase_admin' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'authenticator' })).not.toBeVisible()
+    })
+
+    test('CRUD operations works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/roles`))
+
+      // Wait for database roles to be populated
+      await waitForApiResponse(page, ref, 'query?key=database-roles')
+
+      // delete role if exists
+      const exists = (await page.getByRole('button', { name: databaseRoleName }).count()) > 0
+      if (exists) {
+        await page.getByRole('button', { name: databaseRoleName }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete' }).click()
+        await page.getByRole('button', { name: 'Confirm' }).click()
+        await expect(
+          page.getByText(`Successfully deleted role: ${databaseRoleName}`),
+          'Delete confirmation toast should be visible'
+        ).toBeVisible({ timeout: 50000 })
+      }
+
+      // create new role
+      await page.getByRole('button', { name: 'Add role' }).click()
+      await page.getByRole('textbox', { name: 'Name' }).fill(databaseRoleName)
+      await page.getByRole('switch').nth(0).click()
+      await page.getByRole('switch').nth(1).click()
+      await page.getByRole('switch').nth(2).click()
+      await page.getByRole('button', { name: 'Save' }).click()
+      await expect(
+        page.getByText(`Successfully created new role: ${databaseRoleName}`),
+        'Create confirmation toast should be visible'
+      ).toBeVisible({ timeout: 50000 })
+
+      // delete a role
+      await page.getByRole('button', { name: databaseRoleName }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Delete' }).click()
+      await page.getByRole('button', { name: 'Confirm' }).click()
+      await waitForApiResponse(page, ref, 'query?key=roles-delete')
+      await expect(
+        page.getByText(`Successfully deleted role: ${databaseRoleName}`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible({ timeout: 50000 })
+    })
+  })
+})
+
+test.describe('Database Enumerated Types', () => {
+  test('actions works as expected', async ({ page, ref }) => {
+    await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/types?schema=public`))
+
+    // Wait for database enumerated types to be populated
+    await waitForApiResponse(page, ref, 'query?key=schemas')
+
+    // create new type button exists in public schema
+    await expect(page.getByRole('button', { name: 'Create type' })).toBeVisible()
+
+    // filter by schema
+    await page.getByTestId('schema-selector').click()
+    await page.getByPlaceholder('Find schema...').fill('auth')
+    await page.getByRole('option', { name: 'auth' }).click()
+    expect(page.getByText('factor_type')).toBeVisible()
+    expect(page.getByText('code_challenge_method')).toBeVisible()
+    // create new type button does not exist in other schemas
+    expect(page.getByRole('button', { name: 'Create type' })).not.toBeVisible()
+
+    // filter by querying
+    await page.getByRole('textbox', { name: 'Search for a type' }).fill('code')
+    await page.waitForTimeout(500) // wait for enum types to be loaded
+    expect(page.getByText('factor_type')).not.toBeVisible()
+    expect(page.getByText('code_challenge_method')).toBeVisible()
+  })
+
+  test('CRUD operations works as expected', async ({ page, ref }) => {
+    await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/types?schema=public`))
+
+    // Wait for database roles list to be populated
+    await waitForApiResponse(page, ref, 'query?key=schemas')
+
+    // if enum exists, delete it.
+    await page.waitForTimeout(500)
+    if ((await page.getByRole('cell', { name: databaseEnumName, exact: true }).count()) > 0) {
       await page
-        .getByRole('textbox', { name: 'Name of function' })
-        .fill(databaseFunctionNameUpdated)
-      await page.getByRole('button', { name: 'Confirm' }).click()
+        .getByRole('row', { name: `public ${databaseEnumName}` })
+        .getByRole('button')
+        .click()
+      await page.getByRole('menuitem', { name: 'Delete type' }).click()
+      await page.getByRole('heading', { name: 'Confirm to delete enumerated' }).click()
+      await page.getByRole('button', { name: 'Confirm delete' }).click()
+      await expect(page.getByText(`Successfully deleted "${databaseEnumName}"`)).toBeVisible()
+    }
 
-      // validate function update
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=functions-update`) ||
-          response.url().includes('pg-meta/default/query?key=functions-update')
-      )
-      await expect(
-        page.getByText(`Successfully updated function ${databaseFunctionNameUpdated}`),
-        'Function updated confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
-      const updatedFunctionRow = page.getByRole('row', { name: databaseFunctionNameUpdated })
-      await expect(updatedFunctionRow).toContainText(databaseFunctionNameUpdated)
+    // create a new enum
+    await page.getByRole('button', { name: 'Create type' }).click()
+    await page.getByRole('textbox', { name: 'Name' }).fill(databaseEnumName)
+    await page.getByRole('button', { name: 'Create type' }).click()
+    await page.locator('input[name="values.0.value"]').fill(databaseEnumValue1Name)
+    await page.getByRole('button', { name: 'Add value' }).click()
+    await page.locator('input[name="values.1.value"]').fill(databaseEnumValue2Name)
+    await page.getByRole('button', { name: 'Create type' }).click()
 
-      // delete function
-      await updatedFunctionRow.getByRole('button', { name: 'More options' }).click()
+    // Wait for enum response to be completed and validate it
+    await waitForApiResponse(page, ref, 'types')
+    const enumRow = page.getByRole('row', { name: `${databaseEnumName}` })
+    await expect(enumRow).toContainText(databaseEnumName)
+    await expect(enumRow).toContainText(`${databaseEnumValue1Name}, ${databaseEnumValue2Name}`)
+
+    // update enum
+    await enumRow.getByRole('button').click()
+    await page.getByRole('menuitem', { name: 'Update type' }).click()
+    await page.getByRole('button', { name: 'Add value' }).click()
+    await page.locator('input[name="values.2.updatedValue"]').fill(databaseEnumValue3Name)
+    await page.getByRole('button', { name: 'Update type' }).click()
+    const updatedEnumRow = page.getByRole('row', { name: `${databaseEnumName}` })
+    await expect(updatedEnumRow).toContainText(
+      `${databaseEnumValue1Name}, ${databaseEnumValue2Name}, ${databaseEnumValue3Name}`
+    )
+
+    // delete enum
+    await updatedEnumRow.getByRole('button').click()
+    await page.getByRole('menuitem', { name: 'Delete type' }).click()
+    await page.getByRole('heading', { name: 'Confirm to delete enumerated' }).click()
+    await page.getByRole('button', { name: 'Confirm delete' }).click()
+    await expect(page.getByText(`Successfully deleted "${databaseEnumName}"`)).toBeVisible({
+      timeout: 50000,
+    })
+  })
+})
+
+test.describe('Database Functions', () => {
+  test('actions works as expected', async ({ page, ref }) => {
+    await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/functions?schema=public`))
+
+    // Wait for database functions to be populated
+    await waitForApiResponse(page, ref, 'query?key=database-functions')
+
+    // create a new function button exists in public schema
+    await expect(page.getByRole('button', { name: 'Create a new function' })).toBeVisible()
+
+    // change schema -> auth
+    await page.getByTestId('schema-selector').click()
+    await page.getByPlaceholder('Find schema...').fill('auth')
+    await page.getByRole('option', { name: 'auth' }).click()
+    await expect(page.getByText('email')).toBeVisible()
+    await expect(page.getByText('jwt')).toBeVisible()
+    // create a new function button does not exist in other schemas
+    await expect(page.getByRole('button', { name: 'Create a new function' })).not.toBeVisible()
+
+    // filter by querying
+    await page.getByRole('textbox', { name: 'Search for a function' }).fill('email')
+    await page.waitForTimeout(500) // wait for enum types to be loaded
+    await expect(page.getByText('email')).toBeVisible()
+    await expect(page.getByText('jwt')).not.toBeVisible()
+  })
+
+  test('CRUD operations works as expected', async ({ page, ref }) => {
+    await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/functions?schema=public`))
+
+    // Wait for database functions to be populated
+    await waitForApiResponse(page, ref, 'query?key=database-functions')
+
+    // delete function if exists
+    if ((await page.getByRole('button', { name: databaseFunctionName }).count()) > 0) {
+      const functionRow = await page.getByRole('row', { name: databaseFunctionName })
+      await functionRow.getByRole('button', { name: 'More options' }).click()
       await page.getByRole('menuitem', { name: 'Delete function' }).click()
       await page
-        .getByRole('textbox', { name: `Type ${databaseFunctionNameUpdated} to confirm.` })
-        .fill(databaseFunctionNameUpdated)
-      await page
-        .getByRole('button', { name: `Delete function ${databaseFunctionNameUpdated}` })
-        .click()
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=functions-delete`) ||
-          response.url().includes('pg-meta/default/query?key=functions-delete')
-      )
+        .getByRole('textbox', { name: `Type ${databaseFunctionName} to confirm.` })
+        .fill(databaseFunctionName)
+      await page.getByRole('button', { name: `Delete function ${databaseFunctionName}` }).click()
       await expect(
-        page.getByText(`Successfully removed function ${databaseFunctionNameUpdated}`),
+        page.getByText(`Successfully removed ${databaseFunctionName}`),
         'Delete confirmation toast should be visible'
       ).toBeVisible({
         timeout: 50000,
       })
+    }
+
+    // create new function
+    await page.getByRole('button', { name: 'Create a new function' }).click()
+    await page.getByRole('textbox', { name: 'Name of function' }).fill(databaseFunctionName)
+    const editor = await page.getByRole('presentation')
+    await editor.click()
+    await page.keyboard.type(`BEGIN
+END;`)
+    await page.waitForTimeout(500) // wait for text content to be visible
+    expect(await page.getByRole('presentation').textContent()).toBe(`BEGINEND;`)
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    // validate function creation
+    await waitForApiResponse(page, ref, 'query?key=functions-create')
+    await waitForApiResponse(page, ref, 'query?key=database-functions')
+    await expect(
+      page.getByText(`Successfully created function`),
+      'Trigger creation confirmation toast should be visible'
+    ).toBeVisible({
+      timeout: 50000,
     })
-  })
+    const functionRow = await page.getByRole('row', { name: databaseFunctionName })
+    expect(functionRow).toContainText(databaseFunctionName)
 
-  test.describe('Tables', () => {
-    test('actions works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
+    // update function
+    await functionRow.getByRole('button', { name: 'More options' }).click()
+    await page.getByRole('menuitem', { name: 'Edit function', exact: true }).click()
+    await page.getByRole('textbox', { name: 'Name of function' }).fill(databaseFunctionNameUpdated)
+    await page.getByRole('button', { name: 'Confirm' }).click()
 
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-
-      // create index appears on public schema
-      await expect(page.getByRole('button', { name: 'New table' })).toBeVisible()
-      const tableRow = await page.getByRole('row', { name: databaseTableName })
-      await expect(tableRow).toContainText(databaseTableName)
-      await expect(tableRow).toContainText('3 columns')
-
-      // filter by schema
-      await page.getByTestId('schema-selector').click()
-      await page.getByPlaceholder('Find schema...').fill('auth')
-      await page.getByRole('option', { name: 'auth' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=auth`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=auth')
-      )
-      await expect(page.getByText('sso_providers')).toBeVisible()
-      await expect(page.getByRole('button', { name: 'New table' })).not.toBeVisible()
-
-      // filter by querying
-      await page.getByRole('textbox', { name: 'Search for a table' }).fill('mfa')
-      await page.waitForTimeout(500)
-      await expect(page.getByText('sso_providers')).not.toBeVisible()
-      await expect(page.getByText('mfa_factors')).toBeVisible()
+    // validate function update
+    await waitForApiResponse(page, ref, 'query?key=functions-update')
+    await expect(
+      page.getByText(`Successfully updated function ${databaseFunctionNameUpdated}`),
+      'Function updated confirmation toast should be visible'
+    ).toBeVisible({
+      timeout: 50000,
     })
+    const updatedFunctionRow = page.getByRole('row', { name: databaseFunctionNameUpdated })
+    await expect(updatedFunctionRow).toContainText(databaseFunctionNameUpdated)
 
-    test.only('CRUD operations and copy works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
-
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-
-      if ((await page.getByText(databaseTableNameNew, { exact: true }).count()) > 0) {
-        await page.getByRole('row', { name: databaseTableNameNew }).getByRole('button').click()
-        await page.getByRole('menuitem', { name: 'Delete table' }).click()
-        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
-        await page.getByRole('button', { name: 'Delete' }).click()
-        await page.waitForResponse(
-          (response) =>
-            response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
-            response.url().includes('pg-meta/default/query?key=table-delete')
-        )
-      }
-
-      if ((await page.getByText(databaseTableNameUpdated, { exact: true }).count()) > 0) {
-        await page.getByRole('row', { name: databaseTableNameUpdated }).getByRole('button').click()
-        await page.getByRole('menuitem', { name: 'Delete table' }).click()
-        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
-        await page.getByRole('button', { name: 'Delete' }).click()
-        await page.waitForResponse(
-          (response) =>
-            response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
-            response.url().includes('pg-meta/default/query?key=table-delete')
-        )
-      }
-
-      if ((await page.getByText(databaseTableNameDuplicate, { exact: true }).count()) > 0) {
-        await page
-          .getByRole('row', { name: databaseTableNameDuplicate })
-          .getByRole('button')
-          .click()
-        await page.getByRole('menuitem', { name: 'Delete table' }).click()
-        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
-        await page.getByRole('button', { name: 'Delete' }).click()
-        await page.waitForResponse(
-          (response) =>
-            response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
-            response.url().includes('pg-meta/default/query?key=table-delete')
-        )
-      }
-
-      // create a new table
-      await page.getByRole('button', { name: 'New table' }).click()
-      await page.getByTestId('table-name-input').fill(databaseTableNameNew)
-      await page.getByRole('button', { name: 'Save' }).click()
-
-      // validate table creation
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=table-create`) ||
-          response.url().includes('pg-meta/default/query?key=table-create')
-      )
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-      await expect(page.getByText(databaseTableNameNew, { exact: true })).toBeVisible()
-
-      // edit a new table
-      await page.getByRole('row', { name: databaseTableNameNew }).getByRole('button').click()
-      await page.getByRole('menuitem', { name: 'Edit table' }).click()
-      await page.getByTestId('table-name-input').fill(databaseTableNameUpdated)
-      await page.getByRole('button', { name: 'Save' }).click()
-
-      // validate table update
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=table-update`) ||
-          response.url().includes('pg-meta/default/query?key=table-update')
-      )
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-      await expect(page.getByText(databaseTableNameUpdated, { exact: true })).toBeVisible()
-
-      // duplicate table
-      await page.getByRole('row', { name: databaseTableNameUpdated }).getByRole('button').click()
-      await page.getByRole('menuitem', { name: 'Duplicate Table' }).click()
-      await page.getByTestId('table-name-input').fill(databaseTableNameDuplicate)
-      await page.getByRole('textbox', { name: 'Optional' }).fill('')
-      await page.getByRole('button', { name: 'Save' }).click()
-
-      // validate table duplicate
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=`) ||
-          response.url().includes('pg-meta/default/query?key=')
-      )
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-      await expect(page.getByText(databaseTableNameDuplicate, { exact: true })).toBeVisible()
-
-      // delete tables
-      await page
-        .getByRole('row', { name: `${databaseTableNameDuplicate}` })
-        .getByRole('button')
-        .click()
-      await page.getByRole('menuitem', { name: 'Delete table' }).click()
-      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
-      await page.getByRole('button', { name: 'Delete' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
-          response.url().includes('pg-meta/default/query?key=table-delete')
-      )
-
-      await page
-        .getByRole('row', { name: `${databaseTableNameUpdated}` })
-        .getByRole('button')
-        .click()
-      await page.getByRole('menuitem', { name: 'Delete table' }).click()
-      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
-      await page.getByRole('button', { name: 'Delete' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
-          response.url().includes('pg-meta/default/query?key=table-delete')
-      )
-
-      await page.getByRole('row', { name: databaseTableName }).getByRole('button').click()
-      await page.getByRole('menuitem', { name: 'View in Table Editor' }).click()
-      await page.waitForTimeout(1000) // wait for the table editor to be loaded
-      expect(page.url().includes('editor')).toBe(true)
-    })
-  })
-
-  test.describe('Tables columns', () => {
-    test('actions works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
-
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-
-      // create index appears on public schema
-      await expect(page.getByRole('button', { name: 'New table' })).toBeVisible()
-      const tableRow = await page.getByRole('row', { name: databaseTableName })
-      await expect(tableRow).toContainText(databaseTableName)
-      await expect(tableRow).toContainText('3 columns')
-
-      // filter by schema
-      await page.getByTestId('schema-selector').click()
-      await page.getByPlaceholder('Find schema...').fill('auth')
-      await page.getByRole('option', { name: 'auth' }).click()
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=auth`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=auth')
-      )
-      await expect(page.getByText('sso_providers')).toBeVisible()
-      await expect(page.getByRole('button', { name: 'New table' })).not.toBeVisible()
-
-      // filter by querying
-      await page.getByRole('textbox', { name: 'Search for a table' }).fill('mfa')
-      await page.waitForTimeout(500)
-      await expect(page.getByText('sso_providers')).not.toBeVisible()
-      await expect(page.getByText('mfa_factors')).toBeVisible()
-    })
-
-    test('CRUD operations and copy works as expected', async ({ page, ref }) => {
-      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
-
-      // Wait for database roles list to be populated
-      await page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
-          response
-            .url()
-            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
-      )
-
-      // create a new table
-
-      // edit a new table
-
-      // duplicate table
-
-      // delete duplicated table
-
-      // navigate to table editor
+    // delete function
+    await updatedFunctionRow.getByRole('button', { name: 'More options' }).click()
+    await page.getByRole('menuitem', { name: 'Delete function' }).click()
+    await page
+      .getByRole('textbox', { name: `Type ${databaseFunctionNameUpdated} to confirm.` })
+      .fill(databaseFunctionNameUpdated)
+    await page
+      .getByRole('button', { name: `Delete function ${databaseFunctionNameUpdated}` })
+      .click()
+    await waitForApiResponse(page, ref, 'query?key=functions-delete')
+    await expect(
+      page.getByText(`Successfully removed function ${databaseFunctionNameUpdated}`),
+      'Delete confirmation toast should be visible'
+    ).toBeVisible({
+      timeout: 50000,
     })
   })
 })

--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -1,0 +1,923 @@
+import { expect, Page } from '@playwright/test'
+import { env } from '../env.config'
+import { test } from '../utils/test'
+import { toUrl } from '../utils/to-url'
+
+const databaseTableName = 'pw_database_table'
+const databaseTableNameNew = 'pw_database_table_new'
+const databaseTableNameUpdated = 'pw_database_table_updated'
+const databaseTableNameDuplicate = 'pw_database_table_duplicate'
+const databaseColumnName = 'pw_database_column'
+const databaseIndexName = 'pw_database_index'
+const databaseEnumName = 'pw_database_enum'
+const databaseEnumValue1Name = 'pw_database_value1'
+const databaseEnumValue2Name = 'pw_database_value2'
+const databaseEnumValue3Name = 'pw_database_value3'
+const databaseTriggerName = 'pw_database_trigger'
+const databaseTriggerNameUpdated = 'pw_database_trigger_updated'
+const databaseFunctionName = 'pw_database_function'
+const databaseFunctionNameUpdated = 'pw_database_function_updated'
+
+const createTable = async (page: Page, tableName: string, newColumnName: string) => {
+  await page.getByRole('button', { name: 'New table', exact: true }).click()
+  await page.getByTestId('table-name-input').fill(tableName)
+  await page.getByTestId('created_at-extra-options').click()
+  await page.getByText('Is Nullable').click()
+  await page.getByTestId('created_at-extra-options').click({ force: true })
+
+  await page.getByRole('button', { name: 'Add column' }).click()
+  await page.getByRole('textbox', { name: 'column_name' }).fill(newColumnName)
+  await page.getByText('Choose a column type...').click()
+  await page.getByRole('option', { name: 'text Variable-length' }).click()
+
+  await page.getByRole('button', { name: 'Save' }).click()
+
+  await expect(
+    page.getByText(`Table ${tableName} is good to go!`),
+    'Success toast should be visible after table creation'
+  ).toBeVisible({
+    timeout: 50000,
+  })
+
+  await expect(
+    page.getByRole('button', { name: `View ${tableName}`, exact: true }),
+    'Table should be visible after creation'
+  ).toBeVisible()
+}
+
+test.describe('Database', () => {
+  let page: Page
+
+  test.beforeAll(async ({ browser, ref }) => {
+    page = await browser.newPage()
+    await page.goto(toUrl(`/project/${ref}/editor`))
+    await page.waitForTimeout(2000)
+
+    // delete table name if it exists
+    const exists =
+      (await page.getByRole('button', { name: `View ${databaseTableName}`, exact: true }).count()) >
+      0
+
+    if (exists) {
+      await page.getByLabel(`View ${databaseTableName}`, { exact: true }).click()
+      await page
+        .getByLabel(`View ${databaseTableName}`, { exact: true })
+        .getByRole('button')
+        .nth(1)
+        .click()
+      await page.getByText('Delete table').click()
+      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).click()
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await expect(
+        page.getByText(`Successfully deleted table "${databaseTableName}"`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible()
+    }
+
+    // create database table for indexes
+    await createTable(page, databaseTableName, databaseColumnName)
+  })
+
+  test.afterAll(async ({ ref }) => {
+    await page.goto(toUrl(`/project/${ref}/editor`))
+    await page.waitForTimeout(1000)
+
+    // delete table name
+    const exists =
+      (await page.getByRole('button', { name: `View ${databaseTableName}`, exact: true }).count()) >
+      0
+
+    if (exists) {
+      await page.getByLabel(`View ${databaseTableName}`, { exact: true }).click()
+      await page
+        .getByLabel(`View ${databaseTableName}`, { exact: true })
+        .getByRole('button')
+        .nth(1)
+        .click()
+      await page.getByText('Delete table').click()
+      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).click()
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await expect(
+        page.getByText(`Successfully deleted table "${databaseTableName}"`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible()
+    }
+  })
+
+  test.describe('Roles', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/roles`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=database-roles`) ||
+          response.url().includes('pg-meta/default/query?key=database-roles')
+      )
+
+      // filter between active and all roles
+      await page.getByRole('button', { name: 'Active roles' }).click()
+      await expect(page.getByRole('button', { name: 'supabase_admin' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'authenticator' })).toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a role' }).fill('supabase')
+      await expect(page.getByRole('button', { name: 'supabase_admin' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'authenticator' })).not.toBeVisible()
+    })
+
+    test('CRUD operations works as expected', async ({ page, ref }) => {
+      const testRoleName = 'pw_test_role'
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/roles`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=database-roles`) ||
+          response.url().includes('pg-meta/default/query?key=database-roles')
+      )
+
+      // delete pw_test_role if exists
+      const exists = (await page.getByRole('button', { name: testRoleName }).count()) > 0
+      if (exists) {
+        await page.getByRole('button', { name: testRoleName }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete' }).click()
+        await page.getByRole('button', { name: 'Confirm' }).click()
+        await expect(
+          page.getByText(`Successfully deleted role: ${testRoleName}`),
+          'Delete confirmation toast should be visible'
+        ).toBeVisible({
+          timeout: 50000,
+        })
+      }
+
+      // create new role
+      await page.getByRole('button', { name: 'Add role' }).click()
+      await page.getByRole('textbox', { name: 'Name' }).fill(testRoleName)
+      await page.getByRole('switch').nth(0).click()
+      await page.getByRole('switch').nth(1).click()
+      await page.getByRole('switch').nth(2).click()
+      await page.getByRole('button', { name: 'Save' }).click()
+      await expect(
+        page.getByText(`Successfully created new role: ${testRoleName}`),
+        'Create confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+
+      // delete a role
+      await page.getByRole('button', { name: testRoleName }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Delete' }).click()
+      await page.getByRole('button', { name: 'Confirm' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=roles-delete`) ||
+          response.url().includes('pg-meta/default/query?key=roles-delete')
+      )
+      await expect(
+        page.getByText(`Successfully deleted role: ${testRoleName}`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+    })
+  })
+
+  test.describe('Indexes', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/indexes?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=indexes-public`) ||
+          response.url().includes('pg-meta/default/query?key=indexes-public')
+      )
+
+      // create index appears on public schema
+      await expect(page.getByRole('button', { name: 'Create index' })).toBeVisible()
+
+      // filter by schema
+      await page.getByTestId('schema-selector').click()
+      await page.getByPlaceholder('Find schema...').fill('auth')
+      await page.getByRole('option', { name: 'auth' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=indexes-auth`) ||
+          response.url().includes('pg-meta/default/query?key=indexes-auth')
+      )
+      expect(page.getByText('sso_providers_pkey')).toBeVisible()
+      expect(page.getByText('confirmation_token_idx')).toBeVisible()
+      expect(page.getByRole('button', { name: 'Create index' })).not.toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for an index' }).fill('users')
+      await page.waitForTimeout(500)
+      expect(page.getByText('sso_providers_pkey')).not.toBeVisible()
+      expect(page.getByText('confirmation_token_idx')).toBeVisible()
+
+      // check index definition
+      await page.getByRole('row', { name: 'confirmation_token_idx' }).getByRole('button').click()
+      await page.getByText('Index:confirmation_token_idx')
+      await page.waitForTimeout(500) // wait for text content to be visible
+      expect(await page.getByRole('presentation').textContent()).toBe(
+        `CREATE UNIQUE INDEX confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE ((confirmation_token)::text !~ '^[0-9 ]*$'::text)`
+      )
+    })
+
+    test('CRUD operations works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/indexes?schema=public`))
+
+      // Wait for database indexs list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=indexes-public`) ||
+          response.url().includes('pg-meta/default/query?key=indexes-public')
+      )
+
+      // delete pw_test_index if exists
+      const exists = (await page.getByRole('button', { name: databaseIndexName }).count()) > 0
+      if (exists) {
+        await page.getByRole('button', { name: databaseIndexName }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete' }).click()
+        await page.getByRole('button', { name: 'Confirm' }).click()
+        await expect(
+          page.getByText(`Successfully deleted role: ${databaseIndexName}`),
+          'Delete confirmation toast should be visible'
+        ).toBeVisible({
+          timeout: 50000,
+        })
+      }
+
+      // create new index on pw_test_table
+      await page.getByRole('button', { name: 'Create index' }).click()
+      await page.getByRole('button', { name: 'Choose a table' }).click()
+      await page.getByRole('option', { name: databaseTableName }).click()
+      await page.getByText('Choose which columns to create an index on').click()
+      await page.getByRole('option', { name: databaseColumnName }).click()
+      await page.getByRole('button', { name: 'Create index' }).click()
+
+      await expect(
+        page.getByText(`Successfully created index`),
+        'Index creation confirmation toast should be visible.'
+      ).toBeVisible({ timeout: 50000 })
+      await expect(
+        page.getByText(`${databaseTableName}_${databaseColumnName}_idx`, { exact: true })
+      ).toBeVisible()
+
+      // check index definition
+      const newIndexRow = await page.getByRole('row', {
+        name: `${databaseTableName}_${databaseColumnName}_idx`,
+      })
+
+      await newIndexRow.getByRole('button', { name: 'View definition' }).click()
+      await page.waitForTimeout(500) // wait for text content to be visible
+      expect(await page.getByRole('presentation').textContent()).toBe(
+        `CREATE INDEX ${databaseTableName}_${databaseColumnName}_idx ON public.${databaseTableName} USING btree (${databaseColumnName})`
+      )
+      await page.getByRole('button', { name: 'Cancel' }).click()
+
+      // delete the index
+      await newIndexRow.getByRole('button', { name: 'Delete index' }).click()
+      await page.getByRole('button', { name: 'Confirm delete' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=indexes`) ||
+          response.url().includes('pg-meta/default/query?key=indexes')
+      )
+      await expect(
+        page.getByText('Successfully deleted index'),
+        'Index deletion confirmation toast should be visible'
+      ).toBeVisible({ timeout: 50000 })
+    })
+  })
+
+  test.describe('Enumerated Types', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/types?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=schemas`) ||
+          response.url().includes('pg-meta/default/query?key=schemas')
+      )
+
+      // create index appears on public schema
+      await expect(page.getByRole('button', { name: 'Create type' })).toBeVisible()
+
+      // filter by schema
+      await page.getByTestId('schema-selector').click()
+      await page.getByPlaceholder('Find schema...').fill('auth')
+      await page.getByRole('option', { name: 'auth' }).click()
+
+      expect(page.getByText('factor_type')).toBeVisible()
+      expect(page.getByText('code_challenge_method')).toBeVisible()
+      expect(page.getByRole('button', { name: 'Create type' })).not.toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a type' }).fill('code')
+      await page.waitForTimeout(500) // wait for enum types to be loaded
+      expect(page.getByText('factor_type')).not.toBeVisible()
+      expect(page.getByText('code_challenge_method')).toBeVisible()
+    })
+
+    test('CRUD operations works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/types?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=schemas`) ||
+          response.url().includes('pg-meta/default/query?key=schemas')
+      )
+
+      // if exists, delete it.
+      await page.waitForTimeout(500)
+      const exists =
+        (await page.getByRole('cell', { name: databaseEnumName, exact: true }).count()) > 0
+
+      if (exists) {
+        await page
+          .getByRole('row', { name: `public ${databaseEnumName}` })
+          .getByRole('button')
+          .click()
+        await page.getByRole('menuitem', { name: 'Delete type' }).click()
+        await page.getByRole('heading', { name: 'Confirm to delete enumerated' }).click()
+        await page.getByRole('button', { name: 'Confirm delete' }).click()
+        await expect(page.getByText(`Successfully deleted "${databaseEnumName}"`)).toBeVisible()
+      }
+
+      // create a new enum
+      await page.getByRole('button', { name: 'Create type' }).click()
+      await page.getByRole('textbox', { name: 'Name' }).fill(databaseEnumName)
+      await page.getByRole('button', { name: 'Create type' }).click()
+      await page.locator('input[name="values.0.value"]').fill(databaseEnumValue1Name)
+      await page.getByRole('button', { name: 'Add value' }).click()
+      await page.locator('input[name="values.1.value"]').fill(databaseEnumValue2Name)
+      await page.getByRole('button', { name: 'Create type' }).click()
+
+      // Wait for enum response to be completed
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/types`) ||
+          response.url().includes('pg-meta/default/types')
+      )
+
+      // verify enum is created
+      const enumRow = page.getByRole('row', { name: `${databaseEnumName}` })
+      await expect(enumRow).toContainText(databaseEnumName)
+      await expect(enumRow).toContainText(`${databaseEnumValue1Name}, ${databaseEnumValue2Name}`)
+
+      // update enum
+      await enumRow.getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Update type' }).click()
+
+      await page.getByRole('button', { name: 'Add value' }).click()
+      await page.locator('input[name="values.2.updatedValue"]').fill(databaseEnumValue3Name)
+      await page.getByRole('button', { name: 'Update type' }).click()
+
+      const updatedEnumRow = page.getByRole('row', { name: `${databaseEnumName}` })
+      await expect(updatedEnumRow).toContainText(
+        `${databaseEnumValue1Name}, ${databaseEnumValue2Name}, ${databaseEnumValue3Name}`
+      )
+
+      // delete enum
+      await updatedEnumRow.getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Delete type' }).click()
+      await page.getByRole('heading', { name: 'Confirm to delete enumerated' }).click()
+      await page.getByRole('button', { name: 'Confirm delete' }).click()
+      await expect(page.getByText(`Successfully deleted "${databaseEnumName}"`)).toBeVisible({
+        timeout: 50000,
+      })
+    })
+  })
+
+  test.describe('Triggers', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/triggers?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/triggers`) ||
+          response.url().includes('pg-meta/default/triggers')
+      )
+
+      // create index appears on public schema
+      await expect(page.getByRole('button', { name: 'New trigger' })).toBeVisible()
+
+      // filter by schema
+      await page.getByTestId('schema-selector').click()
+      await page.getByPlaceholder('Find schema...').fill('realtime')
+      await page.getByRole('option', { name: 'realtime' }).click()
+
+      await expect(page.getByText('tr_check_filters')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'New trigger' })).not.toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a trigger' }).fill('abc')
+      await page.waitForTimeout(500) // wait for enum types to be loaded
+      await expect(page.getByText('tr_check_filters')).not.toBeVisible()
+    })
+
+    test('CRUD operations works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/triggers?schema=public`))
+
+      // Wait for database indexs list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/triggers`) ||
+          response.url().includes('pg-meta/default/triggers')
+      )
+
+      // delete trigger if exists
+      const exists = (await page.getByRole('button', { name: databaseTriggerName }).count()) > 0
+      if (exists) {
+        const triggerRow = await page.getByRole('row', { name: databaseTriggerName })
+        await triggerRow.getByRole('button', { name: 'More options' }).click()
+        await page.getByRole('menuitem', { name: 'Delete trigger' }).click()
+        await page
+          .getByRole('textbox', { name: `Type ${databaseTriggerName} to confirm.` })
+          .fill(databaseTriggerName)
+        await page.getByRole('button', { name: `Delete trigger ${databaseTriggerName}` }).click()
+        await expect(
+          page.getByText(`Successfully removed ${databaseTriggerName}`),
+          'Delete confirmation toast should be visible'
+        ).toBeVisible({
+          timeout: 50000,
+        })
+      }
+
+      // create new index on pw_test_table
+      await page.getByRole('button', { name: 'New trigger' }).click()
+      await page.getByRole('textbox', { name: 'Name of trigger' }).fill(databaseTriggerName)
+      await page.getByRole('combobox').first().click()
+      await page.getByRole('option', { name: 'public.pw_database_table' }).click()
+      await page.getByRole('checkbox').first().click()
+      await page.getByRole('checkbox').nth(1).click()
+      await page.getByRole('checkbox').nth(2).click()
+      await page.getByRole('button', { name: 'Choose a function to trigger' }).click()
+      await page.getByRole('paragraph').filter({ hasText: 'subscription_check_filters' }).click()
+      await page.getByRole('button', { name: 'Create trigger' }).click()
+
+      // validate trigger creation
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=trigger-create`) ||
+          response.url().includes('pg-meta/default/query?key=trigger-create')
+      )
+      await expect(
+        page.getByText(`Successfully created trigger`),
+        'Trigger creation confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+      const triggerRow = await page.getByRole('row', { name: databaseTriggerName })
+      expect(triggerRow).toContainText('subscription_check_filters')
+      expect(triggerRow).toContainText(databaseTriggerName)
+
+      // update trigger
+      await triggerRow.getByRole('button', { name: 'More options' }).click()
+      await page.getByRole('menuitem', { name: 'Edit trigger' }).click()
+      await page.getByRole('textbox', { name: 'Name of trigger' }).fill(databaseTriggerNameUpdated)
+      await page.getByRole('button', { name: 'Create trigger' }).click()
+
+      // validate trigger update
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=trigger-update`) ||
+          response.url().includes('pg-meta/default/query?key=trigger-update')
+      )
+      await expect(
+        page.getByText(`Successfully updated trigger`),
+        'Trigger updated confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+      const updatedTriggerRow = page.getByRole('row', { name: databaseTriggerNameUpdated })
+      await expect(updatedTriggerRow).toContainText('subscription_check_filters')
+      await expect(updatedTriggerRow).toContainText(databaseTriggerNameUpdated)
+
+      // delete trigger
+      await updatedTriggerRow.getByRole('button', { name: 'More options' }).click()
+      await page.getByRole('menuitem', { name: 'Delete trigger' }).click()
+      await page
+        .getByRole('textbox', { name: `Type ${databaseTriggerNameUpdated} to confirm.` })
+        .fill(databaseTriggerNameUpdated)
+      await page
+        .getByRole('button', { name: `Delete trigger ${databaseTriggerNameUpdated}` })
+        .click()
+      await expect(
+        page.getByText(`Successfully removed ${databaseTriggerNameUpdated}`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+    })
+  })
+
+  test.describe('Functions', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/functions?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=database-functions`) ||
+          response.url().includes('pg-meta/default/query?key=database-functions')
+      )
+
+      // create index appears on public schema
+      await expect(page.getByRole('button', { name: 'Create a new function' })).toBeVisible()
+
+      // filter by schema
+      await page.getByTestId('schema-selector').click()
+      await page.getByPlaceholder('Find schema...').fill('auth')
+      await page.getByRole('option', { name: 'auth' }).click()
+      await expect(page.getByText('email')).toBeVisible()
+      await expect(page.getByText('jwt')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Create a new function' })).not.toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a function' }).fill('email')
+      await page.waitForTimeout(500) // wait for enum types to be loaded
+      await expect(page.getByText('email')).toBeVisible()
+      await expect(page.getByText('jwt')).not.toBeVisible()
+    })
+
+    test('CRUD operations works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/functions?schema=public`))
+
+      // Wait for database indexs list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=database-functions`) ||
+          response.url().includes('pg-meta/default/query?key=database-functions')
+      )
+
+      // delete function if exists
+      const exists = (await page.getByRole('button', { name: databaseFunctionName }).count()) > 0
+      if (exists) {
+        const functionRow = await page.getByRole('row', { name: databaseFunctionName })
+        await functionRow.getByRole('button', { name: 'More options' }).click()
+        await page.getByRole('menuitem', { name: 'Delete function' }).click()
+        await page
+          .getByRole('textbox', { name: `Type ${databaseFunctionName} to confirm.` })
+          .fill(databaseFunctionName)
+        await page.getByRole('button', { name: `Delete function ${databaseFunctionName}` }).click()
+        await expect(
+          page.getByText(`Successfully removed ${databaseFunctionName}`),
+          'Delete confirmation toast should be visible'
+        ).toBeVisible({
+          timeout: 50000,
+        })
+      }
+
+      // create new function
+      await page.getByRole('button', { name: 'Create a new function' }).click()
+      await page.getByRole('textbox', { name: 'Name of function' }).fill(databaseFunctionName)
+      const editor = await page.getByRole('presentation')
+      await editor.click()
+      await page.keyboard.type(`BEGIN
+END;`)
+      await page.waitForTimeout(500) // wait for text content to be visible
+      expect(await page.getByRole('presentation').textContent()).toBe(`BEGINEND;`)
+      await page.getByRole('button', { name: 'Confirm' }).click()
+
+      // validate function creation
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=functions-create`) ||
+          response.url().includes('pg-meta/default/query?key=functions-create')
+      )
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=database-functions`) ||
+          response.url().includes('pg-meta/default/query?key=database-functions')
+      )
+      await expect(
+        page.getByText(`Successfully created function`),
+        'Trigger creation confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+      const functionRow = await page.getByRole('row', { name: databaseFunctionName })
+      expect(functionRow).toContainText(databaseFunctionName)
+
+      // update function
+      await functionRow.getByRole('button', { name: 'More options' }).click()
+      await page.getByRole('menuitem', { name: 'Edit function', exact: true }).click()
+      await page
+        .getByRole('textbox', { name: 'Name of function' })
+        .fill(databaseFunctionNameUpdated)
+      await page.getByRole('button', { name: 'Confirm' }).click()
+
+      // validate function update
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=functions-update`) ||
+          response.url().includes('pg-meta/default/query?key=functions-update')
+      )
+      await expect(
+        page.getByText(`Successfully updated function ${databaseFunctionNameUpdated}`),
+        'Function updated confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+      const updatedFunctionRow = page.getByRole('row', { name: databaseFunctionNameUpdated })
+      await expect(updatedFunctionRow).toContainText(databaseFunctionNameUpdated)
+
+      // delete function
+      await updatedFunctionRow.getByRole('button', { name: 'More options' }).click()
+      await page.getByRole('menuitem', { name: 'Delete function' }).click()
+      await page
+        .getByRole('textbox', { name: `Type ${databaseFunctionNameUpdated} to confirm.` })
+        .fill(databaseFunctionNameUpdated)
+      await page
+        .getByRole('button', { name: `Delete function ${databaseFunctionNameUpdated}` })
+        .click()
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=functions-delete`) ||
+          response.url().includes('pg-meta/default/query?key=functions-delete')
+      )
+      await expect(
+        page.getByText(`Successfully removed function ${databaseFunctionNameUpdated}`),
+        'Delete confirmation toast should be visible'
+      ).toBeVisible({
+        timeout: 50000,
+      })
+    })
+  })
+
+  test.describe('Tables', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+
+      // create index appears on public schema
+      await expect(page.getByRole('button', { name: 'New table' })).toBeVisible()
+      const tableRow = await page.getByRole('row', { name: databaseTableName })
+      await expect(tableRow).toContainText(databaseTableName)
+      await expect(tableRow).toContainText('3 columns')
+
+      // filter by schema
+      await page.getByTestId('schema-selector').click()
+      await page.getByPlaceholder('Find schema...').fill('auth')
+      await page.getByRole('option', { name: 'auth' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=auth`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=auth')
+      )
+      await expect(page.getByText('sso_providers')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'New table' })).not.toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a table' }).fill('mfa')
+      await page.waitForTimeout(500)
+      await expect(page.getByText('sso_providers')).not.toBeVisible()
+      await expect(page.getByText('mfa_factors')).toBeVisible()
+    })
+
+    test.only('CRUD operations and copy works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+
+      if ((await page.getByText(databaseTableNameNew, { exact: true }).count()) > 0) {
+        await page.getByRole('row', { name: databaseTableNameNew }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete table' }).click()
+        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+        await page.getByRole('button', { name: 'Delete' }).click()
+        await page.waitForResponse(
+          (response) =>
+            response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
+            response.url().includes('pg-meta/default/query?key=table-delete')
+        )
+      }
+
+      if ((await page.getByText(databaseTableNameUpdated, { exact: true }).count()) > 0) {
+        await page.getByRole('row', { name: databaseTableNameUpdated }).getByRole('button').click()
+        await page.getByRole('menuitem', { name: 'Delete table' }).click()
+        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+        await page.getByRole('button', { name: 'Delete' }).click()
+        await page.waitForResponse(
+          (response) =>
+            response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
+            response.url().includes('pg-meta/default/query?key=table-delete')
+        )
+      }
+
+      if ((await page.getByText(databaseTableNameDuplicate, { exact: true }).count()) > 0) {
+        await page
+          .getByRole('row', { name: databaseTableNameDuplicate })
+          .getByRole('button')
+          .click()
+        await page.getByRole('menuitem', { name: 'Delete table' }).click()
+        await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+        await page.getByRole('button', { name: 'Delete' }).click()
+        await page.waitForResponse(
+          (response) =>
+            response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
+            response.url().includes('pg-meta/default/query?key=table-delete')
+        )
+      }
+
+      // create a new table
+      await page.getByRole('button', { name: 'New table' }).click()
+      await page.getByTestId('table-name-input').fill(databaseTableNameNew)
+      await page.getByRole('button', { name: 'Save' }).click()
+
+      // validate table creation
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=table-create`) ||
+          response.url().includes('pg-meta/default/query?key=table-create')
+      )
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+      await expect(page.getByText(databaseTableNameNew, { exact: true })).toBeVisible()
+
+      // edit a new table
+      await page.getByRole('row', { name: databaseTableNameNew }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Edit table' }).click()
+      await page.getByTestId('table-name-input').fill(databaseTableNameUpdated)
+      await page.getByRole('button', { name: 'Save' }).click()
+
+      // validate table update
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=table-update`) ||
+          response.url().includes('pg-meta/default/query?key=table-update')
+      )
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+      await expect(page.getByText(databaseTableNameUpdated, { exact: true })).toBeVisible()
+
+      // duplicate table
+      await page.getByRole('row', { name: databaseTableNameUpdated }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'Duplicate Table' }).click()
+      await page.getByTestId('table-name-input').fill(databaseTableNameDuplicate)
+      await page.getByRole('textbox', { name: 'Optional' }).fill('')
+      await page.getByRole('button', { name: 'Save' }).click()
+
+      // validate table duplicate
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=`) ||
+          response.url().includes('pg-meta/default/query?key=')
+      )
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+      await expect(page.getByText(databaseTableNameDuplicate, { exact: true })).toBeVisible()
+
+      // delete tables
+      await page
+        .getByRole('row', { name: `${databaseTableNameDuplicate}` })
+        .getByRole('button')
+        .click()
+      await page.getByRole('menuitem', { name: 'Delete table' }).click()
+      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
+          response.url().includes('pg-meta/default/query?key=table-delete')
+      )
+
+      await page
+        .getByRole('row', { name: `${databaseTableNameUpdated}` })
+        .getByRole('button')
+        .click()
+      await page.getByRole('menuitem', { name: 'Delete table' }).click()
+      await page.getByRole('checkbox', { name: 'Drop table with cascade?' }).check()
+      await page.getByRole('button', { name: 'Delete' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response.url().includes(`pg-meta/${ref}/query?key=table-delete`) ||
+          response.url().includes('pg-meta/default/query?key=table-delete')
+      )
+
+      await page.getByRole('row', { name: databaseTableName }).getByRole('button').click()
+      await page.getByRole('menuitem', { name: 'View in Table Editor' }).click()
+      await page.waitForTimeout(1000) // wait for the table editor to be loaded
+      expect(page.url().includes('editor')).toBe(true)
+    })
+  })
+
+  test.describe('Tables columns', () => {
+    test('actions works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+
+      // create index appears on public schema
+      await expect(page.getByRole('button', { name: 'New table' })).toBeVisible()
+      const tableRow = await page.getByRole('row', { name: databaseTableName })
+      await expect(tableRow).toContainText(databaseTableName)
+      await expect(tableRow).toContainText('3 columns')
+
+      // filter by schema
+      await page.getByTestId('schema-selector').click()
+      await page.getByPlaceholder('Find schema...').fill('auth')
+      await page.getByRole('option', { name: 'auth' }).click()
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=auth`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=auth')
+      )
+      await expect(page.getByText('sso_providers')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'New table' })).not.toBeVisible()
+
+      // filter by querying
+      await page.getByRole('textbox', { name: 'Search for a table' }).fill('mfa')
+      await page.waitForTimeout(500)
+      await expect(page.getByText('sso_providers')).not.toBeVisible()
+      await expect(page.getByText('mfa_factors')).toBeVisible()
+    })
+
+    test('CRUD operations and copy works as expected', async ({ page, ref }) => {
+      await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/tables?schema=public`))
+
+      // Wait for database roles list to be populated
+      await page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(`pg-meta/${ref}/tables?include_columns=true&included_schemas=public`) ||
+          response
+            .url()
+            .includes('pg-meta/default/tables?include_columns=true&included_schemas=public')
+      )
+
+      // create a new table
+
+      // edit a new table
+
+      // duplicate table
+
+      // delete duplicated table
+
+      // navigate to table editor
+    })
+  })
+})

--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     video: 'retain-on-failure',
     headless: IS_CI,
     trace: 'retain-on-failure',
+    permissions: ['clipboard-read', 'clipboard-write'],
   },
   projects: [
     {

--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   forbidOnly: IS_CI,
-  retries: IS_CI ? 3 : 1,
+  retries: IS_CI ? 3 : 0,
   use: {
     baseURL: env.STUDIO_URL,
     screenshot: 'off',

--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   forbidOnly: IS_CI,
-  retries: IS_CI ? 3 : 0,
+  retries: IS_CI ? 3 : 1,
   use: {
     baseURL: env.STUDIO_URL,
     screenshot: 'off',

--- a/e2e/studio/utils/is-local.ts
+++ b/e2e/studio/utils/is-local.ts
@@ -1,0 +1,9 @@
+import { env } from '../env.config'
+
+export function isLocal(url?: string): boolean {
+  if (!url) {
+    return env.STUDIO_URL.includes('localhost') || env.API_URL.includes('127.0.0.1')
+  }
+
+  return url.includes('localhost') || url.includes('127.0.0.1')
+}

--- a/e2e/studio/utils/is-local.ts
+++ b/e2e/studio/utils/is-local.ts
@@ -1,9 +1,0 @@
-import { env } from '../env.config'
-
-export function isLocal(url?: string): boolean {
-  if (!url) {
-    return env.STUDIO_URL.includes('localhost') || env.API_URL.includes('127.0.0.1')
-  }
-
-  return url.includes('localhost') || url.includes('127.0.0.1')
-}

--- a/e2e/studio/utils/wait-for-response.ts
+++ b/e2e/studio/utils/wait-for-response.ts
@@ -1,0 +1,15 @@
+import { Page } from '@playwright/test'
+
+/**
+ * Waits for a API response for a specific endpoint before continuing the playwright test.
+ * @param page - Playwright page object
+ * @param ref - Project reference
+ * @param endpoint - The endpoint to wait for (e.g., 'types', 'triggers')
+ */
+export async function waitForApiResponse(page: Page, ref: string, endpoint: string): Promise<void> {
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes(`pg-meta/${ref}/${endpoint}`) ||
+      response.url().includes(`pg-meta/default/${endpoint}`)
+  )
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- Add playwright tests for database.

| Database section | Test case |
|--------|--------|
| Schema Visualizer | displays all tables with types and foreign key relationships on load | 
| Schema Visualizer | copies schema definition to clipboard when SQL button is clicked | 
| Schema Visualizer | updates visualizer content when switching between schemas | 
| Schema Visualizer | downloads schema diagram as PNG file when export is triggered | 
| Schema Visualizer | navigates to table editor for selected table when icon is clicked | 
| Tables | Create new table button should only appear for public schema | 
| Tables | updates table list when switching to a different schema | 
| Tables | filters out tables that do not match search query | 
| Tables | displays accurate row count and realtime status for each table | 
| Tables | allows creating a new table via new table button | 
| Tables | allows table modification through edit table action | 
| Tables | removes table from database after delete confirmation | 
| Tables | creates table copy when duplicate action is executed | 
| Tables | navigates to table editor when view in table editor action is triggered | 
| Tables | displays all columns with their data types | 
| Tables | allows column modification through edit column action | 
| Tables | enables adding new columns via add column button | 
| Tables | removes column from table after delete confirmation | 
| Tables | filters out columns that do not match search query | 
| Functions | Create function button should only appear for public schema | 
| Functions | updates functions when switching to a different schema | 
| Functions | filters out functions that do not match search query | 
| Functions | allows adding new functions via create function button | 
| Functions | enables updating functions through edit function action | 
| Functions | removes functions through delete function action | 
| Triggers | Create trigger button should only appear for public schema | 
| Triggers | updates triggers when switching to a different schema | 
| Triggers | filters out triggers that do not match search query | 
| Triggers | allows adding new triggers via new trigger button | 
| Triggers | enables updating triggers through edit function action | 
| Triggers | removes triggers through delete function action | 
| Enumerated Types | Create type button should only appear for public schema | 
| Enumerated Types | should update enums when switching to a different schema | 
| Enumerated Types | should hide enums that do not match search query when using table search filter | 
| Enumerated Types | should create enums when create type action is clicked. | 
| Enumerated Types | should modify enums when update type action is clicked | 
| Enumerated Types | should delete enums when delete type action is clicked. | 
| Indexes | Create index button should only appear for public schema | 
| Indexes | should update indexes when switching to a different schema | 
| Indexes | should hide indexes that do not match search query when using table search filter | 
| Indexes | should add indexes using create index button | 
| Indexes | should delete indexes using delete action | 
| Indexes | should show the correct definition for indexes. | 
| Role | should filter roles based on active and all roles. |
| Role | should hide roles that do not match search query when using table search filter |
| Role | should add role with correct permissions |
| Role | role should be delete when delete action is confirmed |

> Expected failures in staging due update in 
> - indexes CRUD - added aria-label to delete icon button
> - Trigger CRUD - added aria-label to action button
> - Function CRUD - added aria-label to action button & added placeholder text to name of function input
> - Schema Visualiser - added aria-label to download schema image icon button.


Entire playwright tests still runs successfully:
<img width="959" height="176" alt="image" src="https://github.com/user-attachments/assets/bba07e84-8fbf-409c-8dbf-83b838f9683b" />


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
