### PR TITLE
Swap useCheckPermissions with useAsyncCheckPermissions part 4: Storage

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ColumnContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ColumnContextMenu.tsx
@@ -3,7 +3,7 @@ import { Item, Menu, Separator, Submenu } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
 
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { ChevronRight, ChevronsDown, ChevronsUp, Clipboard, Eye, FolderPlus } from 'lucide-react'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import {
@@ -17,18 +17,21 @@ interface ColumnContextMenuProps {
   id: string
 }
 
-const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
-  const canUpdateFiles = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+export const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
   const {
     columns,
     selectedItems,
     setSelectedItems,
+    setView,
     setSortBy,
     setSortByOrder,
     addNewFolderPlaceholder,
   } = useStorageExplorerStateSnapshot()
 
-  const snap = useStorageExplorerStateSnapshot()
+  const { can: canUpdateFiles } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   const onSelectCreateFolder = (columnIndex = -1) => {
     addNewFolderPlaceholder(columnIndex)
@@ -80,10 +83,10 @@ const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
         }
         arrow={<ChevronRight size="14" strokeWidth={1} />}
       >
-        <Item onClick={() => snap.setView(STORAGE_VIEWS.COLUMNS)}>
+        <Item onClick={() => setView(STORAGE_VIEWS.COLUMNS)}>
           <span className="ml-2 text-xs">As columns</span>
         </Item>
-        <Item onClick={() => snap.setView(STORAGE_VIEWS.LIST)}>
+        <Item onClick={() => setView(STORAGE_VIEWS.LIST)}>
           <span className="ml-2 text-xs">As list</span>
         </Item>
       </Submenu>
@@ -128,5 +131,3 @@ const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
     </Menu>
   )
 }
-
-export default ColumnContextMenu

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
@@ -12,7 +12,7 @@ const unitMap = {
   years: 3600 * 24 * 365,
 }
 
