### PR TITLE
feat(design-system): add contentlayer watch task to package.json

### DIFF
--- a/apps/design-system/README.md
+++ b/apps/design-system/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+### Watching for MDX changes
+
+If you would like to watch for changes to MDX files with hot reload, you can run the following command in a separate Terminal shell:
+
+```
+pnpm content:dev
+```
+
+This runs Contentlayer concurrently and watches for any changes.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -10,6 +10,7 @@
     "build:registry": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/build-registry.mts && prettier --log-level silent --write \"registry/**/*.{ts,tsx,mdx}\" --cache",
     "start": "next start",
     "lint": "next lint",
+    "content:dev": "contentlayer2 dev",
     "content:build": "contentlayer2 build",
     "clean": "rimraf node_modules .next .turbo",
     "typecheck": "contentlayer2 build && tsc --noEmit -p tsconfig.json"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Very small change that adds a watch task to Contentlayer in our design system. This is mainly added so hot reload works in local development (and saves you from running `content:build` every time you want to see changes.
