### PR TITLE
Self remediate project scoped roles issue

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -76,7 +76,22 @@ export const UpdateRolesConfirmationModal = ({
       .map((id) => {
         return [...org_scoped_roles, ...project_scoped_roles].find((r) => r.id === id)
       })
+      .map((x) => {
+        // [Joshen] This is merely a patch to handle a issue on the BE whereby for a project-scoped member,
+        // if one of the projects that the member is deleted, the roles isn't cleaned up on the BE
+        // Hence adding an FE patch here for dashboard to self-remediate by omitting any project IDs from the role
+        // which no longer exists in the organization projects list
+        if (!!x?.project_ids) {
+          return {
+            ...x,
+            project_ids: x.project_ids.filter((id) => orgProjects.some((p) => id === p.id)),
+          }
+        } else {
+          return x
+        }
+      })
       .filter(Boolean) as OrganizationRole[]
+
     const isChangeWithinOrgScope =
       projectsRoleConfiguration.length === 1 && projectsRoleConfiguration[0].ref === undefined
 

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.utils.ts
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.utils.ts
@@ -41,7 +41,10 @@ export const formatMemberRoleToProjectRoleConfiguration = (
       }
     })
     .filter(Boolean)
-    .flat() as ProjectRoleConfiguration[]
+    .flat()
+    .filter(
+      (p) => p !== undefined && 'baseRoleId' in p && p.ref !== undefined
+    ) as ProjectRoleConfiguration[]
 
   return roleConfiguration
 }


### PR DESCRIPTION
## Context

We've received a report in the Organization Members page, specifically for project-scoped roles whereby for a member which has access to some projects in the organization, if you delete one of the projects that the user has access to, you'll run into errors if you try to update the role access of that member subsequently.

## Changes involved
There's mainly 2 areas of change
- In `UpdateRolesPanel.utils.ts`, filter out project roles which we're unable to find the project for from the GET /projects endpoint. 
  - This ensures that we do not show any project-scoped roles for projects that don't exist in the organization
- In `UpdateRolesConfirmationModal`, filter out project IDs which we're unable to find the project for from the GET /projects endpoint when saving roles
  - This omits any project IDs for projects that don't exist in the organization

## To test
- [ ] In an organization that's on Team plan or above, ensure that you have one member who has project-scoped roles
- [ ] Delete one of the projects that the member has access to
- [ ] Verify that you can still update the role of the member thereafter (by changing roles for a project, removing access to a project, or adding access to another project)