### PR TITLE
fix: estimate number of users when count is large

### DIFF
--- a/apps/studio/components/grid/components/footer/pagination/Pagination.utils.ts
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.utils.ts
@@ -7,5 +7,7 @@ export const formatEstimatedCount = (value: number) => {
 
   const unit = i > 4 ? 'T' : sizes[i]
 
-  return `${(value / Math.pow(k, i > 4 ? 4 : i)).toFixed(1)}${unit}`
+  const formattedValue = value / Math.pow(k, i > 4 ? 4 : i)
+
+  return unit === '' ? `${formattedValue}` : `${formattedValue.toFixed(1)}${unit}`
 }

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -1,6 +1,16 @@
 import { useQueryClient } from '@tanstack/react-query'
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
-import { ArrowDown, ArrowUp, Loader2, RefreshCw, Search, Trash, Users, X } from 'lucide-react'
+import {
+  ArrowDown,
+  ArrowUp,
+  HelpCircle,
+  Loader2,
+  RefreshCw,
+  Search,
+  Trash,
+  Users,
+  X,
+} from 'lucide-react'
 import { UIEvent, useEffect, useMemo, useRef, useState } from 'react'
 import DataGrid, { Column, DataGridHandle, Row } from 'react-data-grid'
 import { toast } from 'sonner'
@@ -14,7 +24,7 @@ import { FilterPopover } from 'components/ui/FilterPopover'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { authKeys } from 'data/auth/keys'
 import { useUserDeleteMutation } from 'data/auth/user-delete-mutation'
-import { useUsersCountQuery } from 'data/auth/users-count-query'
+import { USERS_THRESHOLD_COUNT, useUsersCountQuery } from 'data/auth/users-count-query'
 import { User, useUsersInfiniteQuery } from 'data/auth/users-infinite-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
