### PR TITLE
fix: trailing whitespace allows duplicate redirect URLs

### DIFF
--- a/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/AddNewURLModal.tsx
@@ -41,6 +41,7 @@ export const AddNewURLModal = ({ visible, allowList, onClose }: AddNewURLModalPr
           .string()
           .min(1, 'Please provide a value')
           .regex(urlRegex(), 'Please provide a valid URL')
+          .transform((val) => val.trim())
           .refine((value) => !allowList.includes(value), {
             message: 'URL already exists in the allow list',
           }),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This fixes a bug that happened to me in the Redirect URLs page ([apps/studio/pages/project/[ref]/auth/url-configuration.tsx](https://github.com/supabase/supabase/blob/fb24d913051f0623b04ce3c79ce6d48bf4314430/apps/studio/pages/project/%5Bref%5D/auth/url-configuration.tsx)), where you can add duplicate URLs in the allow-list by adding trailing whitespace after the URL.

## What is the current behavior?

Currently, you can add the same URL twice to the allowlist, by adding whitespace to it (happened to me while copy/pasting URLs to this list). The whitespaces get trimmed after the frontend validation, so we end up with actual duplicates in the allowlist.
![Adding whitespace to input URL](https://s14.gifyu.com/images/bNz4L.gif)

This leads to some painful UX when you want to delete the duplicates, because all duplicates URL will be selected at once, which forces you to delete everything and add your URL again.

![Broken selection](https://s14.gifyu.com/images/bNz4p.gif)

The reason this happens is that when you click a duplicate URL, the selection logic checks `selectedUrls.includes(url)`, which returns true for all instances of that URL value since they're identical strings, not unique positions.

## What is the new behavior?

URLs are now trimmed of leading/trailing whitespace during form validation before checking for duplicates, preventing users from bypassing the duplicate URL check by adding spaces (e.g., "https://example.com" and "https://example.com " are now treated as the same URL).
