### PR TITLE
Fix wrapper create for those without foreign schema support

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -144,16 +144,16 @@ export const CreateWrapperSheet = ({
     }
 
     setFormErrors(errors)
-    if (!isEmpty(errors)) {
-      return
-    }
+    if (!isEmpty(errors)) return
 
     try {
-      await createSchema({
-        projectRef: project?.ref,
-        connectionString: project?.connectionString,
-        name: values.target_schema,
-      })
+      if (selectedMode === 'schema') {
+        await createSchema({
+          projectRef: project?.ref,
+          connectionString: project?.connectionString,
+          name: values.target_schema,
+        })
+      }
 
       await createFDW({
         projectRef: project?.ref,


### PR DESCRIPTION
## Context

Noticed that for wrappers with no support for foreign schema, we're also running the create schema mutation which we shouldnt'. This PR fixes that to only create schema if the selected mode is schema