### PR TITLE
[www]: hide blog post loaders in production deployments

### DIFF
--- a/apps/www/components/Blog/BlogPostRenderer.tsx
+++ b/apps/www/components/Blog/BlogPostRenderer.tsx
@@ -177,9 +177,6 @@ const BlogPostRenderer = ({
 
   return (
     <>
-      {shouldShowDraftLoading && (
-        <div className="fixed top-10 right-10 border rounded-full rounded-tr-none animate-spin transform w-10 h-10 bg-transparent" />
-      )}
       {isDraftMode && <DraftModeBanner />}
       <DefaultLayout className="overflow-x-hidden">
         <div

--- a/apps/www/components/Blog/BlogPostRenderer.tsx
+++ b/apps/www/components/Blog/BlogPostRenderer.tsx
@@ -172,9 +172,12 @@ const BlogPostRenderer = ({
     return `${minutes} min read`
   }
 
+  // only show draft loading in development/preview environments
+  const shouldShowDraftLoading = isLivePreviewLoading && process.env.NODE_ENV !== 'production'
+
   return (
     <>
-      {isLivePreviewLoading && (
+      {shouldShowDraftLoading && (
         <div className="fixed top-10 right-10 border rounded-full rounded-tr-none animate-spin transform w-10 h-10 bg-transparent" />
       )}
       {isDraftMode && <DraftModeBanner />}
@@ -202,7 +205,7 @@ const BlogPostRenderer = ({
                 <div className="space-y-4">
                   <Link href="/blog" className="text-brand hidden lg:inline-flex items-center">
                     Blog{' '}
-                    {isLivePreviewLoading && (
+                    {shouldShowDraftLoading && (
                       <div className="text-xs text-foreground-lighter ml-4">Draft loading...</div>
                     )}
                   </Link>

--- a/apps/www/components/Blog/BlogPostRenderer.tsx
+++ b/apps/www/components/Blog/BlogPostRenderer.tsx
@@ -39,7 +39,6 @@ const BlogPostRenderer = ({
   blogMetaData,
   isDraftMode,
   livePreviewData,
-  isLivePreviewLoading,
   prevPost,
   nextPost,
   authors,
@@ -172,9 +171,6 @@ const BlogPostRenderer = ({
     return `${minutes} min read`
   }
 
-  // only show draft loading in development/preview environments
-  const shouldShowDraftLoading = isLivePreviewLoading && process.env.NODE_ENV !== 'production'
-
   return (
     <>
       {isDraftMode && <DraftModeBanner />}
@@ -201,10 +197,7 @@ const BlogPostRenderer = ({
               <div className="mb-6 lg:mb-10 max-w-5xl space-y-8">
                 <div className="space-y-4">
                   <Link href="/blog" className="text-brand hidden lg:inline-flex items-center">
-                    Blog{' '}
-                    {shouldShowDraftLoading && (
-                      <div className="text-xs text-foreground-lighter ml-4">Draft loading...</div>
-                    )}
+                    Blog
                   </Link>
                   <h1 className="text-2xl sm:text-4xl">{blogMetaData.title}</h1>
                   <div className="text-light flex space-x-3 text-sm">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This hides the live preview loaders in production.

## What is the current behavior?

Weird circle showing off in top-right screen.


