### PR TITLE
blog: Swap the videos on the lw15 blog posts with the deep dive videos

### DIFF
--- a/apps/www/_blog/2025-07-14-jwt-signing-keys.mdx
+++ b/apps/www/_blog/2025-07-14-jwt-signing-keys.mdx
@@ -22,7 +22,7 @@ Today we're announcing some long awaited changes in Supabase:
 <div className="video-container mb-8">
   <iframe
     className="w-full"
-    src="https://www.youtube-nocookie.com/embed/htzj9SkkhhA"
+    src="https://www.youtube-nocookie.com/embed/rwnOal_xRtM"
     title="Introducing JWT Signing Keys"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
     allowfullscreen

--- a/apps/www/_blog/2025-07-15-analytics-buckets.mdx
+++ b/apps/www/_blog/2025-07-15-analytics-buckets.mdx
@@ -22,7 +22,7 @@ Analytics buckets are integrated into Supabase Studio, power table-level views i
 <div className="video-container mb-8">
   <iframe
     className="w-full"
-    src="https://www.youtube-nocookie.com/embed/BigtFoFCVBk"
+    src="https://www.youtube-nocookie.com/embed/8poJ0f3Ucik"
     title="Supabase Analytics Buckets with Iceberg Support"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
     allowfullscreen

--- a/apps/www/_blog/2025-07-16-branching-2-0.mdx
+++ b/apps/www/_blog/2025-07-16-branching-2-0.mdx
@@ -20,7 +20,7 @@ Branching has been a part of Supabase for some time now, a way for you to experi
 <div className="video-container mb-8">
   <iframe
     className="w-full"
-    src="https://www.youtube-nocookie.com/embed/CRARnyYqrOU"
+    src="https://www.youtube-nocookie.com/embed/AMQqhHxz5UI"
     title="Introducing Branching 2.0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
     allowfullscreen

--- a/apps/www/_blog/2025-07-18-persistent-storage-for-faster-edge-functions.mdx
+++ b/apps/www/_blog/2025-07-18-persistent-storage-for-faster-edge-functions.mdx
@@ -35,7 +35,7 @@ await Deno.writeTextFile('/s3/my-bucket/demo.txt', 'hello world')
 <div className="video-container mb-8">
   <iframe
     className="w-full"
-    src="https://www.youtube-nocookie.com/embed/h3mQrDC4g14"
+    src="https://www.youtube-nocookie.com/embed/z8EPAE658iI"
     title="Persistent Storage and Faster Boot Times for Edge Functions"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
     allowfullscreen


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Replaces the videos on the LW15 blog posts with the deep dive videos, because they provide more context of the announced features. 