### PR TITLE
chore: add additional sql editor playwright test

### DIFF
--- a/e2e/studio/env.config.ts
+++ b/e2e/studio/env.config.ts
@@ -7,6 +7,7 @@ export const env = {
   EMAIL: process.env.EMAIL,
   PASSWORD: process.env.PASSWORD,
   PROJECT_REF: process.env.PROJECT_REF || 'default',
+  IS_PLATFORM: process.env.IS_PLATFORM || 'false',
 }
 
 export const STORAGE_STATE_PATH = path.join(__dirname, './playwright/.auth/user.json')

--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -1,19 +1,55 @@
 import { expect, Page } from '@playwright/test'
+import fs from 'fs'
 import { isCLI } from '../utils/is-cli'
 import { test } from '../utils/test'
 import { toUrl } from '../utils/to-url'
+import { waitForApiResponse } from '../utils/wait-for-response'
+import { waitForApiResponseWithTimeout } from '../utils/wait-for-response-with-timeout'
 
-const deleteQuery = async (page: Page, queryName: string) => {
+const sqlSnippetName = 'pw_sql_snippet'
+const sqlSnippetNameDuplicate = 'pw_sql_snippet (Duplicate)'
+const sqlSnippetNameFolder = 'pw_sql_snippet_folder'
+const sqlSnippetNameFavorite = 'pw_sql_snippet_favorite'
+const sqlSnippetNameShare = 'pw_sql_snippet_share'
+const sqlFolderName = 'pw_sql_folder'
+const sqlFolderNameUpdated = 'pw_sql_folder_updated'
+const newSqlSnippetName = 'Untitled query'
+
+/**
+ * Due to how sql editor is created, it's very annoying to test SQL editor in staging, I've created various workarounds to help mitigate flaky tests as much as possible.
+ *
+ * List of problems:
+ * 1. The connection string loading is very intermitten which leads to results not showing on the results tab. Sometimes it loads and sometimes it doesn't.
+ *    > I've created a workaround by waiting for the api call which loads the connection string, and also ignore the error if the API call after 3 seconds. (Assuming that the connection string is already loaded)
+ * 2. The only way to access actions in the sidebar, is by right clicking unlike the table editor. This might cause issues as keyboard and mouse click actions are not consistent enough.
+ *    > The best way to mitigate this, is clear all SQL snippets before and after each tests.
+ * 3. There would random have these errors "Sorry, An unexpected errors has occurred." when sharing sql snippet.
+ *    > Have not figured out why this is happening. My guess is that when we click too fast things are not loaded properly and it's causing errors.
+ *    > Full error: Cannot read properties of undefined (reading 'type')
+ *
+ */
+
+const deleteSqlSnippet = async (page: Page, ref: string, sqlSnippetName: string) => {
   const privateSnippet = page.getByLabel('private-snippets')
-  await privateSnippet.getByText(queryName).first().click({ button: 'right' })
+  await privateSnippet.getByText(sqlSnippetName).last().click({ button: 'right' })
   await page.getByRole('menuitem', { name: 'Delete query' }).click()
   await expect(page.getByRole('heading', { name: 'Confirm to delete query' })).toBeVisible()
   await page.getByRole('button', { name: 'Delete 1 query' }).click()
+  await waitForApiResponse(page, 'projects', ref, 'content', { method: 'DELETE' })
+  await page.waitForTimeout(500)
+}
+
+const deleteFolder = async (page: Page, ref: string, folderName: string) => {
+  await page.getByText(folderName, { exact: true }).click({ button: 'right' })
+  await page.getByRole('menuitem', { name: 'Delete folder' }).click()
+  await page.getByRole('button', { name: 'Delete folder' }).click()
+  await waitForApiResponse(page, 'projects', ref, 'content/folders', {
+    method: 'DELETE',
+  })
 }
 
 test.describe('SQL Editor', () => {
   let page: Page
-  const pwTestQueryName = 'pw-test-query'
 
   test.beforeAll(async ({ browser, ref }) => {
     test.setTimeout(60000)
@@ -34,55 +70,48 @@ test.describe('SQL Editor', () => {
   })
 
   test.beforeEach(async ({ ref }) => {
+    test.setTimeout(60000)
+
+    await page.goto(toUrl(`/project/${ref}/sql/new?skip=true`))
+    // this is required to load the connection string
+    if (!isCLI()) {
+      await waitForApiResponseWithTimeout(
+        page,
+        (response) => response.url().includes('profile/permissions'),
+        3000
+      )
+      await waitForApiResponseWithTimeout(
+        page,
+        (response) => response.url().includes('profile'),
+        3000
+      )
+    }
+  })
+
+  test.afterAll(async ({ ref }) => {
     if ((await page.getByLabel('private-snippets').count()) === 0) {
       return
     }
 
-    //  since in local, we don't have access to the supabase platform, reloading would reload all the sql snippets.
     if (isCLI()) {
+      //  In self-hosted environments, we don't have access to the supabase platform, reloading would clear/reset all the sql snippets.
       await page.reload()
+      return
     }
 
-    // remove sql snippets for - "Untitled query" and "pw test query"
+    // remove sql snippets for "Untitled query" and "pw_sql_snippet"
     const privateSnippet = page.getByLabel('private-snippets')
     let privateSnippetText = await privateSnippet.textContent()
-    while (privateSnippetText.includes('Untitled query')) {
-      deleteQuery(page, 'Untitled query')
-
-      await page.waitForResponse(
-        (response) =>
-          (response.url().includes(`projects/${ref}/content`) ||
-            response.url().includes('projects/default/content')) &&
-          response.request().method() === 'DELETE'
-      )
-      await expect(
-        page.getByText('Successfully deleted 1 query'),
-        'Delete confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
-      await page.waitForTimeout(1000)
+    while (privateSnippetText.includes(newSqlSnippetName)) {
+      await deleteSqlSnippet(page, ref, newSqlSnippetName)
       privateSnippetText =
         (await page.getByLabel('private-snippets').count()) > 0
           ? await privateSnippet.textContent()
           : ''
     }
 
-    while (privateSnippetText.includes(pwTestQueryName)) {
-      deleteQuery(page, pwTestQueryName)
-      await page.waitForResponse(
-        (response) =>
-          (response.url().includes(`projects/${ref}/content`) ||
-            response.url().includes('projects/default/content')) &&
-          response.request().method() === 'DELETE'
-      )
-      await expect(
-        page.getByText('Successfully deleted 1 query'),
-        'Delete confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
-      await page.waitForTimeout(1000)
+    while (privateSnippetText.includes(sqlSnippetName)) {
+      await deleteSqlSnippet(page, ref, sqlSnippetName)
       privateSnippetText =
         (await page.getByLabel('private-snippets').count()) > 0
           ? await privateSnippet.textContent()
@@ -90,46 +119,29 @@ test.describe('SQL Editor', () => {
     }
   })
 
-  test('should check if SQL editor can run simple commands', async () => {
-    await page.getByTestId('sql-editor-new-query-button').click()
-    await page.getByRole('menuitem', { name: 'Create a new snippet' }).click()
-
-    // write some sql in the editor
-    // This has to be done since the editor is not editable (input, textarea, etc.)
-    await page.waitForTimeout(1000)
-    const editor = page.getByRole('code').nth(0)
-    await editor.click()
+  test('should check if SQL editor is working as expected', async ({ ref }) => {
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.type(`select 'hello world';`)
     await page.getByTestId('sql-run-button').click()
 
     // verify the result
-    await expect(page.getByRole('gridcell', { name: 'hello world' })).toBeVisible({
-      timeout: 5000,
-    })
+    await waitForApiResponse(page, 'pg-meta', ref, 'query?key=', { method: 'POST' })
+    await expect(page.getByRole('gridcell', { name: 'hello world' })).toBeVisible()
 
     // SQL written in the editor should not be the previous query.
-    await page.waitForTimeout(1000)
-    await editor.click()
+    await page.locator('.view-lines').click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.type(`select length('hello');`)
     await page.getByTestId('sql-run-button').click()
 
     // verify the result is updated.
-    await expect(page.getByRole('gridcell', { name: '5' })).toBeVisible({
-      timeout: 5000,
-    })
-  })
+    await waitForApiResponse(page, 'pg-meta', ref, 'query?key=', { method: 'POST' })
+    await expect(page.getByRole('gridcell', { name: '5' })).toBeVisible()
 
-  test('destructive query would tripper a warning modal', async () => {
-    await page.getByTestId('sql-editor-new-query-button').click()
-    await page.getByRole('menuitem', { name: 'Create a new snippet' }).click()
-
-    // write some sql in the editor
-    // This has to be done since the editor is not editable (input, textarea, etc.)
-    await page.waitForTimeout(1000)
-    const editor = page.getByRole('code').nth(0)
-    await editor.click()
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.type(`delete table 'test';`)
     await page.getByTestId('sql-run-button').click()
@@ -137,96 +149,386 @@ test.describe('SQL Editor', () => {
     // verify warning modal is visible
     expect(page.getByRole('heading', { name: 'Potential issue detected with' })).toBeVisible()
     expect(page.getByText('Query has destructive')).toBeVisible()
-
-    // reset test
     await page.getByRole('button', { name: 'Cancel' }).click()
-    await page.waitForTimeout(500)
-    await editor.click()
-    await page.keyboard.press('ControlOrMeta+KeyA')
-    await page.keyboard.press('Backspace')
+
+    // clear SQL snippet
+    if (!isCLI()) {
+      await deleteSqlSnippet(page, ref, newSqlSnippetName)
+    } else {
+      await page.reload()
+    }
   })
 
-  test('should create and load a new snippet', async ({ ref }) => {
-    const runButton = page.getByTestId('sql-run-button')
-    await page.getByRole('button', { name: 'Favorites' }).click()
-    await page.getByRole('button', { name: 'Shared' }).click()
-
-    // write some sql in the editor
-    await page.getByTestId('sql-editor-new-query-button').click()
-    await page.getByRole('menuitem', { name: 'Create a new snippet' }).click()
-    const editor = page.getByRole('code').nth(0)
-    await page.waitForTimeout(1000)
-    await editor.click()
+  test('exporting works as expected', async ({ ref }) => {
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
+    await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.type(`select 'hello world';`)
-    await expect(page.getByText("select 'hello world';")).toBeVisible()
-    await runButton.click()
+    await page.getByTestId('sql-run-button').click()
 
-    // snippet exists
-    const privateSnippet = page.getByLabel('private-snippets')
-    await expect(privateSnippet).toContainText('Untitled query')
+    // export as markdown
+    await page.getByRole('button', { name: 'Export' }).click()
+    await page.getByRole('menuitem', { name: 'Copy as markdown' }).click()
+    await page.waitForTimeout(500)
+    const copiedMarkdownResult = await page.evaluate(() => navigator.clipboard.readText())
+    expect(copiedMarkdownResult).toBe(`| ?column?    |
+| ----------- |
+| hello world |`)
+
+    // export as JSON
+    await page.getByRole('button', { name: 'Export' }).click()
+    await page.getByRole('menuitem', { name: 'Copy as JSON' }).click()
+    await page.waitForTimeout(500)
+    const copiedJsonResult = await page.evaluate(() => navigator.clipboard.readText())
+    expect(copiedJsonResult).toBe(`[
+  {
+    "?column?": "hello world"
+  }
+]`)
+
+    // export as CSV
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: 'Export' }).click()
+    await page.getByRole('menuitem', { name: 'Download CSV' }).click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toContain('.csv')
+    const downloadPath = await download.path()
+    const csvContent = fs.readFileSync(downloadPath, 'utf-8').replace(/\r?\n/g, '\n')
+    expect(csvContent).toBe(`?column?
+hello world`)
+    fs.unlinkSync(downloadPath)
+
+    // clear SQL snippet
+    if (!isCLI()) {
+      await deleteSqlSnippet(page, ref, newSqlSnippetName)
+    } else {
+      await page.reload()
+    }
+  })
+
+  test('snippet favourite works as expected', async ({ ref }) => {
+    if (!isCLI()) {
+      // clean up private snippets and snippets shared with the team
+      await waitForApiResponseWithTimeout(
+        page,
+        (response) => response.url().includes('query?key=table-columns'),
+        3000
+      )
+      const privateSnippetSection = page.getByLabel('private-snippets')
+      if ((await privateSnippetSection.getByText(newSqlSnippetName, { exact: true }).count()) > 0) {
+        await deleteSqlSnippet(page, ref, newSqlSnippetName)
+      }
+
+      if (
+        (await privateSnippetSection.getByText(sqlSnippetNameFavorite, { exact: true }).count()) > 0
+      ) {
+        await deleteSqlSnippet(page, ref, sqlSnippetNameFavorite)
+      }
+    }
+
+    // create sql snippet
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
+    await page.keyboard.press('ControlOrMeta+KeyA')
+    await page.keyboard.type(`select 'hello world';`)
+    await page.getByTestId('sql-run-button').click()
+
+    // rename snippet
+    const privateSnippetSection = page.getByLabel('private-snippets')
+    await privateSnippetSection.getByText(newSqlSnippetName).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename query', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Rename' })).toBeVisible()
+    await page.getByRole('textbox', { name: 'Name' }).fill(sqlSnippetNameFavorite)
+    await page.getByRole('button', { name: 'Rename query', exact: true }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(
+      privateSnippetSection.getByText(sqlSnippetNameFavorite, { exact: true })
+    ).toBeVisible()
+    await page.waitForTimeout(2000) // wait for sql snippets cache to invalidate.
+
+    // open up shared and favourites sections
+    await page.getByRole('button', { name: 'Favorites' }).click()
 
     // favourite snippets
     await page.getByTestId('sql-editor-utility-actions').click()
     await page.getByRole('menuitem', { name: 'Add to favorites', exact: true }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
     const favouriteSnippetsSection = page.getByLabel('favorite-snippets')
-    await expect(favouriteSnippetsSection).toContainText('Untitled query')
+    await expect(
+      favouriteSnippetsSection.getByText(sqlSnippetNameFavorite, { exact: true })
+    ).toBeVisible()
 
     // unfavorite snippets
-    await page.waitForTimeout(500)
     await page.getByTestId('sql-editor-utility-actions').click()
     await page.getByRole('menuitem', { name: 'Remove from favorites' }).click()
-    await expect(favouriteSnippetsSection).not.toBeVisible()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(
+      favouriteSnippetsSection.getByText(sqlSnippetNameFavorite, { exact: true })
+    ).not.toBeVisible()
+
+    // clear SQL snippet
+    if (!isCLI()) {
+      await deleteSqlSnippet(page, ref, sqlSnippetNameFavorite)
+    } else {
+      await page.reload()
+    }
+  })
+
+  test('share with team works as expected', async ({ ref }) => {
+    if (!isCLI()) {
+      console.log('Sharing and unsharing SQL snippet has issues in staging')
+      return
+    }
+
+    // clean up private snippets and snippets shared with the team
+    await waitForApiResponseWithTimeout(
+      page,
+      (response) => response.url().includes('query?key=table-columns'),
+      3000
+    )
+    const privateSnippetSection = page.getByLabel('private-snippets')
+    if ((await privateSnippetSection.getByText(newSqlSnippetName, { exact: true }).count()) > 0) {
+      await deleteSqlSnippet(page, ref, newSqlSnippetName)
+    }
+
+    if ((await privateSnippetSection.getByText(sqlSnippetNameShare, { exact: true }).count()) > 0) {
+      // this would delete snippets from both favorite and private snippets sections
+      await deleteSqlSnippet(page, ref, sqlSnippetNameShare)
+    }
+
+    if ((await page.getByRole('button', { name: 'Shared' }).textContent()).includes('(')) {
+      const sharedSnippetSection = page.getByLabel('project-level-snippets')
+      await page.getByRole('button', { name: 'Shared' }).click()
+
+      let sharedSnippetText = await sharedSnippetSection.textContent()
+      while (sharedSnippetText.includes(sqlSnippetNameShare)) {
+        await sharedSnippetSection.getByText(sqlSnippetName).last().click({ button: 'right' })
+        await page.getByRole('menuitem', { name: 'Delete query' }).click()
+        await expect(page.getByRole('heading', { name: 'Confirm to delete query' })).toBeVisible()
+        await page.getByRole('button', { name: 'Delete 1 query' }).click()
+        await waitForApiResponse(page, 'projects', ref, 'content', { method: 'DELETE' })
+        await page.waitForTimeout(500)
+        sharedSnippetText =
+          (await page.getByLabel('project-level-snippets').count()) > 0
+            ? await sharedSnippetSection.textContent()
+            : ''
+      }
+      await page.getByRole('button', { name: 'Shared' }).click()
+    }
+
+    // create sql snippet
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
+    await page.keyboard.press('ControlOrMeta+KeyA')
+    await page.keyboard.type(`select 'hello world';`)
+    await page.getByTestId('sql-run-button').click()
 
     // rename snippet
-    await privateSnippet.getByText('Untitled query').click({ button: 'right' })
+    await privateSnippetSection.getByText(newSqlSnippetName).click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Rename query', exact: true }).click()
     await expect(page.getByRole('heading', { name: 'Rename' })).toBeVisible()
-    await page.getByRole('textbox', { name: 'Name' }).fill(pwTestQueryName)
+    await page.getByRole('textbox', { name: 'Name' }).fill(sqlSnippetNameShare)
     await page.getByRole('button', { name: 'Rename query', exact: true }).click()
-    await page.waitForResponse(
-      (response) =>
-        (response.url().includes(`projects/${ref}/content`) ||
-          response.url().includes('projects/default/content')) &&
-        response.request().method() === 'PUT' &&
-        response.status().toString().startsWith('2')
-    )
-    await expect(privateSnippet.getByText(pwTestQueryName, { exact: true })).toBeVisible({
-      timeout: 50000,
-    })
-    const privateSnippet2 = await privateSnippet.getByText(pwTestQueryName, { exact: true })
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(
+      privateSnippetSection.getByText(sqlSnippetNameShare, { exact: true })
+    ).toBeVisible()
+    await page.waitForTimeout(2000) // wait for sql snippets cache to invalidate.
+
+    // open up shared and favourites sections
+    await page.getByRole('button', { name: 'Shared' }).click()
 
     // share with a team
-    await privateSnippet2.click({ button: 'right' })
+    const snippet = privateSnippetSection.getByText(sqlSnippetNameShare, { exact: true })
+    await snippet.click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Share query with team' }).click()
     await expect(page.getByRole('heading', { name: 'Confirm to share query' })).toBeVisible()
+    await page.waitForTimeout(1000)
     await page.getByRole('button', { name: 'Share query', exact: true }).click()
-    await page.waitForResponse(
-      (response) =>
-        (response.url().includes(`projects/${ref}/content`) ||
-          response.url().includes('projects/default/content')) &&
-        response.request().method() === 'PUT' &&
-        response.status().toString().startsWith('2')
-    )
-    const sharedSnippet = await page.getByLabel('project-level-snippets')
-    await expect(sharedSnippet).toContainText(pwTestQueryName)
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    const sharedSnippet = page.getByLabel('project-level-snippets')
+    await expect(sharedSnippet.getByText(sqlSnippetNameShare, { exact: true })).toBeVisible({
+      timeout: 5000,
+    })
 
     // unshare a snippet
-    await sharedSnippet.getByText(pwTestQueryName).click({ button: 'right' })
+    await sharedSnippet.getByText(sqlSnippetNameShare).click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Unshare query with team' }).click()
     await expect(page.getByRole('heading', { name: 'Confirm to unshare query:' })).toBeVisible()
     await page.getByRole('button', { name: 'Unshare query', exact: true }).click()
-    await expect(sharedSnippet).not.toBeVisible()
+    await expect(sharedSnippet.getByText(sqlSnippetNameShare, { exact: true })).not.toBeVisible()
 
-    // delete snippet (for non-local environment)
+    // clear SQL snippet
     if (!isCLI()) {
-      deleteQuery(page, pwTestQueryName)
-
-      await expect(
-        page.getByText('Successfully deleted 1 query'),
-        'Delete confirmation toast should be visible'
-      ).toBeVisible({
-        timeout: 50000,
-      })
+      await deleteSqlSnippet(page, ref, sqlSnippetNameShare)
+    } else {
+      await page.reload()
     }
+  })
+
+  test('folders works as expected', async ({ ref }) => {
+    if (!isCLI()) {
+      // clean up folders and snippets
+      await waitForApiResponseWithTimeout(
+        page,
+        (response) => response.url().includes('query?key=table-columns'),
+        3000
+      )
+      const privateSnippetSection = page.getByLabel('private-snippets')
+      if ((await privateSnippetSection.getByText(sqlFolderName, { exact: true }).count()) > 0) {
+        await deleteFolder(page, ref, sqlFolderName)
+      }
+      if (
+        (await privateSnippetSection.getByText(sqlFolderNameUpdated, { exact: true }).count()) > 0
+      ) {
+        await deleteFolder(page, ref, sqlFolderNameUpdated)
+      }
+    } else {
+      console.log('This test does not work in self-hosted environments.')
+      return
+    }
+
+    // create sql snippet
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
+    await page.keyboard.press('ControlOrMeta+KeyA')
+    await page.keyboard.type(`select 'hello world';`)
+    await page.getByTestId('sql-run-button').click()
+
+    // rename snippet
+    const privateSnippetSection = page.getByLabel('private-snippets')
+    await privateSnippetSection.getByText(newSqlSnippetName).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename query', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Rename' })).toBeVisible()
+    await page.getByRole('textbox', { name: 'Name' }).fill(sqlSnippetNameFolder)
+    await page.getByRole('button', { name: 'Rename query', exact: true }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(
+      privateSnippetSection.getByText(sqlSnippetNameFolder, { exact: true })
+    ).toBeVisible()
+    await page.waitForTimeout(2000) // wait for sql snippets cache to invalidate.
+
+    // create a folder
+    await page.getByTestId('sql-editor-new-query-button').click()
+    await page.getByRole('menuitem', { name: 'Create a new folder' }).click()
+    await page.getByRole('tree', { name: 'private-snippets' }).getByRole('textbox').click()
+    await page
+      .getByRole('tree', { name: 'private-snippets' })
+      .getByRole('textbox')
+      .fill(sqlFolderName)
+    await page.waitForTimeout(500)
+    await page.locator('.view-lines').click() // blur input and renames folder
+    await waitForApiResponse(page, 'projects', ref, 'content/folders', { method: 'POST' })
+    await expect(page.getByText('Successfully created folder')).toBeVisible()
+
+    // rename a folder
+    await privateSnippetSection.getByText(sqlFolderName).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename folder' }).click()
+    await page
+      .getByRole('treeitem', { name: sqlFolderName })
+      .getByRole('textbox')
+      .fill(sqlFolderNameUpdated)
+    await page.waitForTimeout(500)
+    await page.locator('.view-lines').click() // blur input and renames folder
+    await waitForApiResponse(page, 'projects', ref, 'content/folders', { method: 'PATCH' })
+
+    // move sql snippet into folder
+    await privateSnippetSection.getByText(sqlSnippetNameFolder).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Move query' }).click()
+    await page.getByRole('button', { name: 'Root of the editor (Current)' }).click()
+    await page.getByRole('option', { name: sqlFolderNameUpdated, exact: true }).click()
+    await page.getByRole('button', { name: 'Move file' }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(page.getByText('Successfully moved')).toBeVisible({
+      timeout: 5000,
+    })
+
+    // delete a folder + deleting a folder would also remove the SQL snippets within
+    await privateSnippetSection
+      .getByText(sqlFolderNameUpdated, { exact: true })
+      .click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Delete folder' }).click()
+    await expect(page.getByRole('heading', { name: 'Confirm to delete folder' })).toBeVisible()
+    await page.getByRole('button', { name: 'Delete folder' }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content/folders', {
+      method: 'DELETE',
+    })
+    await expect(page.getByText('Successfully deleted folder', { exact: true })).toBeVisible({
+      timeout: 5000,
+    })
+    await expect(privateSnippetSection.getByText(sqlFolderNameUpdated)).not.toBeVisible()
+    await expect(privateSnippetSection.getByText(sqlSnippetNameFolder)).not.toBeVisible()
+  })
+
+  test('other SQL snippets actions work as expected', async ({ ref }) => {
+    if (!isCLI()) {
+      // clean up 'Untitled query', 'pw_sql_snippet' and 'pw_sql_snippet (Duplicate)' snippets if exists
+      await waitForApiResponseWithTimeout(
+        page,
+        (response) => response.url().includes('query?key=table-columns'),
+        3000
+      )
+      const privateSnippet = page.getByLabel('private-snippets')
+      if ((await privateSnippet.getByText(newSqlSnippetName).count()) > 0) {
+        deleteSqlSnippet(page, ref, newSqlSnippetName)
+      }
+      if ((await privateSnippet.getByText(sqlSnippetNameDuplicate, { exact: true }).count()) > 0) {
+        await deleteSqlSnippet(page, ref, sqlSnippetNameDuplicate)
+      }
+      if ((await privateSnippet.getByText(sqlSnippetName, { exact: true }).count()) > 0) {
+        await deleteSqlSnippet(page, ref, sqlSnippetName)
+      }
+    } else {
+      console.log('This test does not work in self-hosted environments.')
+      return
+    }
+
+    // create sql snippet
+    await expect(page.getByText('Loading...')).not.toBeVisible()
+    await page.locator('.view-lines').click()
+    await page.keyboard.press('ControlOrMeta+KeyA')
+    await page.keyboard.type(`select 'hello world';`)
+    await page.getByTestId('sql-run-button').click()
+
+    // rename snippet
+    const privateSnippetSection = page.getByLabel('private-snippets')
+    await privateSnippetSection.getByText(newSqlSnippetName).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Rename query', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Rename' })).toBeVisible()
+    await page.getByRole('textbox', { name: 'Name' }).fill(sqlSnippetName)
+    await page.getByRole('button', { name: 'Rename query', exact: true }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(privateSnippetSection.getByText(sqlSnippetName, { exact: true })).toBeVisible()
+    await page.waitForTimeout(2000) // wait for sql snippets cache to invalidate.
+
+    // duplicate SQL snippet
+    await privateSnippetSection
+      .getByTitle(sqlSnippetName, { exact: true })
+      .click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Duplicate query' }).click()
+    await waitForApiResponse(page, 'projects', ref, 'content', { method: 'PUT' })
+    await expect(
+      privateSnippetSection.getByText(sqlSnippetNameDuplicate, { exact: true })
+    ).toBeVisible()
+
+    // filter SQL snippets
+    const searchBar = page.getByRole('textbox', { name: 'Search queries...' })
+    await searchBar.fill('Duplicate')
+    await expect(page.getByText(sqlSnippetName, { exact: true })).not.toBeVisible()
+    await expect(page.getByRole('link', { name: sqlSnippetNameDuplicate })).toBeVisible()
+    await expect(page.getByText('result found')).toBeVisible()
+    await searchBar.fill('') // clear search bar
+
+    // download as migration file
+    await privateSnippetSection
+      .getByTitle(sqlSnippetName, { exact: true })
+      .click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Download as migration file' }).click()
+    await expect(page.getByText('supabase migration new')).toBeVisible()
+    await page.getByRole('button', { name: 'Close' }).click()
+
+    // delete all files used in this test
+    await deleteSqlSnippet(page, ref, sqlSnippetNameDuplicate)
+    await deleteSqlSnippet(page, ref, sqlSnippetName)
   })
 })

--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -8,11 +8,12 @@ dotenv.config({ path: path.resolve(__dirname, '.env.local') })
 const IS_CI = !!process.env.CI
 
 export default defineConfig({
-  timeout: 60 * 1000,
+  // timeout: 60 * 1000,
+  timeout: 30000,
   testDir: './features',
   testMatch: /.*\.spec\.ts/,
   forbidOnly: IS_CI,
-  retries: IS_CI ? 3 : 1,
+  retries: IS_CI ? 3 : 0,
   use: {
     baseURL: env.STUDIO_URL,
     screenshot: 'off',

--- a/e2e/studio/utils/is-cli.ts
+++ b/e2e/studio/utils/is-cli.ts
@@ -1,8 +1,8 @@
 import { env } from '../env.config'
 
 /**
- * Returns true if running in CLI/self-hosted mode (IS_PLATFORM=false),
- * false if running in hosted mode (IS_PLATFORM=true).
+ * Returns true if running in CLI/self-hosted mode (locally),
+ * false if running in hosted mode.
  */
 export function isCLI(): boolean {
   // IS_PLATFORM=true = hosted mode

--- a/e2e/studio/utils/wait-for-response-with-timeout.ts
+++ b/e2e/studio/utils/wait-for-response-with-timeout.ts
@@ -1,0 +1,26 @@
+import { Page, Response } from '@playwright/test'
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+/**
+ * Waits for a API response for a specific endpoint before continuing the playwright test. If no api response we still continue with the playwright tests.
+ * @param page - Playwright page object
+ * @param basePath - Base path of API endpoint to wait for (e.g. 'pg-meta', 'platform/projects', etc.)
+ * @param ref - Project reference
+ * @param action - Action path of API endpoint to wait for (e.g. 'types', 'triggers', 'content', etc.)
+ * @param options - Optional object which checks more scenarios
+ */
+export async function waitForApiResponseWithTimeout(
+  page: Page,
+  urlMatcher: string | RegExp | ((response: Response) => boolean),
+  timeOutMs?: number
+): Promise<Response | null> {
+  try {
+    return await page.waitForResponse(urlMatcher, { timeout: timeOutMs || 5000 })
+  } catch (error) {
+    if (error.name === 'TimeoutError') {
+      return null
+    }
+    throw error
+  }
+}

--- a/e2e/studio/utils/wait-for-response.ts
+++ b/e2e/studio/utils/wait-for-response.ts
@@ -1,15 +1,36 @@
 import { Page } from '@playwright/test'
 
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
 /**
  * Waits for a API response for a specific endpoint before continuing the playwright test.
  * @param page - Playwright page object
+ * @param basePath - Base path of API endpoint to wait for (e.g. 'pg-meta', 'platform/projects', etc.)
  * @param ref - Project reference
- * @param endpoint - The endpoint to wait for (e.g., 'types', 'triggers')
+ * @param action - Action path of API endpoint to wait for (e.g. 'types', 'triggers', 'content', etc.)
+ * @param options - Optional object which checks more scenarios
  */
-export async function waitForApiResponse(page: Page, ref: string, endpoint: string): Promise<void> {
-  await page.waitForResponse(
-    (response) =>
-      response.url().includes(`pg-meta/${ref}/${endpoint}`) ||
-      response.url().includes(`pg-meta/default/${endpoint}`)
-  )
+export async function waitForApiResponse(
+  page: Page,
+  basePath: string,
+  ref: string,
+  action: string,
+  options?: Options
+): Promise<void> {
+  // regex trims "/" both start and end.
+  const trimmedBasePath = basePath.replace(/^\/+|\/+$/g, '')
+  const httpMethod = options?.method
+
+  await page.waitForResponse((response) => {
+    const urlMatches =
+      response.url().includes(`${trimmedBasePath}/${ref}/${action}`) ||
+      response.url().includes(`${trimmedBasePath}/default/${action}`)
+
+    // checks HTTP method if exists
+    return httpMethod ? urlMatches && response.request().method() === httpMethod : urlMatches
+  })
+}
+
+type Options = {
+  method?: HttpMethod
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- Add additional playwright test for sql snippets

All sql snippets playwright tests passing in local
<img width="918" height="204" alt="image" src="https://github.com/user-attachments/assets/a8355b0e-1180-4014-9876-51d50f15c870" />

All sql snippet playwright tests passing in staging
<img width="928" height="222" alt="image" src="https://github.com/user-attachments/assets/087a2290-8109-44a4-a6b7-61abc892ccaf" />

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
