### PR TITLE
fix: #27295 resolves PostGis not found in extension path

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -178,6 +178,7 @@ services:
       PGRST_DB_USE_LEGACY_GUCS: "false"
       PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET}
       PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY}
+      PGRST_DB_EXTRA_SEARCH_PATH: public,extensions
     command:
       [
         "postgrest"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Supabase self-hosted does not work with PostGIS: https://github.com/supabase/supabase/issues/27295

## What is the new behavior?

Adds a default env variable `PGRST_DB_EXTRA_SEARCH_PATH` to search also in the extensions db


## Additional context

Solution was found by @suplere with his comment : https://github.com/supabase/supabase/issues/27295#issuecomment-2668917162
Reference to doc : https://docs.postgrest.org/en/v13/references/configuration.html#db-extra-search-path