-const CustomExpiryModal = () => {
+export const CustomExpiryModal = () => {
   const { onCopyUrl } = useCopyUrl()
   const snap = useStorageExplorerStateSnapshot()
   const { selectedFileCustomExpiry, setSelectedFileCustomExpiry } = snap
@@ -100,5 +100,3 @@ const CustomExpiryModal = () => {
     </Modal>
   )
 }
-
-export default CustomExpiryModal

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
@@ -5,10 +5,10 @@ import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { cn } from 'ui'
 import { CONTEXT_MENU_KEYS, STORAGE_VIEWS } from '../Storage.constants'
 import type { StorageColumn, StorageItemWithColumn } from '../Storage.types'
-import ColumnContextMenu from './ColumnContextMenu'
-import FileExplorerColumn from './FileExplorerColumn'
-import FolderContextMenu from './FolderContextMenu'
-import ItemContextMenu from './ItemContextMenu'
+import { ColumnContextMenu } from './ColumnContextMenu'
+import { FileExplorerColumn } from './FileExplorerColumn'
+import { FolderContextMenu } from './FolderContextMenu'
+import { ItemContextMenu } from './ItemContextMenu'
 
 export interface FileExplorerProps {
   columns: StorageColumn[]
@@ -20,7 +20,7 @@ export interface FileExplorerProps {
   onColumnLoadMore: (index: number, column: StorageColumn) => void
 }
 
-const FileExplorer = ({
+export const FileExplorer = ({
   columns = [],
   selectedItems = [],
   itemSearchString,
@@ -90,5 +90,3 @@ const FileExplorer = ({
     </div>
   )
 }
-
-export default FileExplorer

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -8,7 +8,7 @@ import { toast } from 'sonner'
 
 import InfiniteList from 'components/ui/InfiniteList'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { BASE_PATH } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
@@ -20,7 +20,7 @@ import {
   STORAGE_VIEWS,
 } from '../Storage.constants'
 import type { StorageColumn, StorageItemWithColumn } from '../Storage.types'
-import FileExplorerRow from './FileExplorerRow'
+import { FileExplorerRow } from './FileExplorerRow'
 
 const DragOverOverlay = ({ isOpen, onDragLeave, onDrop, folderIsEmpty }: any) => {
   return (
@@ -68,7 +68,7 @@ export interface FileExplorerColumnProps {
   onColumnLoadMore: (index: number, column: StorageColumn) => void
 }
 
-const FileExplorerColumn = ({
+export const FileExplorerColumn = ({
   index = 0,
   column,
   fullWidth = false,
@@ -83,7 +83,10 @@ const FileExplorerColumn = ({
   const fileExplorerColumnRef = useRef<any>(null)
 
   const snap = useStorageExplorerStateSnapshot()
-  const canUpdateStorage = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateStorage } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   useEffect(() => {
     if (fileExplorerColumnRef) {
@@ -275,5 +278,3 @@ const FileExplorerColumn = ({
     </div>
   )
 }
-
-export default FileExplorerColumn

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
@@ -1,11 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { compact, debounce, isEqual, noop } from 'lodash'
-import { useCallback, useEffect, useRef, useState } from 'react'
-
-import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import APIDocsButton from 'components/ui/APIDocsButton'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import {
   Check,
   ChevronLeft,
@@ -20,6 +14,12 @@ import {
   Upload,
   X,
 } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import APIDocsButton from 'components/ui/APIDocsButton'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import {
   Button,
@@ -137,10 +137,10 @@ const HeaderBreadcrumbs = ({
 interface FileExplorerHeader {
   itemSearchString: string
   setItemSearchString: (value: string) => void
-  onFilesUpload: (event: any, columnIndex: number) => void
+  onFilesUpload: (event: any, columnIndex?: number) => void
 }
 
-const FileExplorerHeader = ({
+export const FileExplorerHeader = ({
   itemSearchString = '',
   setItemSearchString = noop,
   onFilesUpload = noop,
@@ -179,7 +179,10 @@ const FileExplorerHeader = ({
 
   const breadcrumbs = columns.map((column) => column.name)
   const backDisabled = columns.length <= 1
-  const canUpdateStorage = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateStorage } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   useEffect(() => {
     if (itemSearchString) setSearchString(itemSearchString)
@@ -423,7 +426,6 @@ const FileExplorerHeader = ({
         <div className="h-6 border-r border-control" />
         <div className="flex items-center space-x-1 px-2">
           <div className="hidden">
-            {/* @ts-ignore */}
             <input ref={uploadButtonRef} type="file" multiple onChange={onFilesUpload} />
           </div>
           <ButtonTooltip
@@ -505,5 +507,3 @@ const FileExplorerHeader = ({
     </div>
   )
 }
-
-export default FileExplorerHeader

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeaderSelection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeaderSelection.tsx
@@ -3,14 +3,17 @@ import { Download, Move, Trash2, X } from 'lucide-react'
 
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { Button } from 'ui'
 import { downloadFile } from './StorageExplorer.utils'
 
-const FileExplorerHeaderSelection = () => {
+export const FileExplorerHeaderSelection = () => {
   const { ref: projectRef, bucketId } = useParams()
-  const canUpdateFiles = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateFiles } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   const {
     selectedItems,
@@ -80,5 +83,3 @@ const FileExplorerHeaderSelection = () => {
     </div>
   )
 }
-
-export default FileExplorerHeaderSelection

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -19,7 +19,7 @@ import SVG from 'react-inlinesvg'
 
 import { useParams } from 'common'
 import type { ItemRenderer } from 'components/ui/InfiniteList'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { BASE_PATH } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
@@ -47,7 +47,7 @@ import {
   URL_EXPIRY_DURATION,
 } from '../Storage.constants'
 import { StorageItem, StorageItemWithColumn } from '../Storage.types'
-import FileExplorerRowEditing from './FileExplorerRowEditing'
+import { FileExplorerRowEditing } from './FileExplorerRowEditing'
 import { copyPathToFolder, downloadFile } from './StorageExplorer.utils'
 import { useCopyUrl } from './useCopyUrl'
 
@@ -98,13 +98,13 @@ export const RowIcon = ({
   return <File size={16} strokeWidth={2} />
 }
 
-export interface FileExplorerRowProps {
+interface FileExplorerRowProps {
   view: STORAGE_VIEWS
   columnIndex: number
   selectedItems: StorageItemWithColumn[]
 }
 
-const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = ({
+export const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = ({
   index: itemIndex,
   item,
   view = STORAGE_VIEWS.COLUMNS,
@@ -139,7 +139,10 @@ const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = ({
   const isOpened =
     openedFolders.length > columnIndex ? openedFolders[columnIndex].name === item.name : false
   const isPreviewed = !isEmpty(selectedFilePreview) && isEqual(selectedFilePreview?.id, item.id)
-  const canUpdateFiles = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateFiles } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   const onSelectFile = async (columnIndex: number, file: StorageItem) => {
     popColumnAtIndex(columnIndex)
@@ -455,5 +458,3 @@ const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = ({
     </div>
   )
 }
-
-export default FileExplorerRow

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -12,7 +12,11 @@ export interface FileExplorerRowEditingProps {
   columnIndex: number
 }
 
-const FileExplorerRowEditing = ({ item, view, columnIndex }: FileExplorerRowEditingProps) => {
+export const FileExplorerRowEditing = ({
+  item,
+  view,
+  columnIndex,
+}: FileExplorerRowEditingProps) => {
   const { renameFile, renameFolder, addNewFolder, updateRowStatus } =
     useStorageExplorerStateSnapshot()
 
@@ -112,5 +116,3 @@ const FileExplorerRowEditing = ({ item, view, columnIndex }: FileExplorerRowEdit
     </div>
   )
 }
-
-export default FileExplorerRowEditing

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FolderContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FolderContextMenu.tsx
@@ -3,7 +3,7 @@ import { Clipboard, Download, Edit, Trash2 } from 'lucide-react'
 import { Item, Menu, Separator } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
 
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { copyPathToFolder } from './StorageExplorer.utils'
 
@@ -11,10 +11,13 @@ interface FolderContextMenuProps {
   id: string
 }
 
-const FolderContextMenu = ({ id = '' }: FolderContextMenuProps) => {
+export const FolderContextMenu = ({ id = '' }: FolderContextMenuProps) => {
   const { openedFolders, downloadFolder, setSelectedItemToRename, setSelectedItemsToDelete } =
     useStorageExplorerStateSnapshot()
-  const canUpdateFiles = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateFiles } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   return (
     <Menu id={id} animation="fade">
@@ -42,5 +45,3 @@ const FolderContextMenu = ({ id = '' }: FolderContextMenuProps) => {
     </Menu>
   )
 }
-
-export default FolderContextMenu

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
@@ -4,7 +4,7 @@ import { Item, Menu, Separator, Submenu } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
 
 import { useParams } from 'common'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { URL_EXPIRY_DURATION } from '../Storage.constants'
 import { StorageItemWithColumn } from '../Storage.types'
@@ -15,7 +15,7 @@ interface ItemContextMenuProps {
   id: string
 }
 
-const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
+export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
   const { ref: projectRef, bucketId } = useParams()
   const snap = useStorageExplorerStateSnapshot()
   const { setSelectedFileCustomExpiry } = snap
@@ -28,7 +28,10 @@ const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
   } = useStorageExplorerStateSnapshot()
   const { onCopyUrl } = useCopyUrl()
   const isPublic = selectedBucket.public
-  const canUpdateFiles = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateFiles } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   const onHandleClick = async (event: any, item: StorageItemWithColumn, expiresIn?: number) => {
     if (item.isCorrupted) return
@@ -106,5 +109,3 @@ const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
     </Menu>
   )
 }
-
-export default ItemContextMenu

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/MoveItemsModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/MoveItemsModal.tsx
@@ -12,7 +12,7 @@ interface MoveItemsModalProps {
   onSelectMove: (path: string) => void
 }
 
-const MoveItemsModal = ({
+export const MoveItemsModal = ({
   bucketName = '',
   visible = false,
   selectedItemsToMove = [],
@@ -87,5 +87,3 @@ const MoveItemsModal = ({
     </Modal>
   )
 }
-
-export default MoveItemsModal

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -6,7 +6,7 @@ import SVG from 'react-inlinesvg'
 
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { BASE_PATH } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
@@ -115,7 +115,7 @@ const PreviewFile = ({ item }: { item: StorageItem }) => {
   )
 }
 
-const PreviewPane = () => {
+export const PreviewPane = () => {
   const { ref: projectRef, bucketId } = useParams()
 
   const {
@@ -127,7 +127,10 @@ const PreviewPane = () => {
   } = useStorageExplorerStateSnapshot()
   const { onCopyUrl } = useCopyUrl()
 
-  const canUpdateFiles = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+  const { can: canUpdateFiles } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_WRITE,
+    '*'
+  )
 
   if (!file) return null
 
@@ -139,148 +142,144 @@ const PreviewPane = () => {
   const updatedAt = file.updated_at ? new Date(file.updated_at).toLocaleString() : 'Unknown'
 
   return (
-    <>
-      <Transition
-        show={isOpen}
-        enter="transition ease-out duration-150"
-        enterFrom="transform opacity-0"
-        enterTo="transform opacity-100"
-        leave="transition ease-in duration-100"
-        leaveFrom="transform opacity-100"
-        leaveTo="transform opacity-0"
-      >
-        <div className="h-full border-l border-overlay bg-surface-100 p-4" style={{ width }}>
-          {/* Preview Header */}
-          <div className="flex w-full justify-end text-foreground-lighter transition-colors hover:text-foreground">
-            <X
-              className="cursor-pointer"
-              size={14}
-              strokeWidth={2}
-              onClick={() => setSelectedFilePreview(undefined)}
-            />
-          </div>
+    <Transition
+      show={isOpen}
+      enter="transition ease-out duration-150"
+      enterFrom="transform opacity-0"
+      enterTo="transform opacity-100"
+      leave="transition ease-in duration-100"
+      leaveFrom="transform opacity-100"
+      leaveTo="transform opacity-0"
+    >
+      <div className="h-full border-l border-overlay bg-surface-100 p-4" style={{ width }}>
+        {/* Preview Header */}
+        <div className="flex w-full justify-end text-foreground-lighter transition-colors hover:text-foreground">
+          <X
+            className="cursor-pointer"
+            size={14}
+            strokeWidth={2}
+            onClick={() => setSelectedFilePreview(undefined)}
+          />
+        </div>
 
-          {/* Preview Thumbnail*/}
-          <div className="my-4 border border-overlay">
-            <div className="flex h-56 w-full items-center 2xl:h-72">
-              <PreviewFile item={file} />
-            </div>
-          </div>
-
-          <div className="w-full space-y-6">
-            {/* Preview Information */}
-            <div className="space-y-1">
-              <h5 className="break-words text-base text-foreground">{file.name}</h5>
-              {file.isCorrupted && (
-                <div className="flex items-center space-x-2">
-                  <AlertCircle size={14} strokeWidth={2} className="text-foreground-light" />
-                  <p className="text-sm text-foreground-light">
-                    File is corrupted, please delete and reupload this file again
-                  </p>
-                </div>
-              )}
-              {mimeType && (
-                <p className="text-sm text-foreground-light">
-                  {mimeType}
-                  {size && <span> - {size}</span>}
-                </p>
-              )}
-            </div>
-
-            {/* Preview Metadata */}
-            <div className="space-y-2">
-              <div>
-                <label className="mb-1 text-xs text-foreground-lighter">Added on</label>
-                <p className="text-sm text-foreground-light">{createdAt}</p>
-              </div>
-              <div>
-                <label className="mb-1 text-xs text-foreground-lighter">Last modified</label>
-                <p className="text-sm text-foreground-light">{updatedAt}</p>
-              </div>
-            </div>
-
-            {/* Actions */}
-            <div className="flex space-x-2 border-b border-overlay pb-4">
-              <Button
-                type="default"
-                icon={<Download size={16} strokeWidth={2} />}
-                disabled={file.isCorrupted}
-                onClick={async () => await downloadFile({ projectRef, bucketId, file })}
-              >
-                Download
-              </Button>
-              {selectedBucket.public ? (
-                <Button
-                  type="outline"
-                  icon={<Clipboard size={16} strokeWidth={2} />}
-                  onClick={() => onCopyUrl(file.name)}
-                  disabled={file.isCorrupted}
-                >
-                  Get URL
-                </Button>
-              ) : (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="outline"
-                      icon={<Clipboard size={16} strokeWidth={2} />}
-                      iconRight={<ChevronDown />}
-                      disabled={file.isCorrupted}
-                    >
-                      Get URL
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent side="bottom" align="center">
-                    <DropdownMenuItem
-                      key="expires-one-week"
-                      onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.WEEK)}
-                    >
-                      Expire in 1 week
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      key="expires-one-month"
-                      onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.MONTH)}
-                    >
-                      Expire in 1 month
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      key="expires-one-year"
-                      onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.YEAR)}
-                    >
-                      Expire in 1 year
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      key="custom-expiry"
-                      onClick={() => setSelectedFileCustomExpiry(file)}
-                    >
-                      Custom expiry
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
-            <ButtonTooltip
-              type="outline"
-              disabled={!canUpdateFiles}
-              size="tiny"
-              icon={<Trash2 strokeWidth={2} />}
-              onClick={() => setSelectedItemsToDelete([file])}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text: !canUpdateFiles
-                    ? 'You need additional permissions to delete this file'
-                    : undefined,
-                },
-              }}
-            >
-              Delete file
-            </ButtonTooltip>
+        {/* Preview Thumbnail*/}
+        <div className="my-4 border border-overlay">
+          <div className="flex h-56 w-full items-center 2xl:h-72">
+            <PreviewFile item={file} />
           </div>
         </div>
-      </Transition>
-    </>
+
+        <div className="w-full space-y-6">
+          {/* Preview Information */}
+          <div className="space-y-1">
+            <h5 className="break-words text-base text-foreground">{file.name}</h5>
+            {file.isCorrupted && (
+              <div className="flex items-center space-x-2">
+                <AlertCircle size={14} strokeWidth={2} className="text-foreground-light" />
+                <p className="text-sm text-foreground-light">
+                  File is corrupted, please delete and reupload this file again
+                </p>
+              </div>
+            )}
+            {mimeType && (
+              <p className="text-sm text-foreground-light">
+                {mimeType}
+                {size && <span> - {size}</span>}
+              </p>
+            )}
+          </div>
+
+          {/* Preview Metadata */}
+          <div className="space-y-2">
+            <div>
+              <label className="mb-1 text-xs text-foreground-lighter">Added on</label>
+              <p className="text-sm text-foreground-light">{createdAt}</p>
+            </div>
+            <div>
+              <label className="mb-1 text-xs text-foreground-lighter">Last modified</label>
+              <p className="text-sm text-foreground-light">{updatedAt}</p>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex space-x-2 border-b border-overlay pb-4">
+            <Button
+              type="default"
+              icon={<Download size={16} strokeWidth={2} />}
+              disabled={file.isCorrupted}
+              onClick={async () => await downloadFile({ projectRef, bucketId, file })}
+            >
+              Download
+            </Button>
+            {selectedBucket.public ? (
+              <Button
+                type="outline"
+                icon={<Clipboard size={16} strokeWidth={2} />}
+                onClick={() => onCopyUrl(file.name)}
+                disabled={file.isCorrupted}
+              >
+                Get URL
+              </Button>
+            ) : (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="outline"
+                    icon={<Clipboard size={16} strokeWidth={2} />}
+                    iconRight={<ChevronDown />}
+                    disabled={file.isCorrupted}
+                  >
+                    Get URL
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="bottom" align="center">
+                  <DropdownMenuItem
+                    key="expires-one-week"
+                    onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.WEEK)}
+                  >
+                    Expire in 1 week
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    key="expires-one-month"
+                    onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.MONTH)}
+                  >
+                    Expire in 1 month
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    key="expires-one-year"
+                    onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.YEAR)}
+                  >
+                    Expire in 1 year
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    key="custom-expiry"
+                    onClick={() => setSelectedFileCustomExpiry(file)}
+                  >
+                    Custom expiry
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+          <ButtonTooltip
+            type="outline"
+            disabled={!canUpdateFiles}
+            size="tiny"
+            icon={<Trash2 strokeWidth={2} />}
+            onClick={() => setSelectedItemsToDelete([file])}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text: !canUpdateFiles
+                  ? 'You need additional permissions to delete this file'
+                  : undefined,
+              },
+            }}
+          >
+            Delete file
+          </ButtonTooltip>
+        </div>
+      </div>
+    </Transition>
   )
 }
-
-export default PreviewPane

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -8,12 +8,12 @@ import { IS_PLATFORM } from 'lib/constants'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
 import { ConfirmDeleteModal } from './ConfirmDeleteModal'
-import CustomExpiryModal from './CustomExpiryModal'
-import FileExplorer from './FileExplorer'
-import FileExplorerHeader from './FileExplorerHeader'
-import FileExplorerHeaderSelection from './FileExplorerHeaderSelection'
-import MoveItemsModal from './MoveItemsModal'
-import PreviewPane from './PreviewPane'
+import { CustomExpiryModal } from './CustomExpiryModal'
+import { FileExplorer } from './FileExplorer'
+import { FileExplorerHeader } from './FileExplorerHeader'
+import { FileExplorerHeaderSelection } from './FileExplorerHeaderSelection'
+import { MoveItemsModal } from './MoveItemsModal'
+import { PreviewPane } from './PreviewPane'
 
 interface StorageExplorerProps {
   bucket: Bucket
@@ -126,7 +126,7 @@ export const StorageExplorer = ({ bucket }: StorageExplorerProps) => {
 
   /** File manipulation methods */
 
-  const onFilesUpload = async (event: any, columnIndex = -1) => {
+  const onFilesUpload = async (event: any, columnIndex: number = -1) => {
     event.persist()
     const items = event.target.files || event.dataTransfer.items
     const isDrop = !isEmpty(get(event, ['dataTransfer', 'items'], []))

--- a/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
@@ -9,7 +9,7 @@ import { useParams } from 'common'
 import { useIsProjectActive } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import { useS3AccessKeyCreateMutation } from 'data/storage/s3-access-key-create-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import {
   Button,
   Dialog,
@@ -39,7 +39,10 @@ export const CreateCredentialModal = ({ visible, onOpenChange }: CreateCredentia
   const isProjectActive = useIsProjectActive()
   const [showSuccess, setShowSuccess] = useState(false)
 
-  const canCreateCredentials = useCheckPermissions(PermissionAction.STORAGE_ADMIN_WRITE, '*')
+  const { can: canCreateCredentials } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_ADMIN_WRITE,
+    '*'
+  )
 
   const { data: config } = useProjectStorageConfigQuery({ projectRef })
   const isS3ConnectionEnabled = config?.features.s3Protocol.enabled

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageCredItem.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageCredItem.tsx
@@ -3,7 +3,7 @@ import { differenceInDays } from 'date-fns'
 import { MoreVertical, TrashIcon } from 'lucide-react'
 
 import CopyButton from 'components/ui/CopyButton'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import {
   Button,
   DropdownMenu,
@@ -25,7 +25,10 @@ export const StorageCredItem = ({
   access_key: string
   onDeleteClick: (id: string) => void
 }) => {
-  const canRemoveAccessKey = useCheckPermissions(PermissionAction.STORAGE_ADMIN_WRITE, '*')
+  const { can: canRemoveAccessKey } = useAsyncCheckProjectPermissions(
+    PermissionAction.STORAGE_ADMIN_WRITE,
+    '*'
+  )
 
   function daysSince(date: string) {
     const now = new Date()


### PR DESCRIPTION
## Context

Following up from the previous [PR](https://github.com/supabase/supabase/pull/37899), copying the PR description for ease of reference:

We'll be favouring the use of useAsyncCheckProjectPermissions over useCheckPermissions as it'll allow us to access the loading state of the permissions. We should then also factor that in to prevent any premature "no permissions" UI rendering

Opting to do this in smaller PRs since its a bit nuanced

We can only swap useCheckPermissions with useAsyncCheckProjectPermissions for project permissions, organization permissions will still need to use the former for now until we introduce a new useAsyncCheckOrgPermissions
Also need to add loading states where missing for pages that are currently prematurely showing the no perms UI

## Changes involved
- Swap `useCheckPermissions` with `useAsyncCheckProjectPermissions` in more files
  - Note: adjusted loading behaviour for the following
    - `StorageSettings/S3Connection.tsx`
- (Unrelated) Remove more `export default` for Storage related files

## Affected UI
Probably just need a quick skim on these pages, mainly just to make sure that there's (1) No incorrect "perms denied" UI, if you're the owner of the org you should have access to everything (2) No pre-mature "perms denied UI" (can test by refreshing on that page)
- Storage + Storage Settings