### PR TITLE
Replace deprecated components on `/authorize` page

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails.tsx
@@ -8,6 +8,7 @@ export interface AuthorizeRequesterDetailsProps {
   name: string
   domain: string
   scopes: OAuthScope[]
+  showOnlyScopes?: boolean
 }
 
 export const ScopeSection = ({
@@ -55,31 +56,43 @@ export const AuthorizeRequesterDetails = ({
   name,
   domain,
   scopes,
+  showOnlyScopes = false,
 }: AuthorizeRequesterDetailsProps) => {
   return (
     <div className="flex gap-y-4 flex-col">
-      <div className="flex flex-row gap-x-4 items-center">
-        <div className="flex items-center">
-          <div
-            className="w-14 h-14 md:w-16 md:h-16 bg-center bg-no-repeat bg-cover flex items-center justify-center rounded-md border border-control"
-            style={{
-              backgroundImage: !!icon ? `url('${icon}')` : 'none',
-            }}
-          >
-            {!icon && <p className="text-foreground-light text-lg">{name[0]}</p>}
+      {!showOnlyScopes && (
+        <div className="flex flex-row gap-x-4 items-center">
+          <div className="flex items-center">
+            <div
+              className="w-12 h-12 md:w-14 md:h-14 bg-center bg-no-repeat bg-cover flex items-center justify-center rounded-md border border-control"
+              style={{
+                backgroundImage: !!icon ? `url('${icon}')` : 'none',
+              }}
+            >
+              {!icon && <p className="text-foreground-light text-lg">{name[0]}</p>}
+            </div>
           </div>
+          <p className="text-foreground">
+            {name} ({domain}) is requesting API access to an organization.
+          </p>
         </div>
-        <p className="text-foreground">
-          {name} ({domain}) is requesting API access to an organization.
-        </p>
-      </div>
+      )}
       <div>
-        <h2>Permissions</h2>
-        <p className="text-sm text-foreground-light">
-          The following scopes will apply for the{' '}
-          <span className="text-amber-900">selected organization and all of its projects.</span>
-        </p>
+        {!showOnlyScopes && (
+          <>
+            <h3>Permissions</h3>
+            <p className="text-sm text-foreground-light">
+              The following scopes will apply for the{' '}
+              <span className="text-amber-900">selected organization and all of its projects.</span>
+            </p>
+          </>
+        )}
         <div className="pt-2">
+          {scopes.length === 0 && (
+            <p className="text-foreground-lighter text-sm">
+              No permissions requested, {name} will not have access to your organization or projects
+            </p>
+          )}
           <ScopeSection
             description={PERMISSIONS_DESCRIPTIONS.ANALYTICS}
             hasReadScope={scopes.includes(OAuthScope.ANALYTICS_READ)}

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs'
-import { AlertCircle } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -8,7 +7,6 @@ import { toast } from 'sonner'
 import { useParams } from 'common'
 import { AuthorizeRequesterDetails } from 'components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails'
 import APIAuthorizationLayout from 'components/layouts/APIAuthorizationLayout'
-import { FormPanel } from 'components/ui/Forms/FormPanel'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useApiAuthorizationApproveMutation } from 'data/api-authorization/api-authorization-approve-mutation'
 import { useApiAuthorizationDeclineMutation } from 'data/api-authorization/api-authorization-decline-mutation'
@@ -17,13 +15,23 @@ import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { withAuth } from 'hooks/misc/withAuth'
 import type { NextPageWithLayout } from 'types'
 import {
-  Alert,
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Button,
-  Listbox,
+  WarningIcon,
+  CheckIcon,
+  Card,
+  CardContent,
+  CardHeader,
+  CardFooter,
+  Select_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
 } from 'ui'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 
 // Need to handle if no organizations in account
 // Need to handle if not logged in yet state
@@ -93,42 +101,51 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
 
   if (isLoading) {
     return (
-      <FormPanel header={<p>Authorize API access</p>}>
-        <div className="px-8 py-6 space-y-2">
+      <Card>
+        <CardHeader>Authorize API access</CardHeader>
+        <CardContent className="space-y-2">
           <ShimmeringLoader />
           <ShimmeringLoader className="w-3/4" />
           <ShimmeringLoader className="w-1/2" />
-        </div>
-      </FormPanel>
+        </CardContent>
+      </Card>
     )
   }
 
   if (auth_id === undefined) {
     return (
-      <FormPanel header={<p>Authorization for API access</p>}>
-        <div className="px-8 py-6">
-          <Alert withIcon variant="warning" title="Missing authorization ID">
-            Please provide a valid authorization ID in the URL
-          </Alert>
-        </div>
-      </FormPanel>
+      <Card>
+        <CardHeader>Authorization for API access</CardHeader>
+        <CardContent>
+          <Alert_Shadcn_ variant="warning">
+            <WarningIcon />
+            <AlertTitle_Shadcn_>Missing authorization ID</AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              Please provide a valid authorization ID in the URL
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
+        </CardContent>
+      </Card>
     )
   }
 
   if (isError) {
     return (
-      <FormPanel header={<p>Authorize API access</p>}>
-        <div className="px-8 py-6">
-          <Alert
-            withIcon
-            variant="warning"
-            title="Failed to fetch details for API authorization request"
-          >
-            <p>Please retry your authorization request from the requesting app</p>
-            {error !== undefined && <p className="mt-2">Error: {error?.message}</p>}
-          </Alert>
-        </div>
-      </FormPanel>
+      <Card>
+        <CardHeader>Authorize API access</CardHeader>
+        <CardContent>
+          <Alert_Shadcn_ variant="warning">
+            <WarningIcon />
+            <AlertTitle_Shadcn_>
+              Failed to fetch details for API authorization request"
+            </AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              <p>Please retry your authorization request from the requesting app</p>
+              {error !== undefined && <p className="mt-2">Error: {error?.message}</p>}
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
+        </CardContent>
+      </Card>
     )
   }
 
@@ -138,19 +155,24 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
     )
 
     return (
-      <FormPanel header={<p>Authorize API access for {requester?.name}</p>}>
-        <div className="w-full px-8 py-6 space-y-8">
-          <Alert withIcon variant="success" title="This authorization request has been approved">
-            <p>
-              {requester.name} has read and write access to the organization "
-              {approvedOrganization?.name ?? 'Unknown'}" and all of its projects
-            </p>
-            <p className="mt-2">
-              Approved on: {dayjs(requester.approved_at).format('DD MMM YYYY HH:mm:ss (ZZ)')}
-            </p>
-          </Alert>
-        </div>
-      </FormPanel>
+      <Card>
+        <CardHeader>Authorize API access for {requester?.name}</CardHeader>
+        <CardContent>
+          <Alert_Shadcn_>
+            <CheckIcon />
+            <AlertTitle_Shadcn_>This authorization request has been approved</AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              <p>
+                {requester.name} has read and write access to the organization "
+                {approvedOrganization?.name ?? 'Unknown'}" and all of its projects
+              </p>
+              <p className="mt-2">
+                Approved on: {dayjs(requester.approved_at).format('DD MMM YYYY HH:mm:ss (ZZ)')}
+              </p>
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
+        </CardContent>
+      </Card>
     )
   }
 
@@ -164,43 +186,9 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
   searchParams.set('returnTo', pathname)
 
   return (
-    <FormPanel
-      header={<p>Authorize API access for {requester?.name}</p>}
-      footer={
-        <div className="flex items-center justify-end py-4 px-8">
-          <div className="flex items-center space-x-2">
-            <Button
-              type="default"
-              loading={isDeclining}
-              disabled={
-                isApproving || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)
-              }
-              onClick={onDeclineRequest}
-            >
-              Decline
-            </Button>
-            {isLoadingOrganizations ? (
-              <Button loading={isLoadingOrganizations}>Authorize {requester?.name}</Button>
-            ) : isSuccessOrganizations && organizations.length === 0 ? (
-              <Link href={`/new?${searchParams.toString()}`}>
-                <Button loading={isLoadingOrganizations}>Create an organization</Button>
-              </Link>
-            ) : (
-              <Button
-                loading={isApproving}
-                disabled={
-                  isDeclining || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)
-                }
-                onClick={onApproveRequest}
-              >
-                Authorize {requester?.name}
-              </Button>
-            )}
-          </div>
-        </div>
-      }
-    >
-      <div className="w-full px-8 py-6 space-y-8">
+    <Card>
+      <CardHeader>Authorize API access for {requester?.name}</CardHeader>
+      <CardContent className="space-y-8">
         {/* API Authorization requester details */}
         <AuthorizeRequesterDetails
           icon={requester.icon}
