### PR TITLE
chore: add lint warning for pg version

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -300,6 +300,15 @@ export const lintInfoMap: LintInfo[] = [
     docsLink: 'https://supabase.com/docs/guides/auth/auth-mfa',
     category: 'security',
   },
+  {
+    name: 'vulnerable_postgres_version',
+    title: 'Postgres version has security patches available',
+    icon: <LockIcon className="text-foreground-muted" size={15} strokeWidth={1} />,
+    link: ({ projectRef }) => `/project/${projectRef}/settings/infrastructure`,
+    linkText: 'View settings',
+    docsLink: 'https://supabase.com/docs/guides/platform/upgrading',
+    category: 'security',
+  },
 ]
 
 export const LintCTA = ({

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -3692,6 +3692,7 @@ export interface components {
           | 'auth_password_policy_missing'
           | 'leaked_service_key'
           | 'no_backup_admin'
+          | 'vulnerable_postgres_version'
         remediation: string
         title: string
       }[]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Additional context

<img width="1375" height="656" alt="Screenshot 2025-08-28 at 16 36 38" src="https://github.com/user-attachments/assets/9b633b45-8461-4eee-8bf9-e1f72aa57d65" />
