### PR TITLE
Switch homepage flag from ConfigCat to PostHog

### DIFF
--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -1,4 +1,3 @@
-import { useFlag } from 'common'
 import { usePHFlag } from 'hooks/ui/useFlag'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ProjectLayoutWithAuth } from 'components/layouts/ProjectLayout/ProjectLayout'

--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -1,4 +1,5 @@
 import { useFlag } from 'common'
+import { usePHFlag } from 'hooks/ui/useFlag'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ProjectLayoutWithAuth } from 'components/layouts/ProjectLayout/ProjectLayout'
 import type { NextPageWithLayout } from 'types'
@@ -6,7 +7,7 @@ import HomeNew from 'components/interfaces/HomeNew/Home'
 import Home from 'components/interfaces/Home/Home'
 
 const HomePage: NextPageWithLayout = () => {
-  const isHomeNew = useFlag('homeNew')
+  const isHomeNew = usePHFlag('homeNew')
   if (isHomeNew) {
     return <HomeNew />
   }


### PR DESCRIPTION
## Summary
- Replace `useFlag` with `usePHFlag` for the new homepage feature flag

## Why
Having feature flags and analytics in the same tool lets us track flag exposure events alongside user behavior without having to wire up separate integrations.

## Test plan
- [ ] Verify homepage shows correctly with flag enabled
- [ ] Verify fallback to old homepage with flag disabled
- [ ] Verify load time performance (it looks like the loading skeleton will need to be updated using either platform)