### PR TITLE
fix: Revert permissions change in Vercel integrations component.

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
@@ -18,6 +18,7 @@ import {
   ScaffoldSectionDetail,
 } from 'components/layouts/Scaffold'
 import NoPermission from 'components/ui/NoPermission'
+import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useOrgIntegrationsQuery } from 'data/integrations/integrations-query-org-only'
 import { useIntegrationsVercelInstalledConnectionDeleteMutation } from 'data/integrations/integrations-vercel-installed-connection-delete-mutation'
 import { useVercelProjectsQuery } from 'data/integrations/integrations-vercel-projects-query'
@@ -25,14 +26,13 @@ import type {
   IntegrationName,
   IntegrationProjectConnection,
 } from 'data/integrations/integrations.types'
-import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { pluralize } from 'lib/helpers'
 import { getIntegrationConfigurationUrl } from 'lib/integration-utils'
 import { useSidePanelsStateSnapshot } from 'state/side-panels'
 import { Button, cn } from 'ui'
-import { GenericSkeletonLoader } from 'ui-patterns'
 import { IntegrationImageHandler } from '../IntegrationsSettings'
 import VercelIntegrationConnectionForm from './VercelIntegrationConnectionForm'
 
@@ -43,13 +43,18 @@ const VercelSection = ({ isProjectScoped }: { isProjectScoped: boolean }) => {
   const sidePanelsStateSnapshot = useSidePanelsStateSnapshot()
   const isBranch = project?.parent_project_ref !== undefined
 
-  const { can: canReadVercelConnection, isLoading: isLoadingPermissions } =
-    useAsyncCheckProjectPermissions(PermissionAction.READ, 'integrations.vercel_connections')
-  const { can: canCreateVercelConnection } = useAsyncCheckProjectPermissions(
+  // placeholder for isLoading state when a useAsyncCheckOrgPermissions hook is added
+  // This component in used both in /org/[slug]/integrations and /project/[slug]/settings/integrations
+  const isLoadingPermissions = false
+  const canReadVercelConnection = useCheckPermissions(
+    PermissionAction.READ,
+    'integrations.vercel_connections'
+  )
+  const canCreateVercelConnection = useCheckPermissions(
     PermissionAction.CREATE,
     'integrations.vercel_connections'
   )
-  const { can: canUpdateVercelConnection } = useAsyncCheckProjectPermissions(
+  const canUpdateVercelConnection = useCheckPermissions(
     PermissionAction.UPDATE,
     'integrations.vercel_connections'
   )


### PR DESCRIPTION
This PR reverts this change https://github.com/supabase/supabase/pull/37899/files#diff-1be98329c7b0bc643acf274d192af3447a59c3e4e6dcf62a774c491531d86d89. The component in question `VercelSection` is used both in project and org pages while using `useAsyncCheckProjectPermissions` which requires project ref in the URL (which is not available in org pages). This bug shows up as never ending loading state in the org integrations page.