### PR TITLE
fix: let api handle signing key validation error

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/fields/StorageTypeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/StorageTypeField.tsx
@@ -91,7 +91,7 @@ export function StorageTypeField({ form, disableInput }: StorageTypeFieldProps) 
               />
             ) : (
               <FormControl_Shadcn_>
-                <SelectTrigger_Shadcn_ className="h-14 max-w-[420px] [&>span]:w-full">
+                <SelectTrigger_Shadcn_ className="h-14 max-w-[420px]">
                   <SelectValue_Shadcn_ />
                 </SelectTrigger_Shadcn_>
               </FormControl_Shadcn_>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
@@ -25,10 +25,6 @@ import {
 
 const RSA_JWK_REQUIRED_PROPERTIES = ['kty', 'n', 'e', 'p', 'q', 'd', 'dq', 'dp', 'qi']
 const EC_JWK_REQUIRED_PROPERTIES = ['kty', 'crv', 'x', 'y', 'd']
-const ALLOWED_JWK_PROPERTIES = new Set([
-  ...RSA_JWK_REQUIRED_PROPERTIES,
-  ...EC_JWK_REQUIRED_PROPERTIES,
-])
 
 export const CreateKeyDialog = ({
   projectRef,
@@ -145,11 +141,7 @@ export const CreateKeyDialog = ({
                     .replace(/=/g, '')
                 : stringToBase64URL(privateKey),
             }
-          : Object.fromEntries(
-              Object.entries(JSON.parse(privateKey)).filter(([prop]) =>
-                ALLOWED_JWK_PROPERTIES.has(prop)
-              )
-            )
+          : JSON.parse(privateKey)
         : null,
     })
   }

--- a/apps/studio/next-env.d.ts
+++ b/apps/studio/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -50,7 +50,7 @@ const SelectTrigger = React.forwardRef<
       'flex w-full items-center justify-between rounded-md border border-strong hover:border-stronger bg-alternative dark:bg-muted hover:bg-selection text-xs ring-offset-background-control data-[placeholder]:text-foreground-lighter focus:outline-none ring-border-control focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-all duration-200',
       'data-[state=open]:bg-selection data-[state=open]:border-stronger',
       'gap-2',
-      '[&>span]:truncate [&>span]:w-[20ch] text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
+      '[&>span]:truncate text-left', // [kemal] This is to prevent double lines rendering when a string is particularly long.
       SelectTriggerVariants({ size }),
       className
     )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Currently unsupported signing key properties like `kid` are filtered out, giving users the wrong impression that their import was complete.

It would be clearer to let api report errors on invalid keys instead.

## Additional context

Add any other context or screenshots.
