### PR TITLE
feat(replication): Add ability to copy pipeline id and filter logs by pipeline id

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
@@ -244,6 +244,13 @@ export const DestinationPanel = ({
     }
   }, [destinationData, pipelineData, editMode, defaultValues, form])
 
+  // Ensure the form always reflects the freshest data whenever the panel opens
+  useEffect(() => {
+    if (visible) {
+      form.reset(defaultValues)
+    }
+  }, [visible, defaultValues, form])
+
   return sourceId ? (
     <>
       <Sheet open={visible} onOpenChange={onClose}>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
@@ -74,6 +74,7 @@ interface DestinationPanelProps {
     destinationId: number
     pipelineId?: number
     enabled: boolean
+    statusName?: string
   }
 }
 
@@ -178,7 +179,8 @@ export const DestinationPanel = ({
           sourceId,
         })
         // Set request status only right before starting, then fire and close
-        const snapshot = existingDestination.enabled ? 'started' : 'stopped'
+        const snapshot = existingDestination.statusName ??
+          (existingDestination.enabled ? 'started' : 'stopped')
         if (existingDestination.enabled) {
           setRequestStatus(
             existingDestination.pipelineId,

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
@@ -13,7 +12,6 @@ import { useReplicationPipelineByIdQuery } from 'data/replication/pipeline-by-id
 import { useReplicationPublicationsQuery } from 'data/replication/publications-query'
 import { useStartPipelineMutation } from 'data/replication/start-pipeline-mutation'
 import { useUpdateDestinationPipelineMutation } from 'data/replication/update-destination-pipeline-mutation'
-import { replicationKeys } from 'data/replication/keys'
 import {
   PipelineStatusRequestStatus,
   usePipelineRequestStatus,
@@ -87,7 +85,6 @@ export const DestinationPanel = ({
 }: DestinationPanelProps) => {
   const { ref: projectRef } = useParams()
   const { setRequestStatus } = usePipelineRequestStatus()
-  const queryClient = useQueryClient()
 
   const editMode = !!existingDestination
   const [publicationPanelVisible, setPublicationPanelVisible] = useState(false)
@@ -197,7 +194,7 @@ export const DestinationPanel = ({
           )
           toast.success('Settings applied. Starting the pipeline...')
         }
-        await startPipeline({ projectRef, pipelineId: existingDestination.pipelineId })
+        startPipeline({ projectRef, pipelineId: existingDestination.pipelineId })
         onClose()
       } else {
         const bigQueryConfig: any = {
@@ -227,7 +224,7 @@ export const DestinationPanel = ({
         // Set request status only right before starting, then fire and close
         setRequestStatus(pipelineId, PipelineStatusRequestStatus.StartRequested, undefined)
         toast.success('Destination created. Starting the pipeline...')
-        await startPipeline({ projectRef, pipelineId })
+        startPipeline({ projectRef, pipelineId })
         onClose()
       }
     } catch (error) {
@@ -246,28 +243,6 @@ export const DestinationPanel = ({
       form.reset(defaultValues)
     }
   }, [destinationData, pipelineData, editMode, defaultValues, form])
-
-  // When the panel transitions from closed -> open, refresh item data and reset the form once
-  const wasVisibleRef = useRef<boolean>(visible)
-  useEffect(() => {
-    const becameOpen = !wasVisibleRef.current && visible
-    wasVisibleRef.current = visible
-    if (!becameOpen) return
-
-    // Reset immediately with whatever is cached to avoid showing stale edits
-    form.reset(defaultValues)
-
-    // Refetch fresh values in edit mode
-    if (!editMode || !projectRef) return
-    const destId = existingDestination?.destinationId
-    const pipeId = existingDestination?.pipelineId
-    if (destId) {
-      queryClient.invalidateQueries(replicationKeys.destinationById(projectRef, destId))
-    }
-    if (pipeId) {
-      queryClient.invalidateQueries(replicationKeys.pipelineById(projectRef, pipeId))
-    }
-  }, [visible])
 
   return sourceId ? (
     <>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
@@ -179,8 +179,8 @@ export const DestinationPanel = ({
           sourceId,
         })
         // Set request status only right before starting, then fire and close
-        const snapshot = existingDestination.statusName ??
-          (existingDestination.enabled ? 'started' : 'stopped')
+        const snapshot =
+          existingDestination.statusName ?? (existingDestination.enabled ? 'started' : 'stopped')
         if (existingDestination.enabled) {
           setRequestStatus(
             existingDestination.pipelineId,

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -125,7 +125,20 @@ export const DestinationRow = ({
       )}
       {isPipelineSuccess && (
         <Table.tr>
-          <Table.td>{isPipelineLoading ? <ShimmeringLoader /> : destinationName}</Table.td>
+          <Table.td>
+            {isPipelineLoading ? (
+              <ShimmeringLoader />
+            ) : pipeline?.id ? (
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="cursor-help">{destinationName}</span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Pipeline ID: {pipeline.id}</TooltipContent>
+              </Tooltip>
+            ) : (
+              destinationName
+            )}
+          </Table.td>
           <Table.td>{isPipelineLoading ? <ShimmeringLoader /> : type}</Table.td>
           <Table.td>
             {isPipelineLoading || !pipeline ? (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -211,6 +211,7 @@ export const DestinationRow = ({
           pipelineId: pipeline?.id,
           enabled:
             statusName === PipelineStatusName.STARTED || statusName === PipelineStatusName.FAILED,
+          statusName,
         }}
       />
     </>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -151,6 +151,7 @@ export const DestinationRow = ({
                 isError={isPipelineStatusError}
                 isSuccess={isPipelineStatusSuccess}
                 requestStatus={requestStatus}
+                pipelineId={pipeline?.id}
               />
             )}
           </Table.td>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -131,7 +131,7 @@ export const DestinationRow = ({
             ) : pipeline?.id ? (
               <Tooltip>
                 <TooltipTrigger>
-                  <span className="cursor-help">{destinationName}</span>
+                  <span className="cursor-default">{destinationName}</span>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Pipeline ID: {pipeline.id}</TooltipContent>
               </Tooltip>
@@ -209,7 +209,8 @@ export const DestinationRow = ({
           sourceId,
           destinationId: destinationId,
           pipelineId: pipeline?.id,
-          enabled: statusName === PipelineStatusName.STARTED,
+          enabled:
+            statusName === PipelineStatusName.STARTED || statusName === PipelineStatusName.FAILED,
         }}
       />
     </>

--- a/apps/studio/components/interfaces/Database/Replication/Pipeline.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/Pipeline.utils.ts
@@ -1,5 +1,6 @@
 import { ReplicationPipelineStatusData } from 'data/replication/pipeline-status-query'
 import { PipelineStatusRequestStatus } from 'state/replication-pipeline-request-status'
+import { PipelineStatusName } from './PipelineStatus'
 
 export const PIPELINE_ERROR_MESSAGES = {
   RETRIEVE_PIPELINE: 'Failed to retrieve pipeline information',
@@ -24,7 +25,7 @@ export const getStatusName = (
 
 export const PIPELINE_ENABLE_ALLOWED_FROM = ['stopped'] as const
 export const PIPELINE_DISABLE_ALLOWED_FROM = ['started', 'failed'] as const
-export const PIPELINE_ACTIONABLE_STATES = ['failed', 'started', 'stopped'] as const
+export const PIPELINE_ACTIONABLE_STATES = ['failed', 'started', 'stopped'] as PipelineStatusName[]
 
 const PIPELINE_STATE_MESSAGES = {
   enabling: {

--- a/apps/studio/components/interfaces/Database/Replication/PipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/PipelineStatus.tsx
@@ -1,7 +1,8 @@
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
 import { useParams } from 'common'
 import { InlineLink } from 'components/ui/InlineLink'
 import { ReplicationPipelineStatusData } from 'data/replication/pipeline-status-query'
-import { AlertTriangle, Loader2 } from 'lucide-react'
 import { PipelineStatusRequestStatus } from 'state/replication-pipeline-request-status'
 import { ResponseError } from 'types'
 import { cn, Tooltip, TooltipContent, TooltipTrigger, WarningIcon } from 'ui'
@@ -131,6 +132,12 @@ export const PipelineStatus = ({
 
   const statusConfig = getStatusConfig()
 
+  const pipelineLogsUrl = pipelineId
+    ? `/project/${ref}/logs/etl-replication-logs?f=${encodeURIComponent(
+        JSON.stringify({ pipeline_id: pipelineId })
+      )}`
+    : `/project/${ref}/logs/etl-replication-logs`
+
   return (
     <>
       {isLoading && <ShimmeringLoader />}
@@ -157,19 +164,7 @@ export const PipelineStatus = ({
             {['unknown', 'failed'].includes(pipelineStatus?.name ?? '') && (
               <>
                 {' '}
-                Check the{' '}
-                <InlineLink
-                  href={
-                    pipelineId
-                      ? `/project/${ref}/logs/etl-replication-logs?f=${encodeURIComponent(
-                          JSON.stringify({ pipeline_id: pipelineId })
-                        )}`
-                      : `/project/${ref}/logs/etl-replication-logs`
-                  }
-                >
-                  logs
-                </InlineLink>{' '}
-                for more information.
+                Check the <InlineLink href={pipelineLogsUrl}>logs</InlineLink> for more information.
               </>
             )}
           </TooltipContent>

--- a/apps/studio/components/interfaces/Database/Replication/PipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/PipelineStatus.tsx
@@ -23,6 +23,7 @@ interface PipelineStatusProps {
   isError: boolean
   isSuccess: boolean
   requestStatus?: PipelineStatusRequestStatus
+  pipelineId?: number
 }
 
 export const PipelineStatus = ({
@@ -32,6 +33,7 @@ export const PipelineStatus = ({
   isError,
   isSuccess,
   requestStatus,
+  pipelineId,
 }: PipelineStatusProps) => {
   const { ref } = useParams()
 
@@ -156,8 +158,18 @@ export const PipelineStatus = ({
               <>
                 {' '}
                 Check the{' '}
-                <InlineLink href={`/project/${ref}/logs/etl-replication-logs`}>logs</InlineLink> for
-                more information.
+                <InlineLink
+                  href={
+                    pipelineId
+                      ? `/project/${ref}/logs/etl-replication-logs?f=${encodeURIComponent(
+                          JSON.stringify({ pipeline_id: pipelineId })
+                        )}`
+                      : `/project/${ref}/logs/etl-replication-logs`
+                  }
+                >
+                  logs
+                </InlineLink>{' '}
+                for more information.
               </>
             )}
           </TooltipContent>

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -146,6 +146,7 @@ export const ReplicationPipelineStatus = () => {
                 isError={isPipelineStatusError}
                 isSuccess={isPipelineStatusSuccess}
                 requestStatus={requestStatus}
+                pipelineId={pipelineId}
               />
             </div>
           </div>
@@ -178,7 +179,15 @@ export const ReplicationPipelineStatus = () => {
             />
           </div>
           <Button asChild type="default">
-            <Link href={`/project/${projectRef}/logs/etl-replication-logs`}>View logs</Link>
+            <Link
+              href={`/project/${projectRef}/logs/etl-replication-logs${
+                pipelineId
+                  ? `?f=${encodeURIComponent(JSON.stringify({ pipeline_id: pipelineId }))}`
+                  : ''
+              }`}
+            >
+              View logs
+            </Link>
           </Button>
           <Button
             type={statusName === 'stopped' ? 'primary' : 'default'}

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -1,4 +1,4 @@
-import { Activity, ChevronLeft, ExternalLink, Search, X } from 'lucide-react'
+import { Activity, ChevronLeft, ExternalLink, Search, X, Play, Pause, RotateCcw, Ban } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -188,20 +188,40 @@ export const ReplicationPipelineStatus = () => {
               View logs
             </Link>
           </Button>
-          <Button
-            type={statusName === 'stopped' ? 'primary' : 'default'}
-            onClick={onPrimaryAction}
-            loading={isPipelineError || isStartingPipeline || isStoppingPipeline}
-            disabled={!['stopped', 'started', 'failed'].includes(statusName || '')}
-          >
-            {statusName === 'stopped'
-              ? 'Start'
-              : statusName === 'started'
-              ? 'Stop'
-              : statusName === 'failed'
-              ? 'Restart'
-              : 'No action allowed now'}
-          </Button>
+          {(() => {
+            const isUnavailable =
+              isEnablingDisabling || !PIPELINE_ACTIONABLE_STATES.includes((statusName ?? '') as any)
+
+            const label =
+              statusName === 'stopped'
+                ? 'Start'
+                : statusName === 'started'
+                ? 'Stop'
+                : statusName === 'failed'
+                ? 'Restart'
+                : 'Action unavailable'
+
+            const icon =
+              statusName === 'stopped'
+                ? <Play />
+                : statusName === 'started'
+                ? <Pause />
+                : statusName === 'failed'
+                ? <RotateCcw />
+                : <Ban />
+
+            return (
+              <Button
+                type={statusName === 'stopped' ? 'primary' : 'default'}
+                onClick={onPrimaryAction}
+                loading={isPipelineError || isStartingPipeline || isStoppingPipeline}
+                disabled={isUnavailable}
+                icon={icon}
+              >
+                {label}
+              </Button>
+            )
+          })()}
         </div>
       </div>
 

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -1,4 +1,14 @@
-import { Activity, ChevronLeft, ExternalLink, Search, X, Play, Pause, RotateCcw, Ban } from 'lucide-react'
+import {
+  Activity,
+  Ban,
+  ChevronLeft,
+  ExternalLink,
+  Pause,
+  Play,
+  RotateCcw,
+  Search,
+  X,
+} from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -22,12 +32,10 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { ErroredTableDetails } from './ErroredTableDetails'
 import {
   PIPELINE_ACTIONABLE_STATES,
-  PIPELINE_DISABLE_ALLOWED_FROM,
-  PIPELINE_ENABLE_ALLOWED_FROM,
   PIPELINE_ERROR_MESSAGES,
   getStatusName,
 } from './Pipeline.utils'
-import { PipelineStatus } from './PipelineStatus'
+import { PipelineStatus, PipelineStatusName } from './PipelineStatus'
 import { STATUS_REFRESH_FREQUENCY_MS } from './Replication.constants'
 import { TableState } from './ReplicationPipelineStatus.types'
 import { getDisabledStateConfig, getStatusConfig } from './ReplicationPipelineStatus.utils'
@@ -104,6 +112,30 @@ export const ReplicationPipelineStatus = () => {
     requestStatus === PipelineStatusRequestStatus.RestartRequested
   const showDisabledState = !isPipelineRunning || isEnablingDisabling
 
+  const logsUrl = `/project/${projectRef}/logs/etl-replication-logs${
+    pipelineId ? `?f=${encodeURIComponent(JSON.stringify({ pipeline_id: pipelineId }))}` : ''
+  }`
+
+  const label =
+    statusName === 'stopped'
+      ? 'Start'
+      : statusName === 'started'
+        ? 'Stop'
+        : statusName === 'failed'
+          ? 'Restart'
+          : 'Action unavailable'
+
+  const icon =
+    statusName === 'stopped' ? (
+      <Play />
+    ) : statusName === 'started' ? (
+      <Pause />
+    ) : statusName === 'failed' ? (
+      <RotateCcw />
+    ) : (
+      <Ban />
+    )
+
   const onPrimaryAction = async () => {
     if (!projectRef) return console.error('Project ref is required')
     if (!pipeline) return toast.error(PIPELINE_ERROR_MESSAGES.NO_PIPELINE_FOUND)
@@ -135,93 +167,58 @@ export const ReplicationPipelineStatus = () => {
           <Button asChild type="outline" icon={<ChevronLeft />} style={{ padding: '5px' }}>
             <Link href={`/project/${projectRef}/database/replication`} />
           </Button>
-          <div>
-            <div className="flex items-center gap-x-3">
-              <h3 className="text-xl font-semibold">{destinationName || 'Pipeline'}</h3>
-              <PipelineStatus
-                pipelineStatus={pipelineStatusData?.status}
-                error={pipelineStatusError}
-                isLoading={isPipelineStatusLoading}
-                isError={isPipelineStatusError}
-                isSuccess={isPipelineStatusSuccess}
-                requestStatus={requestStatus}
-                pipelineId={pipelineId}
-              />
-            </div>
+          <div className="flex items-center gap-x-3">
+            <h3 className="text-xl font-semibold">{destinationName || 'Pipeline'}</h3>
+            <PipelineStatus
+              pipelineStatus={pipelineStatusData?.status}
+              error={pipelineStatusError}
+              isLoading={isPipelineStatusLoading}
+              isError={isPipelineStatusError}
+              isSuccess={isPipelineStatusSuccess}
+              requestStatus={requestStatus}
+              pipelineId={pipelineId}
+            />
           </div>
         </div>
         <div className="flex items-center gap-x-2">
-          <div className="relative">
-            <Search
-              className="absolute left-2 top-1/2 transform -translate-y-1/2 text-foreground-lighter"
-              size={14}
-            />
-            <Input
-              className="pl-7 h-[26px] text-xs"
-              placeholder="Search for tables"
-              value={filterString}
-              disabled={isPipelineError}
-              onChange={(e) => setFilterString(e.target.value)}
-              actions={
-                filterString.length > 0
-                  ? [
-                      <X
-                        key="close"
-                        className="mx-2 cursor-pointer text-foreground"
-                        size={14}
-                        strokeWidth={2}
-                        onClick={() => setFilterString('')}
-                      />,
-                    ]
-                  : undefined
-              }
-            />
-          </div>
+          <Input
+            icon={<Search size={12} />}
+            className="pl-7 h-[26px] text-xs"
+            placeholder="Search for tables"
+            value={filterString}
+            disabled={isPipelineError}
+            onChange={(e) => setFilterString(e.target.value)}
+            actions={
+              filterString.length > 0
+                ? [
+                    <X
+                      key="close"
+                      className="mx-2 cursor-pointer text-foreground"
+                      size={14}
+                      strokeWidth={2}
+                      onClick={() => setFilterString('')}
+                    />,
+                  ]
+                : undefined
+            }
+          />
+
           <Button asChild type="default">
-            <Link
-              href={`/project/${projectRef}/logs/etl-replication-logs${
-                pipelineId
-                  ? `?f=${encodeURIComponent(JSON.stringify({ pipeline_id: pipelineId }))}`
-                  : ''
-              }`}
-            >
-              View logs
-            </Link>
+            <Link href={logsUrl}>View logs</Link>
           </Button>
-          {(() => {
-            const isUnavailable =
-              isEnablingDisabling || !PIPELINE_ACTIONABLE_STATES.includes((statusName ?? '') as any)
 
-            const label =
-              statusName === 'stopped'
-                ? 'Start'
-                : statusName === 'started'
-                ? 'Stop'
-                : statusName === 'failed'
-                ? 'Restart'
-                : 'Action unavailable'
-
-            const icon =
-              statusName === 'stopped'
-                ? <Play />
-                : statusName === 'started'
-                ? <Pause />
-                : statusName === 'failed'
-                ? <RotateCcw />
-                : <Ban />
-
-            return (
-              <Button
-                type={statusName === 'stopped' ? 'primary' : 'default'}
-                onClick={onPrimaryAction}
-                loading={isPipelineError || isStartingPipeline || isStoppingPipeline}
-                disabled={isUnavailable}
-                icon={icon}
-              >
-                {label}
-              </Button>
-            )
-          })()}
+          <Button
+            type={statusName === 'stopped' ? 'primary' : 'default'}
+            onClick={onPrimaryAction}
+            loading={isPipelineError || isStartingPipeline || isStoppingPipeline}
+            disabled={
+              isEnablingDisabling ||
+              !PIPELINE_ACTIONABLE_STATES.includes(statusName as PipelineStatusName)
+            }
+            icon={icon}
+          >
+            {label}
+          </Button>
         </div>
       </div>
 
@@ -265,6 +262,7 @@ export const ReplicationPipelineStatus = () => {
           )}
 
           <div className="w-full overflow-hidden overflow-x-auto">
+            {/* [Joshen] Should update to use new Table components next time */}
             <Table
               head={[
                 <Table.th key="table">Table</Table.th>,

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -357,6 +357,10 @@ export const SQL_FILTER_TEMPLATES: any = {
   pg_cron_logs: {
     ..._SQL_FILTER_COMMON,
   },
+  etl_replication_logs: {
+    ..._SQL_FILTER_COMMON,
+    pipeline_id: (value: string | number) => `pipeline_id = ${value}`,
+  },
 }
 
 export enum LogsTableName {

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -104,9 +104,7 @@ export const useUpdateDestinationPipelineMutation = ({
           queryClient.invalidateQueries(replicationKeys.destinations(projectRef)),
           queryClient.invalidateQueries(replicationKeys.pipelines(projectRef)),
           // Invalidate item-level caches used by the editor panel
-          queryClient.invalidateQueries(
-            replicationKeys.destinationById(projectRef, destinationId)
-          ),
+          queryClient.invalidateQueries(replicationKeys.destinationById(projectRef, destinationId)),
           queryClient.invalidateQueries(replicationKeys.pipelineById(projectRef, pipelineId)),
         ])
 

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -97,11 +97,17 @@ export const useUpdateDestinationPipelineMutation = ({
     (vars) => updateDestinationPipeline(vars),
     {
       async onSuccess(data, variables, context) {
-        const { projectRef } = variables
+        const { projectRef, destinationId, pipelineId } = variables
 
         await Promise.all([
+          // Invalidate lists
           queryClient.invalidateQueries(replicationKeys.destinations(projectRef)),
           queryClient.invalidateQueries(replicationKeys.pipelines(projectRef)),
+          // Invalidate item-level caches used by the editor panel
+          queryClient.invalidateQueries(
+            replicationKeys.destinationById(projectRef, destinationId)
+          ),
+          queryClient.invalidateQueries(replicationKeys.pipelineById(projectRef, pipelineId)),
         ])
 
         await onSuccess?.(data, variables, context)


### PR DESCRIPTION
This PR adds the following changes:
- The pipeline ID now can be seen by hovering over the name of the destination (useful for debugging purposes).
- When you click on view logs, now the system filters by `pipeline_id` to show the logs of the specific pipeline.
- The button for starting and stopping the pipeline has been improved and it's now more state aware. When there are state transitions it switches to a disabled state.
- The update config in the destination panel is now working correctly, before it was just referencing the value before the last update.

### Screenshots

<img width="1122" height="287" alt="image" src="https://github.com/user-attachments/assets/4ad57100-93b2-4726-a6ae-f8e53870143b" />

<img width="408" height="292" alt="image" src="https://github.com/user-attachments/assets/310f52fc-d4eb-46b0-8fec-d1d75c5a0204" />

<img width="383" height="270" alt="image" src="https://github.com/user-attachments/assets/164a6a60-899f-4229-9299-359ce278d1bd" />