### PR TITLE
Fix button text consistency for database triggers

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -401,7 +401,7 @@ const CreateFunction = ({ func, visible, setVisible }: CreateFunctionProps) => {
               disabled={isCreating || isUpdating}
               loading={isCreating || isUpdating}
             >
-              Confirm
+              {isEditing ? 'Save' : 'Create'} function
             </Button>
           </SheetFooter>
         </div>

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -451,7 +451,7 @@ export const TriggerSheet = ({ selectedTrigger, open, setOpen }: TriggerSheetPro
               Cancel
             </Button>
             <Button form={formId} htmlType="submit" loading={isCreating || isUpdating}>
-              Create trigger
+              {isEditing ? 'Save' : 'Create'} trigger
             </Button>
           </SheetFooter>
         </SheetContent>


### PR DESCRIPTION
Fixes FE-1826

## Context

Tiny consistency fix - when editing a trigger the CTA still says "Create trigger" in the side panel, so this fixes it to show "Save trigger" instead

<img width="204" height="74" alt="image" src="https://github.com/user-attachments/assets/ecc076a5-fa7d-420f-ac3b-e18dafdd23c8" />

Separately though, there's a general consistency issue with the primary CTA texts across the panels on the database pages (some say "Save", "Confirm", and "Save/Create entity") - we'll need to address this along the way. For now I've also done this update for the functions side panel to say "Save/Create function" instead of just "Confirm"