### PR TITLE
Fix restart DB TS error

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
@@ -80,6 +80,7 @@ const RestartServerButton = () => {
   }
 
   const onRestartSuccess = () => {
+    console.log('onRestartSuccess')
     setProjectStatus(queryClient, projectRef, 'RESTARTING')
     toast.success('Restarting server...')
     router.push(`/project/${projectRef}`)

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
@@ -80,7 +80,6 @@ const RestartServerButton = () => {
   }
 
   const onRestartSuccess = () => {
-    console.log('onRestartSuccess')
     setProjectStatus(queryClient, projectRef, 'RESTARTING')
     toast.success('Restarting server...')
     router.push(`/project/${projectRef}`)

--- a/apps/studio/data/projects/projects-query.ts
+++ b/apps/studio/data/projects/projects-query.ts
@@ -82,17 +82,20 @@ export function setProjectStatus(
   projectRef: Project['ref'],
   status: Project['status']
 ) {
-  client.setQueriesData<Project[] | undefined>(
+  client.setQueriesData<PaginatedProjectsResponse | undefined>(
     projectKeys.list(),
     (old) => {
       if (!old) return old
 
-      return old.map((project) => {
-        if (project.ref === projectRef) {
-          return { ...project, status }
-        }
-        return project
-      })
+      return {
+        ...old,
+        projects: old.projects.map((project) => {
+          if (project.ref === projectRef) {
+            return { ...project, status }
+          }
+          return project
+        }),
+      }
     },
     { updatedAt: Date.now() }
   )


### PR DESCRIPTION
## Context

We received a report that the "Fast database reboot" CTA in projects settings was throwing a toast error - on investigation this is stemming from the client side (API request is fired successfully), and its from a bug that was introduced in this [PR](https://github.com/supabase/supabase/pull/38192)

`setProjectStatus` needed to be updated as it wasn't using the right shape of the projects data (was previously just an array but its now an object like `{ projects: [], pagination: {}}`

Verified the fix working locally