### PR TITLE
fix(studio): empty state of access tokens width

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
@@ -110,7 +110,7 @@ export const AccessTokenList = ({ searchString = '', onDeleteSuccess }: AccessTo
     return (
       <TableContainer>
         <TableRow>
-          <TableCell colSpan={4} className="p-0">
+          <TableCell colSpan={5} className="p-0">
             <AlertError
               error={error}
               subject="Failed to retrieve access tokens"
@@ -135,7 +135,7 @@ export const AccessTokenList = ({ searchString = '', onDeleteSuccess }: AccessTo
     return (
       <TableContainer>
         <TableRow>
-          <TableCell colSpan={4} className="py-12">
+          <TableCell colSpan={5} className="py-12">
             <p className="text-sm text-center text-foreground">No access tokens found</p>
             <p className="text-sm text-center text-foreground-light">
               You do not have any tokens created yet


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Very minor bug I noticed while clicking around. Increases the col span of the empty state.

| Before | After |
|--------|--------|
| <img width="1010" height="370" alt="Screenshot 2025-09-02 at 16 34 24" src="https://github.com/user-attachments/assets/c62d324f-561a-4fcb-81e2-705f0600e1b3" /> | <img width="983" height="373" alt="Screenshot 2025-09-02 at 16 34 37" src="https://github.com/user-attachments/assets/2ceeba86-812d-4ef3-b8d0-3f944b6bf131" /> |
