### PR TITLE
chore: Add lint warning on using default exports in the apps (except in app and pages folder)

### DIFF
--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -3,5 +3,14 @@ module.exports = {
   rules: {
     '@next/next/no-html-link-for-pages': 'off',
     'react/jsx-key': 'off',
+    'no-restricted-exports': ['warn', { restrictDefaultExports: { direct: true } }],
   },
+  overrides: [
+    {
+      files: ['pages/**', 'app/**'],
+      rules: {
+        'no-restricted-exports': 'off',
+      },
+    },
+  ],
 }


### PR DESCRIPTION
This PR adds lint warning on files which use `export default`. The default export is a code smell, makes it hard to search for components. More info at https://basarat.gitbook.io/typescript/main-1/defaultisbad.

This PR only adds it to the apps, packages don't have linting setup at the moment.

<img width="563" height="174" alt="Screenshot 2025-08-15 at 15 12 32" src="https://github.com/user-attachments/assets/3b2bbd44-ae8b-45f2-9658-6f362ff0353b" />
<img width="370" height="177" alt="Screenshot 2025-08-15 at 15 12 42" src="https://github.com/user-attachments/assets/4a36947e-13f5-4e35-b005-a859b03ffa37" />
