### PR TITLE
Fix table editor incorrectly showing type change notice for foreign key

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -64,8 +64,6 @@ export const ForeignKeySelector = ({
   const hasTypeErrors = (errors?.types ?? []).filter((x: any) => x !== undefined).length > 0
   const hasTypeNotices = (errors?.typeNotice ?? []).filter((x: any) => x !== undefined).length > 0
 
-  console.log(errors)
-
   const { data: schemas } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -416,7 +416,7 @@ export const ForeignKeySelector = ({
                             <li key={`type-error-${idx}`}>
                               <div className="flex items-center gap-x-1">
                                 <code className="text-xs">{fk.columns[idx]?.source}</code>{' '}
-                                <ArrowRight /> {x.targetType}
+                                <ArrowRight size={14} /> {x.targetType}
                               </div>
                             </li>
                           )

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -64,6 +64,8 @@ export const ForeignKeySelector = ({
   const hasTypeErrors = (errors?.types ?? []).filter((x: any) => x !== undefined).length > 0
   const hasTypeNotices = (errors?.typeNotice ?? []).filter((x: any) => x !== undefined).length > 0
 
+  console.log(errors)
+
   const { data: schemas } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
@@ -164,13 +166,7 @@ export const ForeignKeySelector = ({
 
       // [Joshen] Doing this way so that its more readable
       // If either source or target not selected yet, thats okay
-      if (source === '' || target === '') {
-        return typeErrors.push(undefined)
-      }
-
-      if (sourceColumn?.isNewColumn && targetType !== '') {
-        return typeNotice.push({ sourceType, targetType })
-      }
+      if (source === '' || target === '') return
 
       // If source and target are in the same type of data types, thats okay
       if (
@@ -178,13 +174,14 @@ export const ForeignKeySelector = ({
         (TEXT_TYPES.includes(sourceType) && TEXT_TYPES.includes(targetType)) ||
         (TEXT_TYPES.includes(sourceType) && TEXT_TYPES.includes(targetType)) ||
         (sourceType === 'uuid' && targetType === 'uuid')
-      ) {
-        return typeErrors.push(undefined)
-      }
+      )
+        return
 
       // Otherwise just check if the format is equal to each other
-      if (sourceType === targetType) {
-        return typeErrors.push(undefined)
+      if (sourceType === targetType) return
+
+      if (sourceColumn?.isNewColumn && targetType !== '') {
+        return typeNotice.push({ sourceType, targetType })
       }
 
       typeErrors.push({ sourceType, targetType })


### PR DESCRIPTION
## Context

The ForeignKeySelector of the Table Editor incorrectly shows a type change notice even if the source column type and target column type matches
<img width="478" height="169" alt="image" src="https://github.com/user-attachments/assets/a1aa163d-b765-4a7e-b06e-ec09496ed2b0" />

## Changes involved
- Correctly order of early returns in `validateType`
- Avoid unnecessary pushing of `undefined` into typeNotice or typeErrors

## To test
- Select "New table" and ensure that one of your columns is of type `uuid` 
- Add a foreign key to the `auth.users` table on the `id` column
- Because the type matches, you shouldn't see the notice
- Also just check that the notice shows up correctly when it should, by selecting a target column of a different type