### PR TITLE
fix(replication): Use correct url for tables

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -324,7 +324,7 @@ export const ReplicationPipelineStatus = () => {
                                 <a
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  href={`/project/${projectRef}/editor/${table.table_id}`}
+                                  href={`dashboard/project/${projectRef}/editor/${table.table_id}`}
                                 />
                               </ButtonTooltip>
                             </div>

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus.tsx
@@ -321,10 +321,10 @@ export const ReplicationPipelineStatus = () => {
                                   content: { side: 'bottom', text: 'Open in Table Editor' },
                                 }}
                               >
-                                <a
+                                <Link
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  href={`dashboard/project/${projectRef}/editor/${table.table_id}`}
+                                  href={`/project/${projectRef}/editor/${table.table_id}`}
                                 />
                               </ButtonTooltip>
                             </div>


### PR DESCRIPTION
This PR fixes the link to point to the right URL for the table editor.