### PR TITLE
Chore/align bucket and object naming validation with storage api

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -196,10 +196,9 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
               name="name"
               render={({ field }) => (
                 <FormItemLayout
+                  layout="vertical"
                   label="Name of bucket"
                   labelOptional="Buckets cannot be renamed once created."
-                  description="Only lowercase letters, numbers, dots, and hyphens"
-                  layout="vertical"
                 >
                   <FormControl_Shadcn_>
                     <Input_Shadcn_ {...field} placeholder="Enter bucket name" />
@@ -208,12 +207,12 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
               )}
             />
 
-            <div className="flex flex-col gap-y-2 mt-6">
+            <div className="flex flex-col gap-y-2 mt-2">
               <FormField_Shadcn_
                 control={form.control}
                 name="type"
                 render={({ field }) => (
-                  <FormItemLayout>
+                  <FormItemLayout label="Bucket type">
                     <FormControl_Shadcn_>
                       <RadioGroupStacked
                         id="type"

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -39,6 +39,7 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { inverseValidBucketNameRegex, validBucketNameRegex } from './CreateBucketModal.utils'
 import { convertFromBytes, convertToBytes } from './StorageSettings/StorageSettings.utils'
 
 export interface CreateBucketModalProps {
@@ -46,29 +47,42 @@ export interface CreateBucketModalProps {
   onClose: () => void
 }
 
-const FormSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, 'Please provide a name for your bucket')
-    .regex(
-      /^[a-z0-9.-]+$/,
-      'The name of the bucket must only contain lowercase letters, numbers, dots, and hyphens'
-    )
-    .refine((value) => !value.endsWith(' '), 'The name of the bucket cannot end with a whitespace')
-    .refine(
-      (value) => value !== 'public',
-      '"public" is a reserved name. Please choose another name'
-    ),
-  type: z.enum(['STANDARD', 'ANALYTICS']).default('STANDARD'),
-  public: z.boolean().default(false),
-  has_file_size_limit: z.boolean().default(false),
-  formatted_size_limit: z.coerce
-    .number()
-    .min(0, 'File size upload limit has to be at least 0')
-    .default(0),
-  allowed_mime_types: z.string().trim().default(''),
-})
+const FormSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, 'Please provide a name for your bucket')
+      .max(100, 'Bucket name should be below 100 characters')
+      .refine(
+        (value) => !value.endsWith(' '),
+        'The name of the bucket cannot end with a whitespace'
+      )
+      .refine(
+        (value) => value !== 'public',
+        '"public" is a reserved name. Please choose another name'
+      ),
+    type: z.enum(['STANDARD', 'ANALYTICS']).default('STANDARD'),
+    public: z.boolean().default(false),
+    has_file_size_limit: z.boolean().default(false),
+    formatted_size_limit: z.coerce
+      .number()
+      .min(0, 'File size upload limit has to be at least 0')
+      .default(0),
+    allowed_mime_types: z.string().trim().default(''),
+  })
+  .superRefine((data, ctx) => {
+    if (!validBucketNameRegex.test(data.name)) {
+      const [match] = data.name.match(inverseValidBucketNameRegex) ?? []
+      ctx.addIssue({
+        path: ['name'],
+        code: z.ZodIssueCode.custom,
+        message: !!match
+          ? `Bucket name cannot contain the "${match}" character`
+          : 'Bucket name contains an invalid special character',
+      })
+    }
+  })
 
 export type CreateBucketForm = z.infer<typeof FormSchema>
 

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.utils.ts
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.utils.ts
@@ -1,0 +1,14 @@
+// [Joshen] These are referenced from the storage API directly here
+// https://github.com/supabase/storage/blob/69e4a40799a9d10be0a63a37cbb46d7d9bea0e17/src/storage/limits.ts#L59
+
+// only allow s3 safe characters and characters which require special handling for now
+// the slash restriction come from bucket naming rules
+// and the rest of the validation rules are based on S3 object key validation.
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+export const validBucketNameRegex = /^(\w|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/
+export const inverseValidBucketNameRegex = /[^A-Za-z0-9_!\-.*'() &$@=;:+,?]/
+
+// only allow s3 safe characters and characters which require special handling for now
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+export const validObjectKeyRegex = /^(\w|\/|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.utils.ts
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.utils.ts
@@ -12,3 +12,4 @@ export const inverseValidBucketNameRegex = /[^A-Za-z0-9_!\-.*'() &$@=;:+,?]/
 // only allow s3 safe characters and characters which require special handling for now
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
 export const validObjectKeyRegex = /^(\w|\/|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/
+export const inverseValidObjectKeyRegex = /[^A-Za-z0-9_\/!\-.*'() &$@=;:+,?]/

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -2,7 +2,7 @@ import { has } from 'lodash'
 import { useEffect, useRef, useState } from 'react'
 
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
-import { STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
+import { STORAGE_ROW_STATUS, STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
 import { StorageItem } from '../Storage.types'
 import { RowIcon } from './FileExplorerRow'
 
@@ -13,7 +13,8 @@ export interface FileExplorerRowEditingProps {
 }
 
 const FileExplorerRowEditing = ({ item, view, columnIndex }: FileExplorerRowEditingProps) => {
-  const { renameFile, renameFolder, addNewFolder } = useStorageExplorerStateSnapshot()
+  const { renameFile, renameFolder, addNewFolder, updateRowStatus } =
+    useStorageExplorerStateSnapshot()
 
   const inputRef = useRef<any>(null)
   const [itemName, setItemName] = useState(item.name)
@@ -28,7 +29,22 @@ const FileExplorerRowEditing = ({ item, view, columnIndex }: FileExplorerRowEdit
       await renameFile(item, name, columnIndex)
     } else if (has(item, 'id')) {
       const itemWithColumnIndex = { ...item, columnIndex }
-      renameFolder(itemWithColumnIndex, name, columnIndex)
+      renameFolder({
+        folder: itemWithColumnIndex,
+        newName: name,
+        columnIndex,
+        onError: () => {
+          if (event.type === 'blur') {
+            updateRowStatus({
+              name: itemWithColumnIndex.name,
+              status: STORAGE_ROW_STATUS.READY,
+              columnIndex,
+            })
+          } else {
+            inputRef.current.select()
+          }
+        },
+      })
     } else {
       addNewFolder({
         folderName: name,


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase/issues/34470#issuecomment-2883734179

## Context

There's an inconsistency between the Storage UI on the dashboard and the Storage API itself's naming convention for buckets and folders. This PR aligns the naming validation between both such that the dashboard will be identical to that of the Storage API.

## Changes
- Update bucket naming validation, we'd also try to show which character is causing the error if an invalid character is provided
  - Can test with for e.g `new/bucket/name` (slashes are not allowed)
- Update folder naming validation, we'd also try to show which character is causing the error if an invalid character is provided
  - Can test with for e.g `folder#name` (hashes are not allowed) 