### PR TITLE
Update sveltekit.mdx to remove VITE_ prefix from env vars.

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -66,8 +66,8 @@ hideToc: true
       <$CodeTabs>
 
         ```text name=.env
-        VITE_PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
-        VITE_PUBLIC_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+        PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        PUBLIC_SUPABASE_ANON_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
         ```
 
       </$CodeTabs>
@@ -89,16 +89,16 @@ hideToc: true
 
         ```js name=src/lib/supabaseClient.js
           import { createClient } from '@supabase/supabase-js';
-        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+        import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 
-        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY)
+        export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
         ```
 
         ```ts name=src/lib/supabaseClient.ts
           import { createClient } from '@supabase/supabase-js';
-        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+        import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 
-        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_ANON_KEY)
+        export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
         ```
 
       </$CodeTabs>


### PR DESCRIPTION
`VITE_` prefix is deprecated and caused errors in my setup, which is node 24.2.0 / vite 7.1.1.  Sample app works fine once I change the vars to just be `PUBLIC_*`

ChatGPT explains: https://chatgpt.com/share/68973c0f-3114-8009-9d5f-6dcdb3f823c3

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Error is thrown when accessing the URL after starting the sample project:

`[vite] (ssr) Error when evaluating SSR module /src/routes/+page.server.ts: VITE_PUBLIC_SUPABASE_URL is not defined`

## What is the new behavior?

No error is thrown.

## Additional context

This is my first PR and I'm following your links, but if you wanted an Issue opened separately first then please accept my apologies.
