### PR TITLE
docs(realtime): add more examples

### DIFF
--- a/apps/docs/content/guides/realtime.mdx
+++ b/apps/docs/content/guides/realtime.mdx
@@ -21,13 +21,29 @@ Supabase provides a globally distributed [Realtime](https://github.com/supabase/
       description: 'Mouse movements and chat messages.',
       href: 'https://multiplayer.dev',
     },
-  ].map((x) => (
-    <div className="col-span-12" key={x.href}>
-      <Link href={x.href} passHref>
-        <GlassPanel title={x.name}>{x.description}</GlassPanel>
-      </Link>
-    </div>
-  ))}
+    {
+      name: 'Chat',
+      description: 'Supabase UI chat component',
+      href: 'https://supabase.com/ui/docs/nextjs/realtime-cursor'
+    },
+    {
+      name: 'Avatar Stack',
+      description: 'Supabase UI avatar stack component',
+      href: 'https://supabase.com/ui/docs/nextjs/realtime-avatar-stack'
+    },
+    {
+      name: 'Realtime Cursor',
+      description: 'Supabase UI realtime cursor',
+      href: 'https://supabase.com/ui/docs/nextjs/realtime-cursor'
+    }
+].map((x) => (
+  <div className="col-span-6" key={x.href}>
+    <Link href={x.href} target="_blank" passHref>
+      <GlassPanel title={x.name}>{x.description}</GlassPanel>
+    </Link>
+  </div>
+))}
+
 </div>
 
 ## Resources

--- a/apps/docs/content/guides/realtime.mdx
+++ b/apps/docs/content/guides/realtime.mdx
@@ -18,22 +18,22 @@ Supabase provides a globally distributed [Realtime](https://github.com/supabase/
   {[
     {
       name: 'Multiplayer.dev',
-      description: 'Mouse movements and chat messages.',
+      description: 'Showcase application displaying cursor movements and chat messages using Broadcast.',
       href: 'https://multiplayer.dev',
     },
     {
       name: 'Chat',
-      description: 'Supabase UI chat component',
-      href: 'https://supabase.com/ui/docs/nextjs/realtime-cursor'
+      description: 'Supabase UI chat component using Broadcast to send message between users.',
+      href: 'https://supabase.com/ui/docs/nextjs/realtime-chat'
     },
     {
       name: 'Avatar Stack',
-      description: 'Supabase UI avatar stack component',
+      description: 'Supabase UI avatar stack component using Presence to track connected users.',
       href: 'https://supabase.com/ui/docs/nextjs/realtime-avatar-stack'
     },
     {
       name: 'Realtime Cursor',
-      description: 'Supabase UI realtime cursor',
+      description: "Supabase UI realtime cursor component using Broadcast to share users' cursors to build collaborative applications.",
       href: 'https://supabase.com/ui/docs/nextjs/realtime-cursor'
     }
 ].map((x) => (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add more Realtime examples:

<img width="1568" height="888" alt="Realtime___Supabase_Docs" src="https://github.com/user-attachments/assets/15b3874e-ccba-4276-9e46-9e1689253150" />


## What is the current behavior?

Only https://multiplayer.dev example

## What is the new behavior?

Also show the Supabase UI components

## Additional context

Add any other context or screenshots.
