### PR TITLE
docs: fix jwt signing key cli ref

### DIFF
--- a/apps/docs/spec/common-cli-sections.json
+++ b/apps/docs/spec/common-cli-sections.json
@@ -102,6 +102,12 @@
         "type": "cli-command"
       },
       {
+        "id": "supabase-gen-signing-key",
+        "title": "Generate a JWT signing key",
+        "slug": "supabase-gen-signing-key",
+        "type": "cli-command"
+      },
+      {
         "id": "supabase-gen-types",
         "title": "Generate types (Postgres schema)",
         "slug": "supabase-gen-types",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Docs updated

## What is the current behavior?

I can see the supabase gen signing-key sub command here but doesn't display anywhere else on the cli reference page

<img width="813" height="616" alt="image" src="https://github.com/user-attachments/assets/cf72ceff-0b11-4497-9426-a87bafe25bab" />

## What is the new behavior?

I have added it the `common-cli-sections.json` to fix the above issue
<img width="1190" height="655" alt="image" src="https://github.com/user-attachments/assets/dc61d6e5-5b28-4cd8-9067-a9131ea089fb" />


## Additional context


