### PR TITLE
Chore/refactor dashboard history logic

### DIFF
--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -12,7 +12,7 @@ import { Plus, X } from 'lucide-react'
 import { useRouter } from 'next/router'
 
 import { useParams } from 'common'
-import { useAppStateSnapshot } from 'state/app-state'
+import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
 import { editorEntityTypes, useTabsStateSnapshot, type Tab } from 'state/tabs'
 import {
   cn,
@@ -32,7 +32,7 @@ import { TabPreview } from './TabPreview'
 export const EditorTabs = () => {
   const { ref, id } = useParams()
   const router = useRouter()
-  const appSnap = useAppStateSnapshot()
+  const { setLastVisitedSnippet, setLastVisitedTable } = useDashboardHistory()
 
   const editor = useEditorType()
   const tabs = useTabsStateSnapshot()
@@ -68,8 +68,10 @@ export const EditorTabs = () => {
   }
 
   const onClearDashboardHistory = () => {
-    if (ref && editor) {
-      appSnap.setDashboardHistory(ref, editor === 'table' ? 'editor' : editor, undefined)
+    if (editor === 'table') {
+      setLastVisitedTable(undefined)
+    } else if (editor === 'sql') {
+      setLastVisitedSnippet(undefined)
     }
   }
 

--- a/apps/studio/hooks/misc/useDashboardHistory.ts
+++ b/apps/studio/hooks/misc/useDashboardHistory.ts
@@ -1,0 +1,30 @@
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { useLocalStorageQuery } from './useLocalStorage'
+
+type DashboardHistory = { editor?: string; sql?: string }
+const DEFAULT_HISTORY = { editor: undefined, sql: undefined } as DashboardHistory
+
+export const useDashboardHistory = () => {
+  // [Joshen] History should always refer to the project that the user is currently on
+  const { ref } = useParams()
+
+  const [history, setHistory, { isSuccess }] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY(ref ?? ''),
+    DEFAULT_HISTORY
+  )
+
+  const setLastVisitedTable = (id?: string) => {
+    setHistory({ ...history, editor: id })
+  }
+
+  const setLastVisitedSnippet = (id?: string) => {
+    setHistory({ ...history, sql: id })
+  }
+
+  return {
+    history,
+    setLastVisitedTable,
+    setLastVisitedSnippet,
+    isHistoryLoaded: isSuccess,
+  }
+}

--- a/apps/studio/hooks/misc/useDashboardHistory.ts
+++ b/apps/studio/hooks/misc/useDashboardHistory.ts
@@ -8,7 +8,7 @@ export const useDashboardHistory = () => {
   // [Joshen] History should always refer to the project that the user is currently on
   const { ref } = useParams()
 
-  const [history, setHistory, { isSuccess }] = useLocalStorageQuery(
+  const [history, setHistory, { isSuccess }] = useLocalStorageQuery<DashboardHistory>(
     LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY(ref ?? ''),
     DEFAULT_HISTORY
   )

--- a/apps/studio/hooks/misc/useDashboardHistory.ts
+++ b/apps/studio/hooks/misc/useDashboardHistory.ts
@@ -2,7 +2,7 @@ import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { useLocalStorageQuery } from './useLocalStorage'
 
 type DashboardHistory = { editor?: string; sql?: string }
-const DEFAULT_HISTORY = { editor: undefined, sql: undefined } as DashboardHistory
+const DEFAULT_HISTORY = { editor: undefined, sql: undefined }
 
 export const useDashboardHistory = () => {
   // [Joshen] History should always refer to the project that the user is currently on

--- a/apps/studio/pages/project/[ref]/editor/index.tsx
+++ b/apps/studio/pages/project/[ref]/editor/index.tsx
@@ -8,7 +8,7 @@ import { EditorBaseLayout } from 'components/layouts/editors/EditorBaseLayout'
 import TableEditorLayout from 'components/layouts/TableEditorLayout/TableEditorLayout'
 import { TableEditorMenu } from 'components/layouts/TableEditorLayout/TableEditorMenu'
 import { NewTab } from 'components/layouts/Tabs/NewTab'
-import { useAppStateSnapshot } from 'state/app-state'
+import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
 import { editorEntityTypes, useTabsStateSnapshot } from 'state/tabs'
 import type { NextPageWithLayout } from 'types'
 
@@ -16,26 +16,28 @@ const TableEditorPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const tabStore = useTabsStateSnapshot()
-  const appSnap = useAppStateSnapshot()
+  const { history, isHistoryLoaded } = useDashboardHistory()
 
   const onTableCreated = (table: { id: number }) => {
     router.push(`/project/${projectRef}/editor/${table.id}`)
   }
 
   useEffect(() => {
-    const lastOpenedTab = appSnap.dashboardHistory.editor
+    if (isHistoryLoaded) {
+      const lastOpenedTable = history.editor
+      const lastTabId = tabStore.openTabs.find((id) =>
+        editorEntityTypes.table.includes(tabStore.tabsMap[id]?.type)
+      )
 
-    const lastTabId = tabStore.openTabs.find((id) =>
-      editorEntityTypes.table.includes(tabStore.tabsMap[id]?.type)
-    )
-    if (lastOpenedTab !== undefined) {
-      router.push(`/project/${projectRef}/editor/${appSnap.dashboardHistory.editor}`)
-    } else if (lastTabId) {
       // Handle redirect to last opened table tab, or last table tab
-      const lastTab = tabStore.tabsMap[lastTabId]
-      if (lastTab) router.push(`/project/${projectRef}/editor/${lastTab.metadata?.tableId}`)
+      if (lastOpenedTable !== undefined) {
+        router.push(`/project/${projectRef}/editor/${history.editor}`)
+      } else if (lastTabId) {
+        const lastTab = tabStore.tabsMap[lastTabId]
+        if (lastTab) router.push(`/project/${projectRef}/editor/${lastTab.metadata?.tableId}`)
+      }
     }
-  }, [])
+  }, [isHistoryLoaded])
 
   return (
     <>

--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -1,12 +1,18 @@
-import { useFlag } from 'common'
+import { useFlag, useParams } from 'common'
 import { Home } from 'components/interfaces/Home/Home'
 import { HomeV2 } from 'components/interfaces/HomeNew/Home'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ProjectLayoutWithAuth } from 'components/layouts/ProjectLayout/ProjectLayout'
+import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
 import type { NextPageWithLayout } from 'types'
 
 const HomePage: NextPageWithLayout = () => {
   const isHomeNew = useFlag('homeNew')
+
+  const { ref } = useParams()
+  const { history } = useDashboardHistory()
+  console.log(ref, history)
+
   if (isHomeNew) {
     return <HomeV2 />
   }

--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -1,17 +1,12 @@
-import { useFlag, useParams } from 'common'
+import { useFlag } from 'common'
 import { Home } from 'components/interfaces/Home/Home'
 import { HomeV2 } from 'components/interfaces/HomeNew/Home'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ProjectLayoutWithAuth } from 'components/layouts/ProjectLayout/ProjectLayout'
-import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
 import type { NextPageWithLayout } from 'types'
 
 const HomePage: NextPageWithLayout = () => {
   const isHomeNew = useFlag('homeNew')
-
-  const { ref } = useParams()
-  const { history } = useDashboardHistory()
-  console.log(ref, history)
 
   if (isHomeNew) {
     return <HomeV2 />

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
@@ -9,8 +10,7 @@ import { useEditorType } from 'components/layouts/editors/EditorsLayout.hooks'
 import SQLEditorLayout from 'components/layouts/SQLEditorLayout/SQLEditorLayout'
 import { SQLEditorMenu } from 'components/layouts/SQLEditorLayout/SQLEditorMenu'
 import { useContentIdQuery } from 'data/content/content-id-query'
-import Link from 'next/link'
-import { useAppStateSnapshot } from 'state/app-state'
+import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
 import { SnippetWithContent, useSnippets, useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { createTabId, useTabsStateSnapshot } from 'state/tabs'
 import type { NextPageWithLayout } from 'types'
@@ -23,8 +23,8 @@ const SqlEditor: NextPageWithLayout = () => {
 
   const editor = useEditorType()
   const tabs = useTabsStateSnapshot()
-  const appSnap = useAppStateSnapshot()
   const snapV2 = useSqlEditorV2StateSnapshot()
+  const { history, setLastVisitedSnippet } = useDashboardHistory()
 
   const allSnippets = useSnippets(ref!)
   const snippet = allSnippets.find((x) => x.id === id)
@@ -59,11 +59,11 @@ const SqlEditor: NextPageWithLayout = () => {
     if (
       id === 'new' &&
       skip !== 'true' && // [Joshen] Skip flag implies to skip loading the last visited snippet
-      appSnap.dashboardHistory.sql !== undefined &&
+      history.sql !== undefined &&
       content === undefined
     ) {
-      const snippet = allSnippets.find((snippet) => snippet.id === appSnap.dashboardHistory.sql)
-      if (snippet !== undefined) router.push(`/project/${ref}/sql/${appSnap.dashboardHistory.sql}`)
+      const snippet = allSnippets.find((snippet) => snippet.id === history.sql)
+      if (snippet !== undefined) router.push(`/project/${ref}/sql/${history.sql}`)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, allSnippets, content])
@@ -104,9 +104,7 @@ const SqlEditor: NextPageWithLayout = () => {
                     id: tabId,
                     router,
                     editor,
-                    onClearDashboardHistory: () => {
-                      if (ref) appSnap.setDashboardHistory(ref, 'sql', undefined)
-                    },
+                    onClearDashboardHistory: () => setLastVisitedSnippet(undefined),
                   })
                 }}
               >

--- a/apps/studio/pages/project/[ref]/sql/index.tsx
+++ b/apps/studio/pages/project/[ref]/sql/index.tsx
@@ -6,35 +6,39 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import { EditorBaseLayout } from 'components/layouts/editors/EditorBaseLayout'
 import SQLEditorLayout from 'components/layouts/SQLEditorLayout/SQLEditorLayout'
 import { SQLEditorMenu } from 'components/layouts/SQLEditorLayout/SQLEditorMenu'
-import { useAppStateSnapshot } from 'state/app-state'
+import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
 import { useTabsStateSnapshot } from 'state/tabs'
 import type { NextPageWithLayout } from 'types'
 
-const TableEditorPage: NextPageWithLayout = () => {
+const SQLEditorIndexPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const store = useTabsStateSnapshot()
-  const appSnap = useAppStateSnapshot()
+
+  const { history, isHistoryLoaded } = useDashboardHistory()
 
   useEffect(() => {
-    // Handle redirect to last opened snippet tab, or last snippet tab
-    const lastOpenedTab = appSnap.dashboardHistory.sql
-    const lastTabId = store.openTabs.find((id) => store.tabsMap[id]?.type === 'sql')
-    if (lastOpenedTab !== undefined) {
-      router.push(`/project/${projectRef}/sql/${appSnap.dashboardHistory.sql}`)
-    } else if (lastTabId) {
-      const lastTab = store.tabsMap[lastTabId]
-      if (lastTab) router.push(`/project/${projectRef}/sql/${lastTab.id.replace('sql-', '')}`)
-    } else {
-      router.push(`/project/${projectRef}/sql/new`)
+    if (isHistoryLoaded) {
+      // Handle redirect to last opened snippet tab, or last snippet tab
+      const lastOpenedTab = history.sql
+      const lastTabId = store.openTabs.find((id) => store.tabsMap[id]?.type === 'sql')
+
+      if (lastOpenedTab !== undefined) {
+        router.push(`/project/${projectRef}/sql/${history.sql}`)
+      } else if (lastTabId) {
+        const lastTab = store.tabsMap[lastTabId]
+        if (lastTab) router.push(`/project/${projectRef}/sql/${lastTab.id.replace('sql-', '')}`)
+      } else {
+        router.push(`/project/${projectRef}/sql/new`)
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [isHistoryLoaded])
 
   return null
 }
 
-TableEditorPage.getLayout = (page) => (
+SQLEditorIndexPage.getLayout = (page) => (
   <DefaultLayout>
     <EditorBaseLayout productMenu={<SQLEditorMenu />} product="SQL Editor">
       <SQLEditorLayout>{page}</SQLEditorLayout>
@@ -42,4 +46,4 @@ TableEditorPage.getLayout = (page) => (
   </DefaultLayout>
 )
 
-export default TableEditorPage
+export default SQLEditorIndexPage

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -1,19 +1,9 @@
 import { proxy, snapshot, useSnapshot } from 'valtio'
 
-import { LOCAL_STORAGE_KEYS as COMMON_LOCAL_STORAGE_KEYS, LOCAL_STORAGE_KEYS } from 'common'
-type DashboardHistoryType = {
-  sql?: string
-  editor?: string
-}
-
-const EMPTY_DASHBOARD_HISTORY: DashboardHistoryType = {
-  sql: undefined,
-  editor: undefined,
-}
+import { LOCAL_STORAGE_KEYS as COMMON_LOCAL_STORAGE_KEYS } from 'common'
 
 const getInitialState = () => {
   return {
-    dashboardHistory: EMPTY_DASHBOARD_HISTORY,
     activeDocsSection: ['introduction'],
     docsLanguage: 'js',
     showProjectApiDocs: false,
@@ -30,16 +20,6 @@ const getInitialState = () => {
 
 export const appState = proxy({
   ...getInitialState(),
-
-  setDashboardHistory: (ref: string, key: 'sql' | 'editor', id: string | undefined) => {
-    if (appState.dashboardHistory[key] !== id) {
-      appState.dashboardHistory[key] = id
-      localStorage.setItem(
-        LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY(ref),
-        JSON.stringify(appState.dashboardHistory)
-      )
-    }
-  },
 
   activeDocsSection: ['introduction'],
   docsLanguage: 'js' as 'js' | 'bash',


### PR DESCRIPTION
## Context
Addresses a bug report which users are running into client errors of `Node with id=xxx doesn't exist in the tree` when landing on the SQL Editor.
Briefly what's happening after investigating:

- User's opening the SQL Editor (`/sql`) which automatically loads the last visited snippet (e.g Snippet ID `a`)
  - Snippet `a` belongs to the user based on `owner_id`
  - Snippet `a` has a `folder_id` as well which indicates it lives in a folder
- However, based on the GET /folders request in the network tab, the contents/folders getting returned are for project ID `1` for example
  - Whereas both the snippet and its folder belong in project ID `2`
  - User has access to both Project IDs `1` and `2`, so there's no security issues here
- Because snippet `a` belongs to the user, dashboard loads the snippet's contents correctly
  - The request to fetch the content of a snippet is solely based on the content ID, doesn't consider the project ref
  - It then tries to open the folder of `a` as a UI indication ([ref](https://github.com/supabase/supabase/blob/97c16123b122f9d3ba6e26ee8bcc32fc7c799c45/apps/studio/pages/project/%5Bref%5D/sql/%5Bid%5D.tsx#L51)) which causes the client error as the folder doesn't exist in the project

## Hypothesis
- For context, the dashboard stores the last visited snippet so that each time you land on `/sql`, we'll just load up the last visited snippet for convenience
- Last visited snippet is saved in local storage under a key that includes the project's ref to uniquely save histories across projects
- Dashboard could've incorrectly saved the last visited snippet under the wrong project ref (more details in next section "Problems identified")
  - Lines up with user running into the error by using visiting /sql

## Problems identified:
- The way we're tracking dashboard history is rather inefficient
- We're loading from local storage, and subsequently then loading into the app valtio store
  - Latter is unnecessary, should just use local storage as source of truth
- Each time we were calling `setDashboardHistory` from `app-state`, we always had to pass in a `ref`
  - Potentially very finicky here, my guess as to what happened to the user was that we saved the last visited snippet from a project into another project's dashboard history

## Changes involved
- These should mitigate saving history into the wrong project
  - Created a `useDashboardHistory` hook, updated UI to use this instead
    - Calls `useParam` to ensure that it's always using the project's `ref` that the user is currently on
  - Removed dashboard history related logic from `app-state.tsx`
- These should help unblock the users atm who are running this erro state on the SQL Editor because of malformed history
  - If the loaded SQL snippet doesn't belong to the project, skip loading into the SQL Editor valtio store + redirect back to /new + reset last visited snippet
  - This will then also prevent the `Node with id=xxx doesn't exist in the tree` if the snippet belonged to a folder as no folders will be opened then

## To test
- [ ] Verify that history for SQL Editor still works
  - Open a snippet, go back to project home page, refresh, then open the SQL Editor via the side nav, last visited snippet should open
- [ ] Verify that history for Table Editor still works
  - Same steps as above, just for Table Editor
- [ ] Verify that history for SQL Editor works across projects
  - In one project, open 2 snippets (remember what the last visited snippet was), then go back to your list of projects + refresh
  - Open another project and go to the SQL editor via the side nav, verify that there's no unexpected outcomes
  - Now in that project, open 2 snippets again (remember what the last visited snippet was here), then go back to your list of projects + refresh
  - Now go back to the first project and open the SQL editor via the side nav, verify that the last visited snippet for this project opens up as expected
  - Go back to the second project and open the SQL editor via the side nav, verify that the last visited snippet for this project opens up as expected
- [ ] Verify that history for Table Editor works across projects
  - Same steps as above, just for Table Editor
