### PR TITLE
Fix cron panel if unable to parse command

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
@@ -1,21 +1,21 @@
-import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, Badge, Toggle } from 'ui'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { X } from 'lucide-react'
 import { toast } from 'sonner'
+import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, Badge, Toggle } from 'ui'
 
 import { useConsentState } from 'common'
+import { LOCAL_STORAGE_KEYS } from 'common/constants/local-storage'
 import Panel from 'components/ui/Panel'
 import { useSendResetMutation } from 'data/telemetry/send-reset-mutation'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
-import { LOCAL_STORAGE_KEYS } from 'common/constants/local-storage'
 
 export const TermsUpdateBanner = () => {
-  const [termsUpdateAcknowledged, setTermsUpdateAcknowledged] = useLocalStorageQuery(
+  const [termsUpdateAcknowledged, setTermsUpdateAcknowledged, { isSuccess }] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.TERMS_OF_SERVICE_ACKNOWLEDGED,
     false
   )
 
-  if (termsUpdateAcknowledged) return null
+  if (!isSuccess || termsUpdateAcknowledged) return null
 
   return (
     <Alert_Shadcn_ className="mb-4 relative">

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -237,6 +237,8 @@ export const CreateCronJobSheet = ({
   })
 
   const isEdited = form.formState.isDirty
+  // if the form hasn't been touched and the user clicked esc or the backdrop, close the sheet
+  if (!isEdited && isClosing) onClose()
 
   const onClosePanel = () => {
     if (isEdited) {
@@ -270,11 +272,6 @@ export const CreateCronJobSheet = ({
       'values.functionName',
     ],
   })
-
-  useEffect(() => {
-    // if the form hasn't been touched and the user clicked esc or the backdrop, close the sheet
-    if (isClosing && !isEdited) onClose()
-  }, [isClosing, isEdited, onClose])
 
   // update the snippet field when the user changes the any values in the form
   useEffect(() => {

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -226,17 +226,13 @@ export const CreateCronJobSheet = ({
 
   const cronJobValues = parseCronJobCommand(selectedCronJob?.command || '', project?.ref!)
 
-  // [Joshen] Keeping the var name here generic, in case there's other cases that might fail parsing
-  const unableToParseCronJob =
-    cronJobValues.type === 'http_request' && cronJobValues.endpoint === ''
-
   const form = useForm<CreateCronJobForm>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       name: selectedCronJob?.jobname || '',
       schedule: selectedCronJob?.schedule || '*/5 * * * *',
       supportsSeconds,
-      values: { ...cronJobValues, type: unableToParseCronJob ? 'sql_snippet' : cronJobValues.type },
+      values: cronJobValues,
     },
   })
 
@@ -279,13 +275,6 @@ export const CreateCronJobSheet = ({
     // if the form hasn't been touched and the user clicked esc or the backdrop, close the sheet
     if (isClosing && !isEdited) onClose()
   }, [isClosing, isEdited, onClose])
-
-  useEffect(() => {
-    if (cronType === 'sql_snippet' && unableToParseCronJob && selectedCronJob?.command) {
-      form.setValue('values.snippet', selectedCronJob.command)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEdited, cronType])
 
   // update the snippet field when the user changes the any values in the form
   useEffect(() => {

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -30,12 +30,10 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a sql function command when the command is SELECT public.test_fn(1, 2)', () => {
+  it('should return a sql snippet command when the command is SELECT public.test_fn(1, 2)', () => {
     const command = 'SELECT public.test_fn(1, 2)'
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
-      type: 'sql_function',
-      schema: 'public',
-      functionName: 'test_fn',
+      type: 'sql_snippet',
       snippet: command,
     })
   })
@@ -190,6 +188,14 @@ describe('parseCronJobCommand', () => {
       httpBody: '{"key": "value"}',
       timeoutMs: 5000,
       type: 'http_request',
+      snippet: command,
+    })
+  })
+
+  it('should return SQL snippet type if the command is a HTTP request that cannot be parsed properly due to positional notationa', () => {
+    const command = `SELECT net.http_post( 'https://webhook.site/dacc2028-a588-462c-9597-c8968e61d0fa', '{"message":"Hello from Supabase"}'::jsonb, '{}'::jsonb, '{"Content-Type":"application/json"}'::jsonb );`
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      type: 'sql_snippet',
       snippet: command,
     })
   })

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -30,6 +30,16 @@ describe('parseCronJobCommand', () => {
     })
   })
 
