### PR TITLE
e2e testing setup cleanup

### DIFF
--- a/e2e/studio/env.config.ts
+++ b/e2e/studio/env.config.ts
@@ -1,12 +1,20 @@
 import path from 'path'
+import dotenv from 'dotenv'
+
+dotenv.config({
+  path: path.resolve(__dirname, '.env.local'),
+  override: true,
+})
 
 export const env = {
-  STUDIO_URL: process.env.STUDIO_URL,
-  API_URL: process.env.API_URL || 'https://api.supabase.green',
-  AUTHENTICATION: process.env.AUTHENTICATION,
+  STUDIO_URL: process.env.STUDIO_URL || 'http://localhost:8082/',
+  API_URL: process.env.API_URL || 'http://localhost:8082/api',
+  AUTHENTICATION: process.env.AUTHENTICATION || 'false',
   EMAIL: process.env.EMAIL,
   PASSWORD: process.env.PASSWORD,
   PROJECT_REF: process.env.PROJECT_REF || 'default',
+  IS_PLATFORM: process.env.IS_PLATFORM || false,
 }
 
-export const STORAGE_STATE_PATH = path.join(__dirname, './playwright/.auth/user.json')
+export const STORAGE_STATE_PATH =
+  env.AUTHENTICATION === `true` ? path.join(__dirname, './playwright/.auth/user.json') : undefined

--- a/e2e/studio/features/home.spec.ts
+++ b/e2e/studio/features/home.spec.ts
@@ -1,10 +1,9 @@
 import { expect } from '@playwright/test'
 import { test } from '../utils/test'
