### PR TITLE
Make project infinite query keys fully unique

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -190,7 +190,6 @@ export function DiskManagementForm() {
   const isPlanUpgradeRequired = org?.plan.id === 'free'
 
   const { formState } = form
-  const { computeSize: formComputeSize, storageType: formStorageType } = form.watch()
   const usedSize = Math.round(((diskUtil?.metrics.fs_used_bytes ?? 0) / GB) * 100) / 100
   const totalSize = formState.defaultValues?.totalSize || 0
   const usedPercentage = (usedSize / totalSize) * 100

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -190,6 +190,7 @@ export function DiskManagementForm() {
   const isPlanUpgradeRequired = org?.plan.id === 'free'
 
   const { formState } = form
+  const { computeSize: formComputeSize, storageType: formStorageType } = form.watch()
   const usedSize = Math.round(((diskUtil?.metrics.fs_used_bytes ?? 0) / GB) * 100) / 100
   const totalSize = formState.defaultValues?.totalSize || 0
   const usedPercentage = (usedSize / totalSize) * 100

--- a/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
@@ -55,6 +55,8 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
   const { data: org } = useSelectedOrganizationQuery()
   const { data: project, isLoading: isProjectLoading } = useSelectedProjectQuery()
 
+  const { computeSize, storageType } = form.watch()
+
   const {
     data: addons,
     isLoading: isAddonsLoading,
@@ -111,7 +113,7 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
         >
           <FormItemLayout
             layout="horizontal"
-            label={'Compute size'}
+            label="Compute size"
             id={field.name}
             className="gap-5"
             labelOptional={
@@ -125,7 +127,7 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
                   }
                   beforePrice={Number(computeSizePrice.oldPrice)}
                   afterPrice={Number(computeSizePrice.newPrice)}
-                  free={showUpgradeBadge && form.watch('computeSize') === 'ci_micro' ? true : false}
+                  free={showUpgradeBadge && computeSize === 'ci_micro' ? true : false}
                 />
                 <p className="text-foreground-lighter">
                   Hardware resources allocated to your Postgres database

--- a/apps/studio/components/interfaces/DiskManagement/fields/StorageTypeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/StorageTypeField.tsx
@@ -91,7 +91,7 @@ export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) 
               />
             ) : (
               <FormControl_Shadcn_>
-                <SelectTrigger_Shadcn_ className="h-14 max-w-[420px]">
+                <SelectTrigger_Shadcn_ className="h-14 max-w-[420px] [&>span]:w-full">
                   <SelectValue_Shadcn_ />
                 </SelectTrigger_Shadcn_>
               </FormControl_Shadcn_>

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -243,17 +243,17 @@ const TransferProjectButton = () => {
                 {transferPreviewData &&
                   (transferPreviewData.warnings.length > 0 ||
                     transferPreviewData.info.length > 0) && (
-                    <Admonition type={'caution'} showIcon={false} className="mt-3">
-                      <div className="space-y-1">
+                    <Admonition type="caution" showIcon={false} className="mt-3">
+                      <div className="flex flex-col gap-y-2">
                         {transferPreviewData.warnings.map((warning) => (
                           <div key={warning.key} className="flex items-center gap-2">
-                            <WarningIcon className="flex-shrink-0 mt-0.25" />
+                            <WarningIcon className="flex-shrink-0" />
                             <p className="mb-0.5">{warning.message}</p>
                           </div>
                         ))}
                         {transferPreviewData.info.map((info) => (
-                          <div key={info.key} className="flex items-center gap-2">
-                            <InfoIcon className="flex-shrink-0 mt-0.25" />
+                          <div key={info.key} className="flex items-start gap-2">
+                            <InfoIcon className="flex-shrink-0 mt-0.5" />
                             <p className="mb-0.5">{info.message}</p>
                           </div>
                         ))}

--- a/apps/studio/data/projects/keys.ts
+++ b/apps/studio/data/projects/keys.ts
@@ -8,7 +8,7 @@ export const projectKeys = {
       search?: string
       statuses?: string[]
     }
-  ) => ['all-projects', slug, params] as const,
+  ) => ['all-projects-infinite', slug, params] as const,
   status: (projectRef: string | undefined) => ['project', projectRef, 'status'] as const,
   types: (projectRef: string | undefined) => ['project', projectRef, 'types'] as const,
   detail: (projectRef: string | undefined) => ['project', projectRef, 'detail'] as const,


### PR DESCRIPTION
## Context

Internal bug report with Compute and Disk section with running into this client side error when trying to change disk configuration
<img width="518" height="150" alt="image" src="https://github.com/user-attachments/assets/dc2b595f-5965-49ce-8b92-38f51f76b91c" />

Tracing it down, it looks like this is stemming from [here](https://github.com/supabase/supabase/blob/master/apps/studio/data/projects/projects-query.ts#L91) as `setProjectStatus` is being called when updating addons [here](https://github.com/supabase/supabase/blob/5fa0987a80dd86a5eff2ecb6eba1f19bdd6b9b44/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx#L228)

## Hypothesis 

- I tried to `console.log` what `old` looks like in `setProjectStatus` and it (inconsistently) returned `old` as `{pages: [...], pageParams: { ... }` which made me think that `projectKeys.list()` might be conflicting between `projects-query` and `projects-infinite-query` (which was recently added [here](https://github.com/supabase/supabase/pull/38298))

## Changes involved
- Am opting to make the query key for `projects-infinite-query` fully unique by renaming the first item in its query key array to `projects-all-infinite` so that there's no chance of conflicting with the key from `projects-query`
- (Unrelated) Fix style issue in Storage Type select here
  <img width="784" height="99" alt="image" src="https://github.com/user-attachments/assets/36d3bee6-dd87-4d6e-8dba-92ed1ecc6394" />
  <img width="792" height="106" alt="image" src="https://github.com/user-attachments/assets/1e13448f-b633-41d8-ad9e-14ef53efad1a" />
- (Unrelated) Fix small icon positioning issue in Transfer Project modal here
  <img width="165" height="134" alt="image" src="https://github.com/user-attachments/assets/3ee4c291-5710-4b7f-80df-99888576e035" />
  <img width="143" height="124" alt="image" src="https://github.com/user-attachments/assets/843587e8-97b7-48cc-b24d-90f588705fc1" />

## To test

Just needs to make sure that this flow works without issues:
- Create project in free organization
- Transfer project to paid organization
- Update compute and disk of project
  - Large, IO2, IOPs at 3500
