### PR TITLE
fix(studio): server-side request forgery projectRef

### DIFF
--- a/apps/studio/pages/api/edge-functions/body.ts
+++ b/apps/studio/pages/api/edge-functions/body.ts
@@ -23,11 +23,19 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { projectRef, slug } = req.body || {}
 
+    // Validate projectRef and slug to prevent SSRF
+    const validPattern = /^[a-zA-Z0-9_-]+$/
     if (!projectRef) {
       return res.status(400).json({ error: 'projectRef is required' })
     }
     if (!slug) {
       return res.status(400).json({ error: 'slug is required' })
+    }
+    if (!validPattern.test(projectRef)) {
+      return res.status(400).json({ error: 'Invalid projectRef format' })
+    }
+    if (!validPattern.test(slug)) {
+      return res.status(400).json({ error: 'Invalid slug format' })
     }
 
     // Get authorization token from the request


### PR DESCRIPTION
https://github.com/supabase/supabase/blob/5cc2617b5f8eeb361e9e5b7f7084109188298714/apps/studio/pages/api/edge-functions/body.ts#L53-L58

Directly incorporating user input in the URL of an outgoing HTTP request can enable a request forgery attack, in which the request is altered to target an unintended API endpoint or resource. If the server performing the request is connected to an internal network, this can give an attacker the means to bypass the network boundary and make requests against internal services. A forged request may perform an unintended action on behalf of the attacker, or cause information leak if redirected to an external server or if the request response is fed back to the user. It may also compromise the server making the request, if the request response is handled in an unsafe way.



fix the SSRF vulnerability, we need to validate and sanitize the user-provided `projectRef` and `slug` before using them in the URL. The best approach is to ensure that both values conform to a strict pattern (e.g., only alphanumeric characters, dashes, and underscores), and reject any input that does not match. This prevents path traversal and other abuses. The validation should be performed immediately after extracting the values from `req.body`, before constructing the URL. If either value fails validation, return a 400 error with an appropriate message. This change should be made in the `handlePost` function in `apps/studio/pages/api/edge-functions/body.ts`. We can use a regular expression to enforce the allowed pattern.