@@ -40,6 +50,9 @@ import {
   SelectItem_Shadcn_,
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
@@ -93,6 +106,9 @@ export const UsersV2 = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [isDeletingUsers, setIsDeletingUsers] = useState(false)
 
+  const [forceExactCount, setForceExactCount] = useState(false)
+  const [showFetchExactCountModal, setShowFetchExactCountModal] = useState(false)
+
   const [
     columnConfiguration,
     setColumnConfiguration,
@@ -133,20 +149,31 @@ export const UsersV2 = () => {
     }
   )
 
-  const { data: countData, refetch: refetchCount } = useUsersCountQuery({
+  const {
+    data: countData,
+    refetch: refetchCount,
+    isLoading: isLoadingCount,
+  } = useUsersCountQuery({
     projectRef,
     connectionString: project?.connectionString,
     keywords: filterKeywords,
     filter: filter === 'all' ? undefined : filter,
     providers: selectedProviders,
+    forceExactCount,
   })
 
   const { mutateAsync: deleteUser } = useUserDeleteMutation()
 
-  const totalUsers = countData ?? 0
+  const totalUsers = countData?.count ?? 0
   const users = useMemo(() => data?.pages.flatMap((page) => page.result) ?? [], [data?.pages])
   // [Joshen] Only relevant for when selecting one user only
   const selectedUserFromCheckbox = users.find((u) => u.id === [...selectedUsers][0])
+
+  const formatEstimatedCount = (count: number) => {
+    if (count >= 1e6) return `${(count / 1e6).toFixed(1)}M`
+    if (count >= 1e3) return `${(count / 1e3).toFixed(1)}K`
+    return count.toString()
+  }
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
     const isScrollingHorizontally = xScroll.current !== event.currentTarget.scrollLeft
@@ -576,7 +603,43 @@ export const UsersV2 = () => {
         </ResizablePanelGroup>
 
         <div className="flex justify-between min-h-9 h-9 overflow-hidden items-center px-6 w-full border-t text-xs text-foreground-light">
-          {isLoading || isRefetching ? 'Loading users...' : `Total: ${totalUsers} users`}
+          <div className="flex items-center gap-x-2">
+            {isLoadingCount ? (
+              'Loading user count...'
+            ) : (
+              <>
+                <span>
+                  Total:{' '}
+                  {countData?.is_estimate
+                    ? formatEstimatedCount(totalUsers)
+                    : totalUsers.toLocaleString()}{' '}
+                  user{totalUsers !== 1 ? 's' : ''}
+                  {countData?.is_estimate && ' (estimated)'}
+                </span>
+                {countData?.is_estimate && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="tiny"
+                        type="text"
+                        className="px-1.5"
+                        icon={<HelpCircle />}
+                        onClick={() => {
+                          setShowFetchExactCountModal(true)
+                        }}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="w-72">
+                      This is an estimated value as your project has more than{' '}
+                      {USERS_THRESHOLD_COUNT.toLocaleString()} users.
+                      <br />
+                      <span className="text-brand">Click to retrieve the exact count.</span>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+          </div>
           {(isLoading || isRefetching || isFetchingNextPage) && (
             <span className="flex items-center gap-2">
               <Loader2 size={14} className="animate-spin" /> Loading...
@@ -622,6 +685,23 @@ export const UsersV2 = () => {
           setSelectedUserToDelete(undefined)
         }}
       />
+
+      <ConfirmationModal
+        variant="warning"
+        visible={showFetchExactCountModal}
+        title="Fetch exact user count"
+        confirmLabel="Fetch exact count"
+        onCancel={() => setShowFetchExactCountModal(false)}
+        onConfirm={() => {
+          setForceExactCount(true)
+          setShowFetchExactCountModal(false)
+        }}
+      >
+        <p className="text-sm text-foreground-light">
+          Your project has more than {USERS_THRESHOLD_COUNT.toLocaleString()} users, and fetching
+          the exact count may cause performance issues on your database.
+        </p>
+      </ConfirmationModal>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -24,8 +24,9 @@ import { FilterPopover } from 'components/ui/FilterPopover'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { authKeys } from 'data/auth/keys'
 import { useUserDeleteMutation } from 'data/auth/user-delete-mutation'
-import { USERS_THRESHOLD_COUNT, useUsersCountQuery } from 'data/auth/users-count-query'
+import { useUsersCountQuery } from 'data/auth/users-count-query'
 import { User, useUsersInfiniteQuery } from 'data/auth/users-infinite-query'
+import { THRESHOLD_COUNT } from 'data/table-rows/table-rows-count-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -631,7 +632,7 @@ export const UsersV2 = () => {
                     </TooltipTrigger>
                     <TooltipContent side="top" className="w-72">
                       This is an estimated value as your project has more than{' '}
-                      {USERS_THRESHOLD_COUNT.toLocaleString()} users.
+                      {THRESHOLD_COUNT.toLocaleString()} users.
                       <br />
                       <span className="text-brand">Click to retrieve the exact count.</span>
                     </TooltipContent>
@@ -698,8 +699,8 @@ export const UsersV2 = () => {
         }}
       >
         <p className="text-sm text-foreground-light">
-          Your project has more than {USERS_THRESHOLD_COUNT.toLocaleString()} users, and fetching
-          the exact count may cause performance issues on your database.
+          Your project has more than {THRESHOLD_COUNT.toLocaleString()} users, and fetching the
+          exact count may cause performance issues on your database.
         </p>
       </ConfirmationModal>
     </>

--- a/apps/studio/data/auth/keys.ts
+++ b/apps/studio/data/auth/keys.ts
@@ -30,6 +30,7 @@ export const authKeys = {
       keywords: string | undefined
       filter: string | undefined
       providers: string[] | undefined
+      forceExactCount?: boolean
     }
   ) =>
     ['projects', projectRef, 'users-count', ...(params ? [params].filter(Boolean) : [])] as const,

--- a/apps/studio/data/auth/users-count-query.ts
+++ b/apps/studio/data/auth/users-count-query.ts
@@ -1,8 +1,23 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
-import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { executeSql, type ExecuteSqlError } from 'data/sql/execute-sql-query'
 import { authKeys } from './keys'
-import { Filter } from './users-infinite-query'
+import { type Filter } from './users-infinite-query'
+
+export const USERS_THRESHOLD_COUNT = 10 // Set to 10 for testing, set back to 50_000 before merge
+
+const COUNT_ESTIMATE_SQL = /* SQL */ `
+CREATE OR REPLACE FUNCTION pg_temp.count_estimate(
+    query text
+) RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE
+    plan jsonb;
+BEGIN
+    EXECUTE 'EXPLAIN (FORMAT JSON)' || query INTO plan;
+    RETURN plan->0->'Plan'->'Plan Rows';
+END;
+$$;
+`.trim()
 
 type UsersCountVariables = {
   projectRef?: string
@@ -10,21 +25,25 @@ type UsersCountVariables = {
   keywords?: string
   filter?: Filter
   providers?: string[]
+  forceExactCount?: boolean
 }
 
 const getUsersCountSql = ({
   filter,
   keywords,
   providers,
+  forceExactCount = false,
 }: {
   filter?: Filter
   keywords?: string
   providers?: string[]
+  forceExactCount?: boolean
 }) => {
   const hasValidKeywords = keywords && keywords !== ''
 
   const conditions: string[] = []
   const baseQueryCount = `select count(*) from auth.users`
+  const baseQuerySelect = `select * from auth.users`
 
   if (hasValidKeywords) {
     // [Joshen] Escape single quotes properly
@@ -57,15 +76,50 @@ const getUsersCountSql = ({
   }
 
   const combinedConditions = conditions.map((x) => `(${x})`).join(' and ')
+  const whereClause = conditions.length > 0 ? ` where ${combinedConditions}` : ''
 
-  return `${baseQueryCount}${conditions.length > 0 ? ` where ${combinedConditions}` : ''};`
+  if (forceExactCount) {
+    return `select (${baseQueryCount}${whereClause}), false as is_estimate;`
+  } else {
+    const selectBaseSql = `${baseQuerySelect}${whereClause}`
+    const countBaseSql = `${baseQueryCount}${whereClause}`
+
+    const escapedSelectSql = selectBaseSql.replaceAll("'", "''")
+
+    const sql = `
+${COUNT_ESTIMATE_SQL}
+
+with approximation as (
+    select reltuples as estimate
+    from pg_class
+    where oid = 'auth.users'::regclass
+)
+select 
+  case 
+    when estimate = -1 then (select pg_temp.count_estimate('${escapedSelectSql}'))::int
+    when estimate > ${USERS_THRESHOLD_COUNT} then ${conditions.length > 0 ? `(select pg_temp.count_estimate('${escapedSelectSql}'))::int` : 'estimate::int'}
+    else (${countBaseSql})
+  end as count,
+  estimate = -1 or estimate > ${USERS_THRESHOLD_COUNT} as is_estimate
+from approximation;
+`.trim()
+
+    return sql
+  }
 }
 
 export async function getUsersCount(
-  { projectRef, connectionString, keywords, filter, providers }: UsersCountVariables,
+  {
+    projectRef,
+    connectionString,
+    keywords,
+    filter,
+    providers,
+    forceExactCount,
+  }: UsersCountVariables,
   signal?: AbortSignal
 ) {
-  const sql = getUsersCountSql({ filter, keywords, providers })
+  const sql = getUsersCountSql({ filter, keywords, providers, forceExactCount })
 
   const { result } = await executeSql(
     {
@@ -78,25 +132,51 @@ export async function getUsersCount(
   )
 
   const count = result?.[0]?.count
+  const isEstimate = result?.[0]?.is_estimate
 
   if (typeof count !== 'number') {
     throw new Error('Error fetching users count')
   }
 
-  return count
+  return {
+    count,
+    is_estimate: isEstimate ?? true,
+  }
 }
 
 export type UsersCountData = Awaited<ReturnType<typeof getUsersCount>>
 export type UsersCountError = ExecuteSqlError
 
 export const useUsersCountQuery = <TData = UsersCountData>(
-  { projectRef, connectionString, keywords, filter, providers }: UsersCountVariables,
+  {
+    projectRef,
+    connectionString,
+    keywords,
+    filter,
+    providers,
+    forceExactCount,
+  }: UsersCountVariables,
   { enabled = true, ...options }: UseQueryOptions<UsersCountData, UsersCountError, TData> = {}
 ) =>
   useQuery<UsersCountData, UsersCountError, TData>(
-    authKeys.usersCount(projectRef, { keywords, filter, providers }),
+    authKeys.usersCount(projectRef, {
+      keywords,
+      filter,
+      providers,
+      forceExactCount,
+    }),
     ({ signal }) =>
-      getUsersCount({ projectRef, connectionString, keywords, filter, providers }, signal),
+      getUsersCount(
+        {
+          projectRef,
+          connectionString,
+          keywords,
+          filter,
+          providers,
+          forceExactCount,
+        },
+        signal
+      ),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
       ...options,

--- a/apps/studio/data/table-rows/table-rows-count-query.ts
+++ b/apps/studio/data/table-rows/table-rows-count-query.ts
@@ -16,7 +16,7 @@ type GetTableRowsCountArgs = {
 }
 
 export const THRESHOLD_COUNT = 50000
-const COUNT_ESTIMATE_SQL = /* SQL */ `
+export const COUNT_ESTIMATE_SQL = /* SQL */ `
 CREATE OR REPLACE FUNCTION pg_temp.count_estimate(
     query text
 ) RETURNS integer LANGUAGE plpgsql AS $$


### PR DESCRIPTION
In the Auth Users table, we always fetch an exact count of users. This can be a problem for projects with many (>50K) users as the count(*) might cause performance issues on the database. We already have logic on the Table Editor to only run automatic count estimates (fetching the exact count only if user requests it), this change ports the same logic over to Auth Users.

https://github.com/user-attachments/assets/2737e5fb-f23e-426f-98c7-ec7ddda87cbf

## To test

For testing, the threshold has been set very low (10 users).

1. Create 11 users on your project.
2. Run `vacuum analyze` to make sure planner statistics are up to date.
3. Check that the Auth Users table has an estimated count at the bottom.
4. Delete a user to get back down to 10.
5. Run `vacuum analyze` again.
6. Check that the Auth Users table has an exact count at the bottom.