### PR TITLE
fix: Populate state field in billing address form

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
@@ -61,6 +61,7 @@ export const BillingCustomerData = () => {
       line1: customerProfile?.address?.line1,
       line2: customerProfile?.address?.line2 ?? undefined,
       postal_code: customerProfile?.address?.postal_code ?? undefined,
+      state: customerProfile?.address?.state ?? undefined,
       billing_name: customerProfile?.billing_name,
       tax_id_type: taxId?.type,
       tax_id_value: taxId?.value,


### PR DESCRIPTION
## Issue

The state field in the billing address form shows as empty on page load, even when state data exists on the backend. Users could enter and save state information, but it doesn't display on subsequent visits.

## Root Cause

The `initialCustomerData` object was missing the `state` field mapping from `customerProfile.address.state`, causing the form to initialize with an empty state value regardless of the data sent from the backend.

## Solution

Added the missing state field mapping in `BillingCustomerData.tsx`:

```typescript
state: customerProfile?.address?.state ?? undefined,
```

## Testing Instructions

### Before

1. Navigate to Organization → Billing → Billing Address & Tax ID
2. Fill out the address form including the state field (e.g., "California")
3. Click Save - should succeed with success message
4. Refresh the page
5. State field appears empty despite being saved

### After

1. Navigate to Organization → Billing → Billing Address & Tax ID  
2. Fill out the address form including the state field (e.g., "California")
3. Click Save - should succeed with success toast
4. Refresh the page
5. State field should now displays the saved value ("California")
