### PR TITLE
fix: search sync + sentry errors issues

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -45,6 +45,7 @@ jobs:
           sparse-checkout: |
             apps/docs
             apps/www/.env.local.example
+            examples
             supabase
 
       - uses: pnpm/action-setup@v4
@@ -63,7 +64,9 @@ jobs:
       - name: Update embeddings
         working-directory: ./apps/docs
         if: ${{ !inputs.refresh }}
-        run: pnpm run embeddings
+        run: |
+          pnpm run codegen:examples
+          pnpm run embeddings
 
       - name: Refresh embeddings
         working-directory: ./apps/docs

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -90,7 +90,9 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
             )}
             <hr className="not-prose border-t-0 border-b my-8" />
 
-            {content && <MDXRemoteBase source={content} options={mdxOptions} />}
+            {content && (
+              <MDXRemoteBase source={content} options={mdxOptions} customPreprocess={(x) => x} />
+            )}
             {children}
 
             <footer className="mt-16 not-prose">

--- a/apps/docs/features/docs/GuidesMdx.utils.tsx
+++ b/apps/docs/features/docs/GuidesMdx.utils.tsx
@@ -73,7 +73,7 @@ const getGuidesMarkdownInternal = async (slug: string[]) => {
       editLink,
     }
   } catch (error: unknown) {
-    if (error instanceof FileNotFoundError) {
+    if (error instanceof Error && error.cause instanceof FileNotFoundError) {
       // Not using console.error because this includes pages that are genuine
       // 404s and clutters up the logs
       console.log('Could not read Markdown at path: %s', fullPath)


### PR DESCRIPTION
Fixes three issues:
1. Search sync: The embedded content now includes denormalized examples, so the examples codegen needs to be run before embeddings are created. Otherwise, the GitHub Action will fail because it cannot find the examples to use for content inclusion.
2. Sentry errors on pages that fail to load: Sentry errors were being sent for genuine 404s because the check for FileNotFoundErrors was wrong. The error that is caught is wrapped in a new Error by Result.unwrap(), so it's the child of this error, error.cause, that is potentially a FileNotFoundError, not the error itself.
3. Double processing of MDX causing code blocks to be rewritten twice.