### PR TITLE
docs: fix link in realtime concepts

### DIFF
--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -57,7 +57,7 @@ roomOne.send({
 
 Other clients can receive the message in real-time by subscribing to the Channel with topic `room-one`. These clients continue to receive messages as long as they are subscribed and connected to the same Channel topic.
 
-You can also use [Broadcast using the REST API](/docs/guides/realtime/broad cast#broadcast-using-the-rest-api) and [Broadcast using the Database](/docs/guides/realtime/broadcast#broadcast-using-the-database) to send messages to a Channel which allows you to do more advanced use-cases.
+You can also use [Broadcast using the REST API](/docs/guides/realtime/broadcast#broadcast-using-the-rest-api) and [Broadcast using the Database](/docs/guides/realtime/broadcast#broadcast-using-the-database) to send messages to a Channel which allows you to do more advanced use-cases.
 
 An example use-case is sharing a user's cursor position with other clients in an online game.
 


### PR DESCRIPTION
The docs link was being properly formatted because of a space in the URL

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The link to Broadcast using the REST API isn't working because of a space in the URL.
<img width="883" height="92" alt="image" src="https://github.com/user-attachments/assets/22dc8e97-25ea-4f0c-9932-819709e83862" />


## What is the new behavior?

Removed space

## Additional context


