### PR TITLE
feat: mcp registry domain verification

### DIFF
--- a/apps/www/public/.well-known/mcp-registry-auth
+++ b/apps/www/public/.well-known/mcp-registry-auth
@@ -1,0 +1,1 @@
+v=MCPv1; k=ed25519; p=NoXlL5xtpMAM/AUDNnBJRRg11eWyAOZaeY8gCD1QKwU=


### PR DESCRIPTION
We are adding our MCP server to the [official MCP registry](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/). As part of the publish process, the registry needs to validate that we own `supabase.com`. To verify ownership, we can add a `.well-known/mcp-registry-auth` endpoint with the content:

```
v=MCPv1; k=ed25519; p=PUBLIC_KEY
```

Where public key is derived from a private key that we generated:

```
# Get public key
openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64
```

See [registry docs](https://github.com/modelcontextprotocol/registry/blob/72f9f80d680f2e88309f4025106d5f44124b359f/docs/reference/cli/commands.md#http-verification) for more info.

This PR creates this endpoint.