### PR TITLE
fix padding in project homepage

### DIFF
--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -112,7 +112,7 @@ const Home: NextPageWithLayout = () => {
   const replicasCount = Math.max(0, (replicasData?.length ?? 1) - 1)
 
   return (
-    <div className="w-full">
+    <div className="w-full px-4">
       <div className={cn('py-16 ', !isPaused && 'border-b border-muted ')}>
         <div className="mx-auto max-w-7xl flex flex-col gap-y-4">
           <div className="flex flex-col md:flex-row md:items-center gap-6 justify-between w-full">


### PR DESCRIPTION
## BEFORE
cramped, tight, ugly
<img width="2320" height="1684" alt="CleanShot 2025-08-18 at 17 00 19@2x" src="https://github.com/user-attachments/assets/8db511fe-fced-4fde-bf11-871d496d7983" />


## AFTER. 
fresh, spacious, clean
<img width="2308" height="1570" alt="CleanShot 2025-08-18 at 17 00 32@2x" src="https://github.com/user-attachments/assets/9fb70bed-f5d8-464c-8991-a439e6e0234b" />
