### PR TITLE
docs: Fix "anon_key" secret name on "Scheduling Edge Functions" page

### DIFF
--- a/apps/docs/content/guides/functions/schedule-functions.mdx
+++ b/apps/docs/content/guides/functions/schedule-functions.mdx
@@ -31,7 +31,7 @@ Store `project_url` and `anon_key` in Supabase Vault:
 
 ```sql
 select vault.create_secret('https://project-ref.supabase.co', 'project_url');
-select vault.create_secret('YOUR_SUPABASE_PUBLISHABLE_KEY', 'publishable_key');
+select vault.create_secret('YOUR_SUPABASE_PUBLISHABLE_KEY', 'anon_key');
 ```
 
 Make a POST request to a Supabase Edge Function every minute:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs fix on this page: https://supabase.com/docs/guides/functions/schedule-functions

In the SQL to create 2nd secret the name "publishable_key" is used, but in the CRON SQL another key is referenced with the name "anon_key":

<img width="1014" height="765" alt="image" src="https://github.com/user-attachments/assets/fe12ebdb-9f4d-47e3-882d-cc9ef8a8874c" />


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
