### PR TITLE
Consolidate oauth apps perms descriptions, and make project perms clearer

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails.tsx
@@ -1,6 +1,8 @@
 import { OAuthScope } from '@supabase/shared-types/out/constants'
 import { Check } from 'lucide-react'
 
+import { PERMISSIONS_DESCRIPTIONS } from './OAuthApps.constants'
+
 export interface AuthorizeRequesterDetailsProps {
   icon: string | null
   name: string
@@ -48,7 +50,7 @@ export const ScopeSection = ({
   return null
 }
 
-const AuthorizeRequesterDetails = ({
+export const AuthorizeRequesterDetails = ({
   icon,
   name,
   domain,
@@ -79,57 +81,57 @@ const AuthorizeRequesterDetails = ({
         </p>
         <div className="pt-2">
           <ScopeSection
-            description="access to analytics logs."
+            description={PERMISSIONS_DESCRIPTIONS.ANALYTICS}
             hasReadScope={scopes.includes(OAuthScope.ANALYTICS_READ)}
             hasWriteScope={scopes.includes(OAuthScope.ANALYTICS_WRITE)}
           />
           <ScopeSection
-            description="access to auth configurations and SSO providers."
+            description={PERMISSIONS_DESCRIPTIONS.AUTH}
             hasReadScope={scopes.includes(OAuthScope.AUTH_READ)}
             hasWriteScope={scopes.includes(OAuthScope.AUTH_WRITE)}
           />
           <ScopeSection
-            description="access to Postgres configurations, SQL snippets, SSL enforcement configurations and Typescript schema types."
+            description={PERMISSIONS_DESCRIPTIONS.DATABASE}
             hasReadScope={scopes.includes(OAuthScope.DATABASE_READ)}
             hasWriteScope={scopes.includes(OAuthScope.DATABASE_WRITE)}
           />
           <ScopeSection
-            description="access to custom domains and vanity subdomains."
+            description={PERMISSIONS_DESCRIPTIONS.DOMAINS}
             hasReadScope={scopes.includes(OAuthScope.DOMAINS_READ)}
             hasWriteScope={scopes.includes(OAuthScope.DOMAINS_WRITE)}
           />
           <ScopeSection
-            description="access to edge functions."
+            description={PERMISSIONS_DESCRIPTIONS.EDGE_FUNCTIONS}
             hasReadScope={scopes.includes(OAuthScope.EDGE_FUNCTIONS_READ)}
             hasWriteScope={scopes.includes(OAuthScope.EDGE_FUNCTIONS_WRITE)}
           />
           <ScopeSection
-            description="access to environments/branches."
+            description={PERMISSIONS_DESCRIPTIONS.ENVIRONMENT}
             hasReadScope={scopes.includes(OAuthScope.ENVIRONMENT_READ)}
             hasWriteScope={scopes.includes(OAuthScope.ENVIRONMENT_WRITE)}
           />
           <ScopeSection
-            description="access to the organization and all its members."
+            description={PERMISSIONS_DESCRIPTIONS.ORGANIZATIONS}
             hasReadScope={scopes.includes(OAuthScope.ORGANIZATIONS_READ)}
             hasWriteScope={scopes.includes(OAuthScope.ORGANIZATIONS_WRITE)}
           />
           <ScopeSection
-            description="access to metadata, its upgrade status, network restrictions and network bans."
+            description={PERMISSIONS_DESCRIPTIONS.PROJECTS}
             hasReadScope={scopes.includes(OAuthScope.PROJECTS_READ)}
             hasWriteScope={scopes.includes(OAuthScope.PROJECTS_WRITE)}
           />
           <ScopeSection
-            description="access to PostgREST configurations."
+            description={PERMISSIONS_DESCRIPTIONS.REST}
             hasReadScope={scopes.includes(OAuthScope.REST_READ)}
             hasWriteScope={scopes.includes(OAuthScope.REST_WRITE)}
           />
           <ScopeSection
-            description="access to API keys, secrets and pgsodium configurations."
+            description={PERMISSIONS_DESCRIPTIONS.SECRETS}
             hasReadScope={scopes.includes(OAuthScope.SECRETS_READ)}
             hasWriteScope={scopes.includes(OAuthScope.SECRETS_WRITE)}
           />
           <ScopeSection
-            description="access to storage buckets and files."
+            description={PERMISSIONS_DESCRIPTIONS.STORAGE}
             hasReadScope={scopes.includes(OAuthScope.STORAGE_READ)}
             hasWriteScope={scopes.includes(OAuthScope.STORAGE_WRITE)}
           />
@@ -138,5 +140,3 @@ const AuthorizeRequesterDetails = ({
     </div>
   )
 }
-
-export default AuthorizeRequesterDetails

--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts
@@ -1,0 +1,15 @@
+export const PERMISSIONS_DESCRIPTIONS = {
+  ANALYTICS: 'access to analytics logs.',
+  AUTH: 'access to auth configurations and SSO providers.',
+  DATABASE:
+    'access to Postgres configurations, SQL snippets, SSL enforcement configurations and Typescript schema types.',
+  DOMAINS: 'access to custom domains and vanity subdomains.',
+  EDGE_FUNCTIONS: 'access to edge functions.',
+  ENVIRONMENT: 'access to environments/branches.',
+  ORGANIZATIONS: 'access to the organization and all its members.',
+  PROJECTS:
+    "access to creation and deletion of projects, each project's metadata, upgrade status, network restrictions and network bans.",
+  REST: 'access to PostgREST configurations.',
+  SECRETS: 'access to API keys, secrets and pgsodium configurations.',
+  STORAGE: 'access to storage buckets and files.',
+}

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'ui'
+import { PERMISSIONS_DESCRIPTIONS } from '../OAuthApps.constants'
 
 const ScopeDropdownCheckboxItem = ({
   children,
@@ -66,12 +67,12 @@ const Scope = ({
 
   return (
     <div
-      className="flex flex-row justify-between p-4 border first:rounded-t last:rounded-b"
+      className="flex flex-row justify-between p-4 border first:rounded-t last:rounded-b gap-x-2"
       key={title}
     >
       <div className="flex flex-col">
         <span className="text-foreground text-sm">{title}</span>
-        <span className="text-foreground-light text-xs">{description}</span>
+        <span className="text-foreground-light text-xs capitalize-sentence">{description}</span>
       </div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -109,7 +110,7 @@ export const ScopesPanel = ({
     <div className="-space-y-px">
       <Scope
         title="Analytics"
-        description="Analytics logs."
+        description={PERMISSIONS_DESCRIPTIONS.ANALYTICS}
         readScopeName={OAuthScope.ANALYTICS_READ}
         writeScopeName={OAuthScope.ANALYTICS_WRITE}
         scopes={scopes}
@@ -117,7 +118,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Auth"
-        description="Auth configurations and SSO providers."
+        description={PERMISSIONS_DESCRIPTIONS.AUTH}
         readScopeName={OAuthScope.AUTH_READ}
         writeScopeName={OAuthScope.AUTH_WRITE}
         scopes={scopes}
@@ -125,7 +126,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Database"
-        description="Postgres configurations, SQL snippets, SSL enforcement configurations and Typescript schema types."
+        description={PERMISSIONS_DESCRIPTIONS.DATABASE}
         readScopeName={OAuthScope.DATABASE_READ}
         writeScopeName={OAuthScope.DATABASE_WRITE}
         scopes={scopes}
@@ -133,7 +134,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Domains"
-        description="Custom domains and vanity subdomains."
+        description={PERMISSIONS_DESCRIPTIONS.DOMAINS}
         readScopeName={OAuthScope.DOMAINS_READ}
         writeScopeName={OAuthScope.DOMAINS_WRITE}
         scopes={scopes}
@@ -141,7 +142,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Edge Functions"
-        description="Edge functions."
+        description={PERMISSIONS_DESCRIPTIONS.EDGE_FUNCTIONS}
         readScopeName={OAuthScope.EDGE_FUNCTIONS_READ}
         writeScopeName={OAuthScope.EDGE_FUNCTIONS_WRITE}
         scopes={scopes}
@@ -149,7 +150,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Environment"
-        description="Environments/branches."
+        description={PERMISSIONS_DESCRIPTIONS.ENVIRONMENT}
         readScopeName={OAuthScope.ENVIRONMENT_READ}
         writeScopeName={OAuthScope.ENVIRONMENT_WRITE}
         scopes={scopes}
@@ -157,7 +158,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Organizations"
-        description="Organizations and all its members."
+        description={PERMISSIONS_DESCRIPTIONS.ORGANIZATIONS}
         readScopeName={OAuthScope.ORGANIZATIONS_READ}
         writeScopeName={OAuthScope.ORGANIZATIONS_WRITE}
         scopes={scopes}
@@ -165,7 +166,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Projects"
-        description="Metadata, upgrade status, network restrictions and network bans."
+        description={PERMISSIONS_DESCRIPTIONS.PROJECTS}
         readScopeName={OAuthScope.PROJECTS_READ}
         writeScopeName={OAuthScope.PROJECTS_WRITE}
         scopes={scopes}
@@ -173,7 +174,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="REST"
-        description="PostgREST configurations."
+        description={PERMISSIONS_DESCRIPTIONS.REST}
         readScopeName={OAuthScope.REST_READ}
         writeScopeName={OAuthScope.REST_WRITE}
         scopes={scopes}
@@ -181,7 +182,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Secrets"
-        description="API keys, secrets and pgsodium configurations."
+        description={PERMISSIONS_DESCRIPTIONS.SECRETS}
         readScopeName={OAuthScope.SECRETS_READ}
         writeScopeName={OAuthScope.SECRETS_WRITE}
         scopes={scopes}
@@ -189,7 +190,7 @@ export const ScopesPanel = ({
       />
       <Scope
         title="Storage"
-        description="Storage buckets and files."
+        description={PERMISSIONS_DESCRIPTIONS.STORAGE}
         readScopeName={OAuthScope.STORAGE_READ}
         writeScopeName={OAuthScope.STORAGE_WRITE}
         scopes={scopes}

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -26,7 +26,7 @@ import {
   SidePanel,
   cn,
 } from 'ui'
-import AuthorizeRequesterDetails from '../AuthorizeRequesterDetails'
+import { AuthorizeRequesterDetails } from '../AuthorizeRequesterDetails'
 import { OAuthSecrets } from '../OAuthSecrets/OAuthSecrets'
 import { ScopesPanel } from './Scopes'
 

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -1,10 +1,10 @@
 import { OAuthScope } from '@supabase/shared-types/out/constants'
+import { useQueryClient } from '@tanstack/react-query'
 import { CheckCircle2, ChevronRight, ChevronsLeftRight } from 'lucide-react'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
-import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { useApiAuthorizationApproveMutation } from 'data/api-authorization/api-authorization-approve-mutation'
 import { ApiAuthorizationResponse } from 'data/api-authorization/api-authorization-query'
@@ -22,6 +22,7 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { ScopeSection } from '../OAuthApps/AuthorizeRequesterDetails'
+import { PERMISSIONS_DESCRIPTIONS } from '../OAuthApps/OAuthApps.constants'
 import { ProjectClaimLayout } from './layout'
 
 export const ProjectClaimConfirm = ({
@@ -188,57 +189,57 @@ export const ProjectClaimConfirm = ({
               >
                 <div>
                   <ScopeSection
-                    description="access to analytics logs."
+                    description={PERMISSIONS_DESCRIPTIONS.ANALYTICS}
                     hasReadScope={requester.scopes.includes(OAuthScope.ANALYTICS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.ANALYTICS_WRITE)}
                   />
                   <ScopeSection
-                    description="access to auth configurations and SSO providers."
+                    description={PERMISSIONS_DESCRIPTIONS.AUTH}
                     hasReadScope={requester.scopes.includes(OAuthScope.AUTH_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.AUTH_WRITE)}
                   />
                   <ScopeSection
-                    description="access to Postgres configurations, SQL snippets, SSL enforcement configurations and Typescript schema types."
+                    description={PERMISSIONS_DESCRIPTIONS.DATABASE}
                     hasReadScope={requester.scopes.includes(OAuthScope.DATABASE_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.DATABASE_WRITE)}
                   />
                   <ScopeSection
-                    description="access to custom domains and vanity subdomains."
+                    description={PERMISSIONS_DESCRIPTIONS.DOMAINS}
                     hasReadScope={requester.scopes.includes(OAuthScope.DOMAINS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.DOMAINS_WRITE)}
                   />
                   <ScopeSection
-                    description="access to edge functions."
+                    description={PERMISSIONS_DESCRIPTIONS.EDGE_FUNCTIONS}
                     hasReadScope={requester.scopes.includes(OAuthScope.EDGE_FUNCTIONS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.EDGE_FUNCTIONS_WRITE)}
                   />
                   <ScopeSection
-                    description="access to environments/branches."
+                    description={PERMISSIONS_DESCRIPTIONS.ENVIRONMENT}
                     hasReadScope={requester.scopes.includes(OAuthScope.ENVIRONMENT_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.ENVIRONMENT_WRITE)}
                   />
                   <ScopeSection
-                    description="access to the organization and all its members."
+                    description={PERMISSIONS_DESCRIPTIONS.ORGANIZATIONS}
                     hasReadScope={requester.scopes.includes(OAuthScope.ORGANIZATIONS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.ORGANIZATIONS_WRITE)}
                   />
                   <ScopeSection
-                    description="access to metadata, its upgrade status, network restrictions and network bans."
+                    description={PERMISSIONS_DESCRIPTIONS.PROJECTS}
                     hasReadScope={requester.scopes.includes(OAuthScope.PROJECTS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.PROJECTS_WRITE)}
                   />
                   <ScopeSection
-                    description="access to PostgREST configurations."
+                    description={PERMISSIONS_DESCRIPTIONS.REST}
                     hasReadScope={requester.scopes.includes(OAuthScope.REST_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.REST_WRITE)}
                   />
                   <ScopeSection
-                    description="access to API keys, secrets and pgsodium configurations."
+                    description={PERMISSIONS_DESCRIPTIONS.SECRETS}
                     hasReadScope={requester.scopes.includes(OAuthScope.SECRETS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.SECRETS_WRITE)}
                   />
                   <ScopeSection
-                    description="access to storage buckets and files."
+                    description={PERMISSIONS_DESCRIPTIONS.STORAGE}
                     hasReadScope={requester.scopes.includes(OAuthScope.STORAGE_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.STORAGE_WRITE)}
                   />

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
-import AuthorizeRequesterDetails from 'components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails'
+import { AuthorizeRequesterDetails } from 'components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails'
 import APIAuthorizationLayout from 'components/layouts/APIAuthorizationLayout'
 import { FormPanel } from 'components/ui/Forms/FormPanel'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'


### PR DESCRIPTION
## Context

Fixes FE-1725

This is related to OAuth Apps (from the organization settings page) - specifically the permissions for projects. It's not clear that giving write permissions also allows users to create and delete projects too, so this PR aims to make that clearer.

Am also consolidating the permission descriptions into a constants as this is used across a couple of files, and am also gonna use the same description in the side panel when creating a new OAuth App

## Before
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/74051b99-c7ca-49cd-bce7-d0bb007b7a49" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5593e387-428c-4627-ac3a-46c4a8d1aa6d" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/50d8ecc7-c7f5-4ddc-ae8e-0d1b66db5e5d" />


## After
<img width="500" alt="image" src="https://github.com/user-attachments/assets/21db7022-0607-4ca5-be0c-cc16ac24a91f" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5b11a300-e01f-4ead-b339-e3fefd8f3efb" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/543cdebb-8df7-47f3-89b1-de3e2920efbe" />


## Changes involved
- Consolidate OAuth Apps permissions description into a constants
  - Used by `AuthorizeRequesterDetails.tsx` and `confirm.tsx`
- Have `Scopes.tsx` also use the same permissions descriptions for consistency