### PR TITLE
Chore/custom content hook

### DIFF
--- a/apps/studio/components/interfaces/Organization/Documents/CustomDocument.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/CustomDocument.tsx
@@ -4,12 +4,12 @@ import {
   ScaffoldSectionContent,
   ScaffoldSectionDetail,
 } from 'components/layouts/Scaffold'
-import { CustomContentsDetails } from 'hooks/custom-content/useCustomContent'
+import { CustomContentTypes } from 'hooks/custom-content/CustomContent.types'
 import { ExternalLink } from 'lucide-react'
 import { Button } from 'ui'
 
 interface CustomDocumentProps {
-  doc: CustomContentsDetails['organization:legal_documents'][number]
+  doc: CustomContentTypes['organizationLegalDocuments'][number]
 }
 
 export const CustomDocument = ({ doc }: CustomDocumentProps) => {

--- a/apps/studio/components/interfaces/Organization/Documents/CustomDocument.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/CustomDocument.tsx
@@ -1,0 +1,33 @@
+import {
+  ScaffoldContainer,
+  ScaffoldSection,
+  ScaffoldSectionContent,
+  ScaffoldSectionDetail,
+} from 'components/layouts/Scaffold'
+import { CustomContentsDetails } from 'hooks/custom-content/useCustomContent'
+import { ExternalLink } from 'lucide-react'
+import { Button } from 'ui'
+
+interface CustomDocumentProps {
+  doc: CustomContentsDetails['organization:legal_documents'][number]
+}
+
+export const CustomDocument = ({ doc }: CustomDocumentProps) => {
+  return (
+    <ScaffoldContainer id={doc.id}>
+      <ScaffoldSection>
+        <ScaffoldSectionDetail className="sticky top-12 flex flex-col gap-y-8">
+          <p className="text-base m-0">{doc.name}</p>
+          <p className="text-sm text-foreground-light m-0">{doc.description}</p>
+        </ScaffoldSectionDetail>
+        <ScaffoldSectionContent className="flex items-center justify-center h-full">
+          <Button asChild type="default" iconRight={<ExternalLink />}>
+            <a download href={doc.action.url} target="_blank" rel="noreferrer noopener">
+              {doc.action.text}
+            </a>
+          </Button>
+        </ScaffoldSectionContent>
+      </ScaffoldSection>
+    </ScaffoldContainer>
+  )
+}

--- a/apps/studio/components/interfaces/Organization/Documents/Documents.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/Documents.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 
 import { ScaffoldContainer, ScaffoldDivider, ScaffoldSection } from 'components/layouts/Scaffold'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
+import { Fragment } from 'react'
+import { CustomDocument } from './CustomDocument'
 import { DPA } from './DPA'
 import { HIPAA } from './HIPAA'
 import { SecurityQuestionnaire } from './SecurityQuestionnaire'
@@ -8,6 +11,19 @@ import { SOC2 } from './SOC2'
 import { TIA } from './TIA'
 
 const Documents = () => {
+  const { organizationLegalDocuments } = useCustomContent(['organization:legal_documents'])
+
+  if (Array.isArray(organizationLegalDocuments)) {
+    return organizationLegalDocuments.map((doc, idx) => {
+      return (
+        <Fragment key={doc.id}>
+          <CustomDocument doc={doc} />
+          {idx !== organizationLegalDocuments.length - 1 && <ScaffoldDivider />}
+        </Fragment>
+      )
+    })
+  }
+
   return (
     <>
       <ScaffoldContainer id="dpa">

--- a/apps/studio/hooks/custom-content/CustomContent.types.ts
+++ b/apps/studio/hooks/custom-content/CustomContent.types.ts
@@ -1,0 +1,8 @@
+export type CustomContentTypes = {
+  organizationLegalDocuments: {
+    id: string
+    name: string
+    description: string
+    action: { text: string; url: string }
+  }[]
+}

--- a/apps/studio/hooks/custom-content/custom-content.json
+++ b/apps/studio/hooks/custom-content/custom-content.json
@@ -1,5 +1,5 @@
 {
   "$schema": "./custom-content.schema.json",
 
-  "test": {}
+  "organization:legal_documents": null
 }

--- a/apps/studio/hooks/custom-content/custom-content.json
+++ b/apps/studio/hooks/custom-content/custom-content.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "./custom-content.schema.json",
+
+  "test": {}
+}

--- a/apps/studio/hooks/custom-content/custom-content.sample.json
+++ b/apps/studio/hooks/custom-content/custom-content.sample.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "./custom-content.schema.json",
+
+  "organization:legal_documents": [
+    {
+      "id": "doc1",
+      "name": "Document 1",
+      "description": "This is a description of Document 1",
+      "action": {
+        "text": "Download document",
+        "url": "https://supabase.com"
+      }
+    },
+    {
+      "id": "doc2",
+      "name": "Document 2",
+      "description": "This is a description of Document 2",
+      "action": {
+        "text": "Download document",
+        "url": "https://supabase.com"
+      }
+    }
+  ]
+}

--- a/apps/studio/hooks/custom-content/custom-content.schema.json
+++ b/apps/studio/hooks/custom-content/custom-content.schema.json
@@ -8,7 +8,22 @@
 
     "organization:legal_documents": {
       "type": ["array", "null"],
-      "description": "Renders a provided set of documents under the organization legal documents page"
+      "description": "Renders a provided set of documents under the organization legal documents page",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "action": {
+            "type": "object",
+            "properties": {
+              "text": { "type": "string" },
+              "url": { "type": "string" }
+            }
+          }
+        }
+      }
     }
   },
   "required": ["organization:legal_documents"],

