### PR TITLE
feat(studio): update other account sections to match access tokens

### DIFF
--- a/apps/studio/pages/account/me.tsx
+++ b/apps/studio/pages/account/me.tsx
@@ -15,6 +15,11 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useProfile } from 'lib/profile'
 import type { NextPageWithLayout } from 'types'
+import {
+  ScaffoldContainer,
+  ScaffoldHeader,
+  ScaffoldSectionTitle,
+} from 'components/layouts/Scaffold'
 
 const User: NextPageWithLayout = () => {
   return <ProfileCard />
@@ -39,43 +44,52 @@ const ProfileCard = () => {
   const { error, isLoading, isError, isSuccess } = useProfile()
 
   return (
-    <article>
-      {isLoading && (
-        <Panel>
-          <div className="p-4">
-            <GenericSkeletonLoader />
-          </div>
-        </Panel>
-      )}
-      {isError && (
-        <Panel>
-          <div className="p-4">
-            <AlertError error={error} subject="Failed to retrieve account information" />
-          </div>
-        </Panel>
-      )}
-      {isSuccess && (
-        <>
-          {profileShowInformation && isSuccess ? <ProfileInformation /> : null}
-          <AccountIdentities />
-        </>
-      )}
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader className="pt-0">
+          <ScaffoldSectionTitle>Preferences</ScaffoldSectionTitle>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
+        <article>
+          {isLoading && (
+            <Panel>
+              <div className="p-4">
+                <GenericSkeletonLoader />
+              </div>
+            </Panel>
+          )}
+          {isError && (
+            <Panel>
+              <div className="p-4">
+                <AlertError error={error} subject="Failed to retrieve account information" />
+              </div>
+            </Panel>
+          )}
+          {isSuccess && (
+            <>
+              {profileShowInformation && isSuccess ? <ProfileInformation /> : null}
+              <AccountIdentities />
+            </>
+          )}
 
-      <section>
-        <AccountConnections />
-      </section>
+          <section>
+            <AccountConnections />
+          </section>
 
-      <section>
-        <ThemeSettings />
-      </section>
+          <section>
+            <ThemeSettings />
+          </section>
 
-      <section>
-        <AnalyticsSettings />
-      </section>
+          <section>
+            <AnalyticsSettings />
+          </section>
 
-      <section>
-        <AccountDeletion />
-      </section>
-    </article>
+          <section>
+            <AccountDeletion />
+          </section>
+        </article>
+      </ScaffoldContainer>
+    </>
   )
 }

--- a/apps/studio/pages/account/security.tsx
+++ b/apps/studio/pages/account/security.tsx
@@ -15,6 +15,11 @@ import {
   CollapsibleContent_Shadcn_,
   CollapsibleTrigger_Shadcn_,
 } from 'ui'
+import {
+  ScaffoldContainer,
+  ScaffoldHeader,
+  ScaffoldSectionTitle,
+} from 'components/layouts/Scaffold'
 
 const collapsibleClasses = [
   'bg-surface-100',
@@ -33,28 +38,37 @@ const Security: NextPageWithLayout = () => {
   const { data } = useMfaListFactorsQuery()
 
   return (
-    <Collapsible_Shadcn_ className={cn(collapsibleClasses)}>
-      <CollapsibleTrigger_Shadcn_ asChild>
-        <button
-          type="button"
-          className="group flex w-full items-center justify-between rounded py-3 px-4 md:px-6 text-foreground"
-        >
-          <div className="flex flex-row gap-4 items-center py-1">
-            <Smartphone strokeWidth={1.5} />
-            <span className="text-sm">Authenticator app</span>
-          </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader className="pt-0">
+          <ScaffoldSectionTitle>Security</ScaffoldSectionTitle>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
+        <Collapsible_Shadcn_ className={cn(collapsibleClasses)}>
+          <CollapsibleTrigger_Shadcn_ asChild>
+            <button
+              type="button"
+              className="group flex w-full items-center justify-between rounded py-3 px-4 md:px-6 text-foreground"
+            >
+              <div className="flex flex-row gap-4 items-center py-1">
+                <Smartphone strokeWidth={1.5} />
+                <span className="text-sm">Authenticator app</span>
+              </div>
 
-          {data ? (
-            <Badge variant={data.totp.length === 0 ? 'default' : 'brand'}>
-              {data.totp.length} app{data.totp.length === 1 ? '' : 's'} configured
-            </Badge>
-          ) : null}
-        </button>
-      </CollapsibleTrigger_Shadcn_>
-      <CollapsibleContent_Shadcn_ className="group border-t border-default bg-surface-100 py-6 px-4 md:px-6 text-foreground">
-        <TOTPFactors />
-      </CollapsibleContent_Shadcn_>
-    </Collapsible_Shadcn_>
+              {data ? (
+                <Badge variant={data.totp.length === 0 ? 'default' : 'brand'}>
+                  {data.totp.length} app{data.totp.length === 1 ? '' : 's'} configured
+                </Badge>
+              ) : null}
+            </button>
+          </CollapsibleTrigger_Shadcn_>
+          <CollapsibleContent_Shadcn_ className="group border-t border-default bg-surface-100 py-6 px-4 md:px-6 text-foreground">
+            <TOTPFactors />
+          </CollapsibleContent_Shadcn_>
+        </Collapsible_Shadcn_>
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/account/tokens.tsx
+++ b/apps/studio/pages/account/tokens.tsx
@@ -11,7 +11,6 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import {
   ScaffoldContainer,
-  ScaffoldDescription,
   ScaffoldHeader,
   ScaffoldSectionTitle,
 } from 'components/layouts/Scaffold'
@@ -27,12 +26,8 @@ const UserAccessTokens: NextPageWithLayout = () => {
   return (
     <>
       <ScaffoldContainer>
-        <ScaffoldHeader className="pt-0 mb-6">
+        <ScaffoldHeader className="pt-0">
           <ScaffoldSectionTitle>Access Tokens</ScaffoldSectionTitle>
-          <ScaffoldDescription>
-            Personal access tokens can be used to control your whole account and use features added
-            in the future. Be careful when sharing them!
-          </ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
       <ScaffoldContainer bottomPadding>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Matches the Security and Preferences view with the same scaffolding as the newly updated Access Tokens view.

| Before | After |
|--------|--------|
| <img width="1311" height="321" alt="Screenshot 2025-08-19 at 14 26 59" src="https://github.com/user-attachments/assets/41d1ae3f-58aa-42b8-be55-785e6944cb37" /> | <img width="1221" height="360" alt="Screenshot 2025-08-19 at 14 26 38" src="https://github.com/user-attachments/assets/27a8e256-6d2b-4912-888e-7ea9afb68637" /> |

This is in anticipation of a bigger update for the entire area. 
