### PR TITLE
Remove captureException in SessionTimeoutModal

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SessionTimeoutModal.tsx
+++ b/apps/studio/components/interfaces/SignIn/SessionTimeoutModal.tsx
@@ -1,6 +1,3 @@
-import * as Sentry from '@sentry/nextjs'
-import { useEffect } from 'react'
-
 import { InlineLink } from 'components/ui/InlineLink'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
@@ -15,12 +12,6 @@ export const SessionTimeoutModal = ({
   onClose,
   redirectToSignIn,
 }: SessionTimeoutModalProps) => {
-  useEffect(() => {
-    if (visible) {
-      Sentry.captureException(new Error('Session error detected'))
-    }
-  }, [visible])
-
   return (
     <ConfirmationModal
       visible={visible}


### PR DESCRIPTION
Parking this one if we deem that this captureException is not really needed / useful - as its eating up a significant number of events on our Sentry