### PR TITLE
feat: ensure customer puts down address on upgrade

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
@@ -32,39 +32,18 @@ interface BillingCustomerDataFormProps {
 }
 
 // Define the expected form values structure and validation schema
-export const BillingCustomerDataSchema = z
-  .object({
-    billing_name: z.string().min(3, 'Name must be at least 3 letters long'),
-    line1: z.string().optional(),
-    line2: z.string().optional(),
-    city: z.string().optional(),
-    state: z.string().optional(),
-    postal_code: z.string().optional(),
-    country: z.string().optional(),
-    tax_id_type: z.string(),
-    tax_id_value: z.string(),
-    tax_id_name: z.string(),
-  })
-  .refine(
-    (data) => {
-      // its fine to just set the name, but once any other field is set, requires full address
-      const hasAnyField = data.line1 || data.line2 || data.city || data.state || data.postal_code
-      // If any field has value, country and line1 must have values.
-      return !hasAnyField || (!!data.country && !!data.line1)
-    },
-    {
-      message: 'Country and Address line 1 are required if any other field is provided.',
-      path: ['line1'],
-    }
-  )
-  .refine((data) => !(!!data.line1 && !data.country), {
-    message: 'Please select a country',
-    path: ['country'],
-  })
-  .refine((data) => !(!!data.country && !data.line1), {
-    message: 'Please provide an address line 1',
-    path: ['line1'],
-  })
+export const BillingCustomerDataSchema = z.object({
+  billing_name: z.string().min(3, 'Name must be at least 3 letters long'),
+  line1: z.string().trim().min(3, 'Address line 1 is required'),
+  line2: z.string().optional(),
+  city: z.string().trim().min(2, 'City is required'),
+  state: z.string().trim(),
+  postal_code: z.string().trim().min(1, 'Postal code is required'),
+  country: z.string().trim().min(1, 'Country is required'),
+  tax_id_type: z.string(),
+  tax_id_value: z.string(),
+  tax_id_name: z.string(),
+})
 
 export type BillingCustomerDataFormValues = z.infer<typeof BillingCustomerDataSchema>
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
@@ -63,8 +63,6 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
     })
   const { data: taxId, isLoading: isCustomerTaxIdLoading } = useOrganizationTaxIdQuery({ slug })
 
-  const hidePaymentMethodsWithoutAddress = useFlag('hidePaymentMethodsWithoutAddress')
-
   const { data: allPaymentMethods, isLoading } = useOrganizationPaymentMethodsQuery({ slug })
 
   const paymentMethods = useMemo(() => {
@@ -74,18 +72,16 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
         defaultPaymentMethodId: null,
       }
 
-    const filtered = allPaymentMethods.data.filter(
-      (pm) => !hidePaymentMethodsWithoutAddress || pm.has_address
-    )
     return {
-      data: filtered,
+      // force customer to put down address via payment method creation flow if they don't have an address set
+      data: customerProfile?.address == null ? [] : allPaymentMethods.data,
       defaultPaymentMethodId: allPaymentMethods.data.some(
         (pm) => pm.id === allPaymentMethods.defaultPaymentMethodId
       )
         ? allPaymentMethods.defaultPaymentMethodId
         : null,
     }
-  }, [allPaymentMethods])
+  }, [allPaymentMethods, customerProfile])
 
   const captchaRefCallback = useCallback((node: any) => {
     setCaptchaRef(node)
@@ -223,7 +219,7 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
       />
 
       <div>
-        {isLoading ? (
+        {isLoading || isCustomerProfileLoading ? (
           <div className="flex items-center px-4 py-2 space-x-4 border rounded-md border-strong bg-surface-200">
             <Loader className="animate-spin" size={14} />
             <p className="text-sm text-foreground-light">Retrieving payment methods</p>


### PR DESCRIPTION
For customers who have not yet put down a billing address, we want to ensure that they put down an address when they upgrade their plan.

Customers can also no longer unset their billing address.
