### PR TITLE
ref(replication): Add alpha banner and remove batch size

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
@@ -60,11 +60,7 @@ const FormSchema = z.object({
   datasetId: z.string().min(1, 'Dataset id is required'),
   serviceAccountKey: z.string().min(1, 'Service account key is required'),
   publicationName: z.string().min(1, 'Publication is required'),
-  maxFillMs: z
-    .number()
-    .min(1, 'Max Fill milliseconds should be greater than 0')
-    .int()
-    .optional(),
+  maxFillMs: z.number().min(1, 'Max Fill milliseconds should be greater than 0').int().optional(),
   maxStalenessMins: z.number().nonnegative().optional(),
 })
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel.tsx
@@ -6,7 +6,6 @@ import * as z from 'zod'
 
 import { useParams } from 'common'
 import { useCreateDestinationPipelineMutation } from 'data/replication/create-destination-pipeline-mutation'
-import { useCreateTenantSourceMutation } from 'data/replication/create-tenant-source-mutation'
 import { useReplicationDestinationByIdQuery } from 'data/replication/destination-by-id-query'
 import { useReplicationPipelineByIdQuery } from 'data/replication/pipeline-by-id-query'
 import { useReplicationPublicationsQuery } from 'data/replication/publications-query'
@@ -21,9 +20,6 @@ import {
   AccordionContent_Shadcn_,
   AccordionItem_Shadcn_,
   AccordionTrigger_Shadcn_,
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
   Button,
   Form_Shadcn_,
   FormControl_Shadcn_,
@@ -43,7 +39,6 @@ import {
   SheetSection,
   SheetTitle,
   TextArea_Shadcn_,
-  WarningIcon,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import NewPublicationPanel from './NewPublicationPanel'
@@ -88,9 +83,6 @@ export const DestinationPanel = ({
 
   const editMode = !!existingDestination
   const [publicationPanelVisible, setPublicationPanelVisible] = useState(false)
-
-  const { mutateAsync: createTenantSource, isLoading: creatingTenantSource } =
-    useCreateTenantSourceMutation()
 
   const { mutateAsync: createDestinationPipeline, isLoading: creatingDestinationPipeline } =
     useCreateDestinationPipelineMutation({
@@ -231,11 +223,6 @@ export const DestinationPanel = ({
     }
   }
 
-  const onEnableReplication = async () => {
-    if (!projectRef) return console.error('Project ref is required')
-    await createTenantSource({ projectRef })
-  }
-
   useEffect(() => {
     if (editMode && destinationData && pipelineData) {
       form.reset(defaultValues)
@@ -249,7 +236,7 @@ export const DestinationPanel = ({
     }
   }, [visible, defaultValues, form])
 
-  return sourceId ? (
+  return (
     <>
       <Sheet open={visible} onOpenChange={onClose}>
         <SheetContent showClose={false} size="default">
@@ -467,54 +454,12 @@ export const DestinationPanel = ({
           </div>
         </SheetContent>
       </Sheet>
+
       <NewPublicationPanel
         visible={publicationPanelVisible}
         sourceId={sourceId}
         onClose={() => setPublicationPanelVisible(false)}
       />
     </>
-  ) : (
-    <Sheet open={visible} onOpenChange={onClose}>
-      <SheetContent showClose={false} size="default">
-        <div className="flex flex-col h-full" tabIndex={-1}>
-          <SheetHeader>
-            <SheetTitle>Enable Replication (Alpha)</SheetTitle>
-          </SheetHeader>
-          <SheetSection className="flex-grow overflow-auto">
-            <div className="rounded-md border bg-surface-100 p-5">
-              <div className="flex items-start gap-3">
-                <WarningIcon />
-                <div className="flex-1">
-                  <AlertTitle_Shadcn_ className="mb-1">Replication is in Alpha</AlertTitle_Shadcn_>
-                  <AlertDescription_Shadcn_>
-                    This feature is in active development and may change as we gather feedback.
-                    Availability and behavior can evolve during the Alpha phase.
-                  </AlertDescription_Shadcn_>
-                  <div className="text-sm text-foreground-light mt-3">
-                    <p className="mb-2">
-                      Pricing is not final yet. You can enable replication now; we’ll announce
-                      pricing later and notify you before any charges apply.
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-x-2 mt-4">
-                    <Button
-                      type="primary"
-                      loading={creatingTenantSource}
-                      onClick={onEnableReplication}
-                    >
-                      Enable replication
-                    </Button>
-                    <Button type="default" disabled={creatingTenantSource} onClick={onClose}>
-                      Not now
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </SheetSection>
-          <SheetFooter></SheetFooter>
-        </div>
-      </SheetContent>
-    </Sheet>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -1,19 +1,21 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { Plus, Search } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
 import { useParams } from 'common'
 import Table from 'components/to-be-cleaned/Table'
-import AlertError from 'components/ui/AlertError'
+import { AlertError } from 'components/ui/AlertError'
+import { DocsButton } from 'components/ui/DocsButton'
 import { useReplicationDestinationsQuery } from 'data/replication/destinations-query'
+import { replicationKeys } from 'data/replication/keys'
+import { fetchReplicationPipelineVersion } from 'data/replication/pipeline-version-query'
 import { useReplicationPipelinesQuery } from 'data/replication/pipelines-query'
 import { useReplicationSourcesQuery } from 'data/replication/sources-query'
-import { fetchReplicationPipelineVersion } from 'data/replication/pipeline-version-query'
-import { replicationKeys } from 'data/replication/keys'
-import { useQueryClient } from '@tanstack/react-query'
 import { Button, cn, Input_Shadcn_ } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
 import { DestinationPanel } from './DestinationPanel'
 import { DestinationRow } from './DestinationRow'
+import { EnableReplicationModal } from './EnableReplicationModal'
 import { PIPELINE_ERROR_MESSAGES } from './Pipeline.utils'
 
 export const Destinations = () => {
@@ -26,11 +28,13 @@ export const Destinations = () => {
     error: sourcesError,
     isLoading: isSourcesLoading,
     isError: isSourcesError,
+    isSuccess: isSourcesSuccess,
   } = useReplicationSourcesQuery({
     projectRef,
   })
 
   const sourceId = sourcesData?.sources.find((s) => s.name === projectRef)?.id
+  const replicationNotEnabled = isSourcesSuccess && !sourceId
 
   const {
     data: destinationsData,
@@ -52,7 +56,7 @@ export const Destinations = () => {
     projectRef,
   })
 
-  const anyDestinations = isDestinationsSuccess && destinationsData.destinations.length > 0
+  const hasDestinations = isDestinationsSuccess && destinationsData.destinations.length > 0
 
   const filteredDestinations =
     filterString.length === 0
@@ -103,9 +107,11 @@ export const Destinations = () => {
               />
             </div>
           </div>
-          <Button type="default" icon={<Plus />} onClick={() => setShowNewDestinationPanel(true)}>
-            Add destination
-          </Button>
+          {!!sourceId && (
+            <Button type="default" icon={<Plus />} onClick={() => setShowNewDestinationPanel(true)}>
+              Add destination
+            </Button>
+          )}
         </div>
       </div>
 
@@ -119,7 +125,23 @@ export const Destinations = () => {
           />
         )}
 
-        {anyDestinations ? (
+        {replicationNotEnabled && (
+          <div className="border rounded-md p-4 md:p-12 flex flex-col gap-y-4">
+            <div className="flex flex-col gap-y-1">
+              <h3>Run analysis on your data via integrations with Replication</h3>
+              <p className="text-sm text-foreground-light">
+                Enable replication on your project to send data to your first destination
+              </p>
+            </div>
+            <div className="flex gap-x-2">
+              <EnableReplicationModal />
+              {/* [Joshen] Placeholder for when we have documentation */}
+              <DocsButton href="https://supabase.com/docs" />
+            </div>
+          </div>
+        )}
+
+        {hasDestinations ? (
           <Table
             head={[
               <Table.th key="name">Name</Table.th>,
@@ -147,7 +169,7 @@ export const Destinations = () => {
                 />
               )
             })}
-          ></Table>
+          />
         ) : (
           !isSourcesLoading &&
           !isDestinationsLoading &&
@@ -180,7 +202,7 @@ export const Destinations = () => {
       {!isSourcesLoading &&
         !isDestinationsLoading &&
         filteredDestinations.length === 0 &&
-        anyDestinations && (
+        hasDestinations && (
           <div className="text-center py-8 text-foreground-light">
             <p>No destinations match "{filterString}"</p>
           </div>

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -125,7 +125,7 @@ export const Destinations = () => {
           />
         )}
 
-        {replicationNotEnabled && (
+        {replicationNotEnabled ? (
           <div className="border rounded-md p-4 md:p-12 flex flex-col gap-y-4">
             <div className="flex flex-col gap-y-1">
               <h3>Run analysis on your data via integrations with Replication</h3>
@@ -139,9 +139,7 @@ export const Destinations = () => {
               <DocsButton href="https://supabase.com/docs" />
             </div>
           </div>
-        )}
-
-        {hasDestinations ? (
+        ) : hasDestinations ? (
           <Table
             head={[
               <Table.th key="name">Name</Table.th>,

--- a/apps/studio/components/interfaces/Database/Replication/EnableReplicationModal.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/EnableReplicationModal.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { useParams } from 'common'
+import { useCreateTenantSourceMutation } from 'data/replication/create-tenant-source-mutation'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+import { Admonition } from 'ui-patterns'
+
+export const EnableReplicationModal = () => {
+  const { ref: projectRef } = useParams()
+  const [open, setOpen] = useState(false)
+
+  const { mutateAsync: createTenantSource, isLoading: creatingTenantSource } =
+    useCreateTenantSourceMutation({
+      onSuccess: () => {
+        toast.success('Replication has been successfully enabled!')
+        setOpen(false)
+      },
+      onError: (error) => {
+        toast.error(`Failed to enable replication: ${error.message}`)
+      },
+    })
+
+  const onEnableReplication = async () => {
+    if (!projectRef) return console.error('Project ref is required')
+    await createTenantSource({ projectRef })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="primary" className="w-min">
+          Enable replication
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm to enable Replication</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection className="flex flex-col gap-y-2 !p-0">
+          <Admonition
+            type="warning"
+            className="rounded-none border-0 mb-0"
+            title="Replication is currently in Alpha"
+          >
+            <p className="text-sm !leading-normal">
+              This feature is in active development and may change as we gather feedback.
+              Availability and behavior can evolve while in Alpha.
+            </p>
+            <p className="text-sm !leading-normal">
+              Pricing has not been finalized yet. You can enable replication now; we’ll announce
+              pricing later and notify you before any charges apply.
+            </p>
+          </Admonition>
+        </DialogSection>
+        <DialogFooter>
+          <Button type="default" disabled={creatingTenantSource}>
+            Cancel
+          </Button>
+          <Button type="primary" loading={creatingTenantSource} onClick={onEnableReplication}>
+            Enable replication
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -19,7 +19,7 @@ export interface AlertErrorProps {
 
 // [Joshen] To standardize the language for all error UIs
 
-const AlertError = ({
+export const AlertError = ({
   projectRef,
   subject,
   error,

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.ts
@@ -22,7 +22,6 @@ export type CreateDestinationPipelineParams = {
   pipelineConfig: {
     publicationName: string
     batch?: {
-      maxSize: number
       maxFillMs: number
     }
   }
@@ -60,7 +59,6 @@ async function createDestinationPipeline(
         ...(batch
           ? {
               batch: {
-                max_size: batch.maxSize,
                 max_fill_ms: batch.maxFillMs,
               },
             }

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -24,7 +24,6 @@ export type UpdateDestinationPipelineParams = {
   pipelineConfig: {
     publicationName: string
     batch?: {
-      maxSize: number
       maxFillMs: number
     }
   }
@@ -64,7 +63,6 @@ async function updateDestinationPipeline(
           publication_name: publicationName,
           ...(batch && {
             batch: {
-              max_size: batch.maxSize,
               max_fill_ms: batch.maxFillMs,
             },
           }),

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5142,12 +5142,7 @@ export interface components {
            * @description Maximum fill time in milliseconds
            * @example 200
            */
-          max_fill_ms: number
-          /**
-           * @description Maximum batch size
-           * @example 5000
-           */
-          max_size: number
+          max_fill_ms?: number
         }
         /**
          * @description Publication name
@@ -5170,12 +5165,7 @@ export interface components {
            * @description Maximum fill time in milliseconds
            * @example 200
            */
-          max_fill_ms: number
-          /**
-           * @description Maximum batch size
-           * @example 5000
-           */
-          max_size: number
+          max_fill_ms?: number
         }
         /**
          * @description Publication name
@@ -8015,12 +8005,7 @@ export interface components {
            * @description Maximum fill time in milliseconds
            * @example 200
            */
-          max_fill_ms: number
-          /**
-           * @description Maximum batch size
-           * @example 5000
-           */
-          max_size: number
+          max_fill_ms?: number
         }
         /**
          * @description Publication name
@@ -8075,12 +8060,7 @@ export interface components {
              * @description Maximum fill time in milliseconds
              * @example 200
              */
-            max_fill_ms: number
-            /**
-             * @description Maximum batch size
-             * @example 5000
-             */
-            max_size: number
+            max_fill_ms?: number
           }
           /**
            * @description Publication name
@@ -9429,12 +9409,7 @@ export interface components {
            * @description Maximum fill time in milliseconds
            * @example 200
            */
-          max_fill_ms: number
-          /**
-           * @description Maximum batch size
-           * @example 5000
-           */
-          max_size: number
+          max_fill_ms?: number
         }
         /**
          * @description Publication name
@@ -9457,12 +9432,7 @@ export interface components {
            * @description Maximum fill time in milliseconds
            * @example 200
            */
-          max_fill_ms: number
-          /**
-           * @description Maximum batch size
-           * @example 5000
-           */
-          max_size: number
+          max_fill_ms?: number
         }
         /**
          * @description Publication name


### PR DESCRIPTION
This PR removes the batch size configuration from the replication UI and adds a new banner for enabling replication which clearly communicates that it is in alpha.

### Screenshots

<img width="758" height="376" alt="image" src="https://github.com/user-attachments/assets/1a2c63bb-7094-4a51-9b8d-370d557ca273" />

<img width="766" height="427" alt="image" src="https://github.com/user-attachments/assets/76b9f41c-f200-4476-a89f-0bbe852f4eaf" />