### PR TITLE
Fix filtering issue

### DIFF
--- a/apps/studio/lib/ai/tools/fallback-tools.ts
+++ b/apps/studio/lib/ai/tools/fallback-tools.ts
@@ -370,8 +370,10 @@ export const getFallbackTools = ({
               )
             : []
 
+          const dataArray = Array.isArray(data) ? data : []
+
           // Filter functions by requested schemas
-          const filteredFunctions = data.filter((func) => schemas.includes(func.schema))
+          const filteredFunctions = dataArray.filter((func) => schemas.includes(func.schema))
 
           const formattedFunctions = filteredFunctions
             .map(


### PR DESCRIPTION
Error in handlePost: TypeError: Cannot read properties of undefined (reading 'filter')
    at t (.next/server/pages/api/ai/sql/generate-v4.js:8:224)
    at async Module.m (.next/server/pages/api/ai/sql/generate-v4.js:8:3511)
    
   This is one of the remaining errors we get from the generate-v4 endpoint. Hard to pinpoint exactly but could potentially be coming from self-hosted installs.