### PR TITLE
fix: Revert the `getProjects` query to use the v1 of `/platform/projects` API endpoint

### DIFF
--- a/apps/studio/data/projects/projects-query.ts
+++ b/apps/studio/data/projects/projects-query.ts
@@ -22,14 +22,13 @@ export async function getProjects({
   signal?: AbortSignal
   headers?: Record<string, string>
 }) {
-  const { data, error } = await get('/platform/projects', {
-    signal,
-    headers: { ...headers, Version: '2' },
-  })
+  const { data, error } = await get('/platform/projects', { signal, headers })
 
   if (error) handleError(error)
-  // [Joshen] API TS issue
-  return data as unknown as PaginatedProjectsResponse
+  // The /platform/projects endpoint has a v2 which is activated by passing a {version: '2'} header. The v1 API returns
+  // all projects while the v2 returns paginated list of projects. Wrapping the v1 API response into a
+  // { projects: ProjectInfo[] } is intentional to be forward compatible with the structure of v2 for easier migration.
+  return { projects: data }
 }
 
 export type ProjectsData = Awaited<ReturnType<typeof getProjects>>


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase/issues/38257