### PR TITLE
docs: add product-specific troubleshooting views

### DIFF
--- a/apps/docs/app/guides/auth/troubleshooting/page.tsx
+++ b/apps/docs/app/guides/auth/troubleshooting/page.tsx
@@ -1,0 +1,15 @@
+import SectionTroubleshootingPage, {
+  generateSectionTroubleshootingMetadata,
+} from '~/features/docs/TroubleshootingSection.page'
+
+export default async function AuthTroubleshootingPage() {
+  return (
+    <SectionTroubleshootingPage
+      topic="auth"
+      sectionName="Auth"
+      description="Search or browse troubleshooting guides for common authentication issues, including login problems, session management, and provider configuration."
+    />
+  )
+}
+
+export const metadata = generateSectionTroubleshootingMetadata('auth', 'Auth')

--- a/apps/docs/app/guides/database/troubleshooting/page.tsx
+++ b/apps/docs/app/guides/database/troubleshooting/page.tsx
@@ -1,0 +1,15 @@
+import SectionTroubleshootingPage, {
+  generateSectionTroubleshootingMetadata,
+} from '~/features/docs/TroubleshootingSection.page'
+
+export default async function DatabaseTroubleshootingPage() {
+  return (
+    <SectionTroubleshootingPage
+      topic="database"
+      sectionName="Database"
+      description="Search or browse troubleshooting guides for common database issues, including connection problems, query optimization, and configuration."
+    />
+  )
+}
+
+export const metadata = generateSectionTroubleshootingMetadata('database', 'Database')

--- a/apps/docs/app/guides/functions/troubleshooting/page.tsx
+++ b/apps/docs/app/guides/functions/troubleshooting/page.tsx
@@ -1,0 +1,15 @@
+import SectionTroubleshootingPage, {
+  generateSectionTroubleshootingMetadata,
+} from '~/features/docs/TroubleshootingSection.page'
+
+export default async function FunctionsTroubleshootingPage() {
+  return (
+    <SectionTroubleshootingPage
+      topic="functions"
+      sectionName="Edge Functions"
+      description="Search or browse troubleshooting guides for common Edge Functions issues, including deployment problems, runtime errors, and environment configuration."
+    />
+  )
+}
+
+export const metadata = generateSectionTroubleshootingMetadata('functions', 'Edge Functions')

--- a/apps/docs/app/guides/realtime/troubleshooting/page.tsx
+++ b/apps/docs/app/guides/realtime/troubleshooting/page.tsx
@@ -1,0 +1,15 @@
+import SectionTroubleshootingPage, {
+  generateSectionTroubleshootingMetadata,
+} from '~/features/docs/TroubleshootingSection.page'
+
+export default async function RealtimeTroubleshootingPage() {
+  return (
+    <SectionTroubleshootingPage
+      topic="realtime"
+      sectionName="Realtime"
+      description="Search or browse troubleshooting guides for common realtime issues, including connection problems, subscription management, and message delivery."
+    />
+  )
+}
+
+export const metadata = generateSectionTroubleshootingMetadata('realtime', 'Realtime')

--- a/apps/docs/app/guides/storage/troubleshooting/page.tsx
+++ b/apps/docs/app/guides/storage/troubleshooting/page.tsx
@@ -1,0 +1,15 @@
+import SectionTroubleshootingPage, {
+  generateSectionTroubleshootingMetadata,
+} from '~/features/docs/TroubleshootingSection.page'
+
+export default async function StorageTroubleshootingPage() {
+  return (
+    <SectionTroubleshootingPage
+      topic="storage"
+      sectionName="Storage"
+      description="Search or browse troubleshooting guides for common storage issues, including file upload problems, bucket configuration, and security policies."
+    />
+  )
+}
+
+export const metadata = generateSectionTroubleshootingMetadata('storage', 'Storage')

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -653,7 +653,10 @@ export const auth = {
     },
     {
       name: 'Debugging',
-      items: [{ name: 'Error Codes', url: '/guides/auth/debugging/error-codes' }],
+      items: [
+        { name: 'Error Codes', url: '/guides/auth/debugging/error-codes' },
+        { name: 'Troubleshooting', url: '/guides/auth/troubleshooting' },
+      ],
     },
     {
       name: 'Third-party auth',
@@ -961,6 +964,10 @@ export const database: NavMenuConstant = {
         {
           name: 'Supavisor',
           url: '/guides/database/supavisor',
+        },
+        {
+          name: 'Troubleshooting',
+          url: '/guides/database/troubleshooting',
         },
       ],
     },