--- a/apps/studio/hooks/custom-content/custom-content.schema.json
+++ b/apps/studio/hooks/custom-content/custom-content.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+
+    "test": {
+      "type": "object",
+      "description": "Test custom content"
+    }
+  },
+  "required": ["test"],
+  "additionalProperties": false
+}

--- a/apps/studio/hooks/custom-content/custom-content.schema.json
+++ b/apps/studio/hooks/custom-content/custom-content.schema.json
@@ -6,11 +6,11 @@
       "type": "string"
     },
 
-    "test": {
-      "type": "object",
-      "description": "Test custom content"
+    "organization:legal_documents": {
+      "type": ["array", "null"],
+      "description": "Renders a provided set of documents under the organization legal documents page"
     }
   },
-  "required": ["test"],
+  "required": ["organization:legal_documents"],
   "additionalProperties": false
 }

--- a/apps/studio/hooks/custom-content/useCustomContent.test.ts
+++ b/apps/studio/hooks/custom-content/useCustomContent.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, cleanup } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  cleanup()
+})
+
+describe('useCustomContent', () => {
+  it('should return null if content is not found in the custom-content.json file', async () => {
+    vi.doMock('./custom-content.json', () => ({
+      default: {
+        'organization:legal_documents': null,
+      },
+    }))
+
+    const { useCustomContent } = await import('./useCustomContent')
+    const { result } = renderHook(() => useCustomContent(['organization:legal_documents']))
+    expect(result.current.organizationLegalDocuments).toEqual(null)
+  })
+
+  it('should return the content for the key passed in if it exists in the custom-content.json file', async () => {
+    vi.doMock('./custom-content.json', () => ({
+      default: {
+        'organization:legal_documents': {
+          someValue: 'foo',
+        },
+      },
+    }))
+
+    const { useCustomContent } = await import('./useCustomContent')
+    const { result } = renderHook(() => useCustomContent(['organization:legal_documents']))
+    expect(result.current.organizationLegalDocuments).toEqual({ someValue: 'foo' })
+  })
+})

--- a/apps/studio/hooks/custom-content/useCustomContent.ts
+++ b/apps/studio/hooks/custom-content/useCustomContent.ts
@@ -1,0 +1,38 @@
+import customContentRaw from './custom-content.json'
+
+// [Joshen] See if we can de-dupe any of the logic here with enabled-features
+// For now just getting something working going first
+
+const customContentStaticObj = customContentRaw as Omit<typeof customContentRaw, '$schema'>
+type CustomContent = keyof typeof customContentStaticObj
+
+type SnakeToCamelCase<S extends string> = S extends `${infer First}_${infer Rest}`
+  ? `${First}${SnakeToCamelCase<Capitalize<Rest>>}`
+  : S
+
+type CustomContentToCamelCase<S extends CustomContent> = S extends `${infer P}:${infer R}`
+  ? `${SnakeToCamelCase<P>}${Capitalize<SnakeToCamelCase<R>>}`
+  : SnakeToCamelCase<S>
+
+function contentToCamelCase(feature: CustomContent) {
+  return feature
+    .replace(/:/g, '_')
+    .split('_')
+    .map((word, index) => (index === 0 ? word : word[0].toUpperCase() + word.slice(1)))
+    .join('') as CustomContentToCamelCase<typeof feature>
+}
+
+const useCustomContent = <T extends CustomContent[]>(
+  contents: T
+): {
+  [key in CustomContentToCamelCase<T[number]>]: (typeof customContentStaticObj)[CustomContent]
+} => {
+  // [Joshen] Running into some TS errors without the `as` here - must be overlooking something super simple
+  return Object.fromEntries(
+    contents.map((content) => [contentToCamelCase(content), customContentStaticObj[content]])
+  ) as {
+    [key in CustomContentToCamelCase<T[number]>]: (typeof customContentStaticObj)[CustomContent]
+  }
+}
+
+export { customContentStaticObj as CUSTOM_CONTENT_SCHEMA, useCustomContent }

