### PR TITLE
Fix roles

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.utils.ts
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.utils.ts
@@ -42,9 +42,16 @@ export const formatMemberRoleToProjectRoleConfiguration = (
     })
     .filter(Boolean)
     .flat()
-    .filter(
-      (p) => p !== undefined && 'baseRoleId' in p && p.ref !== undefined
-    ) as ProjectRoleConfiguration[]
+    .filter((p) => {
+      // [Joshen] Validate only for project scoped roles
+      // This filters out project scoped roles for projects that the user doesn't have access to
+      // (e.g if the project was deleted)
+      if ('baseRoleId' in p!) {
+        return p.ref !== undefined
+      } else {
+        return p
+      }
+    }) as ProjectRoleConfiguration[]
 
   return roleConfiguration
 }


### PR DESCRIPTION
## Context

There's a bug introduced [here](https://github.com/supabase/supabase/pull/38428) that's affecting updating of roles for org-scoped roles, whereby the introduced `filter` in `formatMemberRoleToProjectRoleConfiguration` was incorrectly filtering out org-scoped roles, resulting in users seeing this callout when editing roles for a user that only has org-scoped roles
<img width="487" height="152" alt="image" src="https://github.com/user-attachments/assets/77188090-e5c7-46c1-b3b3-d2d6b6530378" />

## To test
- [ ] Verify that you can change the role of a user with an org-scoped role
- [ ] Verify for a user with project-scoped roles, if one of the project that the user has access to was deleted, you can still update that user's role thereafter