### PR TITLE
Fix LinkedIn Developer URL

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
@@ -188,4 +188,4 @@ Do reach out to support if you have any concerns around this change.
 
 - [Supabase - Get started for free](https://supabase.com)
 - [Supabase JS Client](https://github.com/supabase/supabase-js)
-- [LinkedIn Developer Dashboard](https://api.LinkedIn.com/apps)
+- [LinkedIn Developer Dashboard](https://www.linkedin.com/developers/apps)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

Outdated link to LinkedIn Dev portal

https://supabase.com/docs/guides/auth/social-login/auth-linkedin


## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
