### PR TITLE
fix(studio): usage project selector truncation

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -177,10 +177,7 @@ const Usage = () => {
                       else setSelectedProjectRefInputValue(value)
                     }}
                   >
-                    <SelectTrigger_Shadcn_
-                      size="tiny"
-                      className="w-[180px] [&>span]:truncate [&>span]:!w-[24ch]"
-                    >
+                    <SelectTrigger_Shadcn_ size="tiny" className="w-[180px]">
                       <SelectValue_Shadcn_ placeholder="Select a project" />
                     </SelectTrigger_Shadcn_>
                     <SelectContent_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -177,7 +177,10 @@ const Usage = () => {
                       else setSelectedProjectRefInputValue(value)
                     }}
                   >
-                    <SelectTrigger_Shadcn_ size="tiny" className="w-[180px]">
+                    <SelectTrigger_Shadcn_
+                      size="tiny"
+                      className="w-[180px] [&>span]:truncate [&>span]:!w-[24ch]"
+                    >
                       <SelectValue_Shadcn_ placeholder="Select a project" />
                     </SelectTrigger_Shadcn_>
                     <SelectContent_Shadcn_>

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -50,7 +50,7 @@ const SelectTrigger = React.forwardRef<
       'flex w-full items-center justify-between rounded-md border border-strong hover:border-stronger bg-alternative dark:bg-muted hover:bg-selection text-xs ring-offset-background-control data-[placeholder]:text-foreground-lighter focus:outline-none ring-border-control focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-all duration-200',
       'data-[state=open]:bg-selection data-[state=open]:border-stronger',
       'gap-2',
-      '[&>span]:truncate [&>span]:w-[18ch] text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
+      '[&>span]:truncate [&>span]:w-[20ch] text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
       SelectTriggerVariants({ size }),
       className
     )}
@@ -58,7 +58,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 text-foreground-lighter" strokeWidth={1.5} />
+      <ChevronDown className="h-4 w-4 text-foreground-lighter flex-shrink-0" strokeWidth={1.5} />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -50,6 +50,7 @@ const SelectTrigger = React.forwardRef<
       'flex w-full items-center justify-between rounded-md border border-strong hover:border-stronger bg-alternative dark:bg-muted hover:bg-selection text-xs ring-offset-background-control data-[placeholder]:text-foreground-lighter focus:outline-none ring-border-control focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-all duration-200',
       'data-[state=open]:bg-selection data-[state=open]:border-stronger',
       'gap-2',
+      '[&>span]:truncate [&>span]:w-[24ch] text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
       SelectTriggerVariants({ size }),
       className
     )}

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -50,7 +50,7 @@ const SelectTrigger = React.forwardRef<
       'flex w-full items-center justify-between rounded-md border border-strong hover:border-stronger bg-alternative dark:bg-muted hover:bg-selection text-xs ring-offset-background-control data-[placeholder]:text-foreground-lighter focus:outline-none ring-border-control focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-all duration-200',
       'data-[state=open]:bg-selection data-[state=open]:border-stronger',
       'gap-2',
-      '[&>span]:truncate [&>span]:w-[24ch] text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
+      '[&>span]:truncate [&>span]:w-[18ch] text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
       SelectTriggerVariants({ size }),
       className
     )}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes the project selector truncation for selected value in the selector.

| Before | After |
|--------|--------|
| <img width="424" height="150" alt="Screenshot 2025-09-09 at 09 01 06" src="https://github.com/user-attachments/assets/177508e7-054d-46ed-af44-d9086cb00e38" /> | <img width="422" height="154" alt="Screenshot 2025-09-09 at 09 01 12" src="https://github.com/user-attachments/assets/eb2cf827-484b-4640-9a1c-ddfeb86e1ce7" /> | 



