### PR TITLE
Chore/refactor database publications page

### DIFF
--- a/apps/studio/components/interfaces/Database/Publications/PublicationSkeleton.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationSkeleton.tsx
@@ -1,32 +1,29 @@
-import Table from 'components/to-be-cleaned/Table'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
-import { Toggle } from 'ui'
+import { Switch, TableCell, TableRow } from 'ui'
 
 export interface PublicationSkeletonProps {
   index?: number
 }
 
-const PublicationSkeleton = ({ index }: PublicationSkeletonProps) => {
+export const PublicationSkeleton = ({ index }: PublicationSkeletonProps) => {
   return (
-    <Table.tr className="border-t">
-      <Table.td className="px-4 py-3" style={{ width: '25%' }}>
+    <TableRow>
+      <TableCell style={{ width: '35%' }}>
         <ShimmeringLoader className="h-4 w-24 my-0.5 p-0" delayIndex={index} />
-      </Table.td>
-      <Table.td className="hidden lg:table-cell" style={{ width: '25%' }}>
+      </TableCell>
+      <TableCell className="hidden lg:table-cell" style={{ width: '15%' }}>
         <ShimmeringLoader className="h-4 w-14 my-0.5 p-0" delayIndex={index} />
-      </Table.td>
+      </TableCell>
       {Array.from({ length: 4 }).map((_, i) => (
-        <Table.td key={i}>
-          <Toggle size="tiny" checked={false} disabled={true} />
-        </Table.td>
+        <TableCell key={i}>
+          <Switch size="small" checked={false} disabled={true} />
+        </TableCell>
       ))}
-      <Table.td className="px-4 py-3 pr-2">
+      <TableCell className="px-4 py-3 pr-2">
         <div className="flex justify-end">
           <ShimmeringLoader className="h-6 w-12 p-0" delayIndex={index} />
         </div>
-      </Table.td>
-    </Table.tr>
+      </TableCell>
+    </TableRow>
   )
 }
-
-export default PublicationSkeleton

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -166,7 +166,7 @@ export const PublicationsList = () => {
                             {x.tables === null
                               ? 'All tables'
                               : `${x.tables.length} ${
-                                  x.tables.length > 1 || x.tables.length == 0 ? 'tables' : 'table'
+                                  x.tables.length === 1 ? 'table' : 'tables'
                                 }`}
                           </Link>
                         </Button>

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { AlertCircle, Search } from 'lucide-react'
+import { AlertCircle, Info, Search } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 import { toast } from 'sonner'
@@ -22,6 +22,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
@@ -63,10 +66,11 @@ export const PublicationsList = () => {
     { event: 'Delete', key: 'publish_delete' },
     { event: 'Truncate', key: 'publish_truncate' },
   ]
-  const publications =
+  const publications = (
     filterString.length === 0
       ? data
       : data.filter((publication) => publication.name.includes(filterString))
+  ).sort((a, b) => a.id - b.id)
 
   const [toggleListenEventValue, setToggleListenEventValue] = useState<{
     publication: any
@@ -141,7 +145,26 @@ export const PublicationsList = () => {
               {isSuccess &&
                 publications.map((x) => (
                   <TableRow key={x.name}>
-                    <TableCell>{x.name}</TableCell>
+                    <TableCell className="flex items-center gap-x-2 items-center">
+                      {x.name}
+                      {/* [Joshen] Making this tooltip very specific for these 2 publications */}
+                      {['supabase_realtime', 'supabase_realtime_messages_publication'].includes(
+                        x.name
+                      ) && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Info size={14} className="text-foreground-light" />
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {x.name === 'supabase_realtime'
+                              ? 'This publication is managed by Supabase and handles Postgres changes'
+                              : x.name === 'supabase_realtime_messages_publication'
+                                ? 'This publication is managed by Supabase and handles broadcasts from the database'
+                                : undefined}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </TableCell>
                     <TableCell>{x.id}</TableCell>
                     {publicationEvents.map((event) => (
                       <TableCell key={event.key}>
@@ -165,9 +188,7 @@ export const PublicationsList = () => {
                           <Link href={`/project/${ref}/database/publications/${x.id}`}>
                             {x.tables === null
                               ? 'All tables'
-                              : `${x.tables.length} ${
-                                  x.tables.length === 1 ? 'table' : 'tables'
-                                }`}
+                              : `${x.tables.length} ${x.tables.length === 1 ? 'table' : 'tables'}`}
                           </Link>
                         </Button>
                       </div>

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -1,18 +1,20 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ChevronLeft, Search } from 'lucide-react'
+import Link from 'next/link'
 import { useMemo, useState } from 'react'
 
 import { useParams } from 'common'
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 import AlertError from 'components/ui/AlertError'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { Loading } from 'components/ui/Loading'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import Link from 'next/link'
-import { Button, Card, Input, Table, TableBody, TableHead, TableHeader, TableRow } from 'ui'
+import { Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
 import { Admonition } from 'ui-patterns'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import PublicationsTableItem from './PublicationsTableItem'
 
 export const PublicationsTables = () => {
@@ -51,16 +53,23 @@ export const PublicationsTables = () => {
       <div className="mb-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <Button asChild type="outline" icon={<ChevronLeft />} style={{ padding: '5px' }}>
+            <ButtonTooltip
+              asChild
+              type="outline"
+              icon={<ChevronLeft />}
+              style={{ padding: '5px' }}
+              tooltip={{ content: { side: 'bottom', text: 'Go back to publications list' } }}
+            >
               <Link href={`/project/${ref}/database/publications`} />
-            </Button>
+            </ButtonTooltip>
             <div>
               <Input
-                size="small"
-                placeholder={'Filter'}
+                size="tiny"
+                placeholder="Search for a table"
                 value={filterString}
                 onChange={(e) => setFilterString(e.target.value)}
-                icon={<Search size="14" />}
+                icon={<Search size={12} />}
+                className="w-48 pl-8"
               />
             </div>
           </div>
@@ -102,14 +111,24 @@ export const PublicationsTables = () => {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {!!selectedPublication &&
+                  {!!selectedPublication ? (
                     tables.map((table) => (
                       <PublicationsTableItem
                         key={table.id}
                         table={table}
                         selectedPublication={selectedPublication}
                       />
-                    ))}
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={4}>
+                        <p>The selected publication with ID {id} cannot be found</p>
+                        <p className="text-foreground-light">
+                          Head back to the list of publications to select one from there
+                        </p>
+                      </TableCell>
+                    </TableRow>
+                  )}
                 </TableBody>
               </Table>
             </Card>

--- a/apps/studio/data/tables/tables-query.ts
+++ b/apps/studio/data/tables/tables-query.ts
@@ -3,10 +3,10 @@ import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-
 import { sortBy } from 'lodash'
 import { useCallback } from 'react'
 
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { get, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { tableKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type TablesVariables = {
   projectRef?: string

--- a/apps/studio/pages/project/[ref]/database/publications/[id].tsx
+++ b/apps/studio/pages/project/[ref]/database/publications/[id].tsx
@@ -1,36 +1,17 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useState } from 'react'
 
-import { PublicationsList } from 'components/interfaces/Database/Publications/PublicationsList'
 import { PublicationsTables } from 'components/interfaces/Database/Publications/PublicationsTables'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
-import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import type { NextPageWithLayout } from 'types'
 
-// [Joshen] Technically, best that we have these as separate URLs
-// makes it easier to manage state, but foresee that this page might
-// be consolidated somewhere else eventually for better UX
-
 const DatabasePublications: NextPageWithLayout = () => {
-  const { data: project } = useSelectedProjectQuery()
-
-  const { data } = useDatabasePublicationsQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
-  const publications = data ?? []
-
   const { can: canViewPublications, isSuccess: isPermissionsLoaded } =
     useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'publications')
-
-  const [selectedPublicationId, setSelectedPublicationId] = useState<number>()
-  const selectedPublication = publications.find((pub) => pub.id === selectedPublicationId)
 
   if (isPermissionsLoaded && !canViewPublications) {
     return <NoPermission isFullPage resourceText="view database publications" />
@@ -41,14 +22,7 @@ const DatabasePublications: NextPageWithLayout = () => {
       <ScaffoldSection>
         <div className="col-span-12">
           <FormHeader title="Database Publications" />
-          {selectedPublication === undefined ? (
-            <PublicationsList onSelectPublication={setSelectedPublicationId} />
-          ) : (
-            <PublicationsTables
-              selectedPublication={selectedPublication}
-              onSelectBack={() => setSelectedPublicationId(undefined)}
-            />
-          )}
+          <PublicationsTables />
         </div>
       </ScaffoldSection>
     </ScaffoldContainer>

--- a/apps/studio/pages/project/[ref]/database/publications/[id].tsx
+++ b/apps/studio/pages/project/[ref]/database/publications/[id].tsx
@@ -3,8 +3,8 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { PublicationsTables } from 'components/interfaces/Database/Publications/PublicationsTables'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
@@ -19,11 +19,8 @@ const DatabasePublications: NextPageWithLayout = () => {
 
   return (
     <ScaffoldContainer>
-      <ScaffoldSection>
-        <div className="col-span-12">
-          <FormHeader title="Database Publications" />
-          <PublicationsTables />
-        </div>
+      <ScaffoldSection isFullWidth>
+        <PublicationsTables />
       </ScaffoldSection>
     </ScaffoldContainer>
   )
@@ -31,7 +28,9 @@ const DatabasePublications: NextPageWithLayout = () => {
 
 DatabasePublications.getLayout = (page) => (
   <DefaultLayout>
-    <DatabaseLayout title="Database">{page}</DatabaseLayout>
+    <DatabaseLayout title="Database">
+      <PageLayout title="Database Publications">{page}</PageLayout>
+    </DatabaseLayout>
   </DefaultLayout>
 )
 

--- a/apps/studio/pages/project/[ref]/database/publications/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/publications/index.tsx
@@ -3,8 +3,8 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { PublicationsList } from 'components/interfaces/Database/Publications/PublicationsList'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
@@ -19,11 +19,8 @@ const DatabasePublications: NextPageWithLayout = () => {
 
   return (
     <ScaffoldContainer>
-      <ScaffoldSection>
-        <div className="col-span-12">
-          <FormHeader title="Database Publications" />
-          <PublicationsList />
-        </div>
+      <ScaffoldSection isFullWidth>
+        <PublicationsList />
       </ScaffoldSection>
     </ScaffoldContainer>
   )
@@ -31,7 +28,9 @@ const DatabasePublications: NextPageWithLayout = () => {
 
 DatabasePublications.getLayout = (page) => (
   <DefaultLayout>
-    <DatabaseLayout title="Database">{page}</DatabaseLayout>
+    <DatabaseLayout title="Database">
+      <PageLayout title="Database Publications">{page}</PageLayout>
+    </DatabaseLayout>
   </DefaultLayout>
 )
 

--- a/apps/studio/pages/project/[ref]/database/publications/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/publications/index.tsx
@@ -1,0 +1,38 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+
+import { PublicationsList } from 'components/interfaces/Database/Publications/PublicationsList'
+import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
+import DefaultLayout from 'components/layouts/DefaultLayout'
+import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
+import { FormHeader } from 'components/ui/Forms/FormHeader'
+import NoPermission from 'components/ui/NoPermission'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
+import type { NextPageWithLayout } from 'types'
+
+const DatabasePublications: NextPageWithLayout = () => {
+  const { can: canViewPublications, isSuccess: isPermissionsLoaded } =
+    useAsyncCheckProjectPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'publications')
+
+  if (isPermissionsLoaded && !canViewPublications) {
+    return <NoPermission isFullPage resourceText="view database publications" />
+  }
+
+  return (
+    <ScaffoldContainer>
+      <ScaffoldSection>
+        <div className="col-span-12">
+          <FormHeader title="Database Publications" />
+          <PublicationsList />
+        </div>
+      </ScaffoldSection>
+    </ScaffoldContainer>
+  )
+}
+
+DatabasePublications.getLayout = (page) => (
+  <DefaultLayout>
+    <DatabaseLayout title="Database">{page}</DatabaseLayout>
+  </DefaultLayout>
+)
+
+export default DatabasePublications


### PR DESCRIPTION
## Context

General UI tidy up, expanding on what Saxon's done already previously [here](https://github.com/supabase/supabase/pull/37823). This one's just focused on the Database Publications page.

Also addresses a point of confusion that was brought up in an internal friction log:
- At the top level page, we show the number of tables which have publications toggled on for
  <img width="228" height="115" alt="image" src="https://github.com/user-attachments/assets/e7137be6-2f13-4794-bbcf-3af3793a74b3" />
- However, for `supabase_realtime_messages_publication`, when viewing the publication, i can't seem to find the table that was toggled on
- Realised that we aren't showing the full list of tables, as we're hiding tables from protected schemas
- So this PR also addresses this confusion by showing _all_ tables, but disabling the toggle for tables within protected schemas

## Changes involved
- Refactor Database Publications page to have publications on their own route, rather than controlled by client state
- Replace old table components in the publications page to the new ones from `ui`
- Use PageLayout in Database publications page
- Show _all_ tables within a publication, but show a disabled tooltip for tables which are in protected schemas (we were previously hiding them which was confusing)
  <img width="351" height="135" alt="image" src="https://github.com/user-attachments/assets/0979bb52-05c5-4a46-a736-de9145230226" />
