### PR TITLE
Fix policy header actions

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -143,7 +143,7 @@ export const PolicyTableRow = ({
                   <TableHead className="w-[40%]">Name</TableHead>
                   <TableHead className="w-[20%]">Command</TableHead>
                   <TableHead className="w-[30%]">Applied to</TableHead>
-                  <TableHead className="w-0 text-right">
+                  <TableHead className="text-right">
                     <span className="sr-only">Actions</span>
                   </TableHead>
                 </TableRow>


### PR DESCRIPTION
## Context

Bug identified that's only happening on Safari - Auth -> Policies page table

Last column in the table is seemingly rendered outside of the table
<img width="438" height="349" alt="image" src="https://github.com/user-attachments/assets/039c6d1b-5cdb-48b5-ab7f-121e70f27be6" />


This PR fixes that