### PR TITLE
fix: do not auto submit on toggling data branch

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -46,9 +46,6 @@ import {
   Input_Shadcn_,
   Label_Shadcn_ as Label,
   Switch,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   cn,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -92,7 +89,11 @@ export const CreateBranchModal = () => {
     useCheckGithubBranchValidity({
       onError: () => {},
     })
-  const { data: cloneBackups, error: cloneBackupsError } = useCloneBackupsQuery(
+  const {
+    data: cloneBackups,
+    error: cloneBackupsError,
+    isLoading: isLoadingCloneBackups,
+  } = useCloneBackupsQuery(
     { projectRef },
     {
       // [Joshen] Only trigger this request when the modal is opened
@@ -362,7 +363,7 @@ export const CreateBranchModal = () => {
                       label={
                         <>
                           <Label className="mr-2">Include data</Label>
-                          {!disableBackupsCheck && noPhysicalBackups && (
+                          {!disableBackupsCheck && (isLoadingCloneBackups || noPhysicalBackups) && (
                             <Badge variant="warning" size="small">
                               Requires PITR
                             </Badge>
@@ -370,11 +371,14 @@ export const CreateBranchModal = () => {
                         </>
                       }
                       layout="flex-row-reverse"
+                      className="[&>div>label]:mb-1"
                       description="Clone production data into this branch"
                     >
                       <FormControl_Shadcn_>
                         <Switch
-                          disabled={!disableBackupsCheck && noPhysicalBackups}
+                          disabled={
+                            !disableBackupsCheck && (isLoadingCloneBackups || noPhysicalBackups)
+                          }
                           checked={field.value}
                           onCheckedChange={field.onChange}
                         />

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -359,26 +359,26 @@ export const CreateBranchModal = () => {
                   name="withData"
                   render={({ field }) => (
                     <FormItemLayout
-                      label="Include data"
+                      label={
+                        <>
+                          <Label className="mr-2">Include data</Label>
+                          {!disableBackupsCheck && noPhysicalBackups && (
+                            <Badge variant="warning" size="small">
+                              Requires PITR
+                            </Badge>
+                          )}
+                        </>
+                      }
                       layout="flex-row-reverse"
                       description="Clone production data into this branch"
                     >
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <FormControl_Shadcn_>
-                            <Switch
-                              disabled={!disableBackupsCheck && noPhysicalBackups}
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
-                          </FormControl_Shadcn_>
-                        </TooltipTrigger>
-                        {!disableBackupsCheck && noPhysicalBackups && (
-                          <TooltipContent side="bottom">
-                            PITR is required for the project to clone data into the branch
-                          </TooltipContent>
-                        )}
-                      </Tooltip>
+                      <FormControl_Shadcn_>
+                        <Switch
+                          disabled={!disableBackupsCheck && noPhysicalBackups}
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl_Shadcn_>
                     </FormItemLayout>
                   )}
                 />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

1. Open create branch modal
2. Provide a branch name
3. Toggle include prod data

Observe branch creation form is submitted immediately.

## Additional context

<img width="605" height="567" alt="Screenshot 2025-09-07 at 12 11 16 PM" src="https://github.com/user-attachments/assets/e9c9aed9-9cc3-4a84-9691-69c23b28762e" />
