### PR TITLE
Update mcp.mdx

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -172,7 +172,7 @@ You can add the Supabase MCP server to Amp in two ways:
          "command": "npx",
          "args": [
            "-y",
-           "@supabase/mcp-server-supabase@latest",
+           "@supabase/mcp-server-supabase",
            "--read-only",
            "--project-ref=<project-ref>"
          ],


### PR DESCRIPTION
Supabase MCP Server Documentation error with Cursor integration #38143
Improve documentation
Link
https://supabase.com/docs/guides/getting-started/mcp?queryGroups=os&os=mac#cursor

Describe the problem
The official Supabase MCP server documentation contains incorrect package installation syntax that causes runtime errors. The documentation shows using @supabase/mcp-server-supabase@latest in the Cursor configuration, but this breaks the GraphQL dependency resolution and causes the error:

Error: Cannot find module './type/validate.js'
This results in the MCP server showing "No tools or prompts" with a red error indicator in Cursor, making developers think the integration is completely broken.

Describe the improvement
{
"mcpServers": {
"supabase": {
"command": "npx",
"args": [
"-y",
"@supabase/mcp-server-supabase", // Remove @latest
"--read-only",
"--project-ref="
],
"env": {
"SUPABASE_ACCESS_TOKEN": ""
}
}
}
}

Additional context
Use "@supabase/mcp-server-supabase" instead of "@supabase/mcp-server-supabase@latest" to fix GraphQL dependency errors.