### PR TITLE
fix: marketing company stats

### DIFF
--- a/apps/www/components/Enterprise/Performance.tsx
+++ b/apps/www/components/Enterprise/Performance.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import { cn, Badge } from 'ui'
 
 import SectionContainer from '~/components/Layouts/SectionContainer'
+import { companyStats } from '~/data/company-stats'
 
 interface Props {
   id: string
@@ -77,11 +78,13 @@ const GraphLabel: FC<{ className?: string }> = ({ className }) => (
     )}
   >
     <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
-      <span className="label !text-[10px] !leading-3">Users</span>
+      <span className="label !text-[10px] !leading-3">Developers</span>
       <div className="flex items-center gap-2">
-        <span className="text-foreground-light text-2xl">930,550</span>
+        <span className="text-foreground-light text-2xl">
+          {companyStats.developersRegistered.text}
+        </span>
         <Badge variant="success" size="small" className="h-[24px] px-2">
-          +13.4%
+          {companyStats.developersRegisteredChange.text}
         </Badge>
       </div>
     </div>

--- a/apps/www/components/Enterprise/Performance.tsx
+++ b/apps/www/components/Enterprise/Performance.tsx
@@ -1,8 +1,7 @@
 import React, { FC } from 'react'
-import { cn, Badge } from 'ui'
 
 import SectionContainer from '~/components/Layouts/SectionContainer'
-import { companyStats } from '~/data/company-stats'
+import UsersGrowthChart from '~/components/UsersGrowthChart'
 
 interface Props {
   id: string
@@ -31,72 +30,10 @@ const Performance: FC<Props> = (props) => {
           ))}
         </div>
       </div>
-      <div className="relative xl:absolute z-0 inset-0 mt-4 -mb-8 sm:mt-0 sm:-mb-20 md:-mt-20 md:-mb-36 xl:mt-0 xl:top-10 w-full aspect-[2.15/1]">
-        <GraphLabel className="" />
-        <svg
-          width="100%"
-          height="100%"
-          viewBox="0 0 1403 599"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="absolute inset-0 w-full h-full"
-        >
-          <path
-            d="M1402.27 0.744141C896.689 410.854 286.329 492.876 0.476562 492.876V598.744H1402.27V0.744141Z"
-            fill="url(#paint0_linear_585_9420)"
-          />
-          <path
-            d="M11.4209 492.744C295.041 492.744 900.636 410.744 1402.27 0.744141"
-            stroke="hsl(var(--foreground-lighter))"
-          />
-          <defs>
-            <linearGradient
-              id="paint0_linear_585_9420"
-              x1="701.374"
-              y1="170.846"
-              x2="701.374"
-              y2="561.839"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stopColor="hsl(var(--border-overlay))" />
-              <stop offset="1" stopColor="hsl(var(--border-overlay))" stopOpacity="0" />
-            </linearGradient>
-          </defs>
-        </svg>
-        <div className="absolute inset-0 w-full h-full bg-[radial-gradient(50%_50%_at_50%_50%,_transparent_0%,_hsl(var(--background-default))_100%)]" />
-      </div>
+      <UsersGrowthChart />
     </SectionContainer>
   )
 }
