### PR TITLE
Update monthly-active-users.mdx code formatting

### DIFF
--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
@@ -30,7 +30,10 @@ Your billing cycle runs from January 1 to January 31. Although User-1 was signed
 
 <StepHikeCompact.Step step={2}>
   <StepHikeCompact.Details title="Sign User-1 out on January 4" fullWidth>
-    ```javascript const {error} = await supabase.auth.signOut() ```
+      
+     ```javascript
+       const {error} = await supabase.auth.signOut()
+      ```
   </StepHikeCompact.Details>
 </StepHikeCompact.Step>
 

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
@@ -32,8 +32,9 @@ Your billing cycle runs from January 1 to January 31. Although User-1 was signed
   <StepHikeCompact.Details title="Sign User-1 out on January 4" fullWidth>
       
      ```javascript
-       const {error} = await supabase.auth.signOut()
-      ```
+     const {error} = await supabase.auth.signOut()
+     ```
+
   </StepHikeCompact.Details>
 </StepHikeCompact.Step>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. I was reading through the docs, saw this issue and made a small quick fix :)

## What is the current behavior?

<img width="606" height="154" alt="Screenshot 2025-08-03 at 12 48 38" src="https://github.com/user-attachments/assets/bd2aae76-1766-4db4-b4dc-90262f97453a" />

## What is the new behavior?

Fixed

