### PR TITLE
chore: add BillingManagedBy constant

### DIFF
--- a/apps/studio/components/ui/PartnerManagedResource.tsx
+++ b/apps/studio/components/ui/PartnerManagedResource.tsx
@@ -3,9 +3,10 @@ import { ExternalLink } from 'lucide-react'
 import { useVercelRedirectQuery } from 'data/integrations/vercel-redirect-query'
 import { Alert_Shadcn_, AlertTitle_Shadcn_, Button } from 'ui'
 import PartnerIcon from './PartnerIcon'
+import { MANAGED_BY, ManagedBy } from 'lib/constants/infrastructure'
 
 interface PartnerManagedResourceProps {
-  partner: 'vercel-marketplace' | 'aws-marketplace'
+  partner: ManagedBy
   resource: string
   cta?: {
     installationId?: string
@@ -15,11 +16,13 @@ interface PartnerManagedResourceProps {
 }
 
 export const PARTNER_TO_NAME = {
-  'vercel-marketplace': 'Vercel Marketplace',
-  'aws-marketplace': 'AWS Marketplace',
+  [MANAGED_BY.VERCEL_MARKETPLACE]: 'Vercel Marketplace',
+  [MANAGED_BY.AWS_MARKETPLACE]: 'AWS Marketplace',
+  [MANAGED_BY.SUPABASE]: 'Supabase',
 } as const
 
 function PartnerManagedResource({ partner, resource, cta }: PartnerManagedResourceProps) {
+  const isManagedBySupabase = partner === MANAGED_BY.SUPABASE
   const ctaEnabled = cta !== undefined
 
   const { data, isLoading, isError } = useVercelRedirectQuery(
@@ -27,9 +30,11 @@ function PartnerManagedResource({ partner, resource, cta }: PartnerManagedResour
       installationId: cta?.installationId,
     },
     {
-      enabled: ctaEnabled,
+      enabled: ctaEnabled && !isManagedBySupabase,
     }
   )
+
+  if (isManagedBySupabase) return null
 
   const ctaUrl = (data?.url ?? '') + (cta?.path ?? '')
 

--- a/apps/studio/data/organizations/organizations-query.ts
+++ b/apps/studio/data/organizations/organizations-query.ts
@@ -5,6 +5,7 @@ import { get, handleError } from 'data/fetchers'
 import { useProfile } from 'lib/profile'
 import type { Organization, ResponseError } from 'types'
 import { organizationKeys } from './keys'
+import { MANAGED_BY, ManagedBy } from 'lib/constants/infrastructure'
 
 export type OrganizationBase = components['schemas']['OrganizationResponse']
 
@@ -12,8 +13,22 @@ export function castOrganizationResponseToOrganization(org: OrganizationBase): O
   return {
     ...org,
     billing_email: org.billing_email ?? 'Unknown',
-    managed_by: org.slug.startsWith('vercel_icfg_') ? 'vercel-marketplace' : 'supabase',
+    managed_by: getManagedBy(org),
     partner_id: org.slug.startsWith('vercel_') ? org.slug.replace('vercel_', '') : undefined,
+  }
+}
+
+function getManagedBy(org: OrganizationBase): ManagedBy {
+  switch (org.billing_partner) {
+    case 'vercel_marketplace':
+      return MANAGED_BY.VERCEL_MARKETPLACE
+    // TODO(ignacio): Uncomment this when we've deployed the AWS Marketplace new slug
+    // case 'aws_marketplace':
+    // return MANAGED_BY.AWS_MARKETPLACE
+    case 'aws':
+      return MANAGED_BY.AWS_MARKETPLACE
+    default:
+      return MANAGED_BY.SUPABASE
   }
 }
 

--- a/apps/studio/lib/constants/infrastructure.ts
+++ b/apps/studio/lib/constants/infrastructure.ts
@@ -11,6 +11,14 @@ export const AWS_REGIONS_DEFAULT =
 // TO DO, change default to US region for prod
 export const FLY_REGIONS_DEFAULT = FLY_REGIONS.SOUTHEAST_ASIA
 
+export const MANAGED_BY = {
+  VERCEL_MARKETPLACE: 'vercel-marketplace',
+  AWS_MARKETPLACE: 'aws-marketplace',
+  SUPABASE: 'supabase',
+}
+
+export type ManagedBy = (typeof MANAGED_BY)[keyof typeof MANAGED_BY]
+
 export const PRICING_TIER_LABELS_ORG = {
   FREE: 'Free - $0/month',
   PRO: 'Pro - $25/month',

--- a/apps/studio/types/base.ts
+++ b/apps/studio/types/base.ts
@@ -2,9 +2,10 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { OrganizationBase } from 'data/organizations/organizations-query'
 import { PlanId } from 'data/subscriptions/types'
 import jsonLogic from 'json-logic-js'
+import { ManagedBy } from 'lib/constants/infrastructure'
 
 export interface Organization extends OrganizationBase {
-  managed_by: 'supabase' | 'vercel-marketplace' | 'aws-marketplace'
+  managed_by: ManagedBy
   partner_id?: string
   plan: { id: PlanId; name: string }
 }


### PR DESCRIPTION
### Changes
- Adds a `BILLING_MANAGED_BY` constant to more easily add support for different billing partners in the future (see https://github.com/supabase/supabase/pull/37670).
- Adds a `BillingManagedBy` type
- Modifies `PartnerManagedResourceProps` to use the new constant

### Testing
- Head over to `http://localhost:8082/org/_/billing` and pick a Vercel-managed organization
- Assert that the `This organization is managed by Vercel.` banner appears at the top of the page
- Assert that the `Invoices` section redirects to Vercel
- Head over to `http://localhost:8082/org/_/billing` and pick a AWS-managed organization
- Assert that the `This organization is managed by AWS Marketplace.` banner appears at the top of the page