### PR TITLE
Fix TableEditor keyboard copy action copies who cell value even when only a subset is highlighted while editing cell

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -214,10 +214,14 @@ export function useLoadTableEditorStateFromLocalStorageIntoUrl({
 }
 
 export const handleCopyCell = (
-  { column, row }: { column: CalculatedColumn<any, unknown>; row: any },
+  {
+    mode,
+    column,
+    row,
+  }: { mode: 'SELECT' | 'EDIT'; column: CalculatedColumn<any, unknown>; row: any },
   event: CellKeyboardEvent
 ) => {
-  if (event.code === 'KeyC' && (event.metaKey || event.ctrlKey)) {
+  if (mode === 'SELECT' && event.code === 'KeyC' && (event.metaKey || event.ctrlKey)) {
     const colKey = column.key
     const cellValue = row[colKey] ?? ''
     const value = formatClipboardValue(cellValue)

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -128,9 +128,7 @@ export const Grid = memo(
         }
       }
 
-      const removeAllFilters = () => {
-        onApplyFilters([])
-      }
+      const removeAllFilters = () => onApplyFilters([])
 
       return (
         <div


### PR DESCRIPTION
## Context

We've received a feedback for the TableEditor that while editing a cell, if I'm highlighting a subset of the cell value in the cell editor and hit the keyboard shortcut to copy the value, the dashboard copies the entire cell value instead of the highlighted segment

Realised that this is due to the `onCellKeydown` parameter that we're passing in within the `Grid.tsx` component which intended behaviour is to copy the cell value when the cell is selected. Fix here is thus to only copy the cell value while the cell is selected, not while it's being edited

## To test
- On a table with JSON column (easier to test with a JSON column)
  - [ ] Select a cell with some value (cell editor shouldn't open) then hit CMD+C, cell value should be copied
  - [ ] Now double click the cell to edit it and highlight only a specific segment of the value, then hit CMD+C, only the highlighted segment should be copied