### PR TITLE
docs: Add Xcode isntructions to Swift ref docs

### DIFF
--- a/apps/docs/docs/ref/swift/installing.mdx
+++ b/apps/docs/docs/ref/swift/installing.mdx
@@ -20,6 +20,10 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
     - `Functions`
     - `Storage`
 
+    If you use Xcode, follow [Apple's dependencies guide](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to add supabase-swift to your project. Use https://github.com/supabase-community/supabase-swift.git for the url when Xcode asks.
+
+    If you don't want the full Supabase environment, you can add individual packages, such as Functions, `Auth`, `Realtime`, `Storage`, or `PostgREST`.
+
   </RefSubLayout.Details>
 
   <RefSubLayout.Examples>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR adds Xcode instructions to the swift reference docs.