### PR TITLE
[Replace `yup`] Refactor deprecated components in `DiskSizeConfigurationModal`

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -1,36 +1,33 @@
 import Link from 'next/link'
 
 import { useParams } from 'common'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
+import { DocsButton } from 'components/ui/DocsButton'
+import { ScaffoldSection, ScaffoldSectionTitle } from 'components/layouts/Scaffold'
 import { Button } from 'ui'
-import { NoticeBar } from './ui/NoticeBar'
+import { Admonition } from 'ui-patterns/admonition'
 
 // [Joshen] Only used for non AWS projects
-export function DiskManagementPanelForm() {
+export const DiskManagementPanelForm = () => {
   const { ref: projectRef } = useParams()
 
   return (
-    <div id="disk-management">
-      <FormHeader
-        title="Disk Management"
-        docsUrl="https://supabase.com/docs/guides/platform/database-size#disk-management"
-      />
-      <NoticeBar
-        visible={true}
-        type="default"
-        title="Disk Management has moved"
-        description="Disk configuration is now managed alongside Project Compute on the new Compute and Disk page."
-        actions={
-          <Button type="default" asChild>
-            <Link
-              href={`/project/${projectRef}/settings/compute-and-disk`}
-              className="!no-underline"
-            >
-              Go to Compute and Disk
-            </Link>
-          </Button>
-        }
-      />
-    </div>
+    <ScaffoldSection id="disk-management" className="gap-6">
+      <ScaffoldSectionTitle className="flex items-center justify-between  gap-2">
+        Disk Management
+        <DocsButton href="https://supabase.com/docs/guides/platform/database-size#disk-management" />
+      </ScaffoldSectionTitle>
+
+      <Admonition title="Disk Management has moved">
+        <p>
+          Disk configuration is now managed alongside Project Compute on the new Compute and Disk
+          page.
+        </p>
+        <Button type="default" asChild>
+          <Link href={`/project/${projectRef}/settings/compute-and-disk`} className="!no-underline">
+            Go to Compute and Disk
+          </Link>
+        </Button>
+      </Admonition>
+    </ScaffoldSection>
   )
 }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -17,7 +17,7 @@ export const DiskManagementPanelForm = () => {
         <DocsButton href="https://supabase.com/docs/guides/platform/database-size#disk-management" />
       </ScaffoldSectionTitle>
 
-      <Admonition title="Disk Management has moved">
+      <Admonition type="default" title="Disk Management has moved">
         <p>
           Disk configuration is now managed alongside Project Compute on the new Compute and Disk
           page.

--- a/apps/studio/components/interfaces/Settings/Database/BannedIPs.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/BannedIPs.tsx
@@ -7,17 +7,21 @@ import { useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { DocsButton } from 'components/ui/DocsButton'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
-import { FormPanel } from 'components/ui/Forms/FormPanel'
+import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useBannedIPsDeleteMutation } from 'data/banned-ips/banned-ips-delete-mutations'
 import { useBannedIPsQuery } from 'data/banned-ips/banned-ips-query'
 import { useUserIPAddressQuery } from 'data/misc/user-ip-address-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { Badge, Skeleton } from 'ui'
+import {
+  ScaffoldSection,
+  ScaffoldSectionTitle,
+  ScaffoldSectionDescription,
+} from 'components/layouts/Scaffold'
+import { Badge, Card, CardContent } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
-const BannedIPs = () => {
+export const BannedIPs = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
@@ -75,60 +79,64 @@ const BannedIPs = () => {
   }
 
   return (
-    <div id="banned-ips">
-      <div className="flex items-center justify-between mb-6">
-        <FormHeader
-          className="mb-0"
-          title="Network Bans"
-          description="List of IP addresses that are temporarily blocked if their traffic pattern looks abusive"
-        />
+    <ScaffoldSection id="banned-ips" className="gap-6">
+      <ScaffoldSectionTitle className="flex items-center justify-between  gap-2">
+        <div className="flex flex-col gap-1">
+          Network Bans
+          <ScaffoldSectionDescription>
+            List of IP addresses that are temporarily blocked if their traffic pattern looks
+            abusive.
+          </ScaffoldSectionDescription>
+        </div>
         <DocsButton href="https://supabase.com/docs/reference/cli/supabase-network-bans" />
-      </div>
-      <FormPanel>
-        {ipListLoading ? (
-          <div className="px-8 py-4 space-y-4">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-full" />
-          </div>
-        ) : ipListError ? (
-          <AlertError
-            className="border-0 rounded-none"
-            error={ipListError}
-            subject="Failed to retrieve banned IP addresses"
-          />
-        ) : ipList && ipList.banned_ipv4_addresses.length > 0 ? (
-          ipList.banned_ipv4_addresses.map((ip) => (
-            <div key={ip} className="px-8 py-4 flex items-center justify-between">
-              <div className="flex items-center space-x-5">
-                <Globe size={16} className="text-foreground-lighter" />
+      </ScaffoldSectionTitle>
+
+      {ipListLoading ? (
+        <Card>
+          <CardContent>
+            <GenericSkeletonLoader />
+          </CardContent>
+        </Card>
+      ) : ipListError ? (
+        <AlertError
+          className="border-0 rounded-none"
+          error={ipListError}
+          subject="Failed to retrieve banned IP addresses"
+        />
+      ) : ipList && ipList.banned_ipv4_addresses.length > 0 ? (
+        <Card>
+          {ipList.banned_ipv4_addresses.map((ip) => (
+            <CardContent className="flex items-center justify-between gap-4">
+              <Globe size={16} className="text-foreground-light" />
+              <div className="w-full flex items-center gap-4">
+                {ip === userIPAddress && <Badge variant="warning">Your IP address</Badge>}
                 <p className="text-sm font-mono">{ip}</p>
-                {ip === userIPAddress && <Badge>Your IP address</Badge>}
               </div>
-              <div>
-                <ButtonTooltip
-                  type="default"
-                  disabled={!canUnbanNetworks}
-                  onClick={() => openConfirmationModal(ip)}
-                  tooltip={{
-                    content: {
-                      side: 'bottom',
-                      text: !canUnbanNetworks
-                        ? 'You need additional permissions to unban networks'
-                        : undefined,
-                    },
-                  }}
-                >
-                  Unban IP
-                </ButtonTooltip>
-              </div>
-            </div>
-          ))
-        ) : (
-          <p className="text-foreground-light text-sm px-8 py-4">
+              <ButtonTooltip
+                type="default"
+                disabled={!canUnbanNetworks}
+                onClick={() => openConfirmationModal(ip)}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: !canUnbanNetworks
+                      ? 'You need additional permissions to unban networks'
+                      : undefined,
+                  },
+                }}
+              >
+                Unban IP
+              </ButtonTooltip>
+            </CardContent>
+          ))}
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="text-sm text-foreground-light">
             There are no banned IP addresses for your project.
-          </p>
-        )}
-      </FormPanel>
+          </CardContent>
+        </Card>
+      )}
 
       <ConfirmationModal
         variant="destructive"
@@ -145,8 +153,6 @@ const BannedIPs = () => {
           description: `Are you sure you want to unban this IP address ${selectedIPToUnban}?`,
         }}
       />
-    </div>
+    </ScaffoldSection>
   )
 }
-
-export default BannedIPs

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/ConfirmDisableReadOnlyModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/ConfirmDisableReadOnlyModal.tsx
@@ -9,7 +9,7 @@ interface ConfirmDisableReadOnlyModeModalProps {
   onClose: () => void
 }
 
