### PR TITLE
feat: missing billing info banner

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
@@ -111,7 +111,10 @@ export const BillingCustomerData = () => {
         <div className="sticky space-y-2 top-12 pr-3">
           <p className="text-foreground text-base m-0">Billing Address &amp; Tax ID</p>
           <p className="text-sm text-foreground-light m-0">
-            This will be reflected in every upcoming invoice, past invoices are not affected
+            Changes will be reflected in every upcoming invoice, past invoices are not affected
+          </p>
+          <p className="text-sm text-foreground-light m-0">
+            A Tax ID are only required for registered businesses.
           </p>
         </div>
       </ScaffoldSectionDetail>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
@@ -114,7 +114,7 @@ export const BillingCustomerData = () => {
             Changes will be reflected in every upcoming invoice, past invoices are not affected
           </p>
           <p className="text-sm text-foreground-light m-0">
-            A Tax ID are only required for registered businesses.
+            A Tax ID is only required for registered businesses.
           </p>
         </div>
       </ScaffoldSectionDetail>

--- a/apps/studio/components/interfaces/Organization/restriction.constants.ts
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.ts
@@ -21,4 +21,8 @@ export const RESTRICTION_MESSAGES = {
     title: 'Outstanding Invoices in other Organization',
     message: 'Please pay invoices for other Organization to avoid service disruption.',
   },
+  MISSING_BILLING_INFO: {
+    title: 'Missing Billing Information',
+    message: 'Please add a billing address. If you are a registered business, please add a tax ID, too.'
+  }
 } as const

--- a/apps/studio/components/interfaces/Organization/restriction.constants.ts
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.ts
@@ -23,6 +23,7 @@ export const RESTRICTION_MESSAGES = {
   },
   MISSING_BILLING_INFO: {
     title: 'Missing Billing Information',
-    message: 'Please add a billing address. If you are a registered business, please add a tax ID, too.'
-  }
+    message:
+      'Please add a billing address. If you are a registered business, please add a tax ID, too.',
+  },
 } as const

--- a/apps/studio/components/interfaces/Organization/restriction.constants.ts
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.ts
@@ -24,6 +24,6 @@ export const RESTRICTION_MESSAGES = {
   MISSING_BILLING_INFO: {
     title: 'Missing Billing Information',
     message:
-      'Please add a billing address. If you are a registered business, please add a tax ID, too.',
+      'Please add a billing address. If you are a registered business, please add a tax ID too.',
   },
 } as const

--- a/apps/studio/hooks/misc/useOrganizationRestrictions.ts
+++ b/apps/studio/hooks/misc/useOrganizationRestrictions.ts
@@ -30,7 +30,7 @@ export function useOrganizationRestrictions() {
     (invoice) => invoice.organization_id === org?.id
   )
 
-  if (org && org.plan.id !== 'free' && billingCustomer && !billingCustomer.address?.line1)  {
+  if (org && org.plan.id !== 'free' && billingCustomer && !billingCustomer.address?.line1) {
     warnings.push({
       type: 'warning',
       title: RESTRICTION_MESSAGES.MISSING_BILLING_INFO.title,

--- a/apps/studio/hooks/misc/useOrganizationRestrictions.ts
+++ b/apps/studio/hooks/misc/useOrganizationRestrictions.ts
@@ -4,6 +4,8 @@ import { RESTRICTION_MESSAGES } from 'components/interfaces/Organization/restric
 import { useOverdueInvoicesQuery } from 'data/invoices/invoices-overdue-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useBillingCustomerDataForm } from 'components/interfaces/Organization/BillingSettings/BillingCustomerData/useBillingCustomerDataForm'
+import { useOrganizationCustomerProfileQuery } from 'data/organizations/organization-customer-profile-query'
 
 export type WarningBannerProps = {
   type: 'danger' | 'warning' | 'note'
@@ -17,6 +19,7 @@ export function useOrganizationRestrictions() {
 
   const { data: overdueInvoices } = useOverdueInvoicesQuery()
   const { data: organizations } = useOrganizationsQuery()
+  const { data: billingCustomer } = useOrganizationCustomerProfileQuery({ slug: org?.slug })
 
   const warnings: WarningBannerProps[] = []
 
@@ -26,6 +29,15 @@ export function useOrganizationRestrictions() {
   const thisOrgHasOverdueInvoices = overdueInvoices?.filter(
     (invoice) => invoice.organization_id === org?.id
   )
+
+  if (org && org.plan.id !== 'free' && billingCustomer && !billingCustomer.address?.line1)  {
+    warnings.push({
+      type: 'warning',
+      title: RESTRICTION_MESSAGES.MISSING_BILLING_INFO.title,
+      message: RESTRICTION_MESSAGES.MISSING_BILLING_INFO.message,
+      link: `/org/${org?.slug}/billing#address`,
+    })
+  }
 
   if (thisOrgHasOverdueInvoices?.length) {
     warnings.push({


### PR DESCRIPTION
For compliance reasons we need a billing address for all paying customers. This PR adds a nudge for customers that have not yet put down their billing address.

<img width="1265" height="95" alt="Screenshot 2025-09-10 at 11 40 00" src="https://github.com/user-attachments/assets/09a4b1cb-ae4f-401c-9ede-854c39f37dd8" />