-
-const GraphLabel: FC<{ className?: string }> = ({ className }) => (
-  <div
-    className={cn(
-      'absolute z-10 inset-0 left-auto right-[20%] -top-8 md:top-0 xl:top-[15%] w-fit h-[200px] lg:h-[400px]',
-      'flex flex-col items-center gap-1',
-      className
-    )}
-  >
-    <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
-      <span className="label !text-[10px] !leading-3">Developers</span>
-      <div className="flex items-center gap-2">
-        <span className="text-foreground-light text-2xl">
-          {companyStats.developersRegistered.text}
-        </span>
-        <Badge variant="success" size="small" className="h-[24px] px-2">
-          {companyStats.developersRegisteredChange.text}
-        </Badge>
-      </div>
-    </div>
-    <div
-      className={cn(
-        'relative w-2 h-2 min-w-2 min-h-2 rounded-full border-2 border-stronger',
-        'after:absolute after:inset-0 after:top-full after:mx-auto after:w-[2px] after:h-[150px] after:lg:h-[250px]',
-        'after:bg-gradient-to-b after:from-border-stronger after:to-transparent'
-      )}
-    />
-  </div>
-)
 
 interface HighlightItemProps {
   highlight: Highlight

--- a/apps/www/components/Solutions/ResultsSection.tsx
+++ b/apps/www/components/Solutions/ResultsSection.tsx
@@ -3,6 +3,7 @@ import { cn, Badge, AnimatedCounter } from 'ui'
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import { motion } from 'framer-motion'
 import { useMedia } from 'react-use'
+import { companyStats } from '~/data/company-stats'
 
 export interface ResultsSectionProps {
   id: string
@@ -102,17 +103,21 @@ const GraphLabel: FC<{ className?: string }> = ({ className }) => {
         <div className="flex items-center gap-2">
           <span className="text-foreground-light text-2xl">
             {isMobileOrTablet ? (
-              '5,230,550'
+              companyStats.developersRegistered.text
             ) : (
-              <AnimatedCounter value={5230550} duration={2.68} delay={0.5} />
+              <AnimatedCounter
+                value={companyStats.developersRegistered.number}
+                duration={2.68}
+                delay={0.5}
+              />
             )}
           </span>
           <Badge variant="success" size="small" className="h-[24px] px-2">
             {isMobileOrTablet ? (
-              '+28.3%'
+              companyStats.developersRegisteredChange.text
             ) : (
               <AnimatedCounter
-                value={28.3}
+                value={companyStats.developersRegisteredChange.number}
                 duration={2.68}
                 delay={0.5}
                 isPercentage={true}

--- a/apps/www/components/Solutions/ResultsSection.tsx
+++ b/apps/www/components/Solutions/ResultsSection.tsx
@@ -1,9 +1,7 @@
-import React, { FC, useMemo, useEffect, useState } from 'react'
-import { cn, Badge, AnimatedCounter } from 'ui'
+import React, { FC } from 'react'
+
 import SectionContainer from '~/components/Layouts/SectionContainer'
-import { motion } from 'framer-motion'
-import { useMedia } from 'react-use'
-import { companyStats } from '~/data/company-stats'
+import UsersGrowthChart from '~/components/UsersGrowthChart'
 
 export interface ResultsSectionProps {
   id: string
@@ -32,144 +30,10 @@ const ResultsSection: FC<ResultsSectionProps> = (props) => {
           ))}
         </div>
       </div>
-      <div className="relative xl:absolute z-0 inset-0 mt-4 -mb-8 sm:mt-0 sm:-mb-20 md:-mt-20 md:-mb-36 xl:mt-0 xl:top-10 w-full aspect-[2.15/1]">
-        <GraphLabel className="" />
-        <GraphPath className="absolute inset-0 w-full h-full" />
-
-        <svg
-          width="100%"
-          height="100%"
-          viewBox="0 0 1403 599"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="absolute inset-0 w-full h-full"
-        >
-          <path
-            d="M1402.27 0.744141C896.689 410.854 286.329 492.876 0.476562 492.876V598.744H1402.27V0.744141Z"
-            fill="url(#paint0_linear_585_9420)"
-          />
-          <path
-            d="M11.4209 492.744C295.041 492.744 900.636 410.744 1402.27 0.744141"
-            stroke="hsl(var(--foreground-lighter))"
-          />
-          <defs>
-            <linearGradient
-              id="paint0_linear_585_9420"
-              x1="701.374"
-              y1="170.846"
-              x2="701.374"
-              y2="561.839"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stopColor="hsl(var(--border-overlay))" />
-              <stop offset="1" stopColor="hsl(var(--border-overlay))" stopOpacity="0" />
-            </linearGradient>
-          </defs>
-        </svg>
-        <div className="absolute inset-0 w-full h-full bg-[radial-gradient(50%_50%_at_50%_50%,_transparent_0%,_hsl(var(--background-default))_100%)]" />
-      </div>
+      <UsersGrowthChart />
     </SectionContainer>
   )
 }
-
-const GraphLabel: FC<{ className?: string }> = ({ className }) => {
-  const isMobileOrTablet = useMedia('(max-width: 1280px)')
-  const [isClient, setIsClient] = useState(false)
-
-  useEffect(() => {
-    setIsClient(true)
-  }, [])
-
-  // Use client-side flag to prevent hydration mismatch
-  const shouldShowAnimated = useMemo(() => {
-    // Always show animated version until client-side hydration is complete
-    if (!isClient) return true
-    return !isMobileOrTablet
-  }, [isClient, isMobileOrTablet])
-
-  // Use the same server-safe logic for motion props
-  const motionProps = shouldShowAnimated
-    ? {
-        initial: { offsetDistance: '0%', rotate: '0deg', opacity: 0 },
-        whileInView: { offsetDistance: '80%', rotate: '30deg', opacity: 1 },
-        viewport: { once: true },
-        transition: { type: 'spring', duration: 2.68, bounce: 0, delay: 0.25 },
-        style: {
-          offsetPath: 'path("M0 493.132C285.852 493.132 896.213 411.11 1401.8 1")',
-        },
-      }
-    : undefined
-
-  // Use the same server-safe logic for component selection
-  const Component = shouldShowAnimated ? motion.div : 'div'
-
-  return (
-    <Component
-      className={cn(
-        'absolute z-10 -top-10 2xl:top-[20%] left-[38%] md:top-[10%] md:left-[50%] lg:top-0 xl:left-0 w-fit h-[200px] lg:h-[400px]',
-        'flex flex-col items-center gap-1',
-        className
-      )}
-      {...motionProps}
-    >
-      <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
-        <span className="label !text-[10px] !leading-3">Users</span>
-        <div className="flex items-center gap-2">
-          <span className="text-foreground-light text-2xl">
-            {shouldShowAnimated ? (
-              <AnimatedCounter
-                value={companyStats.developersRegistered.number}
-                duration={2.68}
-                delay={0.5}
-              />
-            ) : (
-              companyStats.developersRegistered.text
-            )}
-          </span>
-          <Badge variant="success" size="small" className="h-[24px] px-2">
-            {shouldShowAnimated ? (
-              <AnimatedCounter
-                value={companyStats.developersRegisteredChange.number}
-                duration={2.68}
-                delay={0.5}
-                isPercentage={true}
-                prefix="+"
-              />
-            ) : (
-              companyStats.developersRegisteredChange.text
-            )}
-          </Badge>
-        </div>
-      </div>
-      <div
-        className={cn(
-          'relative w-2 h-2 min-w-2 min-h-2 rounded-full border-2 border-stronger',
-          'after:absolute after:inset-0 after:top-full after:mx-auto after:w-[2px] after:h-[150px] after:lg:h-[250px]',
-          'after:bg-gradient-to-b after:from-border-stronger after:to-transparent'
-        )}
-      />
-    </Component>
-  )
-}
-
-const GraphPath: FC<{ className?: string }> = ({ className }) => (
-  <svg
-    width="100%"
-    height="100%"
-    viewBox="0 0 1403 494"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    className={className}
-  >
-    <motion.path
-      transition={{ duration: 0.5, delay: 0.5 }}
-      initial={{ pathLength: 0.001 }}
-      whileInView={{ pathLength: 1 }}
-      viewport={{ once: true }}
-      d="M0 493.132C285.852 493.132 896.213 411.11 1401.8 1"
-    />
-  </svg>
-)
 
 interface HighlightItemProps {
   highlight: Highlight

--- a/apps/www/components/Supasquad/PerfectTiming.tsx
+++ b/apps/www/components/Supasquad/PerfectTiming.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
-import { cn, Badge } from 'ui'
+
 import SectionContainer from '~/components/Layouts/SectionContainer'
-import { companyStats } from '~/data/company-stats'
+import UsersGrowthChart from '~/components/UsersGrowthChart'
 
 export interface PerfectTimingProps {
   id: string
@@ -30,72 +30,10 @@ const PerfectTiming = (props: PerfectTimingProps) => {
           ))}
         </div>
       </div>
-      <div className="relative xl:absolute z-0 inset-0 mt-4 -mb-8 sm:mt-0 sm:-mb-20 md:-mt-20 md:-mb-36 xl:mt-0 xl:top-10 w-full aspect-[2.15/1]">
-        <GraphLabel className="" />
-        <svg
-          width="100%"
-          height="100%"
-          viewBox="0 0 1403 599"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="absolute inset-0 w-full h-full"
-        >
-          <path
-            d="M1402.27 0.744141C896.689 410.854 286.329 492.876 0.476562 492.876V598.744H1402.27V0.744141Z"
-            fill="url(#paint0_linear_585_9420)"
-          />
-          <path
-            d="M11.4209 492.744C295.041 492.744 900.636 410.744 1402.27 0.744141"
-            stroke="hsl(var(--foreground-lighter))"
-          />
-          <defs>
-            <linearGradient
-              id="paint0_linear_585_9420"
-              x1="701.374"
-              y1="170.846"
-              x2="701.374"
-              y2="561.839"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stopColor="hsl(var(--border-overlay))" />
-              <stop offset="1" stopColor="hsl(var(--border-overlay))" stopOpacity="0" />
-            </linearGradient>
-          </defs>
-        </svg>
-        <div className="absolute inset-0 w-full h-full bg-[radial-gradient(50%_50%_at_50%_50%,_transparent_0%,_hsl(var(--background-default))_100%)]" />
-      </div>
+      <UsersGrowthChart />
     </SectionContainer>
   )
 }
