### PR TITLE
docs(realtime): JWT claims can be accessed when authorising channels

### DIFF
--- a/apps/docs/content/guides/realtime/authorization.mdx
+++ b/apps/docs/content/guides/realtime/authorization.mdx
@@ -50,13 +50,11 @@ Increased RLS complexity can impact database performance and connection time, le
 
 </Admonition>
 
-## Helper functions
-
-You can use the following helper functions when writing RLS policies:
+## Accessing request information
 
 ### `realtime.topic`
 
-Returns the Channel topic the user is attempting to connect to.
+You can use the `realtime.topic` helper function when writing RLS policies. It returns the Channel topic the user is attempting to connect to.
 
 ```sql
 create policy "authenticated can read all messages on topic"
@@ -65,6 +63,21 @@ for select
 to authenticated
 using (
   (select realtime.topic()) = 'room-1'
+);
+```
+
+### JWT claims
+
+The user claims can be accessed using the `current_setting` function. The claims are available as a JSON object in the `request.jwt.claims` setting.
+
+```sql
+create policy "authenticated with supabase.io email can read all"
+on "realtime"."messages"
+for select
+to authenticated
+using (
+  -- Only users with the email claim ending with @supabase.io
+  (((current_setting('request.jwt.claims'))::json ->> 'email') ~~ '%@supabase.io')
 );
 ```
 

--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -805,7 +805,7 @@ The `realtime.send` function provides the most flexibility by allowing you to br
 
 ```sql
 SELECT realtime.send (
-	to_jsonb ('{}'::text), -- JSONB Payload
+	'{}'::jsonb, -- JSONB Payload
 	'event', -- Event name
 	'topic', -- Topic
 	FALSE -- Public / Private flag


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documents that JWT claims can be used for Realtime policies.

Also fixed the broadcast from database example.

## What is the current behavior?

Not documented.

## What is the new behavior?

Yes documented.

## Additional context

Add any other context or screenshots.
