### PR TITLE
fix: clean up storage connection url logic

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/SimpleConfigurationDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/SimpleConfigurationDetails.tsx
@@ -20,20 +20,16 @@ const wrapperMeta = {
 
 export const SimpleConfigurationDetails = ({ bucketName }: { bucketName: string }) => {
   const { project } = useProjectContext()
-
   const { data: apiKeys } = useAPIKeysQuery({ projectRef: project?.ref })
   const { data: settings } = useProjectSettingsV2Query({ projectRef: project?.ref })
-  const protocol = settings?.app_config?.protocol ?? 'https'
-  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
-
   const { serviceKey } = getKeys(apiKeys)
   const serviceApiKey = serviceKey?.api_key ?? 'SUPABASE_CLIENT_SERVICE_KEY'
 
   const values: Record<string, string> = {
     vault_token: serviceApiKey,
     warehouse: bucketName,
-    's3.endpoint': getConnectionURL(project?.ref ?? '', protocol, endpoint),
-    catalog_uri: getCatalogURI(project?.ref ?? '', protocol, endpoint),
+    's3.endpoint': getConnectionURL(project?.ref ?? '', settings),
+    catalog_uri: getCatalogURI(project?.ref ?? '', settings),
   }
 
   return (

--- a/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
@@ -79,10 +79,8 @@ export const S3Connection = () => {
     defaultValues: { s3ConnectionEnabled: false },
   })
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
-  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
   const hasStorageCreds = storageCreds?.data && storageCreds.data.length > 0
-  const s3connectionUrl = getConnectionURL(projectRef ?? '', protocol, endpoint)
+  const s3connectionUrl = getConnectionURL(projectRef ?? '', settings)
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (data) => {
     if (!projectRef) return console.error('Project ref is required')

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.utils.ts
@@ -1,3 +1,4 @@
+import { ProjectSettings } from 'data/config/project-settings-v2-query'
 import { StorageSizeUnits } from './StorageSettings.constants'
 
 const k = 1024
@@ -25,7 +26,9 @@ export const convertToBytes = (size: number, unit: StorageSizeUnits = StorageSiz
   return size * Math.pow(k, i)
 }
 
-function getStorageURL(projectRef: string, protocol: string, endpoint?: string) {
+function getStorageURL(projectRef: string, settings?: ProjectSettings) {
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
   const projUrl = endpoint
     ? `${protocol}://${endpoint}`
     : `https://${projectRef}.storage.supabase.co`
@@ -33,14 +36,14 @@ function getStorageURL(projectRef: string, protocol: string, endpoint?: string) 
   return url
 }
 
-export function getConnectionURL(projectRef: string, protocol: string, endpoint?: string) {
-  const url = getStorageURL(projectRef, protocol, endpoint)
+export function getConnectionURL(projectRef: string, settings?: ProjectSettings) {
+  const url = getStorageURL(projectRef, settings)
   url.pathname = '/storage/v1/s3'
   return url.toString()
 }
 
-export function getCatalogURI(projectRef: string, protocol: string, endpoint?: string) {
-  const url = getStorageURL(projectRef, protocol, endpoint)
+export function getCatalogURI(projectRef: string, settings?: ProjectSettings) {
+  const url = getStorageURL(projectRef, settings)
   url.pathname = '/storage/v1/iceberg'
   return url.toString()
 }

--- a/apps/studio/data/storage/iceberg-wrapper-create-mutation.ts
+++ b/apps/studio/data/storage/iceberg-wrapper-create-mutation.ts
@@ -20,8 +20,6 @@ export const useIcebergWrapperCreateMutation = () => {
   const { secretKey, serviceKey } = getKeys(apiKeys)
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: project?.ref })
-  const protocol = settings?.app_config?.protocol ?? 'https'
-  const endpoint = settings?.app_config?.storage_endpoint || settings?.app_config?.endpoint
 
   const apiKey = secretKey?.api_key ?? serviceKey?.api_key ?? 'SUPABASE_CLIENT_API_KEY'
 
@@ -53,8 +51,8 @@ export const useIcebergWrapperCreateMutation = () => {
         vault_aws_secret_access_key: createS3KeyData?.secret_key,
         vault_token: apiKey,
         warehouse: bucketName,
-        's3.endpoint': getConnectionURL(project?.ref ?? '', protocol, endpoint),
-        catalog_uri: getCatalogURI(project?.ref ?? '', protocol, endpoint),
+        's3.endpoint': getConnectionURL(project?.ref ?? '', settings),
+        catalog_uri: getCatalogURI(project?.ref ?? '', settings),
       },
       mode: 'skip',
       tables: [],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor `getConnectionURL()` and `getCatalogURI()` to take `ProjectSettings` object to unify the `protocol` and `endpoint` logic in one place.
