### PR TITLE
Add trim to zod validation for project name in create project form

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -111,6 +111,7 @@ const FormSchema = z.object({
   }),
   projectName: z
     .string()
+    .trim()
     .min(1, 'Please enter a project name.') // Required field check
     .min(3, 'Project name must be at least 3 characters long.') // Minimum length check
     .max(64, 'Project name must be no longer than 64 characters.'), // Maximum length check


### PR DESCRIPTION
## Context

Fixes FE-1686

You can technically create a project name that's just purely spaces like `   ` 😅 
This PR fixes that by adding `.trim()` in the zod schema - this also trims the actual name that eventually get's sent to the POST project endpoint as well

## To test
- Verify that you cannot create a project with just spaces for names
- Verify that even if you create a project with whitespaces on each ends, they'll get trimmed when you create the project