### PR TITLE
chore: api keys ux improvements

### DIFF
--- a/apps/design-system/content/docs/icons.mdx
+++ b/apps/design-system/content/docs/icons.mdx
@@ -1,6 +1,24 @@
 ---
 title: Icons
-description: Icons system breakdown. Copy values of Icons.
+description: Icons make actions and navigation across Supabase easier.
 ---
+
+## Principles
+
+1. Paired: Icons should accompany text, as they aren’t often obvious enough on their own.
+2. Clear: Icons should be legible at small sizes and unembellished. Let the text do the heavy lifting.
+3. Consistent: Use the same icons for similar actions throughout Supabase. This makes the app easier to use.
+
+## Tints
+
+Destructive actions, such as deleting an API key, don’t need to be [tinted](color-usage#text) with `text-destructive` because there should be a confirmation dialog as a failsafe right after.
+
+## UI Icons
+
+We rely on Lucide icons for most of our UI icons.
+
+## Custom Icons
+
+Tap on an icon below to copy the JSX, SVG, or import path.
 
 <Icons />

--- a/apps/studio/components/interfaces/APIKeys/APIKeyDeleteDialog.tsx
+++ b/apps/studio/components/interfaces/APIKeys/APIKeyDeleteDialog.tsx
@@ -56,7 +56,7 @@ export const APIKeyDeleteDialog = ({ apiKey, lastSeen }: APIKeyDeleteDialogProps
           },
         }}
       >
-        <Trash2 className="size-4 text-destructive" strokeWidth={1.5} /> Delete API key
+        <Trash2 size={14} strokeWidth={1.5} /> Delete API key
       </DropdownMenuItemTooltip>
       <TextConfirmModal
         visible={isOpen}

--- a/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
@@ -1,7 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
-import { AnimatePresence, motion } from 'framer-motion'
-import { Eye } from 'lucide-react'
+
+import { Eye, EyeOff } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -67,13 +67,13 @@ export function ApiKeyPill({
     }
   }, [show, data?.api_key, projectRef, queryClient, apiKey.id])
 
