### PR TITLE
Small fix to prevent layout shift in SQL editor when running query

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -676,7 +676,7 @@ export const SQLEditor = () => {
           direction="vertical"
           autoSaveId={LOCAL_STORAGE_KEYS.SQL_EDITOR_SPLIT_SIZE}
         >
-          <ResizablePanel maxSize={70}>
+          <ResizablePanel defaultSize={50} maxSize={70}>
             <div className="flex-grow overflow-y-auto border-b h-full">
               {isLoading ? (
                 <div className="flex h-full w-full items-center justify-center">
@@ -793,7 +793,7 @@ export const SQLEditor = () => {
 
           <ResizableHandle withHandle />
 
-          <ResizablePanel maxSize={70}>
+          <ResizablePanel defaultSize={50} maxSize={70}>
             {isLoading ? (
               <div className="flex h-full w-full items-center justify-center">
                 <Loader2 className="animate-spin text-brand" />
@@ -811,7 +811,7 @@ export const SQLEditor = () => {
             )}
           </ResizablePanel>
 
-          <div className="max-h-9">
+          <div className="h-9">
             {results?.rows !== undefined && !isExecuting && (
               <GridFooter className="flex items-center justify-between gap-2">
                 <Tooltip>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -78,7 +78,7 @@ const UtilityActions = ({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            data-testId="sql-editor-utility-actions"
+            data-testid="sql-editor-utility-actions"
             type="default"
             className={cn('px-1', isAiOpen ? 'block 2xl:hidden' : 'hidden')}
             icon={<MoreVertical className="text-foreground-light" />}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -133,7 +133,7 @@ export const SQLEditorMenu = () => {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
-                data-testId="sql-editor-new-query-button"
+                data-testid="sql-editor-new-query-button"
                 type="default"
                 icon={<Plus className="text-foreground" />}
                 className="w-[26px]"


### PR DESCRIPTION
## Context

Internal feedback pointed out that the SQL Editor layout shifts a bit when running queries (ref before demo video)

This is due to the results footer of the SQL Editor only taking up height when there are results (it's rendered outside of the Resizeable panels), hence leading to the layout shift. Fix to change `max-h-9` to `h-9` so that the results footer takes up the full height irregardless to prevent the layout shift

## Before

https://github.com/user-attachments/assets/7356c679-a657-4289-bb54-7eefac2cb8b7

## After

https://github.com/user-attachments/assets/7b067ad1-e9a1-4cfd-8806-d55db0919d1a