-const ConfirmDisableReadOnlyModeModal = ({
+export const ConfirmDisableReadOnlyModeModal = ({
   visible,
   onClose,
 }: ConfirmDisableReadOnlyModeModalProps) => {
@@ -49,5 +49,3 @@ const ConfirmDisableReadOnlyModeModal = ({
     </Modal>
   )
 }
-
-export default ConfirmDisableReadOnlyModeModal

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseReadOnlyAlert.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseReadOnlyAlert.tsx
@@ -19,59 +19,60 @@ export const DatabaseReadOnlyAlert = () => {
     (resourceWarnings ?? [])?.find((warning) => warning.project === projectRef)
       ?.is_readonly_mode_enabled ?? false
 
+  if (!isReadOnlyMode) return null
+
   return (
     <>
-      {isReadOnlyMode && (
-        <Alert_Shadcn_ variant="destructive">
-          <AlertTriangle />
-          <AlertTitle_Shadcn_>
-            Project is in read-only mode and database is no longer accepting write requests
-          </AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_>
-            You have reached 95% of your project's disk space, and read-only mode has been enabled
-            to preserve your database's stability and prevent your project from exceeding its
-            current billing plan. To resolve this, you may:
-            <ul className="list-disc pl-6 mt-1">
+      <Alert_Shadcn_ variant="destructive">
+        <AlertTriangle />
+        <AlertTitle_Shadcn_>
+          Project is in read-only mode and database is no longer accepting write requests
+        </AlertTitle_Shadcn_>
+        <AlertDescription_Shadcn_>
+          You have reached 95% of your project's disk space, and read-only mode has been enabled to
+          preserve your database's stability and prevent your project from exceeding its current
+          billing plan. To resolve this, you may:
+          <ul className="list-disc pl-6 mt-1">
+            <li>
+              Temporarily disable read-only mode to free up space and reduce your database size
+            </li>
+            {organization?.plan.id === 'free' ? (
               <li>
-                Temporarily disable read-only mode to free up space and reduce your database size
+                <Link
+                  href={`/org/${organization?.slug}/billing?panel=subscriptionPlan&source=databaseReadOnlyAlertUpgradePlan`}
+                >
+                  <a className="text underline">Upgrade to the Pro Plan</a>
+                </Link>{' '}
+                to increase your database size limit to 8GB.
               </li>
-              {organization?.plan.id === 'free' ? (
-                <li>
-                  <Link
-                    href={`/org/${organization?.slug}/billing?panel=subscriptionPlan&source=databaseReadOnlyAlertUpgradePlan`}
-                  >
-                    <a className="text underline">Upgrade to the Pro Plan</a>
-                  </Link>{' '}
-                  to increase your database size limit to 8GB.
-                </li>
-              ) : organization?.plan.id === 'pro' && organization?.usage_billing_enabled ? (
-                <li>
-                  <Link
-                    href={`/org/${organization?.slug}/billing?panel=subscriptionPlan&source=databaseReadOnlyAlertSpendCap`}
-                  >
-                    <a className="text-foreground underline">Disable your Spend Cap</a>
-                  </Link>{' '}
-                  to allow your project to auto-scale and expand beyond the 8GB database size limit
-                </li>
-              ) : null}
-            </ul>
-          </AlertDescription_Shadcn_>
-          <div className="mt-4 flex items-center space-x-2">
-            <Button type="default" onClick={() => setShowConfirmationModal(true)}>
-              Disable read-only mode
-            </Button>
-            <Button asChild type="default" icon={<ExternalLink />}>
-              <a
-                href="https://supabase.com/docs/guides/platform/database-size#disabling-read-only-mode"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Learn more
-              </a>
-            </Button>
-          </div>
-        </Alert_Shadcn_>
-      )}
+            ) : organization?.plan.id === 'pro' && organization?.usage_billing_enabled ? (
+              <li>
+                <Link
+                  href={`/org/${organization?.slug}/billing?panel=subscriptionPlan&source=databaseReadOnlyAlertSpendCap`}
+                >
+                  <a className="text-foreground underline">Disable your Spend Cap</a>
+                </Link>{' '}
+                to allow your project to auto-scale and expand beyond the 8GB database size limit
+              </li>
+            ) : null}
+          </ul>
+        </AlertDescription_Shadcn_>
+        <div className="mt-4 flex items-center space-x-2">
+          <Button type="default" onClick={() => setShowConfirmationModal(true)}>
+            Disable read-only mode
+          </Button>
+          <Button asChild type="default" icon={<ExternalLink />}>
+            <a
+              href="https://supabase.com/docs/guides/platform/database-size#disabling-read-only-mode"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Learn more
+            </a>
+          </Button>
+        </div>
+      </Alert_Shadcn_>
+
       <ConfirmDisableReadOnlyModeModal
         visible={showConfirmationModal}
         onClose={() => setShowConfirmationModal(false)}

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseReadOnlyAlert.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseReadOnlyAlert.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 import { useResourceWarningsQuery } from 'data/usage/resource-warnings-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { AlertDescription_Shadcn_, AlertTitle_Shadcn_, Alert_Shadcn_, Button } from 'ui'
-import ConfirmDisableReadOnlyModeModal from './DatabaseSettings/ConfirmDisableReadOnlyModal'
+import { ConfirmDisableReadOnlyModeModal } from './ConfirmDisableReadOnlyModal'
 
 export const DatabaseReadOnlyAlert = () => {
   const { ref: projectRef } = useParams()

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseSettings.tsx
@@ -1,0 +1,16 @@
+import {
+  ScaffoldSection,
+  ScaffoldSectionTitle,
+  ScaffoldSectionDescription,
+} from 'components/layouts/Scaffold'
+import { DatabaseReadOnlyAlert } from './DatabaseReadOnlyAlert'
+import { ResetDbPassword } from './ResetDbPassword'
+
+export const DatabaseSettings = () => {
+  return (
+    <ScaffoldSection id="database-settings" className="gap-6">
+      <DatabaseReadOnlyAlert />
+      <ResetDbPassword />
+    </ScaffoldSection>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseSettings.tsx
@@ -1,8 +1,4 @@
-import {
-  ScaffoldSection,
-  ScaffoldSectionTitle,
-  ScaffoldSectionDescription,
-} from 'components/layouts/Scaffold'
+import { ScaffoldSection } from 'components/layouts/Scaffold'
 import { DatabaseReadOnlyAlert } from './DatabaseReadOnlyAlert'
 import { ResetDbPassword } from './ResetDbPassword'
 

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword.tsx
@@ -15,7 +15,6 @@ import passwordStrength from 'lib/password-strength'
 import { generateStrongPassword } from 'lib/project'
 import {
   Card,
-  CardHeader,
   CardContent,
   Dialog,
   DialogTrigger,
@@ -137,6 +136,7 @@ export const ResetDbPassword = ({ disabled = false }) => {
                 Reset database password
               </ButtonTooltip>
             </DialogTrigger>
+
             <DialogContent>
               <DialogHeader>
                 <DialogTitle>Reset database password</DialogTitle>
@@ -163,6 +163,7 @@ export const ResetDbPassword = ({ disabled = false }) => {
                   />
                 </FormLayout>
               </DialogSection>
+
               <DialogFooter>
                 <Button
                   htmlType="reset"

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -81,6 +81,7 @@ Read more about [disk management](https://supabase.com/docs/guides/platform/data
           />
           <Card>
             <CardHeader>Disk Size Configuration</CardHeader>
+
             <CardContent className="flex justify-between items-center">
               <FormLayout
                 layout="flex-row-reverse"
@@ -106,6 +107,7 @@ Read more about [disk management](https://supabase.com/docs/guides/platform/data
                 </Button>
               </FormLayout>
             </CardContent>
+
             <CardContent className="flex justify-between items-center">
               <FormLayout
                 layout="flex-row-reverse"

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -1,39 +1,37 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { ExternalLink, Info } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
-import { SetStateAction } from 'react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
 import { Markdown } from 'components/interfaces/Markdown'
 import DiskSizeConfigurationModal from 'components/interfaces/Settings/Database/DiskSizeConfigurationModal'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
-import Panel from 'components/ui/Panel'
 import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mutation'
 import { useDatabaseSizeQuery } from 'data/database/database-size-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { useUrlState } from 'hooks/ui/useUrlState'
 import { formatBytes } from 'lib/helpers'
-import { AlertDescription_Shadcn_, AlertTitle_Shadcn_, Alert_Shadcn_, Button, InfoIcon } from 'ui'
+import { ScaffoldSection, ScaffoldSectionTitle } from 'components/layouts/Scaffold'
+import { Button, Card, CardHeader, CardContent } from 'ui'
+import { Admonition } from 'ui-patterns'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 
 export interface DiskSizeConfigurationProps {
   disabled?: boolean
 }
 
-const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps) => {
+export const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps) => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
-
-  const [{ show_increase_disk_size_modal }, setUrlParams] = useUrlState()
-  const showIncreaseDiskSizeModal = show_increase_disk_size_modal === 'true'
-  const setShowIncreaseDiskSizeModal = (value: SetStateAction<boolean>) => {
-    const show = typeof value === 'function' ? value(showIncreaseDiskSizeModal) : value
-    setUrlParams({ show_increase_disk_size_modal: show ? 'true' : undefined })
-  }
+  const [showIncreaseDiskSizeModal, setShowIncreaseDiskSizeModal] = useQueryState(
+    `show_increase_disk_size_modal`,
+    parseAsBoolean.withDefault(false)
+  )
 
   const { can: canUpdateDiskSizeConfig } = useAsyncCheckProjectPermissions(
     PermissionAction.UPDATE,
@@ -61,124 +59,106 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
   const databaseSizeBytesUsed = data ?? 0
 
   return (
-    <div id="diskManagement">
-      <FormHeader title="Disk Management" />
+    <ScaffoldSection id="disk-management" className="gap-6">
+      <ScaffoldSectionTitle className="flex items-center justify-between">
+        Disk Management
+        <DocsButton href="https://supabase.com/docs/guides/platform/database-size#disk-management" />
+      </ScaffoldSectionTitle>
       {organization?.usage_billing_enabled === true ? (
-        <div className="flex flex-col gap-3">
-          <Panel className="!m-0">
-            <Panel.Content>
-              <div>
-                <div>
-                  {currentDiskSize && (
-                    <span className="text-foreground-light flex gap-2 items-baseline">
-                      <h4 className="text-foreground">Current Disk Storage</h4>
-                    </span>
-                  )}
-                  <div className="grid grid-cols-2 items-center">
-                    <p className="text-sm text-lighter max-w-lg">
-                      Supabase employs auto-scaling storage and allows for manual disk size
-                      adjustments when necessary
-                    </p>
-                    <div className="flex items-end justify-end">
-                      <ButtonTooltip
-                        type="default"
-                        disabled={!canUpdateDiskSizeConfig || disabled}
-                        onClick={() => setShowIncreaseDiskSizeModal(true)}
-                        tooltip={{
-                          content: {
-                            side: 'bottom',
-                            text: !canUpdateDiskSizeConfig
-                              ? 'You need additional permissions to increase the disk size'
-                              : undefined,
-                          },
-                        }}
-                      >
-                        Increase disk size
-                      </ButtonTooltip>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-12 gap-2 mt-12 items-start">
-                    <div className="col-span-4 grid grid-cols-2 gap-x-12 gap-y-4 items-start">
-                      <div className="grid gap-2 col-span-1">
-                        <h5>Space used</h5>
-                        <span className="text-lg">
-                          {formatBytes(databaseSizeBytesUsed, 2, 'GB')}
-                        </span>
-                      </div>
-                      <div className="grid gap-2 col-span-1">
-                        <h5>Total size</h5>
-                        <span className="text-lg">{currentDiskSize} GB</span>
-                      </div>
-
-                      <div className="col-span-2 mt-4">
-                        <Button asChild type="default" iconRight={<ExternalLink size={14} />}>
-                          <Link
-                            href={`/project/${projectRef}/reports/database#database-size-report`}
-                          >
-                            View detailed summary
-                          </Link>
-                        </Button>
-                      </div>
-                    </div>
-
-                    <div className="col-span-8">
-                      <Alert_Shadcn_>
-                        <Info size={16} />
-                        <AlertTitle_Shadcn_>Importing a lot of data?</AlertTitle_Shadcn_>
-                        <AlertDescription_Shadcn_>
-                          <Markdown
-                            className="max-w-full"
-                            content={`
-We auto-scale your disk as you need more storage, but can only do this once every 6 hours.
-If you upload more than 1.5x the current size of your storage, your database will go
-into read-only mode. If you know how big your database is going to be, you can
-manually increase the size here.
+        <>
+          <Admonition
+            type="default"
+            title="Importing a lot of data?"
+            description={
+              <Markdown
+                content={`
+We auto-scale your disk as you need more storage, but can only do this once every 6 hours. If you upload more than 1.5x the current size of your storage, your database will go into read-only mode. If you know how big your database is going to be, you can manually increase the size here.
 
 Read more about [disk management](https://supabase.com/docs/guides/platform/database-size#disk-management) and how to [free up storage space](https://supabase.com/docs/guides/platform/database-size#vacuum-operations).
 `}
-                          />
-                        </AlertDescription_Shadcn_>
-                      </Alert_Shadcn_>
+              />
+            }
+          />
+          <Card>
+            <CardHeader>Disk Size Configuration</CardHeader>
+            <CardContent className="flex justify-between items-center">
+              <FormLayout
+                layout="flex-row-reverse"
+                className="w-full"
+                label="Current Disk Storage"
+                description={
+                  <div className="flex text-lg mt-2 gap-6">
+                    <div className="flex flex-col items-center gap-1">
+                      <h5>Space used</h5>
+                      {formatBytes(databaseSizeBytesUsed, 2, 'GB')}
+                    </div>
+                    <div className="flex flex-col items-center gap-1">
+                      <h5>Total size</h5>
+                      {currentDiskSize} GB
                     </div>
                   </div>
-                </div>
-              </div>
-            </Panel.Content>
-          </Panel>
-        </div>
-      ) : (
-        <Alert_Shadcn_>
-          <InfoIcon />
-          <AlertTitle_Shadcn_>
-            {organization?.plan?.id === 'free'
-              ? 'Disk size configuration is not available for projects on the Free Plan'
-              : 'Disk size configuration is only available when the spend cap has been disabled'}
-          </AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_>
-            {organization?.plan?.id === 'free' ? (
-              <p>
-                If you are intending to use more than 500MB of disk space, then you will need to
-                upgrade to at least the Pro Plan.
-              </p>
-            ) : (
-              <p>
-                If you are intending to use more than 8GB of disk space, then you will need to
-                disable your spend cap.
-              </p>
-            )}
-            <Button asChild type="default" className="mt-3">
-              <Link
-                href={`/org/${organization?.slug}/billing?panel=${
-                  organization?.plan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
-                }`}
-                target="_blank"
+                }
               >
-                {organization?.plan?.id === 'free' ? 'Upgrade subscription' : 'Disable spend cap'}
-              </Link>
-            </Button>
-          </AlertDescription_Shadcn_>
-        </Alert_Shadcn_>
+                <Button asChild type="default" iconRight={<ExternalLink size={14} />}>
+                  <Link href={`/project/${projectRef}/reports/database#database-size-report`}>
+                    View detailed summary
+                  </Link>
+                </Button>
+              </FormLayout>
+            </CardContent>
+            <CardContent className="flex justify-between items-center">
+              <FormLayout
+                layout="flex-row-reverse"
+                label="Manage Disk Size"
+                description="Supabase employs auto-scaling storage and allows for manual disk size adjustments when necessary."
+              >
+                <ButtonTooltip
+                  type="default"
+                  disabled={!canUpdateDiskSizeConfig || disabled}
+                  onClick={() => setShowIncreaseDiskSizeModal(true)}
+                  tooltip={{
+                    content: {
+                      side: 'bottom',
+                      text: !canUpdateDiskSizeConfig
+                        ? 'You need additional permissions to increase the disk size'
+                        : undefined,
+                    },
+                  }}
+                >
+                  Increase disk size
+                </ButtonTooltip>
+              </FormLayout>
+            </CardContent>
+          </Card>
+        </>
+      ) : (
+        <Admonition
+          type="default"
+          title={
+            organization?.plan?.id === 'free'
+              ? 'Disk size configuration is not available for projects on the Free Plan'
+              : 'Disk size configuration is only available when the spend cap has been disabled'
+          }
+          description={
+            <>
+              <p>
+                {organization?.plan?.id === 'free'
+                  ? `If you are intending to use more than 500MB of disk space, then you will need to upgrade to at least the Pro Plan.`
+                  : `If you are intending to use more than 8GB of disk space, then you will need to disable your spend cap.`}
+              </p>
+              <Button asChild type="default" className="mt-4">
+                <Link
+                  href={`/org/${organization?.slug}/billing?panel=${
+                    organization?.plan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
+                  }`}
+                  target="_blank"
+                >
+                  {organization?.plan?.id === 'free' ? 'Upgrade subscription' : 'Disable spend cap'}
+                </Link>
+              </Button>
+            </>
+          }
+        />
       )}
 
       <DiskSizeConfigurationModal
@@ -186,8 +166,6 @@ Read more about [disk management](https://supabase.com/docs/guides/platform/data
         loading={isUpdatingDiskSize}
         hideModal={setShowIncreaseDiskSizeModal}
       />
-    </div>
+    </ScaffoldSection>
   )
 }
-
-export default DiskSizeConfiguration

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -1,43 +1,88 @@
-import { SupportCategories } from '@supabase/shared-types/out/constants'
-import dayjs from 'dayjs'
 import { ExternalLink, Info } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import Link from 'next/link'
-import { SetStateAction } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import z from 'zod'
+import dayjs from 'dayjs'
 import { toast } from 'sonner'
-import { number, object } from 'yup'
+import { PermissionAction, SupportCategories } from '@supabase/shared-types/out/constants'
 
-import { useParams } from 'common'
+import { useParams } from 'common/hooks'
 import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mutation'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
   Button,
-  Form,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Form_Shadcn_,
   InfoIcon,
-  InputNumber,
-  Modal,
+  Input_Shadcn_,
   WarningIcon,
 } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
-export interface DiskSizeConfigurationProps {
-  visible: boolean
-  hideModal: (value: SetStateAction<boolean>) => void
-  loading: boolean
+export interface DiskSizeConfigurationModalProps {
+  disabled?: boolean
 }
 
-const DiskSizeConfigurationModal = ({
-  visible,
-  loading,
-  hideModal,
-}: DiskSizeConfigurationProps) => {
+const formId = 'disk-resize-form'
+
+export const DiskSizeConfigurationModal = ({ disabled = false }) => {
   const { ref: projectRef } = useParams()
   const { data: organization } = useSelectedOrganizationQuery()
   const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
+  const [visible, setVisible] = useQueryState(
+    `show_increase_disk_size_modal`,
+    parseAsBoolean.withDefault(false)
+  )
+
+  const { can: canUpdateDiskSizeConfig } = useAsyncCheckProjectPermissions(
+    PermissionAction.UPDATE,
+    'projects',
+    {
+      resource: {
+        project_id: project?.id,
+      },
+    }
+  )
+
+  const { mutate: updateProjectUsage, isLoading: isUpdatingDiskSize } =
+    useProjectDiskResizeMutation({
+      onSuccess: (_, variables) => {
+        toast.success(`Successfully updated disk size to ${variables.volumeSize} GB`)
+        setVisible(false)
+      },
+    })
+  const minDiskSize = project?.volumeSizeGb ?? 0
+  const maxDiskSize = 200
+  const schema = z.object({
+    volumeSize: z.coerce
+      .number({ required_error: 'Please enter a GB amount you want to resize the disk up to.' })
+      .min(minDiskSize, `Must be more than ${minDiskSize} GB`)
+      // to do, update with max_disk_volume_size_gb
+      .max(maxDiskSize, 'Must not be more than 200 GB'),
+  })
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: { volumeSize: minDiskSize },
+  })
   const { lastDatabaseResizeAt } = project ?? {}
 
   const { data: projectSubscriptionData, isLoading: isLoadingSubscription } =
@@ -55,59 +100,51 @@ const DiskSizeConfigurationModal = ({
           timeTillNextAvailableDatabaseResize % 60
         } minute(s)`
 
-  const { mutate: updateProjectUsage, isLoading: isUpdatingDiskSize } =
-    useProjectDiskResizeMutation({
-      onSuccess: (res, variables) => {
-        toast.success(`Successfully updated disk size to ${variables.volumeSize} GB`)
-        hideModal(false)
-      },
-    })
-
-  const confirmResetDbPass = async (values: { [prop: string]: any }) => {
+  const onSubmit: SubmitHandler<z.infer<typeof schema>> = async ({ volumeSize }) => {
     if (!projectRef) return console.error('Project ref is required')
-    const volumeSize = values['new-disk-size']
     updateProjectUsage({ projectRef, volumeSize })
   }
 
-  const currentDiskSize = project?.volumeSizeGb ?? 0
-
-  const maxDiskSize = 200
-
-  const INITIAL_VALUES = {
-    'new-disk-size': currentDiskSize,
-  }
-
-  const diskSizeValidationSchema = object({
-    'new-disk-size': number()
-      .required('Please enter a GB amount you want to resize the disk up to.')
-      .min(Number(currentDiskSize ?? 0), `Must be more than ${currentDiskSize} GB`)
-      // to do, update with max_disk_volume_size_gb
-      .max(Number(maxDiskSize), 'Must not be more than 200 GB'),
-  })
-
   return (
-    <Modal
-      header="Increase Disk Storage Size"
-      size="medium"
-      visible={visible}
-      loading={loading}
-      onCancel={() => hideModal(false)}
-      hideFooter
+    <Dialog
+      open={visible}
+      onOpenChange={(open) => {
+        if (!open) {
+          form.reset()
+          setVisible(false)
+        }
+      }}
     >
-      {isLoading ? (
-        <div className="flex flex-col gap-4 p-4">
-          <ShimmeringLoader />
-          <ShimmeringLoader />
-        </div>
-      ) : projectSubscriptionData?.usage_billing_enabled === true ? (
-        <Form
-          name="disk-resize-form"
-          initialValues={INITIAL_VALUES}
-          validationSchema={diskSizeValidationSchema}
-          onSubmit={confirmResetDbPass}
+      <DialogTrigger asChild>
+        <ButtonTooltip
+          type="default"
+          disabled={!canUpdateDiskSizeConfig || disabled}
+          onClick={() => setVisible(true)}
+          tooltip={{
+            content: {
+              side: 'bottom',
+              text: !canUpdateDiskSizeConfig
+                ? 'You need additional permissions to increase the disk size'
+                : undefined,
+            },
+          }}
         >
-          {() =>
-            currentDiskSize >= maxDiskSize ? (
+          Increase disk size
+        </ButtonTooltip>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Increase Disk Storage Size</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        {isLoading ? (
+          <DialogSection className="flex flex-col gap-4 p-4">
+            <ShimmeringLoader />
+            <ShimmeringLoader />
+          </DialogSection>
+        ) : projectSubscriptionData?.usage_billing_enabled === true ? (
+          minDiskSize >= maxDiskSize ? (
+            <DialogSection>
               <Alert_Shadcn_ variant="warning" className="rounded-t-none border-0">
                 <WarningIcon />
                 <AlertTitle_Shadcn_>Maximum manual disk size increase reached</AlertTitle_Shadcn_>
@@ -125,94 +162,124 @@ const DiskSizeConfigurationModal = ({
                   </Button>
                 </AlertDescription_Shadcn_>
               </Alert_Shadcn_>
-            ) : (
-              <>
-                <Modal.Content className="w-full space-y-4">
-                  <Alert_Shadcn_ variant={isAbleToResizeDatabase ? 'default' : 'warning'}>
-                    <Info size={16} />
-                    <AlertTitle_Shadcn_>
-                      This operation is only possible every 6 hours
-                    </AlertTitle_Shadcn_>
-                    <AlertDescription_Shadcn_>
-                      <div className="mb-4">
-                        {isAbleToResizeDatabase
-                          ? `Upon updating your disk size, the next disk size update will only be available from ${dayjs().format(
-                              'DD MMM YYYY, HH:mm (ZZ)'
-                            )}`
-                          : `Your database was last resized at ${dayjs(lastDatabaseResizeAt).format(
-                              'DD MMM YYYY, HH:mm (ZZ)'
-                            )}. You can resize your database again in approximately ${formattedTimeTillNextAvailableResize}`}
-                      </div>
-                      <Button asChild type="default" iconRight={<ExternalLink size={14} />}>
-                        <Link href="https://supabase.com/docs/guides/platform/database-size#disk-management">
-                          Read more about disk management
-                        </Link>
-                      </Button>
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
-                  <InputNumber
-                    required
-                    id="new-disk-size"
-                    label="New disk size"
-                    labelOptional="GB"
-                    disabled={!isAbleToResizeDatabase}
-                  />
-                </Modal.Content>
-                <Modal.Separator />
-                <Modal.Content className="flex space-x-2 justify-end">
-                  <Button type="default" onClick={() => hideModal(false)}>
-                    Cancel
-                  </Button>
-                  <Button
-                    htmlType="submit"
-                    type="primary"
-                    disabled={!isAbleToResizeDatabase || isUpdatingDiskSize}
-                    loading={isUpdatingDiskSize}
+            </DialogSection>
+          ) : (
+            <>
+              <DialogSection>
+                <Form_Shadcn_ {...form}>
+                  <form
+                    id={formId}
+                    className="flex flex-col gap-4"
+                    onSubmit={form.handleSubmit(onSubmit)}
                   >
-                    Update disk size
-                  </Button>
-                </Modal.Content>
-              </>
-            )
-          }
-        </Form>
-      ) : (
-        <Alert_Shadcn_ className="border-none">
-          <InfoIcon />
-          <AlertTitle_Shadcn_>
-            {projectSubscriptionData?.plan?.id === 'free'
-              ? 'Disk size configuration is not available for projects on the Free Plan'
-              : 'Disk size configuration is only available when the spend cap has been disabled'}
-          </AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_>
-            {projectSubscriptionData?.plan?.id === 'free' ? (
-              <p>
-                If you are intending to use more than 500MB of disk space, then you will need to
-                upgrade to at least the Pro Plan.
-              </p>
-            ) : (
-              <p>
-                If you are intending to use more than 8GB of disk space, then you will need to
-                disable your spend cap.
-              </p>
-            )}
-            <Button asChild type="default" className="mt-3">
-              <Link
-                href={`/org/${organization?.slug}/billing?panel=${
-                  projectSubscriptionData?.plan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
-                }`}
-                target="_blank"
-              >
+                    <Alert_Shadcn_ variant={isAbleToResizeDatabase ? 'default' : 'warning'}>
+                      <Info size={16} />
+                      <AlertTitle_Shadcn_>
+                        This operation is only possible every 6 hours
+                      </AlertTitle_Shadcn_>
+                      <AlertDescription_Shadcn_>
+                        <div className="mb-4">
+                          {isAbleToResizeDatabase
+                            ? `Upon updating your disk size, the next disk size update will only be available from ${dayjs().format(
+                                'DD MMM YYYY, HH:mm (ZZ)'
+                              )}`
+                            : `Your database was last resized at ${dayjs(
+                                lastDatabaseResizeAt
+                              ).format(
+                                'DD MMM YYYY, HH:mm (ZZ)'
+                              )}. You can resize your database again in approximately ${formattedTimeTillNextAvailableResize}`}
+                        </div>
+                        <Button asChild type="default" iconRight={<ExternalLink size={14} />}>
+                          <Link href="https://supabase.com/docs/guides/platform/database-size#disk-management">
+                            Read more about disk management
+                          </Link>
+                        </Button>
+                      </AlertDescription_Shadcn_>
+                    </Alert_Shadcn_>
+                    <FormField_Shadcn_
+                      key="volumeSize"
+                      name="volumeSize"
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormItemLayout name="volumeSize" label="New disk size" labelOptional="GB">
+                          <FormControl_Shadcn_>
+                            <Input_Shadcn_
+                              id="volumeSize"
+                              type="number"
+                              min={minDiskSize}
+                              max={maxDiskSize}
+                              required
+                              disabled={!isAbleToResizeDatabase}
+                              {...field}
+                            />
+                          </FormControl_Shadcn_>
+                        </FormItemLayout>
+                      )}
+                    />
+                  </form>
+                </Form_Shadcn_>
+              </DialogSection>
+              <DialogFooter>
+                <Button
+                  type="default"
+                  onClick={() => {
+                    form.reset()
+                    setVisible(false)
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  form={formId}
+                  htmlType="submit"
+                  disabled={!isAbleToResizeDatabase || isUpdatingDiskSize}
+                  loading={isUpdatingDiskSize}
+                >
+                  Update disk size
+                </Button>
+              </DialogFooter>
+            </>
+          )
+        ) : (
+          <DialogSection>
+            <Alert_Shadcn_ className="border-none">
+              <InfoIcon />
+              <AlertTitle_Shadcn_>
                 {projectSubscriptionData?.plan?.id === 'free'
-                  ? 'Upgrade subscription'
-                  : 'Disable spend cap'}
-              </Link>
-            </Button>
-          </AlertDescription_Shadcn_>
-        </Alert_Shadcn_>
-      )}
-    </Modal>
+                  ? 'Disk size configuration is not available for projects on the Free Plan'
+                  : 'Disk size configuration is only available when the spend cap has been disabled'}
+              </AlertTitle_Shadcn_>
+              <AlertDescription_Shadcn_>
+                {projectSubscriptionData?.plan?.id === 'free' ? (
+                  <p>
+                    If you are intending to use more than 500MB of disk space, then you will need to
+                    upgrade to at least the Pro Plan.
+                  </p>
+                ) : (
+                  <p>
+                    If you are intending to use more than 8GB of disk space, then you will need to
+                    disable your spend cap.
+                  </p>
+                )}
+                <Button asChild type="default" className="mt-3">
+                  <Link
+                    href={`/org/${organization?.slug}/billing?panel=${
+                      projectSubscriptionData?.plan?.id === 'free'
+                        ? 'subscriptionPlan'
+                        : 'costControl'
+                    }`}
+                    target="_blank"
+                  >
+                    {projectSubscriptionData?.plan?.id === 'free'
+                      ? 'Upgrade subscription'
+                      : 'Disable spend cap'}
+                  </Link>
+                </Button>
+              </AlertDescription_Shadcn_>
+            </Alert_Shadcn_>
+          </DialogSection>
+        )}
+      </DialogContent>
+    </Dialog>
   )
 }
-
-export default DiskSizeConfigurationModal

--- a/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
@@ -1,28 +1,33 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { AlertCircle, ChevronDown, Globe, Lock } from 'lucide-react'
+import { ChevronDown, Globe, Lock, Unlock } from 'lucide-react'
 import { useState } from 'react'
 
 import { useParams } from 'common'
+import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { DocsButton } from 'components/ui/DocsButton'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
-import { FormPanel } from 'components/ui/Forms/FormPanel'
-import Panel from 'components/ui/Panel'
-import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useNetworkRestrictionsQuery } from 'data/network-restrictions/network-restrictions-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import {
+  ScaffoldSection,
+  ScaffoldSectionTitle,
+  ScaffoldSectionDescription,
+} from 'components/layouts/Scaffold'
+import {
   Badge,
   Button,
+  Card,
+  CardHeader,
+  CardContent,
+  CardFooter,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 import AddRestrictionModal from './AddRestrictionModal'
 import AllowAllModal from './AllowAllModal'
 import DisallowAllModal from './DisallowAllModal'
@@ -34,24 +39,27 @@ interface AccessButtonProps {
 }
 
 const AllowAllAccessButton = ({ disabled, onClick }: AccessButtonProps) => (
-  <Tooltip>
-    <TooltipTrigger asChild>
-      <Button type="default" disabled={disabled} onClick={() => onClick(true)}>
-        Allow all access
-      </Button>
-    </TooltipTrigger>
-    {disabled && (
-      <TooltipContent side="bottom">
-        You need additional permissions to update network restrictions
-      </TooltipContent>
-    )}
-  </Tooltip>
+  <ButtonTooltip
+    type="default"
+    disabled={disabled}
+    onClick={() => onClick(true)}
+    tooltip={{
+      content: {
+        side: 'bottom',
+        text: disabled
+          ? 'You need additional permissions to update network restrictions'
+          : undefined,
+      },
+    }}
+  >
+    Allow all access
+  </ButtonTooltip>
 )
 
 const DisallowAllAccessButton = ({ disabled, onClick }: AccessButtonProps) => (
   <ButtonTooltip
-    disabled={disabled}
     type="default"
+    disabled={disabled}
     onClick={() => onClick(true)}
     tooltip={{
       content: {
@@ -66,7 +74,7 @@ const DisallowAllAccessButton = ({ disabled, onClick }: AccessButtonProps) => (
   </ButtonTooltip>
 )
 
-const NetworkRestrictions = () => {
+export const NetworkRestrictions = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [isAddingAddress, setIsAddingAddress] = useState<undefined | 'IPv4' | 'IPv6'>()
@@ -97,191 +105,168 @@ const NetworkRestrictions = () => {
   const isAllowedAll = restrictedIps.includes('0.0.0.0/0') && restrictedIps.includes('::/0')
   const isDisallowedAll = restrictedIps.length === 0
 
-  if (!hasAccessToRestrictions) return null
+  //if (!hasAccessToRestrictions) return null
 
   return (
     <>
-      <section id="network-restrictions">
-        <div className="flex items-center justify-between mb-6">
-          <FormHeader
-            className="mb-0"
-            title="Network Restrictions"
-            description="Allow specific IP ranges to have access to your database."
-          />
-          <div className="flex items-center gap-x-2">
-            <DocsButton href="https://supabase.com/docs/guides/platform/network-restrictions" />
-            {!canUpdateNetworkRestrictions ? (
-              <ButtonTooltip
-                disabled
-                type="primary"
-                tooltip={{
-                  content: {
-                    side: 'bottom',
-                    text: 'You need additional permissions to update network restrictions',
-                  },
-                }}
-              >
-                Add restriction
-              </ButtonTooltip>
-            ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="primary"
-                    disabled={!canUpdateNetworkRestrictions}
-                    iconRight={<ChevronDown size={14} />}
-                  >
-                    Add restriction
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" side="bottom" className="w-48">
-                  <DropdownMenuItem
-                    key="IPv4"
-                    disabled={isLoading}
-                    onClick={() => setIsAddingAddress('IPv4')}
-                  >
-                    <p className="block text-foreground">Add IPv4 restriction</p>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    key="IPv6"
-                    disabled={isLoading}
-                    onClick={() => setIsAddingAddress('IPv6')}
-                  >
-                    <p className="block text-foreground">Add IPv6 restriction</p>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+      <ScaffoldSection id="network-restrictions" className="gap-6">
+        <ScaffoldSectionTitle className="flex items-center justify-between  gap-2">
+          <div className="flex flex-col gap-1">
+            Network Restrictions
+            <ScaffoldSectionDescription>
+              Allow specific IP ranges to have access to your database.
+            </ScaffoldSectionDescription>
           </div>
-        </div>
+
+          <DocsButton href="https://supabase.com/docs/guides/platform/network-restrictions" />
+
+          {!canUpdateNetworkRestrictions ? (
+            <ButtonTooltip
+              disabled
+              type="primary"
+              tooltip={{
+                content: {
+                  side: 'bottom',
+                  text: 'You need additional permissions to update network restrictions',
+                },
+              }}
+            >
+              Add restriction
+            </ButtonTooltip>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="primary"
+                  disabled={!canUpdateNetworkRestrictions}
+                  iconRight={<ChevronDown size={14} />}
+                >
+                  Add restriction
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" side="bottom" className="w-48">
+                <DropdownMenuItem
+                  key="IPv4"
+                  disabled={isLoading}
+                  onClick={() => setIsAddingAddress('IPv4')}
+                >
+                  <p className="block text-foreground">Add IPv4 restriction</p>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  key="IPv6"
+                  disabled={isLoading}
+                  onClick={() => setIsAddingAddress('IPv6')}
+                >
+                  <p className="block text-foreground">Add IPv6 restriction</p>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </ScaffoldSectionTitle>
+
         {isLoading ? (
-          <Panel>
-            <Panel.Content>
-              <div className="space-y-2">
-                <ShimmeringLoader />
-                <ShimmeringLoader className="w-[70%]" />
-                <ShimmeringLoader className="w-[50%]" />
-              </div>
-            </Panel.Content>
-          </Panel>
+          <Card>
+            <CardContent>
+              <GenericSkeletonLoader />
+            </CardContent>
+          </Card>
         ) : hasApplyError ? (
-          <Panel>
-            <Panel.Content>
-              <div className="flex items-center justify-between">
-                <div className="space-y-2">
-                  <div className="flex items-center space-x-2">
-                    <AlertCircle size={20} strokeWidth={1.5} className="text-foreground-light" />
-                    <p className="text-sm">Your network restrictions were not applied correctly</p>
-                  </div>
-                  <p className="text-sm text-foreground-light">
-                    Please try to add your network restrictions again
-                  </p>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <AllowAllAccessButton
-                    disabled={!canUpdateNetworkRestrictions}
-                    onClick={setIsAllowingAll}
-                  />
-                  <DisallowAllAccessButton
-                    disabled={!canUpdateNetworkRestrictions}
-                    onClick={setIsDisallowingAll}
-                  />
-                </div>
-              </div>
-            </Panel.Content>
-          </Panel>
-        ) : (
-          <FormPanel>
-            {isUninitialized || isAllowedAll ? (
-              <div className="px-8 py-8 flex items-center justify-between">
-                <div className="flex items-start space-x-4">
-                  <div className="space-y-1">
-                    <p className="text-foreground-light text-sm">
-                      Your database can be accessed by all IP addresses
-                    </p>
-                    <p className="text-foreground-light text-sm">
-                      You may start limiting access to your database by adding a network
-                      restriction.
-                    </p>
-                  </div>
-                </div>
-                <div>
-                  <DisallowAllAccessButton
-                    disabled={!canUpdateNetworkRestrictions}
-                    onClick={setIsDisallowingAll}
-                  />
-                </div>
-              </div>
-            ) : isDisallowedAll ? (
-              <div className="px-8 py-8 flex items-center justify-between">
-                <div className="flex items-start space-x-4">
-                  <Lock size={20} className="text-foreground-light" strokeWidth={1.5} />
-                  <div className="space-y-1">
-                    <p className="text-foreground-light text-sm">
-                      Your database <span className="text-amber-900 opacity-80">cannot</span> be
-                      accessed externally
-                    </p>
-                    <p className="text-foreground-light text-sm">
+          <Admonition type="warning" title="Your network restrictions were not applied correctly">
+            <p>Please try to add your network restrictions again</p>
+            <div className="flex gap-2">
+              <AllowAllAccessButton
+                disabled={!canUpdateNetworkRestrictions}
+                onClick={setIsAllowingAll}
+              />
+              <DisallowAllAccessButton
+                disabled={!canUpdateNetworkRestrictions}
+                onClick={setIsDisallowingAll}
+              />
+            </div>
+          </Admonition>
+        ) : isUninitialized || isAllowedAll ? (
+          <Card>
+            <CardContent className="flex gap-4">
+              <Unlock />
+              <FormLayout
+                layout="flex-row-reverse"
+                label="Any IP address can access your database"
+                description="You may start limiting access to your database by adding a network restriction."
+              >
+                <DisallowAllAccessButton
+                  disabled={!canUpdateNetworkRestrictions}
+                  onClick={setIsDisallowingAll}
+                />
+              </FormLayout>
+            </CardContent>
+          </Card>
+        ) : isDisallowedAll ? (
+          <Card>
+            <CardContent className="flex gap-4">
+              <Lock />
+              <FormLayout
+                layout="flex-row-reverse"
+                label={
+                  <>
+                    Your database <span className="text-amber-900 opacity-80">cannot</span> be
+                    accessed externally
+                  </>
+                }
+                description={
+                  <div className="space-y-1 xl:max-w-lg">
+                    <p>
                       All external IP addresses have been disallowed from accessing your project's
                       database.
                     </p>
-                    <p className="text-foreground-light text-sm">
+                    <p>
                       Note: Restrictions only apply to your database, and not to Supabase services
                     </p>
                   </div>
-                </div>
-                <div>
-                  <AllowAllAccessButton
-                    disabled={!canUpdateNetworkRestrictions}
-                    onClick={setIsAllowingAll}
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className="divide-y">
-                <div className="px-8 py-3 flex items-center justify-between">
-                  <div>
-                    <p className="text-foreground-light text-sm">
-                      Only the following IP addresses have access to your database
-                    </p>
-                    <p className="text-foreground-light text-sm">
-                      You may remove all of them to allow all IP addresses to have access to your
-                      database
-                    </p>
-                    <p className="text-foreground-light text-sm">
-                      Note: Restrictions only apply to your database, and not to Supabase services
-                    </p>
+                }
+              >
+                <AllowAllAccessButton
+                  disabled={!canUpdateNetworkRestrictions}
+                  onClick={setIsAllowingAll}
+                />
+              </FormLayout>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card>
+            <CardHeader>Only the following IP addresses have access to your database</CardHeader>
+            {restrictedIps.map((ip) => {
+              return (
+                <CardContent className="flex items-center justify-between gap-4">
+                  <Globe size={16} className="text-foreground-light" />
+                  <div className="w-full flex items-center gap-4">
+                    <Badge>{ipv4Restrictions.includes(ip) ? 'IPv4' : 'IPv6'}</Badge>
+                    <p className="text-sm font-mono">{ip}</p>
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <AllowAllAccessButton
-                      disabled={!canUpdateNetworkRestrictions}
-                      onClick={setIsAllowingAll}
-                    />
-                    <DisallowAllAccessButton
-                      disabled={!canUpdateNetworkRestrictions}
-                      onClick={setIsDisallowingAll}
-                    />
-                  </div>
-                </div>
-                {restrictedIps.map((ip) => {
-                  return (
-                    <div key={ip} className="px-8 py-4 flex items-center justify-between">
-                      <div className="flex items-center space-x-5">
-                        <Globe size={16} className="text-foreground-light" />
-                        <Badge>{ipv4Restrictions.includes(ip) ? 'IPv4' : 'IPv6'}</Badge>
-                        <p className="text-sm font-mono">{ip}</p>
-                      </div>
-                      <Button type="default" onClick={() => setSelectedRestrictionToRemove(ip)}>
-                        Remove
-                      </Button>
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-          </FormPanel>
+                  <Button type="default" onClick={() => setSelectedRestrictionToRemove(ip)}>
+                    Remove
+                  </Button>
+                </CardContent>
+              )
+            })}
+            <CardContent className="text-sm text-foreground-light space-y-1">
+              <p>
+                You may remove all of them to allow all IP addresses to have access to your database
+              </p>
+              <p>Note: Restrictions only apply to your database, and not to Supabase services</p>
+            </CardContent>
+            <CardFooter className="justify-end">
+              <AllowAllAccessButton
+                disabled={!canUpdateNetworkRestrictions}
+                onClick={setIsAllowingAll}
+              />
+              <DisallowAllAccessButton
+                disabled={!canUpdateNetworkRestrictions}
+                onClick={setIsDisallowingAll}
+              />
+            </CardFooter>
+          </Card>
         )}
-      </section>
+      </ScaffoldSection>
 
       <AllowAllModal visible={isAllowingAll} onClose={() => setIsAllowingAll(false)} />
       <DisallowAllModal visible={isDisallowingAll} onClose={() => setIsDisallowingAll(false)} />
@@ -299,5 +284,3 @@ const NetworkRestrictions = () => {
     </>
   )
 }
-
-export default NetworkRestrictions

--- a/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
@@ -105,7 +105,7 @@ export const NetworkRestrictions = () => {
   const isAllowedAll = restrictedIps.includes('0.0.0.0/0') && restrictedIps.includes('::/0')
   const isDisallowedAll = restrictedIps.length === 0
 
-  //if (!hasAccessToRestrictions) return null
+  if (!hasAccessToRestrictions) return null
 
   return (
     <>

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -86,6 +86,7 @@ export const SSLConfiguration = () => {
 
       <Card>
         <CardHeader>SSL Configuration</CardHeader>
+
         <CardContent id="pause-project" className="flex flex-col gap-4">
           <FormLayout
             layout="flex-row-reverse"

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -5,19 +5,19 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { DocsButton } from 'components/ui/DocsButton'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
-import { FormPanel } from 'components/ui/Forms/FormPanel'
-import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms/FormSection'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useSSLEnforcementQuery } from 'data/ssl-enforcement/ssl-enforcement-query'
 import { useSSLEnforcementUpdateMutation } from 'data/ssl-enforcement/ssl-enforcement-update-mutation'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { Alert, Button, Switch, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { ScaffoldSection, ScaffoldSectionTitle } from 'components/layouts/Scaffold'
+import { Card, CardHeader, CardContent, Switch, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { Admonition } from 'ui-patterns/admonition'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 
-const SSLConfiguration = () => {
+export const SSLConfiguration = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [isEnforced, setIsEnforced] = useState(false)
@@ -78,123 +78,104 @@ const SSLConfiguration = () => {
   }
 
   return (
-    <div id="ssl-configuration">
-      <div className="flex items-center justify-between mb-6">
-        <FormHeader className="mb-0" title="SSL Configuration" description="" />
+    <ScaffoldSection id="ssl-configuration" className="gap-6">
+      <ScaffoldSectionTitle className="flex items-center justify-between">
+        SSL
         <DocsButton href="https://supabase.com/docs/guides/platform/ssl-enforcement" />
-      </div>
-      <FormPanel>
-        <FormSection
-          header={
-            <FormSectionLabel
-              className="lg:col-span-7"
-              description={
-                <div className="space-y-4">
-                  <p className="text-sm text-foreground-light">
-                    Reject non-SSL connections to your database
-                  </p>
-                  {isSuccess && !sslEnforcementConfiguration?.appliedSuccessfully && (
-                    <Alert
-                      withIcon
-                      variant="warning"
-                      title="SSL enforcement was not updated successfully"
-                    >
-                      Please try updating again, or contact{' '}
-                      <Link
-                        href="/support/new"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="underline"
-                      >
-                        support
-                      </Link>{' '}
-                      if this error persists
-                    </Alert>
-                  )}
-                </div>
-              }
-            >
-              Enforce SSL on incoming connections
-            </FormSectionLabel>
-          }
-        >
-          <FormSectionContent loading={false} className="lg:!col-span-5">
-            <div className="flex items-center justify-end mt-2.5 space-x-2">
-              {(isLoading || isSubmitting) && (
-                <Loader2 className="animate-spin" strokeWidth={1.5} size={16} />
-              )}
-              {isSuccess && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
-                    <div>
-                      <Switch
-                        size="large"
-                        checked={isEnforced}
-                        disabled={
-                          isLoading ||
-                          isSubmitting ||
-                          !canUpdateSSLEnforcement ||
-                          !hasAccessToSSLEnforcement
-                        }
-                        onCheckedChange={toggleSSLEnforcement}
-                      />
-                    </div>
-                  </TooltipTrigger>
-                  {(!canUpdateSSLEnforcement || !hasAccessToSSLEnforcement) && (
-                    <TooltipContent side="bottom" className="w-64 text-center">
-                      {!canUpdateSSLEnforcement
-                        ? 'You need additional permissions to update SSL enforcement for your project'
-                        : !hasAccessToSSLEnforcement
-                          ? 'Your project does not have access to SSL enforcement'
-                          : undefined}
-                    </TooltipContent>
-                  )}
-                </Tooltip>
-              )}
-            </div>
-          </FormSectionContent>
-        </FormSection>
+      </ScaffoldSectionTitle>
 
-        <div className="grid grid-cols-1 items-center lg:grid-cols-2 p-8">
-          <div className="space-y-2">
-            <p className="block text-sm">SSL Certificate</p>
-            <div style={{ maxWidth: '420px' }}>
-              <p className="text-sm opacity-50">
-                Use this certificate when connecting to your database to prevent snooping and
-                man-in-the-middle attacks.
-              </p>
-            </div>
-          </div>
-          <div className="flex items-end justify-end">
-            {!hasSSLCertificate ? (
-              <ButtonTooltip
-                disabled
-                type="default"
-                icon={<Download />}
-                tooltip={{
-                  content: {
-                    side: 'bottom',
-                    text: 'Projects before 15:08 (GMT+08), 29th April 2021 do not have SSL certificates installed',
-                  },
-                }}
-              >
-                Download certificate
-              </ButtonTooltip>
+      <Card>
+        <CardHeader>SSL Configuration</CardHeader>
+        <CardContent id="pause-project" className="flex flex-col gap-4">
+          <FormLayout
+            layout="flex-row-reverse"
+            label="Enforce SSL on incoming connections"
+            description="Reject non-SSL connections to your database"
+          >
+            {isLoading || isSubmitting ? (
+              <div className="w-11 flex justify-center">
+                <Loader2 className="animate-spin" strokeWidth={1.5} size={16} />
+              </div>
             ) : (
-              <Button type="default" icon={<Download />}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
+                  <div>
+                    <Switch
+                      size="large"
+                      checked={isEnforced}
+                      disabled={
+                        isLoading ||
+                        isSubmitting ||
+                        !isSuccess ||
+                        !canUpdateSSLEnforcement ||
+                        !hasAccessToSSLEnforcement
+                      }
+                      onCheckedChange={toggleSSLEnforcement}
+                    />
+                  </div>
+                </TooltipTrigger>
+                {(!canUpdateSSLEnforcement || !hasAccessToSSLEnforcement) && (
+                  <TooltipContent side="bottom" className="w-64 text-center">
+                    {!canUpdateSSLEnforcement
+                      ? 'You need additional permissions to update SSL enforcement for your project'
+                      : !hasAccessToSSLEnforcement
+                        ? 'Your project does not have access to SSL enforcement'
+                        : undefined}
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            )}
+          </FormLayout>
+          {isSuccess && !sslEnforcementConfiguration?.appliedSuccessfully && (
+            <Admonition
+              type="warning"
+              title="SSL enforcement was not updated successfully"
+              description={
+                <>
+                  Please try updating again, or contact{' '}
+                  <Link href="/support/new" target="_blank" rel="noreferrer" className="underline">
+                    support
+                  </Link>{' '}
+                  if this error persists
+                </>
+              }
+            />
+          )}
+        </CardContent>
+
+        <CardContent className="flex justify-between items-center">
+          <FormLayout
+            layout="flex-row-reverse"
+            label="SSL Certificate"
+            description="Use this certificate when connecting to your database to prevent snooping and man-in-the-middle attacks."
+          >
+            <ButtonTooltip
+              type="default"
+              icon={<Download />}
+              disabled={!hasSSLCertificate}
+              tooltip={{
+                content: {
+                  side: 'bottom',
+                  text: !hasSSLCertificate
+                    ? 'Projects before 15:08 (GMT+08), 29th April 2021 do not have SSL certificates installed'
+                    : undefined,
+                },
+              }}
+            >
+              {hasSSLCertificate ? (
                 <a
                   href={`https://supabase-downloads.s3-ap-southeast-1.amazonaws.com/${env}/ssl/${env}-ca-2021.crt`}
                 >
                   Download certificate
                 </a>
-              </Button>
-            )}
-          </div>
-        </div>
-      </FormPanel>
-    </div>
+              ) : (
+                `Download certificate`
+              )}
+            </ButtonTooltip>
+          </FormLayout>
+        </CardContent>
+      </Card>
+    </ScaffoldSection>
   )
 }
-
-export default SSLConfiguration

--- a/apps/studio/components/interfaces/Settings/Database/index.ts
+++ b/apps/studio/components/interfaces/Settings/Database/index.ts
@@ -1,2 +1,7 @@
+export { DatabaseSettings } from './DatabaseSettings/DatabaseSettings'
 export { ConnectionPooling } from './ConnectionPooling/ConnectionPooling'
-export { default as NetworkRestrictions } from './NetworkRestrictions/NetworkRestrictions'
+export { SSLConfiguration } from './SSLConfiguration'
+export { DiskSizeConfiguration } from './DiskSizeConfiguration'
+export { NetworkRestrictions } from './NetworkRestrictions/NetworkRestrictions'
+export { BannedIPs } from './BannedIPs'
+export { PoolingModesModal } from './PoolingModesModal'

--- a/apps/studio/pages/project/[ref]/database/settings.tsx
+++ b/apps/studio/pages/project/[ref]/database/settings.tsx
@@ -12,12 +12,7 @@ import {
 } from 'components/interfaces/Settings/Database'
 import { DiskManagementPanelForm } from 'components/interfaces/DiskManagement/DiskManagementPanelForm'
 import { useIsAwsCloudProvider, useIsAwsK8sCloudProvider } from 'hooks/misc/useSelectedProject'
-import {
-  ScaffoldContainer,
-  ScaffoldHeader,
-  ScaffoldTitle,
-  ScaffoldSection,
-} from 'components/layouts/Scaffold'
+import { ScaffoldContainer, ScaffoldHeader, ScaffoldTitle } from 'components/layouts/Scaffold'
 
 const ProjectSettings: NextPageWithLayout = () => {
   const isAws = useIsAwsCloudProvider()

--- a/apps/studio/pages/project/[ref]/database/settings.tsx
+++ b/apps/studio/pages/project/[ref]/database/settings.tsx
@@ -1,16 +1,23 @@
-import { DiskManagementPanelForm } from 'components/interfaces/DiskManagement/DiskManagementPanelForm'
-import { ConnectionPooling, NetworkRestrictions } from 'components/interfaces/Settings/Database'
-import BannedIPs from 'components/interfaces/Settings/Database/BannedIPs'
-import { DatabaseReadOnlyAlert } from 'components/interfaces/Settings/Database/DatabaseReadOnlyAlert'
-import ResetDbPassword from 'components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword'
-import DiskSizeConfiguration from 'components/interfaces/Settings/Database/DiskSizeConfiguration'
-import { PoolingModesModal } from 'components/interfaces/Settings/Database/PoolingModesModal'
-import SSLConfiguration from 'components/interfaces/Settings/Database/SSLConfiguration'
-import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
-import DefaultLayout from 'components/layouts/DefaultLayout'
-import { ScaffoldContainer, ScaffoldHeader, ScaffoldTitle } from 'components/layouts/Scaffold'
-import { useIsAwsCloudProvider, useIsAwsK8sCloudProvider } from 'hooks/misc/useSelectedProject'
 import type { NextPageWithLayout } from 'types'
+import DefaultLayout from 'components/layouts/DefaultLayout'
+import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
+import {
+  DatabaseSettings,
+  ConnectionPooling,
+  SSLConfiguration,
+  DiskSizeConfiguration,
+  NetworkRestrictions,
+  BannedIPs,
+  PoolingModesModal,
+} from 'components/interfaces/Settings/Database'
+import { DiskManagementPanelForm } from 'components/interfaces/DiskManagement/DiskManagementPanelForm'
+import { useIsAwsCloudProvider, useIsAwsK8sCloudProvider } from 'hooks/misc/useSelectedProject'
+import {
+  ScaffoldContainer,
+  ScaffoldHeader,
+  ScaffoldTitle,
+  ScaffoldSection,
+} from 'components/layouts/Scaffold'
 
 const ProjectSettings: NextPageWithLayout = () => {
   const isAws = useIsAwsCloudProvider()
@@ -19,33 +26,30 @@ const ProjectSettings: NextPageWithLayout = () => {
   const showNewDiskManagementUI = isAws || isAwsK8s
 
   return (
-    <>
-      <ScaffoldContainer>
-        <ScaffoldHeader>
-          <ScaffoldTitle>Database Settings</ScaffoldTitle>
-        </ScaffoldHeader>
-      </ScaffoldContainer>
-      <ScaffoldContainer bottomPadding>
-        <div className="space-y-10">
-          <div className="flex flex-col gap-y-10">
-            <DatabaseReadOnlyAlert />
-            <ResetDbPassword />
-            <ConnectionPooling />
-          </div>
+    <ScaffoldContainer bottomPadding>
+      <ScaffoldHeader>
+        <ScaffoldTitle>Database Settings</ScaffoldTitle>
+      </ScaffoldHeader>
 
-          <SSLConfiguration />
-          {showNewDiskManagementUI ? (
-            // This form is hidden if Disk and Compute form is enabled, new form is on ./settings/compute-and-disk
-            <DiskManagementPanelForm />
-          ) : (
-            <DiskSizeConfiguration />
-          )}
-          <NetworkRestrictions />
-          <BannedIPs />
-        </div>
-      </ScaffoldContainer>
+      <DatabaseSettings />
+
+      <ConnectionPooling />
+
+      <SSLConfiguration />
+
+      {showNewDiskManagementUI ? (
+        // This form is hidden if Disk and Compute form is enabled, new form is on ./settings/compute-and-disk
+        <DiskManagementPanelForm />
+      ) : (
+        <DiskSizeConfiguration />
+      )}
+
+      <NetworkRestrictions />
+
+      <BannedIPs />
+
       <PoolingModesModal />
-    </>
+    </ScaffoldContainer>
   )
 }
 


### PR DESCRIPTION
This builds on #38075 and is extracted from #37886, refactoring the `DiskSizeConfigrationModal` used in the Database Settings -> Disk Management section and the Project -> Reports -> Database page.

It replaces `yup` with `zod` and all deprecated UI components except for `useProjectDiskResizeMutation` which I'm not sure what to use instead. It now self-contains it's trigger and permissions checking, so it's usage is now just a one-liner.

Because this is branched off of #38075 it will remain in draft mode until that branch is reviewed and merged. 