-  async function onSubmitShow() {
+  async function onSubmitToggle() {
     // Don't reveal key if not allowed or loading
     if (isSecret && !canManageSecretKeys) return
     if (isLoadingPermission) return
 
-    // This will enable the API key query to fetch and reveal the key
-    setShowState(true)
+    // Toggle the show state
+    setShowState(!show)
   }
 
   async function onCopy() {
@@ -108,74 +108,50 @@ export function ApiKeyPill({
 
   return (
     <>
-      <AnimatePresence mode="wait" initial={false}>
-        <div
-          className={cn(
-            InputVariants({ size: 'tiny' }),
-            'flex-1 grow gap-0 font-mono rounded-full',
-            isSecret ? 'overflow-hidden' : '',
-            show ? 'ring-1 ring-foreground-lighter ring-opacity-50' : 'ring-0 ring-opacity-0',
-            'transition-all',
-            'max-w-[100px] sm:max-w-[140px] md:max-w-[180px] lg:max-w-[340px]',
-            'cursor-text',
-            'relative'
-          )}
-          style={{ userSelect: 'all' }}
-        >
-          {isSecret ? (
-            <>
-              <span>{apiKey?.api_key.slice(0, 15)}</span>
-              <motion.span
-                key={show ? 'shown' : 'hidden'}
-                initial={{ opacity: 0, y: show ? 16 : -16 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: show ? 16 : -16 }}
-                transition={{
-                  duration: 0.1,
-                  y: { type: 'spring', stiffness: 1000, damping: 55 },
-                }}
-              >
-                {show && data?.api_key ? data?.api_key.slice(15) : '••••••••••••••••'}
-              </motion.span>
-            </>
-          ) : (
-            <span>{apiKey?.api_key}</span>
-          )}
-        </div>
-      </AnimatePresence>
+      <div
+        className={cn(
+          InputVariants({ size: 'tiny' }),
+          'w-[100px] sm:w-[140px] md:w-[180px] lg:w-[340px] gap-0 font-mono rounded-full',
+          isSecret ? 'overflow-hidden' : '',
+          show ? 'ring-1 ring-foreground-lighter ring-opacity-50' : 'ring-0 ring-opacity-0',
+          'transition-all',
+          'cursor-text',
+          'relative'
+        )}
+        style={{ userSelect: 'all' }}
+      >
+        {isSecret ? (
+          <>
+            <span>{apiKey?.api_key.slice(0, 15)}</span>
+            <span>{show && data?.api_key ? data?.api_key.slice(15) : '••••••••••••••••'}</span>
+          </>
+        ) : (
+          <span>{apiKey?.api_key}</span>
+        )}
+      </div>
 
-      {/* Reveal button - only shown for secret keys and when not already revealed */}
+      {/* Toggle button */}
       {isSecret && (
-        <AnimatePresence initial={false}>
-          {!show && (
-            <motion.div
-              initial={{ opacity: 0, scale: 1, width: 0 }}
-              animate={{ opacity: 1, scale: 1, width: 'auto' }}
-              exit={{ opacity: 0, scale: 1, width: 0 }}
-              transition={{ duration: 0.12 }}
-              style={{ overflow: 'hidden' }}
-            >
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="outline"
-                    className="rounded-full px-2 pointer-events-auto cursor-default"
-                    icon={<Eye strokeWidth={2} />}
-                    onClick={onSubmitShow}
-                    disabled={isRestricted}
-                  />
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {isRestricted
-                    ? 'You need additional permissions to reveal secret API keys'
-                    : isLoadingPermission
-                      ? 'Loading permissions...'
-                      : 'Reveal API key'}
-                </TooltipContent>
-              </Tooltip>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="outline"
+              className="rounded-full px-2 pointer-events-auto"
+              icon={show ? <EyeOff strokeWidth={2} /> : <Eye strokeWidth={2} />}
+              onClick={onSubmitToggle}
+              disabled={isRestricted}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isRestricted
+              ? 'You need additional permissions to reveal secret API keys'
+              : isLoadingPermission
+                ? 'Loading permissions...'
+                : show
+                  ? 'Hide API key'
+                  : 'Reveal API key'}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       <Tooltip>
@@ -184,7 +160,7 @@ export function ApiKeyPill({
             type="default"
             asyncText={onCopy}
             iconOnly
-            className="rounded-full px-2 pointer-events-auto cursor-default"
+            className="rounded-full px-2 pointer-events-auto"
             disabled={isRestricted || isLoadingPermission}
           />
         </TooltipTrigger>

--- a/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.tsx
+++ b/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.tsx
@@ -7,7 +7,16 @@ import CopyButton from 'components/ui/CopyButton'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { useAPIKeysQuery } from 'data/api-keys/api-keys-query'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
-import { cn, EyeOffIcon, Input_Shadcn_, Skeleton, WarningIcon } from 'ui'
+import {
+  cn,
+  EyeOffIcon,
+  Input_Shadcn_,
+  Skeleton,
+  WarningIcon,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 
 // to add in later with follow up PR
 // import CreatePublishableAPIKeyDialog from './CreatePublishableAPIKeyDialog'
@@ -47,14 +56,25 @@ export const PublishableAPIKeys = () => {
             <span className="text-sm">Publishable key</span>
             <div className="flex items-center gap-2">
               <ApiKeyInput />
-              <CopyButton
-                iconOnly
-                size="tiny"
-                type="default"
-                className="px-2 rounded-full"
-                disabled={isPermissionsLoading || isLoadingApiKeys || !canReadAPIKeys}
-                text={apiKey?.api_key}
-              />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CopyButton
+                    iconOnly
+                    size="tiny"
+                    type="default"
+                    className="px-2 rounded-full"
+                    disabled={isPermissionsLoading || isLoadingApiKeys || !canReadAPIKeys}
+                    text={apiKey?.api_key}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {!canReadAPIKeys
+                    ? 'You need additional permissions to copy publishable keys'
+                    : isLoadingApiKeys
+                      ? 'Loading permissions...'
+                      : 'Copy publishable key'}
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
           {error && canReadAPIKeys ? (


### PR DESCRIPTION
## What kind of change does this PR introduce?

UX polish on API Keys page.

## What is the current behavior?

@raulb spotted some inconsistency on the [API Keys page](https://supabase.com/dashboard/project/_/settings/api-keys/new). Namely:

- Inconsistent destructive action colouring
- Inconsistent cursor states

<img width="728" height="258" alt="image" src="https://github.com/user-attachments/assets/5927b6fa-266d-4bd1-aeb7-960f5e993cce" />

![publishable-key](https://github.com/user-attachments/assets/f6c7bb75-3d33-4b40-bef0-8941c66333b8)

## What is the new behavior?

Makes the above consistent and adds documentation to the design system:

- No destructive colouring to actions that have a follow-up confirmation step (e.g. dialog)
    - Matches other parts of the app (e.g. Table Editor)
 -  `cursor-pointer` for anything interactive
 - Simplified API Keys hide/show functionality to remove layout shift
    - Also allows for API key to be re-hidden after shown
