### PR TITLE
feat(replication): Delete destination and pipeline atomically

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -84,8 +84,11 @@ export const DestinationRow = ({
 
     try {
       await stopPipeline({ projectRef, pipelineId: pipeline.id })
-      // using the new endpoint that deletes both destination and pipeline together
-      await deleteDestinationPipeline({ projectRef, destinationId: destinationId, pipelineId: pipeline.id })
+      await deleteDestinationPipeline({
+        projectRef,
+        destinationId: destinationId,
+        pipelineId: pipeline.id,
+      })
     } catch (error) {
       toast.error(PIPELINE_ERROR_MESSAGES.DELETE_DESTINATION)
     }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner'
 import { useParams } from 'common'
 import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
-import { useDeleteDestinationMutation } from 'data/replication/delete-destination-mutation'
+import { useDeleteDestinationPipelineMutation } from 'data/replication/delete-destination-pipeline-mutation'
 import { useReplicationPipelineStatusQuery } from 'data/replication/pipeline-status-query'
 import { Pipeline } from 'data/replication/pipelines-query'
 import { useStopPipelineMutation } from 'data/replication/stop-pipeline-mutation'
@@ -69,7 +69,7 @@ export const DestinationRow = ({
     : PipelineStatusRequestStatus.None
 
   const { mutateAsync: stopPipeline } = useStopPipelineMutation()
-  const { mutateAsync: deleteDestination } = useDeleteDestinationMutation({})
+  const { mutateAsync: deleteDestinationPipeline } = useDeleteDestinationPipelineMutation({})
 
   const pipelineStatus = pipelineStatusData?.status
   const statusName = getStatusName(pipelineStatus)
@@ -84,9 +84,8 @@ export const DestinationRow = ({
 
     try {
       await stopPipeline({ projectRef, pipelineId: pipeline.id })
-      // deleting the destination also deletes the pipeline because of cascade delete
-      // so we don't need to call deletePipeline explicitly
-      await deleteDestination({ projectRef, destinationId: destinationId })
+      // using the new endpoint that deletes both destination and pipeline together
+      await deleteDestinationPipeline({ projectRef, destinationId: destinationId, pipelineId: pipeline.id })
     } catch (error) {
       toast.error(PIPELINE_ERROR_MESSAGES.DELETE_DESTINATION)
     }

--- a/apps/studio/data/replication/delete-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/delete-destination-pipeline-mutation.ts
@@ -17,10 +17,13 @@ async function deleteDestinationPipeline(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const { data, error } = await del('/platform/replication/{ref}/destinations-pipelines/{destination_id}/{pipeline_id}', {
-    params: { path: { ref: projectRef, destination_id: destinationId, pipeline_id: pipelineId } },
-    signal,
-  })
+  const { data, error } = await del(
+    '/platform/replication/{ref}/destinations-pipelines/{destination_id}/{pipeline_id}',
+    {
+      params: { path: { ref: projectRef, destination_id: destinationId, pipeline_id: pipelineId } },
+      signal,
+    }
+  )
   if (error) {
     handleError(error)
   }

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -3434,7 +3434,8 @@ export interface paths {
     put?: never
     /** Update a replication destination and pipeline. */
     post: operations['ReplicationDestinationsPipelinesController_updateDestinationPipeline']
-    delete?: never
+    /** Delete a replication destination and pipeline. */
+    delete: operations['ReplicationDestinationsPipelinesController_deleteDestinationPipeline']
     options?: never
     head?: never
     patch?: never
@@ -6582,6 +6583,8 @@ export interface components {
     }
     OrganizationResponse: {
       billing_email: string | null
+      /** @enum {string|null} */
+      billing_partner: 'fly' | 'aws' | 'vercel_marketplace' | null
       id: number
       is_owner: boolean
       name: string
@@ -6634,9 +6637,8 @@ export interface components {
     }
     OrganizationSlugResponse: {
       billing_email: string | null
-      billing_metadata: {
-        [key: string]: unknown
-      } | null
+      /** @enum {string|null} */
+      billing_partner: 'fly' | 'aws' | 'vercel_marketplace' | null
       has_oriole_project: boolean
       id: number
       name: string
@@ -19118,6 +19120,44 @@ export interface operations {
         content?: never
       }
       /** @description Returned when the API fails to update the replication destination or pipeline. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationDestinationsPipelinesController_deleteDestinationPipeline: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Destination id */
+        destination_id: number
+        /** @description Pipeline id */
+        pipeline_id: number
+        /** @description Project reference */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returned when the replication destination and pipeline are deleted. */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to delete the replication destination or pipeline. */
       500: {
         headers: {
           [name: string]: unknown

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -4809,6 +4809,8 @@ export interface components {
         }
       | {
           billing_email: string | null
+          /** @enum {string|null} */
+          billing_partner: 'fly' | 'aws' | 'vercel_marketplace' | null
           id: number
           is_owner: boolean
           name: string


### PR DESCRIPTION
This PR implements the deletion of a destination and pipeline via a new endpoint which can atomically delete both.