### PR TITLE
Fix security definer RLS example

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -425,7 +425,7 @@ $$;
 create policy "rls_test_select"
 on test_table
 to authenticated
-using ( private.has_good_role() );
+using ( (select private.has_good_role()) );
 ```
 
 <Admonition type="caution">


### PR DESCRIPTION
Seems like at some point surrounding the security definer function private.has_good_role() with a select (like all functions should have for RLS) was changed.   I can't find the PR doing it though.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Doc fix

## What is the current behavior?
Example is not performant.

## What is the new behavior?
Adds a wrapping select to make it so.

## Additional context

Add any other context or screenshots.
