### PR TITLE
feat: clearer upload limits

### DIFF
--- a/apps/studio/components/interfaces/Storage/BucketRow.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketRow.tsx
@@ -28,7 +28,7 @@ export interface BucketRowProps {
   isSelected: boolean
 }
 
-const BucketRow = ({ bucket, projectRef = '', isSelected = false }: BucketRowProps) => {
+export const BucketRow = ({ bucket, projectRef = '', isSelected = false }: BucketRowProps) => {
   const { can: canUpdateBuckets } = useAsyncCheckProjectPermissions(
     PermissionAction.STORAGE_WRITE,
     '*'
@@ -118,5 +118,3 @@ const BucketRow = ({ bucket, projectRef = '', isSelected = false }: BucketRowPro
     </div>
   )
 }
-
-export default BucketRow

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -150,6 +150,7 @@ const CreateBucketModal = () => {
       )
     }
 
+    // [Joshen] Should shift this into superRefine in the form schema
     try {
       const fileSizeLimit =
         values.has_file_size_limit && values.formatted_size_limit !== undefined
@@ -189,9 +190,8 @@ const CreateBucketModal = () => {
       setVisible(false)
       toast.success(`Successfully created bucket ${values.name}`)
       router.push(`/project/${ref}/storage/buckets/${values.name}`)
-    } catch (error) {
-      console.error(error)
-      toast.error('Failed to create bucket')
+    } catch (error: any) {
+      toast.error(`Failed to create bucket: ${error.message}`)
     }
   }
 

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -75,7 +75,7 @@ const FormSchema = z
     formatted_size_limit: z.coerce
       .number()
       .min(0, 'File size upload limit has to be at least 0')
-      .default(0),
+      .optional(),
     allowed_mime_types: z.string().trim().default(''),
   })
   .superRefine((data, ctx) => {
@@ -126,7 +126,7 @@ const CreateBucketModal = () => {
       public: false,
       type: 'STANDARD',
       has_file_size_limit: false,
-      formatted_size_limit: 0,
+      formatted_size_limit: undefined,
       allowed_mime_types: '',
     },
   })
