### PR TITLE
Add troubleshooting section for Docker password issues

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -469,6 +469,24 @@ docker rm supabase-analytics
 
 ---
 
+### Troubleshooting: Docker fails after password changes
+
+If you’ve updated passwords (e.g. `POSTGRES_PASSWORD`) in your `.env` file, the containers may fail to restart or connect properly. This can happen due to persistent volumes or stale configs.
+
+To reset your setup cleanly:
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
+- `-v` removes volumes (like the Postgres data volume)
+- `--build` ensures services use the updated `.env` settings
+
+> ⚠️ **Warning:** This will delete local database volumes unless you’re using a persistent mount. Backup your data first!
+
+---
+
 ## Demo
 
 A minimal setup working on Ubuntu, hosted on DigitalOcean.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

No guidance currently exists for handling issues that arise when environment variables (like POSTGRES_PASSWORD) are changed. This may confuse users when Docker containers fail to restart properly due to persistent volumes or stale configurations.

## What is the new behavior?

Adds a new troubleshooting section in the docs that explains:
	•	Why Docker may fail after .env password changes.
	•	How to reset the environment cleanly using docker compose down -v and up --build.
	•	A warning about volume deletion and the need to back up data.

## Additional context

This update is meant to help users recover from common setup issues, especially after modifying sensitive values like database passwords in .env files.
