### PR TITLE
Add Emmett to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -41,6 +41,7 @@ Divit D
 Eduardo Gurgel
 Egor Romanov
 Eleftheria Trivyzaki
+Emmett Folger
 Etienne Stalmans
 Fabrizio Fenoglio
 Felipe Stival


### PR DESCRIPTION
This adds my name to the humans.txt file

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a single line with my name to humans.txt

## What is the current behavior?

I am not on the list :(

## What is the new behavior?

I am on the list :)
