### PR TITLE
fix: specify that 3rd party JWTs must have kid header parameter

### DIFF
--- a/apps/docs/content/guides/auth/third-party/overview.mdx
+++ b/apps/docs/content/guides/auth/third-party/overview.mdx
@@ -26,7 +26,7 @@ This is made possible if the providers are using JWTs signed with asymmetric key
 
 There are some limitations you should be aware of when using third-party authentication providers with Supabase.
 
-1. The third-party provider must use asymmetrically signed JWTs (exposed as an OIDC Issuer Discovery URL by the third-party authentication provider). Using symmetrically signed JWTs is not possible at this time.
+1. The third-party provider must use asymmetrically signed JWTs (exposed as an OIDC Issuer Discovery URL by the third-party authentication provider). The signed JWTs must have a `kid` header parameter to identify which key must be used. Using symmetrically signed JWTs is not possible at this time.
 2. The JWT signing keys from the third-party provider are stored in the configuration of your project, and are checked for changes periodically. If you are rotating your keys (when supported) allow up to 30 minutes for the change to be picked up.
 3. It is not possible to disable Supabase Auth at this time.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Specify that 3rd party JWTs must have kid header parameter
