### PR TITLE
fix custom report charts colors

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -126,19 +126,19 @@ export const ChartBlock = ({
 
   const getCellColor = (attribute: string, value: number) => {
     const threshold = METRIC_THRESHOLDS[attribute as keyof typeof METRIC_THRESHOLDS]
-    if (!threshold) return 'var(--chart-1)'
+    if (!threshold) return 'hsl(var(--chart-1))'
     if (threshold.check === 'gt') {
       return value >= threshold.danger
-        ? 'var(--chart-destructive)'
+        ? 'hsl(var(--chart-destructive))'
         : value >= threshold.warning
-          ? 'var(--chart-warning)'
-          : 'var(--chart-1)'
+          ? 'hsl(var(--chart-warning))'
+          : 'hsl(var(--chart-1))'
     } else {
       return value <= threshold.danger
-        ? 'var(--chart-destructive)'
+        ? 'hsl(var(--chart-destructive))'
         : value <= threshold.warning
-          ? 'var(--chart-warning)'
-          : 'var(--chart-1)'
+          ? 'hsl(var(--chart-warning))'
+          : 'hsl(var(--chart-1))'
     }
   }
 
@@ -286,7 +286,7 @@ export const ChartBlock = ({
                     />
                   }
                 />
-                <Line dataKey={metricLabel} stroke="var(--chart-1)" radius={4} />
+                <Line dataKey={metricLabel} stroke="hsl(var(--chart-1))" radius={4} />
               </LineChart>
             )}
           </ChartContainer>


### PR DESCRIPTION
## before
<img width="1110" height="644" alt="CleanShot 2025-07-31 at 13 50 18@2x" src="https://github.com/user-attachments/assets/a81a9d67-7cbf-447d-a120-c3f31fc83c5f" />


## after

<img width="724" height="620" alt="CleanShot 2025-07-31 at 13 44 17@2x" src="https://github.com/user-attachments/assets/f5c6a499-0f6e-4659-8a87-f6a17ea5d5ba" />
