### PR TITLE
fix: client side exception in cron jobs details

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.tsx
@@ -33,30 +33,34 @@ const cronJobColumns = [
     minWidth: 200,
     value: (row: CronJobRun) => (
       <div className="flex items-center gap-1.5">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="text-xs cursor-pointer truncate max-w-[300px]">
-              {row.return_message}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent
-            side="bottom"
-            align="start"
-            className="min-w-[200px] max-w-[300px] text-wrap p-0"
-          >
-            <p className="text-xs font-mono px-2 py-1 border-b bg-surface-100">Message</p>
-            <CodeBlock
-              hideLineNumbers
-              language="sql"
-              value={row.return_message.trim()}
-              className={cn(
-                'py-0 px-3.5 max-w-full prose dark:prose-dark border-0 rounded-t-none',
-                '[&>code]:m-0 [&>code>span]:flex [&>code>span]:flex-wrap min-h-11',
-                '[&>code]:text-xs'
-              )}
-            />
-          </TooltipContent>
-        </Tooltip>
+        {row.return_message ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-xs cursor-pointer truncate max-w-[300px]">
+                {row.return_message}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent
+              side="bottom"
+              align="start"
+              className="min-w-[200px] max-w-[300px] text-wrap p-0"
+            >
+              <p className="text-xs font-mono px-2 py-1 border-b bg-surface-100">Message</p>
+              <CodeBlock
+                hideLineNumbers
+                language="sql"
+                value={row.return_message.trim()}
+                className={cn(
+                  'py-0 px-3.5 max-w-full prose dark:prose-dark border-0 rounded-t-none',
+                  '[&>code]:m-0 [&>code>span]:flex [&>code>span]:flex-wrap min-h-11',
+                  '[&>code]:text-xs'
+                )}
+              />
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span>-</span>
+        )}
       </div>
     ),
   },
@@ -78,7 +82,9 @@ const cronJobColumns = [
     name: 'End Time',
     minWidth: 120,
     value: (row: CronJobRun) => (
-      <div className="text-xs">{row.status === 'succeeded' ? formatDate(row.end_time) : '-'}</div>
+      <div className="flex items-center text-xs">
+        {row.end_time ? formatDate(row.end_time) : '-'}
+      </div>
     ),
   },
 
@@ -89,7 +95,7 @@ const cronJobColumns = [
     value: (row: CronJobRun) => (
       <div className="flex items-center">
         <span className="text-xs">
-          {row.status === 'succeeded' ? calculateDuration(row.start_time, row.end_time) : ''}
+          {row.start_time && row.end_time ? calculateDuration(row.start_time, row.end_time) : ''}
         </span>
       </div>
     ),
@@ -119,16 +125,19 @@ const columns = cronJobColumns.map((col) => {
       const value = col.value(props.row)
 
       if (['start_time', 'end_time'].includes(col.id)) {
-        const formattedValue = dayjs((props.row as any)[(col as any).id]).valueOf()
-        return (
-          <div className="flex items-center">
-            <TimestampInfo
-              utcTimestamp={formattedValue}
-              labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
-              className="text-xs"
-            />
-          </div>
-        )
+        const rawValue = (props.row as any)[(col as any).id]
+        if (rawValue) {
+          const formattedValue = dayjs(rawValue).valueOf()
+          return (
+            <div className="flex items-center">
+              <TimestampInfo
+                utcTimestamp={formattedValue}
+                labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
+                className="text-xs"
+              />
+            </div>
+          )
+        }
       }
 
       return value

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-runs-infinite-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-runs-infinite-query.ts
@@ -20,9 +20,9 @@ export type CronJobRun = {
   command: string
   // statuses https://github.com/citusdata/pg_cron/blob/f5d111117ddc0f4d83a1bad34d61b857681b6720/include/job_metadata.h#L20
   status: 'starting' | 'running' | 'sending' | 'connecting' | 'succeeded' | 'failed'
-  return_message: string
+  return_message: string | null
   start_time: string
-  end_time: string
+  end_time: string | null
 }
 
 export const CRON_JOB_RUNS_PAGE_SIZE = 30


### PR DESCRIPTION
The cron jobs details table will throw a client side exception while cron jobs are in running status. This is because the types that we've defined for cron job details expect both return_message and end_time to be strings, but they will be null until the cron job is finished.

Fixed the types and added some defensive checks to fix the bug.

Also made some minor tweaks to the table. Figured that end time and duration can also be shown for failed jobs, doesn't only have to be succeeded ones.

Before:

<img width="1511" height="638" alt="CleanShot 2025-09-10 at 18 28 48" src="https://github.com/user-attachments/assets/ed8f9435-e40d-4acf-bad0-15440c28e3b8" />

After:

<img width="1608" height="546" alt="CleanShot 2025-09-10 at 18 25 48" src="https://github.com/user-attachments/assets/5b3478e3-1580-48e7-853d-f100a01328e7" />

## To test

Make a cron job that will run for long enough that you can check the running state. `select pg_sleep_for('5 minutes')` will work.