### PR TITLE
truncate branch project card

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -65,7 +65,7 @@ const ProjectCard = ({
                   <div className="w-fit p-1 border rounded-md flex items-center">
                     <Github size={12} strokeWidth={1.5} />
                   </div>
-                  <p className="text-xs !ml-2 text-foreground-light">{githubRepository}</p>
+                  <p className="text-xs !ml-2 text-foreground-light truncate">{githubRepository}</p>
                 </>
               )}
             </div>


### PR DESCRIPTION
<img width="432" height="209" alt="image" src="https://github.com/user-attachments/assets/29a67bd0-d07f-4a4f-9438-27753a962e14" />

Truncates really long git branch names in project list