### PR TITLE
fix(studio): column sizes for access tokens

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
@@ -152,8 +152,10 @@ export const AccessTokenList = ({ searchString = '', onDeleteSuccess }: AccessTo
         {filteredTokens?.map((x) => {
           return (
             <TableRow key={x.token_alias}>
-              <TableCell className="w-36">
-                <p className="truncate">{x.name}</p>
+              <TableCell className="w-36 max-w-36">
+                <p className="truncate" title={x.name}>
+                  {x.name}
+                </p>
               </TableCell>
               <TableCell className="max-w-96">
                 <p className="font-mono text-foreground-light truncate">{x.token_alias}</p>

--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
@@ -50,6 +50,7 @@ const RowLoading = () => (
 )
 
 const tableHeaderClass = 'text-left font-mono uppercase text-xs text-foreground-lighter h-auto py-2'
+
 const TableContainer = ({ children }: { children: React.ReactNode }) => (
   <Card className="w-full overflow-hidden">
     <CardContent className="p-0">
@@ -151,13 +152,13 @@ export const AccessTokenList = ({ searchString = '', onDeleteSuccess }: AccessTo
         {filteredTokens?.map((x) => {
           return (
             <TableRow key={x.token_alias}>
-              <TableCell className="w-48">
+              <TableCell className="w-36">
                 <p className="truncate">{x.name}</p>
               </TableCell>
-              <TableCell>
-                <span className="font-mono text-foreground-light">{x.token_alias}</span>
+              <TableCell className="max-w-96">
+                <p className="font-mono text-foreground-light truncate">{x.token_alias}</p>
               </TableCell>
-              <TableCell>
+              <TableCell className="min-w-32">
                 <p className="text-foreground-light">
                   {x.last_used_at ? (
                     <Tooltip>
@@ -171,7 +172,7 @@ export const AccessTokenList = ({ searchString = '', onDeleteSuccess }: AccessTo
                   )}
                 </p>
               </TableCell>
-              <TableCell>
+              <TableCell className="min-w-32">
                 {x.expires_at ? (
                   dayjs(x.expires_at).isBefore(dayjs()) ? (
                     <Tooltip>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This fixes the column widths for the access tokens table so they don't collapse despite small strings for dates.

| Before | After |
|--------|--------|
| <img width="326" height="231" alt="Screenshot 2025-08-21 at 14 03 17" src="https://github.com/user-attachments/assets/ff44b367-5893-44d8-abfd-ec0fcef2e51a" /> | <img width="372" height="196" alt="Screenshot 2025-08-21 at 14 03 45" src="https://github.com/user-attachments/assets/8790bd20-bc48-4dec-a7e1-e7539620fddc" /> | 
