### PR TITLE
docs: adjust pricing wording for log drains

### DIFF
--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -590,7 +590,7 @@ export const pricing: Pricing = {
           free: false,
           pro: false,
           team: [
-            '$60 per drain per month',
+            '$0.0822 per drain, per hour',
             '+ $0.20 per million events',
             '+ $0.09 per GB bandwidth',
           ],


### PR DESCRIPTION
This adjusts the log drains pricing wording to be clearer on how it is billed, which is per hour.
https://supabase.slack.com/archives/C08D303DC57/p1753810942453589?thread_ts=1753720546.522159&cid=C08D303DC57