### PR TITLE
fix(studio): storage settings inputs

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -171,8 +171,8 @@ const StorageSettings = () => {
                 </div>
 
                 <div className="relative flex flex-col col-span-12 gap-x-6 gap-y-2 lg:col-span-8">
-                  <div className="grid grid-cols-12 col-span-12 gap-2 items-start">
-                    <div className="col-span-8">
+                  <div className="flex items-center gap-2">
+                    <div className="flex-grow">
                       <FormField_Shadcn_
                         control={form.control}
                         name="fileSizeLimit"
@@ -194,7 +194,7 @@ const StorageSettings = () => {
                         )}
                       />
                     </div>
-                    <div className="col-span-4">
+                    <div className="flex-shrink-0">
                       <FormField_Shadcn_
                         control={form.control}
                         name="unit"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The inputs for upload file size limit were overflowing out of the box, even on larger screens. Uses flex instead of grid to handle the inputs gracefully.

## What is the current behavior?

See image below:
<img width="953" height="494" alt="Screenshot 2025-08-05 at 14 42 34" src="https://github.com/user-attachments/assets/1f9fe053-a317-4e67-aae5-4324661ca93a" />


## What is the new behavior?

New behaviour fixes how we handle the side by side inputs and it looks like this:
<img width="914" height="466" alt="Screenshot 2025-08-05 at 14 44 27" src="https://github.com/user-attachments/assets/a1962ae2-4b9e-4247-b3a8-755a6ae7e328" />
