### PR TITLE
fix: The mail confirm setting should be negated

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -36,7 +36,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
   const [open, setOpen] = useState(false)
   const { mutate: updateAuthConfig, isLoading: isUpdatingConfig } = useAuthConfigUpdateMutation()
 
-  const doubleNegativeKeys = ['MAILER_AUTOCONFIRM', 'SMS_AUTOCONFIRM']
+  const doubleNegativeKeys = ['SMS_AUTOCONFIRM']
   const canUpdateConfig: boolean = useCheckPermissions(
     PermissionAction.UPDATE,
     'custom_config_gotrue'

--- a/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
@@ -64,7 +64,7 @@ const BasicAuthSettingsForm = () => {
         DISABLE_SIGNUP: !authConfig.DISABLE_SIGNUP,
         EXTERNAL_ANONYMOUS_USERS_ENABLED: authConfig.EXTERNAL_ANONYMOUS_USERS_ENABLED,
         SECURITY_MANUAL_LINKING_ENABLED: authConfig.SECURITY_MANUAL_LINKING_ENABLED,
-        // The backend uses true to represent that email confirmation is required
+        // The backend uses false to represent that email confirmation is required
         MAILER_AUTOCONFIRM: !authConfig.MAILER_AUTOCONFIRM,
         SITE_URL: authConfig.SITE_URL,
       })
@@ -79,7 +79,7 @@ const BasicAuthSettingsForm = () => {
       payload.PASSWORD_REQUIRED_CHARACTERS = ''
     }
 
-    // The backend uses true to represent that email confirmation is required
+    // The backend uses false to represent that email confirmation is required
     payload.MAILER_AUTOCONFIRM = !values.MAILER_AUTOCONFIRM
 
     updateAuthConfig(

--- a/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
@@ -64,7 +64,8 @@ const BasicAuthSettingsForm = () => {
         DISABLE_SIGNUP: !authConfig.DISABLE_SIGNUP,
         EXTERNAL_ANONYMOUS_USERS_ENABLED: authConfig.EXTERNAL_ANONYMOUS_USERS_ENABLED,
         SECURITY_MANUAL_LINKING_ENABLED: authConfig.SECURITY_MANUAL_LINKING_ENABLED,
-        MAILER_AUTOCONFIRM: authConfig.MAILER_AUTOCONFIRM,
+        // The backend uses true to represent that email confirmation is required
+        MAILER_AUTOCONFIRM: !authConfig.MAILER_AUTOCONFIRM,
         SITE_URL: authConfig.SITE_URL,
       })
     }
@@ -77,6 +78,9 @@ const BasicAuthSettingsForm = () => {
     if (payload.PASSWORD_REQUIRED_CHARACTERS === NO_REQUIRED_CHARACTERS) {
       payload.PASSWORD_REQUIRED_CHARACTERS = ''
     }
+
+    // The backend uses true to represent that email confirmation is required
+    payload.MAILER_AUTOCONFIRM = !values.MAILER_AUTOCONFIRM
 
     updateAuthConfig(
       { projectRef: projectRef!, config: payload },


### PR DESCRIPTION
This PR fixes an issue caused by https://github.com/supabase/supabase/pull/37573 where the `MAILER_AUTOCONFIRM` setting should be negated because the UI shows an inverted state.