### PR TITLE
fix wrapper name row ui

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -8,7 +8,16 @@ import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import type { FDW } from 'data/fdw/fdws-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
-import { Badge, Sheet, SheetContent, TableCell, TableRow } from 'ui'
+import {
+  Badge,
+  Sheet,
+  SheetContent,
+  TableCell,
+  TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 import { INTEGRATIONS } from '../Landing/Integrations.constants'
 import DeleteWrapperModal from './DeleteWrapperModal'
 import { EditWrapperSheet } from './EditWrapperSheet'
@@ -74,7 +83,12 @@ const WrapperRow = ({ wrapper }: WrapperRowProps) => {
                   <div className="relative w-3 h-3 flex items-center justify-center">
                     {integration.icon({ className: 'p-0' })}
                   </div>
-                  {target}{' '}
+                  <Tooltip>
+                    <TooltipTrigger className="truncate max-w-28">{target}</TooltipTrigger>
+                    <TooltipContent className="max-w-64">
+                      <pre className="text-xs whitespace-pre-wrap">{target}</pre>
+                    </TooltipContent>
+                  </Tooltip>
                   <ChevronRight
                     size={12}
                     strokeWidth={1.5}

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -99,7 +99,14 @@ const WrapperRow = ({ wrapper }: WrapperRowProps) => {
                 <Link href={`/project/${ref}/editor/${table.id}`}>
                   <Badge className="transition hover:bg-surface-300 pl-5 rounded-l-none gap-2 h-6 font-mono text-[0.75rem] border-l-0">
                     <Table2 size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
-                    {table.schema}.{table.table_name}
+                    <Tooltip>
+                      <TooltipTrigger className="truncate max-w-28">
+                        {table.schema}.{table.table_name}
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-64 whitespace-pre-wrap break-words">
+                        {table.schema}.{table.table_name}
+                      </TooltipContent>
+                    </Tooltip>
                   </Badge>
                 </Link>
               </div>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -85,8 +85,8 @@ const WrapperRow = ({ wrapper }: WrapperRowProps) => {
                   </div>
                   <Tooltip>
                     <TooltipTrigger className="truncate max-w-28">{target}</TooltipTrigger>
-                    <TooltipContent className="max-w-64">
-                      <pre className="text-xs whitespace-pre-wrap">{target}</pre>
+                    <TooltipContent className="max-w-64 whitespace-pre-wrap break-words">
+                      {target}
                     </TooltipContent>
                   </Tooltip>
                   <ChevronRight


### PR DESCRIPTION
- truncate long names
- add tooltip so full name can still be seen

https://github.com/user-attachments/assets/39152cc6-9a52-4c3e-9f88-34a9cfad9394



## BEFORE
<img width="1324" height="948" alt="CleanShot 2025-08-22 at 11 56 56@2x" src="https://github.com/user-attachments/assets/dab550ba-b452-41a1-ab43-04d5ff0a25ad" />


## AFTER
<img width="1136" height="892" alt="CleanShot 2025-08-22 at 11 57 16@2x" src="https://github.com/user-attachments/assets/7796f394-7e65-4e4c-a81b-cc98d33a3b65" />