### PR TITLE
fix: write queries in ai assistant

### DIFF
--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { Code, Play } from 'lucide-react'
 import { DragEvent, ReactNode, useEffect, useMemo, useState } from 'react'
 import { Bar, BarChart, CartesianGrid, Cell, Tooltip, XAxis, YAxis } from 'recharts'
@@ -8,10 +9,9 @@ import { ReportBlockContainer } from 'components/interfaces/Reports/ReportBlock/
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import Results from 'components/interfaces/SQLEditor/UtilityPanel/Results'
 import { usePrimaryDatabase } from 'data/read-replicas/replicas-query'
-import { QueryResponseError, useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
-import dayjs from 'dayjs'
-import { Parameter, parseParameters } from 'lib/sql-parameters'
-import { Dashboards } from 'types'
+import { type QueryResponseError, useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
+import { type Parameter, parseParameters } from 'lib/sql-parameters'
+import type { Dashboards } from 'types'
 import { ChartContainer, ChartTooltipContent, cn, CodeBlock, SQL_ICON } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 import { ButtonTooltip } from '../ButtonTooltip'
@@ -172,9 +172,10 @@ export const QueryBlock = ({
       setQueryError(undefined)
     },
     onError: (error) => {
+      const readOnlyTransaction = /cannot execute .+ in a read-only transaction/.test(error.message)
       const permissionDenied = error.message.includes('permission denied')
       const notOwner = error.message.includes('must be owner')
-      if (permissionDenied || notOwner) {
+      if (readOnlyTransaction || permissionDenied || notOwner) {
         setReadOnlyError(true)
         if (showRunButtonIfNotReadOnly) setShowWarning('hasWriteOperation')
       } else {


### PR DESCRIPTION
Some read-only errors from running SQL in the AI Assistant aren't being
properly detected, so the action item to review and confirm running the
SQL isn't showing up. Add matching against another variant of read-only
error message that can show up.