### PR TITLE
Remove error display temporarily

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -218,7 +218,6 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     onFinish: handleChatFinish,
   })
 
-  const formattedError = tryParseJson(error?.message ?? {})
   const isChatLoading = chatStatus === 'submitted' || chatStatus === 'streaming'
 
   const updateMessage = useCallback(
@@ -445,10 +444,6 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
                       <p>
                         Sorry, I'm having trouble responding right now. If the error persists while
                         retrying, you may try clearing the conversation's messages and try again.
-                      </p>
-
-                      <p className="text-foreground-lighter text-xs mt-1">
-                        Error: {formattedError.message}
                       </p>
                     </div>
                   </div>

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -83,7 +83,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     }
     // [Joshen] Am also filtering out any tool calls which state is "input-streaming"
     // this happens when a user stops the assistant response while the tool is being called
-    if (msg && msg.role === 'assistant') {
+    if (msg && msg.role === 'assistant' && msg.parts) {
       const cleanedParts = msg.parts.filter((part: any) => {
         return !(part.type.startsWith('tool-') && part.state === 'input-streaming')
       })


### PR DESCRIPTION
Msg occasionally does not have parts which was causing error in generate-v4. The response was lacking a message causing crash in client-side.