### PR TITLE
fix: diff all schemas on branch merge

### DIFF
--- a/apps/docs/content/guides/deployment/branching/dashboard.mdx
+++ b/apps/docs/content/guides/deployment/branching/dashboard.mdx
@@ -58,8 +58,6 @@ When reviewing a merge request you may see a notice at the top of the page askin
 There are a few limitations you should be aware of before deciding to use branching without git.
 
 - Custom roles created through the dashboard are not captured on branch creation
-- Only public schema changes are supported right now
-- Extensions are not included in the diff process
 - Branches can only be merged to main; merging between preview branches is not supported
 - If your branch is out of date, you can pull in latest changes from main, but keep in mind that all functions will be overwritten
 - Deleting functions must be done manually on main branch

--- a/apps/studio/components/interfaces/App/FeaturePreview/Branching2Preview.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/Branching2Preview.tsx
@@ -26,10 +26,6 @@ export const Branching2Preview = () => {
         <ul className="list-disc pl-6 text-sm text-foreground-light space-y-1">
           <li>Custom roles created through the dashboard are not captured on branch creation.</li>
           <li>
-            Only <code>public</code> schema changes are supported right now.
-          </li>
-          <li>Extensions are not included in the diff process</li>
-          <li>
             Branches can only be merged to <code>main</code>; merging between preview branches is
             not supported.
           </li>

--- a/apps/studio/data/branches/branch-merge-mutation.ts
+++ b/apps/studio/data/branches/branch-merge-mutation.ts
@@ -21,7 +21,7 @@ export async function mergeBranch({
   migration_version,
 }: BranchMergeVariables) {
   // Step 1: Get the diff output from the branch
-  const diffContent = await getBranchDiff({ branchId: id, includedSchemas: 'public' })
+  const diffContent = await getBranchDiff({ branchId: id })
 
   let migrationCreated = false
 

--- a/apps/www/_blog/2025-07-16-branching-2-0.mdx
+++ b/apps/www/_blog/2025-07-16-branching-2-0.mdx
@@ -108,8 +108,6 @@ When ready, click the merge button and watch your changes be deployed to product
 There are a few limitations you should be aware of before deciding to use branching without git.
 
 - Custom roles created through the dashboard are not captured on branch creation.
-- Only public schema changes are supported right now.
-- Extensions are not included in the diff process
 - Branches can only be merged to main; merging between preview branches is not supported.
 - If your branch is out of date, you can pull in latest changes from main, but keep in mind that all functions will be overwritten.
 - Deleting functions must be done manually on main branch.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Diff endpoint now supports all schemas and extensions.

## Additional context

Add any other context or screenshots.
