### PR TITLE
feat: remove server-side page tracking calls

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -77,29 +77,7 @@ export function handlePageTelemetry(
     })
   }
 
-  // Send to backend
-  // TODO: Remove this once migration to client-side page telemetry is complete
-  const sharedData = getSharedTelemetryData(pathname)
-  const { session_id, ...backendData } = sharedData // Remove session_id from backend payload (it's already in the cookie)
-
-  const payload =
-    telemetryDataOverride !== undefined
-      ? { feature_flags: featureFlags, ...telemetryDataOverride }
-      : {
-          ...backendData,
-          ...(slug || ref
-            ? {
-                groups: {
-                  ...(slug ? { organization: slug } : {}),
-                  ...(ref ? { project: ref } : {}),
-                },
-              }
-            : {}),
-          feature_flags: featureFlags,
-        }
-  return post(`${ensurePlatformSuffix(API_URL)}/telemetry/page`, payload, {
-    headers: { Version: '2' },
-  })
+  return Promise.resolve()
 }
 
 export function handlePageLeaveTelemetry(
@@ -122,22 +100,7 @@ export function handlePageLeaveTelemetry(
     })
   }
 
-  // Send to backend
-  // TODO: Remove this once migration to client-side page telemetry is complete
-  return post(`${ensurePlatformSuffix(API_URL)}/telemetry/page-leave`, {
-    pathname,
-    page_url: isBrowser ? window.location.href : '',
-    page_title: isBrowser ? document?.title : '',
-    feature_flags: featureFlags,
-    ...(slug || ref
-      ? {
-          groups: {
-            ...(slug ? { organization: slug } : {}),
-            ...(ref ? { project: ref } : {}),
-          },
-        }
-      : {}),
-  })
+  return Promise.resolve()
 }
 
 export const PageTelemetry = ({


### PR DESCRIPTION
## Summary
- Removed server-side API calls for page view and page leave tracking
- Client-side PostHog tracking remains fully functional
- Generic events and user identification continue to use server-side tracking as requested

Resolves GROWTH-451

## Changes
- Removed `/platform/telemetry/page` API call from `handlePageTelemetry()`
- Removed `/platform/telemetry/page-leave` API call from `handlePageLeaveTelemetry()`
- Both functions now return `Promise.resolve()` while maintaining client-side PostHog tracking
- Kept `sendTelemetryEvent()` and `sendTelemetryIdentify()` unchanged for continued server-side tracking of non-page view events

## Test plan
- [x] Confirm no more page view events are coming from `posthog-node` (screenshot below)
- [x] Verify PostHog continues to receive page view events
- [x] Confirm generic telemetry events still work through server-side tracking (e.g. `studio_pricing_side_panel_opened`)
- [x] Confirm sessions and `destinct_id`s are consistent across apps ([how to test this](https://www.notion.so/supabase/How-To-Test-PostHog-Session-Continuity-Across-Apps-2545004b775f800da800cfa6f3f28a2b?source=copy_link))
- [x] Confirm `posthog-node` events are still sent for non-page view / page leave events

<img width="1622" height="601" alt="image" src="https://github.com/user-attachments/assets/c5cd077b-0e42-41aa-947e-eba7e49b2dd7" />
