### PR TITLE
ref(replication): Remove replication lag

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -293,11 +293,6 @@ export const ReplicationPipelineStatus = () => {
                               <div className="text-sm text-foreground">
                                 {statusConfig.description}
                               </div>
-                              {'lag' in table.state && (
-                                <div className="text-xs text-foreground-light">
-                                  Lag: {table.state.lag}ms
-                                </div>
-                              )}
                               {table.state.name === 'error' && (
                                 <ErroredTableDetails
                                   state={table.state}


### PR DESCRIPTION
This PR removes the replication lag metric from the UI since right now we are not going to release ETL with such a metric and we want to avoid confusing users.