### PR TITLE
Use overflow auto instead of scroll

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
@@ -233,8 +233,8 @@ export const ProjectList = ({ organization: organization_, rewriteHref }: Projec
         <ul
           onScroll={handleScroll}
           className={cn(
-            'min-h-0 overflow-auto w-full mx-auto ',
-            'grid grid-cols-1 gap-2 md:gap-4 overflow-y-scroll',
+            'min-h-0 w-full mx-auto overflow-y-auto',
+            'grid grid-cols-1 gap-2 md:gap-4',
             'sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 pb-6'
           )}
         >


### PR DESCRIPTION
## Context

Addressing a scrollbar issue on the projects list - we've introduced infinite scrolling [here](https://github.com/supabase/supabase/pull/38298) for the projects list but got an internal report that the scrollbar seems to be persisting showing up. Realised that it might be cause we're using `overflow-y-scroll`, so just changing that to `overflow-y-auto` and removing an unnecessary `overflow-auto`

<img width="170" height="188" alt="image" src="https://github.com/user-attachments/assets/3f3b52fe-45d6-4230-ac8d-b000a1852b90" />
