### PR TITLE
fix(studio): empty team drop downs

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -27,6 +27,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'ui'
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { LeaveTeamButton } from './LeaveTeamButton'
 import { useGetRolesManagementPermissions } from './TeamSettings.utils'
@@ -190,60 +191,50 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
             <>
               {isPendingInviteAcceptance ? (
                 <>
-                  {canRevokeInvite ? (
-                    <DropdownMenuItem onClick={() => handleRevokeInvitation(member)}>
-                      <div className="flex flex-col">
-                        <p>Cancel invitation</p>
-                        <p className="text-foreground-lighter">Revoke this invitation.</p>
-                      </div>
-                    </DropdownMenuItem>
-                  ) : (
-                    <DropdownMenuItem disabled>
-                      <div className="flex flex-col">
-                        <p>Cancel invitation</p>
-                        <p className="text-foreground-lighter">Additional permissions required</p>
-                      </div>
-                    </DropdownMenuItem>
-                  )}
-                  {canResendInvite ? (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={() => handleResendInvite(member)}>
-                        <div className="flex flex-col">
-                          <p>Resend invitation</p>
-                          <p className="text-foreground-lighter">Invites expire after 24hrs.</p>
-                        </div>
-                      </DropdownMenuItem>
-                    </>
-                  ) : (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem disabled>
-                        <div className="flex flex-col">
-                          <p>Resend invitation</p>
-                          <p className="text-foreground-lighter">Additional permissions required</p>
-                        </div>
-                      </DropdownMenuItem>
-                    </>
-                  )}
+                  <DropdownMenuItemTooltip
+                    className="gap-x-2"
+                    disabled={!canRevokeInvite}
+                    onClick={() => handleRevokeInvitation(member)}
+                    tooltip={{
+                      content: {
+                        side: 'left',
+                        text: 'Additional permissions required',
+                      },
+                    }}
+                  >
+                    <p>Cancel invitation</p>
+                  </DropdownMenuItemTooltip>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItemTooltip
+                    className="gap-x-2"
+                    disabled={!canResendInvite}
+                    onClick={() => handleResendInvite(member)}
+                    tooltip={{
+                      content: {
+                        side: 'left',
+                        text: 'Additional permissions required',
+                      },
+                    }}
+                  >
+                    <p>Resend invitation</p>
+                  </DropdownMenuItemTooltip>
                 </>
               ) : (
                 organizationMembersDeletionEnabled && (
-                  <DropdownMenuItem
-                    className="space-x-2 items-start"
+                  <DropdownMenuItemTooltip
+                    className="gap-x-2"
                     disabled={!canRemoveMember}
-                    onClick={() => {
-                      setIsDeleteModalOpen(true)
+                    onClick={() => setIsDeleteModalOpen(true)}
+                    tooltip={{
+                      content: {
+                        side: 'left',
+                        text: 'Additional permissions required',
+                      },
                     }}
                   >
                     <Trash size={16} />
-                    <div className="flex flex-col">
-                      <p>Remove member</p>
-                      {!canRemoveMember && (
-                        <p className="text-foreground-lighter">Additional permissions required</p>
-                      )}
-                    </div>
-                  </DropdownMenuItem>
+                    <p>Remove member</p>
+                  </DropdownMenuItemTooltip>
                 )
               )}
             </>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 import { useOrganizationCreateInvitationMutation } from 'data/organization-members/organization-invitation-create-mutation'
 import { useOrganizationDeleteInvitationMutation } from 'data/organization-members/organization-invitation-delete-mutation'
 import { useOrganizationRolesV2Query } from 'data/organization-members/organization-roles-query'
@@ -23,11 +24,9 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'ui'
-import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { LeaveTeamButton } from './LeaveTeamButton'
 import { useGetRolesManagementPermissions } from './TeamSettings.utils'
@@ -198,7 +197,7 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
                     tooltip={{
                       content: {
                         side: 'left',
-                        text: 'Additional permissions required',
+                        text: 'Additional permissions required to cancel invitation',
                       },
                     }}
                   >
@@ -212,7 +211,7 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
                     tooltip={{
                       content: {
                         side: 'left',
-                        text: 'Additional permissions required',
+                        text: 'Additional permissions required to resend invitation',
                       },
                     }}
                   >
@@ -228,7 +227,7 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
                     tooltip={{
                       content: {
                         side: 'left',
-                        text: 'Additional permissions required',
+                        text: 'Additional permissions required to remove member',
                       },
                     }}
                   >

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -190,21 +190,38 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
             <>
               {isPendingInviteAcceptance ? (
                 <>
-                  {canRevokeInvite && (
+                  {canRevokeInvite ? (
                     <DropdownMenuItem onClick={() => handleRevokeInvitation(member)}>
                       <div className="flex flex-col">
                         <p>Cancel invitation</p>
                         <p className="text-foreground-lighter">Revoke this invitation.</p>
                       </div>
                     </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem disabled>
+                      <div className="flex flex-col">
+                        <p>Cancel invitation</p>
+                        <p className="text-foreground-lighter">Additional permissions required</p>
+                      </div>
+                    </DropdownMenuItem>
                   )}
-                  {canResendInvite && (
+                  {canResendInvite ? (
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem onClick={() => handleResendInvite(member)}>
                         <div className="flex flex-col">
                           <p>Resend invitation</p>
                           <p className="text-foreground-lighter">Invites expire after 24hrs.</p>
+                        </div>
+                      </DropdownMenuItem>
+                    </>
+                  ) : (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem disabled>
+                        <div className="flex flex-col">
+                          <p>Resend invitation</p>
+                          <p className="text-foreground-lighter">Additional permissions required</p>
                         </div>
                       </DropdownMenuItem>
                     </>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -18,7 +18,7 @@ import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useProfile } from 'lib/profile'
 import {
   Button,
@@ -43,7 +43,7 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const organizationMembersDeletionEnabled = useIsFeatureEnabled('organization_members:delete')
 
-  const selectedOrganization = useSelectedOrganization()
+  const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const { data: permissions } = usePermissionsQuery()
   const { data: allProjects } = useProjectsQuery()
   const { data: members } = useOrganizationMembersQuery({ slug })
@@ -186,7 +186,7 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
               icon={<MoreVertical />}
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent side="bottom" align="end" className="w-52">
+          <DropdownMenuContent side="bottom" align="end" className="w-40">
             <>
               {isPendingInviteAcceptance ? (
                 <>
@@ -231,7 +231,7 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
                       },
                     }}
                   >
-                    <Trash size={16} />
+                    <Trash size={12} />
                     <p>Remove member</p>
                   </DropdownMenuItemTooltip>
                 )


### PR DESCRIPTION
This fixes dropdowns returning empty on team invites when a user is signed in as a developer. For now it adds conditionals to show the option is not available for that role, but perhaps we can handle a little more gracefully.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This fixes a small UI bug within the Teams area member list, where users signed in with the `Developer` role see empty drop down menus on pending invites.

## What is the current behavior?

Current behaviour returns as follows:
<img width="1021" height="387" alt="Screenshot 2025-07-29 at 13 19 18" src="https://github.com/user-attachments/assets/dbd9a5df-cc2f-49b2-a0aa-b5d3aa646389" />


## What is the new behavior?

For the time being I've updated the conditional checks on `canRevokeInvite` and `canSendInvite` to be `if` statements. This ensures we handle it somewhat gracefully for now. An open question is, can the `Developer` role do anything with the dropdown menu anyway? Might be worth hiding it from their scope?

Updated behaviour is like so:
<img width="861" height="449" alt="Screenshot 2025-07-29 at 14 40 17" src="https://github.com/user-attachments/assets/b31e18a1-dc03-4838-88dc-5ed1289ac63f" />


## Additional context

Please let me know if this is taken care of in another PR, if so, feel free to close this! 




