### PR TITLE
Fix missing loading prop in ConfirmationModal for disabling extension

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
@@ -193,6 +193,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
         confirmLabel="Disable"
         variant="destructive"
         confirmLabelLoading="Disabling"
+        loading={isDisabling}
         onCancel={() => setIsDisableModalOpen(false)}
         onConfirm={() => onConfirmDisable()}
       >


### PR DESCRIPTION
Fixes FE-1830

## Context

Confirmation modal for disabling extension gets stuck in a loading state if there are errors - was just missing a `loading` prop from the disable extension RQ mutation