### PR TITLE
storage explorer: fix validation in folder creation

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -345,7 +345,7 @@ function createStorageExplorerState({
         })
       }
 
-      const newFolder = state.columns[columnIndex].items.find((x) => x.name === formattedName)
+      const newFolder = state.columns[columnIndex].items?.find((x) => x.name === formattedName)
       if (newFolder) state.openFolder(columnIndex, newFolder)
     },
 

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1654,7 +1654,9 @@ function createStorageExplorerState({
       const currentColumnItems = currentColumn.items.filter(
         (item) => item.status !== STORAGE_ROW_STATUS.EDITING
       )
-      const hasSameNameInColumn = currentColumnItems.filter((item) => item.name === name).length > 0
+      const hasSameNameInColumn =
+        currentColumnItems.filter((item) => item.name.toLowerCase() === name.toLowerCase()).length >
+        0
 
       if (hasSameNameInColumn) {
         if (autofix) {


### PR DESCRIPTION
- does not allow creating folders with same name but different casing


<img width="2442" height="1096" alt="CleanShot 2025-08-19 at 14 58 34@2x" src="https://github.com/user-attachments/assets/3104a392-ef40-4145-ad10-7990be768c37" />
