### PR TITLE
Auto select smart region as default in new project page

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -253,7 +253,7 @@ const Wizard: NextPageWithLayout = () => {
 
   const regionError = smartRegionEnabled ? availableRegionsError : defaultRegionError
   const defaultRegion = smartRegionEnabled
-    ? availableRegionsData?.recommendations.specific[0]?.name
+    ? availableRegionsData?.recommendations.smartGroup.name
     : _defaultRegion
 
   const isAdmin = useCheckPermissions(PermissionAction.CREATE, 'projects')


### PR DESCRIPTION
## Context

We recently introduced smart regions for project creation (as opposed to choosing a specific country to spin up your project from) although this isn't live yet, only on staging and local.

Changes here are to default the region selection to the recommended smart region as per defined by API, instead of the recommended specific country