@@ -211,9 +199,13 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
 
         {/* Expiry warning */}
         {isExpired && (
-          <Alert withIcon variant="warning" title="This authorization request is expired">
-            Please retry your authorization request from the requesting app
-          </Alert>
+          <Alert_Shadcn_ variant="warning">
+            <WarningIcon />
+            <AlertTitle_Shadcn_>This authorization request is expired</AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              Please retry your authorization request from the requesting app
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
         )}
 
         {/* Organization selection */}
@@ -224,11 +216,11 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
           </div>
         ) : organizations?.length === 0 ? (
           <Alert_Shadcn_ variant="warning">
-            <AlertCircle className="h-4 w-4" />
+            <WarningIcon />
             <AlertTitle_Shadcn_>
               Organization is needed for installing an integration
             </AlertTitle_Shadcn_>
-            <AlertDescription_Shadcn_ className="">
+            <AlertDescription_Shadcn_>
               Your account isn't associated with any organizations. To use this integration, it must
               be installed within an organization. You'll be redirected to create an organization
               first.
@@ -236,40 +228,75 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
           </Alert_Shadcn_>
         ) : organization_slug && !selectedOrgSlug ? (
           <Alert_Shadcn_ variant="warning">
-            <AlertCircle className="h-4 w-4" />
+            <WarningIcon />
             <AlertTitle_Shadcn_>
               Organization is needed for installing an integration
             </AlertTitle_Shadcn_>
-            <AlertDescription_Shadcn_ className="">
+            <AlertDescription_Shadcn_>
               Your account is not a member of the pre-selected organization. To use this
               integration, it must be installed within an organization your account is associated
               with.
             </AlertDescription_Shadcn_>
           </Alert_Shadcn_>
         ) : (
-          <Listbox
+          <FormLayout
             label={
               organization_slug
                 ? 'API access will be granted to pre-selected organization:'
                 : 'Select an organization to grant API access to:'
             }
-            value={selectedOrgSlug}
-            disabled={isExpired || Boolean(organization_slug)}
-            onChange={setSelectedOrgSlug}
           >
-            {(organizations ?? []).map((organization) => (
-              <Listbox.Option
-                key={organization?.slug}
-                label={organization?.name}
-                value={organization?.slug}
-              >
-                {organization.name}
-              </Listbox.Option>
-            ))}
-          </Listbox>
+            <Select_Shadcn_
+              value={selectedOrgSlug}
+              disabled={isExpired || Boolean(organization_slug)}
+              onValueChange={setSelectedOrgSlug}
+            >
+              <SelectTrigger_Shadcn_ size="small">
+                <SelectValue_Shadcn_ asChild>
+                  <>{selectedOrgSlug}</>
+                </SelectValue_Shadcn_>
+              </SelectTrigger_Shadcn_>
+              <SelectContent_Shadcn_>
+                {(organizations ?? []).map((organization) => (
+                  <SelectItem_Shadcn_
+                    key={organization?.slug}
+                    value={organization?.slug}
+                    className="text-xs"
+                  >
+                    {organization.name}
+                  </SelectItem_Shadcn_>
+                ))}
+              </SelectContent_Shadcn_>
+            </Select_Shadcn_>
+          </FormLayout>
         )}
