### PR TITLE
Fix CSV import for postgres array types

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest'
+import { formatRowsForInsert } from './SidePanelEditor.utils'
+
+describe('SidePanelEditor.utils.test.ts', () => {
+  test('formatRowsForInsert should for format rows with basic data types correctly', () => {
+    const rows = [
+      { id: 1, text: 'A' },
+      { id: 2, text: 'B' },
+      { id: 3, text: 'C' },
+    ]
+    const headers = ['id', 'text']
+    const columns = [
+      { id: '1', name: 'id', data_type: 'bigint', format: 'int8', is_nullable: false },
+      { id: '2', name: 'text', data_type: 'text', format: 'text', is_nullable: true },
+    ]
+
+    const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
+    expect(formattedRows).toEqual(rows)
+  })
+
+  test('formatRowsForInsert should handle nullable columns if value is an empty string', () => {
+    const rows = [
+      { id: 1, text: 'A' },
+      { id: 2, text: '' },
+      { id: 3, text: 'C' },
+    ]
+    const headers = ['id', 'text']
+    const columns = [
+      { id: '1', name: 'id', data_type: 'bigint', format: 'int8', is_nullable: false },
+      { id: '2', name: 'text', data_type: 'text', format: 'text', is_nullable: true },
+    ]
+
+    const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
+    expect(formattedRows).toEqual([
+      { id: 1, text: 'A' },
+      { id: 2, text: null },
+      { id: 3, text: 'C' },
+    ])
+  })
+
+  test('formatRowsForInsert should handle JSON object values properly', () => {
+    const rows = [{ id: 1, value: '{"key": "value"}' }]
+    const headers = ['id', 'value']
+    const columns = [
+      { id: '1', name: 'id', data_type: 'bigint', format: 'int8', is_nullable: false },
+      { id: '2', name: 'value', data_type: 'json', format: 'jsonb', is_nullable: true },
+    ]
+
+    const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
+    expect(formattedRows).toEqual([{ id: 1, value: { key: 'value' } }])
+  })
+
+  test('formatRowsForInsert should handle JSON array values properly', () => {
+    const rows = [{ id: 1, value: '["item1", "item2", "item3"]' }]
+    const headers = ['id', 'value']
+    const columns = [
+      { id: '1', name: 'id', data_type: 'bigint', format: 'int8', is_nullable: false },
+      { id: '2', name: 'value', data_type: 'json', format: 'jsonb', is_nullable: true },
+    ]
+
+    const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
+    expect(formattedRows).toEqual([{ id: 1, value: ['item1', 'item2', 'item3'] }])
+  })
+
+  test('formatRowsForInsert should handle Postgres array values properly', () => {
+    const rows = [{ id: 1, value: '{"item1", "item2", "item3"}' }]
+    const headers = ['id', 'value']
+    const columns = [
+      { id: '1', name: 'id', data_type: 'bigint', format: 'int8', is_nullable: false },
+      { id: '2', name: 'value', data_type: 'ARRAY', format: '_text', is_nullable: true },
+    ]
+
+    const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
+    expect(formattedRows).toEqual([{ id: 1, value: ['item1', 'item2', 'item3'] }])
+  })
+})

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.test.ts
@@ -73,4 +73,16 @@ describe('SidePanelEditor.utils.test.ts', () => {
     const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
     expect(formattedRows).toEqual([{ id: 1, value: ['item1', 'item2', 'item3'] }])
   })
+
+  test('formatRowsForInsert should handle Postgres array values properly if provided JSON string', () => {
+    const rows = [{ id: 1, value: '["item1", "item2", "item3"]' }]
+    const headers = ['id', 'value']
+    const columns = [
+      { id: '1', name: 'id', data_type: 'bigint', format: 'int8', is_nullable: false },
+      { id: '2', name: 'value', data_type: 'ARRAY', format: '_text', is_nullable: true },
+    ]
+
+    const formattedRows = formatRowsForInsert({ rows, headers, columns: columns as any })
+    expect(formattedRows).toEqual([{ id: 1, value: ['item1', 'item2', 'item3'] }])
+  })
 })

--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -142,7 +142,7 @@ export const EditorTabs = () => {
             strategy={horizontalListSortingStrategy}
           >
             {editorTabs.map((tab, index) => (
-              <ContextMenu_Shadcn_>
+              <ContextMenu_Shadcn_ key={tab.id}>
                 <ContextMenuTrigger_Shadcn_>
                   <SortableTab
                     key={tab.id}


### PR DESCRIPTION
## Context

There's an issue with the Table Editor's CSV import, specifically if your table has an `array` type column.

A quick way to reproduce this is to create a simple table as such:
```
create table public.test (
  id bigint generated by default as identity primary key,
  text text[] null
);
```

And then importing this CSV into the table through the Table Editor:
```
id,text
1,"{""apple"", ""pear""}"
2,"{""watermelon"", ""orange""}"
3,"{""coconut"", ""banana""}"
```

The `text` column on this table will have NULL values after importing despite a success toast message.

Realised that this is due to the way we're formatting rows for insertion within `insertRowsViaSpreadsheet` and `insertTableRows` which are the methods used when importing data via CSV (either file drop or text copy paste)

## Changes involved
- Consolidate the row formatting function into one between `insertRowsViaSpreadsheet` and `insertTableRows`
- Fix formatting of rows for CSV to convert Postgres arrays into JSON arrays (since we're using pg-meta to form the query to insert rows)
- Add test cases for the formatting

## To test
- Can follow the reproduction steps above within Context - the problem shouldn't happen anymore