### PR TITLE
Part 2 of swapping useCheckPermissions with useAsyncCheckProjectPermissions

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -24,7 +24,7 @@ import { useGitHubConnectionsQuery } from 'data/integrations/github-connections-
 import { projectKeys } from 'data/projects/keys'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useFlag } from 'hooks/ui/useFlag'
@@ -114,7 +114,10 @@ export const CreateBranchModal = () => {
     },
   })
 
-  const canCreateBranch = useCheckPermissions(PermissionAction.CREATE, 'preview_branches')
+  const { can: canCreateBranch } = useAsyncCheckProjectPermissions(
+    PermissionAction.CREATE,
+    'preview_branches'
+  )
 
   const githubConnection = connections?.find((connection) => connection.project.ref === projectRef)
 

--- a/apps/studio/components/interfaces/BranchManagement/Overview.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/Overview.tsx
@@ -23,7 +23,7 @@ import { useBranchResetMutation } from 'data/branches/branch-reset-mutation'
 import { useBranchUpdateMutation } from 'data/branches/branch-update-mutation'
 import type { Branch } from 'data/branches/branches-query'
 import { branchKeys } from 'data/branches/keys'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import {
   Button,
   DropdownMenu,
@@ -169,8 +169,14 @@ const PreviewBranchActions = ({
   const queryClient = useQueryClient()
   const projectRef = branch.parent_project_ref ?? branch.project_ref
 
-  const canDeleteBranches = useCheckPermissions(PermissionAction.DELETE, 'preview_branches')
-  const canUpdateBranches = useCheckPermissions(PermissionAction.UPDATE, 'preview_branches')
+  const { can: canDeleteBranches } = useAsyncCheckProjectPermissions(
+    PermissionAction.DELETE,
+    'preview_branches'
+  )
+  const { can: canUpdateBranches } = useAsyncCheckProjectPermissions(
+    PermissionAction.UPDATE,
+    'preview_branches'
+  )
 
   const { data } = useBranchQuery({ projectRef, id: branch.id })
   const isBranchActiveHealthy = data?.status === 'ACTIVE_HEALTHY'
@@ -381,7 +387,10 @@ const PreviewBranchActions = ({
 // Actions for main (production) branch
 const MainBranchActions = ({ branch, repo }: { branch: Branch; repo: string }) => {
   const { ref: projectRef } = useParams()
-  const canUpdateBranches = useCheckPermissions(PermissionAction.UPDATE, 'preview_branches')
+  const { can: canUpdateBranches } = useAsyncCheckProjectPermissions(
+    PermissionAction.UPDATE,
+    'preview_branches'
+  )
   const [showEditBranchModal, setShowEditBranchModal] = useState(false)
 
   return (

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -9,7 +9,7 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import Panel from 'components/ui/Panel'
 import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
 import {
@@ -55,7 +55,10 @@ export const Connect = () => {
   )
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef }, { enabled: showConnect })
-  const canReadAPIKeys = useCheckPermissions(PermissionAction.READ, 'service_api_keys')
+  const { can: canReadAPIKeys } = useAsyncCheckProjectPermissions(
+    PermissionAction.READ,
+    'service_api_keys'
+  )
 
   const handleParentChange = (value: string) => {
     setSelectedParent(value)

--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -6,7 +6,7 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { InlineLink } from 'components/ui/InlineLink'
 import { useBackupDownloadMutation } from 'data/database/backup-download-mutation'
 import type { DatabaseBackup } from 'data/database/backups-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { Badge, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { TimestampInfo } from 'ui-patterns'
 
@@ -17,9 +17,9 @@ interface BackupItemProps {
   onSelectBackup: () => void
 }
 
-const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProps) => {
+export const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProps) => {
   const { ref: projectRef } = useParams()
-  const canTriggerScheduledBackups = useCheckPermissions(
+  const { can: canTriggerScheduledBackups } = useAsyncCheckProjectPermissions(
     PermissionAction.INFRA_EXECUTE,
     'queue_job.restore.prepare'
   )
@@ -38,8 +38,7 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
   })
 
   const generateSideButtons = (backup: DatabaseBackup) => {
-    // [Joshen] API typing is incorrect here, status is getting typed as Record<string, never>
-    if ((backup as any).status === 'COMPLETED')
+    if (backup.status === 'COMPLETED')
       return (
         <div className="flex space-x-4">
           <ButtonTooltip
@@ -123,5 +122,3 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
     </div>
   )
 }
-
-export default BackupItem

--- a/apps/studio/components/interfaces/Database/Backups/BackupsEmpty.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsEmpty.tsx
@@ -1,6 +1,6 @@
 import { Info } from 'lucide-react'
 
-const BackupsEmpty = () => {
+export const BackupsEmpty = () => {
   return (
     <div className="block w-full rounded border border-muted border-opacity-50 bg-gray-300 p-3">
       <div className="flex space-x-3">
@@ -10,5 +10,3 @@ const BackupsEmpty = () => {
     </div>
   )
 }
-
-export default BackupsEmpty

--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -14,9 +14,9 @@ import { setProjectStatus } from 'data/projects/projects-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
-import BackupItem from './BackupItem'
-import BackupsEmpty from './BackupsEmpty'
-import BackupsStorageAlert from './BackupsStorageAlert'
+import { BackupItem } from './BackupItem'
+import { BackupsEmpty } from './BackupsEmpty'
+import { BackupsStorageAlert } from './BackupsStorageAlert'
 
 const BackupsList = () => {
   const router = useRouter()

--- a/apps/studio/components/interfaces/Database/Backups/BackupsStorageAlert.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsStorageAlert.tsx
@@ -1,7 +1,6 @@
-import { AlertDescription_Shadcn_, Alert_Shadcn_ } from 'ui'
-import { WarningIcon } from 'ui'
+import { AlertDescription_Shadcn_, Alert_Shadcn_, WarningIcon } from 'ui'
 
-const BackupsStorageAlert = () => {
+export const BackupsStorageAlert = () => {
   return (
     <Alert_Shadcn_ variant="default">
       <WarningIcon />
@@ -13,5 +12,3 @@ const BackupsStorageAlert = () => {
     </Alert_Shadcn_>
   )
 }
-
-export default BackupsStorageAlert

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRNotice.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRNotice.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { FormPanel } from 'components/ui/Forms/FormPanel'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { getPITRRetentionDuration } from './PITR.utils'
 
 const PITRNotice = ({}) => {
@@ -14,7 +14,7 @@ const PITRNotice = ({}) => {
   const { data: addonsResponse } = useProjectAddonsQuery({ projectRef })
   const retentionPeriod = getPITRRetentionDuration(addonsResponse?.selected_addons ?? [])
 
-  const canUpdateSubscription = useCheckPermissions(
+  const { can: canUpdateSubscription } = useAsyncCheckProjectPermissions(
     PermissionAction.BILLING_WRITE,
     'stripe.subscriptions'
   )

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
@@ -18,8 +18,8 @@ import {
   Modal,
   WarningIcon,
 } from 'ui'
-import BackupsEmpty from '../BackupsEmpty'
-import BackupsStorageAlert from '../BackupsStorageAlert'
+import { BackupsEmpty } from '../BackupsEmpty'
+import { BackupsStorageAlert } from '../BackupsStorageAlert'
 import type { Timezone } from './PITR.types'
 import { getClientTimezone } from './PITR.utils'
 import PITRStatus from './PITRStatus'

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
@@ -3,13 +3,13 @@ import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { AlertCircle } from 'lucide-react'
 
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { FormPanel } from 'components/ui/Forms/FormPanel'
 import { useBackupsQuery } from 'data/database/backups-query'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { Timezone } from './PITR.types'
 import { TimezoneSelection } from './TimezoneSelection'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 
 interface PITRStatusProps {
   selectedTimezone: Timezone
@@ -41,7 +41,7 @@ const PITRStatus = ({
     .tz(selectedTimezone?.utc[0])
     .format('DD MMM YYYY, HH:mm:ss')
 
-  const canTriggerPhysicalBackup = useCheckPermissions(
+  const { can: canTriggerPhysicalBackup } = useAsyncCheckProjectPermissions(
     PermissionAction.INFRA_EXECUTE,
     'queue_job.walg.prepare_restore'
   )

--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/BackupsList.tsx
@@ -4,7 +4,7 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Badge, Button } from 'ui'
 import { TimestampInfo } from 'ui-patterns'
-import BackupsEmpty from '../BackupsEmpty'
+import { BackupsEmpty } from '../BackupsEmpty'
 
 interface BackupsListProps {
   onSelectRestore: (id: number) => void

--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabaseExtensionDisableMutation } from 'data/database-extensions/database-extension-disable-mutation'
 import { DatabaseExtension } from 'data/database-extensions/database-extensions-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsOrioleDb, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { extensions } from 'shared-data'
 import { Button, cn, Switch, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
@@ -28,7 +28,7 @@ const ExtensionCard = ({ extension }: ExtensionCardProps) => {
   const [isDisableModalOpen, setIsDisableModalOpen] = useState(false)
   const [showConfirmEnableModal, setShowConfirmEnableModal] = useState(false)
 
-  const canUpdateExtensions = useCheckPermissions(
+  const { can: canUpdateExtensions } = useAsyncCheckProjectPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'extensions'
   )

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -9,7 +9,7 @@ import InformationBox from 'components/ui/InformationBox'
 import NoSearchResults from 'components/ui/NoSearchResults'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Input } from 'ui'
 import ExtensionCard from './ExtensionCard'
@@ -42,11 +42,8 @@ const Extensions = () => {
     (ext) => !isNull(ext.installed_version)
   )
 
-  const canUpdateExtensions = useCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_WRITE,
-    'extensions'
-  )
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canUpdateExtensions, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'extensions')
 
   useEffect(() => {
     if (filter !== undefined) setFilterString(filter as string)

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import Table from 'components/to-be-cleaned/Table'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabaseFunctionsQuery } from 'data/database-functions/database-functions-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import {
@@ -50,7 +50,7 @@ const FunctionList = ({
     (func) => func.name.toLocaleLowerCase()
   )
   const projectRef = selectedProject?.ref
-  const canUpdateFunctions = useCheckPermissions(
+  const { can: canUpdateFunctions } = useAsyncCheckProjectPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'functions'
   )

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -12,8 +12,7 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import SchemaSelector from 'components/ui/SchemaSelector'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useDatabaseFunctionsQuery } from 'data/database-functions/database-functions-query'
-import { useSchemasQuery } from 'data/database/schemas-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
@@ -51,15 +50,10 @@ const FunctionsList = ({
     router.push(url)
   }
 
-  const canCreateFunctions = useCheckPermissions(
+  const { can: canCreateFunctions } = useAsyncCheckProjectPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'functions'
   )
-
-  const { data: schemas } = useSchemasQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
 
   const { isSchemaLocked } = useIsProtectedSchema({ schema: selectedSchema })
 

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -12,6 +12,7 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import SchemaSelector from 'components/ui/SchemaSelector'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useDatabaseFunctionsQuery } from 'data/database-functions/database-functions-query'
+import { useSchemasQuery } from 'data/database/schemas-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -56,6 +57,12 @@ const FunctionsList = ({
   )
 
   const { isSchemaLocked } = useIsProtectedSchema({ schema: selectedSchema })
+
+  // [Joshen] This is to preload the data for the Schema Selector
+  useSchemasQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
 
   const {
     data: functions,

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
@@ -1,3 +1,4 @@
+import { PostgresTrigger } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { includes, noop } from 'lodash'
 import { Edit3, MoreVertical, Trash } from 'lucide-react'
@@ -7,7 +8,7 @@ import { useParams } from 'common'
 import Table from 'components/to-be-cleaned/Table'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabaseHooksQuery } from 'data/database-triggers/database-triggers-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
 import {
@@ -23,11 +24,16 @@ import {
 export interface HookListProps {
   schema: string
   filterString: string
-  editHook: (hook: any) => void
-  deleteHook: (hook: any) => void
+  editHook: (hook: PostgresTrigger) => void
+  deleteHook: (hook: PostgresTrigger) => void
 }
 
-const HookList = ({ schema, filterString, editHook = noop, deleteHook = noop }: HookListProps) => {
+export const HookList = ({
+  schema,
+  filterString,
+  editHook = noop,
+  deleteHook = noop,
+}: HookListProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const { data: hooks } = useDatabaseHooksQuery({
@@ -39,16 +45,19 @@ const HookList = ({ schema, filterString, editHook = noop, deleteHook = noop }: 
   const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
 
   const filteredHooks = (hooks ?? []).filter(
-    (x: any) =>
+    (x) =>
       includes(x.name.toLowerCase(), filterString.toLowerCase()) &&
       x.schema === schema &&
       x.function_args.length >= 2
   )
-  const canUpdateWebhook = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
+  const { can: canUpdateWebhook } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'triggers'
+  )
 
   return (
     <>
-      {filteredHooks.map((x: any) => {
+      {filteredHooks.map((x) => {
         const isEdgeFunction = (url: string) =>
           url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`) ||
           url.includes(`https://${ref}.supabase.${restUrlTld}/functions/`)
@@ -134,5 +143,3 @@ const HookList = ({ schema, filterString, editHook = noop, deleteHook = noop }: 
     </>
   )
 }
-
-export default HookList

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
@@ -1,3 +1,4 @@
+import { PostgresTrigger } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { includes, map as lodashMap, uniqBy } from 'lodash'
 import { Search } from 'lucide-react'
@@ -9,20 +10,27 @@ import { DocsButton } from 'components/ui/DocsButton'
 import NoSearchResults from 'components/ui/NoSearchResults'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useDatabaseHooksQuery } from 'data/database-triggers/database-triggers-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import {
+  useAsyncCheckProjectPermissions,
+  usePermissionsLoaded,
+} from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { noop } from 'lib/void'
 import { Input } from 'ui'
-import HooksListEmpty from './HooksListEmpty'
-import SchemaTable from './SchemaTable'
+import { HooksListEmpty } from './HooksListEmpty'
+import { SchemaTable } from './SchemaTable'
 
 export interface HooksListProps {
   createHook: () => void
-  editHook: (hook: any) => void
-  deleteHook: (hook: any) => void
+  editHook: (hook: PostgresTrigger) => void
+  deleteHook: (hook: PostgresTrigger) => void
 }
 
-const HooksList = ({ createHook = noop, editHook = noop, deleteHook = noop }: HooksListProps) => {
+export const HooksList = ({
+  createHook = noop,
+  editHook = noop,
+  deleteHook = noop,
+}: HooksListProps) => {
   const { data: project } = useSelectedProjectQuery()
   const {
     data: hooks,
@@ -41,7 +49,10 @@ const HooksList = ({ createHook = noop, editHook = noop, deleteHook = noop }: Ho
   )
   const filteredHookSchemas = lodashMap(uniqBy(filteredHooks, 'schema'), 'schema')
 
-  const canCreateWebhooks = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
+  const { can: canCreateWebhooks } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'triggers'
+  )
   const isPermissionsLoaded = usePermissionsLoaded()
 
   return (
@@ -108,5 +119,3 @@ const HooksList = ({ createHook = noop, editHook = noop, deleteHook = noop }: Ho
     </div>
   )
 }
-
-export default HooksList

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksListEmpty.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksListEmpty.tsx
@@ -1,6 +1,6 @@
 import Table from 'components/to-be-cleaned/Table'
 
-const HooksListEmpty = () => {
+export const HooksListEmpty = () => {
   return (
     <Table
       className="table-fixed"
@@ -34,5 +34,3 @@ const HooksListEmpty = () => {
     />
   )
 }
-
-export default HooksListEmpty

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/SchemaTable.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/SchemaTable.tsx
@@ -1,16 +1,17 @@
+import { PostgresTrigger } from '@supabase/postgres-meta'
 import { noop } from 'lodash'
 
 import Table from 'components/to-be-cleaned/Table'
-import HookList from './HookList'
+import { HookList } from './HookList'
 
 interface SchemaTableProps {
   schema: string
   filterString: string
-  editHook: (hook: any) => void
-  deleteHook: (hook: any) => void
+  editHook: (hook: PostgresTrigger) => void
+  deleteHook: (hook: PostgresTrigger) => void
 }
 
-const SchemaTable = ({
+export const SchemaTable = ({
   schema,
   filterString,
   editHook = noop,
@@ -55,5 +56,3 @@ const SchemaTable = ({
     </div>
   )
 }
-
-export default SchemaTable

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -1,18 +1,18 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { noop } from 'lodash'
+import { AlertCircle, Search } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { Button, Input, Toggle } from 'ui'
-import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import Table from 'components/to-be-cleaned/Table'
 import InformationBox from 'components/ui/InformationBox'
 import NoSearchResults from 'components/ui/NoSearchResults'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
 import { useDatabasePublicationUpdateMutation } from 'data/database-publications/database-publications-update-mutation'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { AlertCircle, Search } from 'lucide-react'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import PublicationSkeleton from './PublicationSkeleton'
 
 interface PublicationEvent {
@@ -24,7 +24,7 @@ interface PublicationsListProps {
   onSelectPublication: (id: number) => void
 }
 
-const PublicationsList = ({ onSelectPublication = noop }: PublicationsListProps) => {
+export const PublicationsList = ({ onSelectPublication = noop }: PublicationsListProps) => {
   const { data: project } = useSelectedProjectQuery()
   const [filterString, setFilterString] = useState<string>('')
 
@@ -39,11 +39,8 @@ const PublicationsList = ({ onSelectPublication = noop }: PublicationsListProps)
     },
   })
 
-  const canUpdatePublications = useCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_WRITE,
-    'publications'
-  )
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canUpdatePublications, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'publications')
 
   const publicationEvents: PublicationEvent[] = [
     { event: 'Insert', key: 'publish_insert' },
@@ -183,5 +180,3 @@ const PublicationsList = ({ onSelectPublication = noop }: PublicationsListProps)
     </>
   )
 }
-
-export default PublicationsList

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
@@ -1,13 +1,13 @@
 import type { PostgresPublication, PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useState } from 'react'
-import { Badge, Toggle } from 'ui'
+import { toast } from 'sonner'
 
 import Table from 'components/to-be-cleaned/Table'
 import { useDatabasePublicationUpdateMutation } from 'data/database-publications/database-publications-update-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { toast } from 'sonner'
+import { Badge, Toggle } from 'ui'
 
 interface PublicationsTableItemProps {
   table: PostgresTable
@@ -22,7 +22,7 @@ const PublicationsTableItem = ({ table, selectedPublication }: PublicationsTable
     selectedPublication.tables?.find((x: any) => x.id == table.id) != undefined
   )
 
-  const canUpdatePublications = useCheckPermissions(
+  const { can: canUpdatePublications } = useAsyncCheckProjectPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'publications'
   )

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -27,9 +27,8 @@ export const PublicationsTables = ({
   const { data: project } = useSelectedProjectQuery()
   const [filterString, setFilterString] = useState<string>('')
 
-  const { can: canUpdatePublicationss, isLoading: isLoadingPermissions } =
+  const { can: canUpdatePublications, isLoading: isLoadingPermissions } =
     useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'publications')
-  const canUpdatePublications = false
 
   const { data: protectedSchemas } = useProtectedSchemas()
 

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -1,18 +1,18 @@
 import type { PostgresPublication } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { AlertCircle, ChevronLeft, Search } from 'lucide-react'
+import { ChevronLeft, Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
-import InformationBox from 'components/ui/InformationBox'
 import { Loading } from 'components/ui/Loading'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from 'hooks/useProtectedSchemas'
 import { Button, Input } from 'ui'
+import { Admonition } from 'ui-patterns'
 import PublicationsTableItem from './PublicationsTableItem'
 
 interface PublicationsTablesProps {
@@ -27,8 +27,9 @@ export const PublicationsTables = ({
   const { data: project } = useSelectedProjectQuery()
   const [filterString, setFilterString] = useState<string>('')
 
-  const { can: canUpdatePublications, isSuccess: isPermissionsLoaded } =
+  const { can: canUpdatePublicationss, isLoading: isLoadingPermissions } =
     useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'publications')
+  const canUpdatePublications = false
 
   const { data: protectedSchemas } = useProtectedSchemas()
 
@@ -72,18 +73,17 @@ export const PublicationsTables = ({
               />
             </div>
           </div>
-          {isPermissionsLoaded && !canUpdatePublications && (
-            <div className="w-[500px]">
-              <InformationBox
-                icon={<AlertCircle className="text-foreground-light" strokeWidth={2} />}
-                title="You need additional permissions to update database replications"
-              />
-            </div>
+          {!isLoadingPermissions && !canUpdatePublications && (
+            <Admonition
+              type="note"
+              className="w-[500px] m-0"
+              title="You need additional permissions to update database replications"
+            />
           )}
         </div>
       </div>
 
-      {isLoading && (
+      {(isLoading || isLoadingPermissions) && (
         <div className="mt-8">
           <Loading />
         </div>

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -1,5 +1,6 @@
 import type { PostgresPublication } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { AlertCircle, ChevronLeft, Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
@@ -8,10 +9,9 @@ import AlertError from 'components/ui/AlertError'
 import InformationBox from 'components/ui/InformationBox'
 import { Loading } from 'components/ui/Loading'
 import { useTablesQuery } from 'data/tables/tables-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from 'hooks/useProtectedSchemas'
-import { AlertCircle, ChevronLeft, Search } from 'lucide-react'
 import { Button, Input } from 'ui'
 import PublicationsTableItem from './PublicationsTableItem'
 
@@ -20,14 +20,15 @@ interface PublicationsTablesProps {
   onSelectBack: () => void
 }
 
-const PublicationsTables = ({ selectedPublication, onSelectBack }: PublicationsTablesProps) => {
+export const PublicationsTables = ({
+  selectedPublication,
+  onSelectBack,
+}: PublicationsTablesProps) => {
   const { data: project } = useSelectedProjectQuery()
   const [filterString, setFilterString] = useState<string>('')
 
-  const canUpdatePublications = useCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_WRITE,
-    'publications'
-  )
+  const { can: canUpdatePublications, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'publications')
 
   const { data: protectedSchemas } = useProtectedSchemas()
 
@@ -71,7 +72,7 @@ const PublicationsTables = ({ selectedPublication, onSelectBack }: PublicationsT
               />
             </div>
           </div>
-          {!canUpdatePublications && (
+          {isPermissionsLoaded && !canUpdatePublications && (
             <div className="w-[500px]">
               <InformationBox
                 icon={<AlertCircle className="text-foreground-light" strokeWidth={2} />}
@@ -81,6 +82,7 @@ const PublicationsTables = ({ selectedPublication, onSelectBack }: PublicationsT
           )}
         </div>
       </div>
+
       {isLoading && (
         <div className="mt-8">
           <Loading />
@@ -131,5 +133,3 @@ const PublicationsTables = ({ selectedPublication, onSelectBack }: PublicationsT
     </>
   )
 }
-
-export default PublicationsTables

--- a/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -44,7 +44,7 @@ const initialValues = {
   canBypassRls: false,
 }
 
-const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
+export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
   const formId = 'create-new-role'
 
   const { data: project } = useSelectedProjectQuery()
@@ -187,5 +187,3 @@ const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
     </SidePanel>
   )
 }
-
-export default CreateRolePanel

--- a/apps/studio/components/interfaces/Database/Roles/DeleteRoleModal.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/DeleteRoleModal.tsx
@@ -11,7 +11,7 @@ interface DeleteRoleModalProps {
   onClose: () => void
 }
 
-const DeleteRoleModal = ({ role, visible, onClose }: DeleteRoleModalProps) => {
+export const DeleteRoleModal = ({ role, visible, onClose }: DeleteRoleModalProps) => {
   const { data: project } = useSelectedProjectQuery()
 
   const { mutate: deleteDatabaseRole, isLoading: isDeleting } = useDatabaseRoleDeleteMutation({
@@ -50,5 +50,3 @@ const DeleteRoleModal = ({ role, visible, onClose }: DeleteRoleModalProps) => {
     </Modal>
   )
 }
-
-export default DeleteRoleModal

--- a/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -27,7 +27,7 @@ interface RoleRowProps {
   onSelectDelete: (role: PgRole) => void
 }
 
-const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
+export const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
   const { data: project } = useSelectedProjectQuery()
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -219,5 +219,3 @@ const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
     </Form>
   )
 }
-
-export default RoleRow

--- a/apps/studio/components/interfaces/Database/Roles/RoleRowSkeleton.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRowSkeleton.tsx
@@ -6,7 +6,7 @@ export interface RoleRowSkeletonProps {
   index?: number
 }
 
-const RoleRowSkeleton = ({ index }: RoleRowSkeletonProps) => {
+export const RoleRowSkeleton = ({ index }: RoleRowSkeletonProps) => {
   return (
     <div
       className={cn([
@@ -40,5 +40,3 @@ const RoleRowSkeleton = ({ index }: RoleRowSkeletonProps) => {
     </div>
   )
 }
-
-export default RoleRowSkeleton

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -8,13 +8,13 @@ import NoSearchResults from 'components/ui/NoSearchResults'
 import SparkBar from 'components/ui/SparkBar'
 import { useDatabaseRolesQuery } from 'data/database-roles/database-roles-query'
 import { useMaxConnectionsQuery } from 'data/database/max-connections-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Badge, Button, Input, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
-import CreateRolePanel from './CreateRolePanel'
-import DeleteRoleModal from './DeleteRoleModal'
-import RoleRow from './RoleRow'
-import RoleRowSkeleton from './RoleRowSkeleton'
+import { CreateRolePanel } from './CreateRolePanel'
+import { DeleteRoleModal } from './DeleteRoleModal'
+import { RoleRow } from './RoleRow'
+import { RoleRowSkeleton } from './RoleRowSkeleton'
 import { SUPABASE_ROLES } from './Roles.constants'
 
 type SUPABASE_ROLE = (typeof SUPABASE_ROLES)[number]
@@ -27,7 +27,10 @@ const RolesList = () => {
   const [isCreatingRole, setIsCreatingRole] = useState(false)
   const [selectedRoleToDelete, setSelectedRoleToDelete] = useState<any>()
 
-  const canUpdateRoles = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'roles')
+  const { can: canUpdateRoles } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'roles'
+  )
 
   const { data: maxConnData } = useMaxConnectionsQuery({
     projectRef: project?.ref,

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronLeft, Edit, MoreVertical, Plus, Search, Trash, X } from '
 import Link from 'next/link'
 import { useState } from 'react'
 
+import { PostgresColumn } from '@supabase/postgres-meta'
 import { useParams } from 'common'
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 import Table from 'components/to-be-cleaned/Table'
@@ -12,7 +13,7 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import {
@@ -30,11 +31,11 @@ import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
 
 interface ColumnListProps {
   onAddColumn: () => void
-  onEditColumn: (column: any) => void
-  onDeleteColumn: (column: any) => void
+  onEditColumn: (column: PostgresColumn) => void
+  onDeleteColumn: (column: PostgresColumn) => void
 }
 
-const ColumnList = ({
+export const ColumnList = ({
   onAddColumn = noop,
   onEditColumn = noop,
   onDeleteColumn = noop,
@@ -64,7 +65,10 @@ const ColumnList = ({
       : selectedTable?.columns?.filter((column) => column.name.includes(filterString))) ?? []
 
   const { isSchemaLocked } = useIsProtectedSchema({ schema: selectedTable?.schema ?? '' })
-  const canUpdateColumns = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'columns')
+  const { can: canUpdateColumns } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'columns'
+  )
 
   return (
     <div className="space-y-4">
@@ -213,5 +217,3 @@ const ColumnList = ({
     </div>
   )
 }
-
-export default ColumnList

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -23,6 +23,7 @@ import { useParams } from 'common'
 import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 import SchemaSelector from 'components/ui/SchemaSelector'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
@@ -32,7 +33,7 @@ import { useMaterializedViewsQuery } from 'data/materialized-views/materialized-
 import { usePrefetchEditorTablePage } from 'data/prefetchers/project.$ref.editor.$id'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useViewsQuery } from 'data/views/views-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
@@ -64,7 +65,7 @@ interface TableListProps {
   onDuplicateTable: (table: PostgresTable) => void
 }
 
-const TableList = ({
+export const TableList = ({
   onDuplicateTable,
   onAddTable = noop,
   onEditTable = noop,
@@ -80,7 +81,11 @@ const TableList = ({
 
   const [filterString, setFilterString] = useState<string>('')
   const [visibleTypes, setVisibleTypes] = useState<string[]>(Object.values(ENTITY_TYPE))
-  const canUpdateTables = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'tables')
+
+  const { can: canUpdateTables } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'tables'
+  )
 
   const {
     data: tables,
@@ -484,62 +489,58 @@ const TableList = ({
                                 {x.type === ENTITY_TYPE.TABLE && (
                                   <>
                                     <DropdownMenuSeparator />
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <DropdownMenuItem
-                                          className="!pointer-events-auto gap-x-2"
-                                          disabled={!canUpdateTables}
-                                          onClick={() => {
-                                            if (canUpdateTables) onEditTable(x)
-                                          }}
-                                        >
-                                          <Edit size={12} />
-                                          <p>Edit table</p>
-                                        </DropdownMenuItem>
-                                      </TooltipTrigger>
-                                      {!canUpdateTables && (
-                                        <TooltipContent side="left">
-                                          You need additional permissions to edit this table
-                                        </TooltipContent>
-                                      )}
-                                    </Tooltip>
-                                    <DropdownMenuItem
+                                    <DropdownMenuItemTooltip
+                                      className="gap-x-2"
+                                      disabled={!canUpdateTables}
+                                      onClick={() => {
+                                        if (canUpdateTables) onEditTable(x)
+                                      }}
+                                      tooltip={{
+                                        content: {
+                                          side: 'left',
+                                          text: 'You need additional permissions to edit this table',
+                                        },
+                                      }}
+                                    >
+                                      <Edit size={12} />
+                                      <p>Edit table</p>
+                                    </DropdownMenuItemTooltip>
+                                    <DropdownMenuItemTooltip
                                       key="duplicate-table"
-                                      className="space-x-2"
-                                      onClick={(e) => {
-                                        e.stopPropagation()
-                                        if (canUpdateTables) {
-                                          onDuplicateTable(x)
-                                        }
+                                      className="gap-x-2"
+                                      disabled={!canUpdateTables}
+                                      onClick={() => {
+                                        if (canUpdateTables) onDuplicateTable(x)
+                                      }}
+                                      tooltip={{
+                                        content: {
+                                          side: 'left',
+                                          text: 'You need additional permissions to duplicate tables',
+                                        },
                                       }}
                                     >
                                       <Copy size={12} />
                                       <span>Duplicate Table</span>
-                                    </DropdownMenuItem>
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <DropdownMenuItem
-                                          disabled={!canUpdateTables || isSchemaLocked}
-                                          className="!pointer-events-auto gap-x-2"
-                                          onClick={() => {
-                                            if (canUpdateTables && !isSchemaLocked) {
-                                              onDeleteTable({
-                                                ...x,
-                                                schema: selectedSchema,
-                                              })
-                                            }
-                                          }}
-                                        >
-                                          <Trash stroke="red" size={12} />
-                                          <p>Delete table</p>
-                                        </DropdownMenuItem>
-                                      </TooltipTrigger>
-                                      {!canUpdateTables && (
-                                        <TooltipContent side="left">
-                                          You need additional permissions to delete tables
-                                        </TooltipContent>
-                                      )}
-                                    </Tooltip>
+                                    </DropdownMenuItemTooltip>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItemTooltip
+                                      disabled={!canUpdateTables || isSchemaLocked}
+                                      className="gap-x-2"
+                                      onClick={() => {
+                                        if (canUpdateTables && !isSchemaLocked) {
+                                          onDeleteTable({ ...x, schema: selectedSchema })
+                                        }
+                                      }}
+                                      tooltip={{
+                                        content: {
+                                          side: 'left',
+                                          text: 'You need additional permissions to delete tables',
+                                        },
+                                      }}
+                                    >
+                                      <Trash size={12} />
+                                      <p>Delete table</p>
+                                    </DropdownMenuItemTooltip>
                                   </>
                                 )}
                               </DropdownMenuContent>
@@ -557,5 +558,3 @@ const TableList = ({
     </div>
   )
 }
-
-export default TableList

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -5,7 +5,7 @@ import { Check, Edit, Edit2, MoreVertical, Trash, X } from 'lucide-react'
 import Table from 'components/to-be-cleaned/Table'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabaseTriggersQuery } from 'data/database-triggers/database-triggers-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import {
@@ -51,7 +51,10 @@ const TriggerList = ({
     filteredTriggers.filter((x) => x.schema == schema),
     (trigger) => trigger.name.toLocaleLowerCase()
   )
-  const canUpdateTriggers = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
+  const { can: canUpdateTriggers } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'triggers'
+  )
 
   if (_triggers.length === 0 && filterString.length === 0) {
     return (

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
@@ -13,7 +13,7 @@ import SchemaSelector from 'components/ui/SchemaSelector'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useDatabaseTriggersQuery } from 'data/database-triggers/database-triggers-query'
 import { useTablesQuery } from 'data/tables/tables-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema, useProtectedSchemas } from 'hooks/useProtectedSchemas'
@@ -41,7 +41,7 @@ const TriggersList = ({
   const { data: protectedSchemas } = useProtectedSchemas()
   const { isSchemaLocked } = useIsProtectedSchema({ schema: selectedSchema })
 
-  const { data = [], isSuccess } = useTablesQuery({
+  const { data = [] } = useTablesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
@@ -58,7 +58,10 @@ const TriggersList = ({
     connectionString: project?.connectionString,
   })
 
-  const canCreateTriggers = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
+  const { can: canCreateTriggers } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'triggers'
+  )
 
   if (isLoading) {
     return <GenericSkeletonLoader />

--- a/apps/studio/components/interfaces/Database/index.ts
+++ b/apps/studio/components/interfaces/Database/index.ts
@@ -1,12 +1,6 @@
-export { default as ColumnList } from './Tables/ColumnList'
-export { default as TableList } from './Tables/TableList'
-
 export { default as RolesList } from './Roles/RolesList'
 
 export { default as Extensions } from './Extensions/Extensions'
-
-export { default as PublicationsList } from './Publications/PublicationsList'
-export { default as PublicationsTables } from './Publications/PublicationsTables'
 
 export { default as BackupsList } from './Backups/BackupsList'
 

--- a/apps/studio/components/interfaces/Integrations/Webhooks/ListTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Webhooks/ListTab.tsx
@@ -1,31 +1,34 @@
+import { PostgresTrigger } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useState } from 'react'
 
 import DeleteHookModal from 'components/interfaces/Database/Hooks/DeleteHookModal'
 import { EditHookPanel } from 'components/interfaces/Database/Hooks/EditHookPanel'
-import HooksList from 'components/interfaces/Database/Hooks/HooksList/HooksList'
+import { HooksList } from 'components/interfaces/Database/Hooks/HooksList/HooksList'
 import NoPermission from 'components/ui/NoPermission'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 
 export const WebhooksListTab = () => {
   const [selectedHook, setSelectedHook] = useState<any>()
   const [showCreateHookForm, setShowCreateHookForm] = useState<boolean>(false)
   const [showDeleteHookForm, setShowDeleteHookForm] = useState<boolean>(false)
 
-  const canReadWebhooks = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'triggers')
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canReadWebhooks, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_READ,
+    'triggers'
+  )
 
   const createHook = () => {
     setSelectedHook(undefined)
     setShowCreateHookForm(true)
   }
 
-  const editHook = (hook: any) => {
+  const editHook = (hook: PostgresTrigger) => {
     setSelectedHook(hook)
     setShowCreateHookForm(true)
   }
 
-  const deleteHook = (hook: any) => {
+  const deleteHook = (hook: PostgresTrigger) => {
     setSelectedHook(hook)
     setShowDeleteHookForm(true)
   }

--- a/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
@@ -1,3 +1,4 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { isEqual } from 'lodash'
 import { ExternalLink, Loader2, Megaphone } from 'lucide-react'
 import Link from 'next/link'
@@ -6,10 +7,13 @@ import DataGrid, { Row } from 'react-data-grid'
 
 import { useParams } from 'common'
 import { DocsButton } from 'components/ui/DocsButton'
+import NoPermission from 'components/ui/NoPermission'
 import ShimmerLine from 'components/ui/ShimmerLine'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { Button, IconBroadcast, IconDatabaseChanges, IconPresence, cn } from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns'
 import MessageSelection from './MessageSelection'
 import type { LogData } from './Messages.types'
 import NoChannelEmptyState from './NoChannelEmptyState'
@@ -30,9 +34,18 @@ const NoResultAlert = ({
 }) => {
   const { ref } = useParams()
 
+  const { can: canReadAPIKeys, isLoading: isLoadingPermissions } = useAsyncCheckProjectPermissions(
+    PermissionAction.READ,
+    'service_api_keys'
+  )
+
   return (
     <div className="w-full max-w-md flex items-center flex-col">
-      {!hasChannelSet ? (
+      {isLoadingPermissions ? (
+        <GenericSkeletonLoader className="w-80" />
+      ) : !canReadAPIKeys ? (
+        <NoPermission isFullPage resourceText="use the realtime inspector" />
+      ) : !hasChannelSet ? (
         <NoChannelEmptyState />
       ) : (
         <>

--- a/apps/studio/components/interfaces/Realtime/Inspector/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/index.tsx
@@ -14,8 +14,8 @@ import { RealtimeConfig, useRealtimeMessages } from './useRealtimeMessages'
 export const RealtimeInspector = () => {
   const { ref } = useParams()
   const { data: org } = useSelectedOrganizationQuery()
-  const [sendMessageShown, setSendMessageShown] = useState(false)
 
+  const [sendMessageShown, setSendMessageShown] = useState(false)
   const [realtimeConfig, setRealtimeConfig] = useState<RealtimeConfig>({
     enabled: false,
     projectRef: ref!,

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -3,7 +3,7 @@ import { Check, ChevronsUpDown, Plus } from 'lucide-react'
 import { useState } from 'react'
 
 import { useSchemasQuery } from 'data/database/schemas-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import {
   AlertDescription_Shadcn_,
@@ -50,7 +50,10 @@ const SchemaSelector = ({
   portal = true,
 }: SchemaSelectorProps) => {
   const [open, setOpen] = useState(false)
-  const canCreateSchemas = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'schemas')
+  const { can: canCreateSchemas } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'schemas'
+  )
 
   const { data: project } = useSelectedProjectQuery()
   const {

--- a/apps/studio/data/database-triggers/database-triggers-query.ts
+++ b/apps/studio/data/database-triggers/database-triggers-query.ts
@@ -1,8 +1,8 @@
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type DatabaseTriggersVariables = {
   projectRef?: string

--- a/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
+++ b/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
@@ -24,7 +24,7 @@ import { useBranchUpdateMutation } from 'data/branches/branch-update-mutation'
 import { Branch, useBranchesQuery } from 'data/branches/branches-query'
 import { useGitHubConnectionsQuery } from 'data/integrations/github-connections-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import type { NextPageWithLayout } from 'types'
@@ -49,7 +49,10 @@ const MergeRequestsPage: NextPageWithLayout = () => {
   const projectRef =
     project !== undefined ? (isBranch ? project.parent_project_ref : ref) : undefined
 
-  const canReadBranches = useCheckPermissions(PermissionAction.READ, 'preview_branches')
+  const { can: canReadBranches, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
+    PermissionAction.READ,
+    'preview_branches'
+  )
 
   const {
     data: connections,
@@ -163,7 +166,7 @@ const MergeRequestsPage: NextPageWithLayout = () => {
       <ScaffoldSection>
         <div className="col-span-12">
           <div className="space-y-4">
-            {!canReadBranches ? (
+            {isPermissionsLoaded && !canReadBranches ? (
               <NoPermission resourceText="view this project's branches" />
             ) : (
               <>

--- a/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -14,7 +14,7 @@ import NoPermission from 'components/ui/NoPermission'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { useBackupsQuery } from 'data/database/backups-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useIsOrioleDbInAws, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
@@ -57,8 +57,8 @@ const PITR = () => {
   const isEnabled = backups?.pitr_enabled
   const isActiveHealthy = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
-  const isPermissionsLoaded = usePermissionsLoaded()
-  const canReadPhysicalBackups = useCheckPermissions(PermissionAction.READ, 'physical_backups')
+  const { can: canReadPhysicalBackups, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.READ, 'physical_backups')
 
   if (isPermissionsLoaded && !canReadPhysicalBackups) {
     return <NoPermission resourceText="view PITR backups" />

--- a/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
@@ -23,7 +23,7 @@ import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { useDiskAttributesQuery } from 'data/config/disk-attributes-query'
 import { useCloneBackupsQuery } from 'data/projects/clone-query'
 import { useCloneStatusQuery } from 'data/projects/clone-status-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import {
   useIsAwsK8sCloudProvider,
@@ -80,12 +80,11 @@ const RestoreToNewProject = () => {
     isError,
   } = useCloneBackupsQuery({ projectRef: project?.ref }, { enabled: !isFreePlan })
 
-  const plan = organization?.plan?.id
   const isActiveHealthy = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
-  const isPermissionsLoaded = usePermissionsLoaded()
-  const canReadPhysicalBackups = useCheckPermissions(PermissionAction.READ, 'physical_backups')
-  const canTriggerPhysicalBackups = useCheckPermissions(
+  const { can: canReadPhysicalBackups, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.READ, 'physical_backups')
+  const { can: canTriggerPhysicalBackups } = useAsyncCheckProjectPermissions(
     PermissionAction.INFRA_EXECUTE,
     'queue_job.restore.prepare'
   )

--- a/apps/studio/pages/project/[ref]/database/backups/scheduled.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/scheduled.tsx
@@ -14,7 +14,7 @@ import InformationBox from 'components/ui/InformationBox'
 import NoPermission from 'components/ui/NoPermission'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useBackupsQuery } from 'data/database/backups-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsOrioleDbInAws } from 'hooks/misc/useSelectedProject'
 import type { NextPageWithLayout } from 'types'
 import { Admonition } from 'ui-patterns'
@@ -26,9 +26,9 @@ const DatabaseScheduledBackups: NextPageWithLayout = () => {
 
   const isOrioleDbInAws = useIsOrioleDbInAws()
   const isPitrEnabled = backups?.pitr_enabled
-  const isPermissionsLoaded = usePermissionsLoaded()
 
-  const canReadScheduledBackups = useCheckPermissions(PermissionAction.READ, 'back_ups')
+  const { can: canReadScheduledBackups, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.READ, 'back_ups')
 
   return (
     <ScaffoldContainer>

--- a/apps/studio/pages/project/[ref]/database/extensions.tsx
+++ b/apps/studio/pages/project/[ref]/database/extensions.tsx
@@ -6,15 +6,12 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
 
 const DatabaseExtensions: NextPageWithLayout = () => {
-  const canReadExtensions = useCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_READ,
-    'extensions'
-  )
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canReadExtensions, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'extensions')
 
   if (isPermissionsLoaded && !canReadExtensions) {
     return <NoPermission isFullPage resourceText="view database extensions" />

--- a/apps/studio/pages/project/[ref]/database/functions.tsx
+++ b/apps/studio/pages/project/[ref]/database/functions.tsx
@@ -11,7 +11,7 @@ import { EditorPanel } from 'components/ui/EditorPanel/EditorPanel'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
 import { DatabaseFunction } from 'data/database-functions/database-functions-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
 
 const DatabaseFunctionsPage: NextPageWithLayout = () => {
@@ -26,8 +26,10 @@ const DatabaseFunctionsPage: NextPageWithLayout = () => {
     DatabaseFunction | undefined
   >()
 
-  const canReadFunctions = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'functions')
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canReadFunctions, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_READ,
+    'functions'
+  )
 
   const createFunction = () => {
     if (isInlineEditorEnabled) {

--- a/apps/studio/pages/project/[ref]/database/publications.tsx
+++ b/apps/studio/pages/project/[ref]/database/publications.tsx
@@ -1,14 +1,15 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useState } from 'react'
 
-import { PublicationsList, PublicationsTables } from 'components/interfaces/Database'
+import { PublicationsList } from 'components/interfaces/Database/Publications/PublicationsList'
+import { PublicationsTables } from 'components/interfaces/Database/Publications/PublicationsTables'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import type { NextPageWithLayout } from 'types'
 
@@ -25,11 +26,8 @@ const DatabasePublications: NextPageWithLayout = () => {
   })
   const publications = data ?? []
 
-  const canViewPublications = useCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_READ,
-    'publications'
-  )
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canViewPublications, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'publications')
 
   const [selectedPublicationId, setSelectedPublicationId] = useState<number>()
   const selectedPublication = publications.find((pub) => pub.id === selectedPublicationId)

--- a/apps/studio/pages/project/[ref]/database/tables/[id].tsx
+++ b/apps/studio/pages/project/[ref]/database/tables/[id].tsx
@@ -1,7 +1,7 @@
 import { ChevronRight } from 'lucide-react'
 
 import { useParams } from 'common'
-import { ColumnList } from 'components/interfaces/Database'
+import { ColumnList } from 'components/interfaces/Database/Tables/ColumnList'
 import { SidePanelEditor } from 'components/interfaces/TableGridEditor'
 import DeleteConfirmationDialogs from 'components/interfaces/TableGridEditor/DeleteConfirmationDialogs'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'

--- a/apps/studio/pages/project/[ref]/database/tables/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/tables/index.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
 import { PostgresTable } from '@supabase/postgres-meta'
+import { useState } from 'react'
 
 import { useParams } from 'common'
-import { TableList } from 'components/interfaces/Database'
+import { TableList } from 'components/interfaces/Database/Tables/TableList'
 import { SidePanelEditor } from 'components/interfaces/TableGridEditor'
 import DeleteConfirmationDialogs from 'components/interfaces/TableGridEditor/DeleteConfirmationDialogs'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'

--- a/apps/studio/pages/project/[ref]/database/triggers.tsx
+++ b/apps/studio/pages/project/[ref]/database/triggers.tsx
@@ -13,7 +13,7 @@ import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { EditorPanel } from 'components/ui/EditorPanel/EditorPanel'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
 
 const TriggersPage: NextPageWithLayout = () => {
@@ -27,8 +27,10 @@ const TriggersPage: NextPageWithLayout = () => {
   const [editorPanelOpen, setEditorPanelOpen] = useState(false)
   const [selectedTriggerForEditor, setSelectedTriggerForEditor] = useState<PostgresTrigger>()
 
-  const canReadTriggers = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'triggers')
-  const isPermissionsLoaded = usePermissionsLoaded()
+  const { can: canReadTriggers, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_READ,
+    'triggers'
+  )
 
   const createTrigger = () => {
     if (isInlineEditorEnabled) {

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
@@ -14,8 +14,7 @@ import { useEdgeFunctionBodyQuery } from 'data/edge-functions/edge-function-body
 import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'
 import { useEdgeFunctionDeployMutation } from 'data/edge-functions/edge-functions-deploy-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useOrgAiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
@@ -29,7 +28,10 @@ const CodePage = () => {
   const { mutate: sendEvent } = useSendEventMutation()
   const [showDeployWarning, setShowDeployWarning] = useState(false)
 
-  const canDeployFunction = useCheckPermissions(PermissionAction.FUNCTIONS_WRITE, '*')
+  const { can: canDeployFunction } = useAsyncCheckProjectPermissions(
+    PermissionAction.FUNCTIONS_WRITE,
+    '*'
+  )
 
   const { data: selectedFunction } = useEdgeFunctionQuery({ projectRef: ref, slug: functionSlug })
   const {

--- a/apps/studio/pages/project/[ref]/realtime/inspector.tsx
+++ b/apps/studio/pages/project/[ref]/realtime/inspector.tsx
@@ -2,15 +2,18 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import type { NextPageWithLayout } from 'types'
 
 import { RealtimeInspector } from 'components/interfaces/Realtime/Inspector'
-import RealtimeLayout from 'components/layouts/RealtimeLayout/RealtimeLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import RealtimeLayout from 'components/layouts/RealtimeLayout/RealtimeLayout'
 import NoPermission from 'components/ui/NoPermission'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 
 export const InspectorPage: NextPageWithLayout = () => {
-  const canReadAPIKeys = useCheckPermissions(PermissionAction.READ, 'service_api_keys')
+  const { can: canReadAPIKeys, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
+    PermissionAction.READ,
+    'service_api_keys'
+  )
 
-  if (!canReadAPIKeys) {
+  if (isPermissionsLoaded && !canReadAPIKeys) {
     return <NoPermission isFullPage resourceText="access your project's realtime functionalities" />
   }
 

--- a/apps/studio/pages/project/[ref]/realtime/inspector.tsx
+++ b/apps/studio/pages/project/[ref]/realtime/inspector.tsx
@@ -1,22 +1,10 @@
-import { PermissionAction } from '@supabase/shared-types/out/constants'
 import type { NextPageWithLayout } from 'types'
 
 import { RealtimeInspector } from 'components/interfaces/Realtime/Inspector'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import RealtimeLayout from 'components/layouts/RealtimeLayout/RealtimeLayout'
-import NoPermission from 'components/ui/NoPermission'
-import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 
 export const InspectorPage: NextPageWithLayout = () => {
-  const { can: canReadAPIKeys, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
-    PermissionAction.READ,
-    'service_api_keys'
-  )
-
-  if (isPermissionsLoaded && !canReadAPIKeys) {
-    return <NoPermission isFullPage resourceText="access your project's realtime functionalities" />
-  }
-
   return <RealtimeInspector />
 }
 

--- a/apps/studio/pages/project/[ref]/reports/database.tsx
+++ b/apps/studio/pages/project/[ref]/reports/database.tsx
@@ -1,16 +1,16 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, ExternalLink, RefreshCw } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { AlertDescription_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
+import { useParams } from 'common'
 import ReportChart from 'components/interfaces/Reports/ReportChart'
 import ReportHeader from 'components/interfaces/Reports/ReportHeader'
 import ReportPadding from 'components/interfaces/Reports/ReportPadding'
+import { REPORT_DATERANGE_HELPER_LABELS } from 'components/interfaces/Reports/Reports.constants'
 import ReportStickyNav from 'components/interfaces/Reports/ReportStickyNav'
 import ReportWidget from 'components/interfaces/Reports/ReportWidget'
 import DiskSizeConfigurationModal from 'components/interfaces/Settings/Database/DiskSizeConfigurationModal'
@@ -21,26 +21,24 @@ import ReportsLayout from 'components/layouts/ReportsLayout/ReportsLayout'
 import Table from 'components/to-be-cleaned/Table'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import ChartHandler from 'components/ui/Charts/ChartHandler'
+import type { MultiAttribute } from 'components/ui/Charts/ComposedChart.utils'
 import ComposedChartHandler from 'components/ui/Charts/ComposedChartHandler'
 import GrafanaPromoBanner from 'components/ui/GrafanaPromoBanner'
 import Panel from 'components/ui/Panel'
-import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
-
-import { REPORT_DATERANGE_HELPER_LABELS } from 'components/interfaces/Reports/Reports.constants'
 import { analyticsKeys } from 'data/analytics/keys'
 import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mutation'
 import { useDatabaseSizeQuery } from 'data/database/database-size-query'
 import { getReportAttributes, getReportAttributesV2 } from 'data/reports/database-charts'
 import { useDatabaseReport } from 'data/reports/database-report-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useReportDateRange } from 'hooks/misc/useReportDateRange'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useFlag } from 'hooks/ui/useFlag'
 import { formatBytes } from 'lib/helpers'
-
-import type { MultiAttribute } from 'components/ui/Charts/ComposedChart.utils'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import type { NextPageWithLayout } from 'types'
+import { AlertDescription_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
 const DatabaseReport: NextPageWithLayout = () => {
   return (
@@ -99,11 +97,15 @@ const DatabaseUsage = () => {
   const databaseSizeBytes = databaseSizeData ?? 0
   const currentDiskSize = project?.volumeSizeGb ?? 0
 
-  const canUpdateDiskSizeConfig = useCheckPermissions(PermissionAction.UPDATE, 'projects', {
-    resource: {
-      project_id: project?.id,
-    },
-  })
+  const { can: canUpdateDiskSizeConfig } = useAsyncCheckProjectPermissions(
+    PermissionAction.UPDATE,
+    'projects',
+    {
+      resource: {
+        project_id: project?.id,
+      },
+    }
+  )
 
   const REPORT_ATTRIBUTES = getReportAttributes(org!, project!)
   const REPORT_ATTRIBUTES_V2 = getReportAttributesV2(org!, project!)

--- a/apps/studio/pages/project/[ref]/reports/index.tsx
+++ b/apps/studio/pages/project/[ref]/reports/index.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react'
 
 import { useParams } from 'common'
 import { CreateReportModal } from 'components/interfaces/Reports/CreateReportModal'
+import DefaultLayout from 'components/layouts/DefaultLayout'
 import ReportsLayout from 'components/layouts/ReportsLayout/ReportsLayout'
 import ProductEmptyState from 'components/to-be-cleaned/ProductEmptyState'
 import { Loading } from 'components/ui/Loading'
 import { useContentQuery } from 'data/content/content-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useProfile } from 'lib/profile'
 import type { NextPageWithLayout } from 'types'
-import DefaultLayout from 'components/layouts/DefaultLayout'
 
 export const UserReportPage: NextPageWithLayout = () => {
   const router = useRouter()
@@ -36,10 +36,14 @@ export const UserReportPage: NextPageWithLayout = () => {
     }
   )
 
-  const canCreateReport = useCheckPermissions(PermissionAction.CREATE, 'user_content', {
-    resource: { type: 'report', owner_id: profile?.id },
-    subject: { id: profile?.id },
-  })
+  const { can: canCreateReport } = useAsyncCheckProjectPermissions(
+    PermissionAction.CREATE,
+    'user_content',
+    {
+      resource: { type: 'report', owner_id: profile?.id },
+      subject: { id: profile?.id },
+    }
+  )
 
   return (
     <div className="h-full w-full">

--- a/apps/studio/pages/project/[ref]/settings/jwt/signing-keys.tsx
+++ b/apps/studio/pages/project/[ref]/settings/jwt/signing-keys.tsx
@@ -1,16 +1,19 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+
 import JWTSecretKeysTable from 'components/interfaces/JwtSecrets/jwt-secret-keys-table'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import JWTKeysLayout from 'components/layouts/JWTKeys/JWTKeysLayout'
 import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
 import NoPermission from 'components/ui/NoPermission'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
-import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
 
 const JWTSigningKeysPage: NextPageWithLayout = () => {
-  const isPermissionsLoaded = usePermissionsLoaded()
-  const canReadAPIKeys = useCheckPermissions(PermissionAction.READ, 'auth_signing_keys')
+  const { can: canReadAPIKeys, isSuccess: isPermissionsLoaded } = useAsyncCheckProjectPermissions(
+    PermissionAction.READ,
+    'auth_signing_keys'
+  )
 
   return (
     <>

--- a/apps/studio/pages/project/[ref]/settings/log-drains.tsx
+++ b/apps/studio/pages/project/[ref]/settings/log-drains.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'common'
 import { LogDrainDestinationSheetForm } from 'components/interfaces/LogDrains/LogDrainDestinationSheetForm'
 import { LogDrains } from 'components/interfaces/LogDrains/LogDrains'
 import { LogDrainType } from 'components/interfaces/LogDrains/LogDrains.constants'
+import DefaultLayout from 'components/layouts/DefaultLayout'
 import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
 import {
   ScaffoldContainer,
@@ -17,14 +18,14 @@ import { DocsButton } from 'components/ui/DocsButton'
 import { useCreateLogDrainMutation } from 'data/log-drains/create-log-drain-mutation'
 import { LogDrainData, useLogDrainsQuery } from 'data/log-drains/log-drains-query'
 import { useUpdateLogDrainMutation } from 'data/log-drains/update-log-drain-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useCurrentOrgPlan } from 'hooks/misc/useCurrentOrgPlan'
 import type { NextPageWithLayout } from 'types'
 import { Alert_Shadcn_, Button } from 'ui'
-import DefaultLayout from 'components/layouts/DefaultLayout'
 
 const LogDrainsSettings: NextPageWithLayout = () => {
-  const canManageLogDrains = useCheckPermissions(PermissionAction.ANALYTICS_ADMIN_WRITE, 'logflare')
+  const { can: canManageLogDrains, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.ANALYTICS_ADMIN_WRITE, 'logflare')
 
   const [open, setOpen] = useState(false)
   const { ref } = useParams() as { ref: string }
@@ -35,12 +36,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
 
   const logDrainsEnabled = !planLoading && (plan?.id === 'team' || plan?.id === 'enterprise')
 
-  const { data: logDrains } = useLogDrainsQuery(
-    { ref },
-    {
-      enabled: logDrainsEnabled,
-    }
-  )
+  const { data: logDrains } = useLogDrainsQuery({ ref }, { enabled: logDrainsEnabled })
 
   const { mutate: createLogDrain, isLoading: createLoading } = useCreateLogDrainMutation({
     onSuccess: () => {
@@ -144,12 +140,12 @@ const LogDrainsSettings: NextPageWithLayout = () => {
             }
           }}
         />
-        {canManageLogDrains ? (
-          <LogDrains onUpdateDrainClick={handleUpdateClick} onNewDrainClick={handleNewClick} />
-        ) : (
+        {isPermissionsLoaded && !canManageLogDrains ? (
           <Alert_Shadcn_ variant="default">
             You do not have permission to manage log drains
           </Alert_Shadcn_>
+        ) : (
+          <LogDrains onUpdateDrainClick={handleUpdateClick} onNewDrainClick={handleNewClick} />
         )}
       </ScaffoldContainer>
     </>

--- a/apps/studio/pages/project/[ref]/settings/log-drains.tsx
+++ b/apps/studio/pages/project/[ref]/settings/log-drains.tsx
@@ -22,9 +22,10 @@ import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useCurrentOrgPlan } from 'hooks/misc/useCurrentOrgPlan'
 import type { NextPageWithLayout } from 'types'
 import { Alert_Shadcn_, Button } from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns'
 
 const LogDrainsSettings: NextPageWithLayout = () => {
-  const { can: canManageLogDrains, isSuccess: isPermissionsLoaded } =
+  const { can: canManageLogDrains, isLoading: isLoadingPermissions } =
     useAsyncCheckProjectPermissions(PermissionAction.ANALYTICS_ADMIN_WRITE, 'logflare')
 
   const [open, setOpen] = useState(false)
@@ -140,7 +141,10 @@ const LogDrainsSettings: NextPageWithLayout = () => {
             }
           }}
         />
-        {isPermissionsLoaded && !canManageLogDrains ? (
+
+        {isLoadingPermissions ? (
+          <GenericSkeletonLoader />
+        ) : !canManageLogDrains ? (
           <Alert_Shadcn_ variant="default">
             You do not have permission to manage log drains
           </Alert_Shadcn_>


### PR DESCRIPTION
## Context

Following up from the previous [PR](https://github.com/supabase/supabase/pull/37751), copying the PR description for ease of reference:

We'll be favouring the use of useAsyncCheckProjectPermissions over useCheckPermissions as it'll allow us to access the loading state of the permissions. We should then also factor that in to prevent any premature "no permissions" UI rendering

Opting to do this in smaller PRs since its a bit nuanced

We can only swap useCheckPermissions with useAsyncCheckProjectPermissions for project permissions, organization permissions will still need to use the former for now until we introduce a new useAsyncCheckOrgPermissions
Also need to add loading states where missing for pages that are currently prematurely showing the no perms UI

## Changes involved

- Swap `useCheckPermissions` with `useAsyncCheckProjectPermissions` in more files
  - This should address premature "perms denied" UI issues for branching, and realtime inspector
  - All others either do not have a perms denied UI, or their disabled states are behind button tooltips which are fine as they are
- Refactor a couple more files to directly `export` their components instead of `export default`
- Refactor to use DropdownMenuItemTooltip in TablesList

## Affected UI
Probably just need a quick skim on these pages, mainly just to make sure that there's (1) No incorrect "perms denied" UI, if you're the owner of the org you should have access to everything (2) No pre-mature "perms denied UI" (can test by refreshing on that page)

- Database
  - Tables/Columns
  - Backups
  - Extensions
  - Functions
  - Triggers
  - Publications
  - Roles
- Integrations -> Database Webhooks
- Realtime Inspector
- Branching UI
- Connect UI
- Reports
- Log Drains
- Settings -> JWT keys
- Edge Functions -> Code