### PR TITLE
fix(ui): hljs syntax highlighting bumped up on light mode

### DIFF
--- a/packages/ui/src/components/CodeBlock/CodeBlock.utils.ts
+++ b/packages/ui/src/components/CodeBlock/CodeBlock.utils.ts
@@ -3,7 +3,7 @@ export const monokaiCustomTheme = (isDarkMode: boolean) => {
     hljs: {
       display: 'block',
       overflowX: 'auto',
-      color: isDarkMode ? '#ddd' : '#888',
+      color: isDarkMode ? '#ddd' : '#444',
     },
     'hljs-tag': {
       color: '#569cd6',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

When using our `<Code />` component to render `pgsql` and `sql` in light mode as they appeared quite washed. This may need some testing in other areas it may affect. 

| Before | After |
|--------|--------|
| <img width="504" height="258" alt="Screenshot 2025-09-12 at 11 20 23" src="https://github.com/user-attachments/assets/a42cbef7-539f-48be-8d0c-5a6a9247a0c9" /> | <img width="505" height="218" alt="Screenshot 2025-09-12 at 11 20 10" src="https://github.com/user-attachments/assets/1e6303f3-ae2c-47f1-b648-e0b8764743ab" /> | 

