### PR TITLE
only trigger request to /clone in create branch modal when modal is o…

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -89,7 +89,13 @@ export const CreateBranchModal = () => {
     useCheckGithubBranchValidity({
       onError: () => {},
     })
-  const { data: cloneBackups, error: cloneBackupsError } = useCloneBackupsQuery({ projectRef })
+  const { data: cloneBackups, error: cloneBackupsError } = useCloneBackupsQuery(
+    { projectRef },
+    {
+      // [Joshen] Only trigger this request when the modal is opened
+      enabled: showCreateBranchModal,
+    }
+  )
   const targetVolumeSizeGb = cloneBackups?.target_volume_size_gb ?? 0
   const noPhysicalBackups = cloneBackupsError?.message.startsWith(
     'Physical backups need to be enabled'


### PR DESCRIPTION
## Context

We added a check to the /clone endpoint in CreateBranchModal back in [this PR](https://github.com/supabase/supabase/pull/38426), opting to only fire that request when the modal is opened, otherwise the request gets triggered when landing on any project page since the modal is rendered in the header