@@ -151,9 +151,10 @@ const CreateBucketModal = () => {
     }
 
     try {
-      const fileSizeLimit = values.has_file_size_limit
-        ? convertToBytes(values.formatted_size_limit, selectedUnit as StorageSizeUnits)
-        : undefined
+      const fileSizeLimit =
+        values.has_file_size_limit && values.formatted_size_limit !== undefined
+          ? convertToBytes(values.formatted_size_limit, selectedUnit as StorageSizeUnits)
+          : undefined
 
       const allowedMimeTypes = hasAllowedMimeTypes
         ? values.allowed_mime_types.length > 0

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -117,7 +117,7 @@ const CreateBucketModal = () => {
   const { value, unit } = convertFromBytes(data?.fileSizeLimit ?? 0)
   const formattedGlobalUploadLimit = `${value} ${unit}`
 
-  const [selectedUnit, setSelectedUnit] = useState<string>(StorageSizeUnits.BYTES)
+  const [selectedUnit, setSelectedUnit] = useState<string>(StorageSizeUnits.MB)
 
   const form = useForm<CreateBucketForm>({
     resolver: zodResolver(FormSchema),
@@ -186,7 +186,7 @@ const CreateBucketModal = () => {
         await createIcebergWrapper({ bucketName: values.name })
       }
       form.reset()
-      setSelectedUnit(StorageSizeUnits.BYTES)
+      setSelectedUnit(StorageSizeUnits.MB)
       setVisible(false)
       toast.success(`Successfully created bucket ${values.name}`)
       router.push(`/project/${ref}/storage/buckets/${values.name}`)
@@ -197,7 +197,7 @@ const CreateBucketModal = () => {
 
   const handleClose = () => {
     form.reset()
-    setSelectedUnit(StorageSizeUnits.BYTES)
+    setSelectedUnit(StorageSizeUnits.MB)
     setVisible(false)
   }
 

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -191,7 +191,22 @@ const CreateBucketModal = () => {
       toast.success(`Successfully created bucket ${values.name}`)
       router.push(`/project/${ref}/storage/buckets/${values.name}`)
     } catch (error: any) {
-      toast.error(`Failed to create bucket: ${error.message}`)
+      // Handle specific error cases for inline display
+      const errorMessage = error.message?.toLowerCase() || ''
+
+      if (
+        errorMessage.includes('mime type') &&
+        (errorMessage.includes('is not supported') || errorMessage.includes('not supported'))
+      ) {
+        // Set form error for the MIME types field
+        form.setError('allowed_mime_types', {
+          type: 'manual',
+          message: 'Invalid MIME type format. Please check your input.',
+        })
+      } else {
+        // For other errors, show a toast as fallback
+        toast.error(`Failed to create bucket: ${error.message}`)
+      }
     }
   }
 

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -240,7 +240,7 @@ const CreateBucketModal = () => {
 
         <Form_Shadcn_ {...form}>
           <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-            <DialogSection>
+            <DialogSection className="flex flex-col gap-y-2">
               <FormField_Shadcn_
                 key="name"
                 name="name"
@@ -318,49 +318,40 @@ const CreateBucketModal = () => {
             {isStandardBucket ? (
               <>
                 <DialogSection>
-                  <FormField_Shadcn_
-                    key="public"
-                    name="public"
-                    control={form.control}
-                    render={({ field }) => (
-                      <FormItemLayout
-                        hideMessage
-                        name="public"
-                        label="Public bucket"
-                        description="Anyone can read any object without any authorization"
-                        layout="flex"
-                      >
-                        <FormControl_Shadcn_>
-                          <Switch
-                            id="public"
-                            size="large"
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                          />
-                        </FormControl_Shadcn_>
-                      </FormItemLayout>
+                  {/* Visibility */}
+                  <div className="flex flex-col gap-y-2">
+                    <FormField_Shadcn_
+                      key="public"
+                      name="public"
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormItemLayout
+                          hideMessage
+                          name="public"
+                          label="Public bucket"
+                          description="Allow anyone to read objects without authorization"
+                          layout="flex"
+                        >
+                          <FormControl_Shadcn_>
+                            <Switch
+                              id="public"
+                              size="large"
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl_Shadcn_>
+                        </FormItemLayout>
+                      )}
+                    />
+                    {isPublicBucket && (
+                      <Admonition
+                        type="warning"
+                        title="Public buckets are not protected"
+                        description="Users can read objects in public buckets without any authorization. Row level security (RLS) policies are still required for other operations such as object uploads and deletes."
+                      />
                     )}
-                  />
+                  </div>
                 </DialogSection>
-
-                {isPublicBucket && (
-                  <Admonition
-                    type="warning"
-                    className="rounded-none border-x-0 border-b-0 mb-0 [&>div>p]:!leading-normal"
-                    title="Public buckets are not protected"
-                    description={
-                      <>
-                        <p className="mb-2">
-                          Users can read objects in public buckets without any authorization.
-                        </p>
-                        <p>
-                          Row level security (RLS) policies are still required for other operations
-                          such as object uploads and deletes.
-                        </p>
-                      </>
-                    }
-                  />
-                )}
 
                 <DialogSectionSeparator />
 

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { snakeCase } from 'lodash'
-import { ChevronDown, Edit } from 'lucide-react'
+import { Edit } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -26,10 +26,6 @@ import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Button,
-  cn,
-  Collapsible_Shadcn_,
-  CollapsibleContent_Shadcn_,
-  CollapsibleTrigger_Shadcn_,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -122,7 +118,6 @@ const CreateBucketModal = () => {
   const formattedGlobalUploadLimit = `${value} ${unit}`
 
   const [selectedUnit, setSelectedUnit] = useState<string>(StorageSizeUnits.BYTES)
-  const [showConfiguration, setShowConfiguration] = useState(false)
 
   const form = useForm<CreateBucketForm>({
     resolver: zodResolver(FormSchema),
@@ -141,6 +136,7 @@ const CreateBucketModal = () => {
   const isStandardBucket = form.watch('type') === 'STANDARD'
   const hasFileSizeLimit = form.watch('has_file_size_limit')
   const formattedSizeLimit = form.watch('formatted_size_limit')
+  const [hasAllowedMimeTypes, setHasAllowedMimeTypes] = useState(false)
   const icebergWrapperExtensionState = useIcebergWrapperExtension()
   const icebergCatalogEnabled = data?.features?.icebergCatalog?.enabled
 
@@ -159,10 +155,11 @@ const CreateBucketModal = () => {
         ? convertToBytes(values.formatted_size_limit, selectedUnit as StorageSizeUnits)
         : undefined
 
-      const allowedMimeTypes =
-        values.allowed_mime_types.length > 0
+      const allowedMimeTypes = hasAllowedMimeTypes
+        ? values.allowed_mime_types.length > 0
           ? values.allowed_mime_types.split(',').map((x) => x.trim())
           : undefined
+        : undefined
 
       await createBucket({
         projectRef: ref,
@@ -183,7 +180,6 @@ const CreateBucketModal = () => {
       }
       form.reset()
       setSelectedUnit(StorageSizeUnits.BYTES)
-      setShowConfiguration(false)
       setVisible(false)
       toast.success(`Successfully created bucket ${values.name}`)
       router.push(`/project/${ref}/storage/buckets/${values.name}`)
@@ -196,7 +192,6 @@ const CreateBucketModal = () => {
   const handleClose = () => {
     form.reset()
     setSelectedUnit(StorageSizeUnits.BYTES)
-    setShowConfiguration(false)
     setVisible(false)
   }
 
@@ -364,107 +359,113 @@ const CreateBucketModal = () => {
                 <DialogSectionSeparator />
 
                 <DialogSection>
-                  <Collapsible_Shadcn_
-                    open={showConfiguration}
-                    onOpenChange={() => setShowConfiguration(!showConfiguration)}
-                  >
-                    <CollapsibleTrigger_Shadcn_ asChild>
-                      <button className="w-full cursor-pointer flex items-center justify-between">
-                        <p className="text-sm">Additional configuration</p>
-                        <ChevronDown
-                          size={18}
-                          strokeWidth={2}
-                          className={cn('text-foreground-light', showConfiguration && 'rotate-180')}
-                        />
-                      </button>
-                    </CollapsibleTrigger_Shadcn_>
-                    <CollapsibleContent_Shadcn_ className="pt-4 space-y-4">
-                      <div className="space-y-2">
-                        <FormField_Shadcn_
-                          key="has_file_size_limit"
-                          name="has_file_size_limit"
-                          control={form.control}
-                          render={({ field }) => (
-                            <FormItemLayout
-                              name="has_file_size_limit"
-                              label="Restrict file upload size for bucket"
-                              description="Prevent uploading of file sizes greater than a specified limit"
-                              layout="flex"
-                            >
-                              <FormControl_Shadcn_>
-                                <Switch
-                                  id="has_file_size_limit"
-                                  size="large"
-                                  checked={field.value}
-                                  onCheckedChange={field.onChange}
-                                />
-                              </FormControl_Shadcn_>
-                            </FormItemLayout>
-                          )}
-                        />
-                        {hasFileSizeLimit && (
-                          <div className="grid grid-cols-12 col-span-12 gap-x-2 gap-y-1">
-                            <div className="col-span-8">
-                              <FormField_Shadcn_
-                                key="formatted_size_limit"
-                                name="formatted_size_limit"
-                                control={form.control}
-                                render={({ field }) => (
-                                  <FormItemLayout
-                                    name="formatted_size_limit"
-                                    description={`Equivalent to ${convertToBytes(
-                                      formattedSizeLimit,
-                                      selectedUnit as StorageSizeUnits
-                                    ).toLocaleString()} bytes.`}
-                                  >
-                                    <FormControl_Shadcn_>
-                                      <Input_Shadcn_
-                                        id="formatted_size_limit"
-                                        aria-label="File size limit"
-                                        type="number"
-                                        min={0}
-                                        {...field}
-                                      />
-                                    </FormControl_Shadcn_>
-                                  </FormItemLayout>
-                                )}
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <FormField_Shadcn_
+                        key="has_file_size_limit"
+                        name="has_file_size_limit"
+                        control={form.control}
+                        render={({ field }) => (
+                          <FormItemLayout
+                            name="has_file_size_limit"
+                            label="Restrict file size"
+                            description="Prevent uploading of files larger than a specified limit"
+                            layout="flex"
+                          >
+                            <FormControl_Shadcn_>
+                              <Switch
+                                id="has_file_size_limit"
+                                size="large"
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
                               />
-                            </div>
-                            <Select_Shadcn_ value={selectedUnit} onValueChange={setSelectedUnit}>
-                              <SelectTrigger_Shadcn_
-                                aria-label="File size limit unit"
-                                size="small"
-                                className="col-span-4"
-                              >
-                                <SelectValue_Shadcn_ asChild>
-                                  <>{selectedUnit}</>
-                                </SelectValue_Shadcn_>
-                              </SelectTrigger_Shadcn_>
-                              <SelectContent_Shadcn_>
-                                {Object.values(StorageSizeUnits).map((unit: string) => (
-                                  <SelectItem_Shadcn_ key={unit} value={unit} className="text-xs">
-                                    <div>{unit}</div>
-                                  </SelectItem_Shadcn_>
-                                ))}
-                              </SelectContent_Shadcn_>
-                            </Select_Shadcn_>
-                            {IS_PLATFORM && (
-                              <div className="col-span-12">
-                                <p className="text-foreground-light text-sm">
-                                  Note: Individual bucket uploads will still be capped at the{' '}
-                                  <Link
-                                    href={`/project/${ref}/settings/storage`}
-                                    className="font-bold underline"
-                                  >
-                                    global upload limit
-                                  </Link>{' '}
-                                  of {formattedGlobalUploadLimit}
-                                </p>
-                              </div>
-                            )}
-                          </div>
+                            </FormControl_Shadcn_>
+                          </FormItemLayout>
                         )}
-                      </div>
+                      />
+                      {hasFileSizeLimit && (
+                        <div className="grid grid-cols-12 col-span-12 gap-x-2 gap-y-1">
+                          <div className="col-span-8">
+                            <FormField_Shadcn_
+                              key="formatted_size_limit"
+                              name="formatted_size_limit"
+                              control={form.control}
+                              render={({ field }) => (
+                                <FormItemLayout
+                                  name="formatted_size_limit"
+                                  description={
+                                    IS_PLATFORM ? (
+                                      <>
+                                        This project has a{' '}
+                                        <Link
+                                          href={`/project/${ref}/settings/storage`}
+                                          className="font-bold underline"
+                                        >
+                                          global file size limit
+                                        </Link>{' '}
+                                        of {formattedGlobalUploadLimit}.
+                                      </>
+                                    ) : undefined
+                                  }
+                                >
+                                  <FormControl_Shadcn_>
+                                    <Input_Shadcn_
+                                      id="formatted_size_limit"
+                                      aria-label="File size limit"
+                                      type="number"
+                                      min={0}
+                                      placeholder="0"
+                                      {...field}
+                                    />
+                                  </FormControl_Shadcn_>
+                                </FormItemLayout>
+                              )}
+                            />
+                          </div>
+                          <Select_Shadcn_ value={selectedUnit} onValueChange={setSelectedUnit}>
+                            <SelectTrigger_Shadcn_
+                              aria-label="File size limit unit"
+                              size="small"
+                              className="col-span-4"
+                            >
+                              <SelectValue_Shadcn_ asChild>
+                                <>{selectedUnit}</>
+                              </SelectValue_Shadcn_>
+                            </SelectTrigger_Shadcn_>
+                            <SelectContent_Shadcn_>
+                              {Object.values(StorageSizeUnits).map((unit: string) => (
+                                <SelectItem_Shadcn_ key={unit} value={unit} className="text-xs">
+                                  <div>{unit}</div>
+                                </SelectItem_Shadcn_>
+                              ))}
+                            </SelectContent_Shadcn_>
+                          </Select_Shadcn_>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </DialogSection>
+
+                <DialogSectionSeparator />
+
+                <DialogSection>
+                  <div className="space-y-2">
+                    <FormItemLayout
+                      name="has_allowed_mime_types"
+                      label="Restrict MIME types"
+                      description="Allow only certain types of files to be uploaded"
+                      layout="flex"
+                    >
+                      <FormControl_Shadcn_>
+                        <Switch
+                          id="has_allowed_mime_types"
+                          size="large"
+                          checked={hasAllowedMimeTypes}
+                          onCheckedChange={setHasAllowedMimeTypes}
+                        />
+                      </FormControl_Shadcn_>
+                    </FormItemLayout>
+                    {hasAllowedMimeTypes && (
                       <FormField_Shadcn_
                         key="allowed_mime_types"
                         name="allowed_mime_types"
@@ -474,7 +475,7 @@ const CreateBucketModal = () => {
                             name="allowed_mime_types"
                             label="Allowed MIME types"
                             labelOptional="Comma separated values"
-                            description="Wildcards are allowed, e.g. image/*. Leave blank to allow any MIME type."
+                            description="Wildcards are allowed, e.g. image/*."
                           >
                             <FormControl_Shadcn_>
                               <Input_Shadcn_
@@ -486,8 +487,8 @@ const CreateBucketModal = () => {
                           </FormItemLayout>
                         )}
                       />
-                    </CollapsibleContent_Shadcn_>
-                  </Collapsible_Shadcn_>
+                    )}
+                  </div>
                 </DialogSection>
               </>
             ) : (

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -317,185 +317,190 @@ const CreateBucketModal = () => {
 
             {isStandardBucket ? (
               <>
-                <DialogSection>
-                  {/* Visibility */}
-                  <div className="flex flex-col gap-y-2">
+                {/* Visibility */}
+                <DialogSection className="space-y-3">
+                  <FormField_Shadcn_
+                    key="public"
+                    name="public"
+                    control={form.control}
+                    render={({ field }) => (
+                      <FormItemLayout
+                        hideMessage
+                        name="public"
+                        label="Public bucket"
+                        description="Allow anyone to read objects without authorization"
+                        layout="flex"
+                      >
+                        <FormControl_Shadcn_>
+                          <Switch
+                            id="public"
+                            size="large"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl_Shadcn_>
+                      </FormItemLayout>
+                    )}
+                  />
+                  {isPublicBucket && (
+                    <Admonition
+                      type="warning"
+                      title="Public buckets are not protected"
+                      description="Users can read objects in public buckets without any authorization. Row level security (RLS) policies are still required for other operations such as object uploads and deletes."
+                    />
+                  )}
+                </DialogSection>
+
+                <DialogSectionSeparator />
+
+                <DialogSection className="space-y-2">
+                  <FormField_Shadcn_
+                    key="has_file_size_limit"
+                    name="has_file_size_limit"
+                    control={form.control}
+                    render={({ field }) => (
+                      <FormItemLayout
+                        name="has_file_size_limit"
+                        label="Restrict file size"
+                        description="Prevent uploading of files larger than a specified limit"
+                        layout="flex"
+                      >
+                        <FormControl_Shadcn_>
+                          <Switch
+                            id="has_file_size_limit"
+                            size="large"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl_Shadcn_>
+                      </FormItemLayout>
+                    )}
+                  />
+                  {hasFileSizeLimit && (
+                    <div>
+                      <FormField_Shadcn_
+                        key="formatted_size_limit"
+                        name="formatted_size_limit"
+                        control={form.control}
+                        render={({ field }) => (
+                          <FormItemLayout
+                            hideMessage
+                            name="formatted_size_limit"
+                            label="File size limit"
+                          >
+                            <div className="grid grid-cols-12 gap-x-2">
+                              <div className="col-span-8">
+                                <FormControl_Shadcn_>
+                                  <Input_Shadcn_
+                                    id="formatted_size_limit"
+                                    aria-label="File size limit"
+                                    type="number"
+                                    min={0}
+                                    placeholder="0"
+                                    {...field}
+                                  />
+                                </FormControl_Shadcn_>
+                              </div>
+                              <div className="col-span-4">
+                                <Select_Shadcn_
+                                  value={selectedUnit}
+                                  onValueChange={setSelectedUnit}
+                                >
+                                  <SelectTrigger_Shadcn_
+                                    aria-label="File size limit unit"
+                                    size="small"
+                                  >
+                                    <SelectValue_Shadcn_ asChild>
+                                      <>{selectedUnit}</>
+                                    </SelectValue_Shadcn_>
+                                  </SelectTrigger_Shadcn_>
+                                  <SelectContent_Shadcn_>
+                                    {Object.values(StorageSizeUnits).map((unit: string) => (
+                                      <SelectItem_Shadcn_
+                                        key={unit}
+                                        value={unit}
+                                        className="text-xs"
+                                      >
+                                        <div>{unit}</div>
+                                      </SelectItem_Shadcn_>
+                                    ))}
+                                  </SelectContent_Shadcn_>
+                                </Select_Shadcn_>
+                              </div>
+                            </div>
+                          </FormItemLayout>
+                        )}
+                      />
+                      {formattedSizeLimitError?.message === 'exceed_global_limit' && (
+                        <FormMessage_Shadcn_ className="mt-2">
+                          Exceeds global limit of {formattedGlobalUploadLimit}. Increase limit in{' '}
+                          <InlineLink
+                            className="text-destructive decoration-destructive-500 hover:decoration-destructive"
+                            href={`/project/${ref}/settings/storage`}
+                          >
+                            Storage Settings
+                          </InlineLink>{' '}
+                          first.
+                        </FormMessage_Shadcn_>
+                      )}
+
+                      {IS_PLATFORM ? (
+                        <p className="text-sm text-foreground-lighter mt-2">
+                          This project has a{' '}
+                          <InlineLink
+                            className="text-foreground-light hover:text-foreground"
+                            href={`/project/${ref}/settings/storage`}
+                          >
+                            global file size limit
+                          </InlineLink>{' '}
+                          of {formattedGlobalUploadLimit}.
+                        </p>
+                      ) : undefined}
+                    </div>
+                  )}
+                </DialogSection>
+
+                <DialogSectionSeparator />
+
+                <DialogSection className="space-y-2">
+                  <FormItemLayout
+                    name="has_allowed_mime_types"
+                    label="Restrict MIME types"
+                    description="Allow only certain types of files to be uploaded"
+                    layout="flex"
+                  >
+                    <FormControl_Shadcn_>
+                      <Switch
+                        id="has_allowed_mime_types"
+                        size="large"
+                        checked={hasAllowedMimeTypes}
+                        onCheckedChange={setHasAllowedMimeTypes}
+                      />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                  {hasAllowedMimeTypes && (
                     <FormField_Shadcn_
-                      key="public"
-                      name="public"
+                      key="allowed_mime_types"
+                      name="allowed_mime_types"
                       control={form.control}
                       render={({ field }) => (
                         <FormItemLayout
-                          hideMessage
-                          name="public"
-                          label="Public bucket"
-                          description="Allow anyone to read objects without authorization"
-                          layout="flex"
+                          name="allowed_mime_types"
+                          label="Allowed MIME types"
+                          labelOptional="Comma separated values"
+                          description="Wildcards are allowed, e.g. image/*."
                         >
                           <FormControl_Shadcn_>
-                            <Switch
-                              id="public"
-                              size="large"
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
+                            <Input_Shadcn_
+                              id="allowed_mime_types"
+                              {...field}
+                              placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
                             />
                           </FormControl_Shadcn_>
                         </FormItemLayout>
                       )}
                     />
-                    {isPublicBucket && (
-                      <Admonition
-                        type="warning"
-                        title="Public buckets are not protected"
-                        description="Users can read objects in public buckets without any authorization. Row level security (RLS) policies are still required for other operations such as object uploads and deletes."
-                      />
-                    )}
-                  </div>
-                </DialogSection>
-
-                <DialogSectionSeparator />
-
-                <DialogSection>
-                  <div className="space-y-4">
-                    <div className="space-y-2">
-                      <FormField_Shadcn_
-                        key="has_file_size_limit"
-                        name="has_file_size_limit"
-                        control={form.control}
-                        render={({ field }) => (
-                          <FormItemLayout
-                            name="has_file_size_limit"
-                            label="Restrict file size"
-                            description="Prevent uploading of files larger than a specified limit"
-                            layout="flex"
-                          >
-                            <FormControl_Shadcn_>
-                              <Switch
-                                id="has_file_size_limit"
-                                size="large"
-                                checked={field.value}
-                                onCheckedChange={field.onChange}
-                              />
-                            </FormControl_Shadcn_>
-                          </FormItemLayout>
-                        )}
-                      />
-                      {hasFileSizeLimit && (
-                        <>
-                          <div className="grid grid-cols-12 col-span-12 gap-x-2 gap-y-1">
-                            <div className="col-span-8">
-                              <FormField_Shadcn_
-                                key="formatted_size_limit"
-                                name="formatted_size_limit"
-                                control={form.control}
-                                render={({ field }) => (
-                                  <FormItemLayout hideMessage name="formatted_size_limit">
-                                    <FormControl_Shadcn_>
-                                      <Input_Shadcn_
-                                        id="formatted_size_limit"
-                                        aria-label="File size limit"
-                                        type="number"
-                                        min={0}
-                                        placeholder="0"
-                                        {...field}
-                                      />
-                                    </FormControl_Shadcn_>
-                                  </FormItemLayout>
-                                )}
-                              />
-                            </div>
-                            <Select_Shadcn_ value={selectedUnit} onValueChange={setSelectedUnit}>
-                              <SelectTrigger_Shadcn_
-                                aria-label="File size limit unit"
-                                size="small"
-                                className="col-span-4"
-                              >
-                                <SelectValue_Shadcn_ asChild>
-                                  <>{selectedUnit}</>
-                                </SelectValue_Shadcn_>
-                              </SelectTrigger_Shadcn_>
-                              <SelectContent_Shadcn_>
-                                {Object.values(StorageSizeUnits).map((unit: string) => (
-                                  <SelectItem_Shadcn_ key={unit} value={unit} className="text-xs">
-                                    <div>{unit}</div>
-                                  </SelectItem_Shadcn_>
-                                ))}
-                              </SelectContent_Shadcn_>
-                            </Select_Shadcn_>
-                          </div>
-
-                          {formattedSizeLimitError?.message === 'exceed_global_limit' && (
-                            <FormMessage_Shadcn_>
-                              Exceeds global limit of {formattedGlobalUploadLimit}. Increase limit
-                              in{' '}
-                              <InlineLink
-                                className="text-destructive decoration-destructive-500 hover:decoration-destructive"
-                                href={`/project/${ref}/settings/storage`}
-                              >
-                                Storage Settings
-                              </InlineLink>{' '}
-                              first.
-                            </FormMessage_Shadcn_>
-                          )}
-
-                          {IS_PLATFORM ? (
-                            <p className="text-sm text-foreground-light !mt-3">
-                              This project has a{' '}
-                              <InlineLink href={`/project/${ref}/settings/storage`}>
-                                global file size limit
-                              </InlineLink>{' '}
-                              of {formattedGlobalUploadLimit}.
-                            </p>
-                          ) : undefined}
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </DialogSection>
-
-                <DialogSectionSeparator />
-
-                <DialogSection>
-                  <div className="space-y-2">
-                    <FormItemLayout
-                      name="has_allowed_mime_types"
-                      label="Restrict MIME types"
-                      description="Allow only certain types of files to be uploaded"
-                      layout="flex"
-                    >
-                      <FormControl_Shadcn_>
-                        <Switch
-                          id="has_allowed_mime_types"
-                          size="large"
-                          checked={hasAllowedMimeTypes}
-                          onCheckedChange={setHasAllowedMimeTypes}
-                        />
-                      </FormControl_Shadcn_>
-                    </FormItemLayout>
-                    {hasAllowedMimeTypes && (
-                      <FormField_Shadcn_
-                        key="allowed_mime_types"
-                        name="allowed_mime_types"
-                        control={form.control}
-                        render={({ field }) => (
-                          <FormItemLayout
-                            name="allowed_mime_types"
-                            label="Allowed MIME types"
-                            labelOptional="Comma separated values"
-                            description="Wildcards are allowed, e.g. image/*."
-                          >
-                            <FormControl_Shadcn_>
-                              <Input_Shadcn_
-                                id="allowed_mime_types"
-                                {...field}
-                                placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
-                              />
-                            </FormControl_Shadcn_>
-                          </FormItemLayout>
-                        )}
-                      />
-                    )}
-                  </div>
+                  )}
                 </DialogSection>
               </>
             ) : (

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -92,10 +92,10 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
   const isPublicBucket = form.watch('public')
   const hasFileSizeLimit = form.watch('has_file_size_limit')
-  const formattedSizeLimit = form.watch('formatted_size_limit')
   const [hasAllowedMimeTypes, setHasAllowedMimeTypes] = useState(
-    isNonNullable(bucket?.allowed_mime_types?.length)
+    Boolean(bucket?.allowed_mime_types?.length)
   )
+
   const isChangingBucketVisibility = bucket?.public !== isPublicBucket
   const isMakingBucketPrivate = bucket?.public && !isPublicBucket
   const isMakingBucketPublic = !bucket?.public && isPublicBucket

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -212,7 +212,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
         <Form_Shadcn_ {...form}>
           <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-            <DialogSection className="flex flex-col gap-y-6">
+            <DialogSection className="space-y-6">
               <FormField_Shadcn_
                 key="name"
                 name="name"
@@ -232,13 +232,14 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
               />
 
               {/* Visibility */}
-              <div className="flex flex-col gap-y-2">
+              <div className="flex flex-col gap-y-3">
                 <FormField_Shadcn_
                   key="public"
                   name="public"
                   control={form.control}
                   render={({ field }) => (
                     <FormItemLayout
+                      hideMessage
                       name="public"
                       label="Public bucket"
                       description="Allow anyone to read objects without authorization"
@@ -270,7 +271,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                           <>
                             <p className="mb-2">
                               All objects in your bucket will be private and only accessible via
-                              signed URLs, or downloaded with the right authorisation headers.
+                              signed URLs, or downloaded with the right authorization headers.
                             </p>
                             <p>
                               Assets cached in the CDN may still be publicly accessible. You can
@@ -291,160 +292,144 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
             <DialogSectionSeparator />
 
-            <DialogSection>
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <FormField_Shadcn_
-                    key="has_file_size_limit"
+            <DialogSection className="space-y-2">
+              <FormField_Shadcn_
+                key="has_file_size_limit"
+                name="has_file_size_limit"
+                control={form.control}
+                render={({ field }) => (
+                  <FormItemLayout
                     name="has_file_size_limit"
+                    label="Restrict file size"
+                    description="Prevent uploading of files larger than a specified limit"
+                    layout="flex"
+                  >
+                    <FormControl_Shadcn_>
+                      <Switch
+                        id="has_file_size_limit"
+                        size="large"
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                )}
+              />
+              {hasFileSizeLimit && (
+                <div>
+                  <FormField_Shadcn_
+                    key="formatted_size_limit"
+                    name="formatted_size_limit"
                     control={form.control}
                     render={({ field }) => (
                       <FormItemLayout
-                        name="has_file_size_limit"
-                        label="Restrict file size"
-                        description="Prevent uploading of files larger than a specified limit"
-                        layout="flex"
+                        hideMessage
+                        name="formatted_size_limit"
+                        label="File size limit"
                       >
-                        <FormControl_Shadcn_>
-                          <Switch
-                            id="has_file_size_limit"
-                            size="large"
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                          />
-                        </FormControl_Shadcn_>
+                        <div className="grid grid-cols-12 gap-x-2">
+                          <div className="col-span-8">
+                            <FormControl_Shadcn_>
+                              <Input_Shadcn_
+                                id="formatted_size_limit"
+                                aria-label="File size limit"
+                                type="number"
+                                min={0}
+                                placeholder="0"
+                                {...field}
+                              />
+                            </FormControl_Shadcn_>
+                          </div>
+                          <div className="col-span-4">
+                            <Select_Shadcn_ value={selectedUnit} onValueChange={setSelectedUnit}>
+                              <SelectTrigger_Shadcn_ aria-label="File size limit unit" size="small">
+                                <SelectValue_Shadcn_ asChild>
+                                  <>{selectedUnit}</>
+                                </SelectValue_Shadcn_>
+                              </SelectTrigger_Shadcn_>
+                              <SelectContent_Shadcn_>
+                                {Object.values(StorageSizeUnits).map((unit: string) => (
+                                  <SelectItem_Shadcn_ key={unit} value={unit} className="text-xs">
+                                    <div>{unit}</div>
+                                  </SelectItem_Shadcn_>
+                                ))}
+                              </SelectContent_Shadcn_>
+                            </Select_Shadcn_>
+                          </div>
+                        </div>
                       </FormItemLayout>
                     )}
                   />
-                  {hasFileSizeLimit && (
-                    <div>
-                      <FormField_Shadcn_
-                        key="formatted_size_limit"
-                        name="formatted_size_limit"
-                        control={form.control}
-                        render={({ field }) => (
-                          <FormItemLayout
-                            name="formatted_size_limit"
-                            label="File size limit"
-                            hideMessage
-                          >
-                            <div className="grid grid-cols-12 gap-x-2">
-                              <div className="col-span-8">
-                                <FormControl_Shadcn_>
-                                  <Input_Shadcn_
-                                    id="formatted_size_limit"
-                                    aria-label="File size limit"
-                                    type="number"
-                                    min={0}
-                                    placeholder="0"
-                                    {...field}
-                                  />
-                                </FormControl_Shadcn_>
-                              </div>
-                              <div className="col-span-4">
-                                <Select_Shadcn_
-                                  value={selectedUnit}
-                                  onValueChange={setSelectedUnit}
-                                >
-                                  <SelectTrigger_Shadcn_
-                                    aria-label="File size limit unit"
-                                    size="small"
-                                  >
-                                    <SelectValue_Shadcn_ asChild>
-                                      <>{selectedUnit}</>
-                                    </SelectValue_Shadcn_>
-                                  </SelectTrigger_Shadcn_>
-                                  <SelectContent_Shadcn_>
-                                    {Object.values(StorageSizeUnits).map((unit: string) => (
-                                      <SelectItem_Shadcn_
-                                        key={unit}
-                                        value={unit}
-                                        className="text-xs"
-                                      >
-                                        <div>{unit}</div>
-                                      </SelectItem_Shadcn_>
-                                    ))}
-                                  </SelectContent_Shadcn_>
-                                </Select_Shadcn_>
-                              </div>
-                            </div>
-                          </FormItemLayout>
-                        )}
-                      />
-                      {formattedSizeLimitError?.message === 'exceed_global_limit' && (
-                        <FormMessage_Shadcn_ className="mt-2">
-                          Exceeds global limit of {formattedGlobalUploadLimit}. Increase limit in{' '}
-                          <InlineLink
-                            className="text-destructive decoration-destructive-500 hover:decoration-destructive"
-                            href={`/project/${ref}/settings/storage`}
-                          >
-                            Storage Settings
-                          </InlineLink>{' '}
-                          first.
-                        </FormMessage_Shadcn_>
-                      )}
-
-                      {IS_PLATFORM ? (
-                        <p className="text-sm text-foreground-lighter mt-2">
-                          This project has a{' '}
-                          <InlineLink
-                            className="text-foreground-light hover:text-foreground"
-                            href={`/project/${ref}/settings/storage`}
-                          >
-                            global file size limit
-                          </InlineLink>{' '}
-                          of {formattedGlobalUploadLimit}.
-                        </p>
-                      ) : undefined}
-                    </div>
+                  {formattedSizeLimitError?.message === 'exceed_global_limit' && (
+                    <FormMessage_Shadcn_ className="mt-2">
+                      Exceeds global limit of {formattedGlobalUploadLimit}. Increase limit in{' '}
+                      <InlineLink
+                        className="text-destructive decoration-destructive-500 hover:decoration-destructive"
+                        href={`/project/${ref}/settings/storage`}
+                      >
+                        Storage Settings
+                      </InlineLink>{' '}
+                      first.
+                    </FormMessage_Shadcn_>
                   )}
+
+                  {IS_PLATFORM ? (
+                    <p className="text-sm text-foreground-lighter mt-2">
+                      This project has a{' '}
+                      <InlineLink
+                        className="text-foreground-light hover:text-foreground"
+                        href={`/project/${ref}/settings/storage`}
+                      >
+                        global file size limit
+                      </InlineLink>{' '}
+                      of {formattedGlobalUploadLimit}.
+                    </p>
+                  ) : undefined}
                 </div>
-              </div>
+              )}
             </DialogSection>
 
             <DialogSectionSeparator />
 
-            <DialogSection>
-              <div className="space-y-2">
-                <FormItemLayout
-                  name="has_allowed_mime_types"
-                  label="Restrict MIME types"
-                  description="Allow only certain types of files to be uploaded"
-                  layout="flex"
-                >
-                  <FormControl_Shadcn_>
-                    <Switch
-                      id="has_allowed_mime_types"
-                      size="large"
-                      checked={hasAllowedMimeTypes}
-                      onCheckedChange={setHasAllowedMimeTypes}
-                    />
-                  </FormControl_Shadcn_>
-                </FormItemLayout>
-                {hasAllowedMimeTypes && (
-                  <FormField_Shadcn_
-                    key="allowed_mime_types"
-                    name="allowed_mime_types"
-                    control={form.control}
-                    render={({ field }) => (
-                      <FormItemLayout
-                        name="allowed_mime_types"
-                        label="Allowed MIME types"
-                        labelOptional="Comma separated values"
-                        description="Wildcards are allowed, e.g. image/*."
-                      >
-                        <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            id="allowed_mime_types"
-                            {...field}
-                            placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
-                          />
-                        </FormControl_Shadcn_>
-                      </FormItemLayout>
-                    )}
+            <DialogSection className="space-y-2">
+              <FormItemLayout
+                name="has_allowed_mime_types"
+                label="Restrict MIME types"
+                description="Allow only certain types of files to be uploaded"
+                layout="flex"
+              >
+                <FormControl_Shadcn_>
+                  <Switch
+                    id="has_allowed_mime_types"
+                    size="large"
+                    checked={hasAllowedMimeTypes}
+                    onCheckedChange={setHasAllowedMimeTypes}
                   />
-                )}
-              </div>
+                </FormControl_Shadcn_>
+              </FormItemLayout>
+              {hasAllowedMimeTypes && (
+                <FormField_Shadcn_
+                  key="allowed_mime_types"
+                  name="allowed_mime_types"
+                  control={form.control}
+                  render={({ field }) => (
+                    <FormItemLayout
+                      name="allowed_mime_types"
+                      label="Allowed MIME types"
+                      labelOptional="Comma separated values"
+                      description="Wildcards are allowed, e.g. image/*."
+                    >
+                      <FormControl_Shadcn_>
+                        <Input_Shadcn_
+                          id="allowed_mime_types"
+                          {...field}
+                          placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
+                        />
+                      </FormControl_Shadcn_>
+                    </FormItemLayout>
+                  )}
+                />
+              )}
             </DialogSection>
           </form>
         </Form_Shadcn_>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useParams } from 'common'
 import { ChevronDown } from 'lucide-react'
-import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { type SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -255,8 +254,8 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                       render={({ field }) => (
                         <FormItemLayout
                           name="has_file_size_limit"
-                          label="Restrict file upload size for bucket"
-                          description="Prevent uploading of file sizes greater than a specified limit"
+                          label="Restrict file size"
+                          description="Prevent uploading of files larger than a specified limit"
                           layout="flex"
                         >
                           <FormControl_Shadcn_>
@@ -280,10 +279,20 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                             render={({ field }) => (
                               <FormItemLayout
                                 name="formatted_size_limit"
-                                description={`Equivalent to ${convertToBytes(
-                                  formattedSizeLimit,
-                                  selectedUnit as StorageSizeUnits
-                                ).toLocaleString()} bytes.`}
+                                description={
+                                  IS_PLATFORM ? (
+                                    <>
+                                      This project has a{' '}
+                                      <InlineLink
+                                        href={`/project/${ref}/settings/storage`}
+                                        className="font-bold underline"
+                                      >
+                                        global file size limit
+                                      </InlineLink>{' '}
+                                      of {formattedGlobalUploadLimit}.
+                                    </>
+                                  ) : undefined
+                                }
                               >
                                 <FormControl_Shadcn_>
                                   <Input_Shadcn_
@@ -316,20 +325,6 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                             ))}
                           </SelectContent_Shadcn_>
                         </Select_Shadcn_>
-                        {IS_PLATFORM && (
-                          <div className="col-span-12 mt-2">
-                            <p className="text-foreground-light text-sm">
-                              Note: Individual bucket upload will still be capped at the{' '}
-                              <Link
-                                href={`/project/${ref}/settings/storage`}
-                                className="font-bold underline"
-                              >
-                                global upload limit
-                              </Link>{' '}
-                              of {formattedGlobalUploadLimit}
-                            </p>
-                          </div>
-                        )}
                       </div>
                     )}
                   </div>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -1,8 +1,20 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useParams } from 'common'
 import { useEffect, useRef, useState } from 'react'
 import { type SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { useParams } from 'common'
+import { StorageSizeUnits } from 'components/interfaces/Storage/StorageSettings/StorageSettings.constants'
+import {
+  convertFromBytes,
+  convertToBytes,
+} from 'components/interfaces/Storage/StorageSettings/StorageSettings.utils'
+import { InlineLink } from 'components/ui/InlineLink'
+import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
+import { updateBucket } from 'data/storage/bucket-update-mutation'
+import { Bucket } from 'data/storage/buckets-query'
+import { IS_PLATFORM } from 'lib/constants'
 import {
   Button,
   Dialog,
@@ -24,18 +36,6 @@ import {
   Select_Shadcn_,
   Switch,
 } from 'ui'
-import { z } from 'zod'
-
-import { StorageSizeUnits } from 'components/interfaces/Storage/StorageSettings/StorageSettings.constants'
-import {
-  convertFromBytes,
-  convertToBytes,
-} from 'components/interfaces/Storage/StorageSettings/StorageSettings.utils'
-import { InlineLink } from 'components/ui/InlineLink'
-import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
-import { updateBucket } from 'data/storage/bucket-update-mutation'
-import { Bucket } from 'data/storage/buckets-query'
-import { IS_PLATFORM } from 'lib/constants'
 import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
@@ -365,7 +365,8 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                       Exceeds global limit of {formattedGlobalUploadLimit}. Increase limit in{' '}
                       <InlineLink
                         className="text-destructive decoration-destructive-500 hover:decoration-destructive"
-                        href={`/project/${ref}/settings/storage`}
+                        href={`/project/${ref}/storage/settings`}
+                        onClick={onClose}
                       >
                         Storage Settings
                       </InlineLink>{' '}
@@ -378,7 +379,8 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                       This project has a{' '}
                       <InlineLink
                         className="text-foreground-light hover:text-foreground"
-                        href={`/project/${ref}/settings/storage`}
+                        href={`/project/${ref}/storage/settings`}
+                        onClick={onClose}
                       >
                         global file size limit
                       </InlineLink>{' '}

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -370,54 +370,59 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                     </div>
                   )}
                 </div>
-                <div className="space-y-2">
-                  <FormItemLayout
-                    name="has_allowed_mime_types"
-                    label="Restrict MIME types"
-                    description="Allow only certain types of files to be uploaded"
-                    layout="flex"
-                  >
-                    <FormControl_Shadcn_>
-                      <Switch
-                        id="has_allowed_mime_types"
-                        size="large"
-                        checked={hasAllowedMimeTypes}
-                        onCheckedChange={setHasAllowedMimeTypes}
-                      />
-                    </FormControl_Shadcn_>
-                  </FormItemLayout>
-                  {hasAllowedMimeTypes && (
-                    <FormField_Shadcn_
-                      key="allowed_mime_types"
-                      name="allowed_mime_types"
-                      control={form.control}
-                      render={({ field }) => (
-                        <FormItemLayout
-                          name="allowed_mime_types"
-                          label="Allowed MIME types"
-                          labelOptional="Comma separated values"
-                          description={
-                            form.formState.errors.allowed_mime_types ? (
-                              <span className="text-destructive">
-                                {form.formState.errors.allowed_mime_types.message}
-                              </span>
-                            ) : (
-                              'Wildcards are allowed, e.g. image/*.'
-                            )
-                          }
-                        >
-                          <FormControl_Shadcn_>
-                            <Input_Shadcn_
-                              id="allowed_mime_types"
-                              {...field}
-                              placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
-                            />
-                          </FormControl_Shadcn_>
-                        </FormItemLayout>
-                      )}
+              </div>
+            </DialogSection>
+
+            <DialogSectionSeparator />
+
+            <DialogSection>
+              <div className="space-y-2">
+                <FormItemLayout
+                  name="has_allowed_mime_types"
+                  label="Restrict MIME types"
+                  description="Allow only certain types of files to be uploaded"
+                  layout="flex"
+                >
+                  <FormControl_Shadcn_>
+                    <Switch
+                      id="has_allowed_mime_types"
+                      size="large"
+                      checked={hasAllowedMimeTypes}
+                      onCheckedChange={setHasAllowedMimeTypes}
                     />
-                  )}
-                </div>
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+                {hasAllowedMimeTypes && (
+                  <FormField_Shadcn_
+                    key="allowed_mime_types"
+                    name="allowed_mime_types"
+                    control={form.control}
+                    render={({ field }) => (
+                      <FormItemLayout
+                        name="allowed_mime_types"
+                        label="Allowed MIME types"
+                        labelOptional="Comma separated values"
+                        description={
+                          form.formState.errors.allowed_mime_types ? (
+                            <span className="text-destructive">
+                              {form.formState.errors.allowed_mime_types.message}
+                            </span>
+                          ) : (
+                            'Wildcards are allowed, e.g. image/*.'
+                          )
+                        }
+                      >
+                        <FormControl_Shadcn_>
+                          <Input_Shadcn_
+                            id="allowed_mime_types"
+                            {...field}
+                            placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
+                          />
+                        </FormControl_Shadcn_>
+                      </FormItemLayout>
+                    )}
+                  />
+                )}
               </div>
             </DialogSection>
           </form>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -223,7 +223,6 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                 )}
               />
 
-              {/* Visibility */}
               <div className="flex flex-col gap-y-3">
                 <FormField_Shadcn_
                   key="public"
@@ -261,11 +260,11 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
                         {isMakingBucketPrivate && (
                           <>
-                            <p className="mb-2">
-                              All objects in your bucket will be private and only accessible via
-                              signed URLs, or downloaded with the right authorization headers.
+                            <p className="mb-2 !leading-normal">
+                              All objects in your bucket will only accessible via signed URLs, or
+                              downloaded with the right authorization headers.
                             </p>
-                            <p>
+                            <p className="!leading-normal">
                               Assets cached in the CDN may still be publicly accessible. You can
                               consider{' '}
                               <InlineLink href="https://supabase.com/docs/guides/storage/cdn/smart-cdn#cache-eviction">
@@ -335,14 +334,12 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                           <div className="col-span-4">
                             <Select_Shadcn_ value={selectedUnit} onValueChange={setSelectedUnit}>
                               <SelectTrigger_Shadcn_ aria-label="File size limit unit" size="small">
-                                <SelectValue_Shadcn_ asChild>
-                                  <>{selectedUnit}</>
-                                </SelectValue_Shadcn_>
+                                <SelectValue_Shadcn_>{selectedUnit}</SelectValue_Shadcn_>
                               </SelectTrigger_Shadcn_>
                               <SelectContent_Shadcn_>
                                 {Object.values(StorageSizeUnits).map((unit: string) => (
                                   <SelectItem_Shadcn_ key={unit} value={unit} className="text-xs">
-                                    <div>{unit}</div>
+                                    {unit}
                                   </SelectItem_Shadcn_>
                                 ))}
                               </SelectContent_Shadcn_>
@@ -366,7 +363,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                     </FormMessage_Shadcn_>
                   )}
 
-                  {IS_PLATFORM ? (
+                  {IS_PLATFORM && (
                     <p className="text-sm text-foreground-lighter mt-2">
                       This project has a{' '}
                       <InlineLink
@@ -378,7 +375,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                       </InlineLink>{' '}
                       of {formattedGlobalUploadLimit}.
                     </p>
-                  ) : undefined}
+                  )}
                 </div>
               )}
             </DialogSection>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -136,18 +136,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
           // Set form error for the file size limit field
           form.setError('formatted_size_limit', {
             type: 'manual',
-            message: (
-              <span>
-                Exceeds the{' '}
-                <Link
-                  href={`/project/${ref}/settings/storage`}
-                  className="font-bold underline text-destructive underline-destructive"
-                >
-                  global file size limit
-                </Link>{' '}
-                of ${formattedGlobalUploadLimit}.
-              </span>
-            ),
+            message: `Exceeds global limit of ${formattedGlobalUploadLimit}.`,
           })
         } else if (
           errorMessage.includes('mime type') &&
@@ -332,18 +321,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                             <FormItemLayout
                               name="formatted_size_limit"
                               description={
-                                form.formState.errors.formatted_size_limit ? (
-                                  <span className="text-destructive">
-                                    Exceeds the{' '}
-                                    <Link
-                                      href={`/project/${ref}/settings/storage`}
-                                      className="font-bold underline text-destructive underline-destructive"
-                                    >
-                                      global file size limit
-                                    </Link>{' '}
-                                    of {formattedGlobalUploadLimit}.{' '}
-                                  </span>
-                                ) : IS_PLATFORM ? (
+                                IS_PLATFORM ? (
                                   <>
                                     This project has a{' '}
                                     <Link

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -69,6 +69,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
   const [selectedUnit, setSelectedUnit] = useState<string>(StorageSizeUnits.BYTES)
   const { value: fileSizeLimit } = convertFromBytes(bucket?.file_size_limit ?? 0)
+  const bucketIdRef = useRef<string | null>(null)
 
   const form = useForm<z.infer<typeof BucketSchema>>({
     resolver: zodResolver(BucketSchema),
@@ -167,8 +168,13 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
   useEffect(() => {
     if (visible && bucket) {
-      const { unit } = convertFromBytes(bucket.file_size_limit ?? 0)
-      setSelectedUnit(unit)
+      // Only set the selectedUnit when the bucket changes (different bucket ID)
+      // This preserves the user's unit selection when reopening the modal for the same bucket
+      if (bucketIdRef.current !== bucket.id) {
+        const { unit } = convertFromBytes(bucket.file_size_limit ?? 0)
+        setSelectedUnit(unit)
+        bucketIdRef.current = bucket.id
+      }
       // Clear errors when modal opens
       form.clearErrors()
     }

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -182,8 +182,8 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
     if (visible && bucket) {
       // Only set the selectedUnit when the bucket changes (different bucket ID)
       // This preserves the user's unit selection when reopening the modal for the same bucket
-      if (bucketIdRef.current !== bucket.id) {
-        const { unit } = convertFromBytes(bucket.file_size_limit ?? 0)
+      if (bucketIdRef.current !== bucket.id && bucket.file_size_limit) {
+        const { unit } = convertFromBytes(bucket.file_size_limit)
         setSelectedUnit(unit)
         bucketIdRef.current = bucket.id
       }

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -104,6 +104,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
     setIsUpdating(true)
 
     // Client-side validation: Check if bucket limit exceeds global limit
+    // [Joshen] Should shift this into superRefine in the form schema
     if (
       values.has_file_size_limit &&
       values.formatted_size_limit !== undefined &&
@@ -169,10 +170,9 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
         toast.success(`Successfully updated bucket "${bucket?.name}"`)
         onClose()
       }
-    } catch (error) {
+    } catch (error: any) {
       // This should not happen anymore, but keeping as fallback
-      console.error('Unexpected error:', error)
-      toast.error('An unexpected error occurred')
+      toast.error(`Failed to update bucket: ${error.message}`)
     } finally {
       setIsUpdating(false)
     }

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -212,7 +212,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
 
         <Form_Shadcn_ {...form}>
           <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-            <DialogSection className="flex flex-col gap-y-4">
+            <DialogSection className="flex flex-col gap-y-6">
               <FormField_Shadcn_
                 key="name"
                 name="name"
@@ -230,61 +230,64 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                   </FormItemLayout>
                 )}
               />
-              <FormField_Shadcn_
-                key="public"
-                name="public"
-                control={form.control}
-                render={({ field }) => (
-                  <FormItemLayout
-                    name="public"
-                    label="Public bucket"
-                    description="Anyone can read any object without any authorization"
-                    layout="flex"
-                  >
-                    <FormControl_Shadcn_>
-                      <Switch
-                        id="public"
-                        size="large"
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl_Shadcn_>
-                  </FormItemLayout>
-                )}
-              />
-            </DialogSection>
 
-            {isChangingBucketVisibility && (
-              <Admonition
-                type="warning"
-                className="rounded-none border-x-0 border-b-0 mb-0 [&>div>p]:!leading-normal"
-                title={`Warning: Making bucket ${isMakingBucketPublic ? 'public' : 'private'}`}
-                description={
-                  <>
-                    {isMakingBucketPublic && (
-                      <p>This will make all objects in your bucket publicly accessible.</p>
-                    )}
+              {/* Visibility */}
+              <div className="flex flex-col gap-y-2">
+                <FormField_Shadcn_
+                  key="public"
+                  name="public"
+                  control={form.control}
+                  render={({ field }) => (
+                    <FormItemLayout
+                      name="public"
+                      label="Public bucket"
+                      description="Allow anyone to read objects without authorization"
+                      layout="flex"
+                    >
+                      <FormControl_Shadcn_>
+                        <Switch
+                          id="public"
+                          size="large"
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl_Shadcn_>
+                    </FormItemLayout>
+                  )}
+                />
 
-                    {isMakingBucketPrivate && (
+                {isChangingBucketVisibility && (
+                  <Admonition
+                    type="warning"
+                    title={`Warning: Making bucket ${isMakingBucketPublic ? 'public' : 'private'}`}
+                    description={
                       <>
-                        <p className="mb-2">
-                          All objects in your bucket will be private and only accessible via signed
-                          URLs, or downloaded with the right authorisation headers.
-                        </p>
-                        <p>
-                          Assets cached in the CDN may still be publicly accessible. You can
-                          consider{' '}
-                          <InlineLink href="https://supabase.com/docs/guides/storage/cdn/smart-cdn#cache-eviction">
-                            purging the cache
-                          </InlineLink>{' '}
-                          or moving your assets to a new bucket.
-                        </p>
+                        {isMakingBucketPublic && (
+                          <p>This will make all objects in your bucket publicly accessible.</p>
+                        )}
+
+                        {isMakingBucketPrivate && (
+                          <>
+                            <p className="mb-2">
+                              All objects in your bucket will be private and only accessible via
+                              signed URLs, or downloaded with the right authorisation headers.
+                            </p>
+                            <p>
+                              Assets cached in the CDN may still be publicly accessible. You can
+                              consider{' '}
+                              <InlineLink href="https://supabase.com/docs/guides/storage/cdn/smart-cdn#cache-eviction">
+                                purging the cache
+                              </InlineLink>{' '}
+                              or moving your assets to a new bucket.
+                            </p>
+                          </>
+                        )}
                       </>
-                    )}
-                  </>
-                }
-              />
-            )}
+                    }
+                  />
+                )}
+              </div>
+            </DialogSection>
 
             <DialogSectionSeparator />
 
@@ -314,15 +317,19 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                     )}
                   />
                   {hasFileSizeLimit && (
-                    <>
-                      <div className="grid grid-cols-12 col-span-12 gap-x-2 gap-y-1">
-                        <div className="col-span-8">
-                          <FormField_Shadcn_
-                            key="formatted_size_limit"
+                    <div>
+                      <FormField_Shadcn_
+                        key="formatted_size_limit"
+                        name="formatted_size_limit"
+                        control={form.control}
+                        render={({ field }) => (
+                          <FormItemLayout
                             name="formatted_size_limit"
-                            control={form.control}
-                            render={({ field }) => (
-                              <FormItemLayout hideMessage name="formatted_size_limit">
+                            label="File size limit"
+                            hideMessage
+                          >
+                            <div className="grid grid-cols-12 gap-x-2">
+                              <div className="col-span-8">
                                 <FormControl_Shadcn_>
                                   <Input_Shadcn_
                                     id="formatted_size_limit"
@@ -333,32 +340,39 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                                     {...field}
                                   />
                                 </FormControl_Shadcn_>
-                              </FormItemLayout>
-                            )}
-                          />
-                        </div>
-                        <Select_Shadcn_ value={selectedUnit} onValueChange={setSelectedUnit}>
-                          <SelectTrigger_Shadcn_
-                            aria-label="File size limit unit"
-                            size="small"
-                            className="col-span-4"
-                          >
-                            <SelectValue_Shadcn_ asChild>
-                              <>{selectedUnit}</>
-                            </SelectValue_Shadcn_>
-                          </SelectTrigger_Shadcn_>
-                          <SelectContent_Shadcn_>
-                            {Object.values(StorageSizeUnits).map((unit: string) => (
-                              <SelectItem_Shadcn_ key={unit} value={unit} className="text-xs">
-                                <div>{unit}</div>
-                              </SelectItem_Shadcn_>
-                            ))}
-                          </SelectContent_Shadcn_>
-                        </Select_Shadcn_>
-                      </div>
-
+                              </div>
+                              <div className="col-span-4">
+                                <Select_Shadcn_
+                                  value={selectedUnit}
+                                  onValueChange={setSelectedUnit}
+                                >
+                                  <SelectTrigger_Shadcn_
+                                    aria-label="File size limit unit"
+                                    size="small"
+                                  >
+                                    <SelectValue_Shadcn_ asChild>
+                                      <>{selectedUnit}</>
+                                    </SelectValue_Shadcn_>
+                                  </SelectTrigger_Shadcn_>
+                                  <SelectContent_Shadcn_>
+                                    {Object.values(StorageSizeUnits).map((unit: string) => (
+                                      <SelectItem_Shadcn_
+                                        key={unit}
+                                        value={unit}
+                                        className="text-xs"
+                                      >
+                                        <div>{unit}</div>
+                                      </SelectItem_Shadcn_>
+                                    ))}
+                                  </SelectContent_Shadcn_>
+                                </Select_Shadcn_>
+                              </div>
+                            </div>
+                          </FormItemLayout>
+                        )}
+                      />
                       {formattedSizeLimitError?.message === 'exceed_global_limit' && (
-                        <FormMessage_Shadcn_>
+                        <FormMessage_Shadcn_ className="mt-2">
                           Exceeds global limit of {formattedGlobalUploadLimit}. Increase limit in{' '}
                           <InlineLink
                             className="text-destructive decoration-destructive-500 hover:decoration-destructive"
@@ -371,15 +385,18 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
                       )}
 
                       {IS_PLATFORM ? (
-                        <p className="text-sm text-foreground-light !mt-3">
+                        <p className="text-sm text-foreground-lighter mt-2">
                           This project has a{' '}
-                          <InlineLink href={`/project/${ref}/settings/storage`}>
+                          <InlineLink
+                            className="text-foreground-light hover:text-foreground"
+                            href={`/project/${ref}/settings/storage`}
+                          >
                             global file size limit
                           </InlineLink>{' '}
                           of {formattedGlobalUploadLimit}.
                         </p>
                       ) : undefined}
-                    </>
+                    </div>
                   )}
                 </div>
               </div>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -174,21 +174,6 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
     }
   }, [visible, bucket, form])
 
-  // Auto-turn off file size limit toggle when value is 0
-  useEffect(() => {
-    if (formattedSizeLimit === 0 && hasFileSizeLimit) {
-      form.setValue('has_file_size_limit', false)
-    }
-  }, [formattedSizeLimit, hasFileSizeLimit, form])
-
-  // Auto-turn off MIME types toggle when field is empty
-  useEffect(() => {
-    const mimeTypesValue = form.getValues('allowed_mime_types')
-    if (!mimeTypesValue || mimeTypesValue.trim() === '') {
-      setHasAllowedMimeTypes(false)
-    }
-  }, [form.watch('allowed_mime_types')])
-
   return (
     <Dialog
       open={visible}

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -66,7 +66,7 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
   const { value, unit } = convertFromBytes(data?.fileSizeLimit ?? 0)
   const formattedGlobalUploadLimit = `${value} ${unit}`
 
-  const [selectedUnit, setSelectedUnit] = useState<string>(StorageSizeUnits.BYTES)
+  const [selectedUnit, setSelectedUnit] = useState<string>(StorageSizeUnits.MB)
   const { value: fileSizeLimit } = convertFromBytes(bucket?.file_size_limit ?? 0)
   const bucketIdRef = useRef<string | null>(null)
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -19,7 +19,7 @@ interface StorageExplorerProps {
   bucket: Bucket
 }
 
-const StorageExplorer = ({ bucket }: StorageExplorerProps) => {
+export const StorageExplorer = ({ bucket }: StorageExplorerProps) => {
   const { ref } = useParams()
   const storageExplorerRef = useRef(null)
   const {
@@ -211,4 +211,3 @@ const StorageExplorer = ({ bucket }: StorageExplorerProps) => {
 }
 
 StorageExplorer.displayName = 'StorageExplorer'
-export default StorageExplorer

--- a/apps/studio/components/interfaces/Storage/StorageMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageMenu.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 
 import { useParams } from 'common'
-import CreateBucketModal from 'components/interfaces/Storage/CreateBucketModal'
+import { CreateBucketModal } from 'components/interfaces/Storage/CreateBucketModal'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useBucketsQuery } from 'data/storage/buckets-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -16,7 +16,7 @@ import {
   InnerSideBarFilterSortDropdown,
   InnerSideBarFilterSortDropdownItem,
 } from 'ui-patterns/InnerSideMenu'
-import BucketRow from './BucketRow'
+import { BucketRow } from './BucketRow'
 
 const StorageMenu = () => {
   const router = useRouter()

--- a/apps/studio/components/interfaces/Storage/StorageMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageMenu.tsx
@@ -53,8 +53,6 @@ const StorageMenu = () => {
       : sortedBuckets
   const tempNotSupported = error?.message.includes('Tenant config') && isBranch
 
-  console.log({ buckets })
-
   return (
     <>
       <Menu type="pills" className="mt-6 flex flex-grow flex-col">

--- a/apps/studio/components/interfaces/Storage/StorageMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageMenu.tsx
@@ -53,6 +53,8 @@ const StorageMenu = () => {
       : sortedBuckets
   const tempNotSupported = error?.message.includes('Tenant config') && isBranch
 
+  console.log({ buckets })
+
   return (
     <>
       <Menu type="pills" className="mt-6 flex flex-grow flex-col">

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.tsx
@@ -22,7 +22,7 @@ import { StoragePoliciesBucketRow } from './StoragePoliciesBucketRow'
 import StoragePoliciesEditPolicyModal from './StoragePoliciesEditPolicyModal'
 import StoragePoliciesPlaceholder from './StoragePoliciesPlaceholder'
 
-const StoragePolicies = () => {
+export const StoragePolicies = () => {
   const { data: project } = useSelectedProjectQuery()
   const { ref: projectRef } = useParams()
 
@@ -284,5 +284,3 @@ const StoragePolicies = () => {
     </div>
   )
 }
-
-export default StoragePolicies

--- a/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
@@ -171,7 +171,7 @@ export const S3Connection = () => {
                 </CardContent>
 
                 {!canUpdateStorageSettings && (
-                  <CardContent className="pt-0">
+                  <CardContent>
                     <p className="text-sm text-foreground-light">
                       You need additional permissions to update storage settings
                     </p>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -363,9 +363,7 @@ const StorageSettings = () => {
                               </Tooltip>{' '}
                               first
                             </>
-                          ) : (
-                            ''
-                          )}
+                          ) : null}
                         </p>
                       </>
                     ) : (

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -14,6 +14,7 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import { useProjectStorageConfigUpdateUpdateMutation } from 'data/config/project-storage-config-update-mutation'
+import { useBucketsQuery } from 'data/storage/buckets-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { formatBytes } from 'lib/helpers'
@@ -65,6 +66,17 @@ const StorageSettings = () => {
   const isFreeTier = organization?.plan.id === 'free'
   const isSpendCapOn =
     organization?.plan.id === 'pro' && organization?.usage_billing_enabled === false
+
+  const { data: buckets = [], isLoading: isLoadingBuckets } = useBucketsQuery({ projectRef })
+
+  // Calculate the minimum file size limit from existing buckets
+  const minBucketFileSizeLimit = useMemo(() => {
+    const bucketLimits = buckets
+      .filter((bucket: any) => bucket.file_size_limit && bucket.file_size_limit > 0)
+      .map((bucket: any) => bucket.file_size_limit!)
+
+    return bucketLimits.length > 0 ? Math.min(...bucketLimits) : 0
+  }, [buckets])
 
   const [initialValues, setInitialValues] = useState<StorageSettingsState>({
     fileSizeLimit: 0,
@@ -120,6 +132,42 @@ const StorageSettings = () => {
           path: ['fileSizeLimit'],
         })
       }
+
+      // Validate that global limit is not smaller than any bucket's limit
+      if (minBucketFileSizeLimit > 0 && !isLoadingBuckets && buckets.length > 0) {
+        const { value: formattedMinBucketLimit } = convertFromBytes(minBucketFileSizeLimit, unit)
+
+        if (fileSizeLimit < formattedMinBucketLimit) {
+          // Get buckets that would be affected by this too-small global limit
+          const affectedBuckets = buckets
+            .filter((bucket: any) => bucket.file_size_limit && bucket.file_size_limit > 0)
+            .map((bucket: any) => ({
+              name: bucket.name,
+              limit: bucket.file_size_limit!,
+              formattedLimit: convertFromBytes(bucket.file_size_limit!, unit).value,
+            }))
+            .filter((bucket) => bucket.formattedLimit > fileSizeLimit)
+            .sort((a, b) => b.formattedLimit - a.formattedLimit) // Sort by limit descending
+
+          if (affectedBuckets.length > 0) {
+            const primaryBucket = affectedBuckets[0]
+            const otherBucketsCount = affectedBuckets.length - 1
+
+            let errorMessage = `Cannot set global limit lower than that of individual buckets. Remove or decrease the limit on ${primaryBucket.name} (${formatBytes(primaryBucket.limit)})`
+
+            if (otherBucketsCount > 0) {
+              errorMessage += ` +${otherBucketsCount} other bucket${otherBucketsCount === 1 ? '' : 's'}`
+            }
+            errorMessage += ` first.`
+
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: errorMessage,
+              path: ['fileSizeLimit'],
+            })
+          }
+        }
+      }
     })
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -138,6 +186,35 @@ const StorageSettings = () => {
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (data) => {
     if (!projectRef) return console.error('Project ref is required')
     if (!config) return console.error('Storage config is required')
+
+    // Server-side validation: Check if global limit would be smaller than any bucket's limit
+    if (!isLoadingBuckets && buckets.length > 0) {
+      const newGlobalLimitInBytes = convertToBytes(data.fileSizeLimit, data.unit)
+
+      const bucketsWithLimits = buckets.filter(
+        (bucket: any) => bucket.file_size_limit && bucket.file_size_limit > 0
+      )
+
+      const conflictingBuckets = bucketsWithLimits.filter(
+        (bucket: any) => bucket.file_size_limit! > newGlobalLimitInBytes
+      )
+
+      if (conflictingBuckets.length > 0) {
+        const primaryBucket = conflictingBuckets[0]
+        const otherBucketsCount = conflictingBuckets.length - 1
+
+        let errorMessage = `Cannot set global limit lower than the limit set on ${primaryBucket.name} (${formatBytes(primaryBucket.file_size_limit!)})`
+
+        if (otherBucketsCount > 0) {
+          errorMessage += ` +${otherBucketsCount} other bucket${otherBucketsCount === 1 ? '' : 's'}`
+        }
+
+        errorMessage += '. Remove or decrease those limits first.'
+
+        toast.error(errorMessage)
+        return
+      }
+    }
 
     updateStorageConfig({
       projectRef,
@@ -207,6 +284,12 @@ const StorageSettings = () => {
                       description={
                         <>
                           Restrict the size of files uploaded across all buckets.{' '}
+                          {isLoadingBuckets && (
+                            <span className="text-foreground-light">
+                              {' '}
+                              Loading bucket information...
+                            </span>
+                          )}{' '}
                           <InlineLink href="https://supabase.com/docs/guides/storage/uploads/file-limits">
                             Learn more
                           </InlineLink>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -339,33 +339,30 @@ const StorageSettings = () => {
                   )}
                 />
               </CardContent>
-
               {isFreeTier && (
-                <CardContent className="pt-0">
-                  <UpgradeToPro
-                    primaryText="Free Plan has a fixed upload file size limit of 50 MB."
-                    secondaryText={`Upgrade to Pro Plan for a configurable upload file size limit of ${formatBytes(
-                      STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED
-                    )} and unlock image transformations.`}
-                    source="storageSizeLimit"
-                  />
-                </CardContent>
+                <UpgradeToPro
+                  fullWidth
+                  primaryText="Free Plan has a fixed upload file size limit of 50 MB."
+                  secondaryText={`Upgrade to Pro Plan for a configurable upload file size limit of ${formatBytes(
+                    STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED
+                  )} and unlock image transformations.`}
+                  source="storageSizeLimit"
+                />
               )}
               {isSpendCapOn && (
-                <CardContent className="pt-0">
-                  <UpgradeToPro
-                    buttonText="Disable Spend Cap"
-                    primaryText="Reduced max upload file size limit due to Spend Cap"
-                    secondaryText={`Disable your Spend Cap to allow file uploads of up to ${formatBytes(
-                      STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED
-                    )}.`}
-                    source="storageSizeLimit"
-                  />
-                </CardContent>
+                <UpgradeToPro
+                  fullWidth
+                  buttonText="Disable Spend Cap"
+                  primaryText="Reduced max upload file size limit due to Spend Cap"
+                  secondaryText={`Disable your Spend Cap to allow file uploads of up to ${formatBytes(
+                    STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED
+                  )}.`}
+                  source="storageSizeLimit"
+                />
               )}
 
               {!canUpdateStorageSettings && (
-                <CardContent className="pt-0">
+                <CardContent>
                   <p className="text-sm text-foreground-light">
                     You need additional permissions to update storage settings
                   </p>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -335,7 +335,7 @@ export const StorageSettings = () => {
                               </InlineLink>{' '}
                               ({firstAffectBucketLimit.value}
                               {firstAffectBucketLimit.unit})
-                              {affectedBuckets.length > 1 ? (
+                              {affectedBuckets.length > 1 && (
                                 <>
                                   {' '}
                                   and{' '}
@@ -372,7 +372,7 @@ export const StorageSettings = () => {
                                   </Tooltip>{' '}
                                   first
                                 </>
-                              ) : null}
+                              )}
                               .
                             </p>
                           </>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -332,7 +332,7 @@ const StorageSettings = () => {
                               and{' '}
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <span className="underline underline-offset-2 decoration-destructive-500 hover:decoration-destructive">
+                                  <span className="underline underline-offset-2 decoration-dotted decoration-destructive-500 hover:decoration-destructive cursor-default">
                                     +{affectedBuckets.length - 1} other bucket
                                     {affectedBuckets.length > 2 ? 's' : ''}
                                   </span>
@@ -364,6 +364,7 @@ const StorageSettings = () => {
                               first
                             </>
                           ) : null}
+                          .
                         </p>
                       </>
                     ) : (

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -168,20 +168,49 @@ const StorageSettings = () => {
               <CardContent className="pt-6">
                 <FormField_Shadcn_
                   control={form.control}
+                  name="imageTransformationEnabled"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      layout="flex-row-reverse"
+                      label="Enable Image Transformation"
+                      description={
+                        <>
+                          Optimize and resize images on the fly.{' '}
+                          <InlineLink href="https://supabase.com/docs/guides/storage/serving/image-transformations">
+                            Learn more
+                          </InlineLink>
+                          .
+                        </>
+                      }
+                    >
+                      <FormControl_Shadcn_>
+                        <Switch
+                          size="large"
+                          disabled={isFreeTier}
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl_Shadcn_>
+                    </FormItemLayout>
+                  )}
+                />
+              </CardContent>
+
+              <CardContent>
+                <FormField_Shadcn_
+                  control={form.control}
                   name="fileSizeLimit"
                   render={({ field }) => (
                     <FormItemLayout
                       layout="flex-row-reverse"
-                      label="Upload file size limit"
+                      label="Global file size limit"
                       description={
                         <>
-                          {storageUnit !== StorageSizeUnits.BYTES && (
-                            <>
-                              Equivalent to {convertToBytes(limit, storageUnit).toLocaleString()}{' '}
-                              bytes.{' '}
-                            </>
-                          )}
-                          Maximum upload file size is {formatBytes(maxBytes)}.
+                          Restrict the size of files uploaded across all buckets.{' '}
+                          <InlineLink href="https://supabase.com/docs/guides/storage/uploads/file-limits">
+                            Learn more
+                          </InlineLink>
+                          .
                         </>
                       }
                     >
@@ -222,37 +251,6 @@ const StorageSettings = () => {
                             )}
                           />
                         </div>
-                      </FormControl_Shadcn_>
-                    </FormItemLayout>
-                  )}
-                />
-              </CardContent>
-
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="imageTransformationEnabled"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      layout="flex-row-reverse"
-                      label="Enable Image Transformation"
-                      description={
-                        <>
-                          Optimize and resize images on the fly.{' '}
-                          <InlineLink href="https://supabase.com/docs/guides/storage/serving/image-transformations">
-                            Learn more
-                          </InlineLink>
-                          .
-                        </>
-                      }
-                    >
-                      <FormControl_Shadcn_>
-                        <Switch
-                          size="large"
-                          disabled={isFreeTier}
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
                       </FormControl_Shadcn_>
                     </FormItemLayout>
                   )}
@@ -308,7 +306,7 @@ const StorageSettings = () => {
                   loading={isUpdating}
                   disabled={!canUpdateStorageSettings || isUpdating || !form.formState.isDirty}
                 >
-                  Save changes
+                  Save
                 </Button>
               </CardFooter>
             </Card>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -87,7 +87,7 @@ const StorageSettings = () => {
 
   const [initialValues, setInitialValues] = useState<StorageSettingsState>({
     fileSizeLimit: 0,
-    unit: StorageSizeUnits.BYTES,
+    unit: StorageSizeUnits.MB,
     imageTransformationEnabled: !isFreeTier,
   })
 

--- a/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
@@ -71,7 +71,7 @@ describe(`CreateBucketModal`, () => {
     expect(sizeLimitToggle).toBeChecked()
 
     const sizeLimitInput = screen.getByLabelText(`File size limit`)
-    expect(sizeLimitInput).toHaveValue(0)
+    expect(sizeLimitInput).toHaveValue(null)
     await userEvent.type(sizeLimitInput, `25`)
 
     const sizeLimitUnitSelect = screen.getByLabelText(`File size limit unit`)

--- a/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
@@ -75,11 +75,11 @@ describe(`CreateBucketModal`, () => {
     await userEvent.type(sizeLimitInput, `25`)
 
     const sizeLimitUnitSelect = screen.getByLabelText(`File size limit unit`)
-    expect(sizeLimitUnitSelect).toHaveTextContent(`bytes`)
-    await userEvent.click(sizeLimitUnitSelect)
-    const mbOption = screen.getByRole(`option`, { name: `MB` })
-    await userEvent.click(mbOption)
     expect(sizeLimitUnitSelect).toHaveTextContent(`MB`)
+    await userEvent.click(sizeLimitUnitSelect)
+    const bytesOption = screen.getByRole(`option`, { name: `bytes` })
+    await userEvent.click(bytesOption)
+    expect(sizeLimitUnitSelect).toHaveTextContent(`bytes`)
 
     const mimeTypeToggle = screen.getByLabelText(`Restrict MIME types`)
     expect(mimeTypeToggle).not.toBeChecked()

--- a/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
@@ -65,12 +65,7 @@ describe(`CreateBucketModal`, () => {
     await userEvent.click(publicToggle)
     expect(publicToggle).toBeChecked()
 
-    const detailsTrigger = screen.getByRole(`button`, { name: `Additional configuration` })
-    expect(detailsTrigger).toHaveAttribute(`data-state`, `closed`)
-    await userEvent.click(detailsTrigger)
-    expect(detailsTrigger).toHaveAttribute(`data-state`, `open`)
-
-    const sizeLimitToggle = screen.getByLabelText(`Restrict file upload size for bucket`)
+    const sizeLimitToggle = screen.getByLabelText(`Restrict file size`)
     expect(sizeLimitToggle).not.toBeChecked()
     await userEvent.click(sizeLimitToggle)
     expect(sizeLimitToggle).toBeChecked()
@@ -85,6 +80,11 @@ describe(`CreateBucketModal`, () => {
     const mbOption = screen.getByRole(`option`, { name: `MB` })
     await userEvent.click(mbOption)
     expect(sizeLimitUnitSelect).toHaveTextContent(`MB`)
+
+    const mimeTypeToggle = screen.getByLabelText(`Restrict MIME types`)
+    expect(mimeTypeToggle).not.toBeChecked()
+    await userEvent.click(mimeTypeToggle)
+    expect(mimeTypeToggle).toBeChecked()
 
     const mimeTypeInput = screen.getByLabelText(`Allowed MIME types`)
     expect(mimeTypeInput).toHaveValue(``)

--- a/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/CreateBucketModal.test.tsx
@@ -1,13 +1,13 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest'
-import { screen, waitFor, fireEvent } from '@testing-library/dom'
+import { fireEvent, screen, waitFor } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { addAPIMock } from 'tests/lib/msw'
 import { ProjectContextProvider } from 'components/layouts/ProjectLayout/ProjectContext'
+import { addAPIMock } from 'tests/lib/msw'
 
 import { render } from 'tests/helpers'
 import { routerMock } from 'tests/lib/route-mock'
-import CreateBucketModal from '../CreateBucketModal'
+import { CreateBucketModal } from '../CreateBucketModal'
 
 describe(`CreateBucketModal`, () => {
   beforeEach(() => {

--- a/apps/studio/components/interfaces/Storage/__tests__/EditBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/EditBucketModal.test.tsx
@@ -92,11 +92,11 @@ describe(`EditBucketModal`, () => {
     await userEvent.type(sizeLimitInput, `25`)
 
     const sizeLimitUnitSelect = screen.getByLabelText(`File size limit unit`)
-    expect(sizeLimitUnitSelect).toHaveTextContent(`bytes`)
-    await userEvent.click(sizeLimitUnitSelect)
-    const mbOption = screen.getByRole(`option`, { name: `MB` })
-    await userEvent.click(mbOption)
     expect(sizeLimitUnitSelect).toHaveTextContent(`MB`)
+    await userEvent.click(sizeLimitUnitSelect)
+    const mbOption = screen.getByRole(`option`, { name: `GB` })
+    await userEvent.click(mbOption)
+    expect(sizeLimitUnitSelect).toHaveTextContent(`GB`)
 
     const mimeTypeToggle = screen.getByLabelText(`Restrict MIME types`)
     expect(mimeTypeToggle).not.toBeChecked()

--- a/apps/studio/components/interfaces/Storage/__tests__/EditBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/EditBucketModal.test.tsx
@@ -82,12 +82,7 @@ describe(`EditBucketModal`, () => {
     await userEvent.click(publicToggle)
     expect(publicToggle).toBeChecked()
 
-    const detailsTrigger = screen.getByRole(`button`, { name: `Additional configuration` })
-    expect(detailsTrigger).toHaveAttribute(`data-state`, `closed`)
-    await userEvent.click(detailsTrigger)
-    expect(detailsTrigger).toHaveAttribute(`data-state`, `open`)
-
-    const sizeLimitToggle = screen.getByLabelText(`Restrict file upload size for bucket`)
+    const sizeLimitToggle = screen.getByLabelText(`Restrict file size`)
     expect(sizeLimitToggle).not.toBeChecked()
     await userEvent.click(sizeLimitToggle)
     expect(sizeLimitToggle).toBeChecked()
@@ -102,6 +97,11 @@ describe(`EditBucketModal`, () => {
     const mbOption = screen.getByRole(`option`, { name: `MB` })
     await userEvent.click(mbOption)
     expect(sizeLimitUnitSelect).toHaveTextContent(`MB`)
+
+    const mimeTypeToggle = screen.getByLabelText(`Restrict MIME types`)
+    expect(mimeTypeToggle).not.toBeChecked()
+    await userEvent.click(mimeTypeToggle)
+    expect(mimeTypeToggle).toBeChecked()
 
     const mimeTypeInput = screen.getByLabelText(`Allowed MIME types`)
     expect(mimeTypeInput).toHaveValue(``)

--- a/apps/studio/components/interfaces/Storage/__tests__/EditBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/EditBucketModal.test.tsx
@@ -88,7 +88,7 @@ describe(`EditBucketModal`, () => {
     expect(sizeLimitToggle).toBeChecked()
 
     const sizeLimitInput = screen.getByLabelText(`File size limit`)
-    expect(sizeLimitInput).toHaveValue(0)
+    expect(sizeLimitInput).toHaveValue(null)
     await userEvent.type(sizeLimitInput, `25`)
 
     const sizeLimitUnitSelect = screen.getByLabelText(`File size limit unit`)

--- a/apps/studio/components/interfaces/Storage/index.ts
+++ b/apps/studio/components/interfaces/Storage/index.ts
@@ -1,5 +1,0 @@
-export { default as StorageExplorer } from './StorageExplorer/StorageExplorer'
-export { default as StoragePolicies } from './StoragePolicies/StoragePolicies'
-export { default as StorageSettings } from './StorageSettings/StorageSettings'
-
-export { DeleteBucketModal } from './DeleteBucketModal'

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -17,6 +17,7 @@ interface UpgradeToProProps {
   buttonText?: string
   source?: string
   disabled?: boolean
+  fullWidth?: boolean
 }
 
 const UpgradeToPro = ({
@@ -27,6 +28,7 @@ const UpgradeToPro = ({
   buttonText,
   source = 'upgrade',
   disabled = false,
+  fullWidth = false,
 }: UpgradeToProProps) => {
   const { data: project } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
@@ -41,8 +43,8 @@ const UpgradeToPro = ({
   return (
     <div
       className={cn(
-        'block w-full rounded border border-opacity-20 py-4 px-6',
-        'border-overlay bg-surface-200'
+        'block w-full py-4 px-6 bg-surface-200',
+        fullWidth ? 'border-b' : 'border border-opacity-20 border-overlay rounded'
       )}
     >
       <div className="flex gap-x-3">

--- a/apps/studio/data/storage/bucket-create-mutation.ts
+++ b/apps/studio/data/storage/bucket-create-mutation.ts
@@ -6,14 +6,14 @@ import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { storageKeys } from './keys'
 
-export type BucketCreateVariables = Omit<CreateStorageBucketBody, 'public'> & {
+type BucketCreateVariables = Omit<CreateStorageBucketBody, 'public'> & {
   projectRef: string
   isPublic: boolean
 }
 
 type CreateStorageBucketBody = components['schemas']['CreateStorageBucketBody']
 
-export async function createBucket({
+async function createBucket({
   projectRef,
   id,
   type,

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -6,13 +6,13 @@ import type { ResponseError } from 'types'
 import { BucketType } from './buckets-query'
 import { storageKeys } from './keys'
 
-export type BucketDeleteVariables = {
+type BucketDeleteVariables = {
   projectRef: string
   id: string
   type: BucketType
 }
 
-export async function deleteBucket({ projectRef, id, type }: BucketDeleteVariables) {
+async function deleteBucket({ projectRef, id, type }: BucketDeleteVariables) {
   if (!projectRef) throw new Error('projectRef is required')
   if (!id) throw new Error('Bucket name is requried')
 

--- a/apps/studio/data/storage/bucket-update-mutation.ts
+++ b/apps/studio/data/storage/bucket-update-mutation.ts
@@ -2,11 +2,11 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
-import { handleError, patch } from 'data/fetchers'
+import { patch } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { storageKeys } from './keys'
 
-export type BucketUpdateVariables = {
+type BucketUpdateVariables = {
   projectRef: string
   id: string
   isPublic: boolean
@@ -23,7 +23,7 @@ type UpdateStorageBucketBody = Omit<
   file_size_limit: number | null
 }
 
-export async function updateBucket({
+async function updateBucket({
   projectRef,
   id,
   isPublic,

--- a/apps/studio/pages/project/[ref]/storage/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/buckets/[bucketId].tsx
@@ -1,8 +1,8 @@
 import { useParams } from 'common'
 
-import { StorageExplorer } from 'components/interfaces/Storage'
 import { AnalyticBucketDetails } from 'components/interfaces/Storage/AnalyticBucketDetails'
 import StorageBucketsError from 'components/interfaces/Storage/StorageBucketsError'
+import { StorageExplorer } from 'components/interfaces/Storage/StorageExplorer/StorageExplorer'
 import { useSelectedBucket } from 'components/interfaces/Storage/StorageExplorer/useSelectedBucket'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'

--- a/apps/studio/pages/project/[ref]/storage/policies.tsx
+++ b/apps/studio/pages/project/[ref]/storage/policies.tsx
@@ -1,9 +1,9 @@
-import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
+import { StoragePolicies } from 'components/interfaces/Storage/StoragePolicies/StoragePolicies'
 import DefaultLayout from 'components/layouts/DefaultLayout'
-import { StoragePolicies } from 'components/interfaces/Storage'
-import type { NextPageWithLayout } from 'types'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
-import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
+import { ScaffoldContainer } from 'components/layouts/Scaffold'
+import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
+import type { NextPageWithLayout } from 'types'
 
 const StoragePoliciesPage: NextPageWithLayout = () => {
   return <StoragePolicies />

--- a/apps/studio/pages/project/[ref]/storage/settings.tsx
+++ b/apps/studio/pages/project/[ref]/storage/settings.tsx
@@ -1,10 +1,10 @@
-import DefaultLayout from 'components/layouts/DefaultLayout'
-import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
-import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
-import { StorageSettings } from 'components/interfaces/Storage'
 import { S3Connection } from 'components/interfaces/Storage/StorageSettings/S3Connection'
-import type { NextPageWithLayout } from 'types'
+import { StorageSettings } from 'components/interfaces/Storage/StorageSettings/StorageSettings'
+import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
+import { ScaffoldContainer } from 'components/layouts/Scaffold'
+import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
+import type { NextPageWithLayout } from 'types'
 
 const StorageSettingsPage: NextPageWithLayout = () => {
   return (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reduces possible confusion around [global and bucket-specific file size limits](https://supabase.com/docs/guides/storage/uploads/file-limits).

## What is the current behavior?

Problematic UX on the edit/create bucket:
- We show a toast (with confusing copy) instead of inline error

Problematic UX on the global storage settings:
- We don’t expose or notify about bucket-specific limits when touching the global limit

## What is the new behavior?

Improved UX on the edit/create bucket:
- [x] Errors are contextual to their fields. We show an inline error (with clearer copy) instead of the toast
    - [x] Also for MIME type errors
-  [x] We hide all the controls behind a switch so the empty state isn't confusing
- [x] _Restrict file size_ setting: fix both footer text and error footer text to span full width of both fields
- [x] Error should link to global settings (and replace static footer text)
- [x] Replicate changes in _CreateBucketModal_ (or share source to remove duplicity)

Improved design of global storage settings:
- [x] Clearer copywriting
- [x] Fix error state: no red title, proper field error styles, proper width
- [x] Error should link to bucket-specific settings

## Screenshots

### Create or edit bucket

The following UI also now applies to MIME type errors.

| Before | After |
| --- | --- |
| <img width="1204" height="1431" alt="edit-before" src="https://github.com/user-attachments/assets/243d7929-bc57-437a-837b-b7a3577e8b48" /> | <img width="1204" height="1431" alt="edit-after" src="https://github.com/user-attachments/assets/4c3243ae-0f64-407b-8df2-8a5facbbfbd9" /> |
| Error appears as global toast, off-screen | Inline error |

### Global storage settings

| Before | After |
| --- | --- |
| <img width="2317" height="589" alt="global-before" src="https://github.com/user-attachments/assets/fe84a64e-0bb4-4bd2-b7b6-92db691f31fa" />  | <img width="2317" height="589" alt="global-after" src="https://github.com/user-attachments/assets/33b79e23-dc44-4a44-a133-37693ac1b408" /> |
| No error. We currently allow these conflicts | Inline error now preventing global sizes smaller than what’s set on a bucket  |

## Docs to update

- [X] Documentation on [limits](https://supabase.com/docs/guides/storage/uploads/file-limits) (stays the same as the UI just makes things “safer”)
- [ ] Support snippets
- [ ] Support [troubleshooting](https://supabase.com/docs/guides/troubleshooting/upload-file-size-restrictions-Y4wQLT)

## In a future PR

- [ ] Change from dialog to sheet
- [ ] Improve analytics buckets vs standard buckets flow
- [ ] Remove `destructive` red title from _StorageSettings_ when errored (just have right-side styled like that)