### PR TITLE
fix: Correctly change the Apple OAuth link

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -436,7 +436,7 @@ const EXTERNAL_PROVIDER_APPLE = {
     },
     EXTERNAL_APPLE_CLIENT_ID: {
       title: 'Client IDs',
-      description: `Comma separated list of allowed Apple app (Web, OAuth, iOS, macOS, watchOS, or tvOS) bundle IDs for native sign in, or service IDs for Sign in with Apple JS. [Learn more](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js)`,
+      description: `Comma separated list of allowed Apple app (Web, OAuth, iOS, macOS, watchOS, or tvOS) bundle IDs for native sign in, or service IDs for Sign in with Apple JS. [Learn more](https://developer.apple.com/documentation/signinwithapplejs)`,
       type: 'string',
     },
     EXTERNAL_APPLE_SECRET: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Corrects incorrectly configured Apple OAuth links.

## What is the current behavior?

The current Apple OAuth-related link is incorrect.
It's redirecting you to the wrong page.

<img width="481" height="560" alt="스크린샷 2025-08-24 오전 2 09 34" src="https://github.com/user-attachments/assets/a3e57f03-89cd-4864-a4d5-7da3116cf544" />

<img width="1048" height="788" alt="스크린샷 2025-08-24 오전 2 10 06" src="https://github.com/user-attachments/assets/288cb0fc-e069-4648-b4f7-9af5c15bad3b" />

## What is the new behavior?

I'll fix it with the correct link. (https://developer.apple.com/documentation/signinwithapplejs)

<img width="1371" height="658" alt="스크린샷 2025-08-24 오전 2 15 19" src="https://github.com/user-attachments/assets/0c8b6ef5-e3ac-476b-8528-7f18513ed5b4" />

## Additional context

Thanks.