-
-const GraphLabel: FC<{ className?: string }> = ({ className }) => (
-  <div
-    className={cn(
-      'absolute z-10 inset-0 left-auto right-[20%] -top-8 md:top-0 xl:top-[15%] w-fit h-[200px] lg:h-[400px]',
-      'flex flex-col items-center gap-1',
-      className
-    )}
-  >
-    <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
-      <span className="label !text-[10px] !leading-3">Developers</span>
-      <div className="flex items-center gap-2">
-        <span className="text-foreground-light text-2xl">
-          {companyStats.developersRegistered.text}
-        </span>
-        <Badge variant="success" size="small" className="h-[24px] px-2">
-          {companyStats.developersRegisteredChange.text}
-        </Badge>
-      </div>
-    </div>
-    <div
-      className={cn(
-        'relative w-2 h-2 min-w-2 min-h-2 rounded-full border-2 border-stronger',
-        'after:absolute after:inset-0 after:top-full after:mx-auto after:w-[2px] after:h-[150px] after:lg:h-[250px]',
-        'after:bg-gradient-to-b after:from-border-stronger after:to-transparent'
-      )}
-    />
-  </div>
-)
 
 interface HighlightItemProps {
   highlight: Highlight

--- a/apps/www/components/Supasquad/PerfectTiming.tsx
+++ b/apps/www/components/Supasquad/PerfectTiming.tsx
@@ -79,9 +79,11 @@ const GraphLabel: FC<{ className?: string }> = ({ className }) => (
     <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
       <span className="label !text-[10px] !leading-3">Developers</span>
       <div className="flex items-center gap-2">
-        <span className="text-foreground-light text-2xl">{companyStats.developersRegistered}</span>
+        <span className="text-foreground-light text-2xl">
+          {companyStats.developersRegistered.text}
+        </span>
         <Badge variant="success" size="small" className="h-[24px] px-2">
-          {companyStats.developersRegisteredChange}
+          {companyStats.developersRegisteredChange.text}
         </Badge>
       </div>
     </div>

--- a/apps/www/components/UsersGrowthChart.tsx
+++ b/apps/www/components/UsersGrowthChart.tsx
@@ -1,0 +1,148 @@
+import React, { FC, useMemo, useEffect, useState } from 'react'
+import { cn, Badge, AnimatedCounter } from 'ui'
+import { motion } from 'framer-motion'
+import { useMedia } from 'react-use'
+
+import { companyStats } from '~/data/company-stats'
+
+const UsersGrowthChart: FC = () => {
+  return (
+    <div className="relative xl:absolute z-0 inset-0 mt-4 -mb-8 sm:mt-0 sm:-mb-20 md:-mt-20 md:-mb-36 xl:mt-0 xl:top-10 w-full aspect-[2.15/1]">
+      <GraphLabel className="" />
+      <GraphPath className="absolute inset-0 w-full h-full" />
+
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 1403 599"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="absolute inset-0 w-full h-full"
+      >
+        <path
+          d="M1402.27 0.744141C896.689 410.854 286.329 492.876 0.476562 492.876V598.744H1402.27V0.744141Z"
+          fill="url(#paint0_linear_585_9420)"
+        />
+        <path
+          d="M11.4209 492.744C295.041 492.744 900.636 410.744 1402.27 0.744141"
+          stroke="hsl(var(--foreground-lighter))"
+        />
+        <defs>
+          <linearGradient
+            id="paint0_linear_585_9420"
+            x1="701.374"
+            y1="170.846"
+            x2="701.374"
+            y2="561.839"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stopColor="hsl(var(--border-overlay))" />
+            <stop offset="1" stopColor="hsl(var(--border-overlay))" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+      </svg>
+      <div className="absolute inset-0 w-full h-full bg-[radial-gradient(50%_50%_at_50%_50%,_transparent_0%,_hsl(var(--background-default))_100%)]" />
+    </div>
+  )
+}
+
+const GraphLabel: FC<{ className?: string }> = ({ className }) => {
+  const isMobileOrTablet = useMedia('(max-width: 1280px)')
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  // Use client-side flag to prevent hydration mismatch
+  const shouldShowAnimated = useMemo(() => {
+    // Always show animated version until client-side hydration is complete
+    if (!isClient) return true
+    return !isMobileOrTablet
+  }, [isClient, isMobileOrTablet])
+
+  // Use the same server-safe logic for motion props
+  const motionProps = shouldShowAnimated
+    ? {
+        initial: { offsetDistance: '0%', rotate: '0deg', opacity: 0 },
+        whileInView: { offsetDistance: '80%', rotate: '30deg', opacity: 1 },
+        viewport: { once: true },
+        transition: { type: 'spring', duration: 2.68, bounce: 0, delay: 0.25 },
+        style: {
+          offsetPath: 'path("M0 493.132C285.852 493.132 896.213 411.11 1401.8 1")',
+        },
+      }
+    : undefined
+
+  // Use the same server-safe logic for component selection
+  const Component = shouldShowAnimated ? motion.div : 'div'
+
+  return (
+    <Component
+      className={cn(
+        'absolute z-10 -top-10 2xl:top-[20%] left-[38%] md:top-[10%] md:left-[50%] lg:top-0 xl:left-0 w-fit h-[200px] lg:h-[400px]',
+        'flex flex-col items-center gap-1',
+        className
+      )}
+      {...motionProps}
+    >
+      <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
+        <span className="label !text-[10px] !leading-3">Users</span>
+        <div className="flex items-center gap-2">
+          <span className="text-foreground-light text-2xl">
+            {shouldShowAnimated ? (
+              <AnimatedCounter
+                value={companyStats.developersRegistered.number}
+                duration={2.68}
+                delay={0.5}
+              />
+            ) : (
+              companyStats.developersRegistered.text
+            )}
+          </span>
+          <Badge variant="success" size="small" className="h-[24px] px-2">
+            {shouldShowAnimated ? (
+              <AnimatedCounter
+                value={companyStats.developersRegisteredChange.number}
+                duration={2.68}
+                delay={0.5}
+                isPercentage={true}
+                prefix="+"
+              />
+            ) : (
+              companyStats.developersRegisteredChange.text
+            )}
+          </Badge>
+        </div>
+      </div>
+      <div
+        className={cn(
+          'relative w-2 h-2 min-w-2 min-h-2 rounded-full border-2 border-stronger',
+          'after:absolute after:inset-0 after:top-full after:mx-auto after:w-[2px] after:h-[150px] after:lg:h-[250px]',
+          'after:bg-gradient-to-b after:from-border-stronger after:to-transparent'
+        )}
+      />
+    </Component>
+  )
+}
+
+const GraphPath: FC<{ className?: string }> = ({ className }) => (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 1403 494"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <motion.path
+      transition={{ duration: 0.5, delay: 0.5 }}
+      initial={{ pathLength: 0.001 }}
+      whileInView={{ pathLength: 1 }}
+      viewport={{ once: true }}
+      d="M0 493.132C285.852 493.132 896.213 411.11 1401.8 1"
+    />
+  </svg>
+)
+
+export default UsersGrowthChart

--- a/apps/www/components/UsersGrowthChart.tsx
+++ b/apps/www/components/UsersGrowthChart.tsx
@@ -87,7 +87,9 @@ const GraphLabel: FC<{ className?: string }> = ({ className }) => {
       {...motionProps}
     >
       <div className="w-fit text-foreground bg-alternative p-4 rounded-lg border flex flex-col gap-1">
-        <span className="label !text-[10px] !leading-3">Users</span>
+        <span className="label !text-[10px] !leading-3">
+          {companyStats.developersRegistered.label}
+        </span>
         <div className="flex items-center gap-2">
           <span className="text-foreground-light text-2xl">
             {shouldShowAnimated ? (

--- a/apps/www/components/UsersGrowthChart.tsx
+++ b/apps/www/components/UsersGrowthChart.tsx
@@ -65,7 +65,7 @@ const GraphLabel: FC<{ className?: string }> = ({ className }) => {
   const motionProps = shouldShowAnimated
     ? {
         initial: { offsetDistance: '0%', rotate: '0deg', opacity: 0 },
-        whileInView: { offsetDistance: '80%', rotate: '30deg', opacity: 1 },
+        whileInView: { offsetDistance: '62%', rotate: '23.4deg', opacity: 1 },
         viewport: { once: true },
         transition: { type: 'spring', duration: 2.68, bounce: 0, delay: 0.25 },
         style: {

--- a/apps/www/data/company-stats.ts
+++ b/apps/www/data/company-stats.ts
@@ -1,6 +1,18 @@
 export const companyStats = {
-  databasesManaged: '6,500,000+',
-  databasesLaunchedDaily: '35,000+',
-  developersRegistered: '2,500,000+',
-  developersRegisteredChange: '+13.4%',
+  databasesManaged: {
+    number: 6_500_000,
+    text: '6,500,000+',
+  },
+  databasesLaunchedDaily: {
+    number: 35_000,
+    text: '35,000+',
+  },
+  developersRegistered: {
+    number: 2_500_000,
+    text: '2,500,000+',
+  },
+  developersRegisteredChange: {
+    number: 13.4,
+    text: '+13.4%',
+  },
 }

--- a/apps/www/data/company-stats.ts
+++ b/apps/www/data/company-stats.ts
@@ -1,3 +1,6 @@
+// For each stat we provide text and number
+// Text is used for labels and static components
+// Number is used for animated components (eg. AnimatedCounter)
 export const companyStats = {
   databasesManaged: {
     number: 6_500_000,

--- a/apps/www/data/company-stats.ts
+++ b/apps/www/data/company-stats.ts
@@ -5,17 +5,21 @@ export const companyStats = {
   databasesManaged: {
     number: 6_500_000,
     text: '6,500,000+',
+    label: 'Databases managed',
   },
   databasesLaunchedDaily: {
     number: 35_000,
     text: '35,000+',
+    label: 'Databases launched daily',
   },
   developersRegistered: {
     number: 2_500_000,
     text: '2,500,000+',
+    label: 'Users',
   },
   developersRegisteredChange: {
     number: 13.4,
     text: '+13.4%',
+    label: 'Users growth',
   },
 }

--- a/apps/www/data/enterprise.tsx
+++ b/apps/www/data/enterprise.tsx
@@ -139,11 +139,11 @@ export default {
       "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations—whether you're handling high-traffic applications, complex queries, or massive data volumes.",
     highlights: [
       {
-        heading: 'Databases managed',
+        heading: companyStats.databasesManaged.label,
         subheading: companyStats.databasesManaged.text,
       },
       {
-        heading: 'Databases launched daily',
+        heading: companyStats.databasesLaunchedDaily.label,
         subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],

--- a/apps/www/data/enterprise.tsx
+++ b/apps/www/data/enterprise.tsx
@@ -140,11 +140,11 @@ export default {
     highlights: [
       {
         heading: 'Databases managed',
-        subheading: companyStats.databasesManaged,
+        subheading: companyStats.databasesManaged.text,
       },
       {
         heading: 'Databases launched daily',
-        subheading: companyStats.databasesLaunchedDaily,
+        subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],
   },

--- a/apps/www/data/ga.tsx
+++ b/apps/www/data/ga.tsx
@@ -20,11 +20,11 @@ export const data = (isDark: boolean) => ({
   highlightsSection: {
     highlights: [
       {
-        number: companyStats.databasesManaged,
+        number: companyStats.databasesManaged.text,
         text: 'databases managed',
       },
       {
-        number: companyStats.databasesLaunchedDaily,
+        number: companyStats.databasesLaunchedDaily.text,
         text: 'databases launched daily',
       },
       {

--- a/apps/www/data/open-source/contributing/supasquad.tsx
+++ b/apps/www/data/open-source/contributing/supasquad.tsx
@@ -138,11 +138,11 @@ export const data = {
       "Supabase's explosive growth means more builders need help. There are more opportunities to contribute, and more ways to make your mark. Join SupaSquad and help us support this thriving ecosystem of builders.",
     highlights: [
       {
-        heading: 'databases managed',
+        heading: companyStats.databasesManaged.label,
         subheading: companyStats.databasesManaged.text,
       },
       {
-        heading: 'databases launched daily',
+        heading: companyStats.databasesLaunchedDaily.label,
         subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],

--- a/apps/www/data/open-source/contributing/supasquad.tsx
+++ b/apps/www/data/open-source/contributing/supasquad.tsx
@@ -139,11 +139,11 @@ export const data = {
     highlights: [
       {
         heading: 'databases managed',
-        subheading: companyStats.databasesManaged,
+        subheading: companyStats.databasesManaged.text,
       },
       {
         heading: 'databases launched daily',
-        subheading: companyStats.databasesLaunchedDaily,
+        subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],
   },

--- a/apps/www/data/solutions/developers.tsx
+++ b/apps/www/data/solutions/developers.tsx
@@ -595,11 +595,11 @@ const data: () => {
         "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations — whether you're handling high-traffic applications, complex queries, or massive data volumes.",
       highlights: [
         {
-          heading: 'databases managed',
+          heading: companyStats.databasesManaged.label,
           subheading: companyStats.databasesManaged.text,
         },
         {
-          heading: 'databases launched daily',
+          heading: companyStats.databasesLaunchedDaily.label,
           subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],

--- a/apps/www/data/solutions/developers.tsx
+++ b/apps/www/data/solutions/developers.tsx
@@ -596,11 +596,11 @@ const data: () => {
       highlights: [
         {
           heading: 'databases managed',
-          subheading: companyStats.databasesManaged,
+          subheading: companyStats.databasesManaged.text,
         },
         {
           heading: 'databases launched daily',
-          subheading: companyStats.databasesLaunchedDaily,
+          subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],
     },

--- a/apps/www/data/solutions/firebase.tsx
+++ b/apps/www/data/solutions/firebase.tsx
@@ -548,11 +548,11 @@ const data = {
       "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations — whether you're handling high-traffic applications, complex queries, or massive data volumes.",
     highlights: [
       {
-        heading: 'databases managed',
+        heading: companyStats.databasesManaged.label,
         subheading: companyStats.databasesManaged.text,
       },
       {
-        heading: 'databases launched daily',
+        heading: companyStats.databasesLaunchedDaily.label,
         subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],

--- a/apps/www/data/solutions/firebase.tsx
+++ b/apps/www/data/solutions/firebase.tsx
@@ -549,11 +549,11 @@ const data = {
     highlights: [
       {
         heading: 'databases managed',
-        subheading: companyStats.databasesManaged,
+        subheading: companyStats.databasesManaged.text,
       },
       {
         heading: 'databases launched daily',
-        subheading: companyStats.databasesLaunchedDaily,
+        subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],
   },

--- a/apps/www/data/solutions/innovation-teams.tsx
+++ b/apps/www/data/solutions/innovation-teams.tsx
@@ -597,11 +597,11 @@ const data: () => {
       highlights: [
         {
           heading: 'databases managed',
-          subheading: companyStats.databasesManaged,
+          subheading: companyStats.databasesManaged.text,
         },
         {
           heading: 'databases launched daily',
-          subheading: companyStats.databasesLaunchedDaily,
+          subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],
     },

--- a/apps/www/data/solutions/innovation-teams.tsx
+++ b/apps/www/data/solutions/innovation-teams.tsx
@@ -596,11 +596,11 @@ const data: () => {
         "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations — whether you're handling high-traffic applications, complex queries, or massive data volumes.",
       highlights: [
         {
-          heading: 'databases managed',
+          heading: companyStats.databasesManaged.label,
           subheading: companyStats.databasesManaged.text,
         },
         {
-          heading: 'databases launched daily',
+          heading: companyStats.databasesLaunchedDaily.label,
           subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],

--- a/apps/www/data/solutions/neon.tsx
+++ b/apps/www/data/solutions/neon.tsx
@@ -541,11 +541,11 @@ const data = {
     highlights: [
       {
         heading: 'databases managed',
-        subheading: companyStats.databasesManaged,
+        subheading: companyStats.databasesManaged.text,
       },
       {
         heading: 'databases launched daily',
-        subheading: companyStats.databasesLaunchedDaily,
+        subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],
   },

--- a/apps/www/data/solutions/neon.tsx
+++ b/apps/www/data/solutions/neon.tsx
@@ -540,11 +540,11 @@ const data = {
       "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations — whether you're handling high-traffic applications, complex queries, or massive data volumes.",
     highlights: [
       {
-        heading: 'databases managed',
+        heading: companyStats.databasesManaged.label,
         subheading: companyStats.databasesManaged.text,
       },
       {
-        heading: 'databases launched daily',
+        heading: companyStats.databasesLaunchedDaily.label,
         subheading: companyStats.databasesLaunchedDaily.text,
       },
     ],

--- a/apps/www/data/solutions/postgres-developers.tsx
+++ b/apps/www/data/solutions/postgres-developers.tsx
@@ -695,11 +695,11 @@ const data: () => {
         "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations — whether you're handling high-traffic applications, complex queries, or massive data volumes.",
       highlights: [
         {
-          heading: 'databases managed',
+          heading: companyStats.databasesManaged.label,
           subheading: companyStats.databasesManaged.text,
         },
         {
-          heading: 'databases launched daily',
+          heading: companyStats.databasesLaunchedDaily.label,
           subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],

--- a/apps/www/data/solutions/postgres-developers.tsx
+++ b/apps/www/data/solutions/postgres-developers.tsx
@@ -696,11 +696,11 @@ const data: () => {
       highlights: [
         {
           heading: 'databases managed',
-          subheading: companyStats.databasesManaged,
+          subheading: companyStats.databasesManaged.text,
         },
         {
           heading: 'databases launched daily',
-          subheading: companyStats.databasesLaunchedDaily,
+          subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],
     },

--- a/apps/www/data/solutions/startups.tsx
+++ b/apps/www/data/solutions/startups.tsx
@@ -585,11 +585,11 @@ const data: () => {
       highlights: [
         {
           heading: 'databases managed',
-          subheading: companyStats.databasesManaged,
+          subheading: companyStats.databasesManaged.text,
         },
         {
           heading: 'databases launched daily',
-          subheading: companyStats.databasesLaunchedDaily,
+          subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],
     },

--- a/apps/www/data/solutions/startups.tsx
+++ b/apps/www/data/solutions/startups.tsx
@@ -584,11 +584,11 @@ const data: () => {
         "Supabase ensures optimal database performance at any scale, so you can focus on innovating and growing without worrying about infrastructure limitations — whether you're handling high-traffic applications, complex queries, or massive data volumes.",
       highlights: [
         {
-          heading: 'databases managed',
+          heading: companyStats.databasesManaged.label,
           subheading: companyStats.databasesManaged.text,
         },
         {
-          heading: 'databases launched daily',
+          heading: companyStats.databasesLaunchedDaily.label,
           subheading: companyStats.databasesLaunchedDaily.text,
         },
       ],

--- a/packages/ui/src/components/AnimatedCounter/AnimatedCounter.tsx
+++ b/packages/ui/src/components/AnimatedCounter/AnimatedCounter.tsx
@@ -61,7 +61,7 @@ export interface AnimatedCounterProps {
  * <AnimatedCounter
  *   value={13.4}
  *   isPercentage
- *   showPlus
+ *   prefix="+"
  *   duration={3}
  *   delay={0.5}
  * />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Unify users growth chart in 1 component (using the new animated counter).
- Update company stats with last official data.
- Set stats labels on the company stats const (and update components that use labels).
- Fix the animated Users stat position to match the non-animated version.
- Fix strange hydration error.

## What is the current behavior?

Currently the chart is replicated in different marketing pages, and each has different values for the Users metric:
- Several solutions pages like [Enterprise](https://supabase.com/solutions/enterprise) and [Switch from Firebase](https://supabase.com/solutions/switch-from-firebase)
- [SupaSquad page](https://supabase.com/open-source/contributing/supasquad)


## What is the new behavior?

The new `UsersGrowthChart.tsx` component is imported into each parent component used by this pages. And inside this new component we are importing the stats from `company-stats.ts`.

With this new change, whenever we need to update these metrics, we only update `company-stats.ts`.

## Additional context
Current migrate to Firebase page
<img width="2406" height="1404" alt="Screenshot 2025-09-13 at 00 04 27@2x" src="https://github.com/user-attachments/assets/8ac20514-db82-49a1-ab4c-6be489ad54e3" />

Updated version
<img width="2276" height="1312" alt="Screenshot 2025-09-13 at 00 06 33@2x" src="https://github.com/user-attachments/assets/7b629a17-fc9b-4bf5-b399-7f562c78da13" />


