### PR TITLE
docs(auth): add optional ID token claim instructions for Azure login

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -63,6 +63,30 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
   }'
 ```
 
+## (Optional but Recommended) Add email and username claims to the ID token
+
+Some Microsoft accounts—especially older Hotmail or Live accounts—may not return an email address by default in the ID token, which can cause authentication failures in Supabase.
+
+To ensure the email is reliably returned:
+
+1. Go to your App Registration in the [Azure Portal](https://portal.azure.com).
+2. In the left-hand menu, select **Token Configuration**.
+3. Click **+ Add optional claim**.
+4. Select **ID token** as the token type.
+5. Check the following claims:
+   - `email`
+   - `preferred_username`
+6. (Optional) You can also add `xms_edov` to check if the email is verified (see section below).
+7. Enable **Turn on for all account types**.
+8. Click **Add**.
+9. Navigate to **API Permissions** and click **Grant admin consent**.
+
+This step ensures Supabase Auth can extract the user's email from the token payload. Without it, you may encounter this error when logging in:
+
+```text
+500: Error getting user email from external provider
+```
+
 ## Guarding against unverified email domains
 
 Microsoft Entra ID can send out unverified email domains in certain cases. This may open up your project to a vulnerability where a malicious user can impersonate already existing accounts on your project.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

**YES**

---

## What kind of change does this PR introduce?

**Docs update**

---

## What is the current behavior?

The [Azure login guide](https://supabase.com/docs/guides/auth/auth-azure) does not mention the need to explicitly add the `email` claim to the ID token in Azure's Token Configuration.

As a result, users—especially those logging in with older Hotmail/Live accounts—may encounter this error when trying to authenticate via Microsoft:
`500: Error getting user email from external provider`

There is currently no mention of this in the guide, leading to confusion and login failures.

---

## What is the new behavior?

This PR adds an **optional but highly recommended** section after the “Obtain a client ID and secret” step. It walks users through the process of adding `email` and `preferred_username` claims to the ID token in Azure's App Registration to ensure Supabase can reliably extract the user’s email from the ID token.

---

## Additional context

This is based on a real issue encountered while implementing Microsoft login with Supabase. Adding these claims immediately resolved the error. The fix was confirmed by decoding the ID token before and after applying the change.