+  it('should return a sql function command when the command is SELECT auth.jwt () and ends with ;', () => {
+    const command = 'SELECT auth.jwt ();'
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      type: 'sql_function',
+      schema: 'auth',
+      functionName: 'jwt',
+      snippet: command,
+    })
+  })
+
   it('should return a sql snippet command when the command is SELECT public.test_fn(1, 2)', () => {
     const command = 'SELECT public.test_fn(1, 2)'
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -44,8 +44,9 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
     .replaceAll(/\n/g, ' ')
     .replaceAll(/\s+/g, ' ')
     .trim()
+    .toLocaleLowerCase()
 
-  if (command.toLocaleLowerCase().startsWith('select net.')) {
+  if (command.startsWith('select net.')) {
     const methodMatch = command.match(/select net\.([^']+)\(\s*url:=/i)
     const method = methodMatch?.[1] || ''
 
@@ -73,7 +74,7 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
       }
     } else {
       const headersStringMatch = command.match(/headers:='([^']*)'/i)
-      const headersString = headersStringMatch?.[1] || ''
+      const headersString = headersStringMatch?.[1] || '{}'
       try {
         const parsedHeaders = JSON.parse(headersString)
         headersObjs = Object.entries(parsedHeaders).map(([name, value]) => ({

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -125,7 +125,7 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
   }
 
   const regexDBFunction = /select\s+[a-zA-Z-_]*\.?[a-zA-Z-_]*\s*\(.+/g
-  if (command.toLocaleLowerCase().match(regexDBFunction)) {
+  if (command.match(regexDBFunction)) {
     const [schemaName, functionName] = command
       .replace('SELECT ', '')
       .replace(/\(.*\)/, '')

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -129,7 +129,8 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
   if (command.toLocaleLowerCase().match(regexDBFunction)) {
     const [schemaName, functionName] = command
       .replace('SELECT ', '')
-      .replace(/\(.*\)/, '')
+      .replace(/\(.*\);*/, '')
+
       .trim()
       .split('.')
 

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -44,9 +44,8 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
     .replaceAll(/\n/g, ' ')
     .replaceAll(/\s+/g, ' ')
     .trim()
-    .toLocaleLowerCase()
 
-  if (command.startsWith('select net.')) {
+  if (command.toLocaleLowerCase().startsWith('select net.')) {
     const methodMatch = command.match(/select net\.([^']+)\(\s*url:=/i)
     const method = methodMatch?.[1] || ''
 
@@ -113,19 +112,21 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
       }
     }
 
-    return {
-      type: 'http_request',
-      method: method === 'http_get' ? 'GET' : 'POST',
-      endpoint: url,
-      httpHeaders: headersObjs,
-      httpBody: body,
-      timeoutMs: Number(timeout ?? 1000),
-      snippet: originalCommand,
+    if (url !== '') {
+      return {
+        type: 'http_request',
+        method: method === 'http_get' ? 'GET' : 'POST',
+        endpoint: url,
+        httpHeaders: headersObjs,
+        httpBody: body,
+        timeoutMs: Number(timeout ?? 1000),
+        snippet: originalCommand,
+      }
     }
   }
 
-  const regexDBFunction = /select\s+[a-zA-Z-_]*\.?[a-zA-Z-_]*\s*\(.+/g
-  if (command.match(regexDBFunction)) {
+  const regexDBFunction = /select\s+[a-zA-Z-_]*\.?[a-zA-Z-_]*\s*\(\)/g
+  if (command.toLocaleLowerCase().match(regexDBFunction)) {
     const [schemaName, functionName] = command
       .replace('SELECT ', '')
       .replace(/\(.*\)/, '')


### PR DESCRIPTION
## Context

There's a bug with the Cron Job editor when editing an existing cron job of the type "http_request" that was created outside of the cron job interface.

For cron jobs created via this interface (specifically http request types, the declaration of the SQL for the job's command is technically consistent / deterministic, as the dashboard calls the `net.http_xxx` function using named notation. For example:
<img width="410" height="155" alt="image" src="https://github.com/user-attachments/assets/d7630e51-c464-4fe0-983c-cbeeba0d4a9e" />
In this case, when editing such cron job, the dashboard extracts each parameter value through a series of regex [here](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts#L41) (`parseCronJobCommand`), and we're subsequently able to render those values in the side panel editor.

However, cron jobs can also be created through direct SQL (e.g via the SQL editor), in which users may call the `net.http_xxx` function using positional notation (our pg net [docs](https://github.com/supabase/pg_net?tab=readme-ov-file#requests-api) also show examples with this notation) - in which case `parseCronJobCommand` will not be able to extract the parameters since it relies on the `net.http_xxx` call declared with named notation (and hence the side panel will not have any values when editing that cron job through the UI). For example:
<img width="906" height="177" alt="image" src="https://github.com/user-attachments/assets/16f64172-6494-46d2-818c-b95964bedc97" />

## Changes involved

Since we shouldn't be expecting users to declare cron jobs a specific way, and its way too broad to be writing regex for positional notation, am opting to default back to "sql snippet" type if we derive that the cron job is of type "http_request" + we're unable to extract any information from the command. (and only doing this in this specific scenario)

## To test
- Create a cron job through the SQL editor using positional notation, e.g:
```
SELECT net.http_post(  
  'https://webhook.site/dacc2028-a588-462c-9597-c8968e61d0fa',
  '{"message":"Hello from Supabase"}'::jsonb,
  '{}'::jsonb,
  '{"Content-Type":"application/json"}'::jsonb
);
```
- Edit that cron job via the cron job interface, and verify the default type is SQL snippet, and the cron command is rendered correctly
- Verify as well that editing cron jobs created through the cron job UI are all still okay as well (http, edge function, etc)