### PR TITLE
Add feature flag to disable /chore requests trigger in CreateBranchModal

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -65,7 +65,7 @@ export const CreateBranchModal = () => {
   const allowDataBranching = useFlag('allowDataBranching')
   // [Joshen] This is meant to be short lived while we're figuring out how to control
   // requests to this endpoint. Kill switch in case we need to stop the requests
-  const disableBackupsCheck = useFlag('DisableBackupsCheckInCreatebranchmodal')
+  const disableBackupsCheck = useFlag('disableBackupsCheckInCreatebranchmodal')
 
   const isProPlanAndUp = selectedOrg?.plan?.id !== 'free'
   const promptProPlanUpgrade = IS_PLATFORM && !isProPlanAndUp

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -63,6 +63,9 @@ export const CreateBranchModal = () => {
 
   const gitlessBranching = useIsBranching2Enabled()
   const allowDataBranching = useFlag('allowDataBranching')
+  // [Joshen] This is meant to be short lived while we're figuring out how to control
+  // requests to this endpoint. Kill switch in case we need to stop the requests
+  const disableBackupsCheck = useFlag('DisableBackupsCheckInCreatebranchmodal')
 
   const isProPlanAndUp = selectedOrg?.plan?.id !== 'free'
   const promptProPlanUpgrade = IS_PLATFORM && !isProPlanAndUp
@@ -93,7 +96,7 @@ export const CreateBranchModal = () => {
     { projectRef },
     {
       // [Joshen] Only trigger this request when the modal is opened
-      enabled: showCreateBranchModal,
+      enabled: showCreateBranchModal && !disableBackupsCheck,
     }
   )
   const targetVolumeSizeGb = cloneBackups?.target_volume_size_gb ?? 0
@@ -364,13 +367,13 @@ export const CreateBranchModal = () => {
                         <TooltipTrigger>
                           <FormControl_Shadcn_>
                             <Switch
-                              disabled={noPhysicalBackups}
+                              disabled={!disableBackupsCheck && noPhysicalBackups}
                               checked={field.value}
                               onCheckedChange={field.onChange}
                             />
                           </FormControl_Shadcn_>
                         </TooltipTrigger>
-                        {noPhysicalBackups && (
+                        {!disableBackupsCheck && noPhysicalBackups && (
                           <TooltipContent side="bottom">
                             PITR is required for the project to clone data into the branch
                           </TooltipContent>


### PR DESCRIPTION
## Context

Following up from the previous [PR here](https://github.com/supabase/supabase/pull/38454) - we've reduced the number of requests going to `/clone` by only triggering the request when the Create branch modal is opened.

This is just adding a kill switch to completely prevent requests to `/clone` in case we need it (meant to be short lived and can be removed once API optimization is done)

Enabling the feature flag will:
- Stop requests to `/clone`
- Remove the physical backups check for "Include data" toggle (FE will let the API do any required validation - if there is any?)
  - Toggle will no longer be disabled