### PR TITLE
fix(studio): small clean up of block classes

### DIFF
--- a/apps/studio/pages/project/[ref]/settings/auth.tsx
+++ b/apps/studio/pages/project/[ref]/settings/auth.tsx
@@ -17,77 +17,77 @@ const ProjectSettings: NextPageWithLayout = () => {
         </p>
         <Link
           href={`/project/${ref}/auth/providers`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           General user signup
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/providers`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Password settings in email provider
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/sessions`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           User sessions
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/sessions`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Refresh tokens
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/protection`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Bot and abuse protection
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/smtp`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           SMTP settings
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/settings/jwt`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Access token expiry
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/mfa`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Multifactor authentication
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/third-party`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Third party authentication
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/advanced`}
-          className="block py-2 hover:text-foreground border-b flex items-center justify-between"
+          className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Max request duration
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
           href={`/project/${ref}/auth/advanced`}
-          className="block py-2 hover:text-foreground flex items-center justify-between"
+          className="py-2 hover:text-foreground flex items-center justify-between"
         >
           Max direct database connections
           <ChevronRight strokeWidth={1.5} size={16} />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

My linter was throwing problems because we had two Tailwind block element classes applied to the same elements. Clears that up.

I assume it was a bit of Cursor or Claude leftovers, didn't need both `block` and `flex` on the link elements, one or the other suffices. :) 