-import { toUrl } from '../utils/to-url'
 
 test.describe('Project', async () => {
   test('Can navigate to project home page', async ({ page, ref }) => {
-    await page.goto(toUrl(`/project/${ref}`))
+    await page.goto(`/project/${ref}`)
 
     await expect(page.getByRole('link', { name: 'Tables' })).toBeVisible()
   })

--- a/e2e/studio/features/logs.spec.ts
+++ b/e2e/studio/features/logs.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '../utils/test'
-import { toUrl } from '../utils/to-url'
+
 const LOGS_PAGES = [
   { label: 'API Gateway', route: 'edge-logs' },
   // { label: 'Postgres', route: 'postgres-logs' },
@@ -46,7 +46,7 @@ test.describe('Logs', () => {
       /**
        * Navigates to Logs
        */
-      await page.goto(toUrl(`/project/${ref}/logs/${logPage.route}`))
+      await page.goto(`/project/${ref}/logs/${logPage.route}`)
 
       await expect(page.getByRole('heading', { name: 'Logs & Analytics' }), {
         message: 'Logs & Analytics heading should be visible',
@@ -72,9 +72,7 @@ test.describe('Logs', () => {
       /**
        * Can select and view log details
        */
-      await page.waitForLoadState('networkidle', {
-        timeout: 50000,
-      })
+      await page.waitForLoadState('networkidle')
 
       const firstRow = page.getByRole('row', { name: /Random event/ })
 

--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -1,7 +1,6 @@
 import { expect, Page } from '@playwright/test'
 import { isCLI } from '../utils/is-cli'
 import { test } from '../utils/test'
-import { toUrl } from '../utils/to-url'
 
 const deleteQuery = async (page: Page, queryName: string) => {
   const privateSnippet = page.getByLabel('private-snippets')
@@ -16,11 +15,11 @@ test.describe('SQL Editor', () => {
   const pwTestQueryName = 'pw-test-query'
 
   test.beforeAll(async ({ browser, ref }) => {
-    test.setTimeout(60000)
+    test.setTimeout(60_000)
 
     // Create a new table for the tests
     page = await browser.newPage()
-    await page.goto(toUrl(`/project/${ref}/sql/new?skip=true`))
+    await page.goto(`/project/${ref}/sql/new?skip=true`)
 
     await page.evaluate((ref) => {
       localStorage.removeItem('dashboard-history-default')
@@ -59,7 +58,7 @@ test.describe('SQL Editor', () => {
         page.getByText('Successfully deleted 1 query'),
         'Delete confirmation toast should be visible'
       ).toBeVisible({
-        timeout: 50000,
+        timeout: 50_000,
       })
       privateSnippetText =
         (await page.getByLabel('private-snippets').count()) > 0
@@ -79,7 +78,7 @@ test.describe('SQL Editor', () => {
         page.getByText('Successfully deleted 1 query'),
         'Delete confirmation toast should be visible'
       ).toBeVisible({
-        timeout: 50000,
+        timeout: 50_000,
       })
       privateSnippetText =
         (await page.getByLabel('private-snippets').count()) > 0
@@ -113,7 +112,7 @@ test.describe('SQL Editor', () => {
     await expect(page.getByRole('gridcell', { name: '5' })).toBeVisible()
   })
 
-  test('destructive query would tripper a warning modal', async () => {
+  test('destructive query would trigger a warning modal', async () => {
     await page.getByTestId('sql-editor-new-query-button').click()
     await page.getByRole('menuitem', { name: 'Create a new snippet' }).click()
 
@@ -179,7 +178,7 @@ test.describe('SQL Editor', () => {
         response.status().toString().startsWith('2')
     )
     await expect(privateSnippet.getByText(pwTestQueryName, { exact: true })).toBeVisible({
-      timeout: 50000,
+      timeout: 50_000,
     })
     const privateSnippet2 = await privateSnippet.getByText(pwTestQueryName, { exact: true })
 
@@ -213,7 +212,7 @@ test.describe('SQL Editor', () => {
         page.getByText('Successfully deleted 1 query'),
         'Delete confirmation toast should be visible'
       ).toBeVisible({
-        timeout: 50000,
+        timeout: 50_000,
       })
     }
   })

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1,7 +1,6 @@
-import { expect, Page } from '@playwright/test'
 import fs from 'fs'
+import { expect, Page } from '@playwright/test'
 import { test } from '../utils/test'
-import { toUrl } from '../utils/to-url'
 
 const getSelectors = (tableName: string) => ({
   tableButton: (page) => page.getByRole('button', { name: `View ${tableName}` }),
@@ -67,7 +66,7 @@ const createTable = async (page: Page, tableName: string) => {
     page.getByText(`Table ${tableName} is good to go!`),
     'Success toast should be visible after table creation'
   ).toBeVisible({
-    timeout: 50000,
+    timeout: 50_000,
   })
 
   await expect(
@@ -127,15 +126,14 @@ test.skip('Table Editor', () => {
   const tableNameCsv = `pw-test-csv`
 
   test.beforeAll(async ({ browser, ref }) => {
-    test.setTimeout(60000)
+    test.setTimeout(60_000)
 
     /**
      * Create a new table for the tests
      */
     page = await browser.newPage()
-    await page.goto(toUrl(`/project/${ref}/editor`))
+    await page.goto(`/project/${ref}/editor`, { waitUntil: `networkidle` })
 
-    await page.waitForTimeout(2000)
     // delete table name if it exists
     await deleteTable(page, testTableName)
     await deleteTable(page, tableNameRlsEnabled)
@@ -145,7 +143,7 @@ test.skip('Table Editor', () => {
   })
 
   test.afterAll(async () => {
-    test.setTimeout(60000)
+    test.setTimeout(60_000)
 
     // delete all tables related to this test
     await deleteTable(page, testTableName)
@@ -155,10 +153,10 @@ test.skip('Table Editor', () => {
     await deleteTable(page, tableNameCsv)
   })
 
-  test.skip('should perform all table operations sequentially', async ({ ref }) => {
+  test('should perform all table operations sequentially', async ({ ref }) => {
     await createTable(page, testTableName)
     const s = getSelectors(testTableName)
-    test.setTimeout(60000)
+    test.setTimeout(60_000)
 
     // 1. View table definition
     await page.evaluate(() => document.querySelector('.ReactQueryDevtools')?.remove())
@@ -291,7 +289,7 @@ test.skip('Table Editor', () => {
       page.getByText(`Table ${tableNameRlsDisabled} is good to go!`),
       'Success toast should be visible after Rls disabled table is created.'
     ).toBeVisible({
-      timeout: 50000,
+      timeout: 50_000,
     })
 
     await page.getByRole('button', { name: `View ${tableNameRlsDisabled}` }).click()
@@ -310,7 +308,7 @@ test.skip('Table Editor', () => {
       localStorage.removeItem('dashboard-history-default')
       localStorage.removeItem(`dashboard-history-${ref}`)
     }, ref)
-    await page.goto(toUrl(`/project/${ref}/database/types?schema=public`))
+    await page.goto(`/project/${ref}/database/types?schema=public`)
 
     // delete enum if it exists
     await deleteEnum(page, ENUM_NAME, ref)
@@ -335,7 +333,7 @@ test.skip('Table Editor', () => {
     await expect(page.getByRole('cell', { name: 'value1, value2', exact: true })).toBeVisible()
 
     // create a new table with new column for enums
-    await page.goto(toUrl(`/project/${ref}/editor`))
+    await page.goto(`/project/${ref}/editor`)
 
     const s = getSelectors(tableNameEnum)
     await s.newTableBtn(page).click()
@@ -356,7 +354,7 @@ test.skip('Table Editor', () => {
       page.getByText(`Table ${tableNameEnum} is good to go!`),
       'Success toast should be visible after table creation'
     ).toBeVisible({
-      timeout: 50000,
+      timeout: 50_000,
     })
 
     // Wait for the grid to be visible and data to be loaded
@@ -382,7 +380,7 @@ test.skip('Table Editor', () => {
 
     // delete enum and enum table
     await deleteTable(page, tableNameEnum)
-    await page.goto(toUrl(`/project/${ref}/database/types?schema=public`))
+    await page.goto(`/project/${ref}/database/types?schema=public`)
     await deleteEnum(page, ENUM_NAME, ref)
 
     // should end at the init link
@@ -391,7 +389,7 @@ test.skip('Table Editor', () => {
       localStorage.removeItem('dashboard-history-default')
       localStorage.removeItem(`dashboard-history-${ref}`)
     }, ref)
-    await page.goto(toUrl(`/project/${ref}/editor`))
+    await page.goto(`/project/${ref}/editor`)
   })
 
   test('csv import works properly', async () => {

--- a/e2e/studio/global.setup.ts
+++ b/e2e/studio/global.setup.ts
@@ -1,23 +1,18 @@
-import { expect, test as setup } from '@playwright/test'
-import dotenv from 'dotenv'
-import path from 'path'
-import { env, STORAGE_STATE_PATH } from '../env.config'
+import { expect, chromium } from '@playwright/test'
+import { env, STORAGE_STATE_PATH } from './env.config'
 
 /**
  * Run any setup tasks for the tests.
  * Catch errors and show useful messages.
  */
 
-dotenv.config({
-  path: path.resolve(__dirname, '..', '.env.local'),
-  override: true,
-})
-
 const IS_PLATFORM = process.env.IS_PLATFORM
-
 const envHasAuth = env.AUTHENTICATION
 
-setup('Global Setup', async ({ page }) => {
+export default async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+
   console.log(`\n 🧪 Setting up test environment.
     - Studio URL: ${env.STUDIO_URL}
     - API URL: ${env.API_URL}
@@ -28,6 +23,11 @@ setup('Global Setup', async ({ page }) => {
   /**
    * Studio Check
    */
+
+  if (!env.STUDIO_URL || !env.API_URL) {
+    console.error(`Missing environment variables. Check README.md for more information.`)
+    throw new Error('Missing environment variables')
+  }
 
   const studioUrl = env.STUDIO_URL
   const apiUrl = env.API_URL
@@ -69,8 +69,9 @@ To start API locally, run:
   /**
    * Only run authentication if the environment requires it
    */
-  if (!env.AUTHENTICATION) {
+  if (env.AUTHENTICATION !== `true`) {
     console.log(`\n 🔑 Skipping authentication for ${env.STUDIO_URL}`)
+    await browser.close()
     return
   } else {
     if (!env.EMAIL || !env.PASSWORD || !env.PROJECT_REF) {
@@ -83,8 +84,6 @@ To start API locally, run:
   console.log(`\n 🔑 Navigating to sign in page: ${signInUrl}`)
 
   await page.goto(signInUrl, { waitUntil: 'networkidle' })
-  await page.waitForLoadState('domcontentloaded')
-  await page.waitForLoadState('networkidle')
 
   // Check if we're still on the sign-in page
   const currentUrl = page.url()
@@ -97,16 +96,13 @@ To start API locally, run:
     if (currentUrl.includes('/projects')) {
       console.log('\n ✅ Already authenticated, proceeding with tests')
       await page.context().storageState({ path: STORAGE_STATE_PATH })
+      await browser.close()
       return
     }
 
     // If we're redirected somewhere else, try to navigate back to sign-in
     console.log('\n 🔄 Attempting to navigate back to sign-in page')
-    await page.goto(signInUrl, { waitUntil: 'networkidle', timeout: 30000 })
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForLoadState('networkidle', {
-      timeout: 30000,
-    })
+    await page.goto(signInUrl, { waitUntil: 'networkidle', timeout: 30_000 })
 
     // Check URL again after second attempt
     const secondAttemptUrl = page.url()
@@ -154,4 +150,7 @@ To start API locally, run:
   await page.waitForURL('**/organizations')
 
   await page.context().storageState({ path: STORAGE_STATE_PATH })
-})
+
+  await page.close()
+  await browser.close()
+}

--- a/e2e/studio/global.setup.ts
+++ b/e2e/studio/global.setup.ts
@@ -6,9 +6,6 @@ import { env, STORAGE_STATE_PATH } from './env.config'
  * Catch errors and show useful messages.
  */
 
-const IS_PLATFORM = process.env.IS_PLATFORM
-const envHasAuth = env.AUTHENTICATION
-
 export default async () => {
   const browser = await chromium.launch()
   const page = await browser.newPage()
@@ -16,8 +13,8 @@ export default async () => {
   console.log(`\n 🧪 Setting up test environment.
     - Studio URL: ${env.STUDIO_URL}
     - API URL: ${env.API_URL}
-    - Auth: ${envHasAuth ? 'enabled' : 'disabled'}
-    - Is Platform: ${IS_PLATFORM}
+    - Auth: ${env.AUTHENTICATION ? 'enabled' : 'disabled'}
+    - Is Platform: ${env.IS_PLATFORM}
     `)
 
   /**

--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -1,22 +1,14 @@
 import { defineConfig } from '@playwright/test'
 import { env, STORAGE_STATE_PATH } from './env.config'
-import dotenv from 'dotenv'
-import path from 'path'
-
-dotenv.config({ path: path.resolve(__dirname, '.env.local') })
 
 const IS_CI = !!process.env.CI
 
-const CI_TIMEOUT = 60 * 1000
-const DEV_TIMEOUT = 30 * 1000
+const CI_TIMEOUT = 60_000
+const DEV_TIMEOUT = 300_1000
 
 export default defineConfig({
   timeout: IS_CI ? CI_TIMEOUT : DEV_TIMEOUT,
-  expect: {
-    timeout: IS_CI ? CI_TIMEOUT : DEV_TIMEOUT,
-  },
-  testDir: './features',
-  testMatch: /.*\.spec\.ts/,
+  globalSetup: './global.setup.ts',
   forbidOnly: IS_CI,
   retries: IS_CI ? 3 : 0,
   maxFailures: IS_CI ? 1 : undefined,
@@ -29,14 +21,8 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'setup',
-      testMatch: /.*\.setup\.ts/,
-    },
-    {
       name: 'Features',
       testDir: './features',
-      testMatch: /.*\.spec\.ts/,
-      dependencies: ['setup'],
       use: {
         browserName: 'chromium',
         screenshot: 'off',

--- a/e2e/studio/utils/test.ts
+++ b/e2e/studio/utils/test.ts
@@ -1,12 +1,5 @@
 import { test as base } from '@playwright/test'
-import dotenv from 'dotenv'
-import path from 'path'
 import { env } from '../env.config'
-
-dotenv.config({
-  path: path.resolve(__dirname, '../.env.local'),
-  override: true,
-})
 
 export interface TestOptions {
   env: string

--- a/e2e/studio/utils/to-url.ts
+++ b/e2e/studio/utils/to-url.ts
@@ -1,5 +1,0 @@
-import { env } from '../env.config'
-
-export function toUrl(path: `/${string}`) {
-  return `${env.STUDIO_URL}${path}`
-}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:docs": "turbo run dev --filter=docs --parallel",
     "dev:www": "turbo run dev --filter=www --parallel",
     "dev:design-system": "turbo run dev --filter=design-system --parallel",
+    "dev:up": "cd docker && docker-compose up",
     "lint": "turbo run lint",
     "typecheck": "turbo --continue typecheck",
     "test:prettier": "prettier --cache --check '{apps,packages}/**/*.{js,jsx,ts,tsx,css,md,mdx,json}'",


### PR DESCRIPTION
removed unnecessary config, switch to using globalSetup so that all tests appear in playwright UI

consolidated environment variable loading to `env.config.ts`, set defaults to run against local dev server. skip loading storage state in unauthenticated environments

fix auth setup not being skipped because of string boolean truthiness, error on missing studio URL

remove unnecessary `toURL` util, use `baseUrl config setting instead

remove unnecessary repetitive waits/timeouts, rely on autowait features instead

format timeout numbers with underscore syntax for readability