### PR TITLE
Invalidate project upgrade eligibility query when disabling database extension

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -111,7 +111,7 @@ const ExtensionCard = ({ extension }: ExtensionCardProps) => {
 
         <div className={cn('flex h-full flex-col gap-y-3 py-3', X_PADDING)}>
           <p className="text-sm text-foreground-light capitalize-sentence">{extension.comment}</p>
-          <div className="flex items-center gap-x-2">
+          <div className="flex items-center gap-2 flex-wrap">
             {extensionMeta?.github_url && (
               <Button asChild type="default" icon={<Github />} className="rounded-full">
                 <a

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'common'
 import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, Button } from 'ui'
 
 export const ReadReplicasWarning = ({ latestPgVersion }: { latestPgVersion: string }) => {
@@ -59,6 +60,8 @@ export const UnsupportedExtensionsWarning = ({
 }: {
   unsupportedExtensions: string[]
 }) => {
+  const { ref } = useParams()
+
   return (
     <Alert_Shadcn_
       variant="warning"
@@ -72,7 +75,12 @@ export const UnsupportedExtensionsWarning = ({
           <ul className="pl-4">
             {unsupportedExtensions.map((obj: string) => (
               <li className="list-disc" key={obj}>
-                {obj}
+                <a
+                  href={`/project/${ref}/database/extensions?filter=${obj}`}
+                  className="hover:text-foreground transition"
+                >
+                  {obj}
+                </a>
               </li>
             ))}
           </ul>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -27,7 +27,7 @@ export const ObjectsToBeDroppedWarning = ({
       <AlertTitle_Shadcn_>A new version of Postgres is available</AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_ className="flex flex-col gap-3">
         <div>
-          <p className="mb-1">You'll need to remove the following objects before upgrading:</p>
+          <p className="mb-1">The following objects have to be removed before upgrading:</p>
 
           <ul className="pl-4">
             {objectsToBeDropped.map((obj) => (
@@ -67,7 +67,7 @@ export const UnsupportedExtensionsWarning = ({
       <AlertTitle_Shadcn_>A new version of Postgres is available</AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_ className="flex flex-col gap-3">
         <div>
-          <p className="mb-1">You'll need to remove the following extensions before upgrading:</p>
+          <p className="mb-1">The following extensions have to be removed before upgrading:</p>
 
           <ul className="pl-4">
             {unsupportedExtensions.map((obj: string) => (

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'common'
+import Link from 'next/link'
 import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, Button } from 'ui'
 
 export const ReadReplicasWarning = ({ latestPgVersion }: { latestPgVersion: string }) => {
@@ -75,12 +76,12 @@ export const UnsupportedExtensionsWarning = ({
           <ul className="pl-4">
             {unsupportedExtensions.map((obj: string) => (
               <li className="list-disc" key={obj}>
-                <a
+                <Link
                   href={`/project/${ref}/database/extensions?filter=${obj}`}
                   className="hover:text-foreground transition"
                 >
                   {obj}
-                </a>
+                </Link>
               </li>
             ))}
           </ul>

--- a/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
@@ -2,6 +2,7 @@ import pgMeta from '@supabase/pg-meta'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { configKeys } from 'data/config/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
@@ -56,7 +57,10 @@ export const useDatabaseExtensionDisableMutation = ({
   >((vars) => disableDatabaseExtension(vars), {
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseExtensionsKeys.list(projectRef))
+      await Promise.all([
+        queryClient.invalidateQueries(databaseExtensionsKeys.list(projectRef)),
+        queryClient.invalidateQueries(configKeys.upgradeEligibility(projectRef)),
+      ])
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {


### PR DESCRIPTION
Fixes FE-1714

## Context:

Related to this particular warning in the project settings infrastructure page - this warning doesn't go away after disabling the extensions listed here as the RQ for the upgrade eligibility isn't getting invalidated, so this PR fixes that.

Also fixes small style issue in the extension card where the buttons should wrap.

Also added a small QoL improvement to support clicking on the extension name from the upgrade eligibility warning, which will direct users to the database extensions page with the search input filled with the extension name

Before:
<img width="335" height="197" alt="image" src="https://github.com/user-attachments/assets/a56dc850-00ea-4b0b-a442-fc0d845b6038" />

After:
<img width="335" height="228" alt="image" src="https://github.com/user-attachments/assets/fa5a075a-f11b-4b6b-8934-08b9bf19f717" />
