### PR TITLE
docs(auth): add Flutter signInWithIdToken example for Facebook auth

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -121,6 +121,53 @@ Future<void> signInWithFacebook() async {
 }
 ```
 
+### Alternative: Using Facebook SDK with signInWithIdToken
+
+For more control over the Facebook authentication flow, you can use the Facebook SDK directly and then authenticate with Supabase using [`signInWithIdToken()`](/docs/reference/dart/auth-signinwithidtoken):
+
+First, add the Facebook SDK dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  flutter_facebook_auth: ^7.0.1
+```
+
+Then implement the Facebook authentication:
+
+```dart
+import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+Future<void> signInWithFacebook() async {
+  try {
+    final LoginResult result = await FacebookAuth.instance.login(
+      permissions: ['public_profile', 'email'],
+    );
+
+    if (result.status == LoginStatus.success) {
+      final accessToken = result.accessToken!.tokenString;
+
+      await Supabase.instance.client.auth.signInWithIdToken(
+        provider: OAuthProvider.facebook,
+        idToken: accessToken,
+      );
+
+      // Authentication successful
+    } else {
+      // Handle login cancellation or failure
+      throw Exception('Facebook login failed: ${result.status}');
+    }
+  } catch (e) {
+    // Handle errors
+    throw Exception('Facebook authentication error: ${e.toString()}');
+  }
+}
+```
+
+
+
+**Note**: Make sure to configure your Facebook app properly and add the required permissions in the Facebook Developer Console. The `signInWithIdToken` method requires the Facebook access token to be valid and properly scoped.
+
 </TabPanel>
 <TabPanel id="swift" label="Swift">
 

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -164,8 +164,6 @@ Future<void> signInWithFacebook() async {
 }
 ```
 
-
-
 **Note**: Make sure to configure your Facebook app properly and add the required permissions in the Facebook Developer Console. The `signInWithIdToken` method requires the Facebook access token to be valid and properly scoped.
 
 </TabPanel>

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -164,7 +164,9 @@ Future<void> signInWithFacebook() async {
 }
 ```
 
-**Note**: Make sure to configure your Facebook app properly and add the required permissions in the Facebook Developer Console. The `signInWithIdToken` method requires the Facebook access token to be valid and properly scoped.
+<Admonition type="note">
+Make sure to configure your Facebook app properly and add the required permissions in the Facebook Developer Console. The `signInWithIdToken` method requires the Facebook access token to be valid and properly scoped.
+</Admonition>
 
 </TabPanel>
 <TabPanel id="swift" label="Swift">

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -165,6 +165,7 @@ Future<void> signInWithFacebook() async {
 ```
 
 <Admonition type="note">
+
 Make sure to configure your Facebook app properly and add the required permissions in the Facebook Developer Console. The `signInWithIdToken` method requires the Facebook access token to be valid and properly scoped.
 </Admonition>
 

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -167,6 +167,7 @@ Future<void> signInWithFacebook() async {
 <Admonition type="note">
 
 Make sure to configure your Facebook app properly and add the required permissions in the Facebook Developer Console. The `signInWithIdToken` method requires the Facebook access token to be valid and properly scoped.
+
 </Admonition>
 
 </TabPanel>

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -558,12 +558,12 @@ functions:
   - id: sign-in-with-id-token
     title: 'signInWithIdToken()'
     description: |
-      Allows you to perform native Google and Apple sign in by combining it with [google_sign_in](https://pub.dev/packages/google_sign_in) or [sign_in_with_apple](https://pub.dev/packages/sign_in_with_apple) packages.
+      Allows you to perform native Google, Apple, and Facebook sign in by combining it with [google_sign_in](https://pub.dev/packages/google_sign_in), [sign_in_with_apple](https://pub.dev/packages/sign_in_with_apple), or [flutter_facebook_auth](https://pub.dev/packages/flutter_facebook_auth) packages.
     params:
       - name: provider
         isOptional: false
         type: OAuthProvider
-        description: The provider to perform the sign in with. Currently, `OAuthProvider.google` and `OAuthProvider.apple` are supported.
+        description: The provider to perform the sign in with.
       - name: idToken
         isOptional: false
         type: String
@@ -718,6 +718,34 @@ functions:
             idToken: idToken,
             nonce: rawNonce,
           );
+          ```
+      - id: sign-in-with-facebook
+        name: Native Facebook Sign in
+        description: |
+          You can perform native Facebook sign in using [flutter_facebook_auth](https://pub.dev/packages/flutter_facebook_auth).
+          
+          First, set up your Facebook app in the [Facebook Developer Console](https://developers.facebook.com) and configure it in your Supabase dashboard under `Authentication -> Providers -> Facebook`.
+        code: |
+          ```dart
+          import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
+          import 'package:supabase_flutter/supabase_flutter.dart';
+
+          Future<void> signInWithFacebook() async {
+            final LoginResult result = await FacebookAuth.instance.login(
+              permissions: ['public_profile', 'email'],
+            );
+
+            if (result.status == LoginStatus.success) {
+              final accessToken = result.accessToken!.tokenString;
+
+              final response = await supabase.auth.signInWithIdToken(
+                provider: OAuthProvider.facebook,
+                idToken: accessToken,
+              );
+            } else {
+              throw Exception('Facebook login failed: ${result.status}');
+            }
+          }
           ```
   - id: sign-in-with-oauth
     title: 'signInWithOAuth()'

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -743,7 +743,9 @@ functions:
                 idToken: accessToken,
               );
             } else {
-              throw Exception('Facebook login failed: ${result.status}');
+              throw const AuthException(
+                'Facebook login failed: ${result.status}',
+              );
             }
           }
           ```

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -336,6 +336,7 @@ allow_list = [
     "psql",
     "scrypt",
     "sessionStorage",
+    "signInWithIdToken",
     "stdin",
     "stdout",
     "[Ss]ubnet(s)?",


### PR DESCRIPTION
Add documentation section showing how to integrate Facebook authentication in Flutter using the signInWithIdToken method with the Facebook SDK. Includes dependency setup, basic implementation, and error handling.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