@@ -1630,7 +1637,10 @@ export const realtime: NavMenuConstant = {
     {
       name: 'Debugging',
       url: undefined,
-      items: [{ name: 'Operational Error Codes', url: '/guides/realtime/error_codes', items: [] }],
+      items: [
+        { name: 'Operational Error Codes', url: '/guides/realtime/error_codes', items: [] },
+        { name: 'Troubleshooting', url: '/guides/realtime/troubleshooting' },
+      ],
     },
   ],
 }
@@ -1752,6 +1762,7 @@ export const storage: NavMenuConstant = {
       items: [
         { name: 'Logs', url: '/guides/storage/debugging/logs' },
         { name: 'Error Codes', url: '/guides/storage/debugging/error-codes' },
+        { name: 'Troubleshooting', url: '/guides/storage/troubleshooting' },
       ],
     },
     {

--- a/apps/docs/features/docs/Troubleshooting.ui.client.tsx
+++ b/apps/docs/features/docs/Troubleshooting.ui.client.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, RotateCw, Search, X } from 'lucide-react'
 import { useQueryStates } from 'nuqs'
 import { useEffect, useRef, useState, Suspense, useCallback, useMemo } from 'react'
 
+import { useBreakpoint } from 'common'
 import {
   Input_Shadcn_,
   cn,
@@ -13,22 +14,13 @@ import {
   CollapsibleContent_Shadcn_ as CollapsibleContent,
 } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
-
-import {
-  MultiSelector,
-  MultiSelectorContent,
-  MultiSelectorInput,
-  MultiSelectorItem,
-  MultiSelectorList,
-  MultiSelectorTrigger,
-} from 'ui-patterns/multi-select'
+import { MultiSelector } from 'ui-patterns/multi-select'
 import { type ITroubleshootingMetadata } from './Troubleshooting.utils'
 import {
   TROUBLESHOOTING_CONTAINER_ID,
   TROUBLESHOOTING_DATA_ATTRIBUTES,
   troubleshootingSearchParams,
 } from './Troubleshooting.utils.shared'
-import { useBreakpoint } from 'common'
 
 function useTroubleshootingSearchState() {
   const [_state, _setState] = useQueryStates(troubleshootingSearchParams)
@@ -115,10 +107,10 @@ function entryMatchesFilter(
 }
 
 interface TroubleshootingFilterProps {
-  products: string[]
+  className?: string
+  products?: string[]
   errors: ITroubleshootingMetadata['errors']
   keywords: string[]
-  className?: string
 }
 
 export function TroubleshootingFilter(props: TroubleshootingFilterProps) {
@@ -223,18 +215,20 @@ function TroubleshootingFilterInternal({
     <>
       <h2 className="sr-only">Search and filter</h2>
       <div className={cn('flex flex-wrap gap-2 items-center', className)}>
-        <MultiSelector values={selectedProducts} onValuesChange={setSelectedProducts}>
-          <MultiSelector.Trigger badgeLimit={1} className="w-48" label="Products" />
-          <MultiSelector.Content>
-            <MultiSelector.List>
-              {products?.map((product) => (
-                <MultiSelector.Item key={`product-${product}`} value={product}>
-                  {product}
-                </MultiSelector.Item>
-              ))}
-            </MultiSelector.List>
-          </MultiSelector.Content>
-        </MultiSelector>
+        {!!products && (
+          <MultiSelector values={selectedProducts} onValuesChange={setSelectedProducts}>
+            <MultiSelector.Trigger badgeLimit={1} className="w-48" label="Products" />
+            <MultiSelector.Content>
+              <MultiSelector.List>
+                {products?.map((product) => (
+                  <MultiSelector.Item key={`product-${product}`} value={product}>
+                    {product}
+                  </MultiSelector.Item>
+                ))}
+              </MultiSelector.List>
+            </MultiSelector.Content>
+          </MultiSelector>
+        )}
         <MultiSelector values={selectedErrorCodes} onValuesChange={setSelectedErrorCodes}>
           <MultiSelector.Trigger badgeLimit={1} className="w-48" label="Error codes" />
           <MultiSelector.Content>

--- a/apps/docs/features/docs/Troubleshooting.ui.tsx
+++ b/apps/docs/features/docs/Troubleshooting.ui.tsx
@@ -1,15 +1,19 @@
-import { Wrench } from 'lucide-react'
 import Link from 'next/link'
-import { type PropsWithChildren, useCallback } from 'react'
+import { Fragment } from 'react'
 
+import { cn } from 'ui'
+import { TroubleshootingFilter } from './Troubleshooting.ui.client'
 import {
   type ITroubleshootingEntry,
+  type ITroubleshootingMetadata,
   getArticleSlug,
   getTroubleshootingUpdatedDates,
 } from './Troubleshooting.utils'
-import { TroubleshootingFilter } from './Troubleshooting.ui.client'
-import { formatError, TROUBLESHOOTING_DATA_ATTRIBUTES } from './Troubleshooting.utils.shared'
-import { cn } from 'ui'
+import {
+  formatError,
+  TROUBLESHOOTING_DATA_ATTRIBUTES,
+  TROUBLESHOOTING_CONTAINER_ID,
+} from './Troubleshooting.utils.shared'
 
 export async function TroubleshootingPreview({ entry }: { entry: ITroubleshootingEntry }) {
   const dateUpdated = entry.data.database_id.startsWith('pseudo-')
@@ -55,10 +59,10 @@ export async function TroubleshootingPreview({ entry }: { entry: ITroubleshootin
               .map(formatError)
               .filter(Boolean)
               .map((error, index) => (
-                <>
-                  <code key={index}>{error}</code>
+                <Fragment key={error}>
+                  <code>{error}</code>
                   {index < (entry.data.errors?.length || 0) - 1 ? ', ' : ''}
-                </>
+                </Fragment>
               ))}
           </span>
         )}
@@ -80,6 +84,68 @@ export async function TroubleshootingPreview({ entry }: { entry: ITroubleshootin
             return dateUpdated.toLocaleDateString(undefined, options)
           })()}
       </div>
+    </div>
+  )
+}
+
+export function TroubleshootingHeader({
+  title,
+  description,
+  keywords,
+  products,
+  errors,
+}: {
+  title: string
+  description: string
+  keywords: Array<string>
+  products?: Array<string>
+  errors: ITroubleshootingMetadata['errors']
+}) {
+  return (
+    <div className="lg:sticky lg:top-[var(--header-height)] lg:z-10 bg-background">
+      <div className="pt-8 pb-6 px-5">
+        <h1 className="text-4xl tracking-tight mb-7">{title}</h1>
+        <p className="text-lg text-foreground-light">{description}</p>
+        <hr className="my-7" aria-hidden />
+        <TroubleshootingFilter
+          keywords={keywords}
+          products={products}
+          errors={errors}
+          className="mb-0"
+        />
+      </div>
+    </div>
+  )
+}
+
+export function TroubleshootingEntries({
+  name,
+  entries,
+}: {
+  name: string
+  entries: Array<ITroubleshootingEntry>
+}) {
+  return (
+    <div id={TROUBLESHOOTING_CONTAINER_ID} className="@container/troubleshooting">
+      <h2 className="sr-only">Matching troubleshooting entries</h2>
+      {entries.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-foreground-light text-lg">
+            No troubleshooting guides available for {name} yet.
+          </p>
+        </div>
+      ) : (
+        <ul className="grid @4xl/troubleshooting:grid-cols-[78%_15%_7%]">
+          {entries.map((entry) => (
+            <li
+              key={entry.data.database_id}
+              className="grid grid-cols-subgrid @4xl/troubleshooting:col-span-3"
+            >
+              <TroubleshootingPreview entry={entry} />
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/apps/docs/features/docs/TroubleshootingSection.page.tsx
+++ b/apps/docs/features/docs/TroubleshootingSection.page.tsx
@@ -1,0 +1,68 @@
+import { type Metadata } from 'next'
+
+import { TroubleshootingHeader, TroubleshootingEntries } from '~/features/docs/Troubleshooting.ui'
+import {
+  TroubleshootingFilterEmptyState,
+  TroubleshootingListController,
+} from '~/features/docs/Troubleshooting.ui.client'
+import {
+  type ITroubleshootingMetadata,
+  getTroubleshootingEntriesByTopic,
+  getTroubleshootingErrorsByTopic,
+  getTroubleshootingKeywordsByTopic,
+} from '~/features/docs/Troubleshooting.utils'
+import { PROD_URL } from '~/lib/constants'
+
+interface SectionTroubleshootingPageProps {
+  topic: ITroubleshootingMetadata['topics'][number]
+  sectionName: string
+  description?: string
+}
+
+export default async function SectionTroubleshootingPage({
+  topic,
+  sectionName,
+  description,
+}: SectionTroubleshootingPageProps) {
+  // All other fetches are dependent on getTroubleshootingEntriesByTopic, which
+  // is cached, so it's run first to populate the cache
+  const troubleshootingEntries = await getTroubleshootingEntriesByTopic(topic)
+  const [keywords, errors] = await Promise.all([
+    getTroubleshootingKeywordsByTopic(topic),
+    getTroubleshootingErrorsByTopic(topic),
+  ])
+
+  const pageTitle = `${sectionName} Troubleshooting`
+  const pageDescription =
+    description || `Search or browse troubleshooting guides for common ${sectionName} issues.`
+
+  return (
+    <div className="flex flex-col">
+      <TroubleshootingHeader
+        title={pageTitle}
+        description={pageDescription}
+        keywords={keywords}
+        errors={errors}
+      />
+      <div className="flex-1">
+        <div className="px-5 pt-6">
+          <TroubleshootingListController />
+          <TroubleshootingFilterEmptyState />
+          <TroubleshootingEntries name={sectionName} entries={troubleshootingEntries} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function generateSectionTroubleshootingMetadata(
+  topic: string,
+  sectionName: string
+): Metadata {
+  return {
+    title: `Supabase Docs | ${sectionName} Troubleshooting`,
+    alternates: {
+      canonical: `${PROD_URL}/guides/${topic}/troubleshooting`,
+    },
+  }
+}


### PR DESCRIPTION
We have a global troubleshooting view at /guides/troubleshooting, but for greater visibility, we should also have product-specific troubleshooting views. This is the same view and same data as the global page, but filtered down to a specific product.

Added:
- [Database troubleshooting](https://docs-git-charis-docs-337-section-specific-troub-bcbe4c-supabase.vercel.app/docs/guides/database/troubleshooting)
- [Auth troubleshooting](https://docs-git-charis-docs-337-section-specific-troub-bcbe4c-supabase.vercel.app/docs/guides/auth/troubleshooting)
- [Storage troubleshooting](https://docs-git-charis-docs-337-section-specific-troub-bcbe4c-supabase.vercel.app/docs/guides/storage/troubleshooting)
- [Functions troubleshooting](https://docs-git-charis-docs-337-section-specific-troub-bcbe4c-supabase.vercel.app/docs/guides/functions/troubleshooting)
- [Realtime troubleshooting](https://docs-git-charis-docs-337-section-specific-troub-bcbe4c-supabase.vercel.app/docs/guides/realtime/troubleshooting)