### PR TITLE
Small style fix

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -187,7 +187,12 @@ const ColumnType = ({
         <PopoverContent_Shadcn_ className="w-[460px] p-0" side="bottom" align="center">
           <ScrollArea className="h-[335px]">
             <Command_Shadcn_>
-              <CommandInput_Shadcn_ placeholder="Search types..." />
+              <CommandInput_Shadcn_
+                placeholder="Search types..."
+                // [Joshen] Addresses style issues when this component is being used in the old Form component
+                // Specifically in WrapperDynamicColumns - can be cleaned up once we're no longer using that
+                className="!bg-transparent focus:!shadow-none focus:!ring-0"
+              />
               <CommandEmpty_Shadcn_>Type not found.</CommandEmpty_Shadcn_>
 
               <CommandList_Shadcn_>


### PR DESCRIPTION
## Context

Small style fix to `ColumnType` component in `WrapperDynamicColumns` - happening because `WrapperTableEditor` is currently using the old `Form` component which has style overrides for `input[type="text"]`

Before:
<img width="507" height="164" alt="image" src="https://github.com/user-attachments/assets/d958c735-785b-432c-9d0e-b9012a1b6be8" />


After:
<img width="494" height="221" alt="image" src="https://github.com/user-attachments/assets/72d5423c-f0f7-4e2b-8bde-de392464f35e" />
