### PR TITLE
feat: drop file to import data in Table Editor

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, memo, Ref, useRef } from 'react'
 import DataGrid, { CalculatedColumn, DataGridHandle } from 'react-data-grid'
+import { ref as valtioRef } from 'valtio'
 
 import { handleCopyCell } from 'components/grid/SupabaseGrid.utils'
 import { formatForeignKeys } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils'
@@ -80,7 +81,7 @@ export const Grid = memo(
 
       const { isDraggedOver, onDragOver, onFileDrop } = useCsvFileDrop({
         enabled: isTableEmpty && !isForeignTable,
-        onFileDropped: () => tableEditorSnap.onImportData(),
+        onFileDropped: (file) => tableEditorSnap.onImportData(valtioRef(file)),
         onTelemetryEvent: (eventName, properties) => {
           sendEvent({
             action: eventName,

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -82,10 +82,9 @@ export const Grid = memo(
       const { isDraggedOver, onDragOver, onFileDrop } = useCsvFileDrop({
         enabled: isTableEmpty && !isForeignTable,
         onFileDropped: (file) => tableEditorSnap.onImportData(valtioRef(file)),
-        onTelemetryEvent: (eventName, properties) => {
+        onTelemetryEvent: (eventName) => {
           sendEvent({
             action: eventName,
-            properties,
             groups: {
               project: project?.ref ?? 'Unknown',
               organization: org?.slug ?? 'Unknown',
@@ -136,7 +135,7 @@ export const Grid = memo(
       return (
         <div
           className={cn(
-            `flex flex-col relative`,
+            'flex flex-col relative transition-colors',
             containerClass,
             isTableEmpty && isDraggedOver && 'border-2 border-dashed border-brand-600'
           )}
@@ -169,7 +168,7 @@ export const Grid = memo(
               {isSuccess && (
                 <>
                   {(filters ?? []).length === 0 ? (
-                    <div className="flex flex-col items-center justify-center col-span-full h-full transition-colors">
+                    <div className="flex flex-col items-center justify-center col-span-full h-full">
                       <p className="text-sm text-light">
                         {isDraggedOver ? 'Drop your CSV file here' : 'This table is empty'}
                       </p>

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -86,8 +86,8 @@ export const Grid = memo(
             action: eventName,
             properties,
             groups: {
-              project: project!.ref,
-              organization: org!.slug,
+              project: project?.ref ?? 'Unknown',
+              organization: org?.slug ?? 'Unknown',
             },
           })
         },
@@ -199,11 +199,9 @@ export const Grid = memo(
                             >
                               Import data from CSV
                             </Button>
-                            {!isDraggedOver && (
-                              <p className="text-xs text-foreground-light">
-                                or drag and drop a CSV file here
-                              </p>
-                            )}
+                            <p className="text-xs text-foreground-light">
+                              or drag and drop a CSV file here
+                            </p>
                           </div>
                         )
                       )}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.constants.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.constants.ts
@@ -9,6 +9,8 @@ export const UPLOAD_FILE_TYPES = [
 
 export const UPLOAD_FILE_EXTENSIONS = ['csv', 'tsv']
 
+export const MAX_TABLE_EDITOR_IMPORT_CSV_SIZE = 1024 * 1024 * 100 // 100 MiB
+
 export const EMPTY_SPREADSHEET_DATA: SpreadsheetData = {
   headers: [],
   rows: [],

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -72,7 +72,7 @@ const SpreadsheetImport = ({
     setParseProgress(progress)
   }
 
-  // Process a file object directly (used for both upload and drop)
+  // Process a file into table rows and columns (used for both upload and drop)
   const processFile = useCallback(
     async (file: File) => {
       updateEditorDirty(true)
@@ -104,11 +104,23 @@ const SpreadsheetImport = ({
       const [file] = event.target.files || event.dataTransfer.files
       if (file && !flagInvalidFileImport(file)) {
         await processFile(file)
+      } else {
+        event.target.value = ''
       }
-      event.target.value = ''
     },
     [processFile]
   )
+
+  // Handle dropped file from custom event
+  useEffect(() => {
+    const handleDroppedFile = (event: ProcessDroppedFileEvent) => {
+      if (visible) {
+        processFile(event.detail.file)
+      }
+    }
+
+    return addProcessDroppedFileListener(handleDroppedFile)
+  }, [visible, processFile])
 
   const resetSpreadsheetImport = () => {
     setInput('')
@@ -171,17 +183,6 @@ const SpreadsheetImport = ({
   useEffect(() => {
     if (visible && headers.length === 0) resetSpreadsheetImport()
   }, [visible])
-
-  // Handle dropped file from custom event
-  useEffect(() => {
-    const handleDroppedFile = (event: ProcessDroppedFileEvent) => {
-      if (visible) {
-        processFile(event.detail.file)
-      }
-    }
-
-    return addProcessDroppedFileListener(handleDroppedFile)
-  }, [visible, processFile])
 
   return (
     <SidePanel

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -21,6 +21,7 @@ import {
   parseSpreadsheetText,
 } from './SpreadsheetImport.utils'
 import SpreadsheetImportPreview from './SpreadsheetImportPreview'
+import { useChanged } from 'hooks/misc/useChanged'
 
 interface SpreadsheetImportProps {
   debounceDuration?: number
@@ -50,6 +51,7 @@ const SpreadsheetImport = ({
   const fileFromState =
     tableEditorSnap.sidePanel?.type === 'csv-import' ? tableEditorSnap.sidePanel.file : undefined
 
+  const visiblityChanged = useChanged(visible)
   const [tab, setTab] = useState<'fileUpload' | 'pasteText'>('fileUpload')
   const [input, setInput] = useState<string>('')
   const [uploadedFile, setUploadedFile] = useState<File>()
@@ -114,13 +116,13 @@ const SpreadsheetImport = ({
     [processFile]
   )
 
-  const resetSpreadsheetImport = () => {
+  const resetSpreadsheetImport = useCallback(() => {
     setInput('')
     setSpreadsheetData(EMPTY_SPREADSHEET_DATA)
     setUploadedFile(undefined)
     setErrors([])
     updateEditorDirty(false)
-  }
+  }, [updateEditorDirty])
 
   const readSpreadsheetText = async (text: string) => {
     if (text.length > 0) {
@@ -174,12 +176,18 @@ const SpreadsheetImport = ({
   }
 
   useEffect(() => {
-    if (visible) {
+    if (visiblityChanged && visible) {
       if (fileFromState) processFile(fileFromState)
       else if (headers.length === 0) resetSpreadsheetImport()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, fileFromState, processFile])
+  }, [
+    visiblityChanged,
+    visible,
+    fileFromState,
+    processFile,
+    headers.length,
+    resetSpreadsheetImport,
+  ])
 
   return (
     <SidePanel

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -4,13 +4,13 @@ import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import Papa from 'papaparse'
 import { toast } from 'sonner'
-import { Button } from 'ui'
 
 import { tryParseJson } from 'lib/helpers'
+import { Button } from 'ui'
 import {
+  MAX_TABLE_EDITOR_IMPORT_CSV_SIZE,
   UPLOAD_FILE_EXTENSIONS,
   UPLOAD_FILE_TYPES,
-  MAX_TABLE_EDITOR_IMPORT_CSV_SIZE,
 } from './SpreadsheetImport.constants'
 
 const CHUNK_SIZE = 1024 * 1024 * 0.25 // 0.25MB
@@ -196,31 +196,4 @@ export function flagInvalidFileImport(file: File): boolean {
   }
 
   return false
-}
-
-// Custom event type for file drop processing
-const PROCESS_DROPPED_FILE_EVENT = 'supa::tableEditor::processDroppedFile' as const
-export interface ProcessDroppedFileEventDetail {
-  file: File
-}
-
-export interface ProcessDroppedFileEvent extends CustomEvent<ProcessDroppedFileEventDetail> {
-  type: typeof PROCESS_DROPPED_FILE_EVENT
-}
-
-// Helper function to dispatch the custom event
-export function dispatchProcessDroppedFileEvent(file: File): void {
-  const event = new CustomEvent(PROCESS_DROPPED_FILE_EVENT, {
-    detail: { file },
-  }) as ProcessDroppedFileEvent
-  window.dispatchEvent(event)
-}
-
-// Helper function to listen for the custom event
-export function addProcessDroppedFileListener(
-  handler: (event: ProcessDroppedFileEvent) => void
-): () => void {
-  const listener = handler as EventListener
-  window.addEventListener(PROCESS_DROPPED_FILE_EVENT, listener)
-  return () => window.removeEventListener(PROCESS_DROPPED_FILE_EVENT, listener)
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs'
 import { has, includes } from 'lodash'
+import { ExternalLink } from 'lucide-react'
+import Link from 'next/link'
 import Papa from 'papaparse'
 import { toast } from 'sonner'
+import { Button } from 'ui'
 
 import { tryParseJson } from 'lib/helpers'
 import {
@@ -174,7 +177,20 @@ export function flagInvalidFileImport(file: File): boolean {
     return true
   } else if (file.size > MAX_TABLE_EDITOR_IMPORT_CSV_SIZE) {
     toast.error(
-      'The dashboard currently only supports importing of CSVs below 100MB. For bulk data loading, we recommend doing so directly through the database.'
+      <div className="space-y-1">
+        <p>The dashboard currently only supports importing of CSVs below 100MB.</p>
+        <p>For bulk data loading, we recommend doing so directly through the database.</p>
+        <Button asChild type="default" icon={<ExternalLink />} className="!mt-2">
+          <Link
+            href="https://supabase.com/docs/guides/database/tables#bulk-data-loading"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Learn more
+          </Link>
+        </Button>
+      </div>,
+      { duration: Infinity }
     )
     return true
   }

--- a/apps/studio/hooks/misc/useChanged.ts
+++ b/apps/studio/hooks/misc/useChanged.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from 'react'
+
+export function useChanged<T>(value: T): boolean {
+  const prev = useRef<T>()
+  const changed = prev.current !== value
+
+  useEffect(() => {
+    prev.current = value
+  })
+
+  return changed
+}

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,0 +1,76 @@
+import { ImportDataFileDroppedEvent, type TelemetryEvent } from 'common/telemetry-constants'
+import { type DragEvent, useCallback, useState } from 'react'
+
+import {
+  dispatchProcessDroppedFileEvent,
+  flagInvalidFileImport,
+} from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
+
+interface UseCsvFileDropOptions {
+  enabled: boolean
+  onFileDropped: () => void
+  onTelemetryEvent?: (
+    eventName: ImportDataFileDroppedEvent['action'],
+    properties: ImportDataFileDroppedEvent['properties']
+  ) => void
+}
+
+interface UseCsvFileDropReturn {
+  isDraggedOver: boolean
+  onDragOver: (event: DragEvent<HTMLDivElement>) => void
+  onFileDrop: (event: DragEvent<HTMLDivElement>) => void
+}
+
+export function useCsvFileDrop({
+  enabled,
+  onFileDropped,
+  onTelemetryEvent,
+}: UseCsvFileDropOptions): UseCsvFileDropReturn {
+  const [isDraggedOver, setIsDraggedOver] = useState(false)
+
+  const onDragOver = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!enabled) return
+
+      if (event.type === 'dragover' && !isDraggedOver) {
+        setIsDraggedOver(true)
+      } else if (event.type === 'dragleave' || event.type === 'drop') {
+        setIsDraggedOver(false)
+      }
+      event.stopPropagation()
+      event.preventDefault()
+    },
+    [enabled, isDraggedOver]
+  )
+
+  const onFileDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!enabled) return
+
+      onDragOver(event)
+
+      const [file] = event.dataTransfer.files
+      if (flagInvalidFileImport(file)) return
+
+      // Notify parent that a file was dropped
+      onFileDropped()
+
+      // Process the file in the next tick to avoid state issues from React
+      // clearing synthetic event
+      setTimeout(() => {
+        dispatchProcessDroppedFileEvent(file)
+      })
+
+      onTelemetryEvent?.('import_data_file_dropped', {
+        tableType: 'Existing Table',
+      })
+    },
+    [enabled, onDragOver, onFileDropped, onTelemetryEvent]
+  )
+
+  return {
+    isDraggedOver,
+    onDragOver,
+    onFileDrop,
+  }
+}

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,15 +1,12 @@
 import { type DragEvent, useCallback, useState } from 'react'
 
-import { ImportDataFileDroppedEvent } from 'common/telemetry-constants'
+import { type ImportDataFileDroppedEvent } from 'common/telemetry-constants'
 import { flagInvalidFileImport } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
 
 interface UseCsvFileDropOptions {
   enabled: boolean
   onFileDropped: (file: File) => void
-  onTelemetryEvent?: (
-    eventName: ImportDataFileDroppedEvent['action'],
-    properties: ImportDataFileDroppedEvent['properties']
-  ) => void
+  onTelemetryEvent?: (eventName: ImportDataFileDroppedEvent['action']) => void
 }
 
 interface UseCsvFileDropReturn {
@@ -49,10 +46,9 @@ export function useCsvFileDrop({
       const [file] = event.dataTransfer.files
       if (flagInvalidFileImport(file)) return
 
-      // Notify parent that a file was dropped
       onFileDropped(file)
 
-      onTelemetryEvent?.('import_data_file_dropped', { tableType: 'Existing Table' })
+      onTelemetryEvent?.('import_data_dropzone_file_added')
     },
     [enabled, onDragOver, onFileDropped, onTelemetryEvent]
   )

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,14 +1,11 @@
-import { ImportDataFileDroppedEvent, type TelemetryEvent } from 'common/telemetry-constants'
 import { type DragEvent, useCallback, useState } from 'react'
 
-import {
-  dispatchProcessDroppedFileEvent,
-  flagInvalidFileImport,
-} from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
+import { ImportDataFileDroppedEvent } from 'common/telemetry-constants'
+import { flagInvalidFileImport } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
 
 interface UseCsvFileDropOptions {
   enabled: boolean
-  onFileDropped: () => void
+  onFileDropped: (file: File) => void
   onTelemetryEvent?: (
     eventName: ImportDataFileDroppedEvent['action'],
     properties: ImportDataFileDroppedEvent['properties']
@@ -53,17 +50,9 @@ export function useCsvFileDrop({
       if (flagInvalidFileImport(file)) return
 
       // Notify parent that a file was dropped
-      onFileDropped()
+      onFileDropped(file)
 
-      // Process the file in the next tick to avoid state issues from React
-      // clearing synthetic event
-      setTimeout(() => {
-        dispatchProcessDroppedFileEvent(file)
-      })
-
-      onTelemetryEvent?.('import_data_file_dropped', {
-        tableType: 'Existing Table',
-      })
+      onTelemetryEvent?.('import_data_file_dropped', { tableType: 'Existing Table' })
     },
     [enabled, onDragOver, onFileDropped, onTelemetryEvent]
   )

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -26,7 +26,7 @@ export type SidePanel =
       type: 'foreign-row-selector'
       foreignKey: ForeignKeyState
     }
-  | { type: 'csv-import' }
+  | { type: 'csv-import'; file?: File }
 
 export type ConfirmationDialog =
   | { type: 'table'; isDeleteWithCascade: boolean }
@@ -181,10 +181,10 @@ export const createTableEditorState = () => {
         sidePanel: { type: 'foreign-row-selector', foreignKey },
       }
     },
-    onImportData: () => {
+    onImportData: (file?: File) => {
       state.ui = {
         open: 'side-panel',
-        sidePanel: { type: 'csv-import' },
+        sidePanel: { type: 'csv-import', file },
       }
     },
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -914,15 +914,7 @@ export interface ImportDataButtonClickedEvent {
  * @page /dashboard/project/{ref}/editor
  */
 export interface ImportDataFileDroppedEvent {
-  action: 'import_data_file_dropped'
-  properties: {
-    /**
-     * The type of table the data is imported to.
-     * New Table means added when creating new table by clicking from New table sidebar,
-     * Existing Table means added to an existing table by going to the table and clicking from the green Insert button..
-     */
-    tableType: 'New Table' | 'Existing Table'
-  }
+  action: 'import_data_dropzone_file_added'
   groups: TelemetryGroups
 }
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -907,6 +907,26 @@ export interface ImportDataButtonClickedEvent {
 }
 
 /**
+ * User dropped a file into the import data dropzone on an empty table.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/editor
+ */
+export interface ImportDataFileDroppedEvent {
+  action: 'import_data_file_dropped'
+  properties: {
+    /**
+     * The type of table the data is imported to.
+     * New Table means added when creating new table by clicking from New table sidebar,
+     * Existing Table means added to an existing table by going to the table and clicking from the green Insert button..
+     */
+    tableType: 'New Table' | 'Existing Table'
+  }
+  groups: TelemetryGroups
+}
+
+/**
  * User added data from the import data via CSV/spreadsheet successfully.
  *
  * @group Events
@@ -1511,6 +1531,7 @@ export type TelemetryEvent =
   | HelpButtonClickedEvent
   | ExampleProjectCardClickedEvent
   | ImportDataButtonClickedEvent
+  | ImportDataFileDroppedEvent
   | ImportDataAddedEvent
   | SendFeedbackButtonClickedEvent
   | SqlEditorQueryRunButtonClickedEvent


### PR DESCRIPTION
In the Table Editor for an empty table, make the entire grid area a
dropzone so that files can be dropped onto the grid area for importing.
Dropping a file opens the SpreadsheetImport side panel with the dropped
file already loaded.


https://github.com/user-attachments/assets/ce98a13a-5186-4897-a364-6db5b0385545