### PR TITLE
chore: remove troubleshooting codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,6 @@
 
 /apps/studio/ @supabase/Dashboard
 
-# temporary until we've ironed out all the problems with sync workflow
-/apps/docs/content/troubleshooting/ @charislam
-
 /apps/www/ @supabase/marketing
 /apps/www/public/images/blog @supabase/marketing
 /apps/www/lib/redirects.js


### PR DESCRIPTION
Code ownership was temporary while ironing out problems with sync workflow. It seems more stable now, so I'm removing codeownership to make sure people aren't blocked on troubleshooting updates while I'm away.