### PR TITLE
Update sveltekit.mdx

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -420,6 +420,24 @@ export const actions: Actions = {
       redirect(303, '/private')
     }
   },
+oauth: async ({ request, locals: { supabase } }) => {
+    const formData = await request.formData()
+    const provider = formData.get('provider') as 'github' | 'google'
+    
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: provider,
+      options: {
+        redirectTo: 'http://localhost:5173/auth/callback', // change this to your site URL
+      },
+    })
+    
+    if (error) {
+      console.error(error)
+      return redirect(303, '/auth/error')
+    } else {
+      return redirect(303, data.url)
+    }
+  },
 }
 ```
 
@@ -435,6 +453,16 @@ export const actions: Actions = {
   </label>
   <button>Login</button>
   <button formaction="?/signup">Sign up</button>
+</form>
+
+<form method="POST" action="?/oauth">
+  <input type="hidden" name="provider" value="github" />
+  <button type="submit">Login with GitHub</button>
+</form>
+
+<form method="POST" action="?/oauth">
+  <input type="hidden" name="provider" value="google" />
+  <button type="submit">Login with Google</button>
 </form>
 ```
 


### PR DESCRIPTION
Adding working example of the OAuth flow that covers both the server-side and client-side parts

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update, 

## What is the current behavior?

The SvelteKit server-side authentication guide is missing a working code example for the OAuth redirect flow. The guide currently focuses on email/password authentication, which makes it difficult for users to figure out how to implement OAuth providers like GitHub or Google. This was a point of confusion for new users trying to follow the SSR guide.

## What is the new behavior?

This PR adds a complete, working example of the OAuth sign-in flow.

It includes a new server-side action in +page.server.ts that uses signInWithOAuth and handles the redirect to the provider's URL.

It also includes a client-side form in +page.svelte to trigger this server action, providing a clear example for developers to follow.

## Additional context

This contribution directly addresses the need for a complete OAuth example in the SvelteKit guide, which has been a common request. The code snippet uses GitHub and Google as examples, which are easily adaptable for other providers.
