### PR TITLE
- Replace <p> tags with <span> where ShimmeringLoader

### DIFF
--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -141,13 +141,13 @@ const Home: NextPageWithLayout = () => {
                     >
                       Tables
                     </Link>
-                    <p className="text-2xl tabular-nums">
+                    <span className="text-2xl tabular-nums">
                       {isLoadingTables ? (
                         <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
                       ) : (
                         tablesCount
                       )}
-                    </p>
+                    </span>
                   </div>
 
                   {IS_PLATFORM && (
@@ -158,13 +158,13 @@ const Home: NextPageWithLayout = () => {
                       >
                         Functions
                       </Link>
-                      <p className="text-2xl tabular-nums">
+                      <span className="text-2xl tabular-nums">
                         {isLoadingFunctions ? (
                           <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
                         ) : (
                           functionsCount
                         )}
-                      </p>
+                      </span>
                     </div>
                   )}
 
@@ -176,13 +176,13 @@ const Home: NextPageWithLayout = () => {
                       >
                         Replicas
                       </Link>
-                      <p className="text-2xl tabular-nums">
+                      <span className="text-2xl tabular-nums">
                         {isLoadingReplicas ? (
                           <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
                         ) : (
                           replicasCount
                         )}
-                      </p>
+                      </span>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
- Fixes React validateDOMNesting warnings in browser console

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

React is throwing DOM nesting validation warnings in the browser console:
<img width="523" height="747" alt="image" src="https://github.com/user-attachments/assets/6deb7b5d-c6c6-49c0-b1bf-75dbca65f54a" />

## What is the new behavior?

Loading states continue to work as expected

## Additional context

1. Run pnpm dev:studio
2. Open browser dev tools console
3. Navigate to /project/default
4. Refresh page to trigger loading state 
5. Observer DOM nesting warnings in console