### PR TITLE
fix: add demo for custom metadata

### DIFF
--- a/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
@@ -57,6 +57,9 @@ Instead of `https://project-id.supabase.co` use `https://project-id.storage.supa
                     objectName: fileName,
                     contentType: 'image/png',
                     cacheControl: 3600,
+                    metadata: JSON.stringify({ // custom metadata passed to the user_metadata column
+                       yourCustomMetadata: true,
+                    }),
                 },
                 chunkSize: 6 * 1024 * 1024, // NOTE: it must be set to 6MB (for now) do not change it
                 onError: function (error) {
@@ -159,6 +162,7 @@ Instead of `https://project-id.supabase.co` use `https://project-id.storage.supa
                         "objectName",
                         "contentType",
                         "cacheControl",
+                        "metadata",
                     ], // Metadata fields allowed for the upload
                     onError: (error) => console.error("Upload error:", error), // Error handling for uploads
                 }).on("file-added", (file) => {
@@ -168,6 +172,9 @@ Instead of `https://project-id.supabase.co` use `https://project-id.storage.supa
                         bucketName, // Bucket specified by the user of the hook
                         objectName: file.name, // Use file name as object name
                         contentType: file.type, // Set content type based on file MIME type
+                        metadata: JSON.stringify({ // custom metadata passed to the user_metadata column
+                            yourCustomMetadata: true,
+                        }),
                     };
                 });
             };


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update re https://github.com/supabase/storage/issues/736, with thanks to @fenos !

## What is the current behavior?

Adding custom metadata is not documented in the resumable uploads examples.

## What is the new behavior?

Demonstrates how to pass custom metadata.

## Additional context

See https://github.com/supabase/storage/issues/736.
