### PR TITLE
Check error before handling

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
@@ -106,7 +106,7 @@ export const getContextualInvalidationKeys = ({
 }
 
 export const onErrorChat = (error: Error) => {
-  const parsedError = tryParseJson(error.message)
+  const parsedError = error ? tryParseJson(error.message) : undefined
 
   try {
     handleError(parsedError?.error || parsedError || error)


### PR DESCRIPTION
I believe onError within useChat is being called without an error causing a .message on undefined error. This is a temporary fix which will allow user to retry instead of failing. The error happens sporadically only on production, not local.