### PR TITLE
fix: resolve 50% session tracking discrepancy on root route

### DIFF
--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -1,6 +1,10 @@
 import posthog from 'posthog-js'
 import { PostHogConfig } from 'posthog-js'
 
+// Limit the max number of queued events
+// (e.g. if a user navigates around a lot before accepting consent)
+const MAX_PENDING_EVENTS = 200
+
 interface PostHogClientConfig {
   apiKey?: string
   apiHost?: string
@@ -10,7 +14,9 @@ class PostHogClient {
   private initialized = false
   private pendingGroups: Record<string, string> = {}
   private pendingIdentification: { userId: string; properties?: Record<string, any> } | null = null
+  private pendingEvents: Array<{ event: string; properties: Record<string, any> }> = []
   private config: PostHogClientConfig
+  private readonly maxPendingEvents = MAX_PENDING_EVENTS
 
   constructor(config: PostHogClientConfig = {}) {
     this.config = {
@@ -42,9 +48,26 @@ class PostHogClient {
 
         // Apply any pending identification
         if (this.pendingIdentification) {
-          posthog.identify(this.pendingIdentification.userId, this.pendingIdentification.properties)
+          try {
+            posthog.identify(
+              this.pendingIdentification.userId,
+              this.pendingIdentification.properties
+            )
+          } catch (error) {
+            console.error('PostHog identify failed:', error)
+          }
           this.pendingIdentification = null
         }
+
+        // Flush any pending events
+        this.pendingEvents.forEach(({ event, properties }) => {
+          try {
+            posthog.capture(event, properties)
+          } catch (error) {
+            console.error('PostHog capture failed:', error)
+          }
+        })
+        this.pendingEvents = []
       },
     }
 
@@ -53,21 +76,49 @@ class PostHogClient {
   }
 
   capturePageView(properties: Record<string, any>, hasConsent: boolean = true) {
-    if (!hasConsent || !this.initialized) return
+    if (!hasConsent) return
 
-    // Store groups from properties if present (for later group() calls)
-    if (properties.$groups) {
-      Object.entries(properties.$groups).forEach(([type, id]) => {
-        if (id) posthog.group(type, id as string)
-      })
+    if (!this.initialized) {
+      // Queue the event for when PostHog initializes (up to cap)
+      if (this.pendingEvents.length >= this.maxPendingEvents) {
+        this.pendingEvents.shift() // Remove oldest event
+      }
+      this.pendingEvents.push({ event: '$pageview', properties })
+      return
     }
 
-    posthog.capture('$pageview', properties)
+    try {
+      // Store groups from properties if present (for later group() calls)
+      if (properties.$groups) {
+        Object.entries(properties.$groups).forEach(([type, id]) => {
+          if (id) posthog.group(type, id as string)
+        })
+      }
+
+      posthog.capture('$pageview', properties, { transport: 'sendBeacon' })
+    } catch (error) {
+      console.error('PostHog pageview capture failed:', error)
+    }
   }
 
   capturePageLeave(properties: Record<string, any>, hasConsent: boolean = true) {
-    if (!hasConsent || !this.initialized) return
-    posthog.capture('$pageleave', properties)
+    if (!hasConsent) return
+
+    if (!this.initialized) {
+      // Queue the event for when PostHog initializes (up to cap)
+      if (this.pendingEvents.length >= this.maxPendingEvents) {
+        this.pendingEvents.shift() // Remove oldest event
+      }
+      this.pendingEvents.push({ event: '$pageleave', properties })
+      return
+    }
+
+    try {
+      // Use sendBeacon for page leave to survive tab close
+      posthog.capture('$pageleave', properties, { transport: 'sendBeacon' })
+    } catch (error) {
+      console.error('PostHog pageleave capture failed:', error)
+    }
   }
 
   identify(userId: string, properties?: Record<string, any>, hasConsent: boolean = true) {
@@ -79,7 +130,11 @@ class PostHogClient {
       return
     }
 
-    posthog.identify(userId, properties)
+    try {
+      posthog.identify(userId, properties)
+    } catch (error) {
+      console.error('PostHog identify failed:', error)
+    }
   }
 }
 

--- a/packages/common/telemetry-utils.ts
+++ b/packages/common/telemetry-utils.ts
@@ -1,10 +1,36 @@
 import { isBrowser } from './helpers'
 
+// Parse session_id from PostHog cookie since SDK doesn't expose session ID
+// (needed to correlate client and server events)
+function getPostHogSessionId(): string | null {
+  if (!isBrowser) return null
+
+  try {
+    // Parse PostHog cookie to extract session ID
+    const phCookies = document.cookie.split(';').find((cookie) => cookie.trim().startsWith('ph_'))
+
+    if (phCookies) {
+      const cookieValue = decodeURIComponent(phCookies.split('=')[1])
+      const phData = JSON.parse(cookieValue)
+      if (phData.$sesid && Array.isArray(phData.$sesid) && phData.$sesid[1]) {
+        return phData.$sesid[1]
+      }
+    }
+  } catch (error) {
+    console.warn('Could not extract PostHog session ID:', error)
+  }
+
+  return null
+}
+
 export function getSharedTelemetryData(pathname?: string) {
+  const sessionId = getPostHogSessionId()
+
   return {
     page_url: isBrowser ? window.location.href : '',
     page_title: isBrowser ? document?.title : '',
     pathname: pathname ? pathname : isBrowser ? window.location.pathname : '',
+    session_id: sessionId,
     ph: {
       referrer: isBrowser ? document?.referrer : '',
       language: navigator.language ?? 'en-US',


### PR DESCRIPTION
## Summary
- Fixes race condition causing ~50% discrepancy in session tracking between client and server on root route
- Implements event queuing to capture telemetry events before PostHog initializes
- Adds session ID correlation to enable unified tracking analysis between client and server events

Resolves GROWTH-461

## Problem
We observed a discrepancy in unique session counts on the root route only:
- Client-side tracking was missing ~50% of sessions compared to server-side
- This was only happening on the root route, which uses a lot of dynamic imports compared to other pages
- Hypothesis is that users were bouncing before PostHog client library initialized
- This hypothesis can't be fully validated because we don't currently share a unique session id between client and server

<img width="767" height="446" alt="CleanShot 2025-08-11 at 17 59 33" src="https://github.com/user-attachments/assets/e330c114-6dbe-4b72-b479-bd507147fdf7" />

<img width="1730" height="944" alt="CleanShot 2025-08-11 at 18 25 53@2x" src="https://github.com/user-attachments/assets/f2d44fd9-d13f-45be-aeed-bf3724bc9ca3" />

## Solution
1. **Event Queuing**: Queue PV events while PostHog initializes, preventing data loss from early user interactions
2. **Session Correlation**: Extract PostHog session ID from cookies and sync between client/server for unified tracking
3. **Reliable Page Leave**: Use `sendBeacon` API to ensure page-leave events are captured even during navigation
4. **Production Safeguards**: Add `try`/`catch` blocks and memory caps to prevent API errors from breaking our tracking

## Test Plan
- [x] Verify events are queued and sent after PostHog initializes
- [x] Confirm session IDs match between client and server telemetry
- [x] Test page-leave events are captured on navigation
- [x] Vercel preview URLs added to UserCentrics for testing 