### PR TITLE
fix: don't render hidden pages

### DIFF
--- a/apps/docs/app/reference/[...slug]/page.tsx
+++ b/apps/docs/app/reference/[...slug]/page.tsx
@@ -33,6 +33,10 @@ export default async function ReferencePage(props: { params: Promise<{ slug: Arr
     const { sdkId, maybeVersion, path } = parsedPath
 
     const sdkData = REFERENCES[sdkId]
+    if (sdkData.enabled === false) {
+      notFound()
+    }
+
     const latestVersion = sdkData.versions[0]
     const version = maybeVersion ?? latestVersion
 

--- a/apps/docs/components/Navigation/Navigation.types.ts
+++ b/apps/docs/components/Navigation/Navigation.types.ts
@@ -11,6 +11,9 @@ export interface NavMenuSection {
   name: string
   url?: `/${string}` | `https://${string}`
   items: Partial<NavMenuSection>[]
+  icon?: string
+  hasLightIcon?: boolean
+  isDarkMode?: boolean
   enabled?: boolean
 }
 

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -591,7 +591,7 @@ export const PhoneLoginsItems = [
   },
 ]
 
-export const auth = {
+export const auth: NavMenuConstant = {
   icon: 'auth',
   title: 'Auth',
   items: [
@@ -1876,7 +1876,7 @@ export const vectorIndexItems = [
   },
 ]
 
-export const ai = {
+export const ai: NavMenuConstant = {
   icon: 'ai',
   title: 'AI & Vectors',
   url: '/guides/ai',

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react'
 
-import { isFeatureEnabled } from 'common'
+import { isFeatureEnabled } from 'common/enabled-features'
 import type { IconPanel } from 'ui-patterns/IconPanel'
 import type { GlobalMenuItems, NavMenuConstant, NavMenuSection } from '../Navigation.types'
 

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -460,7 +460,7 @@ export const NativeMobileLoginItems = [
   },
 ]
 
-export const SocialLoginItems = [
+export const SocialLoginItems: Array<Partial<NavMenuSection>> = [
   {
     name: 'Google',
     icon: '/docs/img/icons/google-icon',
@@ -1865,7 +1865,7 @@ export const storage: NavMenuConstant = {
   ],
 }
 
-export const vectorIndexItems = [
+export const vectorIndexItems: Array<Partial<NavMenuSection>> = [
   {
     name: 'HNSW indexes',
     url: '/guides/ai/vector-indexes/hnsw-indexes',

--- a/apps/docs/content/navigation.references.ts
+++ b/apps/docs/content/navigation.references.ts
@@ -1,3 +1,13 @@
+import { isFeatureEnabled } from 'common/enabled-features'
+
+const {
+  sdkCsharp: sdkCsharpEnabled,
+  sdkDart: sdkDartEnabled,
+  sdkKotlin: sdkKotlinEnabled,
+  sdkPython: sdkPythonEnabled,
+  sdkSwift: sdkSwiftEnabled,
+} = isFeatureEnabled(['sdk:csharp', 'sdk:dart', 'sdk:kotlin', 'sdk:python', 'sdk:swift'])
+
 export const REFERENCES = {
   javascript: {
     type: 'sdk',
@@ -35,6 +45,7 @@ export const REFERENCES = {
         specFile: 'supabase_dart_v1',
       },
     },
+    enabled: sdkDartEnabled,
   },
   csharp: {
     type: 'sdk',
@@ -53,6 +64,7 @@ export const REFERENCES = {
         specFile: 'supabase_csharp_v0',
       },
     },
+    enabled: sdkCsharpEnabled,
   },
   swift: {
     type: 'sdk',
@@ -71,6 +83,7 @@ export const REFERENCES = {
         specFile: 'supabase_swift_v1',
       },
     },
+    enabled: sdkSwiftEnabled,
   },
   kotlin: {
     type: 'sdk',
@@ -93,6 +106,7 @@ export const REFERENCES = {
         specFile: 'supabase_kt_v1',
       },
     },
+    enabled: sdkKotlinEnabled,
   },
   python: {
     type: 'sdk',
@@ -107,6 +121,7 @@ export const REFERENCES = {
         specFile: 'supabase_py_v2',
       },
     },
+    enabled: sdkPythonEnabled,
   },
   cli: {
     type: 'cli',
@@ -160,7 +175,7 @@ export const REFERENCES = {
 } as const
 
 export const clientSdkIds = Object.keys(REFERENCES).filter(
-  (reference) => REFERENCES[reference].type === 'sdk'
+  (reference) => REFERENCES[reference].type === 'sdk' && REFERENCES[reference].enabled !== false
 )
 
 export const selfHostingServices = Object.keys(REFERENCES).filter(

--- a/apps/docs/features/docs/NavigationPageStatus.utils.ts
+++ b/apps/docs/features/docs/NavigationPageStatus.utils.ts
@@ -1,0 +1,130 @@
+import { type NavMenuConstant } from '~/components/Navigation/Navigation.types'
+import {
+  GLOBAL_MENU_ITEMS,
+  ai,
+  api,
+  auth,
+  cron,
+  database,
+  deployment,
+  functions,
+  gettingstarted,
+  graphql,
+  integrations,
+  local_development,
+  platform,
+  queues,
+  realtime,
+  security,
+  self_hosting,
+  storage,
+  telemetry,
+} from '~/components/Navigation/NavigationMenu/NavigationMenu.constants'
+
+// Map of section names to their nav constants
+const SECTION_NAV_MAPS: Record<string, NavMenuConstant> = {
+  ai,
+  api,
+  auth,
+  cron,
+  database,
+  deployment,
+  functions,
+  'getting-started': gettingstarted,
+  graphql,
+  integrations,
+  'local-development': local_development,
+  platform,
+  queues,
+  realtime,
+  security,
+  'self-hosting': self_hosting,
+  storage,
+  telemetry,
+}
+
+interface ConditionalNavItem {
+  url?: string
+  href?: string
+  enabled?: boolean
+  items?: Readonly<ConditionalNavItem[]>
+  menuItems?: Readonly<ConditionalNavItem[][]>
+}
+
+/**
+ * Recursively walks navigation items and collects all disabled paths.
+ * If a parent is disabled, all its children are also considered disabled.
+ */
+function collectDisabledPaths(
+  items: Readonly<ConditionalNavItem[] | ConditionalNavItem[][]>,
+  disabledPaths: Set<string>,
+  parentDisabled: boolean = false
+): void {
+  for (const item of items) {
+    if (Array.isArray(item)) {
+      // Handle nested arrays (like in GLOBAL_MENU_ITEMS)
+      collectDisabledPaths(item, disabledPaths, parentDisabled)
+    } else {
+      const isCurrentDisabled = parentDisabled || item.enabled === false
+      const itemUrl = item.url || item.href
+
+      if (itemUrl && itemUrl.startsWith('/guides/')) {
+        const normalizedUrl = normalizeUrl(itemUrl)
+        if (isCurrentDisabled) {
+          disabledPaths.add(normalizedUrl)
+        }
+      }
+
+      // Recursively check children, passing down the disabled status
+      if (item.items) {
+        collectDisabledPaths(item.items, disabledPaths, isCurrentDisabled)
+      }
+      if (item.menuItems) {
+        collectDisabledPaths(item.menuItems, disabledPaths, isCurrentDisabled)
+      }
+    }
+  }
+}
+
+/**
+ * Normalizes URLs for comparison by removing leading/trailing slashes and ensuring consistent format
+ */
+function normalizeUrl(url: string): string {
+  return url.replace(/^\/+|\/+$/g, '').toLowerCase()
+}
+
+/**
+ * Creates and caches the set of all disabled guide paths.
+ * This is computed once and reused across all checks.
+ */
+let cachedDisabledPaths: Set<string> | null = null
+
+function getDisabledGuidePaths(): Set<string> {
+  if (cachedDisabledPaths === null) {
+    cachedDisabledPaths = new Set<string>()
+
+    // Collect disabled paths from global menu items
+    collectDisabledPaths(GLOBAL_MENU_ITEMS, cachedDisabledPaths)
+
+    // Collect disabled paths from section-specific navigation
+    Object.values(SECTION_NAV_MAPS).forEach((sectionNav) => {
+      if (sectionNav.items) {
+        collectDisabledPaths([sectionNav], cachedDisabledPaths!)
+      }
+    })
+  }
+
+  return cachedDisabledPaths
+}
+
+/**
+ * Checks if a guides page is enabled based on the navigation menu configuration
+ *
+ * @param guidesPath - The path to the guides page (e.g., "/guides/auth/users")
+ * @returns true if enabled, false if disabled
+ */
+export function checkGuidePageEnabled(guidesPath: string): boolean {
+  const disabledPaths = getDisabledGuidePaths()
+  const normalizedPath = normalizeUrl(guidesPath)
+  return !disabledPaths.has(normalizedPath)
+}

--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -1,5 +1,6 @@
 import { isbot } from 'isbot'
 import { type NextRequest, NextResponse } from 'next/server'
+
 import { clientSdkIds } from '~/content/navigation.references'
 import { BASE_PATH } from '~/lib/constants'
 


### PR DESCRIPTION
Pages that are hidden from navigation (feature flag is toggled off) are still rendered (can be accessed by direct link). This change prevents rendering of those pages, so they will 404 when disabled.