### PR TITLE
fix: Add handling for single quotes in option values when creating FDW.

### DIFF
--- a/apps/studio/data/fdw/fdw-create-mutation.ts
+++ b/apps/studio/data/fdw/fdw-create-mutation.ts
@@ -118,8 +118,9 @@ export function getCreateFDWSql({
     .map((option) => `${option.name} ''%s''`)
   const unencryptedOptionsSqlArray = unencryptedOptions
     .filter((option) => formState[option.name])
-    // wrap all options in double quotes, some option names have dots in them
-    .map((option) => `"${option.name}" ''${formState[option.name]}''`)
+    // wrap all option names in double quotes to handle dots
+    // wrap all options values in single quotes, replace single quotes with 4 single quotes to escape them in SQL past the execute format
+    .map((option) => `"${option.name}" ''${formState[option.name].replace(/'/g, `''''`)}''`)
   const optionsSqlArray = [...encryptedOptionsSqlArray, ...unencryptedOptionsSqlArray].join(',')
 
   const createServerSql = /* SQL */ `


### PR DESCRIPTION
There's a bug in fdw creation API call where it doesn't handle options with `'` in them. I've added code to escape them. 

Because the option value is going through `EXECUTE FORMAT` it needed to be escaped twice (one `'` turns into `''''`).

To test this, try creating a wrapper with a `'` in one of its options.

<img width="593" height="417" alt="Screenshot 2025-08-01 at 23 50 49" src="https://github.com/user-attachments/assets/15d2cceb-31f3-4020-8cea-667f96f52fc1" />
