### PR TITLE
Set unusualLineTerminators for grid monaco editor to auto

### DIFF
--- a/apps/studio/components/grid/components/common/MonacoEditor.tsx
+++ b/apps/studio/components/grid/components/common/MonacoEditor.tsx
@@ -68,6 +68,7 @@ export const MonacoEditor = ({
         lineNumbersMinChars: 0,
         scrollBeyondLastLine: false,
         wordWrap: 'on',
+        unusualLineTerminators: 'auto',
       }}
     />
   )

--- a/apps/studio/components/grid/components/common/MonacoEditor.tsx
+++ b/apps/studio/components/grid/components/common/MonacoEditor.tsx
@@ -68,7 +68,7 @@ export const MonacoEditor = ({
         lineNumbersMinChars: 0,
         scrollBeyondLastLine: false,
         wordWrap: 'on',
-        unusualLineTerminators: 'auto',
+        unusualLineTerminators: 'off',
       }}
     />
   )


### PR DESCRIPTION
## Context

Monaco might prompt users when running into "unusualLineTerminators" - setting this option to `off` to avoid monaco prompting, and not automatically making any changes to the data