### PR TITLE
feat: Display OAuth client secret last used time

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthSecrets/SecretRow.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthSecrets/SecretRow.tsx
@@ -74,6 +74,14 @@ export const SecretRow = ({ secret, appId }: SecretRowProps) => {
               <p className="text-sm text-foreground-lighter">
                 Added {isNew ? 'now' : dayjs(secret.created_at).fromNow()} by {generatedByName}
               </p>
+              {secret.last_used_at && (
+                <p className="text-sm text-foreground-lighter">
+                  Last used {dayjs(secret.last_used_at).fromNow()}
+                </p>
+              )}
+              {!secret.last_used_at && !isNew && (
+                <p className="text-sm text-foreground-lighter">Never used</p>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Add display of last_used_at timestamp for OAuth client secrets in Studio. Shows relative time (e.g., "Last used 2 hours ago") when available, or "Never used" for unused secrets.

<img width="679" height="693" alt="Screenshot 2025-07-28 at 14 47 03" src="https://github.com/user-attachments/assets/f811e445-a657-4f31-93c9-063db3a49e3e" />
