### PR TITLE
fix: embedding upload error

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -46,6 +46,7 @@ jobs:
             apps/docs
             apps/www/.env.local.example
             examples
+            packages
             supabase
 
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Markdown processing for uploads now depends on the 'common' package (for feature flag querying). Added it to the GitHub Workflow to make sure it is accessible during that step. (Actually added the whole packages directory since it seems likely that we might need other stuff from this in the future.)