### PR TITLE
Chore/support copy row in table editor

### DIFF
--- a/apps/studio/components/grid/components/header/Header.utils.ts
+++ b/apps/studio/components/grid/components/header/Header.utils.ts
@@ -1,0 +1,14 @@
+import Papa from 'papaparse'
+
+export const formatRowsForCSV = ({ rows, columns }: { rows: any[]; columns: string[] }) => {
+  const formattedRows = rows.map((row) => {
+    const formattedRow = row
+    Object.keys(row).map((column) => {
+      if (typeof row[column] === 'object' && row[column] !== null)
+        formattedRow[column] = JSON.stringify(formattedRow[column])
+    })
+    return formattedRow
+  })
+  const csv = Papa.unparse(formattedRows, { columns })
+  return csv
+}

--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -1,6 +1,6 @@
-import { Clipboard, Edit, Trash } from 'lucide-react'
+import { ChevronRight, Clipboard, Edit, Trash } from 'lucide-react'
 import { useCallback } from 'react'
-import { Item, ItemParams, Menu } from 'react-contexify'
+import { Item, ItemParams, Menu, Separator, Submenu } from 'react-contexify'
 
 import type { SupaRow } from 'components/grid/types'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
@@ -52,23 +52,44 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
     [rows, snap.gridColumns, snap.selectedCellPosition]
   )
 
+  const onCopyRowContent = useCallback(
+    (p: ItemParams) => {
+      const { props } = p
+      const { rowIdx } = props
+      const row = rows[rowIdx]
+      copyToClipboard(JSON.stringify(row))
+    },
+    [rows]
+  )
+
   return (
-    <>
-      <Menu id={ROW_CONTEXT_MENU_ID} animation={false}>
+    <Menu id={ROW_CONTEXT_MENU_ID} animation={false} className="!min-w-36">
+      <Submenu
+        label={
+          <div className="flex items-center space-x-2">
+            <Clipboard size={12} />
+            <span className="text-xs">Copy</span>
+          </div>
+        }
+        arrow={<ChevronRight size={12} />}
+      >
         <Item onClick={onCopyCellContent}>
-          <Clipboard size={14} />
-          <span className="ml-2 text-xs">Copy cell content</span>
+          <span className="ml-2 text-xs">Copy cell</span>
         </Item>
-        <Item onClick={onEditRowClick} hidden={!snap.editable} data="edit">
-          <Edit size={14} />
-          <span className="ml-2 text-xs">Edit row</span>
+        <Item onClick={onCopyRowContent}>
+          <span className="ml-2 text-xs">Copy row</span>
         </Item>
-        <Item onClick={onDeleteRow} hidden={!snap.editable} data="delete">
-          <Trash size={14} stroke="red" />
-          <span className="ml-2 text-xs">Delete row</span>
-        </Item>
-      </Menu>
-    </>
+      </Submenu>
+      <Item onClick={onEditRowClick} hidden={!snap.editable} data="edit">
+        <Edit size={12} />
+        <span className="ml-2 text-xs">Edit row</span>
+      </Item>
+      <Separator />
+      <Item onClick={onDeleteRow} hidden={!snap.editable} data="delete">
+        <Trash size={12} />
+        <span className="ml-2 text-xs">Delete row</span>
+      </Item>
+    </Menu>
   )
 }
 export default RowContextMenu

--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, Clipboard, Edit, Trash } from 'lucide-react'
 import { useCallback } from 'react'
 import { Item, ItemParams, Menu, Separator, Submenu } from 'react-contexify'
+import { toast } from 'sonner'
 
 import type { SupaRow } from 'components/grid/types'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
@@ -48,6 +49,7 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
       const text = formatClipboardValue(value)
 
       copyToClipboard(text)
+      toast.success('Copied cell value to clipboard')
     },
     [rows, snap.gridColumns, snap.selectedCellPosition]
   )
@@ -58,6 +60,7 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
       const { rowIdx } = props
       const row = rows[rowIdx]
       copyToClipboard(JSON.stringify(row))
+      toast.success('Copied row to clipboard')
     },
     [rows]
   )


### PR DESCRIPTION
Fixes FE-1641

## Context

We've seen a [request](https://x.com/maxrusakovic/status/1922608175275971009) to support copying rows instead of just exporting rows from the Table Editor, so this PR adds the support for that

## Changes involved
- Adds a new Copy button in the Table Editor header to copy as CSV, SQL or JSON
  <img width="335" height="211" alt="image" src="https://github.com/user-attachments/assets/bec021c3-b48e-4068-a63b-eb3e777b29fa" />
  - JFYI we're disabling copy if all rows in the table are selected via the "Select all rows in table" button
    - To prevent potential memory issues if the table turns out to be really really large as clipboard contents live in memory
    <img width="383" height="130" alt="image" src="https://github.com/user-attachments/assets/936c4e78-8b89-4b79-8bfa-e4e13098d0d3" />

- Also adding a new context menu action to copy the row
<img width="622" height="170" alt="image" src="https://github.com/user-attachments/assets/e4cba63d-8b68-4265-8b53-f7d70e1be42b" />

