### PR TITLE
fix: label r2np correctly as it is a beta product

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
@@ -30,7 +30,7 @@ function DatabaseBackupsNav({ active }: Props) {
         <div className="flex items-center gap-1">
           Restore to new project{' '}
           <Badge size="small" className="!text-[10px] px-1.5 py-0">
-            New
+            Beta
           </Badge>
         </div>
       ),


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR switches the label on the R2NP tab to correctly identify the feature as beta and not new. We need to ensure that users of this feature are aware that it is not yet `ga`.