### PR TITLE
Fix SQL Editor search not showing snippets in folders

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -53,7 +53,11 @@ export const SearchList = ({ search }: SearchListProps) => {
   )
   const totalNumber = (count as unknown as { count: number })?.count ?? 0
 
-  const snippets = useMemo(() => data?.pages.flatMap((page) => page.content), [data?.pages])
+  const snippets = useMemo(
+    // [Joshen] Set folder_id to null to ensure flat list
+    () => data?.pages.flatMap((page) => page.content.map((x) => ({ ...x, folder_id: null }))),
+    [data?.pages]
+  )
   const treeState = formatFolderResponseForTreeView({ folders: [], contents: snippets as any })
 
   const snippetsLastItemIds = useMemo(() => getLastItemIds(treeState), [treeState])
@@ -117,6 +121,7 @@ export const SearchList = ({ search }: SearchListProps) => {
                       </span>
                     ),
                   }}
+                  isBranch={false}
                   isOpened={isOpened && !isPreview}
                   isSelected={isActive}
                   isPreview={isPreview}


### PR DESCRIPTION
## Context

We received a report regarding searching in SQL Editor that it doesn't render snippets that are within folders, despite the count showing that there are snippets (Search should be showing a flat list of snippets for easier finding)

e.g:
<img width="297" height="229" alt="image" src="https://github.com/user-attachments/assets/1a856b4b-1ae3-4fdf-9ac6-1dcfb82fe2fb" />

Realised that we need to set (on the client side) `null` for all snippet's `folder_id` parameter so that the UI can render the snippets as a flat list. We don't need the `folder_id` in this specific UI since we dont have any move actions for snippets, but do test a little to check if i might have overlooked anything 🙏 
<img width="299" height="272" alt="image" src="https://github.com/user-attachments/assets/9b3086c5-fabc-45e4-a5e8-73a9d5626827" />

## To test
- [ ] Verify that searching will show results for snippets that are within folders
- [ ] Verify that none of the context menu actions for snippets in the search UI isn't breaking