### PR TITLE
Supabase does support CREATE EVENT TRIGGER now

### DIFF
--- a/apps/docs/content/guides/database/postgres/roles-superuser.mdx
+++ b/apps/docs/content/guides/database/postgres/roles-superuser.mdx
@@ -13,6 +13,5 @@ However, this does mean that some operations, that typically require `superuser`
 ## Unsupported operations
 
 - `CREATE SUBSCRIPTION`
-- `CREATE EVENT TRIGGER`
 - `COPY ... FROM PROGRAM`
 - `ALTER USER ... WITH SUPERUSER`


### PR DESCRIPTION
See https://supabase.com/blog/event-triggers-wo-superuser

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

Docs incorrectly say that `CREATE EVENT TRIGGER` is unsupported:

https://supabase.com/docs/guides/database/postgres/roles-superuser

But it is supported: https://supabase.com/blog/event-triggers-wo-superuser

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