-      </div>
-    </FormPanel>
+      </CardContent>
+      <CardFooter className="justify-end space-x-2">
+        <Button
+          type="default"
+          loading={isDeclining}
+          disabled={isApproving || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
+          onClick={onDeclineRequest}
+        >
+          Decline
+        </Button>
+        {isLoadingOrganizations ? (
+          <Button loading={isLoadingOrganizations}>Authorize {requester?.name}</Button>
+        ) : isSuccessOrganizations && organizations.length === 0 ? (
+          <Link href={`/new?${searchParams.toString()}`}>
+            <Button loading={isLoadingOrganizations}>Create an organization</Button>
+          </Link>
+        ) : (
+          <Button
+            loading={isApproving}
+            disabled={isDeclining || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
+            onClick={onApproveRequest}
+          >
+            Authorize {requester?.name}
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
   )
 }
 


### PR DESCRIPTION
This refactors `/authorize` to replace deprecated components with the recommended shadcn based equivalents. Follows the patterns in `BasicAuthSettingsForm` for the use of `<Card>` components.

I used a `/sandbox` page in development to visually compare basic implementations of the replaced components, however, this should still be inspected for possible errors on staging.

Note that there isn't a "success" alert/admonition, so for sake of consistency with the existing code, this opts to use `<Alet_Shadcn_>` paired with `<CheckIcon />` for the success modal, which will have differences in appearance by necessity. If there is a preferred reference implementation, please let me know!