### PR TITLE
fix(studio): add validation for missing column type on save

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -274,7 +274,11 @@ const ColumnType = ({
       </Popover_Shadcn_>
 
       {/* This line displays the error message */}
-      {error && <p className="text-red-900 transition-all data-show:mt-2 data-show:animate-slide-down-normal data-hide:animate-slide-up-normal text-sm">{error}</p>}
+      {error && (
+        <p className="text-red-900 transition-all data-show:mt-2 data-show:animate-slide-down-normal data-hide:animate-slide-up-normal text-sm">
+          {error}
+        </p>
+      )}
 
       {showRecommendation && recommendation !== undefined && (
         <Alert_Shadcn_ variant="warning" className="mt-2">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -60,6 +60,7 @@ const ColumnType = ({
   value,
   className,
   enumTypes = [],
+  error,
   disabled = false,
   showLabel = true,
   layout = 'horizontal',
@@ -272,6 +273,9 @@ const ColumnType = ({
         </PopoverContent_Shadcn_>
       </Popover_Shadcn_>
 
+      {/* This line displays the error message */}
+      {error && <p className="text-red-900 transition-all data-show:mt-2 data-show:animate-slide-down-normal data-hide:animate-slide-up-normal text-sm">{error}</p>}
+
       {showRecommendation && recommendation !== undefined && (
         <Alert_Shadcn_ variant="warning" className="mt-2">
           <CriticalIcon />
@@ -300,6 +304,8 @@ const ColumnType = ({
           </AlertDescription_Shadcn_>
         </Alert_Shadcn_>
       )}
+
+      {description && <p className="text-sm text-foreground-lighter">{description}</p>}
     </div>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #30556

Currently, in the Table Editor, if a user tries to create a new column and clicks 'Save' without selecting a data type, the UI does not provide any feedback or error message. The save action fails silently, which can be confusing for the user.

## What is the new behavior?

This change adds client-side validation to the column editor. When a user now clicks 'Save' without selecting a column type, the submission is prevented and an error message, "Please select a type for your column," is displayed directly below the 'Type' input field. This provides clear and immediate feedback.

## Implementation Details

To achieve this, the following changes were made to the ColumnType.tsx component:

    A new optional error prop was added to the ColumnTypeProps interface to accept and display a validation message from the parent form.

    Conditional rendering logic was added to display the error prop's content in a styled paragraph tag directly below the Popover component for the type selector.

This approach ensures the ColumnType component can display form-level errors passed down to it, making it more reusable and integrated with our form validation strategy.

## Additional context

Before

Clicking "Save" with no type selected results in no user feedback.

<img width="1916" height="948" alt="Screenshot_20250727_013622" src="https://github.com/user-attachments/assets/f5804866-bab5-446a-9c40-6cbb249c0ac8" />

After

An error message is now clearly displayed, guiding the user.

<img width="1915" height="938" alt="Screenshot_20250727_135322" src="https://github.com/user-attachments/assets/aec6e670-8f86-4f44-89d2-eae2d4cba231" />

