### PR TITLE
Add a CTA to run the command of the cron job

### DIFF
--- a/apps/studio/data/database-cron-jobs/database-cron-job-run-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-job-run-mutation.ts
@@ -1,0 +1,66 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { executeSql } from 'data/sql/execute-sql-query'
+import type { ResponseError } from 'types'
+import { databaseCronJobsKeys } from './keys'
+
+export type DatabaseCronJobRunVariables = {
+  projectRef: string
+  connectionString?: string | null
+  jobId: number
+}
+
+// [Joshen] JFYI pg_cron doesn't support a run job function OOB just yet
+// So this is just merely running the command from within the cron job, will not reset the cron job's timer
+// https://github.com/citusdata/pg_cron/issues/226
+export async function runDatabaseCronJobCommand({
+  projectRef,
+  connectionString,
+  jobId,
+}: DatabaseCronJobRunVariables) {
+  const { result } = await executeSql({
+    projectRef,
+    connectionString,
+    sql: `
+DO $$
+DECLARE
+  job_command text;
+BEGIN
+  select command into job_command from cron.job where jobid = ${jobId};
+  EXECUTE job_command;
+END $$;
+`.trim(),
+    queryKey: databaseCronJobsKeys.create(),
+  })
+
+  return result
+}
+
+type DatabaseCronJobRunData = Awaited<ReturnType<typeof runDatabaseCronJobCommand>>
+
+export const useDatabaseCronJobRunCommandMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<DatabaseCronJobRunData, ResponseError, DatabaseCronJobRunVariables>,
+  'mutationFn'
+> = {}) => {
+  return useMutation<DatabaseCronJobRunData, ResponseError, DatabaseCronJobRunVariables>(
+    (vars) => runDatabaseCronJobCommand(vars),
+    {
+      async onSuccess(data, variables, context) {
+        await onSuccess?.(data, variables, context)
+      },
+      async onError(data, variables, context) {
+        if (onError === undefined) {
+          toast.error(`Failed to run cron job command: ${data.message}`)
+        } else {
+          onError(data, variables, context)
+        }
+      },
+      ...options,
+    }
+  )
+}


### PR DESCRIPTION
Fixes FE-1733

Adds an option to run the command from a cron job manually - helpful for testing if the command of the cron job is working
<img width="228" height="169" alt="image" src="https://github.com/user-attachments/assets/300445df-8f39-4f8d-bd46-c6df47843aae" />

If command is alright, shows a success toast
<img width="397" height="80" alt="image" src="https://github.com/user-attachments/assets/802e198c-9903-44d6-adcd-9919a49b3f19" />

Otherwise will show the SQL error
<img width="410" height="119" alt="image" src="https://github.com/user-attachments/assets/4d86826d-ab13-4743-b334-7edeb870f579" />

JFYI ideally we'd be able to use something from pg_cron that will run the job manually and also reset the job's timer, but that isn't supported atm https://github.com/citusdata/pg_cron/issues/226
