### PR TITLE
feat: bump auth-js to v2.72.0-rc.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@supabase/auth-js':
-      specifier: 2.71.1-rc.1
-      version: 2.71.1-rc.1
+      specifier: 2.72.0-rc.11
+      version: 2.72.0-rc.11
     '@supabase/realtime-js':
       specifier: ^2.11.3
       version: 2.11.3
@@ -41,7 +41,7 @@ catalogs:
       version: 6.3.5
 
 overrides:
-  '@supabase/supabase-js>@supabase/auth-js': 2.71.1-rc.1
+  '@supabase/supabase-js>@supabase/auth-js': 2.72.0-rc.11
   '@tanstack/directive-functions-plugin>vite': ^6.2.7
   '@tanstack/react-start-plugin>vite': ^6.2.7
   esbuild: ^0.25.2
@@ -793,7 +793,7 @@ importers:
         version: 7.5.0
       '@supabase/auth-js':
         specifier: 'catalog:'
-        version: 2.71.1-rc.1
+        version: 2.72.0-rc.11
       '@supabase/mcp-server-supabase':
         specifier: ^0.4.4
         version: 0.4.4(supports-color@8.1.1)
@@ -1856,7 +1856,7 @@ importers:
     dependencies:
       '@supabase/auth-js':
         specifier: 'catalog:'
-        version: 2.71.1-rc.1
+        version: 2.72.0-rc.11
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.49.3
@@ -8025,8 +8025,8 @@ packages:
     resolution: {integrity: sha512-Cq3KKe+G1o7PSBMbmrgpT2JgBeyH2THHr3RdIX2MqF7AnBuspIMgtZ3ktcCgP7kZsTMvnmWymr7zZCT1zeWbMw==}
     engines: {node: '>=12.16'}
 
-  '@supabase/auth-js@2.71.1-rc.1':
-    resolution: {integrity: sha512-tgSFLO19e8Ig7eQON6c02DoyfV3OLEG709UqinbFExvRKB4z1yHBwwaMbkZtoKcu395AFVtekcHtoM9TEmixoQ==}
+  '@supabase/auth-js@2.72.0-rc.11':
+    resolution: {integrity: sha512-7C0xC6ZXbIB8GAoO6saWNMRhKox9OeYvMmpfPJyxFiECg9z78SMhMotiyI3U1Ws47iGiaDonEUnuxDuHAG04nQ==}
 
   '@supabase/functions-js@2.4.4':
     resolution: {integrity: sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==}
@@ -26063,7 +26063,7 @@ snapshots:
 
   '@stripe/stripe-js@7.5.0': {}
 
-  '@supabase/auth-js@2.71.1-rc.1':
+  '@supabase/auth-js@2.72.0-rc.11':
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
@@ -26220,7 +26220,7 @@ snapshots:
 
   '@supabase/supabase-js@2.49.3':
     dependencies:
-      '@supabase/auth-js': 2.71.1-rc.1
+      '@supabase/auth-js': 2.72.0-rc.11
       '@supabase/functions-js': 2.4.4
       '@supabase/node-fetch': 2.6.15
       '@supabase/postgrest-js': 1.19.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   '@types/node': ^22.0.0
-  '@supabase/auth-js': 2.71.1-rc.1
+  '@supabase/auth-js': 2.72.0-rc.11
   '@supabase/supabase-js': ^2.47.14
   '@supabase/realtime-js': ^2.11.3
   next: 15.3.3


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

an RC for `@supabase/auth-js` needs to be deployed on supabase.com before it is declared an official release

## Additional context

Once this PR is merged, the dogfooding tests will run normally [here](https://github.com/supabase/auth-js/pull/1090). If all is well within a week, we can merge the release PR and finally get `2.72` on `auth-js`
