### PR TITLE
Add contextual invalidation support for query block

### DIFF
--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -206,6 +206,7 @@ export const QueryBlock = ({
         projectRef: ref,
         connectionString: readOnlyConnectionString,
         sql,
+        contextualInvalidation: true,
       })
     } catch (error: any) {
       toast.error(`Failed to execute query: ${error.message}`)
@@ -342,6 +343,7 @@ export const QueryBlock = ({
                 projectRef: ref,
                 connectionString: postgresConnectionString,
                 sql,
+                contextualInvalidation: true,
               })
               onRunQuery?.('mutation')
             }


### PR DESCRIPTION
## Context

As per PR title - small QoL improvement for the Assistant, figured it'll be better UX for changes made by the Assistant to be reflected in the UI as well.

E.g if running a query through the Assistant that adds rows to a table, and you have that table opened in the table editor atm, the rows should show up after the query is finished (Notice there's some delay from the running of the query to the updating of the rows, more details on that below RE some inefficiencies with our contextual invalidation logic)

https://github.com/user-attachments/assets/9c45d99a-3b91-49a4-8e35-19bdd4dbc84e

I noticed however that this contextual invalidation logic we currently have feels quite inefficient
- We're invalidating every database related key whenever we're doing contextual invalidation
  - Because of the `await` for `Promise.all` this causes the loading time `executeSql` to be longer as its waiting for all the invalidation to complete before returning a success state
  - Am removing the `await` in this PR because of this, else running queries in the SQL editor will "feel" much slower than it actually is
  - You can compare this actually by running a simple create table query on staging vs this staging preview, the speedup is noticeable
- On that note ^ because we're invalidating every database related key, the _more_ important queries to be invalidated might be delayed then (e.g if i'm on the table editor, and the query is running an insert query, other queries apart from `[table-row`, tableId ]` are getting invalidated first, so the new rows don't show up quicker (which is what's happening in the demo video)
- We probably need to investigate how to optimize the contextual invalidation logic separately

