### PR TITLE
chore(self-hosted): bump up edge-runtime image version to v1.69.6

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -314,7 +314,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.67.4
+    image: supabase/edge-runtime:v1.69.6
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:Z


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Description

Bump up edge-runtime image version to v1.69.6.
https://github.com/supabase/edge-runtime/compare/v1.67.4...v1.69.6