### PR TITLE
Chore/use default badge for paused state in project row

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Github } from 'lucide-react'
+import { Github } from 'lucide-react'
 
 import CardButton from 'components/ui/CardButton'
 import { ComputeBadgeWrapper } from 'components/ui/ComputeBadgeWrapper'
@@ -60,11 +60,6 @@ export const ProjectCard = ({
                     title="Vercel Icon"
                     className="w-3"
                   />
-                </div>
-              )}
-              {isBranchingEnabled && (
-                <div className="w-fit p-1 border rounded-md flex items-center">
-                  <GitBranch size={12} strokeWidth={1.5} />
                 </div>
               )}
               {isGithubIntegrated && (

--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -142,11 +142,13 @@ export const ProjectCardStatus = ({
   if (renderMode === 'badge') {
     const badgeVariant = isCritical
       ? 'destructive'
-      : projectStatus !== 'isHealthy'
-        ? 'warning'
-        : activeWarnings.length > 0
+      : projectStatus === 'isPaused'
+        ? 'default'
+        : projectStatus !== 'isHealthy'
           ? 'warning'
-          : 'success'
+          : activeWarnings.length > 0
+            ? 'warning'
+            : 'success'
 
     return alertDescription ? (
       <Tooltip>

--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -142,13 +142,13 @@ export const ProjectCardStatus = ({
   if (renderMode === 'badge') {
     const badgeVariant = isCritical
       ? 'destructive'
-      : projectStatus === 'isPaused'
-        ? 'default'
-        : projectStatus !== 'isHealthy'
-          ? 'warning'
-          : activeWarnings.length > 0
-            ? 'warning'
-            : 'success'
+      : activeWarnings.length > 0 ||
+          projectStatus === 'isPauseFailed' ||
+          projectStatus === 'isRestoreFailed'
+        ? 'warning'
+        : projectStatus === 'isHealthy'
+          ? 'success'
+          : 'default'
 
     return alertDescription ? (
       <Tooltip>

--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectTableRow.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectTableRow.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Github } from 'lucide-react'
+import { Github } from 'lucide-react'
 import { useRouter } from 'next/router'
 import InlineSVG from 'react-inlinesvg'
 
@@ -63,11 +63,6 @@ export const ProjectTableRow = ({
                     title="Vercel Icon"
                     className="w-3"
                   />
-                </div>
-              )}
-              {isBranchingEnabled && (
-                <div className="w-fit p-1 border rounded-md flex items-center">
-                  <GitBranch size={12} strokeWidth={1.5} />
                 </div>
               )}
               {isGithubIntegrated && (


### PR DESCRIPTION
## Context

We recently [added](https://github.com/supabase/supabase/pull/38021) a table view for projects which includes a column for project status, but i just realised that we're using `warning` variant for the badge for a lot of the status like "paused" which i think is a bit too much - should reserve amber and red for things that require attention.

Am opting to only use warning for failed statuses, and all else to use default (healthy will be green)

(Unrelated) Also removing branching icon from ProjectCard as we have no concept of “enabling” branching anymore

## Before
<img width="514" height="104" alt="image" src="https://github.com/user-attachments/assets/0e1657b1-784e-47d1-a401-aa44b502a154" />

## After
<img width="443" height="101" alt="image" src="https://github.com/user-attachments/assets/efd19d66-c6d5-436c-9d9d-132b4fcaa965" />
