### PR TITLE
Fix region node flags

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -407,7 +407,7 @@ export const RegionNode = ({ data }: any) => {
         <img
           alt="region icon"
           className="w-5 rounded-sm"
-          src={`${BASE_PATH}/img/regions/${region.key}.svg`}
+          src={`${BASE_PATH}/img/regions/${region.region}.svg`}
         />
         <p className="text-sm">{region.name}</p>
       </div>


### PR DESCRIPTION
## Context

Bug is in the infrastructure settings page - `RegionNode` that was introduced [here](https://github.com/supabase/supabase/pull/37371) - just left out this one bit that needed updating as well, as the icon paths and names for the flags have been shifted

## To test
- [ ] Set up some replicas in your project and verify that there's no missing flag icons