### PR TITLE
Fix studio dynamic route mock setup

### DIFF
--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -44,6 +44,7 @@ import { Admonition } from 'ui-patterns'
 import { Bucket } from 'data/storage/buckets-query'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { isNonNullable } from 'lib/isNonNullable'
+import { useRouter } from 'next/router'
 
 export interface EditBucketModalProps {
   visible: boolean
@@ -66,6 +67,8 @@ const formId = 'edit-storage-bucket-form'
 
 export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalProps) => {
   const { ref } = useParams()
+  const router = useRouter()
+  console.log({ external: ref, internal: router.query.ref })
 
   const { mutate: updateBucket, isLoading: isUpdating } = useBucketUpdateMutation()
   const { data } = useProjectStorageConfigQuery({ projectRef: ref }, { enabled: IS_PLATFORM })

--- a/apps/studio/tests/lib/route-mock.ts
+++ b/apps/studio/tests/lib/route-mock.ts
@@ -1,7 +1,7 @@
-import { glob } from 'fs/promises'
+import { glob } from 'node:fs/promises'
+import { normalize, posix, sep, join } from 'node:path'
 import _routerMock from 'next-router-mock'
 import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes'
-import { normalize, posix, sep, join } from 'path'
 
 export const routerMock = _routerMock
 
@@ -22,5 +22,7 @@ const paths = [
   ...(await Array.fromAsync(glob(`${pagesRoot}/**/*\].tsx`))),
   ...(await Array.fromAsync(glob(`${pagesRoot}/**/**\]/**/index.tsx`))),
 ].map(pipe(normalize, toPosix, removePrefix, removeExt))
+
+console.log({ pagesRoot, paths })
 
 routerMock.useParser(createDynamicRouteParser(paths))

--- a/apps/studio/tests/vitestSetup.ts
+++ b/apps/studio/tests/vitestSetup.ts
@@ -18,6 +18,7 @@ import { mswServer } from './lib/msw'
 beforeAll(() => {
   mswServer.listen({ onUnhandledRequest: `error` })
   vi.mock('next/router', () => require('next-router-mock'))
+  vi.mock('next/compat/router', () => require('next-router-mock'))
   vi.mock('next/navigation', async () => {
     const actual = await vi.importActual('next/navigation')
     return {
@@ -34,10 +35,6 @@ beforeAll(() => {
       }),
     }
   })
-
-  vi.mock('next/compat/router', () => require('next-router-mock'))
-
-  routerMock.useParser(createDynamicRouteParser(['/projects/[ref]']))
 })
 
 afterEach(() => {


### PR DESCRIPTION
The intent of this is to fix for tests that are failing in CI but pass locally.

First I need to test assumptions about the setup code and how it runs in our CI container versus local development environments.

The failing tests appear to all have a root cause of `useParams()` returning `undefined` for dynamic route segment parameters, and the cause of this would be an incorrect configuration of `next-router-mock`. The possible cause of this is that the globs we're using to build this list of paths behaves differently in CI.