### PR TITLE
fix: small typo in identites -> identities

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1341,7 +1341,7 @@ functions:
         isSpotlight: true
         code: |
           ```dart
-          // retrieve all identites linked to a user
+          // retrieve all identities linked to a user
           final identities = await supabase.auth.getUserIdentities();
 
           // find the google identity

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1625,7 +1625,7 @@ functions:
         isSpotlight: true
         code: |
           ```js
-          // retrieve all identites linked to a user
+          // retrieve all identities linked to a user
           const identities = await supabase.auth.getUserIdentities()
 
           // find the google identity

--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -1550,7 +1550,7 @@ functions:
         isSpotlight: true
         code: |
           ```python
-          # retrieve all identites linked to a user
+          # retrieve all identities linked to a user
           response = supabase.auth.get_user_identities()
 
           # find the google identity

--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -944,7 +944,7 @@ functions:
         isSpotlight: true
         code: |
           ```swift
-          // retrieve all identites linked to a user
+          // retrieve all identities linked to a user
           let identities = try await supabase.auth.userIdentities()
 
           // find the google identity


### PR DESCRIPTION
Fixes a small typo in the apps/docs/spec files.

I am not exactly sure how this ends up making its way into the documentation. I tried running the make command in the apps/docs/specs directory and it ended with an error before pulling a large amount of changes to various files.

Would appreciate some guidance on how to bring everything up to date.