### PR TITLE
fix: improve wording about transaction pooler

### DIFF
--- a/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
@@ -199,7 +199,7 @@ export const ConnectionPanel = ({
                 <div className="flex flex-col pl-[52px]">
                   <span className="text-xs text-foreground">
                     {type === 'transaction'
-                      ? 'Pre-warmed connection pool to Postgres'
+                      ? 'Clients share a connection pool'
                       : 'Each client has a dedicated connection to Postgres'}
                   </span>
                 </div>


### PR DESCRIPTION
Remove the implication that the pool is prewarmed. After a time if inactivity, the pool is automatically stopped, so it may be cold.
