### PR TITLE
feat: reference for the self referencing view error

### DIFF
--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -234,11 +234,12 @@ Common examples of check constraints that can result in such failures are:
 - validating against the current time, e.g. that the row being inserted references a future event
 - validating the contents of a row against the contents of another table
 
-#### Views that reference themselves
+#### Views that Reference Themselves
 
 Views that directly or indirectly reference themselves can cause **cyclic dependency errors** during a logical backup restore. These views are also **invalid and unusable** , any query against them will result in an error at runtime.
 
 **Example:**
+
 ```
 -- Direct self-reference
 CREATE VIEW my_view AS

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -236,7 +236,7 @@ Common examples of check constraints that can result in such failures are:
 
 #### Views that reference themselves
 
-Views that directly or indirectly reference themselves can cause **cyclic dependency errors** during a logical backup restore. These views are also **invalid and unusable** , any query against them will result in an error at runtime.
+Views that directly or indirectly reference themselves will cause logical restores to fail due to cyclic dependency errors. These views are also invalid and unusable in Postgres, and any query against them will result in a runtime error.
 
 **Example:**
 

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -239,7 +239,7 @@ Common examples of check constraints that can result in such failures are:
 Views that directly or indirectly reference themselves can cause **cyclic dependency errors** during a logical backup restore. These views are also **invalid and unusable** , any query against them will result in an error at runtime.
 
 **Example:**
-```sql
+```
 -- Direct self-reference
 CREATE VIEW my_view AS
   SELECT * FROM my_view;
@@ -247,5 +247,8 @@ CREATE VIEW my_view AS
 -- Indirect circular reference
 CREATE VIEW v1 AS SELECT * FROM v2;
 CREATE VIEW v2 AS SELECT * FROM v1;
+```
+
+-- Drop the ofending view
 
 Postgres documentation [views](https://www.postgresql.org/docs/current/sql-createview.html)

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -249,6 +249,6 @@ CREATE VIEW v1 AS SELECT * FROM v2;
 CREATE VIEW v2 AS SELECT * FROM v1;
 ```
 
--- Drop the ofending view
+-- Drop the offending view.
 
 Postgres documentation [views](https://www.postgresql.org/docs/current/sql-createview.html)

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -234,7 +234,7 @@ Common examples of check constraints that can result in such failures are:
 - validating against the current time, e.g. that the row being inserted references a future event
 - validating the contents of a row against the contents of another table
 
-#### Views that Reference Themselves
+#### Views that reference Themselves
 
 Views that directly or indirectly reference themselves can cause **cyclic dependency errors** during a logical backup restore. These views are also **invalid and unusable** , any query against them will result in an error at runtime.
 

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -250,6 +250,6 @@ CREATE VIEW v1 AS SELECT * FROM v2;
 CREATE VIEW v2 AS SELECT * FROM v1;
 ```
 
--- Drop the offending view.
+-- Drop the offending view from your database, or delete them from the logical backup to make it restorable.
 
 Postgres documentation [views](https://www.postgresql.org/docs/current/sql-createview.html)

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -234,7 +234,7 @@ Common examples of check constraints that can result in such failures are:
 - validating against the current time, e.g. that the row being inserted references a future event
 - validating the contents of a row against the contents of another table
 
-#### Views that reference Themselves
+#### Views that reference themselves
 
 Views that directly or indirectly reference themselves can cause **cyclic dependency errors** during a logical backup restore. These views are also **invalid and unusable** , any query against them will result in an error at runtime.
 

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -233,3 +233,19 @@ Common examples of check constraints that can result in such failures are:
 
 - validating against the current time, e.g. that the row being inserted references a future event
 - validating the contents of a row against the contents of another table
+
+#### Views that Reference Themselves
+
+Views that directly or indirectly reference themselves can cause **cyclic dependency errors** during a logical backup restore. These views are also **invalid and unusable** , any query against them will result in an error at runtime.
+
+**Example:**
+```sql
+-- Direct self-reference
+CREATE VIEW my_view AS
+  SELECT * FROM my_view;
+
+-- Indirect circular reference
+CREATE VIEW v1 AS SELECT * FROM v2;
+CREATE VIEW v2 AS SELECT * FROM v1;
+
+Postgres documentation [views](https://www.postgresql.org/docs/current/sql-createview.html)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
Yes

## What kind of change does this PR introduce?
Documentation update

## What is the current behavior?
The backups guide mentions invalid-check-constraints errors during logical restores but doesn’t cover other common causes, such as views that reference themselves.

## What is the new behavior?
Adds a new subsection under [Backups > Invalid Check Constraints](https://supabase.com/docs/guides/platform/backups#invalid-check-constraints) explaining how self-referencing views can cause restore failures when using logical backups. Includes examples and a link to the official PostgreSQL documentation.

## Additional context
This update helps users troubleshoot and resolve restore issues related to broken view definitions, especially in customer support situations where users encounter errors from invalid or cyclic view references.
https://linear.app/supabase/issue/INDATA-35/add-a-comment-in-the-supabasedoc-or-view-pointing-to-itself