### PR TITLE
fix: Handle a race condition with permissions API and the cell editors in the Table Editor

### DIFF
--- a/apps/studio/components/grid/components/editor/BooleanEditor.tsx
+++ b/apps/studio/components/grid/components/editor/BooleanEditor.tsx
@@ -1,5 +1,4 @@
 import type { RenderEditCellProps } from 'react-data-grid'
-import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Select } from 'ui'
 
 interface Props<TRow, TSummaryRow = unknown> extends RenderEditCellProps<TRow, TSummaryRow> {
@@ -13,8 +12,6 @@ export const BooleanEditor = <TRow, TSummaryRow = unknown>({
   onRowChange,
   onClose,
 }: Props<TRow, TSummaryRow>) => {
-  const snap = useTableEditorTableStateSnapshot()
-  const gridColumn = snap.gridColumns.find((x) => x.name == column.key)
   const value = row[column.key as keyof TRow] as unknown as string
 
   const onBlur = () => onClose(false)
@@ -36,7 +33,7 @@ export const BooleanEditor = <TRow, TSummaryRow = unknown>({
       onBlur={onBlur}
       onChange={onChange}
       defaultValue={value === null ? 'null' : value.toString()}
-      style={{ width: `${gridColumn?.width || column.width}px` }}
+      style={{ width: `${column.width}px` }}
     >
       <Select.Option value="true">TRUE</Select.Option>
       <Select.Option value="false">FALSE</Select.Option>

--- a/apps/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/apps/studio/components/grid/components/editor/JsonEditor.tsx
@@ -10,7 +10,6 @@ import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useGetCellValueMutation } from 'data/table-rows/get-cell-value-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { prettifyJSON, removeJSONTrailingComma, tryParseJson } from 'lib/helpers'
-import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Popover, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { BlockKeys } from '../common/BlockKeys'
 import { MonacoEditor } from '../common/MonacoEditor'
@@ -55,15 +54,12 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
   const { data: project } = useSelectedProjectQuery()
-  const snap = useTableEditorTableStateSnapshot()
 
   const { data: selectedTable } = useTableEditorQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
     id,
   })
-
-  const gridColumn = snap.gridColumns.find((x) => x.name == column.key)
 
   const rawInitialValue = row[column.key as keyof TRow] as unknown
   const initialValue =
@@ -161,13 +157,13 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
       overlay={
         isTruncated && !isSuccess ? (
           <div
-            style={{ width: `${gridColumn?.width || column.width}px` }}
+            style={{ width: `${column.width}px` }}
             className="flex items-center justify-center flex-col relative"
           >
             <MonacoEditor
               readOnly
               onChange={() => {}}
-              width={`${gridColumn?.width || column.width}px`}
+              width={`${column.width}px`}
               value={value ?? ''}
               language="markdown"
             />
@@ -176,7 +172,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
         ) : (
           <BlockKeys value={value} onEscape={cancelChanges} onEnter={saveChanges}>
             <MonacoEditor
-              width={`${gridColumn?.width || column.width}px`}
+              width={`${column.width}px`}
               value={value ?? ''}
               language="json"
               readOnly={!isEditable}

--- a/apps/studio/components/grid/components/editor/SelectEditor.tsx
+++ b/apps/studio/components/grid/components/editor/SelectEditor.tsx
@@ -1,8 +1,6 @@
 import type { RenderEditCellProps } from 'react-data-grid'
 import { Select } from 'ui'
 
-import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
-
 interface SelectEditorProps<TRow, TSummaryRow = unknown>
   extends RenderEditCellProps<TRow, TSummaryRow> {
   isNullable?: boolean
@@ -17,9 +15,6 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
   options,
   isNullable,
 }: SelectEditorProps<TRow, TSummaryRow>) {
-  const snap = useTableEditorTableStateSnapshot()
-  const gridColumn = snap.gridColumns.find((x) => x.name == column.key)
-
   const value = row[column.key as keyof TRow] as unknown as string
 
   function onChange(event: any) {
@@ -42,7 +37,7 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
       size="small"
       defaultValue={value ?? ''}
       className="sb-grid-select-editor !gap-2"
-      style={{ width: `${gridColumn?.width || column.width}px` }}
+      style={{ width: `${column.width}px` }}
       // @ts-ignore
       onChange={onChange}
       onBlur={onBlur}

--- a/apps/studio/components/grid/components/editor/TextEditor.tsx
+++ b/apps/studio/components/grid/components/editor/TextEditor.tsx
@@ -9,7 +9,6 @@ import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useGetCellValueMutation } from 'data/table-rows/get-cell-value-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Button, Popover, Tooltip, TooltipContent, TooltipTrigger, cn } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { BlockKeys } from '../common/BlockKeys'
@@ -30,7 +29,6 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
   isEditable?: boolean
   onExpandEditor: (column: string, row: TRow) => void
 }) => {
-  const snap = useTableEditorTableStateSnapshot()
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
   const { data: project } = useSelectedProjectQuery()
@@ -41,7 +39,6 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
     id,
   })
 
-  const gridColumn = snap.gridColumns.find((x) => x.name == column.key)
   const rawValue = row[column.key as keyof TRow] as unknown
   const initialValue = rawValue || rawValue === '' ? String(rawValue) : null
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
@@ -114,13 +111,13 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
         overlay={
           isTruncated && !isSuccess ? (
             <div
-              style={{ width: `${gridColumn?.width || column.width}px` }}
+              style={{ width: `${column.width}px` }}
               className="flex items-center justify-center flex-col relative"
             >
               <MonacoEditor
                 readOnly
                 onChange={() => {}}
-                width={`${gridColumn?.width || column.width}px`}
+                width={`${column.width}px`}
                 value={value ?? ''}
                 language="markdown"
               />
@@ -134,7 +131,7 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
               ignoreOutsideClicks={isConfirmNextModalOpen}
             >
               <MonacoEditor
-                width={`${gridColumn?.width || column.width}px`}
+                width={`${column.width}px`}
                 value={value ?? ''}
                 readOnly={!isEditable}
                 onChange={onChange}

--- a/apps/studio/state/table-editor-table.tsx
+++ b/apps/studio/state/table-editor-table.tsx
@@ -143,6 +143,18 @@ export const createTableEditorTableState = ({
     editable,
     setEditable: (editable: boolean) => {
       state.editable = editable
+
+      // When changing the editable flag, all grid columns need to be recreated for the editable flag to be propagated.
+      state.gridColumns = getInitialGridColumns(
+        getGridColumns(state.table, {
+          tableId: table.id,
+          editable,
+          onAddColumn: editable ? onAddColumn : undefined,
+          onExpandJSONEditor,
+          onExpandTextEditor,
+        }),
+        { gridColumns: state.gridColumns }
+      )
     },
   })
 


### PR DESCRIPTION
This PR adds code to recreate the grid columns when the `editable` flag changes. This fixes a bug where the permissions would come after the grid has been created and the editable flag will not be propagated when editing table cells.

I've also removed references to `snap.gridColumns` from the Table/JSON/Select editors because the data was already present in the `column` prop. This was a leftover when we used `react-tracked`.

Steps to verify:
1. Add `await new Promise(resolve => setTimeout(() => resolve(), 10000)`
2. Go to Table Editor
3. While the permissions haven't loaded yet, focus a field with text or json editor and try to change its value
4. The editor will be read-only. Once the permissions have loaded, the editor will switch to being editable.

Fixes #33364.