### PR TITLE
fix: Fix the exposed foreign table in the tooltip in table list

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -108,6 +108,14 @@ const EntityListItem: ItemRenderer<Entity, EntityListItemProps> = ({
     selectedSchema
   ).hasLint
 
+  const foreignTableHasLints: boolean = getEntityLintDetails(
+    entity.name,
+    'foreign_table_in_api',
+    ['ERROR', 'WARN'],
+    lints,
+    selectedSchema
+  ).hasLint
+
   const formatTooltipText = (entityType: string) => {
     return Object.entries(ENTITY_TYPE)
       .find(([, value]) => value === entityType)?.[0]
@@ -270,6 +278,7 @@ const EntityListItem: ItemRenderer<Entity, EntityListItemProps> = ({
               tableHasLints={tableHasLints}
               viewHasLints={viewHasLints}
               materializedViewHasLints={materializedViewHasLints}
+              foreignTableHasLints={foreignTableHasLints}
             />
           </div>
         </div>
@@ -427,11 +436,13 @@ const EntityTooltipTrigger = ({
   tableHasLints,
   viewHasLints,
   materializedViewHasLints,
+  foreignTableHasLints,
 }: {
   entity: Entity
   tableHasLints: boolean
   viewHasLints: boolean
   materializedViewHasLints: boolean
+  foreignTableHasLints: boolean
 }) => {
   let tooltipContent = ''
   const accessWarning = 'Data is publicly accessible via API'
@@ -453,7 +464,9 @@ const EntityTooltipTrigger = ({
       }
       break
     case ENTITY_TYPE.FOREIGN_TABLE:
-      tooltipContent = `${accessWarning} as RLS via is not enforced on foreign tables`
+      if (foreignTableHasLints) {
+        tooltipContent = `${accessWarning} as RLS via is not enforced on foreign tables`
+      }
       break
     default:
       break

--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -465,7 +465,7 @@ const EntityTooltipTrigger = ({
       break
     case ENTITY_TYPE.FOREIGN_TABLE:
       if (foreignTableHasLints) {
-        tooltipContent = `${accessWarning} as RLS via is not enforced on foreign tables`
+        tooltipContent = `${accessWarning} as RLS is not enforced on foreign tables`
       }
       break
     default:


### PR DESCRIPTION
This PR fixes a bug where the tooltip was shown always for foreign tables. Now it depends on the proper lint rule.
<img width="468" height="467" alt="Screenshot 2025-08-04 at 22 48 04" src="https://github.com/user-attachments/assets/491aa286-d8e2-4271-ba62-8646739fbd9f" />