--- a/apps/studio/hooks/custom-content/useCustomContent.ts
+++ b/apps/studio/hooks/custom-content/useCustomContent.ts
@@ -1,7 +1,9 @@
 import customContentRaw from './custom-content.json'
+import { CustomContentTypes } from './CustomContent.types'
 
 // [Joshen] See if we can de-dupe any of the logic here with enabled-features
 // For now just getting something working going first
+// Also not sure if CustomContentTypes is the right way to go here with trying to dynamically type
 
 const customContentStaticObj = customContentRaw as Omit<typeof customContentRaw, '$schema'>
 type CustomContent = keyof typeof customContentStaticObj
@@ -25,14 +27,18 @@ function contentToCamelCase(feature: CustomContent) {
 const useCustomContent = <T extends CustomContent[]>(
   contents: T
 ): {
-  [key in CustomContentToCamelCase<T[number]>]: (typeof customContentStaticObj)[CustomContent]
+  [key in CustomContentToCamelCase<T[number]>]:
+    | (typeof customContentStaticObj)[CustomContent]
+    | CustomContentTypes[CustomContentToCamelCase<T[number]>]
 } => {
   // [Joshen] Running into some TS errors without the `as` here - must be overlooking something super simple
   return Object.fromEntries(
     contents.map((content) => [contentToCamelCase(content), customContentStaticObj[content]])
   ) as {
-    [key in CustomContentToCamelCase<T[number]>]: (typeof customContentStaticObj)[CustomContent]
+    [key in CustomContentToCamelCase<T[number]>]:
+      | (typeof customContentStaticObj)[CustomContent]
+      | CustomContentTypes[CustomContentToCamelCase<T[number]>]
   }
 }
 
-export { customContentStaticObj as CUSTOM_CONTENT_SCHEMA, useCustomContent }
+export { useCustomContent }


### PR DESCRIPTION
## Context

Adding support for extending the dashboard with defined content. Attempting to do so in a similar fashion as per how we're doing it with the `useIsFeatureEnabled` hook - so hopefully no new patterns here.

The added `useCustomContent` hook is fully type safe with proper descriptions, although I'll probably need some second opinions on how we can do it better (I doubt what I've got set up is optimal atm)

<img width="529" height="71" alt="image" src="https://github.com/user-attachments/assets/89ec9d11-f638-43a4-b0f0-3bed7d985aa8" />
<img width="660" height="198" alt="image" src="https://github.com/user-attachments/assets/5a55ab92-25d2-4e63-a264-b6900471f7cf" />


## How to extend the dashboard with defined content
1. Add a name and description, as well as its expected shape within `custom-content.schema.json`
    - The naming convention should follow that of `useIsFeatureEnabled` (e.g `group:content`) 
    - This PR includes an example: `organization:legal_documents`

2. Add the default state in `custom-content.json`. Generally we should be defaulting to `null` for hosted studio
    - I've added a `custom-content.sample.json` as a reference
    - If the provided state is not `null`, then the dashboard will render the custom content provided 

3. Will also need to add the expected shape in `CustomContent.types.ts`
    - I'm wondering if there's a better way to do this though, but its cause the value for each content is either `null` or something else
    - Type name needs to be the camel case version of the content name (e.g for `organization:legal_documents` -> `organizationLegalDocuments`)

4. Call `useCustomContent` to check if there's any defined custom content. I've stuck to calling multiple contents at a time for simplicity atm (also prefer to just have one way to use the hook)
    - e.g `const { organizationLegalDocuments } = useCustomContent(['organization:legal_documents'])` 

## To test
- [ ] Verify that if custom content defined for `organization:legal_documents` is provided, it'll override the UI for "Legal Documents" under the Organization
- [ ] Staging preview should be status quo with no changes