### PR TITLE
Fix broken Apple Sign In documentation link

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -5,7 +5,7 @@ description: 'Use Sign in with Apple with Supabase'
 tocVideo: '-tpcZzTdvN0'
 ---
 
-Supabase Auth supports using [Sign in with Apple](https://developer.apple.com/sign-in-with-apple/) on the web and in native apps for iOS, macOS, watchOS or tvOS.
+Supabase Auth supports using [Sign in with Apple](https://support.apple.com/en-us/102609/) on the web and in native apps for iOS, macOS, watchOS or tvOS.
 
 ## Overview
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Replaced the broken Apple documentation link with the current valid URL from apple.com. Fix #37910

## What is the current behavior?

The old link returns "Page not found"

## What is the new behavior?

Now the link is a valid URL. [What is Sign in with Apple?](https://support.apple.com/en-us/102609/)

