### PR TITLE
docs: Fix delete objects limit

### DIFF
--- a/apps/docs/content/guides/storage/management/delete-objects.mdx
+++ b/apps/docs/content/guides/storage/management/delete-objects.mdx
@@ -26,6 +26,12 @@ const supabase = createClient('your_project_url', 'your_supabase_api_key')
 await supabase.storage.from('bucket').remove(['object-path-2', 'folder/avatar2.png'])
 ```
 
+<Admonition type="note">
+
+When deleting objects, there is a limit of 1000 objects at a time using the `remove` method.
+
+</Admonition>
+
 ## RLS
 
 To delete an object, the user must have the `delete` permission on the object. For example:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Deleting Objects](https://supabase.com/docs/guides/storage/management/delete-objects)

## What is the current behavior?

No warning to the user about limit on how many objects can be deleted at one time.

## What is the new behavior?

Spoke to @fenos and confirmed a limit of 1000 objects:

<img width="1469" height="492" alt="Screenshot 2025-08-22 at 19 18 56" src="https://github.com/user-attachments/assets/a81745b7-f020-4a66-9244-a1f83927af03" />


## Additional context

Closes #34772
