### PR TITLE
chore: remove extra space from curl command

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.constants.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.constants.ts
@@ -12,7 +12,7 @@ export const INVOCATION_TABS: InvocationTab[] = [
     label: 'cURL',
     language: 'bash',
     code: (functionUrl, _, apiKey) => `curl -L -X POST '${functionUrl}' \\
-  -H 'Authorization: Bearer ${apiKey}' \\ ${apiKey.includes('publishable') ? `\n  -H 'apikey: ${apiKey}' \\` : ''}
+  -H 'Authorization: Bearer ${apiKey}' \\${apiKey.includes('publishable') ? `\n  -H 'apikey: ${apiKey}' \\` : ''}
   -H 'Content-Type: application/json' \\
   --data '{"name":"Functions"}'`,
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

<img width="931" height="244" alt="Screenshot 2025-08-06 at 3 35 25 PM" src="https://github.com/user-attachments/assets/eb41e921-cc85-4ab2-b640-9a5806429385" />

Extra space in copied curl command is interpreted as invalid bash.

## Additional context

Add any other context or screenshots.
