### PR TITLE
Chore/cron fixes

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -203,6 +203,7 @@ export const CreateCronJobSheet = ({
   const { project } = useProjectContext()
   const { data: org } = useSelectedOrganizationQuery()
   const [searchQuery] = useQueryState('search', parseAsString.withDefault(''))
+  const [isLoadingGetCronJob, setIsLoadingGetCronJob] = useState(false)
 
   const isEditing = !!selectedCronJob?.jobname
   const [showEnableExtensionModal, setShowEnableExtensionModal] = useState(false)
@@ -215,7 +216,9 @@ export const CreateCronJobSheet = ({
   const pgNetExtensionInstalled = pgNetExtension?.installed_version != undefined
 
   const { mutate: sendEvent } = useSendEventMutation()
-  const { mutate: upsertCronJob, isLoading } = useDatabaseCronJobCreateMutation()
+  const { mutate: upsertCronJob, isLoading: isLoadingUpsertCronjob } =
+    useDatabaseCronJobCreateMutation()
+  const isLoading = isLoadingGetCronJob || isLoadingUpsertCronjob
 
   const canToggleExtensions = useCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
@@ -306,6 +309,7 @@ export const CreateCronJobSheet = ({
     if (!project) return console.error('Project is required')
 
     if (!isEditing) {
+      setIsLoadingGetCronJob(true)
       const checkExistingJob = await getDatabaseCronJob({
         projectRef: project.ref,
         connectionString: project.connectionString,
@@ -314,6 +318,7 @@ export const CreateCronJobSheet = ({
       const nameExists = !!checkExistingJob
 
       if (nameExists) {
+        setIsLoadingGetCronJob(false)
         return form.setError('name', {
           type: 'manual',
           message: 'A cron job with this name already exists',
@@ -369,6 +374,7 @@ export const CreateCronJobSheet = ({
         },
       }
     )
+    setIsLoadingGetCronJob(false)
   }
 
   return (

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
@@ -193,9 +193,10 @@ export const CronjobsTab = () => {
             }}
             onScroll={handleScroll}
             renderers={{
-              renderRow(_, props) {
+              renderRow(key, props) {
                 return (
                   <Row
+                    key={props.row.jobid}
                     {...props}
                     onClick={(e) => {
                       const { jobid, jobname } = props.row

--- a/apps/studio/components/layouts/Integrations/layout.tsx
+++ b/apps/studio/components/layouts/Integrations/layout.tsx
@@ -1,21 +1,20 @@
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useRef, useState } from 'react'
 
-import { IntegrationDefinition } from 'components/interfaces/Integrations/Landing/Integrations.constants'
 import { useInstalledIntegrations } from 'components/interfaces/Integrations/Landing/useInstalledIntegrations'
 import { Header } from 'components/layouts/Integrations/header'
 import ProjectLayout from 'components/layouts/ProjectLayout/ProjectLayout'
+import AlertError from 'components/ui/AlertError'
 import { ProductMenu } from 'components/ui/ProductMenu'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
+import ProductMenuItem from 'components/ui/ProductMenu/ProductMenuItem'
 import { useScroll } from 'framer-motion'
-import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { useSelectedProject, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { withAuth } from 'hooks/misc/withAuth'
 import { useFlag } from 'hooks/ui/useFlag'
-import { IntegrationTabs } from './tabs'
 import { Menu, Separator } from 'ui'
-import ProductMenuItem from 'components/ui/ProductMenu/ProductMenuItem'
 import { GenericSkeletonLoader } from 'ui-patterns'
-import AlertError from 'components/ui/AlertError'
+import { IntegrationTabs } from './tabs'
 
 /**
  * Layout component for the Integrations section
@@ -156,7 +155,7 @@ const IntegrationTopHeaderLayout = ({ ...props }: PropsWithChildren) => {
 const IntegrationsLayoutSide = ({ ...props }: PropsWithChildren) => {
   const router = useRouter()
   const page = router.pathname.split('/')[4]
-  const project = useSelectedProject()
+  const { data: project } = useSelectedProjectQuery()
 
   const {
     installedIntegrations: integrations,

--- a/apps/studio/components/layouts/Integrations/tabs.tsx
+++ b/apps/studio/components/layouts/Integrations/tabs.tsx
@@ -97,7 +97,9 @@ export const IntegrationTabs = ({ scroll, isSticky }: IntegrationTabsProps) => {
                       >
                         <NavMenuItem active={true} className="flex items-center gap-2">
                           {tab.childIcon}
-                          <Link href={`${tabUrl}/${childId}`}>
+                          <Link
+                            href={`${tabUrl}/${childId}${childLabel ? `?child-label=${childLabel}` : ''}`}
+                          >
                             {childLabel ? childLabel : childId}
                           </Link>
                         </NavMenuItem>


### PR DESCRIPTION
## Context

Fixes 2 identified issues
- Cron job infinite query was returning a duplicate row for a job that previously succeeded, but latest run failed (if im not wrong). Bug was in the SQL query for fetching the cron jobs, so got that fixed in this PR (Although just to call out that I needed help from AI for this one, so if there's a way to optimize the query please let me know)
- Clicking on the child tab from the integrations page (in this case, e.g. "Test Ping") loses the label in the tabs, because its reading from the `child-label` param in the URL. This PR fixes that as well
  <img width="299" height="63" alt="image" src="https://github.com/user-attachments/assets/a5f19485-7353-4dc7-af45-8f8e6b9597b2" />
