### PR TITLE
fix: use storage endpoint in S3 settings

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/SimpleConfigurationDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/SimpleConfigurationDetails.tsx
@@ -24,7 +24,7 @@ export const SimpleConfigurationDetails = ({ bucketName }: { bucketName: string 
   const { data: apiKeys } = useAPIKeysQuery({ projectRef: project?.ref })
   const { data: settings } = useProjectSettingsV2Query({ projectRef: project?.ref })
   const protocol = settings?.app_config?.protocol ?? 'https'
-  const endpoint = settings?.app_config?.endpoint
+  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
 
   const { serviceKey } = getKeys(apiKeys)
   const serviceApiKey = serviceKey?.api_key ?? 'SUPABASE_CLIENT_SERVICE_KEY'

--- a/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
@@ -80,7 +80,7 @@ export const S3Connection = () => {
   })
 
   const protocol = settings?.app_config?.protocol ?? 'https'
-  const endpoint = settings?.app_config?.endpoint
+  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
   const hasStorageCreds = storageCreds?.data && storageCreds.data.length > 0
   const s3connectionUrl = getConnectionURL(projectRef ?? '', protocol, endpoint)
 

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.utils.ts
@@ -26,7 +26,9 @@ export const convertToBytes = (size: number, unit: StorageSizeUnits = StorageSiz
 }
 
 function getStorageURL(projectRef: string, protocol: string, endpoint?: string) {
-  const projUrl = endpoint ? `${protocol}://${endpoint}` : `https://${projectRef}.supabase.co`
+  const projUrl = endpoint
+    ? `${protocol}://${endpoint}`
+    : `https://${projectRef}.storage.supabase.co`
   const url = new URL(projUrl)
   return url
 }

--- a/apps/studio/data/storage/iceberg-wrapper-create-mutation.ts
+++ b/apps/studio/data/storage/iceberg-wrapper-create-mutation.ts
@@ -1,4 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { snakeCase } from 'lodash'
 
 import { WRAPPERS } from 'components/interfaces/Integrations/Wrappers/Wrappers.constants'
 import {
@@ -8,10 +9,8 @@ import {
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import { FDWCreateVariables, useFDWCreateMutation } from 'data/fdw/fdw-create-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { snakeCase } from 'lodash'
 import { useS3AccessKeyCreateMutation } from './s3-access-key-create-mutation'
 
 export const useIcebergWrapperCreateMutation = () => {
@@ -22,15 +21,13 @@ export const useIcebergWrapperCreateMutation = () => {
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: project?.ref })
   const protocol = settings?.app_config?.protocol ?? 'https'
-  const endpoint = settings?.app_config?.endpoint
+  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
 
   const apiKey = secretKey?.api_key ?? serviceKey?.api_key ?? 'SUPABASE_CLIENT_API_KEY'
 
   const wrapperMeta = WRAPPERS.find((wrapper) => wrapper.name === 'iceberg_wrapper')
 
   const canCreateCredentials = useCheckPermissions(PermissionAction.STORAGE_ADMIN_WRITE, '*')
-
-  const { data: config } = useProjectStorageConfigQuery({ projectRef: project?.ref })
 
   const { mutateAsync: createS3AccessKey, isLoading: isCreatingS3AccessKey } =
     useS3AccessKeyCreateMutation()

--- a/apps/studio/pages/api/platform/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/settings.ts
@@ -30,6 +30,7 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     app_config: {
       db_schema: 'public',
       endpoint: PROJECT_ENDPOINT,
+      storage_endpoint: PROJECT_ENDPOINT,
       // manually added to force the frontend to use the correct URL
       protocol: PROJECT_ENDPOINT_PROTOCOL,
     },

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -7227,6 +7227,7 @@ export interface components {
       app_config?: {
         db_schema: string
         endpoint: string
+        storage_endpoint: string
       }
       cloud_provider: string
       db_dns_name: string


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES


## What is the current behavior?

The project url is displayed on the S3 settings page, but it should show the new storage host name

## What is the new behavior?

Display `storage_endpoint` instead of `endpoint` if it is provided by the API.

## Additional context

This change depends on an update to the platform API to work correctly, but should fallback gracefully to the old behavior until the value of `storage_endpoint` is populated.
