### PR TITLE
docs: web3  and some other js reference improvements

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -699,7 +699,7 @@ export const auth: NavMenuConstant = {
           enabled: allAuthProvidersEnabled,
         },
         {
-          name: 'Web3 (Sign in with Solana)',
+          name: 'Web3 (Ethereum or Solana)',
           url: '/guides/auth/auth-web3',
           enabled: allAuthProvidersEnabled,
         },

--- a/apps/docs/content/guides/auth/auth-web3.mdx
+++ b/apps/docs/content/guides/auth/auth-web3.mdx
@@ -92,7 +92,7 @@ For example if the user is signing in to the page `https://example.com/sign-in` 
 
 ## Sign in with Ethereum
 
-Ethereum defines the [`wallet.ethereum` global scope object](https://eips.ethereum.org/EIPS/eip-1193) that your app uses to interact with your application. Additionally there is a [wallet discovery mechanism (EIP-6963)](https://eips.ethereum.org/EIPS/eip-6963) that your app can use to discover all of the available wallets on the user's browser.
+Ethereum defines the [`window.ethereum` global scope object](https://eips.ethereum.org/EIPS/eip-1193) that your app uses to interact with Ethereum Wallets. Additionally there is a [wallet discovery mechanism (EIP-6963)](https://eips.ethereum.org/EIPS/eip-6963) that your app can use to discover all of the available wallets on the user's browser.
 
 To sign in a user with their Ethereum wallet make sure that the user has installed a wallet application. There are two ways to do this:
 
@@ -104,7 +104,7 @@ To sign in a user with their Ethereum wallet make sure that the user has install
   size="small"
   type="underlined"
   defaultActiveId="window"
-  queryGroup="solanaWallet"
+  queryGroup="ethWallet"
 >
 
 <TabPanel id="window" label="Ethereum Window API (EIP-1193)">

--- a/apps/docs/content/guides/auth/auth-web3.mdx
+++ b/apps/docs/content/guides/auth/auth-web3.mdx
@@ -9,17 +9,43 @@ subtitle: 'Use your Web3 wallet to authenticate users with Supabase'
 Supported Web3 wallets:
 
 - All Solana wallets
-- Coming soon: All Ethereum wallets
+- All Ethereum wallets
 
 ## How does it work?
 
-Sign in with Web3 utilizes the [EIP 4361](https://eips.ethereum.org/EIPS/eip-4361) standard to authenticate wallet addresses off-chain. This standard is adopted by the Solana ecosystem with some minor differences from Ethereum.
+Sign in with Web3 utilizes the [EIP 4361](https://eips.ethereum.org/EIPS/eip-4361) standard to authenticate wallet addresses off-chain. This standard is widely supported by the Ethereum and Solana ecosystems, making it the best choice for verifying wallet ownership.
 
 Authentication works by asking the Web3 wallet application to sign a predefined message with the user's wallet. This message is parsed both by the Web3 wallet application and Supabase Auth to verify its validity and purpose, before creating a user account or session.
 
-The Web3 wallet application uses the information contained in the message to provide the user with a confirmation dialog, asking whether they want to allow sign in with your project.
+An example of such a message is:
 
-Not all Web3 wallet applications show a dedicated confirmation dialog for these sign in messages. In that case the Web3 wallet shows a traditional message signature confirmation dialog.
+```
+example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+I accept the ExampleOrg Terms of Service: https://example.com/tos
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z
+Resources:
+- https://example.com/my-web2-claim.json
+```
+
+It defines the wallet address, timestamp, browser location where the sign-in occurred and includes a customizable statement (`I accept...`) which you can use to ask consent from the user.
+
+Most Web3 wallets are able to recognize these messages and show a dedicated "Confirm Sign In" dialog validating and presenting the information in the message in a secure and responsible way to the user. Even if the wallet does not directly support these messages, it will use the message signature dialog instead.
+
+Finally the Supabase Auth server validates both the message's contents and signature before issuing a valid [User session](/docs/guides/auth/sessions) to your application. Validation rules include:
+
+- Message structure validation
+- Cryptographic signature verification
+- Timestamp validation, ensuring the signature was created within 10 minutes of the sign-in call
+- URI and Domain validation, ensuring these match your server's defined [Redirect URLs](/docs/guides/auth/redirect-urls)
+
+The wallet address is used as the identity identifier, and in the identity data you can also find the statement and additional metadata.
 
 ## Enable the Web3 provider
 
@@ -29,6 +55,9 @@ In the CLI add the following config to your `supabase/config.toml` file:
 
 ```toml
 [auth.web3.solana]
+enabled = true
+
+[auth.web3.ethereum]
 enabled = true
 ```
 
@@ -63,7 +92,65 @@ For example if the user is signing in to the page `https://example.com/sign-in` 
 
 ## Sign in with Ethereum
 
-Sign in with Ethereum wallets is coming soon.
+Ethereum defines the [`wallet.ethereum` global scope object](https://eips.ethereum.org/EIPS/eip-1193) that your app uses to interact with your application. Additionally there is a [wallet discovery mechanism (EIP-6963)](https://eips.ethereum.org/EIPS/eip-6963) that your app can use to discover all of the available wallets on the user's browser.
+
+To sign in a user with their Ethereum wallet make sure that the user has installed a wallet application. There are two ways to do this:
+
+1. Detect the `window.ethereum` global scope object and ensure it's defined. This only works if your user has only one wallet installed on their browser.
+2. Use the wallet discovery mechanism (EIP-6963) to ask the user to choose a wallet before they continue to sign in. Read [the MetaMask guide on the best way to support this](https://docs.metamask.io/wallet/tutorials/react-dapp-local-state).
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="window"
+  queryGroup="solanaWallet"
+>
+
+<TabPanel id="window" label="Ethereum Window API (EIP-1193)">
+
+Use the following code to sign in a user, implicitly relying on the `window.ethereum` global scope wallet API:
+
+```typescript
+const { data, error } = await supabase.auth.signInWithWeb3({
+  chain: 'ethereum',
+  statement: 'I accept the Terms of Service at https://example.com/tos',
+})
+```
+
+</TabPanel>
+
+<TabPanel id="wallet" label="Ethereum Wallet API (EIP-6963)">
+
+Once you've obtained a wallet using the wallet detection (EIP-6963) mechanism, you can pass the selected wallet to the Supabase JavaScript SDK to continue the sign-in process.
+
+```typescript
+const { data, error } = await supabase.auth.signInWithWeb3({
+  chain: 'ethereum',
+  statement: 'I accept the Terms of Service at https://example.com/tos',
+  wallet: selectedWallet, // obtain this using the EIP-6963 mechanism
+})
+```
+
+An excellent guide on using the [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) mechanism is available by [MetaMask](https://docs.metamask.io/wallet/tutorials/react-dapp-local-state).
+
+</TabPanel>
+
+<TabPanel id="custom" label="Ethereum Message and Signature">
+
+If your application relies on a custom Ethereum wallet API, you can pass a [Sign in with Ethereum (EIP-4361)](https://eips.ethereum.org/EIPS/eip-4361) message and signature to complete the sign in process.
+
+```typescript
+const { data, error } = await supabase.auth.signInWithWeb3({
+  chain: 'ethereum',
+  message: '<sign in with ethereum message>',
+  signature: '<hex of the ethereum signature over the message>',
+})
+```
+
+</TabPanel>
+
+</Tabs>
 
 ## Sign in with Solana
 

--- a/apps/docs/features/docs/__snapshots__/Reference.typeSpec.test.ts.snap
+++ b/apps/docs/features/docs/__snapshots__/Reference.typeSpec.test.ts.snap
@@ -16313,7 +16313,7 @@ exports[`TS type spec parsing > matches snapshot 1`] = `
                           },
                           "isOptional": true,
                           "comment": {
-                            "shortText": "Optional statement to include in the Sign in with Solana message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
+                            "shortText": "Optional statement to include in the Sign in with Ethereum message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
                           }
                         },
                         {
@@ -16324,7 +16324,7 @@ exports[`TS type spec parsing > matches snapshot 1`] = `
                           },
                           "isOptional": true,
                           "comment": {
-                            "shortText": "Wallet interface to use. If not specified will default to \`window.solana\`."
+                            "shortText": "Wallet interface to use. If not specified will default to `window.ethereum`."
                           }
                         }
                       ]
@@ -16376,7 +16376,7 @@ exports[`TS type spec parsing > matches snapshot 1`] = `
                             "name": "Hex"
                           },
                           "comment": {
-                            "shortText": "Ed25519 signature of the message."
+                            "shortText": "Ethereum curve (secp256k1) signature of the message."
                           }
                         }
                       ]

--- a/apps/docs/features/docs/__snapshots__/Reference.typeSpec.test.ts.snap
+++ b/apps/docs/features/docs/__snapshots__/Reference.typeSpec.test.ts.snap
@@ -16324,7 +16324,7 @@ exports[`TS type spec parsing > matches snapshot 1`] = `
                           },
                           "isOptional": true,
                           "comment": {
-                            "shortText": "Wallet interface to use. If not specified will default to `window.ethereum`."
+                            "shortText": "Wallet interface to use. If not specified will default to \`window.ethereum\`."
                           }
                         }
                       ]

--- a/apps/docs/spec/api_v1_openapi.json
+++ b/apps/docs/spec/api_v1_openapi.json
@@ -4846,7 +4846,8 @@
                   "type": "object",
                   "properties": { "id": { "type": "number" }, "username": { "type": "string" } },
                   "required": ["id", "username"]
-                }
+                },
+                "favorite": { "type": "boolean" }
               },
               "required": [
                 "id",
@@ -4858,7 +4859,8 @@
                 "description",
                 "project",
                 "owner",
-                "updated_by"
+                "updated_by",
+                "favorite"
               ]
             }
           },
@@ -4891,14 +4893,19 @@
             "properties": { "id": { "type": "number" }, "username": { "type": "string" } },
             "required": ["id", "username"]
           },
+          "favorite": { "type": "boolean" },
           "content": {
             "type": "object",
             "properties": {
-              "favorite": { "type": "boolean" },
+              "favorite": {
+                "type": "boolean",
+                "deprecated": true,
+                "description": "Deprecated: Rely on root-level favorite property instead."
+              },
               "schema_version": { "type": "string" },
               "sql": { "type": "string" }
             },
-            "required": ["favorite", "schema_version", "sql"]
+            "required": ["schema_version", "sql"]
           }
         },
         "required": [
@@ -4912,6 +4919,7 @@
           "project",
           "owner",
           "updated_by",
+          "favorite",
           "content"
         ]
       },

--- a/apps/docs/spec/common-client-libs-sections.json
+++ b/apps/docs/spec/common-client-libs-sections.json
@@ -450,7 +450,7 @@
       },
       {
         "id": "sign-in-with-id-token",
-        "title": "Sign in with ID Token",
+        "title": "Sign in with ID token (native sign-in)",
         "slug": "auth-signinwithidtoken",
         "product": "auth",
         "type": "function"
@@ -487,6 +487,13 @@
         "id": "sign-in-with-sso",
         "title": "Sign in a user through SSO",
         "slug": "auth-signinwithsso",
+        "product": "auth",
+        "type": "function"
+      },
+      {
+        "id": "sign-in-with-web3",
+        "title": "Sign in a user through Web3 (Solana, Ethereum)",
+        "slug": "auth-signinwithweb3",
         "product": "auth",
         "type": "function"
       },

--- a/apps/docs/spec/enrichments/tsdoc_v2/gotrue.json
+++ b/apps/docs/spec/enrichments/tsdoc_v2/gotrue.json
@@ -24,7 +24,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 33,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L33"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L33"
             }
           ],
           "signatures": [
@@ -125,7 +125,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -185,7 +185,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 31,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L31"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L31"
             }
           ],
           "type": {
@@ -214,7 +214,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 30,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L30"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L30"
         }
       ],
       "extendedTypes": [
@@ -243,7 +243,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 18,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L18"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L18"
             }
           ],
           "signatures": [
@@ -337,7 +337,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -392,7 +392,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 14,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L14"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L14"
             }
           ],
           "type": {
@@ -425,7 +425,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 4,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L4"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L4"
         }
       ],
       "extendedTypes": [
@@ -472,7 +472,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 90,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
             }
           ],
           "signatures": [
@@ -527,7 +527,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 90,
                                   "character": 57,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
                                 }
                               ],
                               "type": {
@@ -546,7 +546,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 90,
                                   "character": 42,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
                                 }
                               ],
                               "type": {
@@ -566,7 +566,7 @@
                               "fileName": "src/lib/errors.ts",
                               "line": 90,
                               "character": 40,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
                             }
                           ]
                         }
@@ -623,7 +623,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -675,7 +675,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 89,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
             }
           ],
           "type": {
@@ -705,7 +705,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 89,
                           "character": 28,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                         }
                       ],
                       "type": {
@@ -724,7 +724,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 89,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                         }
                       ],
                       "type": {
@@ -744,7 +744,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 89,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                     }
                   ]
                 }
@@ -764,7 +764,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -796,7 +796,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -820,7 +820,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 95,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L95"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L95"
             }
           ],
           "signatures": [
@@ -850,7 +850,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 100,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L100"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L100"
                         }
                       ],
                       "type": {
@@ -880,7 +880,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 89,
                                       "character": 28,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                                     }
                                   ],
                                   "type": {
@@ -899,7 +899,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 89,
                                       "character": 13,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                                     }
                                   ],
                                   "type": {
@@ -919,7 +919,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 89,
                                   "character": 11,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                                 }
                               ]
                             }
@@ -939,7 +939,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 98,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L98"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L98"
                         }
                       ],
                       "type": {
@@ -959,7 +959,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 97,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L97"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L97"
                         }
                       ],
                       "type": {
@@ -979,7 +979,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 99,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L99"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L99"
                         }
                       ],
                       "type": {
@@ -1000,7 +1000,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 96,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L96"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L96"
                     }
                   ]
                 }
@@ -1028,7 +1028,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 88,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L88"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L88"
         }
       ],
       "extendedTypes": [
@@ -1057,7 +1057,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 83,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L83"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L83"
             }
           ],
           "signatures": [
@@ -1127,7 +1127,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1179,7 +1179,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -1211,7 +1211,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -1240,7 +1240,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 82,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L82"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L82"
         }
       ],
       "extendedTypes": [
@@ -1269,7 +1269,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 162,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L162"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L162"
             }
           ],
           "signatures": [
@@ -1339,7 +1339,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1391,7 +1391,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -1423,7 +1423,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -1452,7 +1452,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 161,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L161"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L161"
         }
       ],
       "extendedTypes": [
@@ -1481,7 +1481,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 77,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L77"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L77"
             }
           ],
           "signatures": [
@@ -1538,7 +1538,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1590,7 +1590,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -1622,7 +1622,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -1651,7 +1651,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 76,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L76"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L76"
         }
       ],
       "extendedTypes": [
@@ -1680,7 +1680,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 114,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
             }
           ],
           "signatures": [
@@ -1735,7 +1735,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 114,
                                   "character": 57,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
                                 }
                               ],
                               "type": {
@@ -1754,7 +1754,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 114,
                                   "character": 42,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
                                 }
                               ],
                               "type": {
@@ -1774,7 +1774,7 @@
                               "fileName": "src/lib/errors.ts",
                               "line": 114,
                               "character": 40,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
                             }
                           ]
                         }
@@ -1831,7 +1831,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1883,7 +1883,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 112,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
             }
           ],
           "type": {
@@ -1913,7 +1913,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 112,
                           "character": 28,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                         }
                       ],
                       "type": {
@@ -1932,7 +1932,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 112,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                         }
                       ],
                       "type": {
@@ -1952,7 +1952,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 112,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                     }
                   ]
                 }
@@ -1972,7 +1972,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -2004,7 +2004,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -2028,7 +2028,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 119,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L119"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L119"
             }
           ],
           "signatures": [
@@ -2058,7 +2058,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 124,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L124"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L124"
                         }
                       ],
                       "type": {
@@ -2088,7 +2088,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 112,
                                       "character": 28,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                                     }
                                   ],
                                   "type": {
@@ -2107,7 +2107,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 112,
                                       "character": 13,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                                     }
                                   ],
                                   "type": {
@@ -2127,7 +2127,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 112,
                                   "character": 11,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                                 }
                               ]
                             }
@@ -2147,7 +2147,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 122,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L122"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L122"
                         }
                       ],
                       "type": {
@@ -2167,7 +2167,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 121,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L121"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L121"
                         }
                       ],
                       "type": {
@@ -2187,7 +2187,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 123,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L123"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L123"
                         }
                       ],
                       "type": {
@@ -2208,7 +2208,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 120,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L120"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L120"
                     }
                   ]
                 }
@@ -2236,7 +2236,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 111,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L111"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L111"
         }
       ],
       "extendedTypes": [
@@ -2265,7 +2265,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 130,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L130"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L130"
             }
           ],
           "signatures": [
@@ -2346,7 +2346,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -2398,7 +2398,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -2430,7 +2430,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -2459,7 +2459,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 129,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L129"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L129"
         }
       ],
       "extendedTypes": [
@@ -2488,7 +2488,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 67,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L67"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L67"
             }
           ],
           "signatures": [
@@ -2545,7 +2545,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -2597,7 +2597,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -2629,7 +2629,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -2658,7 +2658,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 66,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L66"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L66"
         }
       ],
       "extendedTypes": [
@@ -2687,7 +2687,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 48,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L48"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L48"
             }
           ],
           "signatures": [
@@ -2768,7 +2768,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -2820,7 +2820,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 46,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L46"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L46"
             }
           ],
           "type": {
@@ -2847,7 +2847,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 14,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L14"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L14"
             }
           ],
           "type": {
@@ -2885,7 +2885,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 45,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L45"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L45"
         }
       ],
       "extendedTypes": [
@@ -2922,7 +2922,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 150,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L150"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L150"
             }
           ],
           "signatures": [
@@ -3017,7 +3017,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -3069,7 +3069,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -3101,7 +3101,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 148,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L148"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L148"
             }
           ],
           "type": {
@@ -3132,7 +3132,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -3161,7 +3161,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 144,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L144"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L144"
         }
       ],
       "extendedTypes": [
@@ -3190,7 +3190,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 59,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L59"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L59"
             }
           ],
           "signatures": [
@@ -3302,7 +3302,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -3354,7 +3354,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -3385,7 +3385,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -3414,7 +3414,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 55,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L55"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L55"
         }
       ],
       "extendedTypes": [
@@ -3485,7 +3485,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 37,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L37"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L37"
             }
           ],
           "signatures": [
@@ -3524,7 +3524,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 46,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L46"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L46"
                             }
                           ],
                           "type": {
@@ -3622,7 +3622,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 43,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L43"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L43"
                             }
                           ],
                           "type": {
@@ -3638,7 +3638,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 43,
                                   "character": 14,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L43"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L43"
                                 }
                               ],
                               "indexSignature": {
@@ -3678,7 +3678,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 42,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L42"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L42"
                             }
                           ],
                           "type": {
@@ -3698,7 +3698,7 @@
                           "fileName": "src/GoTrueAdminApi.ts",
                           "line": 41,
                           "character": 5,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L41"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L41"
                         }
                       ]
                     }
@@ -3732,7 +3732,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 29,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L29"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L29"
             }
           ],
           "type": {
@@ -3752,7 +3752,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 160,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L160"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L160"
             }
           ],
           "signatures": [
@@ -3819,7 +3819,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 280,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L280"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L280"
             }
           ],
           "signatures": [
@@ -3921,7 +3921,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 126,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L126"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L126"
             }
           ],
           "signatures": [
@@ -3980,7 +3980,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 229,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L229"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L229"
             }
           ],
           "signatures": [
@@ -4054,7 +4054,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 93,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L93"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L93"
             }
           ],
           "signatures": [
@@ -4144,7 +4144,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 97,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L97"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L97"
                             }
                           ],
                           "type": {
@@ -4173,7 +4173,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 100,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L100"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L100"
                             }
                           ],
                           "type": {
@@ -4193,7 +4193,7 @@
                           "fileName": "src/GoTrueAdminApi.ts",
                           "line": 95,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L95"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L95"
                         }
                       ]
                     }
@@ -4228,7 +4228,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 182,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L182"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L182"
             }
           ],
           "signatures": [
@@ -4320,7 +4320,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 185,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                 }
                               ],
                               "type": {
@@ -4346,7 +4346,7 @@
                                               "fileName": "src/GoTrueAdminApi.ts",
                                               "line": 185,
                                               "character": 31,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                             }
                                           ],
                                           "type": {
@@ -4365,7 +4365,7 @@
                                               "fileName": "src/GoTrueAdminApi.ts",
                                               "line": 185,
                                               "character": 16,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                             }
                                           ],
                                           "type": {
@@ -4389,7 +4389,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 185,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                         }
                                       ]
                                     }
@@ -4413,7 +4413,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 185,
                                   "character": 59,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                 }
                               ],
                               "type": {
@@ -4433,7 +4433,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 185,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                             }
                           ]
                         }
@@ -4458,7 +4458,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 186,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                 }
                               ],
                               "type": {
@@ -4481,7 +4481,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 186,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                         }
                                       ],
                                       "type": {
@@ -4500,7 +4500,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 186,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                     }
                                   ]
                                 }
@@ -4517,7 +4517,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 186,
                                   "character": 29,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                 }
                               ],
                               "type": {
@@ -4538,7 +4538,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 186,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                             }
                           ]
                         }
@@ -4564,7 +4564,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 62,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L62"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L62"
             }
           ],
           "signatures": [
@@ -4659,7 +4659,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 65,
                               "character": 15,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                             }
                           ],
                           "type": {
@@ -4678,7 +4678,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 65,
                               "character": 27,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                             }
                           ],
                           "type": {
@@ -4708,7 +4708,7 @@
                           "fileName": "src/GoTrueAdminApi.ts",
                           "line": 65,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                         }
                       ]
                     }
@@ -4732,7 +4732,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 253,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L253"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L253"
             }
           ],
           "signatures": [
@@ -4827,7 +4827,7 @@
           "fileName": "src/GoTrueAdminApi.ts",
           "line": 27,
           "character": 21,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L27"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L27"
         }
       ]
     },
@@ -4849,7 +4849,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 240,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L240"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L240"
             }
           ],
           "signatures": [
@@ -4908,7 +4908,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 167,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L167"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L167"
             }
           ],
           "type": {
@@ -4936,7 +4936,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 171,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L171"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L171"
             }
           ],
           "type": {
@@ -4956,7 +4956,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 651,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L651"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L651"
             }
           ],
           "signatures": [
@@ -5014,7 +5014,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 3181,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3181"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3181"
             }
           ],
           "signatures": [
@@ -5152,7 +5152,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3190,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3190"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3190"
                             }
                           ],
                           "type": {
@@ -5181,7 +5181,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3193,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3193"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3193"
                             }
                           ],
                           "type": {
@@ -5204,7 +5204,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 3193,
                                       "character": 15,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3193"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3193"
                                     }
                                   ],
                                   "type": {
@@ -5228,7 +5228,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3193,
                                   "character": 13,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3193"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3193"
                                 }
                               ]
                             }
@@ -5261,7 +5261,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3187,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3187"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3187"
                             }
                           ],
                           "type": {
@@ -5285,7 +5285,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 3183,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3183"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3183"
                         }
                       ]
                     }
@@ -5319,7 +5319,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3197,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                 }
                               ],
                               "type": {
@@ -5342,7 +5342,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 3197,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                         }
                                       ],
                                       "type": {
@@ -5362,7 +5362,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 3197,
                                           "character": 36,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                         }
                                       ],
                                       "type": {
@@ -5382,7 +5382,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 3197,
                                           "character": 55,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                         }
                                       ],
                                       "type": {
@@ -5404,7 +5404,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 3197,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                     }
                                   ]
                                 }
@@ -5421,7 +5421,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3198,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3198"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3198"
                                 }
                               ],
                               "type": {
@@ -5441,7 +5441,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3196,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3196"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3196"
                             }
                           ]
                         }
@@ -5466,7 +5466,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3200,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3200"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3200"
                                 }
                               ],
                               "type": {
@@ -5485,7 +5485,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3200,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3200"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3200"
                                 }
                               ],
                               "type": {
@@ -5506,7 +5506,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3200,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3200"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3200"
                             }
                           ]
                         }
@@ -5531,7 +5531,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3201,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3201"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3201"
                                 }
                               ],
                               "type": {
@@ -5550,7 +5550,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3201,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3201"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3201"
                                 }
                               ],
                               "type": {
@@ -5570,7 +5570,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3201,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3201"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3201"
                             }
                           ]
                         }
@@ -5596,7 +5596,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1355,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1355"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1355"
             }
           ],
           "signatures": [
@@ -5650,7 +5650,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1448,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1448"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1448"
                                 }
                               ],
                               "type": {
@@ -5673,7 +5673,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 1449,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1449"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1449"
                                         }
                                       ],
                                       "type": {
@@ -5694,7 +5694,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 1448,
                                       "character": 18,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1448"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1448"
                                     }
                                   ]
                                 }
@@ -5711,7 +5711,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1451,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1451"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1451"
                                 }
                               ],
                               "type": {
@@ -5731,7 +5731,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1447,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1447"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1447"
                             }
                           ]
                         }
@@ -5756,7 +5756,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1454,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1454"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1454"
                                 }
                               ],
                               "type": {
@@ -5779,7 +5779,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 1455,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1455"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1455"
                                         }
                                       ],
                                       "type": {
@@ -5799,7 +5799,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 1454,
                                       "character": 18,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1454"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1454"
                                     }
                                   ]
                                 }
@@ -5816,7 +5816,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1457,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1457"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1457"
                                 }
                               ],
                               "type": {
@@ -5837,7 +5837,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1453,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1453"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1453"
                             }
                           ]
                         }
@@ -5862,7 +5862,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1460,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1460"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1460"
                                 }
                               ],
                               "type": {
@@ -5885,7 +5885,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 1461,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1461"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1461"
                                         }
                                       ],
                                       "type": {
@@ -5905,7 +5905,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 1460,
                                       "character": 18,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1460"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1460"
                                     }
                                   ]
                                 }
@@ -5922,7 +5922,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1463,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1463"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1463"
                                 }
                               ],
                               "type": {
@@ -5942,7 +5942,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1459,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1459"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1459"
                             }
                           ]
                         }
@@ -5968,7 +5968,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1599,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1599"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1599"
             }
           ],
           "signatures": [
@@ -6036,7 +6036,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2157,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2157"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2157"
             }
           ],
           "signatures": [
@@ -6080,7 +6080,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2159,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2159"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2159"
                                 }
                               ],
                               "type": {
@@ -6103,7 +6103,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 2160,
                                           "character": 10,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2160"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2160"
                                         }
                                       ],
                                       "type": {
@@ -6127,7 +6127,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 2159,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2159"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2159"
                                     }
                                   ]
                                 }
@@ -6144,7 +6144,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2162,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2162"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2162"
                                 }
                               ],
                               "type": {
@@ -6164,7 +6164,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2158,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2158"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2158"
                             }
                           ]
                         }
@@ -6189,7 +6189,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2164,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2164"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2164"
                                 }
                               ],
                               "type": {
@@ -6208,7 +6208,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2164,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2164"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2164"
                                 }
                               ],
                               "type": {
@@ -6229,7 +6229,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2164,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2164"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2164"
                             }
                           ]
                         }
@@ -6255,7 +6255,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 353,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L353"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L353"
             }
           ],
           "signatures": [
@@ -6300,7 +6300,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2181,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2181"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2181"
             }
           ],
           "signatures": [
@@ -6359,7 +6359,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2055,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2055"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2055"
             }
           ],
           "signatures": [
@@ -6405,7 +6405,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2056,
                           "character": 14,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2056"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2056"
                         }
                       ],
                       "signatures": [
@@ -6497,7 +6497,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2058,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2058"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2058"
                         }
                       ],
                       "type": {
@@ -6520,7 +6520,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2058,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2058"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2058"
                                 }
                               ],
                               "type": {
@@ -6541,7 +6541,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2058,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2058"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2058"
                             }
                           ]
                         }
@@ -6559,7 +6559,7 @@
                       "fileName": "src/GoTrueClient.ts",
                       "line": 2057,
                       "character": 5,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2057"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2057"
                     }
                   ]
                 }
@@ -6578,7 +6578,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1271,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1271"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1271"
             }
           ],
           "signatures": [
@@ -6623,7 +6623,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1804,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1804"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1804"
             }
           ],
           "signatures": [
@@ -6678,7 +6678,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1804,
                               "character": 42,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1804"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1804"
                             }
                           ],
                           "type": {
@@ -6698,7 +6698,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 1804,
                           "character": 40,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1804"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1804"
                         }
                       ]
                     }
@@ -6732,7 +6732,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1306,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1306"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1306"
             }
           ],
           "signatures": [
@@ -6791,7 +6791,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2111,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2111"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2111"
             }
           ],
           "signatures": [
@@ -6865,7 +6865,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2115,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2115"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2115"
                             }
                           ],
                           "type": {
@@ -6894,7 +6894,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2114,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2114"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2114"
                             }
                           ],
                           "type": {
@@ -6914,7 +6914,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2113,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2113"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2113"
                         }
                       ]
                     }
@@ -6948,7 +6948,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2119,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2119"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2119"
                                 }
                               ],
                               "type": {
@@ -6973,7 +6973,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2120,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2120"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2120"
                                 }
                               ],
                               "type": {
@@ -6993,7 +6993,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2118,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2118"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2118"
                             }
                           ]
                         }
@@ -7018,7 +7018,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2122,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2122"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2122"
                                 }
                               ],
                               "type": {
@@ -7037,7 +7037,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2122,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2122"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2122"
                                 }
                               ],
                               "type": {
@@ -7058,7 +7058,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2122,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2122"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2122"
                             }
                           ]
                         }
@@ -7084,7 +7084,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1729,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1729"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1729"
             }
           ],
           "signatures": [
@@ -7137,7 +7137,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1730,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1730"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1730"
                             }
                           ],
                           "type": {
@@ -7156,7 +7156,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1731,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1731"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1731"
                             }
                           ],
                           "type": {
@@ -7176,7 +7176,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 1729,
                           "character": 35,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1729"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1729"
                         }
                       ]
                     }
@@ -7210,7 +7210,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 456,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L456"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L456"
             }
           ],
           "signatures": [
@@ -7282,7 +7282,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1064,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1064"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1064"
             }
           ],
           "signatures": [
@@ -7341,7 +7341,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 639,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L639"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L639"
             }
           ],
           "signatures": [
@@ -7400,7 +7400,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1119,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1119"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1119"
             }
           ],
           "signatures": [
@@ -7475,7 +7475,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 576,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L576"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L576"
             }
           ],
           "signatures": [
@@ -7534,7 +7534,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1233,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1233"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1233"
             }
           ],
           "signatures": [
@@ -7593,7 +7593,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 666,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L666"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L666"
             }
           ],
           "signatures": [
@@ -7662,7 +7662,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 668,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                 }
                               ],
                               "type": {
@@ -7685,7 +7685,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 668,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                         }
                                       ],
                                       "type": {
@@ -7705,7 +7705,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 668,
                                           "character": 34,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                         }
                                       ],
                                       "type": {
@@ -7726,7 +7726,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 668,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                     }
                                   ]
                                 }
@@ -7743,7 +7743,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 669,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L669"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L669"
                                 }
                               ],
                               "type": {
@@ -7763,7 +7763,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 667,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L667"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L667"
                             }
                           ]
                         }
@@ -7788,7 +7788,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 671,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                 }
                               ],
                               "type": {
@@ -7811,7 +7811,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 671,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                         }
                                       ],
                                       "type": {
@@ -7830,7 +7830,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 671,
                                           "character": 31,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                         }
                                       ],
                                       "type": {
@@ -7850,7 +7850,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 671,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                     }
                                   ]
                                 }
@@ -7867,7 +7867,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 671,
                                   "character": 45,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                 }
                               ],
                               "type": {
@@ -7888,7 +7888,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 671,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                             }
                           ]
                         }
@@ -7914,7 +7914,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2011,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2011"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2011"
             }
           ],
           "signatures": [
@@ -8010,7 +8010,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2011,
                               "character": 67,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2011"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2011"
                             }
                           ],
                           "type": {
@@ -8040,7 +8040,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2011,
                           "character": 65,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2011"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2011"
                         }
                       ]
                     }
@@ -8064,7 +8064,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 499,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L499"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L499"
             }
           ],
           "signatures": [
@@ -8143,7 +8143,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2698,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2698"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2698"
             }
           ],
           "signatures": [
@@ -8201,7 +8201,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2711,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2711"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2711"
             }
           ],
           "signatures": [
@@ -8255,7 +8255,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2217,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2217"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2217"
             }
           ],
           "signatures": [
@@ -8313,7 +8313,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2219,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2219"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2219"
                                 }
                               ],
                               "type": {
@@ -8338,7 +8338,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2220,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2220"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2220"
                                 }
                               ],
                               "type": {
@@ -8358,7 +8358,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2218,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2218"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2218"
                             }
                           ]
                         }
@@ -8383,7 +8383,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2222,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2222"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2222"
                                 }
                               ],
                               "type": {
@@ -8402,7 +8402,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2222,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2222"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2222"
                                 }
                               ],
                               "type": {
@@ -8423,7 +8423,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2222,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2222"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2222"
                             }
                           ]
                         }
@@ -8449,7 +8449,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1660,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1660"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1660"
             }
           ],
           "signatures": [
@@ -8508,7 +8508,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1663,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1663"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1663"
                             }
                           ],
                           "type": {
@@ -8528,7 +8528,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 1662,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1662"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1662"
                         }
                       ]
                     }
@@ -8563,7 +8563,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1172,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1172"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1172"
             }
           ],
           "signatures": [
@@ -8634,7 +8634,7 @@
           "fileName": "src/GoTrueClient.ts",
           "line": 158,
           "character": 21,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L158"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L158"
         }
       ]
     },
@@ -8656,7 +8656,7 @@
               "fileName": "src/lib/locks.ts",
               "line": 26,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L26"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L26"
             }
           ],
           "signatures": [
@@ -8709,7 +8709,7 @@
               "fileName": "src/lib/locks.ts",
               "line": 24,
               "character": 18,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L24"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L24"
             }
           ],
           "type": {
@@ -8738,7 +8738,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 31,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L31"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L31"
         }
       ],
       "extendedTypes": [
@@ -8799,7 +8799,7 @@
               "fileName": "src/lib/types.ts",
               "line": 283,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L283"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L283"
             }
           ],
           "type": {
@@ -8862,7 +8862,7 @@
               "fileName": "src/lib/types.ts",
               "line": 289,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L289"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L289"
             }
           ],
           "type": {
@@ -8882,7 +8882,7 @@
           "fileName": "src/lib/types.ts",
           "line": 281,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L281"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L281"
         }
       ]
     },
@@ -8930,7 +8930,7 @@
               "fileName": "src/lib/types.ts",
               "line": 421,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L421"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L421"
             }
           ],
           "type": {
@@ -8959,7 +8959,7 @@
               "fileName": "src/lib/types.ts",
               "line": 447,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L447"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L447"
             }
           ],
           "type": {
@@ -8988,7 +8988,7 @@
               "fileName": "src/lib/types.ts",
               "line": 372,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
             }
           ],
           "type": {
@@ -9021,7 +9021,7 @@
               "fileName": "src/lib/types.ts",
               "line": 428,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L428"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L428"
             }
           ],
           "type": {
@@ -9066,7 +9066,7 @@
               "fileName": "src/lib/types.ts",
               "line": 472,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L472"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L472"
             }
           ],
           "type": {
@@ -9095,7 +9095,7 @@
               "fileName": "src/lib/types.ts",
               "line": 389,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
             }
           ],
           "type": {
@@ -9128,7 +9128,7 @@
               "fileName": "src/lib/types.ts",
               "line": 382,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
             }
           ],
           "type": {
@@ -9169,7 +9169,7 @@
               "fileName": "src/lib/types.ts",
               "line": 465,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L465"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L465"
             }
           ],
           "type": {
@@ -9198,7 +9198,7 @@
               "fileName": "src/lib/types.ts",
               "line": 377,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
             }
           ],
           "type": {
@@ -9231,7 +9231,7 @@
               "fileName": "src/lib/types.ts",
               "line": 435,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L435"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L435"
             }
           ],
           "type": {
@@ -9292,7 +9292,7 @@
               "fileName": "src/lib/types.ts",
               "line": 456,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L456"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L456"
             }
           ],
           "type": {
@@ -9337,7 +9337,7 @@
               "fileName": "src/lib/types.ts",
               "line": 411,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L411"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L411"
             }
           ],
           "type": {
@@ -9357,7 +9357,7 @@
           "fileName": "src/lib/types.ts",
           "line": 400,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L400"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L400"
         }
       ],
       "extendedTypes": [
@@ -9454,7 +9454,7 @@
               "fileName": "src/lib/types.ts",
               "line": 327,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L327"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L327"
             }
           ],
           "type": {
@@ -9497,7 +9497,7 @@
               "fileName": "src/lib/types.ts",
               "line": 322,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L322"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L322"
             }
           ],
           "type": {
@@ -9554,7 +9554,7 @@
               "fileName": "src/lib/types.ts",
               "line": 317,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L317"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L317"
             }
           ],
           "type": {
@@ -9581,7 +9581,7 @@
               "fileName": "src/lib/types.ts",
               "line": 314,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L314"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L314"
             }
           ],
           "type": {
@@ -9608,7 +9608,7 @@
               "fileName": "src/lib/types.ts",
               "line": 325,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L325"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L325"
             }
           ],
           "type": {
@@ -9636,7 +9636,7 @@
               "fileName": "src/lib/types.ts",
               "line": 328,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L328"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L328"
             }
           ],
           "type": {
@@ -9656,7 +9656,7 @@
           "fileName": "src/lib/types.ts",
           "line": 312,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L312"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L312"
         }
       ]
     },
@@ -9704,7 +9704,7 @@
               "fileName": "src/lib/types.ts",
               "line": 851,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L851"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L851"
             }
           ],
           "type": {
@@ -9733,7 +9733,7 @@
               "fileName": "src/lib/types.ts",
               "line": 853,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L853"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L853"
             }
           ],
           "type": {
@@ -9753,7 +9753,7 @@
           "fileName": "src/lib/types.ts",
           "line": 845,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L845"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L845"
         }
       ]
     },
@@ -9789,7 +9789,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1169,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1169"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1169"
             }
           ],
           "signatures": [
@@ -9865,7 +9865,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1159,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1159"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1159"
             }
           ],
           "signatures": [
@@ -9925,7 +9925,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1154,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1154"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1154"
         }
       ]
     },
@@ -9955,7 +9955,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1058,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1058"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1058"
             }
           ],
           "signatures": [
@@ -10014,7 +10014,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1076,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1076"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1076"
             }
           ],
           "signatures": [
@@ -10073,19 +10073,19 @@
               "fileName": "src/lib/types.ts",
               "line": 1050,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1050"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1050"
             },
             {
               "fileName": "src/lib/types.ts",
               "line": 1051,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1051"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1051"
             },
             {
               "fileName": "src/lib/types.ts",
               "line": 1052,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1052"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1052"
             }
           ],
           "signatures": [
@@ -10228,7 +10228,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1101,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1101"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1101"
             }
           ],
           "signatures": [
@@ -10297,7 +10297,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1086,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1086"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1086"
             }
           ],
           "signatures": [
@@ -10391,7 +10391,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1070,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1070"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1070"
             }
           ],
           "signatures": [
@@ -10466,7 +10466,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1064,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1064"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1064"
             }
           ],
           "signatures": [
@@ -10526,7 +10526,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1039,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1039"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1039"
         }
       ]
     },
@@ -10550,7 +10550,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1332,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1332"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1332"
             }
           ],
           "type": {
@@ -10569,7 +10569,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1331,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1331"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1331"
             }
           ],
           "type": {
@@ -10593,7 +10593,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1333,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1333"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1333"
             }
           ],
           "type": {
@@ -10612,7 +10612,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1330,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1330"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1330"
             }
           ],
           "type": {
@@ -10645,7 +10645,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1329,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1329"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1329"
         }
       ],
       "indexSignature": {
@@ -10698,7 +10698,7 @@
               "fileName": "src/lib/types.ts",
               "line": 252,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L252"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L252"
             }
           ],
           "type": {
@@ -10727,7 +10727,7 @@
               "fileName": "src/lib/types.ts",
               "line": 264,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L264"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L264"
             }
           ],
           "type": {
@@ -10754,7 +10754,7 @@
               "fileName": "src/lib/types.ts",
               "line": 260,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L260"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L260"
             }
           ],
           "type": {
@@ -10783,7 +10783,7 @@
               "fileName": "src/lib/types.ts",
               "line": 248,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L248"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L248"
             }
           ],
           "type": {
@@ -10821,7 +10821,7 @@
               "fileName": "src/lib/types.ts",
               "line": 243,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L243"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L243"
             }
           ],
           "type": {
@@ -10857,7 +10857,7 @@
               "fileName": "src/lib/types.ts",
               "line": 256,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L256"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L256"
             }
           ],
           "type": {
@@ -10876,7 +10876,7 @@
               "fileName": "src/lib/types.ts",
               "line": 265,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L265"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L265"
             }
           ],
           "type": {
@@ -10903,7 +10903,7 @@
               "fileName": "src/lib/types.ts",
               "line": 270,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L270"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L270"
             }
           ],
           "type": {
@@ -10924,7 +10924,7 @@
           "fileName": "src/lib/types.ts",
           "line": 239,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L239"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L239"
         }
       ]
     },
@@ -10946,7 +10946,7 @@
               "fileName": "src/lib/types.ts",
               "line": 483,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L483"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L483"
             }
           ],
           "type": {
@@ -10962,7 +10962,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 483,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L483"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L483"
                 }
               ],
               "signatures": [
@@ -11043,7 +11043,7 @@
               "fileName": "src/lib/types.ts",
               "line": 479,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L479"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L479"
             }
           ],
           "type": {
@@ -11062,7 +11062,7 @@
               "fileName": "src/lib/types.ts",
               "line": 487,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L487"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L487"
             }
           ],
           "type": {
@@ -11078,7 +11078,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 487,
                   "character": 15,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L487"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L487"
                 }
               ],
               "signatures": [
@@ -11117,7 +11117,7 @@
           "fileName": "src/lib/types.ts",
           "line": 475,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L475"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L475"
         }
       ]
     },
@@ -11141,7 +11141,7 @@
               "fileName": "src/lib/types.ts",
               "line": 351,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L351"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L351"
             }
           ],
           "type": {
@@ -11160,7 +11160,7 @@
               "fileName": "src/lib/types.ts",
               "line": 342,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L342"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L342"
             }
           ],
           "type": {
@@ -11180,7 +11180,7 @@
               "fileName": "src/lib/types.ts",
               "line": 344,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L344"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L344"
             }
           ],
           "type": {
@@ -11201,7 +11201,7 @@
               "fileName": "src/lib/types.ts",
               "line": 345,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L345"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L345"
             }
           ],
           "type": {
@@ -11222,7 +11222,7 @@
               "fileName": "src/lib/types.ts",
               "line": 355,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L355"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L355"
             }
           ],
           "type": {
@@ -11241,7 +11241,7 @@
               "fileName": "src/lib/types.ts",
               "line": 354,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L354"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L354"
             }
           ],
           "type": {
@@ -11262,7 +11262,7 @@
               "fileName": "src/lib/types.ts",
               "line": 365,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L365"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L365"
             }
           ],
           "type": {
@@ -11283,7 +11283,7 @@
               "fileName": "src/lib/types.ts",
               "line": 352,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L352"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L352"
             }
           ],
           "type": {
@@ -11304,7 +11304,7 @@
               "fileName": "src/lib/types.ts",
               "line": 347,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L347"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L347"
             }
           ],
           "type": {
@@ -11325,7 +11325,7 @@
               "fileName": "src/lib/types.ts",
               "line": 356,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L356"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L356"
             }
           ],
           "type": {
@@ -11346,7 +11346,7 @@
               "fileName": "src/lib/types.ts",
               "line": 364,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L364"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L364"
             }
           ],
           "type": {
@@ -11369,7 +11369,7 @@
               "fileName": "src/lib/types.ts",
               "line": 341,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L341"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L341"
             }
           ],
           "type": {
@@ -11390,7 +11390,7 @@
               "fileName": "src/lib/types.ts",
               "line": 361,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L361"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L361"
             }
           ],
           "type": {
@@ -11415,7 +11415,7 @@
               "fileName": "src/lib/types.ts",
               "line": 350,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L350"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L350"
             }
           ],
           "type": {
@@ -11436,7 +11436,7 @@
               "fileName": "src/lib/types.ts",
               "line": 362,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L362"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L362"
             }
           ],
           "type": {
@@ -11457,7 +11457,7 @@
               "fileName": "src/lib/types.ts",
               "line": 363,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L363"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L363"
             }
           ],
           "type": {
@@ -11478,7 +11478,7 @@
               "fileName": "src/lib/types.ts",
               "line": 358,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L358"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L358"
             }
           ],
           "type": {
@@ -11499,7 +11499,7 @@
               "fileName": "src/lib/types.ts",
               "line": 348,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L348"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L348"
             }
           ],
           "type": {
@@ -11520,7 +11520,7 @@
               "fileName": "src/lib/types.ts",
               "line": 349,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L349"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L349"
             }
           ],
           "type": {
@@ -11541,7 +11541,7 @@
               "fileName": "src/lib/types.ts",
               "line": 353,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L353"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L353"
             }
           ],
           "type": {
@@ -11562,7 +11562,7 @@
               "fileName": "src/lib/types.ts",
               "line": 357,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L357"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L357"
             }
           ],
           "type": {
@@ -11583,7 +11583,7 @@
               "fileName": "src/lib/types.ts",
               "line": 346,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L346"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L346"
             }
           ],
           "type": {
@@ -11604,7 +11604,7 @@
               "fileName": "src/lib/types.ts",
               "line": 359,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L359"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L359"
             }
           ],
           "type": {
@@ -11625,7 +11625,7 @@
               "fileName": "src/lib/types.ts",
               "line": 360,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L360"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L360"
             }
           ],
           "type": {
@@ -11644,7 +11644,7 @@
               "fileName": "src/lib/types.ts",
               "line": 343,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L343"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L343"
             }
           ],
           "type": {
@@ -11668,7 +11668,7 @@
           "fileName": "src/lib/types.ts",
           "line": 340,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L340"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L340"
         }
       ]
     },
@@ -11692,7 +11692,7 @@
               "fileName": "src/lib/types.ts",
               "line": 332,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L332"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L332"
             }
           ],
           "type": {
@@ -11712,7 +11712,7 @@
           "fileName": "src/lib/types.ts",
           "line": 331,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L331"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L331"
         }
       ],
       "indexSignature": {
@@ -11783,7 +11783,7 @@
               "fileName": "src/lib/types.ts",
               "line": 397,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L397"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L397"
             }
           ],
           "type": {
@@ -11812,7 +11812,7 @@
               "fileName": "src/lib/types.ts",
               "line": 372,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
             }
           ],
           "type": {
@@ -11841,7 +11841,7 @@
               "fileName": "src/lib/types.ts",
               "line": 389,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
             }
           ],
           "type": {
@@ -11870,7 +11870,7 @@
               "fileName": "src/lib/types.ts",
               "line": 382,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
             }
           ],
           "type": {
@@ -11899,7 +11899,7 @@
               "fileName": "src/lib/types.ts",
               "line": 377,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
             }
           ],
           "type": {
@@ -11919,7 +11919,7 @@
           "fileName": "src/lib/types.ts",
           "line": 368,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L368"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L368"
         }
       ]
     },
@@ -11943,7 +11943,7 @@
               "fileName": "src/lib/types.ts",
               "line": 300,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L300"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L300"
             }
           ],
           "type": {
@@ -11962,7 +11962,7 @@
               "fileName": "src/lib/types.ts",
               "line": 293,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L293"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L293"
             }
           ],
           "type": {
@@ -11983,7 +11983,7 @@
               "fileName": "src/lib/types.ts",
               "line": 295,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L295"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L295"
             }
           ],
           "type": {
@@ -11999,7 +11999,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 295,
                   "character": 18,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L295"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L295"
                 }
               ],
               "indexSignature": {
@@ -12039,7 +12039,7 @@
               "fileName": "src/lib/types.ts",
               "line": 298,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L298"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L298"
             }
           ],
           "type": {
@@ -12060,7 +12060,7 @@
               "fileName": "src/lib/types.ts",
               "line": 301,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L301"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L301"
             }
           ],
           "type": {
@@ -12079,7 +12079,7 @@
               "fileName": "src/lib/types.ts",
               "line": 299,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L299"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L299"
             }
           ],
           "type": {
@@ -12100,7 +12100,7 @@
               "fileName": "src/lib/types.ts",
               "line": 302,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L302"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L302"
             }
           ],
           "type": {
@@ -12119,7 +12119,7 @@
               "fileName": "src/lib/types.ts",
               "line": 294,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L294"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L294"
             }
           ],
           "type": {
@@ -12139,7 +12139,7 @@
           "fileName": "src/lib/types.ts",
           "line": 292,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L292"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L292"
         }
       ]
     },
@@ -12154,7 +12154,7 @@
           "fileName": "src/lib/types.ts",
           "line": 336,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L336"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L336"
         }
       ],
       "indexSignature": {
@@ -12207,7 +12207,7 @@
               "fileName": "src/lib/types.ts",
               "line": 741,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L741"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L741"
             }
           ],
           "type": {
@@ -12228,7 +12228,7 @@
               "fileName": "src/lib/types.ts",
               "line": 746,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
             }
           ],
           "type": {
@@ -12267,7 +12267,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 754,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L754"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L754"
                     }
                   ],
                   "type": {
@@ -12296,7 +12296,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 748,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L748"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L748"
                     }
                   ],
                   "type": {
@@ -12316,7 +12316,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 746,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
                 }
               ]
             }
@@ -12341,7 +12341,7 @@
               "fileName": "src/lib/types.ts",
               "line": 743,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L743"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L743"
             }
           ],
           "type": {
@@ -12368,7 +12368,7 @@
               "fileName": "src/lib/types.ts",
               "line": 745,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L745"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L745"
             }
           ],
           "type": {
@@ -12389,7 +12389,7 @@
           "fileName": "src/lib/types.ts",
           "line": 739,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L739"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L739"
         }
       ]
     },
@@ -12413,7 +12413,7 @@
               "fileName": "src/lib/types.ts",
               "line": 727,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
             }
           ],
           "type": {
@@ -12452,7 +12452,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 736,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L736"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L736"
                     }
                   ],
                   "type": {
@@ -12481,7 +12481,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 729,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L729"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L729"
                     }
                   ],
                   "type": {
@@ -12501,7 +12501,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 727,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
                 }
               ]
             }
@@ -12526,7 +12526,7 @@
               "fileName": "src/lib/types.ts",
               "line": 722,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L722"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L722"
             }
           ],
           "type": {
@@ -12553,7 +12553,7 @@
               "fileName": "src/lib/types.ts",
               "line": 724,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L724"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L724"
             }
           ],
           "type": {
@@ -12580,7 +12580,7 @@
               "fileName": "src/lib/types.ts",
               "line": 726,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L726"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L726"
             }
           ],
           "type": {
@@ -12601,7 +12601,7 @@
           "fileName": "src/lib/types.ts",
           "line": 720,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L720"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L720"
         }
       ]
     },
@@ -12631,7 +12631,7 @@
               "fileName": "src/lib/types.ts",
               "line": 760,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L760"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L760"
             }
           ],
           "type": {
@@ -12658,7 +12658,7 @@
               "fileName": "src/lib/types.ts",
               "line": 763,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L763"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L763"
             }
           ],
           "type": {
@@ -12679,7 +12679,7 @@
           "fileName": "src/lib/types.ts",
           "line": 758,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L758"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L758"
         }
       ]
     },
@@ -12694,7 +12694,7 @@
           "fileName": "src/lib/types.ts",
           "line": 34,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L34"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L34"
         }
       ],
       "type": {
@@ -12743,7 +12743,7 @@
           "fileName": "src/lib/types.ts",
           "line": 32,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L32"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L32"
         }
       ],
       "type": {
@@ -12762,7 +12762,7 @@
           "fileName": "src/lib/types.ts",
           "line": 601,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L601"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L601"
         }
       ],
       "type": {
@@ -12799,7 +12799,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1120,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
         }
       ],
       "type": {
@@ -12830,7 +12830,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1122,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1122"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1122"
                 }
               ],
               "type": {
@@ -12857,7 +12857,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1125,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1125"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1125"
                 }
               ],
               "type": {
@@ -12877,7 +12877,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1120,
               "character": 45,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
             }
           ]
         }
@@ -12903,7 +12903,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1107,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1107"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1107"
         }
       ],
       "type": {
@@ -12929,7 +12929,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1109,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1109"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1109"
                     }
                   ],
                   "type": {
@@ -12960,7 +12960,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1111,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1111"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1111"
                             }
                           ],
                           "type": {
@@ -12980,7 +12980,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1109,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1109"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1109"
                         }
                       ]
                     }
@@ -12997,7 +12997,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1113,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1113"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1113"
                     }
                   ],
                   "type": {
@@ -13017,7 +13017,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1108,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1108"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1108"
                 }
               ]
             }
@@ -13042,7 +13042,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1115,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1115"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1115"
                     }
                   ],
                   "type": {
@@ -13061,7 +13061,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1115,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1115"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1115"
                     }
                   ],
                   "type": {
@@ -13082,7 +13082,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1115,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1115"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1115"
                 }
               ]
             }
@@ -13110,7 +13110,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1144,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
         }
       ],
       "type": {
@@ -13141,7 +13141,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1146,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1146"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1146"
                 }
               ],
               "type": {
@@ -13161,7 +13161,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1144,
               "character": 44,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
             }
           ]
         }
@@ -13187,7 +13187,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1131,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1131"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1131"
         }
       ],
       "type": {
@@ -13213,7 +13213,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1133,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1133"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1133"
                     }
                   ],
                   "type": {
@@ -13244,7 +13244,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1135,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1135"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1135"
                             }
                           ],
                           "type": {
@@ -13268,7 +13268,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1133,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1133"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1133"
                         }
                       ]
                     }
@@ -13285,7 +13285,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1137,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1137"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1137"
                     }
                   ],
                   "type": {
@@ -13305,7 +13305,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1132,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1132"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1132"
                 }
               ]
             }
@@ -13330,7 +13330,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1139,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1139"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1139"
                     }
                   ],
                   "type": {
@@ -13349,7 +13349,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1139,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1139"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1139"
                     }
                   ],
                   "type": {
@@ -13370,7 +13370,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1139,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1139"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1139"
                 }
               ]
             }
@@ -13389,7 +13389,7 @@
           "fileName": "src/lib/types.ts",
           "line": 977,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L977"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L977"
         }
       ],
       "type": {
@@ -13415,7 +13415,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 979,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L979"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L979"
                     }
                   ],
                   "type": {
@@ -13446,7 +13446,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 987,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L987"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L987"
                             }
                           ],
                           "type": {
@@ -13473,7 +13473,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 981,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L981"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L981"
                             }
                           ],
                           "type": {
@@ -13500,7 +13500,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 984,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L984"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L984"
                             }
                           ],
                           "type": {
@@ -13529,7 +13529,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 979,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L979"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L979"
                         }
                       ]
                     }
@@ -13546,7 +13546,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 989,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L989"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L989"
                     }
                   ],
                   "type": {
@@ -13566,7 +13566,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 978,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L978"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L978"
                 }
               ]
             }
@@ -13591,7 +13591,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 991,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L991"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L991"
                     }
                   ],
                   "type": {
@@ -13610,7 +13610,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 991,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L991"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L991"
                     }
                   ],
                   "type": {
@@ -13631,7 +13631,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 991,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L991"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L991"
                 }
               ]
             }
@@ -13650,7 +13650,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1286,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1286"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1286"
         }
       ],
       "type": {
@@ -13676,7 +13676,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1288,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1288"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1288"
                     }
                   ],
                   "type": {
@@ -13709,7 +13709,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1296,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1296"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1296"
                             }
                           ],
                           "type": {
@@ -13736,7 +13736,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1290,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1290"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1290"
                             }
                           ],
                           "type": {
@@ -13763,7 +13763,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1299,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1299"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1299"
                             }
                           ],
                           "type": {
@@ -13790,7 +13790,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1293,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1293"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1293"
                             }
                           ],
                           "type": {
@@ -13810,7 +13810,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1288,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1288"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1288"
                         }
                       ]
                     }
@@ -13827,7 +13827,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1301,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1301"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1301"
                     }
                   ],
                   "type": {
@@ -13847,7 +13847,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1287,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1287"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1287"
                 }
               ]
             }
@@ -13872,7 +13872,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1304,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1304"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1304"
                     }
                   ],
                   "type": {
@@ -13891,7 +13891,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1305,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1305"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1305"
                     }
                   ],
                   "type": {
@@ -13912,7 +13912,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1303,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1303"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1303"
                 }
               ]
             }
@@ -13931,7 +13931,7 @@
           "fileName": "src/lib/types.ts",
           "line": 965,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L965"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L965"
         }
       ],
       "type": {
@@ -13961,7 +13961,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1251,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1251"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1251"
         }
       ],
       "type": {
@@ -13987,7 +13987,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1253,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1253"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1253"
                     }
                   ],
                   "type": {
@@ -14020,7 +14020,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1277,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1277"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1277"
                             }
                           ],
                           "type": {
@@ -14047,7 +14047,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1255,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1255"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1255"
                             }
                           ],
                           "type": {
@@ -14074,7 +14074,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1261,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1261"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1261"
                             }
                           ],
                           "type": {
@@ -14113,7 +14113,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1265,
                                       "character": 10,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1265"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1265"
                                     }
                                   ],
                                   "type": {
@@ -14140,7 +14140,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1270,
                                       "character": 10,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1270"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1270"
                                     }
                                   ],
                                   "type": {
@@ -14167,7 +14167,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1274,
                                       "character": 10,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1274"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1274"
                                     }
                                   ],
                                   "type": {
@@ -14187,7 +14187,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1261,
                                   "character": 14,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1261"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1261"
                                 }
                               ]
                             }
@@ -14212,7 +14212,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1258,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1258"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1258"
                             }
                           ],
                           "type": {
@@ -14232,7 +14232,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1253,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1253"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1253"
                         }
                       ]
                     }
@@ -14249,7 +14249,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1279,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1279"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1279"
                     }
                   ],
                   "type": {
@@ -14269,7 +14269,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1252,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1252"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1252"
                 }
               ]
             }
@@ -14294,7 +14294,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1282,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1282"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1282"
                     }
                   ],
                   "type": {
@@ -14313,7 +14313,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1283,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1283"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1283"
                     }
                   ],
                   "type": {
@@ -14334,7 +14334,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1281,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1281"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1281"
                 }
               ]
             }
@@ -14353,7 +14353,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1010,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1010"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1010"
         }
       ],
       "type": {
@@ -14379,7 +14379,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1012,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1012"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1012"
                     }
                   ],
                   "type": {
@@ -14410,7 +14410,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1029,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1029"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1029"
                             }
                           ],
                           "type": {
@@ -14441,7 +14441,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1014,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1014"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1014"
                             }
                           ],
                           "type": {
@@ -14491,7 +14491,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1022,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1022"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1022"
                             }
                           ],
                           "type": {
@@ -14521,7 +14521,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1012,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1012"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1012"
                         }
                       ]
                     }
@@ -14538,7 +14538,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1031,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1031"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1031"
                     }
                   ],
                   "type": {
@@ -14558,7 +14558,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1011,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1011"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1011"
                 }
               ]
             }
@@ -14583,7 +14583,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1033,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1033"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1033"
                     }
                   ],
                   "type": {
@@ -14602,7 +14602,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1033,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1033"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1033"
                     }
                   ],
                   "type": {
@@ -14623,7 +14623,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1033,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1033"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1033"
                 }
               ]
             }
@@ -14642,7 +14642,7 @@
           "fileName": "src/lib/types.ts",
           "line": 993,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L993"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L993"
         }
       ],
       "type": {
@@ -14668,7 +14668,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 995,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L995"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L995"
                     }
                   ],
                   "type": {
@@ -14699,7 +14699,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 997,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L997"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L997"
                             }
                           ],
                           "type": {
@@ -14738,7 +14738,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1002,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1002"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1002"
                             }
                           ],
                           "type": {
@@ -14777,7 +14777,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1000,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1000"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1000"
                             }
                           ],
                           "type": {
@@ -14801,7 +14801,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 995,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L995"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L995"
                         }
                       ]
                     }
@@ -14818,7 +14818,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1004,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1004"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1004"
                     }
                   ],
                   "type": {
@@ -14838,7 +14838,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 994,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L994"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L994"
                 }
               ]
             }
@@ -14863,7 +14863,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1006,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1006"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1006"
                     }
                   ],
                   "type": {
@@ -14882,7 +14882,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1006,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1006"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1006"
                     }
                   ],
                   "type": {
@@ -14903,7 +14903,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1006,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1006"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1006"
                 }
               ]
             }
@@ -14922,7 +14922,7 @@
           "fileName": "src/lib/types.ts",
           "line": 967,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L967"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L967"
         }
       ],
       "type": {
@@ -14948,7 +14948,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 969,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L969"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L969"
                     }
                   ],
                   "type": {
@@ -14979,7 +14979,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 971,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L971"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L971"
                             }
                           ],
                           "type": {
@@ -14999,7 +14999,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 969,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L969"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L969"
                         }
                       ]
                     }
@@ -15016,7 +15016,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 973,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L973"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L973"
                     }
                   ],
                   "type": {
@@ -15036,7 +15036,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 968,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L968"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L968"
                 }
               ]
             }
@@ -15061,7 +15061,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 975,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L975"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L975"
                     }
                   ],
                   "type": {
@@ -15080,7 +15080,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 975,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L975"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L975"
                     }
                   ],
                   "type": {
@@ -15101,7 +15101,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 975,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L975"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L975"
                 }
               ]
             }
@@ -15120,7 +15120,7 @@
           "fileName": "src/lib/types.ts",
           "line": 940,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L940"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L940"
         }
       ],
       "type": {
@@ -15146,7 +15146,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 942,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L942"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L942"
                     }
                   ],
                   "type": {
@@ -15177,7 +15177,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 944,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L944"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L944"
                             }
                           ],
                           "type": {
@@ -15204,7 +15204,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 950,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L950"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L950"
                             }
                           ],
                           "type": {
@@ -15231,7 +15231,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 953,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L953"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L953"
                             }
                           ],
                           "type": {
@@ -15266,7 +15266,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 947,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L947"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L947"
                             }
                           ],
                           "type": {
@@ -15293,7 +15293,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 956,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L956"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L956"
                             }
                           ],
                           "type": {
@@ -15314,7 +15314,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 942,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L942"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L942"
                         }
                       ]
                     }
@@ -15331,7 +15331,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 958,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L958"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L958"
                     }
                   ],
                   "type": {
@@ -15351,7 +15351,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 941,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L941"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L941"
                 }
               ]
             }
@@ -15376,7 +15376,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 961,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L961"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L961"
                     }
                   ],
                   "type": {
@@ -15395,7 +15395,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 962,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L962"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L962"
                     }
                   ],
                   "type": {
@@ -15416,7 +15416,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 960,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L960"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L960"
                 }
               ]
             }
@@ -15448,7 +15448,7 @@
           "fileName": "src/lib/types.ts",
           "line": 146,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L146"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L146"
         }
       ],
       "type": {
@@ -15474,7 +15474,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 148,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                     }
                   ],
                   "type": {
@@ -15499,7 +15499,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 148,
                               "character": 41,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                             }
                           ],
                           "type": {
@@ -15527,7 +15527,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 148,
                               "character": 26,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                             }
                           ],
                           "type": {
@@ -15546,7 +15546,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 148,
                               "character": 14,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                             }
                           ],
                           "type": {
@@ -15566,7 +15566,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 148,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                         }
                       ]
                     }
@@ -15583,7 +15583,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 149,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L149"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L149"
                     }
                   ],
                   "type": {
@@ -15603,7 +15603,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 147,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L147"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L147"
                 }
               ]
             }
@@ -15628,7 +15628,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 152,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                     }
                   ],
                   "type": {
@@ -15653,7 +15653,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 152,
                               "character": 41,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                             }
                           ],
                           "type": {
@@ -15681,7 +15681,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 152,
                               "character": 26,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                             }
                           ],
                           "type": {
@@ -15700,7 +15700,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 152,
                               "character": 14,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                             }
                           ],
                           "type": {
@@ -15720,7 +15720,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 152,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                         }
                       ]
                     }
@@ -15737,7 +15737,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 153,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L153"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L153"
                     }
                   ],
                   "type": {
@@ -15758,7 +15758,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 151,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L151"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L151"
                 }
               ]
             }
@@ -15777,7 +15777,7 @@
           "fileName": "src/lib/types.ts",
           "line": 108,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L108"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L108"
         }
       ],
       "type": {
@@ -15803,7 +15803,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 110,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L110"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L110"
                     }
                   ],
                   "type": {
@@ -15826,7 +15826,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 112,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L112"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L112"
                             }
                           ],
                           "type": {
@@ -15855,7 +15855,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 111,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L111"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L111"
                             }
                           ],
                           "type": {
@@ -15885,7 +15885,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 110,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L110"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L110"
                         }
                       ]
                     }
@@ -15902,7 +15902,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 114,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L114"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L114"
                     }
                   ],
                   "type": {
@@ -15922,7 +15922,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 109,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L109"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L109"
                 }
               ]
             }
@@ -15947,7 +15947,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 117,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L117"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L117"
                     }
                   ],
                   "type": {
@@ -15970,7 +15970,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 119,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L119"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L119"
                             }
                           ],
                           "type": {
@@ -15989,7 +15989,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 118,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L118"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L118"
                             }
                           ],
                           "type": {
@@ -16009,7 +16009,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 117,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L117"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L117"
                         }
                       ]
                     }
@@ -16026,7 +16026,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 121,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L121"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L121"
                     }
                   ],
                   "type": {
@@ -16047,7 +16047,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 116,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L116"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L116"
                 }
               ]
             }
@@ -16066,7 +16066,7 @@
           "fileName": "src/lib/types.ts",
           "line": 124,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L124"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L124"
         }
       ],
       "type": {
@@ -16092,7 +16092,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 126,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L126"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L126"
                     }
                   ],
                   "type": {
@@ -16115,7 +16115,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 128,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L128"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L128"
                             }
                           ],
                           "type": {
@@ -16144,7 +16144,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 127,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L127"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L127"
                             }
                           ],
                           "type": {
@@ -16175,7 +16175,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 129,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L129"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L129"
                             }
                           ],
                           "type": {
@@ -16205,7 +16205,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 126,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L126"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L126"
                         }
                       ]
                     }
@@ -16222,7 +16222,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 131,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L131"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L131"
                     }
                   ],
                   "type": {
@@ -16242,7 +16242,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 125,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L125"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L125"
                 }
               ]
             }
@@ -16267,7 +16267,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 134,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L134"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L134"
                     }
                   ],
                   "type": {
@@ -16290,7 +16290,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 136,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L136"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L136"
                             }
                           ],
                           "type": {
@@ -16309,7 +16309,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 135,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L135"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L135"
                             }
                           ],
                           "type": {
@@ -16329,7 +16329,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 134,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L134"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L134"
                         }
                       ]
                     }
@@ -16346,7 +16346,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 138,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L138"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L138"
                     }
                   ],
                   "type": {
@@ -16367,7 +16367,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 133,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L133"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L133"
                 }
               ]
             }
@@ -16386,7 +16386,7 @@
           "fileName": "src/lib/types.ts",
           "line": 156,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L156"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L156"
         }
       ],
       "type": {
@@ -16412,7 +16412,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 158,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L158"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L158"
                     }
                   ],
                   "type": {
@@ -16435,7 +16435,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 160,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L160"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L160"
                             }
                           ],
                           "type": {
@@ -16455,7 +16455,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 159,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L159"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L159"
                             }
                           ],
                           "type": {
@@ -16476,7 +16476,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 158,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L158"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L158"
                         }
                       ]
                     }
@@ -16493,7 +16493,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 162,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L162"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L162"
                     }
                   ],
                   "type": {
@@ -16513,7 +16513,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 157,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L157"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L157"
                 }
               ]
             }
@@ -16538,7 +16538,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 165,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L165"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L165"
                     }
                   ],
                   "type": {
@@ -16561,7 +16561,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 167,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L167"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L167"
                             }
                           ],
                           "type": {
@@ -16580,7 +16580,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 166,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L166"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L166"
                             }
                           ],
                           "type": {
@@ -16600,7 +16600,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 165,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L165"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L165"
                         }
                       ]
                     }
@@ -16617,7 +16617,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 169,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L169"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L169"
                     }
                   ],
                   "type": {
@@ -16638,7 +16638,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 164,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L164"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L164"
                 }
               ]
             }
@@ -16657,7 +16657,7 @@
           "fileName": "src/lib/types.ts",
           "line": 172,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L172"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L172"
         }
       ],
       "type": {
@@ -16683,7 +16683,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 174,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L174"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L174"
                     }
                   ],
                   "type": {
@@ -16706,7 +16706,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 176,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L176"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L176"
                             }
                           ],
                           "type": {
@@ -16726,7 +16726,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 175,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L175"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L175"
                             }
                           ],
                           "type": {
@@ -16748,7 +16748,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 177,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L177"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L177"
                             }
                           ],
                           "type": {
@@ -16769,7 +16769,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 174,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L174"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L174"
                         }
                       ]
                     }
@@ -16786,7 +16786,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 179,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L179"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L179"
                     }
                   ],
                   "type": {
@@ -16806,7 +16806,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 173,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L173"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L173"
                 }
               ]
             }
@@ -16831,7 +16831,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 182,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L182"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L182"
                     }
                   ],
                   "type": {
@@ -16854,7 +16854,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 184,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L184"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L184"
                             }
                           ],
                           "type": {
@@ -16873,7 +16873,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 183,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L183"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L183"
                             }
                           ],
                           "type": {
@@ -16894,7 +16894,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 185,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L185"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L185"
                             }
                           ],
                           "type": {
@@ -16914,7 +16914,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 182,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L182"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L182"
                         }
                       ]
                     }
@@ -16931,7 +16931,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 187,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L187"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L187"
                     }
                   ],
                   "type": {
@@ -16952,7 +16952,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 181,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L181"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L181"
                 }
               ]
             }
@@ -16971,7 +16971,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1008,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1008"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1008"
         }
       ],
       "type": {
@@ -16999,7 +16999,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1196,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1196"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1196"
         }
       ],
       "type": {
@@ -17025,7 +17025,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1199,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1199"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1199"
                     }
                   ],
                   "type": {
@@ -17044,7 +17044,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1198,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1198"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1198"
                     }
                   ],
                   "type": {
@@ -17065,7 +17065,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1197,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1197"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1197"
                 }
               ]
             }
@@ -17090,7 +17090,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1203,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1203"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1203"
                     }
                   ],
                   "type": {
@@ -17110,7 +17110,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1202,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1202"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1202"
                     }
                   ],
                   "type": {
@@ -17130,7 +17130,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1201,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1201"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1201"
                 }
               ]
             }
@@ -17149,7 +17149,7 @@
           "fileName": "src/lib/types.ts",
           "line": 767,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
         }
       ],
       "type": {
@@ -17193,7 +17193,7 @@
           "fileName": "src/lib/types.ts",
           "line": 678,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L678"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L678"
         }
       ],
       "type": {
@@ -17212,7 +17212,7 @@
           "fileName": "src/lib/types.ts",
           "line": 680,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L680"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L680"
         }
       ],
       "type": {
@@ -17238,7 +17238,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 682,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L682"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L682"
                     }
                   ],
                   "type": {
@@ -17259,7 +17259,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 690,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                     }
                   ],
                   "type": {
@@ -17292,7 +17292,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 695,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L695"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L695"
                             }
                           ],
                           "type": {
@@ -17313,7 +17313,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 697,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L697"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L697"
                             }
                           ],
                           "type": {
@@ -17379,7 +17379,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 692,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L692"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L692"
                             }
                           ],
                           "type": {
@@ -17399,7 +17399,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 690,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                         }
                       ]
                     }
@@ -17417,7 +17417,7 @@
                     "summary": [
                       {
                         "kind": "text",
-                        "text": "Optional statement to include in the Sign in with Solana message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
+                        "text": "Optional statement to include in the Sign in with Ethereum message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
                       }
                     ]
                   },
@@ -17426,7 +17426,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 688,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L688"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L688"
                     }
                   ],
                   "type": {
@@ -17450,7 +17450,7 @@
                       },
                       {
                         "kind": "code",
-                        "text": "`window.solana`"
+                        "text": "`window.ethereum`"
                       },
                       {
                         "kind": "text",
@@ -17463,7 +17463,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 685,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L685"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L685"
                     }
                   ],
                   "type": {
@@ -17484,7 +17484,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 681,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L681"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L681"
                 }
               ]
             }
@@ -17509,7 +17509,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 703,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L703"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L703"
                     }
                   ],
                   "type": {
@@ -17560,7 +17560,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 706,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L706"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L706"
                     }
                   ],
                   "type": {
@@ -17581,7 +17581,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 711,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                     }
                   ],
                   "type": {
@@ -17614,7 +17614,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 713,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L713"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L713"
                             }
                           ],
                           "type": {
@@ -17634,7 +17634,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 711,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                         }
                       ]
                     }
@@ -17650,7 +17650,7 @@
                     "summary": [
                       {
                         "kind": "text",
-                        "text": "Ed25519 signature of the message."
+                        "text": "Ethereum curve (secp256k1) signature of the message."
                       }
                     ]
                   },
@@ -17659,7 +17659,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 709,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L709"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L709"
                     }
                   ],
                   "type": {
@@ -17679,7 +17679,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 702,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L702"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L702"
                 }
               ]
             }
@@ -17698,7 +17698,7 @@
           "fileName": "src/lib/types.ts",
           "line": 834,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
         }
       ],
       "type": {
@@ -17729,7 +17729,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 837,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L837"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L837"
                 }
               ],
               "type": {
@@ -17756,7 +17756,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 841,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L841"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L841"
                 }
               ],
               "type": {
@@ -17777,7 +17777,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 842,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L842"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L842"
                 }
               ],
               "type": {
@@ -17809,7 +17809,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 835,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L835"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L835"
                 }
               ],
               "type": {
@@ -17838,7 +17838,7 @@
               "fileName": "src/lib/types.ts",
               "line": 834,
               "character": 44,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
             }
           ]
         }
@@ -17855,7 +17855,7 @@
           "fileName": "src/lib/types.ts",
           "line": 820,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
         }
       ],
       "type": {
@@ -17886,7 +17886,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 823,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L823"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L823"
                 }
               ],
               "type": {
@@ -17907,7 +17907,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 824,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L824"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L824"
                 }
               ],
               "type": {
@@ -17948,7 +17948,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 821,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L821"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L821"
                 }
               ],
               "type": {
@@ -17977,7 +17977,7 @@
               "fileName": "src/lib/types.ts",
               "line": 820,
               "character": 46,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
             }
           ]
         }
@@ -17994,7 +17994,7 @@
           "fileName": "src/lib/types.ts",
           "line": 856,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L856"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L856"
         }
       ],
       "type": {
@@ -18042,7 +18042,7 @@
           "fileName": "src/lib/types.ts",
           "line": 879,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L879"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L879"
         }
       ],
       "type": {
@@ -18073,7 +18073,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 884,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L884"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L884"
                 }
               ],
               "type": {
@@ -18100,7 +18100,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 889,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L889"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L889"
                 }
               ],
               "type": {
@@ -18127,7 +18127,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 893,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L893"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L893"
                 }
               ],
               "type": {
@@ -18154,7 +18154,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 895,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L895"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L895"
                 }
               ],
               "type": {
@@ -18181,7 +18181,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 897,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L897"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L897"
                 }
               ],
               "type": {
@@ -18202,7 +18202,7 @@
               "fileName": "src/lib/types.ts",
               "line": 879,
               "character": 37,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L879"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L879"
             }
           ]
         }
@@ -18219,7 +18219,7 @@
           "fileName": "src/lib/types.ts",
           "line": 862,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L862"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L862"
         }
       ],
       "type": {
@@ -18245,7 +18245,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 864,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L864"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L864"
                     }
                   ],
                   "type": {
@@ -18268,7 +18268,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 865,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L865"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L865"
                             }
                           ],
                           "type": {
@@ -18288,7 +18288,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 866,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L866"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L866"
                             }
                           ],
                           "type": {
@@ -18309,7 +18309,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 864,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L864"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L864"
                         }
                       ]
                     }
@@ -18326,7 +18326,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 868,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L868"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L868"
                     }
                   ],
                   "type": {
@@ -18346,7 +18346,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 863,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L863"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L863"
                 }
               ]
             }
@@ -18371,7 +18371,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 871,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L871"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L871"
                     }
                   ],
                   "type": {
@@ -18394,7 +18394,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 872,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L872"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L872"
                             }
                           ],
                           "type": {
@@ -18413,7 +18413,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 873,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L873"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L873"
                             }
                           ],
                           "type": {
@@ -18433,7 +18433,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 871,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L871"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L871"
                         }
                       ]
                     }
@@ -18450,7 +18450,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 875,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L875"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L875"
                     }
                   ],
                   "type": {
@@ -18471,7 +18471,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 870,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L870"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L870"
                 }
               ]
             }
@@ -18490,7 +18490,7 @@
           "fileName": "src/lib/types.ts",
           "line": 900,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L900"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L900"
         }
       ],
       "type": {
@@ -18534,7 +18534,7 @@
           "fileName": "src/lib/types.ts",
           "line": 827,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
         }
       ],
       "type": {
@@ -18565,7 +18565,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 830,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L830"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L830"
                 }
               ],
               "type": {
@@ -18586,7 +18586,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 831,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L831"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L831"
                 }
               ],
               "type": {
@@ -18618,7 +18618,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 828,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L828"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L828"
                 }
               ],
               "type": {
@@ -18638,7 +18638,7 @@
               "fileName": "src/lib/types.ts",
               "line": 827,
               "character": 41,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
             }
           ]
         }
@@ -18655,7 +18655,7 @@
           "fileName": "src/lib/types.ts",
           "line": 813,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
         }
       ],
       "type": {
@@ -18678,7 +18678,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 815,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L815"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L815"
                 }
               ],
               "type": {
@@ -18699,7 +18699,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 817,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L817"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L817"
                 }
               ],
               "type": {
@@ -18740,7 +18740,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 816,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L816"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L816"
                 }
               ],
               "type": {
@@ -18759,7 +18759,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 814,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L814"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L814"
                 }
               ],
               "type": {
@@ -18779,7 +18779,7 @@
               "fileName": "src/lib/types.ts",
               "line": 813,
               "character": 39,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
             }
           ]
         }
@@ -18796,7 +18796,7 @@
           "fileName": "src/lib/types.ts",
           "line": 60,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L60"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L60"
         }
       ],
       "type": {
@@ -18821,7 +18821,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 70,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L70"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L70"
                 }
               ],
               "type": {
@@ -18842,7 +18842,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 88,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L88"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L88"
                 }
               ],
               "type": {
@@ -18865,7 +18865,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 88,
                           "character": 21,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L88"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L88"
                         }
                       ],
                       "signatures": [
@@ -18928,7 +18928,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 68,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L68"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L68"
                 }
               ],
               "type": {
@@ -18949,7 +18949,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 84,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L84"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L84"
                 }
               ],
               "type": {
@@ -18970,7 +18970,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 86,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L86"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L86"
                 }
               ],
               "type": {
@@ -19001,7 +19001,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 99,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L99"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L99"
                 }
               ],
               "type": {
@@ -19022,7 +19022,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 64,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L64"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L64"
                 }
               ],
               "type": {
@@ -19038,7 +19038,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 64,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L64"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L64"
                     }
                   ],
                   "indexSignature": {
@@ -19089,7 +19089,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 94,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L94"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L94"
                 }
               ],
               "type": {
@@ -19111,7 +19111,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 72,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L72"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L72"
                 }
               ],
               "type": {
@@ -19132,7 +19132,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 74,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L74"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L74"
                 }
               ],
               "type": {
@@ -19154,7 +19154,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 66,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L66"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L66"
                 }
               ],
               "type": {
@@ -19175,7 +19175,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 62,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L62"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L62"
                 }
               ],
               "type": {
@@ -19245,7 +19245,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 82,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L82"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L82"
                 }
               ],
               "type": {
@@ -19266,7 +19266,7 @@
               "fileName": "src/lib/types.ts",
               "line": 60,
               "character": 34,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L60"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L60"
             }
           ]
         }
@@ -19283,7 +19283,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1194,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1194"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1194"
         }
       ],
       "type": {
@@ -19306,7 +19306,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1194,
                   "character": 33,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1194"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1194"
                 }
               ],
               "type": {
@@ -19336,7 +19336,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1194,
               "character": 31,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1194"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1194"
             }
           ]
         }
@@ -19353,7 +19353,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1308,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1308"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1308"
         }
       ],
       "type": {
@@ -19376,7 +19376,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1309,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1309"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1309"
                 }
               ],
               "type": {
@@ -19408,7 +19408,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1310,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1310"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1310"
                 }
               ],
               "type": {
@@ -19427,7 +19427,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1311,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1311"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1311"
                 }
               ],
               "type": {
@@ -19447,7 +19447,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1308,
               "character": 24,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1308"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1308"
             }
           ]
         }
@@ -19464,7 +19464,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1325,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1325"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1325"
         }
       ],
       "type": {
@@ -19488,7 +19488,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1325,
                   "character": 42,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1325"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1325"
                 }
               ],
               "indexSignature": {
@@ -19530,7 +19530,7 @@
           "fileName": "src/lib/types.ts",
           "line": 58,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
         }
       ],
       "type": {
@@ -19546,7 +19546,7 @@
               "fileName": "src/lib/types.ts",
               "line": 58,
               "character": 23,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
             }
           ],
           "signatures": [
@@ -19656,7 +19656,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 58,
                           "character": 69,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                         }
                       ],
                       "signatures": [
@@ -19714,7 +19714,7 @@
           "fileName": "src/lib/types.ts",
           "line": 933,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
         }
       ],
       "type": {
@@ -19745,7 +19745,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 937,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L937"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L937"
                 }
               ],
               "type": {
@@ -19772,7 +19772,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 935,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L935"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L935"
                 }
               ],
               "type": {
@@ -19792,7 +19792,7 @@
               "fileName": "src/lib/types.ts",
               "line": 933,
               "character": 42,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
             }
           ]
         }
@@ -19809,7 +19809,7 @@
           "fileName": "src/lib/types.ts",
           "line": 926,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
         }
       ],
       "type": {
@@ -19842,7 +19842,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 930,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L930"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L930"
                 }
               ],
               "type": {
@@ -19878,7 +19878,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 928,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L928"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L928"
                 }
               ],
               "type": {
@@ -19898,7 +19898,7 @@
               "fileName": "src/lib/types.ts",
               "line": 926,
               "character": 33,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
             }
           ]
         }
@@ -19915,7 +19915,7 @@
           "fileName": "src/lib/types.ts",
           "line": 908,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L908"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L908"
         }
       ],
       "type": {
@@ -19945,7 +19945,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1242,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
         }
       ],
       "type": {
@@ -19976,7 +19976,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1244,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                 }
               ],
               "type": {
@@ -20005,7 +20005,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1246,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                 }
               ],
               "type": {
@@ -20032,7 +20032,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1248,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                 }
               ],
               "type": {
@@ -20052,7 +20052,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1242,
               "character": 35,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
             }
           ]
         }
@@ -20069,7 +20069,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1234,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
         }
       ],
       "type": {
@@ -20100,7 +20100,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1236,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                 }
               ],
               "type": {
@@ -20129,7 +20129,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1240,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                 }
               ],
               "type": {
@@ -20158,7 +20158,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1238,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                 }
               ],
               "type": {
@@ -20178,7 +20178,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1234,
               "character": 34,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
             }
           ]
         }
@@ -20195,7 +20195,7 @@
           "fileName": "src/lib/types.ts",
           "line": 910,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
         }
       ],
       "type": {
@@ -20226,7 +20226,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 912,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L912"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L912"
                 }
               ],
               "type": {
@@ -20246,7 +20246,7 @@
               "fileName": "src/lib/types.ts",
               "line": 910,
               "character": 32,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
             }
           ]
         }
@@ -20263,7 +20263,7 @@
           "fileName": "src/lib/types.ts",
           "line": 915,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
         }
       ],
       "type": {
@@ -20294,7 +20294,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 920,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L920"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L920"
                 }
               ],
               "type": {
@@ -20321,7 +20321,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 923,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L923"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L923"
                 }
               ],
               "type": {
@@ -20348,7 +20348,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 917,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L917"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L917"
                 }
               ],
               "type": {
@@ -20368,7 +20368,7 @@
               "fileName": "src/lib/types.ts",
               "line": 915,
               "character": 30,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
             }
           ]
         }
@@ -20385,7 +20385,7 @@
           "fileName": "src/lib/types.ts",
           "line": 766,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L766"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L766"
         }
       ],
       "type": {
@@ -20413,7 +20413,7 @@
           "fileName": "src/lib/types.ts",
           "line": 190,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L190"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L190"
         }
       ],
       "type": {
@@ -20439,7 +20439,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 192,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L192"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L192"
                     }
                   ],
                   "type": {
@@ -20462,7 +20462,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 193,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L193"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L193"
                             }
                           ],
                           "type": {
@@ -20482,7 +20482,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 194,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L194"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L194"
                             }
                           ],
                           "type": {
@@ -20502,7 +20502,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 192,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L192"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L192"
                         }
                       ]
                     }
@@ -20519,7 +20519,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 196,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L196"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L196"
                     }
                   ],
                   "type": {
@@ -20539,7 +20539,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 191,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L191"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L191"
                 }
               ]
             }
@@ -20564,7 +20564,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 199,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L199"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L199"
                     }
                   ],
                   "type": {
@@ -20587,7 +20587,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 200,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L200"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L200"
                             }
                           ],
                           "type": {
@@ -20607,7 +20607,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 201,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L201"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L201"
                             }
                           ],
                           "type": {
@@ -20627,7 +20627,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 199,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L199"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L199"
                         }
                       ]
                     }
@@ -20644,7 +20644,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 203,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L203"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L203"
                     }
                   ],
                   "type": {
@@ -20665,7 +20665,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 198,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L198"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L198"
                 }
               ]
             }
@@ -20684,7 +20684,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1213,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
         }
       ],
       "type": {
@@ -20717,7 +20717,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1215,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1215"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1215"
                 }
               ],
               "type": {
@@ -20746,7 +20746,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1217,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1217"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1217"
                 }
               ],
               "type": {
@@ -20766,7 +20766,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1213,
               "character": 25,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
             }
           ]
         }
@@ -20783,7 +20783,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1206,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1206"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1206"
         }
       ],
       "type": {
@@ -20806,7 +20806,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1209,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1209"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1209"
                 }
               ],
               "type": {
@@ -20825,7 +20825,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1208,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1208"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1208"
                 }
               ],
               "type": {
@@ -20853,7 +20853,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1210,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1210"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1210"
                 }
               ],
               "type": {
@@ -20873,7 +20873,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1206,
               "character": 25,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1206"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1206"
             }
           ],
           "indexSignature": {
@@ -20921,7 +20921,7 @@
           "fileName": "src/lib/types.ts",
           "line": 8,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L8"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L8"
         }
       ],
       "type": {
@@ -21029,7 +21029,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1314,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1314"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1314"
         }
       ],
       "type": {
@@ -21052,7 +21052,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1321,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1321"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1321"
                 }
               ],
               "type": {
@@ -21072,7 +21072,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1317,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1317"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1317"
                 }
               ],
               "type": {
@@ -21103,7 +21103,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1318,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1318"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1318"
                 }
               ],
               "type": {
@@ -21122,7 +21122,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1319,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1319"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1319"
                 }
               ],
               "type": {
@@ -21141,7 +21141,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1315,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1315"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1315"
                 }
               ],
               "type": {
@@ -21160,7 +21160,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1320,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1320"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1320"
                 }
               ],
               "type": {
@@ -21179,7 +21179,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1322,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1322"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1322"
                 }
               ],
               "type": {
@@ -21198,7 +21198,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1316,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1316"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1316"
                 }
               ],
               "type": {
@@ -21218,7 +21218,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1314,
               "character": 29,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1314"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1314"
             }
           ]
         }
@@ -21235,7 +21235,7 @@
           "fileName": "src/lib/types.ts",
           "line": 769,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L769"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L769"
         }
       ],
       "type": {
@@ -21261,7 +21261,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 772,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L772"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L772"
                     }
                   ],
                   "type": {
@@ -21282,7 +21282,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 773,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L773"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L773"
                     }
                   ],
                   "type": {
@@ -21315,7 +21315,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 777,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L777"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L777"
                             }
                           ],
                           "type": {
@@ -21344,7 +21344,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 775,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L775"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L775"
                             }
                           ],
                           "type": {
@@ -21364,7 +21364,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 773,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L773"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L773"
                         }
                       ]
                     }
@@ -21381,7 +21381,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 771,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L771"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L771"
                     }
                   ],
                   "type": {
@@ -21423,7 +21423,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 770,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L770"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L770"
                 }
               ]
             }
@@ -21450,7 +21450,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 783,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L783"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L783"
                     }
                   ],
                   "type": {
@@ -21483,7 +21483,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 785,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L785"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L785"
                             }
                           ],
                           "type": {
@@ -21503,7 +21503,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 783,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L783"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L783"
                         }
                       ]
                     }
@@ -21520,7 +21520,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 782,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L782"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L782"
                     }
                   ],
                   "type": {
@@ -21539,7 +21539,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 781,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L781"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L781"
                     }
                   ],
                   "type": {
@@ -21581,7 +21581,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 780,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L780"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L780"
                 }
               ]
             }
@@ -21600,7 +21600,7 @@
           "fileName": "src/lib/types.ts",
           "line": 206,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L206"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L206"
         }
       ],
       "type": {
@@ -21626,7 +21626,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 208,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L208"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L208"
                     }
                   ],
                   "type": {
@@ -21665,7 +21665,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 216,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L216"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L216"
                             }
                           ],
                           "type": {
@@ -21685,7 +21685,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 208,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L208"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L208"
                         }
                       ]
                     }
@@ -21702,7 +21702,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 218,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L218"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L218"
                     }
                   ],
                   "type": {
@@ -21722,7 +21722,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 207,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L207"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L207"
                 }
               ]
             }
@@ -21747,7 +21747,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 221,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L221"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L221"
                     }
                   ],
                   "type": {
@@ -21766,7 +21766,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 222,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L222"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L222"
                     }
                   ],
                   "type": {
@@ -21787,7 +21787,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 220,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L220"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L220"
                 }
               ]
             }
@@ -21806,7 +21806,7 @@
           "fileName": "src/lib/types.ts",
           "line": 490,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L490"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L490"
         }
       ],
       "type": {
@@ -21831,7 +21831,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 491,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L491"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L491"
                 }
               ],
               "type": {
@@ -21864,7 +21864,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 499,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L499"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L499"
                         }
                       ],
                       "type": {
@@ -21909,7 +21909,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 497,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L497"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L497"
                         }
                       ],
                       "type": {
@@ -21929,7 +21929,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 491,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L491"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L491"
                     }
                   ]
                 }
@@ -21947,7 +21947,7 @@
               "fileName": "src/lib/types.ts",
               "line": 490,
               "character": 43,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L490"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L490"
             }
           ]
         }
@@ -21964,7 +21964,7 @@
           "fileName": "src/lib/types.ts",
           "line": 617,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L617"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L617"
         }
       ],
       "type": {
@@ -22005,7 +22005,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 623,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L623"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L623"
                 }
               ],
               "type": {
@@ -22042,7 +22042,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 625,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L625"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L625"
                 }
               ],
               "type": {
@@ -22063,7 +22063,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 626,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L626"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L626"
                 }
               ],
               "type": {
@@ -22096,7 +22096,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 628,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L628"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L628"
                         }
                       ],
                       "type": {
@@ -22116,7 +22116,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 626,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L626"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L626"
                     }
                   ]
                 }
@@ -22197,7 +22197,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 619,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L619"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L619"
                 }
               ],
               "type": {
@@ -22243,7 +22243,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 619,
                               "character": 76,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L619"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L619"
                             }
                           ]
                         }
@@ -22304,7 +22304,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 621,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L621"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L621"
                 }
               ],
               "type": {
@@ -22324,7 +22324,7 @@
               "fileName": "src/lib/types.ts",
               "line": 617,
               "character": 43,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L617"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L617"
             }
           ]
         }
@@ -22341,7 +22341,7 @@
           "fileName": "src/lib/types.ts",
           "line": 602,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
         }
       ],
       "type": {
@@ -22366,7 +22366,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 605,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                 }
               ],
               "type": {
@@ -22399,7 +22399,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 611,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                         }
                       ],
                       "type": {
@@ -22415,7 +22415,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 611,
                               "character": 18,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                             }
                           ],
                           "indexSignature": {
@@ -22465,7 +22465,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 607,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L607"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L607"
                         }
                       ],
                       "type": {
@@ -22494,7 +22494,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 609,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L609"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L609"
                         }
                       ],
                       "type": {
@@ -22523,7 +22523,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 613,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L613"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L613"
                         }
                       ],
                       "type": {
@@ -22543,7 +22543,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 605,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                     }
                   ]
                 }
@@ -22568,7 +22568,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 604,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L604"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L604"
                 }
               ],
               "type": {
@@ -22589,7 +22589,7 @@
               "fileName": "src/lib/types.ts",
               "line": 602,
               "character": 41,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
             }
           ]
         }
@@ -22606,7 +22606,7 @@
           "fileName": "src/lib/types.ts",
           "line": 541,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L541"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L541"
         }
       ],
       "type": {
@@ -22640,7 +22640,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 544,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L544"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L544"
                     }
                   ],
                   "type": {
@@ -22661,7 +22661,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 547,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L547"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L547"
                     }
                   ],
                   "type": {
@@ -22694,7 +22694,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 549,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L549"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L549"
                             }
                           ],
                           "type": {
@@ -22714,7 +22714,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 547,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L547"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L547"
                         }
                       ]
                     }
@@ -22739,7 +22739,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 546,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L546"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L546"
                     }
                   ],
                   "type": {
@@ -22759,7 +22759,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 542,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L542"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L542"
                 }
               ]
             }
@@ -22786,7 +22786,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 557,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L557"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L557"
                     }
                   ],
                   "type": {
@@ -22819,7 +22819,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 559,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L559"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L559"
                             }
                           ],
                           "type": {
@@ -22839,7 +22839,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 557,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L557"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L557"
                         }
                       ]
                     }
@@ -22864,7 +22864,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 556,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L556"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L556"
                     }
                   ],
                   "type": {
@@ -22891,7 +22891,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 554,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L554"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L554"
                     }
                   ],
                   "type": {
@@ -22911,7 +22911,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 552,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L552"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L552"
                 }
               ]
             }
@@ -22930,7 +22930,7 @@
           "fileName": "src/lib/types.ts",
           "line": 563,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L563"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L563"
         }
       ],
       "type": {
@@ -22964,7 +22964,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 566,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L566"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L566"
                     }
                   ],
                   "type": {
@@ -22985,7 +22985,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 567,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L567"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L567"
                     }
                   ],
                   "type": {
@@ -23018,7 +23018,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 579,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L579"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L579"
                             }
                           ],
                           "type": {
@@ -23063,7 +23063,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 577,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L577"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L577"
                             }
                           ],
                           "type": {
@@ -23092,7 +23092,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 569,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L569"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L569"
                             }
                           ],
                           "type": {
@@ -23121,7 +23121,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 571,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L571"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L571"
                             }
                           ],
                           "type": {
@@ -23141,7 +23141,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 567,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L567"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L567"
                         }
                       ]
                     }
@@ -23159,7 +23159,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 564,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L564"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L564"
                 }
               ]
             }
@@ -23186,7 +23186,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 585,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L585"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L585"
                     }
                   ],
                   "type": {
@@ -23219,7 +23219,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 595,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L595"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L595"
                             }
                           ],
                           "type": {
@@ -23248,7 +23248,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 597,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L597"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L597"
                             }
                           ],
                           "type": {
@@ -23302,7 +23302,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 593,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L593"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L593"
                             }
                           ],
                           "type": {
@@ -23331,7 +23331,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 587,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L587"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L587"
                             }
                           ],
                           "type": {
@@ -23351,7 +23351,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 585,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L585"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L585"
                         }
                       ]
                     }
@@ -23376,7 +23376,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 584,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L584"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L584"
                     }
                   ],
                   "type": {
@@ -23396,7 +23396,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 582,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L582"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L582"
                 }
               ]
             }
@@ -23415,7 +23415,7 @@
           "fileName": "src/lib/types.ts",
           "line": 789,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L789"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L789"
         }
       ],
       "type": {
@@ -23443,7 +23443,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 794,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L794"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L794"
                     }
                   ],
                   "type": {
@@ -23476,7 +23476,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 798,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L798"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L798"
                             }
                           ],
                           "type": {
@@ -23505,7 +23505,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 796,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L796"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L796"
                             }
                           ],
                           "type": {
@@ -23525,7 +23525,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 794,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L794"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L794"
                         }
                       ]
                     }
@@ -23550,7 +23550,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 792,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L792"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L792"
                     }
                   ],
                   "type": {
@@ -23570,7 +23570,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 790,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L790"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L790"
                 }
               ]
             }
@@ -23603,7 +23603,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 803,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L803"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L803"
                     }
                   ],
                   "type": {
@@ -23624,7 +23624,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 805,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L805"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L805"
                     }
                   ],
                   "type": {
@@ -23657,7 +23657,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 809,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L809"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L809"
                             }
                           ],
                           "type": {
@@ -23686,7 +23686,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 807,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L807"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L807"
                             }
                           ],
                           "type": {
@@ -23706,7 +23706,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 805,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L805"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L805"
                         }
                       ]
                     }
@@ -23724,7 +23724,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 801,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L801"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L801"
                 }
               ]
             }
@@ -23743,7 +23743,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1220,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1220"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1220"
         }
       ],
       "type": {
@@ -23776,7 +23776,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1231,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1231"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1231"
                 }
               ],
               "type": {
@@ -23809,7 +23809,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1220,
               "character": 22,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1220"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1220"
             }
           ]
         }
@@ -23826,7 +23826,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1338,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1338"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1338"
         }
       ],
       "type": {
@@ -23856,7 +23856,7 @@
           "fileName": "src/lib/types.ts",
           "line": 503,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L503"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L503"
         }
       ],
       "type": {
@@ -23890,7 +23890,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 506,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L506"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L506"
                     }
                   ],
                   "type": {
@@ -23911,7 +23911,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 509,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L509"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L509"
                     }
                   ],
                   "type": {
@@ -23944,7 +23944,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 519,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L519"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L519"
                             }
                           ],
                           "type": {
@@ -23989,7 +23989,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 517,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L517"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L517"
                             }
                           ],
                           "type": {
@@ -24018,7 +24018,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 511,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L511"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L511"
                             }
                           ],
                           "type": {
@@ -24038,7 +24038,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 509,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L509"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L509"
                         }
                       ]
                     }
@@ -24063,7 +24063,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 508,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L508"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L508"
                     }
                   ],
                   "type": {
@@ -24083,7 +24083,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 504,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L504"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L504"
                 }
               ]
             }
@@ -24110,7 +24110,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 527,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L527"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L527"
                     }
                   ],
                   "type": {
@@ -24143,7 +24143,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 535,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L535"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L535"
                             }
                           ],
                           "type": {
@@ -24172,7 +24172,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 537,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L537"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L537"
                             }
                           ],
                           "type": {
@@ -24226,7 +24226,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 533,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L533"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L533"
                             }
                           ],
                           "type": {
@@ -24246,7 +24246,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 527,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L527"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L527"
                         }
                       ]
                     }
@@ -24271,7 +24271,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 526,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L526"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L526"
                     }
                   ],
                   "type": {
@@ -24298,7 +24298,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 524,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L524"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L524"
                     }
                   ],
                   "type": {
@@ -24318,7 +24318,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 522,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L522"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L522"
                 }
               ]
             }
@@ -24337,7 +24337,7 @@
           "fileName": "src/lib/types.ts",
           "line": 632,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L632"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L632"
         }
       ],
       "type": {
@@ -24362,7 +24362,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 634,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L634"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L634"
                 }
               ],
               "type": {
@@ -24388,7 +24388,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 635,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L635"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L635"
                             }
                           ],
                           "type": {
@@ -24404,7 +24404,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 635,
                                   "character": 14,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L635"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L635"
                                 }
                               ],
                               "signatures": [
@@ -24435,7 +24435,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 634,
                           "character": 14,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L634"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L634"
                         }
                       ]
                     }
@@ -24460,7 +24460,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 633,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L633"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L633"
                 }
               ],
               "type": {
@@ -24476,7 +24476,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 633,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L633"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L633"
                     }
                   ],
                   "signatures": [
@@ -24546,7 +24546,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 638,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L638"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L638"
                 }
               ],
               "type": {
@@ -24562,7 +24562,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 638,
                       "character": 16,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L638"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L638"
                     }
                   ],
                   "signatures": [
@@ -24649,7 +24649,7 @@
               "fileName": "src/lib/types.ts",
               "line": 632,
               "character": 27,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L632"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L632"
             }
           ]
         }
@@ -24666,7 +24666,7 @@
           "fileName": "src/lib/types.ts",
           "line": 641,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L641"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L641"
         }
       ],
       "type": {
@@ -24692,7 +24692,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 643,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L643"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L643"
                     }
                   ],
                   "type": {
@@ -24713,7 +24713,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 651,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                     }
                   ],
                   "type": {
@@ -24746,7 +24746,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 656,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L656"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L656"
                             }
                           ],
                           "type": {
@@ -24767,7 +24767,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 658,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L658"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L658"
                             }
                           ],
                           "type": {
@@ -24837,7 +24837,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 653,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L653"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L653"
                             }
                           ],
                           "type": {
@@ -24857,7 +24857,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 651,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                         }
                       ]
                     }
@@ -24884,7 +24884,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 649,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L649"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L649"
                     }
                   ],
                   "type": {
@@ -24921,7 +24921,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 646,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L646"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L646"
                     }
                   ],
                   "type": {
@@ -24942,7 +24942,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 642,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L642"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L642"
                 }
               ]
             }
@@ -24967,7 +24967,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 664,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L664"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L664"
                     }
                   ],
                   "type": {
@@ -25018,7 +25018,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 667,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L667"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L667"
                     }
                   ],
                   "type": {
@@ -25039,7 +25039,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 672,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                     }
                   ],
                   "type": {
@@ -25072,7 +25072,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 674,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L674"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L674"
                             }
                           ],
                           "type": {
@@ -25092,7 +25092,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 672,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                         }
                       ]
                     }
@@ -25117,7 +25117,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 670,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L670"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L670"
                     }
                   ],
                   "type": {
@@ -25139,7 +25139,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 663,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L663"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L663"
                 }
               ]
             }
@@ -25158,7 +25158,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1181,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1181"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1181"
         }
       ],
       "type": {
@@ -25239,7 +25239,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1191,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1191"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1191"
                     }
                   ],
                   "type": {
@@ -25259,7 +25259,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1183,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1183"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1183"
                 }
               ]
             }
@@ -25278,7 +25278,7 @@
           "fileName": "src/lib/types.ts",
           "line": 225,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L225"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L225"
         }
       ],
       "type": {
@@ -25304,7 +25304,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 227,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L227"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L227"
                     }
                   ],
                   "type": {
@@ -25327,7 +25327,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 228,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L228"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L228"
                             }
                           ],
                           "type": {
@@ -25348,7 +25348,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 227,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L227"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L227"
                         }
                       ]
                     }
@@ -25365,7 +25365,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 230,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L230"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L230"
                     }
                   ],
                   "type": {
@@ -25385,7 +25385,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 226,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L226"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L226"
                 }
               ]
             }
@@ -25410,7 +25410,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 233,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L233"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L233"
                     }
                   ],
                   "type": {
@@ -25433,7 +25433,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 234,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L234"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L234"
                             }
                           ],
                           "type": {
@@ -25453,7 +25453,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 233,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L233"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L233"
                         }
                       ]
                     }
@@ -25470,7 +25470,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 236,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L236"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L236"
                     }
                   ],
                   "type": {
@@ -25491,7 +25491,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 232,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L232"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L232"
                 }
               ]
             }
@@ -25510,7 +25510,7 @@
           "fileName": "src/lib/types.ts",
           "line": 719,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L719"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L719"
         }
       ],
       "type": {
@@ -25545,7 +25545,7 @@
           "fileName": "src/lib/types.ts",
           "line": 103,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L103"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L103"
         }
       ],
       "type": {
@@ -25568,7 +25568,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 105,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L105"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L105"
                 }
               ],
               "type": {
@@ -25587,7 +25587,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 104,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L104"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L104"
                 }
               ],
               "type": {
@@ -25611,7 +25611,7 @@
               "fileName": "src/lib/types.ts",
               "line": 103,
               "character": 27,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L103"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L103"
             }
           ]
         }
@@ -25628,7 +25628,7 @@
           "fileName": "src/lib/types.ts",
           "line": 102,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L102"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L102"
         }
       ],
       "type": {
@@ -25666,7 +25666,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 102,
                       "character": 80,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L102"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L102"
                     }
                   ]
                 }
@@ -25687,7 +25687,7 @@
           "fileName": "src/lib/types.ts",
           "line": 717,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L717"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L717"
         }
       ],
       "type": {
@@ -25719,7 +25719,7 @@
           "fileName": "src/AuthAdminApi.ts",
           "line": 3,
           "character": 6,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/AuthAdminApi.ts#L3"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/AuthAdminApi.ts#L3"
         }
       ],
       "type": {
@@ -25745,7 +25745,7 @@
           "fileName": "src/AuthClient.ts",
           "line": 3,
           "character": 6,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/AuthClient.ts#L3"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/AuthClient.ts#L3"
         }
       ],
       "type": {
@@ -25771,7 +25771,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1337,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1337"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1337"
         }
       ],
       "type": {
@@ -25814,7 +25814,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 6,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L6"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L6"
         }
       ],
       "type": {
@@ -25841,7 +25841,7 @@
                   "fileName": "src/lib/locks.ts",
                   "line": 10,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L10"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L10"
                 }
               ],
               "type": {
@@ -25862,7 +25862,7 @@
               "fileName": "src/lib/locks.ts",
               "line": 6,
               "character": 25,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L6"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L6"
             }
           ]
         }
@@ -25880,7 +25880,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 41,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L41"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L41"
         }
       ],
       "signatures": [
@@ -25927,7 +25927,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 26,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L26"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L26"
         }
       ],
       "signatures": [
@@ -25974,7 +25974,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 105,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L105"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L105"
         }
       ],
       "signatures": [
@@ -26021,7 +26021,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 135,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L135"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L135"
         }
       ],
       "signatures": [
@@ -26068,7 +26068,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 72,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L72"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L72"
         }
       ],
       "signatures": [
@@ -26115,7 +26115,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 157,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L157"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L157"
         }
       ],
       "signatures": [
@@ -26162,7 +26162,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 59,
           "character": 22,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L59"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L59"
         }
       ],
       "signatures": [
@@ -26305,7 +26305,7 @@
                       "fileName": "src/lib/locks.ts",
                       "line": 62,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L62"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L62"
                     }
                   ],
                   "signatures": [
@@ -26361,7 +26361,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 171,
           "character": 22,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L171"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L171"
         }
       ],
       "signatures": [
@@ -26472,7 +26472,7 @@
                       "fileName": "src/lib/locks.ts",
                       "line": 174,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L174"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L174"
                     }
                   ],
                   "signatures": [
@@ -26555,7 +26555,7 @@
       "fileName": "src/index.ts",
       "line": 1,
       "character": 0,
-      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/index.ts#L1"
+      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/index.ts#L1"
     }
   ]
 }

--- a/apps/docs/spec/enrichments/tsdoc_v2/gotrue_dereferenced.json
+++ b/apps/docs/spec/enrichments/tsdoc_v2/gotrue_dereferenced.json
@@ -24,7 +24,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 33,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L33"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L33"
             }
           ],
           "signatures": [
@@ -125,7 +125,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -185,7 +185,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 31,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L31"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L31"
             }
           ],
           "type": {
@@ -214,7 +214,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 30,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L30"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L30"
         }
       ],
       "extendedTypes": [
@@ -243,7 +243,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 18,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L18"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L18"
             }
           ],
           "signatures": [
@@ -337,7 +337,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -392,7 +392,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 14,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L14"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L14"
             }
           ],
           "type": {
@@ -425,7 +425,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 4,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L4"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L4"
         }
       ],
       "extendedTypes": [
@@ -472,7 +472,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 90,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
             }
           ],
           "signatures": [
@@ -527,7 +527,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 90,
                                   "character": 57,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
                                 }
                               ],
                               "type": {
@@ -546,7 +546,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 90,
                                   "character": 42,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
                                 }
                               ],
                               "type": {
@@ -566,7 +566,7 @@
                               "fileName": "src/lib/errors.ts",
                               "line": 90,
                               "character": 40,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L90"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L90"
                             }
                           ]
                         }
@@ -623,7 +623,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -675,7 +675,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 89,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
             }
           ],
           "type": {
@@ -705,7 +705,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 89,
                           "character": 28,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                         }
                       ],
                       "type": {
@@ -724,7 +724,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 89,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                         }
                       ],
                       "type": {
@@ -744,7 +744,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 89,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                     }
                   ]
                 }
@@ -764,7 +764,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -796,7 +796,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -820,7 +820,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 95,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L95"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L95"
             }
           ],
           "signatures": [
@@ -850,7 +850,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 100,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L100"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L100"
                         }
                       ],
                       "type": {
@@ -880,7 +880,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 89,
                                       "character": 28,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                                     }
                                   ],
                                   "type": {
@@ -899,7 +899,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 89,
                                       "character": 13,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                                     }
                                   ],
                                   "type": {
@@ -919,7 +919,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 89,
                                   "character": 11,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L89"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L89"
                                 }
                               ]
                             }
@@ -939,7 +939,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 98,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L98"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L98"
                         }
                       ],
                       "type": {
@@ -959,7 +959,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 97,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L97"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L97"
                         }
                       ],
                       "type": {
@@ -979,7 +979,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 99,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L99"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L99"
                         }
                       ],
                       "type": {
@@ -1000,7 +1000,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 96,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L96"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L96"
                     }
                   ]
                 }
@@ -1028,7 +1028,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 88,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L88"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L88"
         }
       ],
       "extendedTypes": [
@@ -1057,7 +1057,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 83,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L83"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L83"
             }
           ],
           "signatures": [
@@ -1127,7 +1127,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1179,7 +1179,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -1211,7 +1211,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -1240,7 +1240,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 82,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L82"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L82"
         }
       ],
       "extendedTypes": [
@@ -1269,7 +1269,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 162,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L162"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L162"
             }
           ],
           "signatures": [
@@ -1339,7 +1339,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1391,7 +1391,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -1423,7 +1423,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -1452,7 +1452,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 161,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L161"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L161"
         }
       ],
       "extendedTypes": [
@@ -1481,7 +1481,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 77,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L77"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L77"
             }
           ],
           "signatures": [
@@ -1538,7 +1538,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1590,7 +1590,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -1622,7 +1622,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -1651,7 +1651,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 76,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L76"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L76"
         }
       ],
       "extendedTypes": [
@@ -1680,7 +1680,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 114,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
             }
           ],
           "signatures": [
@@ -1735,7 +1735,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 114,
                                   "character": 57,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
                                 }
                               ],
                               "type": {
@@ -1754,7 +1754,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 114,
                                   "character": 42,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
                                 }
                               ],
                               "type": {
@@ -1774,7 +1774,7 @@
                               "fileName": "src/lib/errors.ts",
                               "line": 114,
                               "character": 40,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L114"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L114"
                             }
                           ]
                         }
@@ -1831,7 +1831,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -1883,7 +1883,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 112,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
             }
           ],
           "type": {
@@ -1913,7 +1913,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 112,
                           "character": 28,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                         }
                       ],
                       "type": {
@@ -1932,7 +1932,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 112,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                         }
                       ],
                       "type": {
@@ -1952,7 +1952,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 112,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                     }
                   ]
                 }
@@ -1972,7 +1972,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -2004,7 +2004,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -2028,7 +2028,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 119,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L119"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L119"
             }
           ],
           "signatures": [
@@ -2058,7 +2058,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 124,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L124"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L124"
                         }
                       ],
                       "type": {
@@ -2088,7 +2088,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 112,
                                       "character": 28,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                                     }
                                   ],
                                   "type": {
@@ -2107,7 +2107,7 @@
                                       "fileName": "src/lib/errors.ts",
                                       "line": 112,
                                       "character": 13,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                                     }
                                   ],
                                   "type": {
@@ -2127,7 +2127,7 @@
                                   "fileName": "src/lib/errors.ts",
                                   "line": 112,
                                   "character": 11,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L112"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L112"
                                 }
                               ]
                             }
@@ -2147,7 +2147,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 122,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L122"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L122"
                         }
                       ],
                       "type": {
@@ -2167,7 +2167,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 121,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L121"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L121"
                         }
                       ],
                       "type": {
@@ -2187,7 +2187,7 @@
                           "fileName": "src/lib/errors.ts",
                           "line": 123,
                           "character": 6,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L123"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L123"
                         }
                       ],
                       "type": {
@@ -2208,7 +2208,7 @@
                       "fileName": "src/lib/errors.ts",
                       "line": 120,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L120"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L120"
                     }
                   ]
                 }
@@ -2236,7 +2236,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 111,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L111"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L111"
         }
       ],
       "extendedTypes": [
@@ -2265,7 +2265,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 130,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L130"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L130"
             }
           ],
           "signatures": [
@@ -2346,7 +2346,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -2398,7 +2398,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -2430,7 +2430,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -2459,7 +2459,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 129,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L129"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L129"
         }
       ],
       "extendedTypes": [
@@ -2488,7 +2488,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 67,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L67"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L67"
             }
           ],
           "signatures": [
@@ -2545,7 +2545,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -2597,7 +2597,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -2629,7 +2629,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -2658,7 +2658,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 66,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L66"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L66"
         }
       ],
       "extendedTypes": [
@@ -2687,7 +2687,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 48,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L48"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L48"
             }
           ],
           "signatures": [
@@ -2768,7 +2768,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -2820,7 +2820,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 46,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L46"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L46"
             }
           ],
           "type": {
@@ -2847,7 +2847,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 14,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L14"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L14"
             }
           ],
           "type": {
@@ -2885,7 +2885,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 45,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L45"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L45"
         }
       ],
       "extendedTypes": [
@@ -2922,7 +2922,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 150,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L150"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L150"
             }
           ],
           "signatures": [
@@ -3017,7 +3017,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -3069,7 +3069,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -3101,7 +3101,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 148,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L148"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L148"
             }
           ],
           "type": {
@@ -3132,7 +3132,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -3161,7 +3161,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 144,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L144"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L144"
         }
       ],
       "extendedTypes": [
@@ -3190,7 +3190,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 59,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L59"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L59"
             }
           ],
           "signatures": [
@@ -3302,7 +3302,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 11,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L11"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L11"
             }
           ],
           "type": {
@@ -3354,7 +3354,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 56,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L56"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L56"
             }
           ],
           "type": {
@@ -3385,7 +3385,7 @@
               "fileName": "src/lib/errors.ts",
               "line": 57,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L57"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L57"
             }
           ],
           "type": {
@@ -3414,7 +3414,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 55,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L55"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L55"
         }
       ],
       "extendedTypes": [
@@ -3485,7 +3485,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 37,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L37"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L37"
             }
           ],
           "signatures": [
@@ -3524,7 +3524,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 46,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L46"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L46"
                             }
                           ],
                           "type": {
@@ -3622,7 +3622,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 43,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L43"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L43"
                             }
                           ],
                           "type": {
@@ -3638,7 +3638,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 43,
                                   "character": 14,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L43"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L43"
                                 }
                               ],
                               "indexSignature": {
@@ -3678,7 +3678,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 42,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L42"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L42"
                             }
                           ],
                           "type": {
@@ -3698,7 +3698,7 @@
                           "fileName": "src/GoTrueAdminApi.ts",
                           "line": 41,
                           "character": 5,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L41"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L41"
                         }
                       ]
                     }
@@ -3732,7 +3732,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 29,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L29"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L29"
             }
           ],
           "type": {
@@ -3771,7 +3771,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1169,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1169"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1169"
                     }
                   ],
                   "signatures": [
@@ -3837,7 +3837,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1120,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
                                 }
                               ],
                               "type": {
@@ -3868,7 +3868,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1122,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1122"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1122"
                                         }
                                       ],
                                       "type": {
@@ -3895,7 +3895,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1125,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1125"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1125"
                                         }
                                       ],
                                       "type": {
@@ -3915,7 +3915,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1120,
                                       "character": 45,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
                                     }
                                   ]
                                 }
@@ -3951,7 +3951,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1159,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1159"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1159"
                     }
                   ],
                   "signatures": [
@@ -4000,7 +4000,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1144,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
                                 }
                               ],
                               "type": {
@@ -4031,7 +4031,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1146,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1146"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1146"
                                         }
                                       ],
                                       "type": {
@@ -4051,7 +4051,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1144,
                                       "character": 44,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
                                     }
                                   ]
                                 }
@@ -4088,7 +4088,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1154,
                   "character": 17,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1154"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1154"
                 }
               ]
             }
@@ -4105,7 +4105,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 160,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L160"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L160"
             }
           ],
           "signatures": [
@@ -4186,7 +4186,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 421,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L421"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L421"
                             }
                           ],
                           "type": {
@@ -4215,7 +4215,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 447,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L447"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L447"
                             }
                           ],
                           "type": {
@@ -4244,7 +4244,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 372,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
                             }
                           ],
                           "type": {
@@ -4277,7 +4277,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 428,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L428"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L428"
                             }
                           ],
                           "type": {
@@ -4322,7 +4322,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 472,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L472"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L472"
                             }
                           ],
                           "type": {
@@ -4351,7 +4351,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 389,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
                             }
                           ],
                           "type": {
@@ -4384,7 +4384,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 382,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
                             }
                           ],
                           "type": {
@@ -4425,7 +4425,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 465,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L465"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L465"
                             }
                           ],
                           "type": {
@@ -4454,7 +4454,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 377,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
                             }
                           ],
                           "type": {
@@ -4487,7 +4487,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 435,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L435"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L435"
                             }
                           ],
                           "type": {
@@ -4548,7 +4548,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 456,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L456"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L456"
                             }
                           ],
                           "type": {
@@ -4593,7 +4593,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 411,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L411"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L411"
                             }
                           ],
                           "type": {
@@ -4613,7 +4613,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 400,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L400"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L400"
                         }
                       ],
                       "extendedTypes": [
@@ -4666,7 +4666,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 280,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L280"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L280"
             }
           ],
           "signatures": [
@@ -4768,7 +4768,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 126,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L126"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L126"
             }
           ],
           "signatures": [
@@ -4808,7 +4808,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 856,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L856"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L856"
                         }
                       ],
                       "type": {
@@ -4825,7 +4825,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 813,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
                               }
                             ],
                             "type": {
@@ -4848,7 +4848,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 815,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L815"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L815"
                                       }
                                     ],
                                     "type": {
@@ -4869,7 +4869,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 817,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L817"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L817"
                                       }
                                     ],
                                     "type": {
@@ -4910,7 +4910,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 816,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L816"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L816"
                                       }
                                     ],
                                     "type": {
@@ -4929,7 +4929,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 814,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L814"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L814"
                                       }
                                     ],
                                     "type": {
@@ -4949,7 +4949,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 813,
                                     "character": 39,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
                                   }
                                 ]
                               }
@@ -4966,7 +4966,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 820,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
                               }
                             ],
                             "type": {
@@ -4997,7 +4997,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 823,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L823"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L823"
                                       }
                                     ],
                                     "type": {
@@ -5018,7 +5018,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 824,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L824"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L824"
                                       }
                                     ],
                                     "type": {
@@ -5059,7 +5059,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 821,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L821"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L821"
                                       }
                                     ],
                                     "type": {
@@ -5088,7 +5088,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 820,
                                     "character": 46,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
                                   }
                                 ]
                               }
@@ -5105,7 +5105,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 827,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
                               }
                             ],
                             "type": {
@@ -5136,7 +5136,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 830,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L830"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L830"
                                       }
                                     ],
                                     "type": {
@@ -5157,7 +5157,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 831,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L831"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L831"
                                       }
                                     ],
                                     "type": {
@@ -5189,7 +5189,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 828,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L828"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L828"
                                       }
                                     ],
                                     "type": {
@@ -5209,7 +5209,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 827,
                                     "character": 41,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
                                   }
                                 ]
                               }
@@ -5226,7 +5226,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 834,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
                               }
                             ],
                             "type": {
@@ -5257,7 +5257,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 837,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L837"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L837"
                                       }
                                     ],
                                     "type": {
@@ -5284,7 +5284,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 841,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L841"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L841"
                                       }
                                     ],
                                     "type": {
@@ -5305,7 +5305,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 842,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L842"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L842"
                                       }
                                     ],
                                     "type": {
@@ -5337,7 +5337,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 835,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L835"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L835"
                                       }
                                     ],
                                     "type": {
@@ -5366,7 +5366,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 834,
                                     "character": 44,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
                                   }
                                 ]
                               }
@@ -5405,7 +5405,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 229,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L229"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L229"
             }
           ],
           "signatures": [
@@ -5479,7 +5479,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 93,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L93"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L93"
             }
           ],
           "signatures": [
@@ -5569,7 +5569,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 97,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L97"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L97"
                             }
                           ],
                           "type": {
@@ -5598,7 +5598,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 100,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L100"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L100"
                             }
                           ],
                           "type": {
@@ -5618,7 +5618,7 @@
                           "fileName": "src/GoTrueAdminApi.ts",
                           "line": 95,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L95"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L95"
                         }
                       ]
                     }
@@ -5653,7 +5653,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 182,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L182"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L182"
             }
           ],
           "signatures": [
@@ -5727,7 +5727,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1213,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
                         }
                       ],
                       "type": {
@@ -5760,7 +5760,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1215,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1215"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1215"
                                 }
                               ],
                               "type": {
@@ -5789,7 +5789,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1217,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1217"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1217"
                                 }
                               ],
                               "type": {
@@ -5809,7 +5809,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1213,
                               "character": 25,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
                             }
                           ]
                         }
@@ -5844,7 +5844,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 185,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                 }
                               ],
                               "type": {
@@ -5870,7 +5870,7 @@
                                               "fileName": "src/GoTrueAdminApi.ts",
                                               "line": 185,
                                               "character": 31,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                             }
                                           ],
                                           "type": {
@@ -5889,7 +5889,7 @@
                                               "fileName": "src/GoTrueAdminApi.ts",
                                               "line": 185,
                                               "character": 16,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                             }
                                           ],
                                           "type": {
@@ -5913,7 +5913,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 185,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                         }
                                       ]
                                     }
@@ -5937,7 +5937,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 185,
                                   "character": 59,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                 }
                               ],
                               "type": {
@@ -5957,7 +5957,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 185,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                             }
                           ]
                         }
@@ -5982,7 +5982,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 186,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                 }
                               ],
                               "type": {
@@ -6005,7 +6005,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 186,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                         }
                                       ],
                                       "type": {
@@ -6024,7 +6024,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 186,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                     }
                                   ]
                                 }
@@ -6041,7 +6041,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 186,
                                   "character": 29,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                 }
                               ],
                               "type": {
@@ -6062,7 +6062,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 186,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                             }
                           ]
                         }
@@ -6088,7 +6088,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 62,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L62"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L62"
             }
           ],
           "signatures": [
@@ -6183,7 +6183,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 65,
                               "character": 15,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                             }
                           ],
                           "type": {
@@ -6202,7 +6202,7 @@
                               "fileName": "src/GoTrueAdminApi.ts",
                               "line": 65,
                               "character": 27,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                             }
                           ],
                           "type": {
@@ -6232,7 +6232,7 @@
                           "fileName": "src/GoTrueAdminApi.ts",
                           "line": 65,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                         }
                       ]
                     }
@@ -6256,7 +6256,7 @@
               "fileName": "src/GoTrueAdminApi.ts",
               "line": 253,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L253"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L253"
             }
           ],
           "signatures": [
@@ -6356,7 +6356,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 421,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L421"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L421"
                             }
                           ],
                           "type": {
@@ -6385,7 +6385,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 447,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L447"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L447"
                             }
                           ],
                           "type": {
@@ -6414,7 +6414,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 372,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
                             }
                           ],
                           "type": {
@@ -6447,7 +6447,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 428,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L428"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L428"
                             }
                           ],
                           "type": {
@@ -6492,7 +6492,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 472,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L472"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L472"
                             }
                           ],
                           "type": {
@@ -6521,7 +6521,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 389,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
                             }
                           ],
                           "type": {
@@ -6554,7 +6554,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 382,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
                             }
                           ],
                           "type": {
@@ -6595,7 +6595,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 465,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L465"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L465"
                             }
                           ],
                           "type": {
@@ -6624,7 +6624,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 377,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
                             }
                           ],
                           "type": {
@@ -6657,7 +6657,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 435,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L435"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L435"
                             }
                           ],
                           "type": {
@@ -6718,7 +6718,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 456,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L456"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L456"
                             }
                           ],
                           "type": {
@@ -6763,7 +6763,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 411,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L411"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L411"
                             }
                           ],
                           "type": {
@@ -6783,7 +6783,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 400,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L400"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L400"
                         }
                       ],
                       "extendedTypes": [
@@ -6845,7 +6845,7 @@
           "fileName": "src/GoTrueAdminApi.ts",
           "line": 27,
           "character": 21,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L27"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L27"
         }
       ]
     },
@@ -6867,7 +6867,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 240,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L240"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L240"
             }
           ],
           "signatures": [
@@ -6907,7 +6907,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 60,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L60"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L60"
                         }
                       ],
                       "type": {
@@ -6932,7 +6932,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 70,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L70"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L70"
                                 }
                               ],
                               "type": {
@@ -6953,7 +6953,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 88,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L88"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L88"
                                 }
                               ],
                               "type": {
@@ -6976,7 +6976,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 88,
                                           "character": 21,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L88"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L88"
                                         }
                                       ],
                                       "signatures": [
@@ -7039,7 +7039,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 68,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L68"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L68"
                                 }
                               ],
                               "type": {
@@ -7060,7 +7060,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 84,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L84"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L84"
                                 }
                               ],
                               "type": {
@@ -7081,7 +7081,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 86,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L86"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L86"
                                 }
                               ],
                               "type": {
@@ -7099,7 +7099,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 601,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L601"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L601"
                                     }
                                   ],
                                   "type": {
@@ -7140,7 +7140,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 99,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L99"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L99"
                                 }
                               ],
                               "type": {
@@ -7161,7 +7161,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 64,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L64"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L64"
                                 }
                               ],
                               "type": {
@@ -7177,7 +7177,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 64,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L64"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L64"
                                     }
                                   ],
                                   "indexSignature": {
@@ -7228,7 +7228,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 94,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L94"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L94"
                                 }
                               ],
                               "type": {
@@ -7246,7 +7246,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 58,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                                     }
                                   ],
                                   "type": {
@@ -7262,7 +7262,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 58,
                                           "character": 23,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                                         }
                                       ],
                                       "signatures": [
@@ -7372,7 +7372,7 @@
                                                       "fileName": "src/lib/types.ts",
                                                       "line": 58,
                                                       "character": 69,
-                                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                                                     }
                                                   ],
                                                   "signatures": [
@@ -7434,7 +7434,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 72,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L72"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L72"
                                 }
                               ],
                               "type": {
@@ -7455,7 +7455,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 74,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L74"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L74"
                                 }
                               ],
                               "type": {
@@ -7473,7 +7473,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1181,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1181"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1181"
                                     }
                                   ],
                                   "type": {
@@ -7554,7 +7554,7 @@
                                                   "fileName": "src/lib/types.ts",
                                                   "line": 1191,
                                                   "character": 2,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1191"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1191"
                                                 }
                                               ],
                                               "type": {
@@ -7574,7 +7574,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 1183,
                                               "character": 4,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1183"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1183"
                                             }
                                           ]
                                         }
@@ -7597,7 +7597,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 66,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L66"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L66"
                                 }
                               ],
                               "type": {
@@ -7618,7 +7618,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 62,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L62"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L62"
                                 }
                               ],
                               "type": {
@@ -7688,7 +7688,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 82,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L82"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L82"
                                 }
                               ],
                               "type": {
@@ -7706,7 +7706,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1181,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1181"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1181"
                                     }
                                   ],
                                   "type": {
@@ -7787,7 +7787,7 @@
                                                   "fileName": "src/lib/types.ts",
                                                   "line": 1191,
                                                   "character": 2,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1191"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1191"
                                                 }
                                               ],
                                               "type": {
@@ -7807,7 +7807,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 1183,
                                               "character": 4,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1183"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1183"
                                             }
                                           ]
                                         }
@@ -7831,7 +7831,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 60,
                               "character": 34,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L60"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L60"
                             }
                           ]
                         }
@@ -7867,7 +7867,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 167,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L167"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L167"
             }
           ],
           "type": {
@@ -7892,7 +7892,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 37,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L37"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L37"
                     }
                   ],
                   "signatures": [
@@ -7931,7 +7931,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 46,
                                       "character": 4,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L46"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L46"
                                     }
                                   ],
                                   "type": {
@@ -8029,7 +8029,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 43,
                                       "character": 4,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L43"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L43"
                                     }
                                   ],
                                   "type": {
@@ -8045,7 +8045,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 43,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L43"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L43"
                                         }
                                       ],
                                       "indexSignature": {
@@ -8085,7 +8085,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 42,
                                       "character": 4,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L42"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L42"
                                     }
                                   ],
                                   "type": {
@@ -8105,7 +8105,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 41,
                                   "character": 5,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L41"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L41"
                                 }
                               ]
                             }
@@ -8139,7 +8139,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 29,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L29"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L29"
                     }
                   ],
                   "type": {
@@ -8178,7 +8178,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1169,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1169"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1169"
                             }
                           ],
                           "signatures": [
@@ -8244,7 +8244,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1120,
                                           "character": 12,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
                                         }
                                       ],
                                       "type": {
@@ -8275,7 +8275,7 @@
                                                   "fileName": "src/lib/types.ts",
                                                   "line": 1122,
                                                   "character": 2,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1122"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1122"
                                                 }
                                               ],
                                               "type": {
@@ -8302,7 +8302,7 @@
                                                   "fileName": "src/lib/types.ts",
                                                   "line": 1125,
                                                   "character": 2,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1125"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1125"
                                                 }
                                               ],
                                               "type": {
@@ -8322,7 +8322,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 1120,
                                               "character": 45,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
                                             }
                                           ]
                                         }
@@ -8358,7 +8358,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1159,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1159"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1159"
                             }
                           ],
                           "signatures": [
@@ -8407,7 +8407,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1144,
                                           "character": 12,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
                                         }
                                       ],
                                       "type": {
@@ -8438,7 +8438,7 @@
                                                   "fileName": "src/lib/types.ts",
                                                   "line": 1146,
                                                   "character": 2,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1146"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1146"
                                                 }
                                               ],
                                               "type": {
@@ -8458,7 +8458,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 1144,
                                               "character": 44,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
                                             }
                                           ]
                                         }
@@ -8495,7 +8495,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1154,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1154"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1154"
                         }
                       ]
                     }
@@ -8512,7 +8512,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 160,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L160"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L160"
                     }
                   ],
                   "signatures": [
@@ -8593,7 +8593,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 421,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L421"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L421"
                                     }
                                   ],
                                   "type": {
@@ -8622,7 +8622,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 447,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L447"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L447"
                                     }
                                   ],
                                   "type": {
@@ -8651,7 +8651,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 372,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
                                     }
                                   ],
                                   "type": {
@@ -8684,7 +8684,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 428,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L428"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L428"
                                     }
                                   ],
                                   "type": {
@@ -8729,7 +8729,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 472,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L472"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L472"
                                     }
                                   ],
                                   "type": {
@@ -8758,7 +8758,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 389,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
                                     }
                                   ],
                                   "type": {
@@ -8791,7 +8791,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 382,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
                                     }
                                   ],
                                   "type": {
@@ -8832,7 +8832,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 465,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L465"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L465"
                                     }
                                   ],
                                   "type": {
@@ -8861,7 +8861,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 377,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
                                     }
                                   ],
                                   "type": {
@@ -8894,7 +8894,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 435,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L435"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L435"
                                     }
                                   ],
                                   "type": {
@@ -8955,7 +8955,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 456,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L456"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L456"
                                     }
                                   ],
                                   "type": {
@@ -9000,7 +9000,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 411,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L411"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L411"
                                     }
                                   ],
                                   "type": {
@@ -9022,7 +9022,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 400,
                                   "character": 17,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L400"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L400"
                                 }
                               ],
                               "extendedTypes": [
@@ -9075,7 +9075,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 280,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L280"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L280"
                     }
                   ],
                   "signatures": [
@@ -9177,7 +9177,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 126,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L126"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L126"
                     }
                   ],
                   "signatures": [
@@ -9217,7 +9217,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 856,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L856"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L856"
                                 }
                               ],
                               "type": {
@@ -9234,7 +9234,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 813,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
                                       }
                                     ],
                                     "type": {
@@ -9257,7 +9257,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 815,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L815"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L815"
                                               }
                                             ],
                                             "type": {
@@ -9278,7 +9278,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 817,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L817"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L817"
                                               }
                                             ],
                                             "type": {
@@ -9319,7 +9319,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 816,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L816"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L816"
                                               }
                                             ],
                                             "type": {
@@ -9338,7 +9338,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 814,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L814"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L814"
                                               }
                                             ],
                                             "type": {
@@ -9358,7 +9358,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 813,
                                             "character": 39,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
                                           }
                                         ]
                                       }
@@ -9375,7 +9375,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 820,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
                                       }
                                     ],
                                     "type": {
@@ -9406,7 +9406,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 823,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L823"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L823"
                                               }
                                             ],
                                             "type": {
@@ -9427,7 +9427,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 824,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L824"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L824"
                                               }
                                             ],
                                             "type": {
@@ -9468,7 +9468,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 821,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L821"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L821"
                                               }
                                             ],
                                             "type": {
@@ -9497,7 +9497,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 820,
                                             "character": 46,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
                                           }
                                         ]
                                       }
@@ -9514,7 +9514,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 827,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
                                       }
                                     ],
                                     "type": {
@@ -9545,7 +9545,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 830,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L830"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L830"
                                               }
                                             ],
                                             "type": {
@@ -9566,7 +9566,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 831,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L831"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L831"
                                               }
                                             ],
                                             "type": {
@@ -9598,7 +9598,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 828,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L828"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L828"
                                               }
                                             ],
                                             "type": {
@@ -9618,7 +9618,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 827,
                                             "character": 41,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
                                           }
                                         ]
                                       }
@@ -9635,7 +9635,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 834,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
                                       }
                                     ],
                                     "type": {
@@ -9666,7 +9666,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 837,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L837"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L837"
                                               }
                                             ],
                                             "type": {
@@ -9693,7 +9693,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 841,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L841"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L841"
                                               }
                                             ],
                                             "type": {
@@ -9714,7 +9714,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 842,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L842"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L842"
                                               }
                                             ],
                                             "type": {
@@ -9746,7 +9746,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 835,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L835"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L835"
                                               }
                                             ],
                                             "type": {
@@ -9775,7 +9775,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 834,
                                             "character": 44,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
                                           }
                                         ]
                                       }
@@ -9814,7 +9814,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 229,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L229"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L229"
                     }
                   ],
                   "signatures": [
@@ -9888,7 +9888,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 93,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L93"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L93"
                     }
                   ],
                   "signatures": [
@@ -9978,7 +9978,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 97,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L97"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L97"
                                     }
                                   ],
                                   "type": {
@@ -10007,7 +10007,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 100,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L100"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L100"
                                     }
                                   ],
                                   "type": {
@@ -10027,7 +10027,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 95,
                                   "character": 13,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L95"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L95"
                                 }
                               ]
                             }
@@ -10062,7 +10062,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 182,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L182"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L182"
                     }
                   ],
                   "signatures": [
@@ -10136,7 +10136,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1213,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
                                 }
                               ],
                               "type": {
@@ -10169,7 +10169,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1215,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1215"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1215"
                                         }
                                       ],
                                       "type": {
@@ -10198,7 +10198,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1217,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1217"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1217"
                                         }
                                       ],
                                       "type": {
@@ -10218,7 +10218,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1213,
                                       "character": 25,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
                                     }
                                   ]
                                 }
@@ -10253,7 +10253,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 185,
                                           "character": 8,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                         }
                                       ],
                                       "type": {
@@ -10279,7 +10279,7 @@
                                                       "fileName": "src/GoTrueAdminApi.ts",
                                                       "line": 185,
                                                       "character": 31,
-                                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                                     }
                                                   ],
                                                   "type": {
@@ -10298,7 +10298,7 @@
                                                       "fileName": "src/GoTrueAdminApi.ts",
                                                       "line": 185,
                                                       "character": 16,
-                                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                                     }
                                                   ],
                                                   "type": {
@@ -10322,7 +10322,7 @@
                                                   "fileName": "src/GoTrueAdminApi.ts",
                                                   "line": 185,
                                                   "character": 14,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                                 }
                                               ]
                                             }
@@ -10346,7 +10346,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 185,
                                           "character": 59,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                         }
                                       ],
                                       "type": {
@@ -10366,7 +10366,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 185,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L185"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L185"
                                     }
                                   ]
                                 }
@@ -10391,7 +10391,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 186,
                                           "character": 8,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                         }
                                       ],
                                       "type": {
@@ -10414,7 +10414,7 @@
                                                   "fileName": "src/GoTrueAdminApi.ts",
                                                   "line": 186,
                                                   "character": 16,
-                                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                                 }
                                               ],
                                               "type": {
@@ -10433,7 +10433,7 @@
                                               "fileName": "src/GoTrueAdminApi.ts",
                                               "line": 186,
                                               "character": 14,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                             }
                                           ]
                                         }
@@ -10450,7 +10450,7 @@
                                           "fileName": "src/GoTrueAdminApi.ts",
                                           "line": 186,
                                           "character": 29,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                         }
                                       ],
                                       "type": {
@@ -10471,7 +10471,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 186,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L186"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L186"
                                     }
                                   ]
                                 }
@@ -10497,7 +10497,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 62,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L62"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L62"
                     }
                   ],
                   "signatures": [
@@ -10592,7 +10592,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 65,
                                       "character": 15,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                                     }
                                   ],
                                   "type": {
@@ -10611,7 +10611,7 @@
                                       "fileName": "src/GoTrueAdminApi.ts",
                                       "line": 65,
                                       "character": 27,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                                     }
                                   ],
                                   "type": {
@@ -10641,7 +10641,7 @@
                                   "fileName": "src/GoTrueAdminApi.ts",
                                   "line": 65,
                                   "character": 13,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L65"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L65"
                                 }
                               ]
                             }
@@ -10665,7 +10665,7 @@
                       "fileName": "src/GoTrueAdminApi.ts",
                       "line": 253,
                       "character": 8,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L253"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L253"
                     }
                   ],
                   "signatures": [
@@ -10765,7 +10765,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 421,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L421"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L421"
                                     }
                                   ],
                                   "type": {
@@ -10794,7 +10794,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 447,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L447"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L447"
                                     }
                                   ],
                                   "type": {
@@ -10823,7 +10823,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 372,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
                                     }
                                   ],
                                   "type": {
@@ -10856,7 +10856,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 428,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L428"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L428"
                                     }
                                   ],
                                   "type": {
@@ -10901,7 +10901,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 472,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L472"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L472"
                                     }
                                   ],
                                   "type": {
@@ -10930,7 +10930,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 389,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
                                     }
                                   ],
                                   "type": {
@@ -10963,7 +10963,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 382,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
                                     }
                                   ],
                                   "type": {
@@ -11004,7 +11004,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 465,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L465"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L465"
                                     }
                                   ],
                                   "type": {
@@ -11033,7 +11033,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 377,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
                                     }
                                   ],
                                   "type": {
@@ -11066,7 +11066,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 435,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L435"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L435"
                                     }
                                   ],
                                   "type": {
@@ -11127,7 +11127,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 456,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L456"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L456"
                                     }
                                   ],
                                   "type": {
@@ -11172,7 +11172,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 411,
                                       "character": 2,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L411"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L411"
                                     }
                                   ],
                                   "type": {
@@ -11194,7 +11194,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 400,
                                   "character": 17,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L400"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L400"
                                 }
                               ],
                               "extendedTypes": [
@@ -11256,7 +11256,7 @@
                   "fileName": "src/GoTrueAdminApi.ts",
                   "line": 27,
                   "character": 21,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueAdminApi.ts#L27"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueAdminApi.ts#L27"
                 }
               ]
             }
@@ -11281,7 +11281,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 171,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L171"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L171"
             }
           ],
           "type": {
@@ -11314,7 +11314,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1058,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1058"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1058"
                     }
                   ],
                   "signatures": [
@@ -11354,7 +11354,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 926,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
                                 }
                               ],
                               "type": {
@@ -11387,7 +11387,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 930,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L930"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L930"
                                         }
                                       ],
                                       "type": {
@@ -11423,7 +11423,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 928,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L928"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L928"
                                         }
                                       ],
                                       "type": {
@@ -11443,7 +11443,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 926,
                                       "character": 33,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
                                     }
                                   ]
                                 }
@@ -11479,7 +11479,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1076,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1076"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1076"
                     }
                   ],
                   "signatures": [
@@ -11519,7 +11519,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 933,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
                                 }
                               ],
                               "type": {
@@ -11550,7 +11550,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 937,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L937"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L937"
                                         }
                                       ],
                                       "type": {
@@ -11577,7 +11577,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 935,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L935"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L935"
                                         }
                                       ],
                                       "type": {
@@ -11597,7 +11597,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 933,
                                       "character": 42,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
                                     }
                                   ]
                                 }
@@ -11633,19 +11633,19 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1050,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1050"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1050"
                     },
                     {
                       "fileName": "src/lib/types.ts",
                       "line": 1051,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1051"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1051"
                     },
                     {
                       "fileName": "src/lib/types.ts",
                       "line": 1052,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1052"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1052"
                     }
                   ],
                   "signatures": [
@@ -11701,7 +11701,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1234,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                                 }
                               ],
                               "type": {
@@ -11732,7 +11732,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1236,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                                         }
                                       ],
                                       "type": {
@@ -11761,7 +11761,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1240,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                                         }
                                       ],
                                       "type": {
@@ -11790,7 +11790,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1238,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                                         }
                                       ],
                                       "type": {
@@ -11810,7 +11810,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1234,
                                       "character": 34,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                                     }
                                   ]
                                 }
@@ -11861,7 +11861,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1242,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                                 }
                               ],
                               "type": {
@@ -11892,7 +11892,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1244,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                                         }
                                       ],
                                       "type": {
@@ -11921,7 +11921,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1246,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                                         }
                                       ],
                                       "type": {
@@ -11948,7 +11948,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 1248,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                                         }
                                       ],
                                       "type": {
@@ -11968,7 +11968,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1242,
                                       "character": 35,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                                     }
                                   ]
                                 }
@@ -12019,7 +12019,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 908,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L908"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L908"
                                 }
                               ],
                               "type": {
@@ -12036,7 +12036,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1234,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                                       }
                                     ],
                                     "type": {
@@ -12067,7 +12067,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 1236,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                                               }
                                             ],
                                             "type": {
@@ -12096,7 +12096,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 1240,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                                               }
                                             ],
                                             "type": {
@@ -12125,7 +12125,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 1238,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                                               }
                                             ],
                                             "type": {
@@ -12145,7 +12145,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 1234,
                                             "character": 34,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                                           }
                                         ]
                                       }
@@ -12162,7 +12162,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1242,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                                       }
                                     ],
                                     "type": {
@@ -12193,7 +12193,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 1244,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                                               }
                                             ],
                                             "type": {
@@ -12222,7 +12222,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 1246,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                                               }
                                             ],
                                             "type": {
@@ -12249,7 +12249,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 1248,
                                                 "character": 2,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                                               }
                                             ],
                                             "type": {
@@ -12269,7 +12269,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 1242,
                                             "character": 35,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                                           }
                                         ]
                                       }
@@ -12308,7 +12308,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1101,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1101"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1101"
                     }
                   ],
                   "signatures": [
@@ -12377,7 +12377,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1086,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1086"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1086"
                     }
                   ],
                   "signatures": [
@@ -12471,7 +12471,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1070,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1070"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1070"
                     }
                   ],
                   "signatures": [
@@ -12527,7 +12527,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 910,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
                                 }
                               ],
                               "type": {
@@ -12558,7 +12558,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 912,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L912"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L912"
                                         }
                                       ],
                                       "type": {
@@ -12578,7 +12578,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 910,
                                       "character": 32,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
                                     }
                                   ]
                                 }
@@ -12614,7 +12614,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1064,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1064"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1064"
                     }
                   ],
                   "signatures": [
@@ -12654,7 +12654,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 915,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
                                 }
                               ],
                               "type": {
@@ -12685,7 +12685,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 920,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L920"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L920"
                                         }
                                       ],
                                       "type": {
@@ -12712,7 +12712,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 923,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L923"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L923"
                                         }
                                       ],
                                       "type": {
@@ -12739,7 +12739,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 917,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L917"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L917"
                                         }
                                       ],
                                       "type": {
@@ -12759,7 +12759,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 915,
                                       "character": 30,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
                                     }
                                   ]
                                 }
@@ -12796,7 +12796,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1039,
                   "character": 17,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1039"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1039"
                 }
               ]
             }
@@ -12813,7 +12813,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 651,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L651"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L651"
             }
           ],
           "signatures": [
@@ -12871,7 +12871,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 3181,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3181"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3181"
             }
           ],
           "signatures": [
@@ -13009,7 +13009,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3190,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3190"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3190"
                             }
                           ],
                           "type": {
@@ -13038,7 +13038,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3193,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3193"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3193"
                             }
                           ],
                           "type": {
@@ -13061,7 +13061,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 3193,
                                       "character": 15,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3193"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3193"
                                     }
                                   ],
                                   "type": {
@@ -13085,7 +13085,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3193,
                                   "character": 13,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3193"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3193"
                                 }
                               ]
                             }
@@ -13118,7 +13118,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3187,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3187"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3187"
                             }
                           ],
                           "type": {
@@ -13142,7 +13142,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 3183,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3183"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3183"
                         }
                       ]
                     }
@@ -13176,7 +13176,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3197,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                 }
                               ],
                               "type": {
@@ -13199,7 +13199,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 3197,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                         }
                                       ],
                                       "type": {
@@ -13219,7 +13219,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 3197,
                                           "character": 36,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                         }
                                       ],
                                       "type": {
@@ -13239,7 +13239,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 3197,
                                           "character": 55,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                         }
                                       ],
                                       "type": {
@@ -13261,7 +13261,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 3197,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3197"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3197"
                                     }
                                   ]
                                 }
@@ -13278,7 +13278,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3198,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3198"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3198"
                                 }
                               ],
                               "type": {
@@ -13298,7 +13298,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3196,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3196"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3196"
                             }
                           ]
                         }
@@ -13323,7 +13323,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3200,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3200"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3200"
                                 }
                               ],
                               "type": {
@@ -13342,7 +13342,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3200,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3200"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3200"
                                 }
                               ],
                               "type": {
@@ -13363,7 +13363,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3200,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3200"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3200"
                             }
                           ]
                         }
@@ -13388,7 +13388,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3201,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3201"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3201"
                                 }
                               ],
                               "type": {
@@ -13407,7 +13407,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 3201,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3201"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3201"
                                 }
                               ],
                               "type": {
@@ -13427,7 +13427,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 3201,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L3201"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L3201"
                             }
                           ]
                         }
@@ -13453,7 +13453,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1355,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1355"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1355"
             }
           ],
           "signatures": [
@@ -13507,7 +13507,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1448,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1448"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1448"
                                 }
                               ],
                               "type": {
@@ -13530,7 +13530,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 1449,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1449"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1449"
                                         }
                                       ],
                                       "type": {
@@ -13551,7 +13551,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 1448,
                                       "character": 18,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1448"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1448"
                                     }
                                   ]
                                 }
@@ -13568,7 +13568,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1451,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1451"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1451"
                                 }
                               ],
                               "type": {
@@ -13588,7 +13588,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1447,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1447"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1447"
                             }
                           ]
                         }
@@ -13613,7 +13613,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1454,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1454"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1454"
                                 }
                               ],
                               "type": {
@@ -13636,7 +13636,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 1455,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1455"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1455"
                                         }
                                       ],
                                       "type": {
@@ -13656,7 +13656,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 1454,
                                       "character": 18,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1454"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1454"
                                     }
                                   ]
                                 }
@@ -13673,7 +13673,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1457,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1457"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1457"
                                 }
                               ],
                               "type": {
@@ -13694,7 +13694,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1453,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1453"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1453"
                             }
                           ]
                         }
@@ -13719,7 +13719,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1460,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1460"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1460"
                                 }
                               ],
                               "type": {
@@ -13742,7 +13742,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 1461,
                                           "character": 14,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1461"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1461"
                                         }
                                       ],
                                       "type": {
@@ -13762,7 +13762,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 1460,
                                       "character": 18,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1460"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1460"
                                     }
                                   ]
                                 }
@@ -13779,7 +13779,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 1463,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1463"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1463"
                                 }
                               ],
                               "type": {
@@ -13799,7 +13799,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1459,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1459"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1459"
                             }
                           ]
                         }
@@ -13825,7 +13825,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1599,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1599"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1599"
             }
           ],
           "signatures": [
@@ -13893,7 +13893,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2157,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2157"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2157"
             }
           ],
           "signatures": [
@@ -13937,7 +13937,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2159,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2159"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2159"
                                 }
                               ],
                               "type": {
@@ -13960,7 +13960,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 2160,
                                           "character": 10,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2160"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2160"
                                         }
                                       ],
                                       "type": {
@@ -13984,7 +13984,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 2159,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2159"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2159"
                                     }
                                   ]
                                 }
@@ -14001,7 +14001,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2162,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2162"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2162"
                                 }
                               ],
                               "type": {
@@ -14021,7 +14021,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2158,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2158"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2158"
                             }
                           ]
                         }
@@ -14046,7 +14046,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2164,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2164"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2164"
                                 }
                               ],
                               "type": {
@@ -14065,7 +14065,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2164,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2164"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2164"
                                 }
                               ],
                               "type": {
@@ -14086,7 +14086,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2164,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2164"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2164"
                             }
                           ]
                         }
@@ -14112,7 +14112,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 353,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L353"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L353"
             }
           ],
           "signatures": [
@@ -14157,7 +14157,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2181,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2181"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2181"
             }
           ],
           "signatures": [
@@ -14197,7 +14197,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 602,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
                         }
                       ],
                       "type": {
@@ -14222,7 +14222,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 605,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                                 }
                               ],
                               "type": {
@@ -14255,7 +14255,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 611,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                                         }
                                       ],
                                       "type": {
@@ -14271,7 +14271,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 611,
                                               "character": 18,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                                             }
                                           ],
                                           "indexSignature": {
@@ -14321,7 +14321,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 607,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L607"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L607"
                                         }
                                       ],
                                       "type": {
@@ -14350,7 +14350,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 609,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L609"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L609"
                                         }
                                       ],
                                       "type": {
@@ -14379,7 +14379,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 613,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L613"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L613"
                                         }
                                       ],
                                       "type": {
@@ -14399,7 +14399,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 605,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                                     }
                                   ]
                                 }
@@ -14424,7 +14424,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 604,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L604"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L604"
                                 }
                               ],
                               "type": {
@@ -14450,7 +14450,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 8,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L8"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L8"
                                     }
                                   ],
                                   "type": {
@@ -14561,7 +14561,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 602,
                               "character": 41,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
                             }
                           ]
                         }
@@ -14597,7 +14597,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2055,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2055"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2055"
             }
           ],
           "signatures": [
@@ -14643,7 +14643,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2056,
                           "character": 14,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2056"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2056"
                         }
                       ],
                       "signatures": [
@@ -14735,7 +14735,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2058,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2058"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2058"
                         }
                       ],
                       "type": {
@@ -14758,7 +14758,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2058,
                                   "character": 12,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2058"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2058"
                                 }
                               ],
                               "type": {
@@ -14783,7 +14783,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 483,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L483"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L483"
                                         }
                                       ],
                                       "type": {
@@ -14799,7 +14799,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 483,
                                               "character": 12,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L483"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L483"
                                             }
                                           ],
                                           "signatures": [
@@ -14880,7 +14880,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 479,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L479"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L479"
                                         }
                                       ],
                                       "type": {
@@ -14899,7 +14899,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 487,
                                           "character": 2,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L487"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L487"
                                         }
                                       ],
                                       "type": {
@@ -14915,7 +14915,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 487,
                                               "character": 15,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L487"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L487"
                                             }
                                           ],
                                           "signatures": [
@@ -14954,7 +14954,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 475,
                                       "character": 17,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L475"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L475"
                                     }
                                   ]
                                 }
@@ -14972,7 +14972,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2058,
                               "character": 10,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2058"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2058"
                             }
                           ]
                         }
@@ -14990,7 +14990,7 @@
                       "fileName": "src/GoTrueClient.ts",
                       "line": 2057,
                       "character": 5,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2057"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2057"
                     }
                   ]
                 }
@@ -15009,7 +15009,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1271,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1271"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1271"
             }
           ],
           "signatures": [
@@ -15054,7 +15054,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1804,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1804"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1804"
             }
           ],
           "signatures": [
@@ -15109,7 +15109,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1804,
                               "character": 42,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1804"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1804"
                             }
                           ],
                           "type": {
@@ -15129,7 +15129,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 1804,
                           "character": 40,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1804"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1804"
                         }
                       ]
                     }
@@ -15163,7 +15163,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1306,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1306"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1306"
             }
           ],
           "signatures": [
@@ -15203,7 +15203,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 769,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L769"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L769"
                         }
                       ],
                       "type": {
@@ -15229,7 +15229,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 772,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L772"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L772"
                                     }
                                   ],
                                   "type": {
@@ -15250,7 +15250,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 773,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L773"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L773"
                                     }
                                   ],
                                   "type": {
@@ -15283,7 +15283,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 777,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L777"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L777"
                                             }
                                           ],
                                           "type": {
@@ -15312,7 +15312,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 775,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L775"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L775"
                                             }
                                           ],
                                           "type": {
@@ -15332,7 +15332,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 773,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L773"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L773"
                                         }
                                       ]
                                     }
@@ -15349,7 +15349,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 771,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L771"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L771"
                                     }
                                   ],
                                   "type": {
@@ -15391,7 +15391,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 770,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L770"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L770"
                                 }
                               ]
                             }
@@ -15418,7 +15418,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 783,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L783"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L783"
                                     }
                                   ],
                                   "type": {
@@ -15451,7 +15451,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 785,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L785"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L785"
                                             }
                                           ],
                                           "type": {
@@ -15471,7 +15471,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 783,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L783"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L783"
                                         }
                                       ]
                                     }
@@ -15488,7 +15488,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 782,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L782"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L782"
                                     }
                                   ],
                                   "type": {
@@ -15507,7 +15507,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 781,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L781"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L781"
                                     }
                                   ],
                                   "type": {
@@ -15549,7 +15549,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 780,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L780"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L780"
                                 }
                               ]
                             }
@@ -15587,7 +15587,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2111,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2111"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2111"
             }
           ],
           "signatures": [
@@ -15661,7 +15661,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2115,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2115"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2115"
                             }
                           ],
                           "type": {
@@ -15690,7 +15690,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2114,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2114"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2114"
                             }
                           ],
                           "type": {
@@ -15710,7 +15710,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2113,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2113"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2113"
                         }
                       ]
                     }
@@ -15744,7 +15744,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2119,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2119"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2119"
                                 }
                               ],
                               "type": {
@@ -15769,7 +15769,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2120,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2120"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2120"
                                 }
                               ],
                               "type": {
@@ -15789,7 +15789,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2118,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2118"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2118"
                             }
                           ]
                         }
@@ -15814,7 +15814,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2122,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2122"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2122"
                                 }
                               ],
                               "type": {
@@ -15833,7 +15833,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2122,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2122"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2122"
                                 }
                               ],
                               "type": {
@@ -15854,7 +15854,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2122,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2122"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2122"
                             }
                           ]
                         }
@@ -15880,7 +15880,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1729,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1729"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1729"
             }
           ],
           "signatures": [
@@ -15933,7 +15933,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1730,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1730"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1730"
                             }
                           ],
                           "type": {
@@ -15952,7 +15952,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1731,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1731"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1731"
                             }
                           ],
                           "type": {
@@ -15972,7 +15972,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 1729,
                           "character": 35,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1729"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1729"
                         }
                       ]
                     }
@@ -16006,7 +16006,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 456,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L456"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L456"
             }
           ],
           "signatures": [
@@ -16059,7 +16059,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 490,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L490"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L490"
                         }
                       ],
                       "type": {
@@ -16084,7 +16084,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 491,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L491"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L491"
                                 }
                               ],
                               "type": {
@@ -16117,7 +16117,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 499,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L499"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L499"
                                         }
                                       ],
                                       "type": {
@@ -16162,7 +16162,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 497,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L497"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L497"
                                         }
                                       ],
                                       "type": {
@@ -16182,7 +16182,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 491,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L491"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L491"
                                     }
                                   ]
                                 }
@@ -16200,7 +16200,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 490,
                               "character": 43,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L490"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L490"
                             }
                           ]
                         }
@@ -16236,7 +16236,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1064,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1064"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1064"
             }
           ],
           "signatures": [
@@ -16276,7 +16276,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 617,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L617"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L617"
                         }
                       ],
                       "type": {
@@ -16317,7 +16317,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 623,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L623"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L623"
                                 }
                               ],
                               "type": {
@@ -16354,7 +16354,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 625,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L625"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L625"
                                 }
                               ],
                               "type": {
@@ -16375,7 +16375,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 626,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L626"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L626"
                                 }
                               ],
                               "type": {
@@ -16408,7 +16408,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 628,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L628"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L628"
                                         }
                                       ],
                                       "type": {
@@ -16428,7 +16428,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 626,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L626"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L626"
                                     }
                                   ]
                                 }
@@ -16509,7 +16509,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 619,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L619"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L619"
                                 }
                               ],
                               "type": {
@@ -16555,7 +16555,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 619,
                                               "character": 76,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L619"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L619"
                                             }
                                           ]
                                         }
@@ -16616,7 +16616,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 621,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L621"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L621"
                                 }
                               ],
                               "type": {
@@ -16636,7 +16636,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 617,
                               "character": 43,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L617"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L617"
                             }
                           ]
                         }
@@ -16672,7 +16672,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 639,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L639"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L639"
             }
           ],
           "signatures": [
@@ -16712,7 +16712,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 602,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
                         }
                       ],
                       "type": {
@@ -16737,7 +16737,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 605,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                                 }
                               ],
                               "type": {
@@ -16770,7 +16770,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 611,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                                         }
                                       ],
                                       "type": {
@@ -16786,7 +16786,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 611,
                                               "character": 18,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                                             }
                                           ],
                                           "indexSignature": {
@@ -16836,7 +16836,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 607,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L607"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L607"
                                         }
                                       ],
                                       "type": {
@@ -16865,7 +16865,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 609,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L609"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L609"
                                         }
                                       ],
                                       "type": {
@@ -16894,7 +16894,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 613,
                                           "character": 4,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L613"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L613"
                                         }
                                       ],
                                       "type": {
@@ -16914,7 +16914,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 605,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                                     }
                                   ]
                                 }
@@ -16939,7 +16939,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 604,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L604"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L604"
                                 }
                               ],
                               "type": {
@@ -16965,7 +16965,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 8,
                                       "character": 12,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L8"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L8"
                                     }
                                   ],
                                   "type": {
@@ -17076,7 +17076,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 602,
                               "character": 41,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
                             }
                           ]
                         }
@@ -17112,7 +17112,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1119,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1119"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1119"
             }
           ],
           "signatures": [
@@ -17168,7 +17168,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 563,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L563"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L563"
                         }
                       ],
                       "type": {
@@ -17202,7 +17202,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 566,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L566"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L566"
                                     }
                                   ],
                                   "type": {
@@ -17223,7 +17223,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 567,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L567"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L567"
                                     }
                                   ],
                                   "type": {
@@ -17256,7 +17256,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 579,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L579"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L579"
                                             }
                                           ],
                                           "type": {
@@ -17301,7 +17301,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 577,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L577"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L577"
                                             }
                                           ],
                                           "type": {
@@ -17330,7 +17330,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 569,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L569"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L569"
                                             }
                                           ],
                                           "type": {
@@ -17359,7 +17359,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 571,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L571"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L571"
                                             }
                                           ],
                                           "type": {
@@ -17379,7 +17379,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 567,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L567"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L567"
                                         }
                                       ]
                                     }
@@ -17397,7 +17397,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 564,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L564"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L564"
                                 }
                               ]
                             }
@@ -17424,7 +17424,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 585,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L585"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L585"
                                     }
                                   ],
                                   "type": {
@@ -17457,7 +17457,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 595,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L595"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L595"
                                             }
                                           ],
                                           "type": {
@@ -17486,7 +17486,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 597,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L597"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L597"
                                             }
                                           ],
                                           "type": {
@@ -17540,7 +17540,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 593,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L593"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L593"
                                             }
                                           ],
                                           "type": {
@@ -17569,7 +17569,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 587,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L587"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L587"
                                             }
                                           ],
                                           "type": {
@@ -17589,7 +17589,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 585,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L585"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L585"
                                         }
                                       ]
                                     }
@@ -17614,7 +17614,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 584,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L584"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L584"
                                     }
                                   ],
                                   "type": {
@@ -17634,7 +17634,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 582,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L582"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L582"
                                 }
                               ]
                             }
@@ -17672,7 +17672,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 576,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L576"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L576"
             }
           ],
           "signatures": [
@@ -17712,7 +17712,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 541,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L541"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L541"
                         }
                       ],
                       "type": {
@@ -17746,7 +17746,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 544,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L544"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L544"
                                     }
                                   ],
                                   "type": {
@@ -17767,7 +17767,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 547,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L547"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L547"
                                     }
                                   ],
                                   "type": {
@@ -17800,7 +17800,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 549,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L549"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L549"
                                             }
                                           ],
                                           "type": {
@@ -17820,7 +17820,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 547,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L547"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L547"
                                         }
                                       ]
                                     }
@@ -17845,7 +17845,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 546,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L546"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L546"
                                     }
                                   ],
                                   "type": {
@@ -17865,7 +17865,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 542,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L542"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L542"
                                 }
                               ]
                             }
@@ -17892,7 +17892,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 557,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L557"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L557"
                                     }
                                   ],
                                   "type": {
@@ -17925,7 +17925,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 559,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L559"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L559"
                                             }
                                           ],
                                           "type": {
@@ -17945,7 +17945,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 557,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L557"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L557"
                                         }
                                       ]
                                     }
@@ -17970,7 +17970,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 556,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L556"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L556"
                                     }
                                   ],
                                   "type": {
@@ -17997,7 +17997,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 554,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L554"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L554"
                                     }
                                   ],
                                   "type": {
@@ -18017,7 +18017,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 552,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L552"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L552"
                                 }
                               ]
                             }
@@ -18055,7 +18055,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1233,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1233"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1233"
             }
           ],
           "signatures": [
@@ -18095,7 +18095,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 789,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L789"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L789"
                         }
                       ],
                       "type": {
@@ -18123,7 +18123,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 794,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L794"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L794"
                                     }
                                   ],
                                   "type": {
@@ -18156,7 +18156,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 798,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L798"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L798"
                                             }
                                           ],
                                           "type": {
@@ -18185,7 +18185,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 796,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L796"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L796"
                                             }
                                           ],
                                           "type": {
@@ -18205,7 +18205,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 794,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L794"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L794"
                                         }
                                       ]
                                     }
@@ -18230,7 +18230,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 792,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L792"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L792"
                                     }
                                   ],
                                   "type": {
@@ -18250,7 +18250,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 790,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L790"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L790"
                                 }
                               ]
                             }
@@ -18283,7 +18283,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 803,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L803"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L803"
                                     }
                                   ],
                                   "type": {
@@ -18304,7 +18304,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 805,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L805"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L805"
                                     }
                                   ],
                                   "type": {
@@ -18337,7 +18337,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 809,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L809"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L809"
                                             }
                                           ],
                                           "type": {
@@ -18366,7 +18366,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 807,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L807"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L807"
                                             }
                                           ],
                                           "type": {
@@ -18386,7 +18386,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 805,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L805"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L805"
                                         }
                                       ]
                                     }
@@ -18404,7 +18404,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 801,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L801"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L801"
                                 }
                               ]
                             }
@@ -18442,7 +18442,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 666,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L666"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L666"
             }
           ],
           "signatures": [
@@ -18493,7 +18493,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 717,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L717"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L717"
                         }
                       ],
                       "type": {
@@ -18510,7 +18510,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 641,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L641"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L641"
                               }
                             ],
                             "type": {
@@ -18536,7 +18536,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 643,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L643"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L643"
                                           }
                                         ],
                                         "type": {
@@ -18557,7 +18557,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 651,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                                           }
                                         ],
                                         "type": {
@@ -18590,7 +18590,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 656,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L656"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L656"
                                                   }
                                                 ],
                                                 "type": {
@@ -18611,7 +18611,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 658,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L658"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L658"
                                                   }
                                                 ],
                                                 "type": {
@@ -18681,7 +18681,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 653,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L653"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L653"
                                                   }
                                                 ],
                                                 "type": {
@@ -18701,7 +18701,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 651,
                                                 "character": 16,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                                               }
                                             ]
                                           }
@@ -18728,7 +18728,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 649,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L649"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L649"
                                           }
                                         ],
                                         "type": {
@@ -18765,7 +18765,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 646,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L646"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L646"
                                           }
                                         ],
                                         "type": {
@@ -18786,7 +18786,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 642,
                                         "character": 4,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L642"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L642"
                                       }
                                     ]
                                   }
@@ -18811,7 +18811,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 664,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L664"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L664"
                                           }
                                         ],
                                         "type": {
@@ -18862,7 +18862,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 667,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L667"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L667"
                                           }
                                         ],
                                         "type": {
@@ -18883,7 +18883,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 672,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                                           }
                                         ],
                                         "type": {
@@ -18916,7 +18916,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 674,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L674"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L674"
                                                   }
                                                 ],
                                                 "type": {
@@ -18936,7 +18936,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 672,
                                                 "character": 16,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                                               }
                                             ]
                                           }
@@ -18961,7 +18961,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 670,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L670"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L670"
                                           }
                                         ],
                                         "type": {
@@ -18983,7 +18983,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 663,
                                         "character": 4,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L663"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L663"
                                       }
                                     ]
                                   }
@@ -19002,7 +19002,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 680,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L680"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L680"
                               }
                             ],
                             "type": {
@@ -19028,7 +19028,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 682,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L682"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L682"
                                           }
                                         ],
                                         "type": {
@@ -19049,7 +19049,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 690,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                                           }
                                         ],
                                         "type": {
@@ -19082,7 +19082,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 695,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L695"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L695"
                                                   }
                                                 ],
                                                 "type": {
@@ -19103,7 +19103,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 697,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L697"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L697"
                                                   }
                                                 ],
                                                 "type": {
@@ -19169,7 +19169,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 692,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L692"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L692"
                                                   }
                                                 ],
                                                 "type": {
@@ -19189,7 +19189,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 690,
                                                 "character": 16,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                                               }
                                             ]
                                           }
@@ -19207,7 +19207,7 @@
                                           "summary": [
                                             {
                                               "kind": "text",
-                                              "text": "Optional statement to include in the Sign in with Solana message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
+                                              "text": "Optional statement to include in the Sign in with Ethereum message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
                                             }
                                           ]
                                         },
@@ -19216,7 +19216,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 688,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L688"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L688"
                                           }
                                         ],
                                         "type": {
@@ -19240,7 +19240,7 @@
                                             },
                                             {
                                               "kind": "code",
-                                              "text": "`window.solana`"
+                                              "text": "`window.ethereum`"
                                             },
                                             {
                                               "kind": "text",
@@ -19253,7 +19253,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 685,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L685"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L685"
                                           }
                                         ],
                                         "type": {
@@ -19274,7 +19274,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 681,
                                         "character": 4,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L681"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L681"
                                       }
                                     ]
                                   }
@@ -19299,7 +19299,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 703,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L703"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L703"
                                           }
                                         ],
                                         "type": {
@@ -19350,7 +19350,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 706,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L706"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L706"
                                           }
                                         ],
                                         "type": {
@@ -19371,7 +19371,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 711,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                                           }
                                         ],
                                         "type": {
@@ -19404,7 +19404,7 @@
                                                     "fileName": "src/lib/types.ts",
                                                     "line": 713,
                                                     "character": 8,
-                                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L713"
+                                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L713"
                                                   }
                                                 ],
                                                 "type": {
@@ -19424,7 +19424,7 @@
                                                 "fileName": "src/lib/types.ts",
                                                 "line": 711,
                                                 "character": 16,
-                                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                                               }
                                             ]
                                           }
@@ -19440,7 +19440,7 @@
                                           "summary": [
                                             {
                                               "kind": "text",
-                                              "text": "Ed25519 signature of the message."
+                                              "text": "Ethereum curve (secp256k1) signature of the message."
                                             }
                                           ]
                                         },
@@ -19449,7 +19449,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 709,
                                             "character": 6,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L709"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L709"
                                           }
                                         ],
                                         "type": {
@@ -19469,7 +19469,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 702,
                                         "character": 4,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L702"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L702"
                                       }
                                     ]
                                   }
@@ -19509,7 +19509,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 668,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                 }
                               ],
                               "type": {
@@ -19532,7 +19532,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 668,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                         }
                                       ],
                                       "type": {
@@ -19552,7 +19552,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 668,
                                           "character": 34,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                         }
                                       ],
                                       "type": {
@@ -19573,7 +19573,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 668,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L668"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L668"
                                     }
                                   ]
                                 }
@@ -19590,7 +19590,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 669,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L669"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L669"
                                 }
                               ],
                               "type": {
@@ -19610,7 +19610,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 667,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L667"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L667"
                             }
                           ]
                         }
@@ -19635,7 +19635,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 671,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                 }
                               ],
                               "type": {
@@ -19658,7 +19658,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 671,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                         }
                                       ],
                                       "type": {
@@ -19677,7 +19677,7 @@
                                           "fileName": "src/GoTrueClient.ts",
                                           "line": 671,
                                           "character": 31,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                         }
                                       ],
                                       "type": {
@@ -19697,7 +19697,7 @@
                                       "fileName": "src/GoTrueClient.ts",
                                       "line": 671,
                                       "character": 14,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                     }
                                   ]
                                 }
@@ -19714,7 +19714,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 671,
                                   "character": 45,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                                 }
                               ],
                               "type": {
@@ -19735,7 +19735,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 671,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L671"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L671"
                             }
                           ]
                         }
@@ -19761,7 +19761,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2011,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2011"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2011"
             }
           ],
           "signatures": [
@@ -19841,7 +19841,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1220,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1220"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1220"
                         }
                       ],
                       "type": {
@@ -19874,7 +19874,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1231,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1231"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1231"
                                 }
                               ],
                               "type": {
@@ -19907,7 +19907,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1220,
                               "character": 22,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1220"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1220"
                             }
                           ]
                         }
@@ -19940,7 +19940,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2011,
                               "character": 67,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2011"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2011"
                             }
                           ],
                           "type": {
@@ -19970,7 +19970,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 2011,
                           "character": 65,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2011"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2011"
                         }
                       ]
                     }
@@ -19994,7 +19994,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 499,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L499"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L499"
             }
           ],
           "signatures": [
@@ -20054,7 +20054,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 503,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L503"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L503"
                         }
                       ],
                       "type": {
@@ -20088,7 +20088,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 506,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L506"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L506"
                                     }
                                   ],
                                   "type": {
@@ -20109,7 +20109,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 509,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L509"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L509"
                                     }
                                   ],
                                   "type": {
@@ -20142,7 +20142,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 519,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L519"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L519"
                                             }
                                           ],
                                           "type": {
@@ -20187,7 +20187,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 517,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L517"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L517"
                                             }
                                           ],
                                           "type": {
@@ -20216,7 +20216,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 511,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L511"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L511"
                                             }
                                           ],
                                           "type": {
@@ -20236,7 +20236,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 509,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L509"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L509"
                                         }
                                       ]
                                     }
@@ -20261,7 +20261,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 508,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L508"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L508"
                                     }
                                   ],
                                   "type": {
@@ -20281,7 +20281,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 504,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L504"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L504"
                                 }
                               ]
                             }
@@ -20308,7 +20308,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 527,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L527"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L527"
                                     }
                                   ],
                                   "type": {
@@ -20341,7 +20341,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 535,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L535"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L535"
                                             }
                                           ],
                                           "type": {
@@ -20370,7 +20370,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 537,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L537"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L537"
                                             }
                                           ],
                                           "type": {
@@ -20424,7 +20424,7 @@
                                               "fileName": "src/lib/types.ts",
                                               "line": 533,
                                               "character": 8,
-                                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L533"
+                                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L533"
                                             }
                                           ],
                                           "type": {
@@ -20444,7 +20444,7 @@
                                           "fileName": "src/lib/types.ts",
                                           "line": 527,
                                           "character": 16,
-                                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L527"
+                                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L527"
                                         }
                                       ]
                                     }
@@ -20469,7 +20469,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 526,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L526"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L526"
                                     }
                                   ],
                                   "type": {
@@ -20496,7 +20496,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 524,
                                       "character": 6,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L524"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L524"
                                     }
                                   ],
                                   "type": {
@@ -20516,7 +20516,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 522,
                                   "character": 4,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L522"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L522"
                                 }
                               ]
                             }
@@ -20554,7 +20554,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2698,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2698"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2698"
             }
           ],
           "signatures": [
@@ -20612,7 +20612,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2711,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2711"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2711"
             }
           ],
           "signatures": [
@@ -20666,7 +20666,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 2217,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2217"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2217"
             }
           ],
           "signatures": [
@@ -20715,7 +20715,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 300,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L300"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L300"
                             }
                           ],
                           "type": {
@@ -20734,7 +20734,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 293,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L293"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L293"
                             }
                           ],
                           "type": {
@@ -20755,7 +20755,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 295,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L295"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L295"
                             }
                           ],
                           "type": {
@@ -20771,7 +20771,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 295,
                                   "character": 18,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L295"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L295"
                                 }
                               ],
                               "indexSignature": {
@@ -20811,7 +20811,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 298,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L298"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L298"
                             }
                           ],
                           "type": {
@@ -20832,7 +20832,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 301,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L301"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L301"
                             }
                           ],
                           "type": {
@@ -20851,7 +20851,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 299,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L299"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L299"
                             }
                           ],
                           "type": {
@@ -20872,7 +20872,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 302,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L302"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L302"
                             }
                           ],
                           "type": {
@@ -20891,7 +20891,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 294,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L294"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L294"
                             }
                           ],
                           "type": {
@@ -20911,7 +20911,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 292,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L292"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L292"
                         }
                       ]
                     }
@@ -20944,7 +20944,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2219,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2219"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2219"
                                 }
                               ],
                               "type": {
@@ -20969,7 +20969,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2220,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2220"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2220"
                                 }
                               ],
                               "type": {
@@ -20989,7 +20989,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2218,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2218"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2218"
                             }
                           ]
                         }
@@ -21014,7 +21014,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2222,
                                   "character": 8,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2222"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2222"
                                 }
                               ],
                               "type": {
@@ -21033,7 +21033,7 @@
                                   "fileName": "src/GoTrueClient.ts",
                                   "line": 2222,
                                   "character": 20,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2222"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2222"
                                 }
                               ],
                               "type": {
@@ -21054,7 +21054,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 2222,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L2222"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L2222"
                             }
                           ]
                         }
@@ -21080,7 +21080,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1660,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1660"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1660"
             }
           ],
           "signatures": [
@@ -21153,7 +21153,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 397,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L397"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L397"
                             }
                           ],
                           "type": {
@@ -21182,7 +21182,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 372,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
                             }
                           ],
                           "type": {
@@ -21211,7 +21211,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 389,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
                             }
                           ],
                           "type": {
@@ -21240,7 +21240,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 382,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
                             }
                           ],
                           "type": {
@@ -21269,7 +21269,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 377,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
                             }
                           ],
                           "type": {
@@ -21289,7 +21289,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 368,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L368"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L368"
                         }
                       ]
                     }
@@ -21323,7 +21323,7 @@
                               "fileName": "src/GoTrueClient.ts",
                               "line": 1663,
                               "character": 6,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1663"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1663"
                             }
                           ],
                           "type": {
@@ -21343,7 +21343,7 @@
                           "fileName": "src/GoTrueClient.ts",
                           "line": 1662,
                           "character": 13,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1662"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1662"
                         }
                       ]
                     }
@@ -21378,7 +21378,7 @@
               "fileName": "src/GoTrueClient.ts",
               "line": 1172,
               "character": 8,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L1172"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L1172"
             }
           ],
           "signatures": [
@@ -21418,7 +21418,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 719,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L719"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L719"
                         }
                       ],
                       "type": {
@@ -21444,7 +21444,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 727,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
                                   }
                                 ],
                                 "type": {
@@ -21483,7 +21483,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 736,
                                             "character": 4,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L736"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L736"
                                           }
                                         ],
                                         "type": {
@@ -21512,7 +21512,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 729,
                                             "character": 4,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L729"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L729"
                                           }
                                         ],
                                         "type": {
@@ -21532,7 +21532,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 727,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
                                       }
                                     ]
                                   }
@@ -21557,7 +21557,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 722,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L722"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L722"
                                   }
                                 ],
                                 "type": {
@@ -21584,7 +21584,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 724,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L724"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L724"
                                   }
                                 ],
                                 "type": {
@@ -21611,7 +21611,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 726,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L726"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L726"
                                   }
                                 ],
                                 "type": {
@@ -21629,7 +21629,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 766,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L766"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L766"
                                       }
                                     ],
                                     "type": {
@@ -21660,7 +21660,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 720,
                                 "character": 17,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L720"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L720"
                               }
                             ]
                           },
@@ -21690,7 +21690,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 741,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L741"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L741"
                                   }
                                 ],
                                 "type": {
@@ -21711,7 +21711,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 746,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
                                   }
                                 ],
                                 "type": {
@@ -21750,7 +21750,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 754,
                                             "character": 4,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L754"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L754"
                                           }
                                         ],
                                         "type": {
@@ -21779,7 +21779,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 748,
                                             "character": 4,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L748"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L748"
                                           }
                                         ],
                                         "type": {
@@ -21799,7 +21799,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 746,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
                                       }
                                     ]
                                   }
@@ -21824,7 +21824,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 743,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L743"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L743"
                                   }
                                 ],
                                 "type": {
@@ -21851,7 +21851,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 745,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L745"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L745"
                                   }
                                 ],
                                 "type": {
@@ -21869,7 +21869,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 767,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
                                       }
                                     ],
                                     "type": {
@@ -21916,7 +21916,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 739,
                                 "character": 17,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L739"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L739"
                               }
                             ]
                           },
@@ -21946,7 +21946,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 760,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L760"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L760"
                                   }
                                 ],
                                 "type": {
@@ -21973,7 +21973,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 763,
                                     "character": 2,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L763"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L763"
                                   }
                                 ],
                                 "type": {
@@ -21991,7 +21991,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 767,
                                         "character": 12,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
                                       }
                                     ],
                                     "type": {
@@ -22038,7 +22038,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 758,
                                 "character": 17,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L758"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L758"
                               }
                             ]
                           }
@@ -22087,7 +22087,7 @@
           "fileName": "src/GoTrueClient.ts",
           "line": 158,
           "character": 21,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/GoTrueClient.ts#L158"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/GoTrueClient.ts#L158"
         }
       ]
     },
@@ -22109,7 +22109,7 @@
               "fileName": "src/lib/locks.ts",
               "line": 26,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L26"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L26"
             }
           ],
           "signatures": [
@@ -22162,7 +22162,7 @@
               "fileName": "src/lib/locks.ts",
               "line": 24,
               "character": 18,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L24"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L24"
             }
           ],
           "type": {
@@ -22191,7 +22191,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 31,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L31"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L31"
         }
       ],
       "extendedTypes": [
@@ -22252,7 +22252,7 @@
               "fileName": "src/lib/types.ts",
               "line": 283,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L283"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L283"
             }
           ],
           "type": {
@@ -22315,7 +22315,7 @@
               "fileName": "src/lib/types.ts",
               "line": 289,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L289"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L289"
             }
           ],
           "type": {
@@ -22335,7 +22335,7 @@
           "fileName": "src/lib/types.ts",
           "line": 281,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L281"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L281"
         }
       ]
     },
@@ -22383,7 +22383,7 @@
               "fileName": "src/lib/types.ts",
               "line": 421,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L421"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L421"
             }
           ],
           "type": {
@@ -22412,7 +22412,7 @@
               "fileName": "src/lib/types.ts",
               "line": 447,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L447"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L447"
             }
           ],
           "type": {
@@ -22441,7 +22441,7 @@
               "fileName": "src/lib/types.ts",
               "line": 372,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
             }
           ],
           "type": {
@@ -22474,7 +22474,7 @@
               "fileName": "src/lib/types.ts",
               "line": 428,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L428"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L428"
             }
           ],
           "type": {
@@ -22519,7 +22519,7 @@
               "fileName": "src/lib/types.ts",
               "line": 472,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L472"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L472"
             }
           ],
           "type": {
@@ -22548,7 +22548,7 @@
               "fileName": "src/lib/types.ts",
               "line": 389,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
             }
           ],
           "type": {
@@ -22581,7 +22581,7 @@
               "fileName": "src/lib/types.ts",
               "line": 382,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
             }
           ],
           "type": {
@@ -22622,7 +22622,7 @@
               "fileName": "src/lib/types.ts",
               "line": 465,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L465"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L465"
             }
           ],
           "type": {
@@ -22651,7 +22651,7 @@
               "fileName": "src/lib/types.ts",
               "line": 377,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
             }
           ],
           "type": {
@@ -22684,7 +22684,7 @@
               "fileName": "src/lib/types.ts",
               "line": 435,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L435"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L435"
             }
           ],
           "type": {
@@ -22745,7 +22745,7 @@
               "fileName": "src/lib/types.ts",
               "line": 456,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L456"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L456"
             }
           ],
           "type": {
@@ -22790,7 +22790,7 @@
               "fileName": "src/lib/types.ts",
               "line": 411,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L411"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L411"
             }
           ],
           "type": {
@@ -22810,7 +22810,7 @@
           "fileName": "src/lib/types.ts",
           "line": 400,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L400"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L400"
         }
       ],
       "extendedTypes": [
@@ -22907,7 +22907,7 @@
               "fileName": "src/lib/types.ts",
               "line": 327,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L327"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L327"
             }
           ],
           "type": {
@@ -22950,7 +22950,7 @@
               "fileName": "src/lib/types.ts",
               "line": 322,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L322"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L322"
             }
           ],
           "type": {
@@ -23007,7 +23007,7 @@
               "fileName": "src/lib/types.ts",
               "line": 317,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L317"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L317"
             }
           ],
           "type": {
@@ -23034,7 +23034,7 @@
               "fileName": "src/lib/types.ts",
               "line": 314,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L314"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L314"
             }
           ],
           "type": {
@@ -23061,7 +23061,7 @@
               "fileName": "src/lib/types.ts",
               "line": 325,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L325"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L325"
             }
           ],
           "type": {
@@ -23089,7 +23089,7 @@
               "fileName": "src/lib/types.ts",
               "line": 328,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L328"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L328"
             }
           ],
           "type": {
@@ -23109,7 +23109,7 @@
           "fileName": "src/lib/types.ts",
           "line": 312,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L312"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L312"
         }
       ]
     },
@@ -23157,7 +23157,7 @@
               "fileName": "src/lib/types.ts",
               "line": 851,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L851"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L851"
             }
           ],
           "type": {
@@ -23186,7 +23186,7 @@
               "fileName": "src/lib/types.ts",
               "line": 853,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L853"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L853"
             }
           ],
           "type": {
@@ -23206,7 +23206,7 @@
           "fileName": "src/lib/types.ts",
           "line": 845,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L845"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L845"
         }
       ]
     },
@@ -23242,7 +23242,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1169,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1169"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1169"
             }
           ],
           "signatures": [
@@ -23308,7 +23308,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1120,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
                         }
                       ],
                       "type": {
@@ -23339,7 +23339,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1122,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1122"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1122"
                                 }
                               ],
                               "type": {
@@ -23366,7 +23366,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1125,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1125"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1125"
                                 }
                               ],
                               "type": {
@@ -23386,7 +23386,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1120,
                               "character": 45,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
                             }
                           ]
                         }
@@ -23422,7 +23422,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1159,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1159"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1159"
             }
           ],
           "signatures": [
@@ -23471,7 +23471,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1144,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
                         }
                       ],
                       "type": {
@@ -23502,7 +23502,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1146,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1146"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1146"
                                 }
                               ],
                               "type": {
@@ -23522,7 +23522,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1144,
                               "character": 44,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
                             }
                           ]
                         }
@@ -23559,7 +23559,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1154,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1154"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1154"
         }
       ]
     },
@@ -23589,7 +23589,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1058,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1058"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1058"
             }
           ],
           "signatures": [
@@ -23629,7 +23629,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 926,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
                         }
                       ],
                       "type": {
@@ -23662,7 +23662,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 930,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L930"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L930"
                                 }
                               ],
                               "type": {
@@ -23698,7 +23698,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 928,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L928"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L928"
                                 }
                               ],
                               "type": {
@@ -23718,7 +23718,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 926,
                               "character": 33,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
                             }
                           ]
                         }
@@ -23754,7 +23754,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1076,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1076"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1076"
             }
           ],
           "signatures": [
@@ -23794,7 +23794,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 933,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
                         }
                       ],
                       "type": {
@@ -23825,7 +23825,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 937,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L937"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L937"
                                 }
                               ],
                               "type": {
@@ -23852,7 +23852,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 935,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L935"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L935"
                                 }
                               ],
                               "type": {
@@ -23872,7 +23872,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 933,
                               "character": 42,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
                             }
                           ]
                         }
@@ -23908,19 +23908,19 @@
               "fileName": "src/lib/types.ts",
               "line": 1050,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1050"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1050"
             },
             {
               "fileName": "src/lib/types.ts",
               "line": 1051,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1051"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1051"
             },
             {
               "fileName": "src/lib/types.ts",
               "line": 1052,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1052"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1052"
             }
           ],
           "signatures": [
@@ -23976,7 +23976,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1234,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                         }
                       ],
                       "type": {
@@ -24007,7 +24007,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1236,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                                 }
                               ],
                               "type": {
@@ -24036,7 +24036,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1240,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                                 }
                               ],
                               "type": {
@@ -24065,7 +24065,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1238,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                                 }
                               ],
                               "type": {
@@ -24085,7 +24085,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1234,
                               "character": 34,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                             }
                           ]
                         }
@@ -24136,7 +24136,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1242,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                         }
                       ],
                       "type": {
@@ -24167,7 +24167,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1244,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                                 }
                               ],
                               "type": {
@@ -24196,7 +24196,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1246,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                                 }
                               ],
                               "type": {
@@ -24223,7 +24223,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1248,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                                 }
                               ],
                               "type": {
@@ -24243,7 +24243,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1242,
                               "character": 35,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                             }
                           ]
                         }
@@ -24294,7 +24294,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 908,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L908"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L908"
                         }
                       ],
                       "type": {
@@ -24311,7 +24311,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 1234,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                               }
                             ],
                             "type": {
@@ -24342,7 +24342,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1236,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                                       }
                                     ],
                                     "type": {
@@ -24371,7 +24371,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1240,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                                       }
                                     ],
                                     "type": {
@@ -24400,7 +24400,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1238,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                                       }
                                     ],
                                     "type": {
@@ -24420,7 +24420,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1234,
                                     "character": 34,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                                   }
                                 ]
                               }
@@ -24437,7 +24437,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 1242,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                               }
                             ],
                             "type": {
@@ -24468,7 +24468,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1244,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                                       }
                                     ],
                                     "type": {
@@ -24497,7 +24497,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1246,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                                       }
                                     ],
                                     "type": {
@@ -24524,7 +24524,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1248,
                                         "character": 2,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                                       }
                                     ],
                                     "type": {
@@ -24544,7 +24544,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1242,
                                     "character": 35,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                                   }
                                 ]
                               }
@@ -24583,7 +24583,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1101,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1101"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1101"
             }
           ],
           "signatures": [
@@ -24652,7 +24652,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1086,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1086"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1086"
             }
           ],
           "signatures": [
@@ -24746,7 +24746,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1070,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1070"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1070"
             }
           ],
           "signatures": [
@@ -24802,7 +24802,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 910,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
                         }
                       ],
                       "type": {
@@ -24833,7 +24833,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 912,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L912"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L912"
                                 }
                               ],
                               "type": {
@@ -24853,7 +24853,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 910,
                               "character": 32,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
                             }
                           ]
                         }
@@ -24889,7 +24889,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1064,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1064"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1064"
             }
           ],
           "signatures": [
@@ -24929,7 +24929,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 915,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
                         }
                       ],
                       "type": {
@@ -24960,7 +24960,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 920,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L920"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L920"
                                 }
                               ],
                               "type": {
@@ -24987,7 +24987,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 923,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L923"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L923"
                                 }
                               ],
                               "type": {
@@ -25014,7 +25014,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 917,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L917"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L917"
                                 }
                               ],
                               "type": {
@@ -25034,7 +25034,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 915,
                               "character": 30,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
                             }
                           ]
                         }
@@ -25071,7 +25071,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1039,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1039"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1039"
         }
       ]
     },
@@ -25095,7 +25095,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1332,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1332"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1332"
             }
           ],
           "type": {
@@ -25114,7 +25114,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1331,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1331"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1331"
             }
           ],
           "type": {
@@ -25138,7 +25138,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1333,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1333"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1333"
             }
           ],
           "type": {
@@ -25157,7 +25157,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1330,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1330"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1330"
             }
           ],
           "type": {
@@ -25190,7 +25190,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1329,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1329"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1329"
         }
       ],
       "indexSignature": {
@@ -25243,7 +25243,7 @@
               "fileName": "src/lib/types.ts",
               "line": 252,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L252"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L252"
             }
           ],
           "type": {
@@ -25272,7 +25272,7 @@
               "fileName": "src/lib/types.ts",
               "line": 264,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L264"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L264"
             }
           ],
           "type": {
@@ -25299,7 +25299,7 @@
               "fileName": "src/lib/types.ts",
               "line": 260,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L260"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L260"
             }
           ],
           "type": {
@@ -25328,7 +25328,7 @@
               "fileName": "src/lib/types.ts",
               "line": 248,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L248"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L248"
             }
           ],
           "type": {
@@ -25366,7 +25366,7 @@
               "fileName": "src/lib/types.ts",
               "line": 243,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L243"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L243"
             }
           ],
           "type": {
@@ -25402,7 +25402,7 @@
               "fileName": "src/lib/types.ts",
               "line": 256,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L256"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L256"
             }
           ],
           "type": {
@@ -25421,7 +25421,7 @@
               "fileName": "src/lib/types.ts",
               "line": 265,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L265"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L265"
             }
           ],
           "type": {
@@ -25448,7 +25448,7 @@
               "fileName": "src/lib/types.ts",
               "line": 270,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L270"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L270"
             }
           ],
           "type": {
@@ -25475,7 +25475,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 351,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L351"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L351"
                     }
                   ],
                   "type": {
@@ -25494,7 +25494,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 342,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L342"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L342"
                     }
                   ],
                   "type": {
@@ -25521,7 +25521,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 332,
                               "character": 2,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L332"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L332"
                             }
                           ],
                           "type": {
@@ -25541,7 +25541,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 331,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L331"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L331"
                         }
                       ],
                       "indexSignature": {
@@ -25581,7 +25581,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 344,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L344"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L344"
                     }
                   ],
                   "type": {
@@ -25602,7 +25602,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 345,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L345"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L345"
                     }
                   ],
                   "type": {
@@ -25623,7 +25623,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 355,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L355"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L355"
                     }
                   ],
                   "type": {
@@ -25642,7 +25642,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 354,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L354"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L354"
                     }
                   ],
                   "type": {
@@ -25663,7 +25663,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 365,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L365"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L365"
                     }
                   ],
                   "type": {
@@ -25684,7 +25684,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 352,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L352"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L352"
                     }
                   ],
                   "type": {
@@ -25705,7 +25705,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 347,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L347"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L347"
                     }
                   ],
                   "type": {
@@ -25726,7 +25726,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 356,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L356"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L356"
                     }
                   ],
                   "type": {
@@ -25747,7 +25747,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 364,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L364"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L364"
                     }
                   ],
                   "type": {
@@ -25770,7 +25770,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 341,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L341"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L341"
                     }
                   ],
                   "type": {
@@ -25791,7 +25791,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 361,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L361"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L361"
                     }
                   ],
                   "type": {
@@ -25816,7 +25816,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 350,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L350"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L350"
                     }
                   ],
                   "type": {
@@ -25837,7 +25837,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 362,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L362"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L362"
                     }
                   ],
                   "type": {
@@ -25858,7 +25858,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 363,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L363"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L363"
                     }
                   ],
                   "type": {
@@ -25879,7 +25879,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 358,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L358"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L358"
                     }
                   ],
                   "type": {
@@ -25900,7 +25900,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 348,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L348"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L348"
                     }
                   ],
                   "type": {
@@ -25921,7 +25921,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 349,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L349"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L349"
                     }
                   ],
                   "type": {
@@ -25942,7 +25942,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 353,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L353"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L353"
                     }
                   ],
                   "type": {
@@ -25963,7 +25963,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 357,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L357"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L357"
                     }
                   ],
                   "type": {
@@ -25984,7 +25984,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 346,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L346"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L346"
                     }
                   ],
                   "type": {
@@ -26005,7 +26005,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 359,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L359"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L359"
                     }
                   ],
                   "type": {
@@ -26026,7 +26026,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 360,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L360"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L360"
                     }
                   ],
                   "type": {
@@ -26045,7 +26045,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 343,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L343"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L343"
                     }
                   ],
                   "type": {
@@ -26063,7 +26063,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 336,
                           "character": 17,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L336"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L336"
                         }
                       ],
                       "indexSignature": {
@@ -26107,7 +26107,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 340,
                   "character": 17,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L340"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L340"
                 }
               ]
             }
@@ -26125,7 +26125,7 @@
           "fileName": "src/lib/types.ts",
           "line": 239,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L239"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L239"
         }
       ]
     },
@@ -26147,7 +26147,7 @@
               "fileName": "src/lib/types.ts",
               "line": 483,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L483"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L483"
             }
           ],
           "type": {
@@ -26163,7 +26163,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 483,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L483"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L483"
                 }
               ],
               "signatures": [
@@ -26244,7 +26244,7 @@
               "fileName": "src/lib/types.ts",
               "line": 479,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L479"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L479"
             }
           ],
           "type": {
@@ -26263,7 +26263,7 @@
               "fileName": "src/lib/types.ts",
               "line": 487,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L487"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L487"
             }
           ],
           "type": {
@@ -26279,7 +26279,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 487,
                   "character": 15,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L487"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L487"
                 }
               ],
               "signatures": [
@@ -26318,7 +26318,7 @@
           "fileName": "src/lib/types.ts",
           "line": 475,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L475"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L475"
         }
       ]
     },
@@ -26342,7 +26342,7 @@
               "fileName": "src/lib/types.ts",
               "line": 351,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L351"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L351"
             }
           ],
           "type": {
@@ -26361,7 +26361,7 @@
               "fileName": "src/lib/types.ts",
               "line": 342,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L342"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L342"
             }
           ],
           "type": {
@@ -26388,7 +26388,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 332,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L332"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L332"
                     }
                   ],
                   "type": {
@@ -26408,7 +26408,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 331,
                   "character": 17,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L331"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L331"
                 }
               ],
               "indexSignature": {
@@ -26448,7 +26448,7 @@
               "fileName": "src/lib/types.ts",
               "line": 344,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L344"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L344"
             }
           ],
           "type": {
@@ -26469,7 +26469,7 @@
               "fileName": "src/lib/types.ts",
               "line": 345,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L345"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L345"
             }
           ],
           "type": {
@@ -26490,7 +26490,7 @@
               "fileName": "src/lib/types.ts",
               "line": 355,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L355"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L355"
             }
           ],
           "type": {
@@ -26509,7 +26509,7 @@
               "fileName": "src/lib/types.ts",
               "line": 354,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L354"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L354"
             }
           ],
           "type": {
@@ -26530,7 +26530,7 @@
               "fileName": "src/lib/types.ts",
               "line": 365,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L365"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L365"
             }
           ],
           "type": {
@@ -26551,7 +26551,7 @@
               "fileName": "src/lib/types.ts",
               "line": 352,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L352"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L352"
             }
           ],
           "type": {
@@ -26572,7 +26572,7 @@
               "fileName": "src/lib/types.ts",
               "line": 347,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L347"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L347"
             }
           ],
           "type": {
@@ -26593,7 +26593,7 @@
               "fileName": "src/lib/types.ts",
               "line": 356,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L356"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L356"
             }
           ],
           "type": {
@@ -26614,7 +26614,7 @@
               "fileName": "src/lib/types.ts",
               "line": 364,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L364"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L364"
             }
           ],
           "type": {
@@ -26637,7 +26637,7 @@
               "fileName": "src/lib/types.ts",
               "line": 341,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L341"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L341"
             }
           ],
           "type": {
@@ -26658,7 +26658,7 @@
               "fileName": "src/lib/types.ts",
               "line": 361,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L361"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L361"
             }
           ],
           "type": {
@@ -26683,7 +26683,7 @@
               "fileName": "src/lib/types.ts",
               "line": 350,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L350"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L350"
             }
           ],
           "type": {
@@ -26704,7 +26704,7 @@
               "fileName": "src/lib/types.ts",
               "line": 362,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L362"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L362"
             }
           ],
           "type": {
@@ -26725,7 +26725,7 @@
               "fileName": "src/lib/types.ts",
               "line": 363,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L363"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L363"
             }
           ],
           "type": {
@@ -26746,7 +26746,7 @@
               "fileName": "src/lib/types.ts",
               "line": 358,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L358"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L358"
             }
           ],
           "type": {
@@ -26767,7 +26767,7 @@
               "fileName": "src/lib/types.ts",
               "line": 348,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L348"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L348"
             }
           ],
           "type": {
@@ -26788,7 +26788,7 @@
               "fileName": "src/lib/types.ts",
               "line": 349,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L349"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L349"
             }
           ],
           "type": {
@@ -26809,7 +26809,7 @@
               "fileName": "src/lib/types.ts",
               "line": 353,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L353"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L353"
             }
           ],
           "type": {
@@ -26830,7 +26830,7 @@
               "fileName": "src/lib/types.ts",
               "line": 357,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L357"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L357"
             }
           ],
           "type": {
@@ -26851,7 +26851,7 @@
               "fileName": "src/lib/types.ts",
               "line": 346,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L346"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L346"
             }
           ],
           "type": {
@@ -26872,7 +26872,7 @@
               "fileName": "src/lib/types.ts",
               "line": 359,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L359"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L359"
             }
           ],
           "type": {
@@ -26893,7 +26893,7 @@
               "fileName": "src/lib/types.ts",
               "line": 360,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L360"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L360"
             }
           ],
           "type": {
@@ -26912,7 +26912,7 @@
               "fileName": "src/lib/types.ts",
               "line": 343,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L343"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L343"
             }
           ],
           "type": {
@@ -26930,7 +26930,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 336,
                   "character": 17,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L336"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L336"
                 }
               ],
               "indexSignature": {
@@ -26974,7 +26974,7 @@
           "fileName": "src/lib/types.ts",
           "line": 340,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L340"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L340"
         }
       ]
     },
@@ -26998,7 +26998,7 @@
               "fileName": "src/lib/types.ts",
               "line": 332,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L332"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L332"
             }
           ],
           "type": {
@@ -27018,7 +27018,7 @@
           "fileName": "src/lib/types.ts",
           "line": 331,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L331"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L331"
         }
       ],
       "indexSignature": {
@@ -27089,7 +27089,7 @@
               "fileName": "src/lib/types.ts",
               "line": 397,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L397"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L397"
             }
           ],
           "type": {
@@ -27118,7 +27118,7 @@
               "fileName": "src/lib/types.ts",
               "line": 372,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L372"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L372"
             }
           ],
           "type": {
@@ -27147,7 +27147,7 @@
               "fileName": "src/lib/types.ts",
               "line": 389,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L389"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L389"
             }
           ],
           "type": {
@@ -27176,7 +27176,7 @@
               "fileName": "src/lib/types.ts",
               "line": 382,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L382"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L382"
             }
           ],
           "type": {
@@ -27205,7 +27205,7 @@
               "fileName": "src/lib/types.ts",
               "line": 377,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L377"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L377"
             }
           ],
           "type": {
@@ -27225,7 +27225,7 @@
           "fileName": "src/lib/types.ts",
           "line": 368,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L368"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L368"
         }
       ]
     },
@@ -27249,7 +27249,7 @@
               "fileName": "src/lib/types.ts",
               "line": 300,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L300"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L300"
             }
           ],
           "type": {
@@ -27268,7 +27268,7 @@
               "fileName": "src/lib/types.ts",
               "line": 293,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L293"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L293"
             }
           ],
           "type": {
@@ -27289,7 +27289,7 @@
               "fileName": "src/lib/types.ts",
               "line": 295,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L295"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L295"
             }
           ],
           "type": {
@@ -27305,7 +27305,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 295,
                   "character": 18,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L295"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L295"
                 }
               ],
               "indexSignature": {
@@ -27345,7 +27345,7 @@
               "fileName": "src/lib/types.ts",
               "line": 298,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L298"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L298"
             }
           ],
           "type": {
@@ -27366,7 +27366,7 @@
               "fileName": "src/lib/types.ts",
               "line": 301,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L301"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L301"
             }
           ],
           "type": {
@@ -27385,7 +27385,7 @@
               "fileName": "src/lib/types.ts",
               "line": 299,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L299"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L299"
             }
           ],
           "type": {
@@ -27406,7 +27406,7 @@
               "fileName": "src/lib/types.ts",
               "line": 302,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L302"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L302"
             }
           ],
           "type": {
@@ -27425,7 +27425,7 @@
               "fileName": "src/lib/types.ts",
               "line": 294,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L294"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L294"
             }
           ],
           "type": {
@@ -27445,7 +27445,7 @@
           "fileName": "src/lib/types.ts",
           "line": 292,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L292"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L292"
         }
       ]
     },
@@ -27460,7 +27460,7 @@
           "fileName": "src/lib/types.ts",
           "line": 336,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L336"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L336"
         }
       ],
       "indexSignature": {
@@ -27513,7 +27513,7 @@
               "fileName": "src/lib/types.ts",
               "line": 741,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L741"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L741"
             }
           ],
           "type": {
@@ -27534,7 +27534,7 @@
               "fileName": "src/lib/types.ts",
               "line": 746,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
             }
           ],
           "type": {
@@ -27573,7 +27573,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 754,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L754"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L754"
                     }
                   ],
                   "type": {
@@ -27602,7 +27602,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 748,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L748"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L748"
                     }
                   ],
                   "type": {
@@ -27622,7 +27622,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 746,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
                 }
               ]
             }
@@ -27647,7 +27647,7 @@
               "fileName": "src/lib/types.ts",
               "line": 743,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L743"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L743"
             }
           ],
           "type": {
@@ -27674,7 +27674,7 @@
               "fileName": "src/lib/types.ts",
               "line": 745,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L745"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L745"
             }
           ],
           "type": {
@@ -27692,7 +27692,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 767,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
                 }
               ],
               "type": {
@@ -27739,7 +27739,7 @@
           "fileName": "src/lib/types.ts",
           "line": 739,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L739"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L739"
         }
       ]
     },
@@ -27763,7 +27763,7 @@
               "fileName": "src/lib/types.ts",
               "line": 727,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
             }
           ],
           "type": {
@@ -27802,7 +27802,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 736,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L736"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L736"
                     }
                   ],
                   "type": {
@@ -27831,7 +27831,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 729,
                       "character": 4,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L729"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L729"
                     }
                   ],
                   "type": {
@@ -27851,7 +27851,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 727,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
                 }
               ]
             }
@@ -27876,7 +27876,7 @@
               "fileName": "src/lib/types.ts",
               "line": 722,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L722"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L722"
             }
           ],
           "type": {
@@ -27903,7 +27903,7 @@
               "fileName": "src/lib/types.ts",
               "line": 724,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L724"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L724"
             }
           ],
           "type": {
@@ -27930,7 +27930,7 @@
               "fileName": "src/lib/types.ts",
               "line": 726,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L726"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L726"
             }
           ],
           "type": {
@@ -27948,7 +27948,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 766,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L766"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L766"
                 }
               ],
               "type": {
@@ -27979,7 +27979,7 @@
           "fileName": "src/lib/types.ts",
           "line": 720,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L720"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L720"
         }
       ]
     },
@@ -28009,7 +28009,7 @@
               "fileName": "src/lib/types.ts",
               "line": 760,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L760"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L760"
             }
           ],
           "type": {
@@ -28036,7 +28036,7 @@
               "fileName": "src/lib/types.ts",
               "line": 763,
               "character": 2,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L763"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L763"
             }
           ],
           "type": {
@@ -28054,7 +28054,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 767,
                   "character": 12,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
                 }
               ],
               "type": {
@@ -28101,7 +28101,7 @@
           "fileName": "src/lib/types.ts",
           "line": 758,
           "character": 17,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L758"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L758"
         }
       ]
     },
@@ -28116,7 +28116,7 @@
           "fileName": "src/lib/types.ts",
           "line": 34,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L34"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L34"
         }
       ],
       "type": {
@@ -28157,7 +28157,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 32,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L32"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L32"
               }
             ],
             "type": {
@@ -28179,7 +28179,7 @@
           "fileName": "src/lib/types.ts",
           "line": 32,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L32"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L32"
         }
       ],
       "type": {
@@ -28198,7 +28198,7 @@
           "fileName": "src/lib/types.ts",
           "line": 601,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L601"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L601"
         }
       ],
       "type": {
@@ -28235,7 +28235,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1120,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
         }
       ],
       "type": {
@@ -28266,7 +28266,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1122,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1122"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1122"
                 }
               ],
               "type": {
@@ -28293,7 +28293,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1125,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1125"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1125"
                 }
               ],
               "type": {
@@ -28313,7 +28313,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1120,
               "character": 45,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1120"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1120"
             }
           ]
         }
@@ -28339,7 +28339,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1107,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1107"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1107"
         }
       ],
       "type": {
@@ -28365,7 +28365,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1109,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1109"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1109"
                     }
                   ],
                   "type": {
@@ -28396,7 +28396,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1111,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1111"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1111"
                             }
                           ],
                           "type": {
@@ -28416,7 +28416,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1109,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1109"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1109"
                         }
                       ]
                     }
@@ -28433,7 +28433,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1113,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1113"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1113"
                     }
                   ],
                   "type": {
@@ -28453,7 +28453,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1108,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1108"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1108"
                 }
               ]
             }
@@ -28478,7 +28478,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1115,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1115"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1115"
                     }
                   ],
                   "type": {
@@ -28497,7 +28497,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1115,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1115"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1115"
                     }
                   ],
                   "type": {
@@ -28518,7 +28518,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1115,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1115"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1115"
                 }
               ]
             }
@@ -28546,7 +28546,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1144,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
         }
       ],
       "type": {
@@ -28577,7 +28577,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1146,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1146"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1146"
                 }
               ],
               "type": {
@@ -28597,7 +28597,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1144,
               "character": 44,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1144"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1144"
             }
           ]
         }
@@ -28623,7 +28623,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1131,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1131"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1131"
         }
       ],
       "type": {
@@ -28649,7 +28649,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1133,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1133"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1133"
                     }
                   ],
                   "type": {
@@ -28680,7 +28680,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1135,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1135"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1135"
                             }
                           ],
                           "type": {
@@ -28704,7 +28704,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1133,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1133"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1133"
                         }
                       ]
                     }
@@ -28721,7 +28721,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1137,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1137"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1137"
                     }
                   ],
                   "type": {
@@ -28741,7 +28741,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1132,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1132"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1132"
                 }
               ]
             }
@@ -28766,7 +28766,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1139,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1139"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1139"
                     }
                   ],
                   "type": {
@@ -28785,7 +28785,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1139,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1139"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1139"
                     }
                   ],
                   "type": {
@@ -28806,7 +28806,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1139,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1139"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1139"
                 }
               ]
             }
@@ -28825,7 +28825,7 @@
           "fileName": "src/lib/types.ts",
           "line": 977,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L977"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L977"
         }
       ],
       "type": {
@@ -28851,7 +28851,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 979,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L979"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L979"
                     }
                   ],
                   "type": {
@@ -28882,7 +28882,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 987,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L987"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L987"
                             }
                           ],
                           "type": {
@@ -28909,7 +28909,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 981,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L981"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L981"
                             }
                           ],
                           "type": {
@@ -28936,7 +28936,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 984,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L984"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L984"
                             }
                           ],
                           "type": {
@@ -28965,7 +28965,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 979,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L979"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L979"
                         }
                       ]
                     }
@@ -28982,7 +28982,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 989,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L989"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L989"
                     }
                   ],
                   "type": {
@@ -29002,7 +29002,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 978,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L978"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L978"
                 }
               ]
             }
@@ -29027,7 +29027,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 991,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L991"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L991"
                     }
                   ],
                   "type": {
@@ -29046,7 +29046,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 991,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L991"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L991"
                     }
                   ],
                   "type": {
@@ -29067,7 +29067,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 991,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L991"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L991"
                 }
               ]
             }
@@ -29086,7 +29086,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1286,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1286"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1286"
         }
       ],
       "type": {
@@ -29112,7 +29112,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1288,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1288"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1288"
                     }
                   ],
                   "type": {
@@ -29145,7 +29145,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1296,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1296"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1296"
                             }
                           ],
                           "type": {
@@ -29172,7 +29172,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1290,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1290"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1290"
                             }
                           ],
                           "type": {
@@ -29199,7 +29199,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1299,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1299"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1299"
                             }
                           ],
                           "type": {
@@ -29226,7 +29226,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1293,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1293"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1293"
                             }
                           ],
                           "type": {
@@ -29246,7 +29246,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1288,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1288"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1288"
                         }
                       ]
                     }
@@ -29263,7 +29263,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1301,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1301"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1301"
                     }
                   ],
                   "type": {
@@ -29283,7 +29283,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1287,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1287"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1287"
                 }
               ]
             }
@@ -29308,7 +29308,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1304,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1304"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1304"
                     }
                   ],
                   "type": {
@@ -29327,7 +29327,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1305,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1305"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1305"
                     }
                   ],
                   "type": {
@@ -29348,7 +29348,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1303,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1303"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1303"
                 }
               ]
             }
@@ -29367,7 +29367,7 @@
           "fileName": "src/lib/types.ts",
           "line": 965,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L965"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L965"
         }
       ],
       "type": {
@@ -29384,7 +29384,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 1251,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1251"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1251"
               }
             ],
             "type": {
@@ -29410,7 +29410,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1253,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1253"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1253"
                           }
                         ],
                         "type": {
@@ -29443,7 +29443,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1277,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1277"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1277"
                                   }
                                 ],
                                 "type": {
@@ -29470,7 +29470,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1255,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1255"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1255"
                                   }
                                 ],
                                 "type": {
@@ -29497,7 +29497,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1261,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1261"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1261"
                                   }
                                 ],
                                 "type": {
@@ -29536,7 +29536,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 1265,
                                             "character": 10,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1265"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1265"
                                           }
                                         ],
                                         "type": {
@@ -29563,7 +29563,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 1270,
                                             "character": 10,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1270"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1270"
                                           }
                                         ],
                                         "type": {
@@ -29590,7 +29590,7 @@
                                             "fileName": "src/lib/types.ts",
                                             "line": 1274,
                                             "character": 10,
-                                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1274"
+                                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1274"
                                           }
                                         ],
                                         "type": {
@@ -29610,7 +29610,7 @@
                                         "fileName": "src/lib/types.ts",
                                         "line": 1261,
                                         "character": 14,
-                                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1261"
+                                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1261"
                                       }
                                     ]
                                   }
@@ -29635,7 +29635,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1258,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1258"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1258"
                                   }
                                 ],
                                 "type": {
@@ -29655,7 +29655,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 1253,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1253"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1253"
                               }
                             ]
                           }
@@ -29672,7 +29672,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1279,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1279"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1279"
                           }
                         ],
                         "type": {
@@ -29692,7 +29692,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1252,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1252"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1252"
                       }
                     ]
                   }
@@ -29717,7 +29717,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1282,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1282"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1282"
                           }
                         ],
                         "type": {
@@ -29736,7 +29736,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1283,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1283"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1283"
                           }
                         ],
                         "type": {
@@ -29757,7 +29757,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1281,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1281"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1281"
                       }
                     ]
                   }
@@ -29776,7 +29776,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 1286,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1286"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1286"
               }
             ],
             "type": {
@@ -29802,7 +29802,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1288,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1288"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1288"
                           }
                         ],
                         "type": {
@@ -29835,7 +29835,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1296,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1296"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1296"
                                   }
                                 ],
                                 "type": {
@@ -29862,7 +29862,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1290,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1290"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1290"
                                   }
                                 ],
                                 "type": {
@@ -29889,7 +29889,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1299,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1299"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1299"
                                   }
                                 ],
                                 "type": {
@@ -29916,7 +29916,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 1293,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1293"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1293"
                                   }
                                 ],
                                 "type": {
@@ -29936,7 +29936,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 1288,
                                 "character": 12,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1288"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1288"
                               }
                             ]
                           }
@@ -29953,7 +29953,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1301,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1301"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1301"
                           }
                         ],
                         "type": {
@@ -29973,7 +29973,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1287,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1287"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1287"
                       }
                     ]
                   }
@@ -29998,7 +29998,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1304,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1304"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1304"
                           }
                         ],
                         "type": {
@@ -30017,7 +30017,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 1305,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1305"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1305"
                           }
                         ],
                         "type": {
@@ -30038,7 +30038,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1303,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1303"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1303"
                       }
                     ]
                   }
@@ -30060,7 +30060,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1251,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1251"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1251"
         }
       ],
       "type": {
@@ -30086,7 +30086,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1253,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1253"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1253"
                     }
                   ],
                   "type": {
@@ -30119,7 +30119,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1277,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1277"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1277"
                             }
                           ],
                           "type": {
@@ -30146,7 +30146,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1255,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1255"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1255"
                             }
                           ],
                           "type": {
@@ -30173,7 +30173,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1261,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1261"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1261"
                             }
                           ],
                           "type": {
@@ -30212,7 +30212,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1265,
                                       "character": 10,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1265"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1265"
                                     }
                                   ],
                                   "type": {
@@ -30239,7 +30239,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1270,
                                       "character": 10,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1270"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1270"
                                     }
                                   ],
                                   "type": {
@@ -30266,7 +30266,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 1274,
                                       "character": 10,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1274"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1274"
                                     }
                                   ],
                                   "type": {
@@ -30286,7 +30286,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1261,
                                   "character": 14,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1261"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1261"
                                 }
                               ]
                             }
@@ -30311,7 +30311,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1258,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1258"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1258"
                             }
                           ],
                           "type": {
@@ -30331,7 +30331,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1253,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1253"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1253"
                         }
                       ]
                     }
@@ -30348,7 +30348,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1279,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1279"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1279"
                     }
                   ],
                   "type": {
@@ -30368,7 +30368,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1252,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1252"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1252"
                 }
               ]
             }
@@ -30393,7 +30393,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1282,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1282"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1282"
                     }
                   ],
                   "type": {
@@ -30412,7 +30412,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1283,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1283"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1283"
                     }
                   ],
                   "type": {
@@ -30433,7 +30433,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1281,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1281"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1281"
                 }
               ]
             }
@@ -30452,7 +30452,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1010,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1010"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1010"
         }
       ],
       "type": {
@@ -30478,7 +30478,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1012,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1012"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1012"
                     }
                   ],
                   "type": {
@@ -30509,7 +30509,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1029,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1029"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1029"
                             }
                           ],
                           "type": {
@@ -30540,7 +30540,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1014,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1014"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1014"
                             }
                           ],
                           "type": {
@@ -30590,7 +30590,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1022,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1022"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1022"
                             }
                           ],
                           "type": {
@@ -30620,7 +30620,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 1012,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1012"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1012"
                         }
                       ]
                     }
@@ -30637,7 +30637,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1031,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1031"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1031"
                     }
                   ],
                   "type": {
@@ -30657,7 +30657,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1011,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1011"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1011"
                 }
               ]
             }
@@ -30682,7 +30682,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1033,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1033"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1033"
                     }
                   ],
                   "type": {
@@ -30701,7 +30701,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1033,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1033"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1033"
                     }
                   ],
                   "type": {
@@ -30722,7 +30722,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1033,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1033"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1033"
                 }
               ]
             }
@@ -30741,7 +30741,7 @@
           "fileName": "src/lib/types.ts",
           "line": 993,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L993"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L993"
         }
       ],
       "type": {
@@ -30767,7 +30767,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 995,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L995"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L995"
                     }
                   ],
                   "type": {
@@ -30798,7 +30798,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 997,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L997"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L997"
                             }
                           ],
                           "type": {
@@ -30837,7 +30837,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1002,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1002"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1002"
                             }
                           ],
                           "type": {
@@ -30876,7 +30876,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1000,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1000"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1000"
                             }
                           ],
                           "type": {
@@ -30900,7 +30900,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 995,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L995"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L995"
                         }
                       ]
                     }
@@ -30917,7 +30917,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1004,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1004"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1004"
                     }
                   ],
                   "type": {
@@ -30937,7 +30937,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 994,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L994"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L994"
                 }
               ]
             }
@@ -30962,7 +30962,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1006,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1006"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1006"
                     }
                   ],
                   "type": {
@@ -30981,7 +30981,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1006,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1006"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1006"
                     }
                   ],
                   "type": {
@@ -31002,7 +31002,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1006,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1006"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1006"
                 }
               ]
             }
@@ -31021,7 +31021,7 @@
           "fileName": "src/lib/types.ts",
           "line": 967,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L967"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L967"
         }
       ],
       "type": {
@@ -31047,7 +31047,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 969,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L969"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L969"
                     }
                   ],
                   "type": {
@@ -31078,7 +31078,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 971,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L971"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L971"
                             }
                           ],
                           "type": {
@@ -31098,7 +31098,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 969,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L969"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L969"
                         }
                       ]
                     }
@@ -31115,7 +31115,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 973,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L973"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L973"
                     }
                   ],
                   "type": {
@@ -31135,7 +31135,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 968,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L968"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L968"
                 }
               ]
             }
@@ -31160,7 +31160,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 975,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L975"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L975"
                     }
                   ],
                   "type": {
@@ -31179,7 +31179,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 975,
                       "character": 18,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L975"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L975"
                     }
                   ],
                   "type": {
@@ -31200,7 +31200,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 975,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L975"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L975"
                 }
               ]
             }
@@ -31219,7 +31219,7 @@
           "fileName": "src/lib/types.ts",
           "line": 940,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L940"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L940"
         }
       ],
       "type": {
@@ -31245,7 +31245,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 942,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L942"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L942"
                     }
                   ],
                   "type": {
@@ -31276,7 +31276,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 944,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L944"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L944"
                             }
                           ],
                           "type": {
@@ -31303,7 +31303,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 950,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L950"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L950"
                             }
                           ],
                           "type": {
@@ -31330,7 +31330,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 953,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L953"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L953"
                             }
                           ],
                           "type": {
@@ -31365,7 +31365,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 947,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L947"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L947"
                             }
                           ],
                           "type": {
@@ -31392,7 +31392,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 956,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L956"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L956"
                             }
                           ],
                           "type": {
@@ -31413,7 +31413,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 942,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L942"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L942"
                         }
                       ]
                     }
@@ -31430,7 +31430,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 958,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L958"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L958"
                     }
                   ],
                   "type": {
@@ -31450,7 +31450,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 941,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L941"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L941"
                 }
               ]
             }
@@ -31475,7 +31475,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 961,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L961"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L961"
                     }
                   ],
                   "type": {
@@ -31494,7 +31494,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 962,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L962"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L962"
                     }
                   ],
                   "type": {
@@ -31515,7 +31515,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 960,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L960"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L960"
                 }
               ]
             }
@@ -31547,7 +31547,7 @@
           "fileName": "src/lib/types.ts",
           "line": 146,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L146"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L146"
         }
       ],
       "type": {
@@ -31573,7 +31573,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 148,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                     }
                   ],
                   "type": {
@@ -31598,7 +31598,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 148,
                               "character": 41,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                             }
                           ],
                           "type": {
@@ -31626,7 +31626,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 148,
                               "character": 26,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                             }
                           ],
                           "type": {
@@ -31645,7 +31645,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 148,
                               "character": 14,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                             }
                           ],
                           "type": {
@@ -31665,7 +31665,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 148,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L148"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L148"
                         }
                       ]
                     }
@@ -31682,7 +31682,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 149,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L149"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L149"
                     }
                   ],
                   "type": {
@@ -31702,7 +31702,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 147,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L147"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L147"
                 }
               ]
             }
@@ -31727,7 +31727,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 152,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                     }
                   ],
                   "type": {
@@ -31752,7 +31752,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 152,
                               "character": 41,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                             }
                           ],
                           "type": {
@@ -31780,7 +31780,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 152,
                               "character": 26,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                             }
                           ],
                           "type": {
@@ -31799,7 +31799,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 152,
                               "character": 14,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                             }
                           ],
                           "type": {
@@ -31819,7 +31819,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 152,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L152"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L152"
                         }
                       ]
                     }
@@ -31836,7 +31836,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 153,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L153"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L153"
                     }
                   ],
                   "type": {
@@ -31857,7 +31857,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 151,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L151"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L151"
                 }
               ]
             }
@@ -31876,7 +31876,7 @@
           "fileName": "src/lib/types.ts",
           "line": 108,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L108"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L108"
         }
       ],
       "type": {
@@ -31902,7 +31902,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 110,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L110"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L110"
                     }
                   ],
                   "type": {
@@ -31925,7 +31925,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 112,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L112"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L112"
                             }
                           ],
                           "type": {
@@ -31954,7 +31954,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 111,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L111"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L111"
                             }
                           ],
                           "type": {
@@ -31984,7 +31984,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 110,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L110"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L110"
                         }
                       ]
                     }
@@ -32001,7 +32001,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 114,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L114"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L114"
                     }
                   ],
                   "type": {
@@ -32021,7 +32021,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 109,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L109"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L109"
                 }
               ]
             }
@@ -32046,7 +32046,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 117,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L117"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L117"
                     }
                   ],
                   "type": {
@@ -32069,7 +32069,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 119,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L119"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L119"
                             }
                           ],
                           "type": {
@@ -32088,7 +32088,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 118,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L118"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L118"
                             }
                           ],
                           "type": {
@@ -32108,7 +32108,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 117,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L117"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L117"
                         }
                       ]
                     }
@@ -32125,7 +32125,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 121,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L121"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L121"
                     }
                   ],
                   "type": {
@@ -32146,7 +32146,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 116,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L116"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L116"
                 }
               ]
             }
@@ -32165,7 +32165,7 @@
           "fileName": "src/lib/types.ts",
           "line": 124,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L124"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L124"
         }
       ],
       "type": {
@@ -32191,7 +32191,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 126,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L126"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L126"
                     }
                   ],
                   "type": {
@@ -32214,7 +32214,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 128,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L128"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L128"
                             }
                           ],
                           "type": {
@@ -32243,7 +32243,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 127,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L127"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L127"
                             }
                           ],
                           "type": {
@@ -32274,7 +32274,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 129,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L129"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L129"
                             }
                           ],
                           "type": {
@@ -32304,7 +32304,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 126,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L126"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L126"
                         }
                       ]
                     }
@@ -32321,7 +32321,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 131,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L131"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L131"
                     }
                   ],
                   "type": {
@@ -32341,7 +32341,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 125,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L125"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L125"
                 }
               ]
             }
@@ -32366,7 +32366,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 134,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L134"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L134"
                     }
                   ],
                   "type": {
@@ -32389,7 +32389,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 136,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L136"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L136"
                             }
                           ],
                           "type": {
@@ -32408,7 +32408,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 135,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L135"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L135"
                             }
                           ],
                           "type": {
@@ -32428,7 +32428,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 134,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L134"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L134"
                         }
                       ]
                     }
@@ -32445,7 +32445,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 138,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L138"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L138"
                     }
                   ],
                   "type": {
@@ -32466,7 +32466,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 133,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L133"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L133"
                 }
               ]
             }
@@ -32485,7 +32485,7 @@
           "fileName": "src/lib/types.ts",
           "line": 156,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L156"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L156"
         }
       ],
       "type": {
@@ -32511,7 +32511,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 158,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L158"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L158"
                     }
                   ],
                   "type": {
@@ -32534,7 +32534,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 160,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L160"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L160"
                             }
                           ],
                           "type": {
@@ -32554,7 +32554,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 159,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L159"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L159"
                             }
                           ],
                           "type": {
@@ -32575,7 +32575,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 158,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L158"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L158"
                         }
                       ]
                     }
@@ -32592,7 +32592,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 162,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L162"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L162"
                     }
                   ],
                   "type": {
@@ -32612,7 +32612,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 157,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L157"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L157"
                 }
               ]
             }
@@ -32637,7 +32637,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 165,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L165"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L165"
                     }
                   ],
                   "type": {
@@ -32660,7 +32660,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 167,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L167"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L167"
                             }
                           ],
                           "type": {
@@ -32679,7 +32679,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 166,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L166"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L166"
                             }
                           ],
                           "type": {
@@ -32699,7 +32699,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 165,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L165"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L165"
                         }
                       ]
                     }
@@ -32716,7 +32716,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 169,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L169"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L169"
                     }
                   ],
                   "type": {
@@ -32737,7 +32737,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 164,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L164"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L164"
                 }
               ]
             }
@@ -32756,7 +32756,7 @@
           "fileName": "src/lib/types.ts",
           "line": 172,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L172"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L172"
         }
       ],
       "type": {
@@ -32782,7 +32782,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 174,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L174"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L174"
                     }
                   ],
                   "type": {
@@ -32805,7 +32805,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 176,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L176"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L176"
                             }
                           ],
                           "type": {
@@ -32825,7 +32825,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 175,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L175"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L175"
                             }
                           ],
                           "type": {
@@ -32847,7 +32847,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 177,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L177"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L177"
                             }
                           ],
                           "type": {
@@ -32868,7 +32868,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 174,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L174"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L174"
                         }
                       ]
                     }
@@ -32885,7 +32885,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 179,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L179"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L179"
                     }
                   ],
                   "type": {
@@ -32905,7 +32905,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 173,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L173"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L173"
                 }
               ]
             }
@@ -32930,7 +32930,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 182,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L182"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L182"
                     }
                   ],
                   "type": {
@@ -32953,7 +32953,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 184,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L184"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L184"
                             }
                           ],
                           "type": {
@@ -32972,7 +32972,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 183,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L183"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L183"
                             }
                           ],
                           "type": {
@@ -32993,7 +32993,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 185,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L185"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L185"
                             }
                           ],
                           "type": {
@@ -33013,7 +33013,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 182,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L182"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L182"
                         }
                       ]
                     }
@@ -33030,7 +33030,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 187,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L187"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L187"
                     }
                   ],
                   "type": {
@@ -33051,7 +33051,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 181,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L181"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L181"
                 }
               ]
             }
@@ -33070,7 +33070,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1008,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1008"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1008"
         }
       ],
       "type": {
@@ -33098,7 +33098,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1196,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1196"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1196"
         }
       ],
       "type": {
@@ -33124,7 +33124,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1199,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1199"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1199"
                     }
                   ],
                   "type": {
@@ -33143,7 +33143,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1198,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1198"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1198"
                     }
                   ],
                   "type": {
@@ -33164,7 +33164,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1197,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1197"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1197"
                 }
               ]
             }
@@ -33189,7 +33189,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1203,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1203"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1203"
                     }
                   ],
                   "type": {
@@ -33209,7 +33209,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1202,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1202"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1202"
                     }
                   ],
                   "type": {
@@ -33229,7 +33229,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1201,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1201"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1201"
                 }
               ]
             }
@@ -33248,7 +33248,7 @@
           "fileName": "src/lib/types.ts",
           "line": 767,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
         }
       ],
       "type": {
@@ -33292,7 +33292,7 @@
           "fileName": "src/lib/types.ts",
           "line": 678,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L678"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L678"
         }
       ],
       "type": {
@@ -33311,7 +33311,7 @@
           "fileName": "src/lib/types.ts",
           "line": 680,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L680"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L680"
         }
       ],
       "type": {
@@ -33337,7 +33337,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 682,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L682"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L682"
                     }
                   ],
                   "type": {
@@ -33358,7 +33358,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 690,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                     }
                   ],
                   "type": {
@@ -33391,7 +33391,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 695,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L695"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L695"
                             }
                           ],
                           "type": {
@@ -33412,7 +33412,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 697,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L697"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L697"
                             }
                           ],
                           "type": {
@@ -33478,7 +33478,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 692,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L692"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L692"
                             }
                           ],
                           "type": {
@@ -33498,7 +33498,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 690,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                         }
                       ]
                     }
@@ -33516,7 +33516,7 @@
                     "summary": [
                       {
                         "kind": "text",
-                        "text": "Optional statement to include in the Sign in with Solana message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
+                        "text": "Optional statement to include in the Sign in with Ethereum message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
                       }
                     ]
                   },
@@ -33525,7 +33525,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 688,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L688"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L688"
                     }
                   ],
                   "type": {
@@ -33549,7 +33549,7 @@
                       },
                       {
                         "kind": "code",
-                        "text": "`window.solana`"
+                        "text": "`window.ethereum`"
                       },
                       {
                         "kind": "text",
@@ -33562,7 +33562,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 685,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L685"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L685"
                     }
                   ],
                   "type": {
@@ -33583,7 +33583,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 681,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L681"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L681"
                 }
               ]
             }
@@ -33608,7 +33608,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 703,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L703"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L703"
                     }
                   ],
                   "type": {
@@ -33659,7 +33659,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 706,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L706"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L706"
                     }
                   ],
                   "type": {
@@ -33680,7 +33680,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 711,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                     }
                   ],
                   "type": {
@@ -33713,7 +33713,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 713,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L713"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L713"
                             }
                           ],
                           "type": {
@@ -33733,7 +33733,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 711,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                         }
                       ]
                     }
@@ -33749,7 +33749,7 @@
                     "summary": [
                       {
                         "kind": "text",
-                        "text": "Ed25519 signature of the message."
+                        "text": "Ethereum curve (secp256k1) signature of the message."
                       }
                     ]
                   },
@@ -33758,7 +33758,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 709,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L709"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L709"
                     }
                   ],
                   "type": {
@@ -33778,7 +33778,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 702,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L702"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L702"
                 }
               ]
             }
@@ -33797,7 +33797,7 @@
           "fileName": "src/lib/types.ts",
           "line": 834,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
         }
       ],
       "type": {
@@ -33828,7 +33828,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 837,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L837"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L837"
                 }
               ],
               "type": {
@@ -33855,7 +33855,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 841,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L841"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L841"
                 }
               ],
               "type": {
@@ -33876,7 +33876,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 842,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L842"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L842"
                 }
               ],
               "type": {
@@ -33908,7 +33908,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 835,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L835"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L835"
                 }
               ],
               "type": {
@@ -33937,7 +33937,7 @@
               "fileName": "src/lib/types.ts",
               "line": 834,
               "character": 44,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
             }
           ]
         }
@@ -33954,7 +33954,7 @@
           "fileName": "src/lib/types.ts",
           "line": 820,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
         }
       ],
       "type": {
@@ -33985,7 +33985,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 823,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L823"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L823"
                 }
               ],
               "type": {
@@ -34006,7 +34006,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 824,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L824"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L824"
                 }
               ],
               "type": {
@@ -34047,7 +34047,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 821,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L821"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L821"
                 }
               ],
               "type": {
@@ -34076,7 +34076,7 @@
               "fileName": "src/lib/types.ts",
               "line": 820,
               "character": 46,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
             }
           ]
         }
@@ -34093,7 +34093,7 @@
           "fileName": "src/lib/types.ts",
           "line": 856,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L856"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L856"
         }
       ],
       "type": {
@@ -34110,7 +34110,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 813,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
               }
             ],
             "type": {
@@ -34133,7 +34133,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 815,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L815"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L815"
                       }
                     ],
                     "type": {
@@ -34154,7 +34154,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 817,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L817"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L817"
                       }
                     ],
                     "type": {
@@ -34195,7 +34195,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 816,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L816"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L816"
                       }
                     ],
                     "type": {
@@ -34214,7 +34214,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 814,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L814"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L814"
                       }
                     ],
                     "type": {
@@ -34234,7 +34234,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 813,
                     "character": 39,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
                   }
                 ]
               }
@@ -34251,7 +34251,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 820,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
               }
             ],
             "type": {
@@ -34282,7 +34282,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 823,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L823"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L823"
                       }
                     ],
                     "type": {
@@ -34303,7 +34303,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 824,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L824"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L824"
                       }
                     ],
                     "type": {
@@ -34344,7 +34344,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 821,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L821"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L821"
                       }
                     ],
                     "type": {
@@ -34373,7 +34373,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 820,
                     "character": 46,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L820"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L820"
                   }
                 ]
               }
@@ -34390,7 +34390,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 827,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
               }
             ],
             "type": {
@@ -34421,7 +34421,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 830,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L830"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L830"
                       }
                     ],
                     "type": {
@@ -34442,7 +34442,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 831,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L831"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L831"
                       }
                     ],
                     "type": {
@@ -34474,7 +34474,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 828,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L828"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L828"
                       }
                     ],
                     "type": {
@@ -34494,7 +34494,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 827,
                     "character": 41,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
                   }
                 ]
               }
@@ -34511,7 +34511,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 834,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
               }
             ],
             "type": {
@@ -34542,7 +34542,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 837,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L837"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L837"
                       }
                     ],
                     "type": {
@@ -34569,7 +34569,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 841,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L841"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L841"
                       }
                     ],
                     "type": {
@@ -34590,7 +34590,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 842,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L842"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L842"
                       }
                     ],
                     "type": {
@@ -34622,7 +34622,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 835,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L835"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L835"
                       }
                     ],
                     "type": {
@@ -34651,7 +34651,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 834,
                     "character": 44,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L834"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L834"
                   }
                 ]
               }
@@ -34679,7 +34679,7 @@
           "fileName": "src/lib/types.ts",
           "line": 879,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L879"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L879"
         }
       ],
       "type": {
@@ -34710,7 +34710,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 884,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L884"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L884"
                 }
               ],
               "type": {
@@ -34737,7 +34737,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 889,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L889"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L889"
                 }
               ],
               "type": {
@@ -34764,7 +34764,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 893,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L893"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L893"
                 }
               ],
               "type": {
@@ -34791,7 +34791,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 895,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L895"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L895"
                 }
               ],
               "type": {
@@ -34818,7 +34818,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 897,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L897"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L897"
                 }
               ],
               "type": {
@@ -34836,7 +34836,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 900,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L900"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L900"
                     }
                   ],
                   "type": {
@@ -34883,7 +34883,7 @@
               "fileName": "src/lib/types.ts",
               "line": 879,
               "character": 37,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L879"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L879"
             }
           ]
         }
@@ -34900,7 +34900,7 @@
           "fileName": "src/lib/types.ts",
           "line": 862,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L862"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L862"
         }
       ],
       "type": {
@@ -34926,7 +34926,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 864,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L864"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L864"
                     }
                   ],
                   "type": {
@@ -34949,7 +34949,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 865,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L865"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L865"
                             }
                           ],
                           "type": {
@@ -34969,7 +34969,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 866,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L866"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L866"
                             }
                           ],
                           "type": {
@@ -34990,7 +34990,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 864,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L864"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L864"
                         }
                       ]
                     }
@@ -35007,7 +35007,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 868,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L868"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L868"
                     }
                   ],
                   "type": {
@@ -35027,7 +35027,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 863,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L863"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L863"
                 }
               ]
             }
@@ -35052,7 +35052,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 871,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L871"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L871"
                     }
                   ],
                   "type": {
@@ -35075,7 +35075,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 872,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L872"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L872"
                             }
                           ],
                           "type": {
@@ -35094,7 +35094,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 873,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L873"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L873"
                             }
                           ],
                           "type": {
@@ -35114,7 +35114,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 871,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L871"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L871"
                         }
                       ]
                     }
@@ -35131,7 +35131,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 875,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L875"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L875"
                     }
                   ],
                   "type": {
@@ -35152,7 +35152,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 870,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L870"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L870"
                 }
               ]
             }
@@ -35171,7 +35171,7 @@
           "fileName": "src/lib/types.ts",
           "line": 900,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L900"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L900"
         }
       ],
       "type": {
@@ -35215,7 +35215,7 @@
           "fileName": "src/lib/types.ts",
           "line": 827,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
         }
       ],
       "type": {
@@ -35246,7 +35246,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 830,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L830"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L830"
                 }
               ],
               "type": {
@@ -35267,7 +35267,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 831,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L831"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L831"
                 }
               ],
               "type": {
@@ -35299,7 +35299,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 828,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L828"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L828"
                 }
               ],
               "type": {
@@ -35319,7 +35319,7 @@
               "fileName": "src/lib/types.ts",
               "line": 827,
               "character": 41,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L827"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L827"
             }
           ]
         }
@@ -35336,7 +35336,7 @@
           "fileName": "src/lib/types.ts",
           "line": 813,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
         }
       ],
       "type": {
@@ -35359,7 +35359,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 815,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L815"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L815"
                 }
               ],
               "type": {
@@ -35380,7 +35380,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 817,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L817"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L817"
                 }
               ],
               "type": {
@@ -35421,7 +35421,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 816,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L816"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L816"
                 }
               ],
               "type": {
@@ -35440,7 +35440,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 814,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L814"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L814"
                 }
               ],
               "type": {
@@ -35460,7 +35460,7 @@
               "fileName": "src/lib/types.ts",
               "line": 813,
               "character": 39,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L813"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L813"
             }
           ]
         }
@@ -35477,7 +35477,7 @@
           "fileName": "src/lib/types.ts",
           "line": 60,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L60"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L60"
         }
       ],
       "type": {
@@ -35502,7 +35502,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 70,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L70"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L70"
                 }
               ],
               "type": {
@@ -35523,7 +35523,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 88,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L88"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L88"
                 }
               ],
               "type": {
@@ -35546,7 +35546,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 88,
                           "character": 21,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L88"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L88"
                         }
                       ],
                       "signatures": [
@@ -35609,7 +35609,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 68,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L68"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L68"
                 }
               ],
               "type": {
@@ -35630,7 +35630,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 84,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L84"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L84"
                 }
               ],
               "type": {
@@ -35651,7 +35651,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 86,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L86"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L86"
                 }
               ],
               "type": {
@@ -35669,7 +35669,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 601,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L601"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L601"
                     }
                   ],
                   "type": {
@@ -35710,7 +35710,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 99,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L99"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L99"
                 }
               ],
               "type": {
@@ -35731,7 +35731,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 64,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L64"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L64"
                 }
               ],
               "type": {
@@ -35747,7 +35747,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 64,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L64"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L64"
                     }
                   ],
                   "indexSignature": {
@@ -35798,7 +35798,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 94,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L94"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L94"
                 }
               ],
               "type": {
@@ -35816,7 +35816,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 58,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                     }
                   ],
                   "type": {
@@ -35832,7 +35832,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 58,
                           "character": 23,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                         }
                       ],
                       "signatures": [
@@ -35942,7 +35942,7 @@
                                       "fileName": "src/lib/types.ts",
                                       "line": 58,
                                       "character": 69,
-                                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                                     }
                                   ],
                                   "signatures": [
@@ -36004,7 +36004,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 72,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L72"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L72"
                 }
               ],
               "type": {
@@ -36025,7 +36025,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 74,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L74"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L74"
                 }
               ],
               "type": {
@@ -36043,7 +36043,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1181,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1181"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1181"
                     }
                   ],
                   "type": {
@@ -36124,7 +36124,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1191,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1191"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1191"
                                 }
                               ],
                               "type": {
@@ -36144,7 +36144,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1183,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1183"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1183"
                             }
                           ]
                         }
@@ -36167,7 +36167,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 66,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L66"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L66"
                 }
               ],
               "type": {
@@ -36188,7 +36188,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 62,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L62"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L62"
                 }
               ],
               "type": {
@@ -36258,7 +36258,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 82,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L82"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L82"
                 }
               ],
               "type": {
@@ -36276,7 +36276,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1181,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1181"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1181"
                     }
                   ],
                   "type": {
@@ -36357,7 +36357,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 1191,
                                   "character": 2,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1191"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1191"
                                 }
                               ],
                               "type": {
@@ -36377,7 +36377,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 1183,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1183"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1183"
                             }
                           ]
                         }
@@ -36399,7 +36399,7 @@
               "fileName": "src/lib/types.ts",
               "line": 60,
               "character": 34,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L60"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L60"
             }
           ]
         }
@@ -36416,7 +36416,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1194,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1194"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1194"
         }
       ],
       "type": {
@@ -36439,7 +36439,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1194,
                   "character": 33,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1194"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1194"
                 }
               ],
               "type": {
@@ -36469,7 +36469,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1194,
               "character": 31,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1194"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1194"
             }
           ]
         }
@@ -36486,7 +36486,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1308,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1308"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1308"
         }
       ],
       "type": {
@@ -36509,7 +36509,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1309,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1309"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1309"
                 }
               ],
               "type": {
@@ -36541,7 +36541,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1310,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1310"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1310"
                 }
               ],
               "type": {
@@ -36560,7 +36560,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1311,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1311"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1311"
                 }
               ],
               "type": {
@@ -36580,7 +36580,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1308,
               "character": 24,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1308"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1308"
             }
           ]
         }
@@ -36597,7 +36597,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1325,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1325"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1325"
         }
       ],
       "type": {
@@ -36621,7 +36621,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1325,
                   "character": 42,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1325"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1325"
                 }
               ],
               "indexSignature": {
@@ -36663,7 +36663,7 @@
           "fileName": "src/lib/types.ts",
           "line": 58,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
         }
       ],
       "type": {
@@ -36679,7 +36679,7 @@
               "fileName": "src/lib/types.ts",
               "line": 58,
               "character": 23,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
             }
           ],
           "signatures": [
@@ -36789,7 +36789,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 58,
                           "character": 69,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L58"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L58"
                         }
                       ],
                       "signatures": [
@@ -36847,7 +36847,7 @@
           "fileName": "src/lib/types.ts",
           "line": 933,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
         }
       ],
       "type": {
@@ -36878,7 +36878,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 937,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L937"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L937"
                 }
               ],
               "type": {
@@ -36905,7 +36905,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 935,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L935"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L935"
                 }
               ],
               "type": {
@@ -36925,7 +36925,7 @@
               "fileName": "src/lib/types.ts",
               "line": 933,
               "character": 42,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L933"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L933"
             }
           ]
         }
@@ -36942,7 +36942,7 @@
           "fileName": "src/lib/types.ts",
           "line": 926,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
         }
       ],
       "type": {
@@ -36975,7 +36975,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 930,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L930"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L930"
                 }
               ],
               "type": {
@@ -37011,7 +37011,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 928,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L928"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L928"
                 }
               ],
               "type": {
@@ -37031,7 +37031,7 @@
               "fileName": "src/lib/types.ts",
               "line": 926,
               "character": 33,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L926"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L926"
             }
           ]
         }
@@ -37048,7 +37048,7 @@
           "fileName": "src/lib/types.ts",
           "line": 908,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L908"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L908"
         }
       ],
       "type": {
@@ -37065,7 +37065,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 1234,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
               }
             ],
             "type": {
@@ -37096,7 +37096,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1236,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                       }
                     ],
                     "type": {
@@ -37125,7 +37125,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1240,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                       }
                     ],
                     "type": {
@@ -37154,7 +37154,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1238,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                       }
                     ],
                     "type": {
@@ -37174,7 +37174,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 1234,
                     "character": 34,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
                   }
                 ]
               }
@@ -37191,7 +37191,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 1242,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
               }
             ],
             "type": {
@@ -37222,7 +37222,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1244,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                       }
                     ],
                     "type": {
@@ -37251,7 +37251,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1246,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                       }
                     ],
                     "type": {
@@ -37278,7 +37278,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 1248,
                         "character": 2,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                       }
                     ],
                     "type": {
@@ -37298,7 +37298,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 1242,
                     "character": 35,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
                   }
                 ]
               }
@@ -37318,7 +37318,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1242,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
         }
       ],
       "type": {
@@ -37349,7 +37349,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1244,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1244"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1244"
                 }
               ],
               "type": {
@@ -37378,7 +37378,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1246,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1246"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1246"
                 }
               ],
               "type": {
@@ -37405,7 +37405,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1248,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1248"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1248"
                 }
               ],
               "type": {
@@ -37425,7 +37425,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1242,
               "character": 35,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1242"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1242"
             }
           ]
         }
@@ -37442,7 +37442,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1234,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
         }
       ],
       "type": {
@@ -37473,7 +37473,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1236,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1236"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1236"
                 }
               ],
               "type": {
@@ -37502,7 +37502,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1240,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1240"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1240"
                 }
               ],
               "type": {
@@ -37531,7 +37531,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1238,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1238"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1238"
                 }
               ],
               "type": {
@@ -37551,7 +37551,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1234,
               "character": 34,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1234"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1234"
             }
           ]
         }
@@ -37568,7 +37568,7 @@
           "fileName": "src/lib/types.ts",
           "line": 910,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
         }
       ],
       "type": {
@@ -37599,7 +37599,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 912,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L912"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L912"
                 }
               ],
               "type": {
@@ -37619,7 +37619,7 @@
               "fileName": "src/lib/types.ts",
               "line": 910,
               "character": 32,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L910"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L910"
             }
           ]
         }
@@ -37636,7 +37636,7 @@
           "fileName": "src/lib/types.ts",
           "line": 915,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
         }
       ],
       "type": {
@@ -37667,7 +37667,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 920,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L920"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L920"
                 }
               ],
               "type": {
@@ -37694,7 +37694,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 923,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L923"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L923"
                 }
               ],
               "type": {
@@ -37721,7 +37721,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 917,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L917"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L917"
                 }
               ],
               "type": {
@@ -37741,7 +37741,7 @@
               "fileName": "src/lib/types.ts",
               "line": 915,
               "character": 30,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L915"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L915"
             }
           ]
         }
@@ -37758,7 +37758,7 @@
           "fileName": "src/lib/types.ts",
           "line": 766,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L766"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L766"
         }
       ],
       "type": {
@@ -37786,7 +37786,7 @@
           "fileName": "src/lib/types.ts",
           "line": 190,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L190"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L190"
         }
       ],
       "type": {
@@ -37812,7 +37812,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 192,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L192"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L192"
                     }
                   ],
                   "type": {
@@ -37835,7 +37835,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 193,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L193"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L193"
                             }
                           ],
                           "type": {
@@ -37855,7 +37855,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 194,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L194"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L194"
                             }
                           ],
                           "type": {
@@ -37875,7 +37875,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 192,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L192"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L192"
                         }
                       ]
                     }
@@ -37892,7 +37892,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 196,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L196"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L196"
                     }
                   ],
                   "type": {
@@ -37912,7 +37912,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 191,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L191"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L191"
                 }
               ]
             }
@@ -37937,7 +37937,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 199,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L199"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L199"
                     }
                   ],
                   "type": {
@@ -37960,7 +37960,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 200,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L200"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L200"
                             }
                           ],
                           "type": {
@@ -37980,7 +37980,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 201,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L201"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L201"
                             }
                           ],
                           "type": {
@@ -38000,7 +38000,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 199,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L199"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L199"
                         }
                       ]
                     }
@@ -38017,7 +38017,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 203,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L203"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L203"
                     }
                   ],
                   "type": {
@@ -38038,7 +38038,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 198,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L198"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L198"
                 }
               ]
             }
@@ -38057,7 +38057,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1213,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
         }
       ],
       "type": {
@@ -38090,7 +38090,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1215,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1215"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1215"
                 }
               ],
               "type": {
@@ -38119,7 +38119,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1217,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1217"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1217"
                 }
               ],
               "type": {
@@ -38139,7 +38139,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1213,
               "character": 25,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1213"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1213"
             }
           ]
         }
@@ -38156,7 +38156,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1206,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1206"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1206"
         }
       ],
       "type": {
@@ -38179,7 +38179,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1209,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1209"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1209"
                 }
               ],
               "type": {
@@ -38198,7 +38198,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1208,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1208"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1208"
                 }
               ],
               "type": {
@@ -38226,7 +38226,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1210,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1210"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1210"
                 }
               ],
               "type": {
@@ -38246,7 +38246,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1206,
               "character": 25,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1206"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1206"
             }
           ],
           "indexSignature": {
@@ -38294,7 +38294,7 @@
           "fileName": "src/lib/types.ts",
           "line": 8,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L8"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L8"
         }
       ],
       "type": {
@@ -38402,7 +38402,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1314,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1314"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1314"
         }
       ],
       "type": {
@@ -38425,7 +38425,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1321,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1321"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1321"
                 }
               ],
               "type": {
@@ -38443,7 +38443,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1008,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1008"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1008"
                     }
                   ],
                   "type": {
@@ -38473,7 +38473,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1317,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1317"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1317"
                 }
               ],
               "type": {
@@ -38504,7 +38504,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1318,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1318"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1318"
                 }
               ],
               "type": {
@@ -38523,7 +38523,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1319,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1319"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1319"
                 }
               ],
               "type": {
@@ -38542,7 +38542,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1315,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1315"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1315"
                 }
               ],
               "type": {
@@ -38561,7 +38561,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1320,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1320"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1320"
                 }
               ],
               "type": {
@@ -38580,7 +38580,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1322,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1322"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1322"
                 }
               ],
               "type": {
@@ -38599,7 +38599,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1316,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1316"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1316"
                 }
               ],
               "type": {
@@ -38619,7 +38619,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1314,
               "character": 29,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1314"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1314"
             }
           ]
         }
@@ -38636,7 +38636,7 @@
           "fileName": "src/lib/types.ts",
           "line": 769,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L769"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L769"
         }
       ],
       "type": {
@@ -38662,7 +38662,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 772,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L772"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L772"
                     }
                   ],
                   "type": {
@@ -38683,7 +38683,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 773,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L773"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L773"
                     }
                   ],
                   "type": {
@@ -38716,7 +38716,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 777,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L777"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L777"
                             }
                           ],
                           "type": {
@@ -38745,7 +38745,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 775,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L775"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L775"
                             }
                           ],
                           "type": {
@@ -38765,7 +38765,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 773,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L773"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L773"
                         }
                       ]
                     }
@@ -38782,7 +38782,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 771,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L771"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L771"
                     }
                   ],
                   "type": {
@@ -38824,7 +38824,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 770,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L770"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L770"
                 }
               ]
             }
@@ -38851,7 +38851,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 783,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L783"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L783"
                     }
                   ],
                   "type": {
@@ -38884,7 +38884,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 785,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L785"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L785"
                             }
                           ],
                           "type": {
@@ -38904,7 +38904,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 783,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L783"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L783"
                         }
                       ]
                     }
@@ -38921,7 +38921,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 782,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L782"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L782"
                     }
                   ],
                   "type": {
@@ -38940,7 +38940,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 781,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L781"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L781"
                     }
                   ],
                   "type": {
@@ -38982,7 +38982,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 780,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L780"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L780"
                 }
               ]
             }
@@ -39001,7 +39001,7 @@
           "fileName": "src/lib/types.ts",
           "line": 206,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L206"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L206"
         }
       ],
       "type": {
@@ -39027,7 +39027,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 208,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L208"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L208"
                     }
                   ],
                   "type": {
@@ -39066,7 +39066,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 216,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L216"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L216"
                             }
                           ],
                           "type": {
@@ -39086,7 +39086,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 208,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L208"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L208"
                         }
                       ]
                     }
@@ -39103,7 +39103,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 218,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L218"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L218"
                     }
                   ],
                   "type": {
@@ -39123,7 +39123,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 207,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L207"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L207"
                 }
               ]
             }
@@ -39148,7 +39148,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 221,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L221"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L221"
                     }
                   ],
                   "type": {
@@ -39167,7 +39167,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 222,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L222"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L222"
                     }
                   ],
                   "type": {
@@ -39188,7 +39188,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 220,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L220"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L220"
                 }
               ]
             }
@@ -39207,7 +39207,7 @@
           "fileName": "src/lib/types.ts",
           "line": 490,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L490"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L490"
         }
       ],
       "type": {
@@ -39232,7 +39232,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 491,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L491"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L491"
                 }
               ],
               "type": {
@@ -39265,7 +39265,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 499,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L499"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L499"
                         }
                       ],
                       "type": {
@@ -39310,7 +39310,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 497,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L497"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L497"
                         }
                       ],
                       "type": {
@@ -39330,7 +39330,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 491,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L491"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L491"
                     }
                   ]
                 }
@@ -39348,7 +39348,7 @@
               "fileName": "src/lib/types.ts",
               "line": 490,
               "character": 43,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L490"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L490"
             }
           ]
         }
@@ -39365,7 +39365,7 @@
           "fileName": "src/lib/types.ts",
           "line": 617,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L617"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L617"
         }
       ],
       "type": {
@@ -39406,7 +39406,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 623,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L623"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L623"
                 }
               ],
               "type": {
@@ -39443,7 +39443,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 625,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L625"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L625"
                 }
               ],
               "type": {
@@ -39464,7 +39464,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 626,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L626"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L626"
                 }
               ],
               "type": {
@@ -39497,7 +39497,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 628,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L628"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L628"
                         }
                       ],
                       "type": {
@@ -39517,7 +39517,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 626,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L626"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L626"
                     }
                   ]
                 }
@@ -39598,7 +39598,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 619,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L619"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L619"
                 }
               ],
               "type": {
@@ -39644,7 +39644,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 619,
                               "character": 76,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L619"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L619"
                             }
                           ]
                         }
@@ -39705,7 +39705,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 621,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L621"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L621"
                 }
               ],
               "type": {
@@ -39725,7 +39725,7 @@
               "fileName": "src/lib/types.ts",
               "line": 617,
               "character": 43,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L617"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L617"
             }
           ]
         }
@@ -39742,7 +39742,7 @@
           "fileName": "src/lib/types.ts",
           "line": 602,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
         }
       ],
       "type": {
@@ -39767,7 +39767,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 605,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                 }
               ],
               "type": {
@@ -39800,7 +39800,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 611,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                         }
                       ],
                       "type": {
@@ -39816,7 +39816,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 611,
                               "character": 18,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L611"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L611"
                             }
                           ],
                           "indexSignature": {
@@ -39866,7 +39866,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 607,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L607"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L607"
                         }
                       ],
                       "type": {
@@ -39895,7 +39895,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 609,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L609"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L609"
                         }
                       ],
                       "type": {
@@ -39924,7 +39924,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 613,
                           "character": 4,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L613"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L613"
                         }
                       ],
                       "type": {
@@ -39944,7 +39944,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 605,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L605"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L605"
                     }
                   ]
                 }
@@ -39969,7 +39969,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 604,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L604"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L604"
                 }
               ],
               "type": {
@@ -39995,7 +39995,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 8,
                       "character": 12,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L8"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L8"
                     }
                   ],
                   "type": {
@@ -40106,7 +40106,7 @@
               "fileName": "src/lib/types.ts",
               "line": 602,
               "character": 41,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L602"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L602"
             }
           ]
         }
@@ -40123,7 +40123,7 @@
           "fileName": "src/lib/types.ts",
           "line": 541,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L541"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L541"
         }
       ],
       "type": {
@@ -40157,7 +40157,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 544,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L544"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L544"
                     }
                   ],
                   "type": {
@@ -40178,7 +40178,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 547,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L547"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L547"
                     }
                   ],
                   "type": {
@@ -40211,7 +40211,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 549,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L549"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L549"
                             }
                           ],
                           "type": {
@@ -40231,7 +40231,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 547,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L547"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L547"
                         }
                       ]
                     }
@@ -40256,7 +40256,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 546,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L546"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L546"
                     }
                   ],
                   "type": {
@@ -40276,7 +40276,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 542,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L542"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L542"
                 }
               ]
             }
@@ -40303,7 +40303,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 557,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L557"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L557"
                     }
                   ],
                   "type": {
@@ -40336,7 +40336,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 559,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L559"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L559"
                             }
                           ],
                           "type": {
@@ -40356,7 +40356,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 557,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L557"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L557"
                         }
                       ]
                     }
@@ -40381,7 +40381,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 556,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L556"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L556"
                     }
                   ],
                   "type": {
@@ -40408,7 +40408,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 554,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L554"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L554"
                     }
                   ],
                   "type": {
@@ -40428,7 +40428,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 552,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L552"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L552"
                 }
               ]
             }
@@ -40447,7 +40447,7 @@
           "fileName": "src/lib/types.ts",
           "line": 563,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L563"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L563"
         }
       ],
       "type": {
@@ -40481,7 +40481,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 566,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L566"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L566"
                     }
                   ],
                   "type": {
@@ -40502,7 +40502,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 567,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L567"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L567"
                     }
                   ],
                   "type": {
@@ -40535,7 +40535,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 579,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L579"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L579"
                             }
                           ],
                           "type": {
@@ -40580,7 +40580,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 577,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L577"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L577"
                             }
                           ],
                           "type": {
@@ -40609,7 +40609,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 569,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L569"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L569"
                             }
                           ],
                           "type": {
@@ -40638,7 +40638,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 571,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L571"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L571"
                             }
                           ],
                           "type": {
@@ -40658,7 +40658,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 567,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L567"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L567"
                         }
                       ]
                     }
@@ -40676,7 +40676,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 564,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L564"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L564"
                 }
               ]
             }
@@ -40703,7 +40703,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 585,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L585"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L585"
                     }
                   ],
                   "type": {
@@ -40736,7 +40736,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 595,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L595"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L595"
                             }
                           ],
                           "type": {
@@ -40765,7 +40765,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 597,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L597"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L597"
                             }
                           ],
                           "type": {
@@ -40819,7 +40819,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 593,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L593"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L593"
                             }
                           ],
                           "type": {
@@ -40848,7 +40848,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 587,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L587"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L587"
                             }
                           ],
                           "type": {
@@ -40868,7 +40868,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 585,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L585"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L585"
                         }
                       ]
                     }
@@ -40893,7 +40893,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 584,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L584"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L584"
                     }
                   ],
                   "type": {
@@ -40913,7 +40913,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 582,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L582"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L582"
                 }
               ]
             }
@@ -40932,7 +40932,7 @@
           "fileName": "src/lib/types.ts",
           "line": 789,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L789"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L789"
         }
       ],
       "type": {
@@ -40960,7 +40960,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 794,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L794"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L794"
                     }
                   ],
                   "type": {
@@ -40993,7 +40993,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 798,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L798"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L798"
                             }
                           ],
                           "type": {
@@ -41022,7 +41022,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 796,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L796"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L796"
                             }
                           ],
                           "type": {
@@ -41042,7 +41042,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 794,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L794"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L794"
                         }
                       ]
                     }
@@ -41067,7 +41067,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 792,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L792"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L792"
                     }
                   ],
                   "type": {
@@ -41087,7 +41087,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 790,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L790"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L790"
                 }
               ]
             }
@@ -41120,7 +41120,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 803,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L803"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L803"
                     }
                   ],
                   "type": {
@@ -41141,7 +41141,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 805,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L805"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L805"
                     }
                   ],
                   "type": {
@@ -41174,7 +41174,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 809,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L809"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L809"
                             }
                           ],
                           "type": {
@@ -41203,7 +41203,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 807,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L807"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L807"
                             }
                           ],
                           "type": {
@@ -41223,7 +41223,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 805,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L805"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L805"
                         }
                       ]
                     }
@@ -41241,7 +41241,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 801,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L801"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L801"
                 }
               ]
             }
@@ -41260,7 +41260,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1220,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1220"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1220"
         }
       ],
       "type": {
@@ -41293,7 +41293,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1231,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1231"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1231"
                 }
               ],
               "type": {
@@ -41326,7 +41326,7 @@
               "fileName": "src/lib/types.ts",
               "line": 1220,
               "character": 22,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1220"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1220"
             }
           ]
         }
@@ -41343,7 +41343,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1338,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1338"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1338"
         }
       ],
       "type": {
@@ -41373,7 +41373,7 @@
           "fileName": "src/lib/types.ts",
           "line": 503,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L503"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L503"
         }
       ],
       "type": {
@@ -41407,7 +41407,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 506,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L506"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L506"
                     }
                   ],
                   "type": {
@@ -41428,7 +41428,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 509,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L509"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L509"
                     }
                   ],
                   "type": {
@@ -41461,7 +41461,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 519,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L519"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L519"
                             }
                           ],
                           "type": {
@@ -41506,7 +41506,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 517,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L517"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L517"
                             }
                           ],
                           "type": {
@@ -41535,7 +41535,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 511,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L511"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L511"
                             }
                           ],
                           "type": {
@@ -41555,7 +41555,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 509,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L509"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L509"
                         }
                       ]
                     }
@@ -41580,7 +41580,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 508,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L508"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L508"
                     }
                   ],
                   "type": {
@@ -41600,7 +41600,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 504,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L504"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L504"
                 }
               ]
             }
@@ -41627,7 +41627,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 527,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L527"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L527"
                     }
                   ],
                   "type": {
@@ -41660,7 +41660,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 535,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L535"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L535"
                             }
                           ],
                           "type": {
@@ -41689,7 +41689,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 537,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L537"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L537"
                             }
                           ],
                           "type": {
@@ -41743,7 +41743,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 533,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L533"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L533"
                             }
                           ],
                           "type": {
@@ -41763,7 +41763,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 527,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L527"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L527"
                         }
                       ]
                     }
@@ -41788,7 +41788,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 526,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L526"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L526"
                     }
                   ],
                   "type": {
@@ -41815,7 +41815,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 524,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L524"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L524"
                     }
                   ],
                   "type": {
@@ -41835,7 +41835,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 522,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L522"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L522"
                 }
               ]
             }
@@ -41854,7 +41854,7 @@
           "fileName": "src/lib/types.ts",
           "line": 632,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L632"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L632"
         }
       ],
       "type": {
@@ -41879,7 +41879,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 634,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L634"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L634"
                 }
               ],
               "type": {
@@ -41905,7 +41905,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 635,
                               "character": 4,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L635"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L635"
                             }
                           ],
                           "type": {
@@ -41921,7 +41921,7 @@
                                   "fileName": "src/lib/types.ts",
                                   "line": 635,
                                   "character": 14,
-                                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L635"
+                                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L635"
                                 }
                               ],
                               "signatures": [
@@ -41952,7 +41952,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 634,
                           "character": 14,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L634"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L634"
                         }
                       ]
                     }
@@ -41977,7 +41977,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 633,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L633"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L633"
                 }
               ],
               "type": {
@@ -41993,7 +41993,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 633,
                       "character": 11,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L633"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L633"
                     }
                   ],
                   "signatures": [
@@ -42063,7 +42063,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 638,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L638"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L638"
                 }
               ],
               "type": {
@@ -42079,7 +42079,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 638,
                       "character": 16,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L638"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L638"
                     }
                   ],
                   "signatures": [
@@ -42166,7 +42166,7 @@
               "fileName": "src/lib/types.ts",
               "line": 632,
               "character": 27,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L632"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L632"
             }
           ]
         }
@@ -42183,7 +42183,7 @@
           "fileName": "src/lib/types.ts",
           "line": 641,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L641"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L641"
         }
       ],
       "type": {
@@ -42209,7 +42209,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 643,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L643"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L643"
                     }
                   ],
                   "type": {
@@ -42230,7 +42230,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 651,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                     }
                   ],
                   "type": {
@@ -42263,7 +42263,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 656,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L656"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L656"
                             }
                           ],
                           "type": {
@@ -42284,7 +42284,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 658,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L658"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L658"
                             }
                           ],
                           "type": {
@@ -42354,7 +42354,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 653,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L653"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L653"
                             }
                           ],
                           "type": {
@@ -42374,7 +42374,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 651,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                         }
                       ]
                     }
@@ -42401,7 +42401,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 649,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L649"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L649"
                     }
                   ],
                   "type": {
@@ -42438,7 +42438,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 646,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L646"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L646"
                     }
                   ],
                   "type": {
@@ -42459,7 +42459,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 642,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L642"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L642"
                 }
               ]
             }
@@ -42484,7 +42484,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 664,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L664"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L664"
                     }
                   ],
                   "type": {
@@ -42535,7 +42535,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 667,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L667"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L667"
                     }
                   ],
                   "type": {
@@ -42556,7 +42556,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 672,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                     }
                   ],
                   "type": {
@@ -42589,7 +42589,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 674,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L674"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L674"
                             }
                           ],
                           "type": {
@@ -42609,7 +42609,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 672,
                           "character": 16,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                         }
                       ]
                     }
@@ -42634,7 +42634,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 670,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L670"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L670"
                     }
                   ],
                   "type": {
@@ -42656,7 +42656,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 663,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L663"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L663"
                 }
               ]
             }
@@ -42675,7 +42675,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1181,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1181"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1181"
         }
       ],
       "type": {
@@ -42756,7 +42756,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 1191,
                       "character": 2,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1191"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1191"
                     }
                   ],
                   "type": {
@@ -42776,7 +42776,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 1183,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1183"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1183"
                 }
               ]
             }
@@ -42795,7 +42795,7 @@
           "fileName": "src/lib/types.ts",
           "line": 225,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L225"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L225"
         }
       ],
       "type": {
@@ -42821,7 +42821,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 227,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L227"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L227"
                     }
                   ],
                   "type": {
@@ -42844,7 +42844,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 228,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L228"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L228"
                             }
                           ],
                           "type": {
@@ -42865,7 +42865,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 227,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L227"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L227"
                         }
                       ]
                     }
@@ -42882,7 +42882,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 230,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L230"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L230"
                     }
                   ],
                   "type": {
@@ -42902,7 +42902,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 226,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L226"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L226"
                 }
               ]
             }
@@ -42927,7 +42927,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 233,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L233"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L233"
                     }
                   ],
                   "type": {
@@ -42950,7 +42950,7 @@
                               "fileName": "src/lib/types.ts",
                               "line": 234,
                               "character": 8,
-                              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L234"
+                              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L234"
                             }
                           ],
                           "type": {
@@ -42970,7 +42970,7 @@
                           "fileName": "src/lib/types.ts",
                           "line": 233,
                           "character": 12,
-                          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L233"
+                          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L233"
                         }
                       ]
                     }
@@ -42987,7 +42987,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 236,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L236"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L236"
                     }
                   ],
                   "type": {
@@ -43008,7 +43008,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 232,
                   "character": 4,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L232"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L232"
                 }
               ]
             }
@@ -43027,7 +43027,7 @@
           "fileName": "src/lib/types.ts",
           "line": 719,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L719"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L719"
         }
       ],
       "type": {
@@ -43053,7 +43053,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 727,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
                   }
                 ],
                 "type": {
@@ -43092,7 +43092,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 736,
                             "character": 4,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L736"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L736"
                           }
                         ],
                         "type": {
@@ -43121,7 +43121,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 729,
                             "character": 4,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L729"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L729"
                           }
                         ],
                         "type": {
@@ -43141,7 +43141,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 727,
                         "character": 12,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L727"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L727"
                       }
                     ]
                   }
@@ -43166,7 +43166,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 722,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L722"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L722"
                   }
                 ],
                 "type": {
@@ -43193,7 +43193,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 724,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L724"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L724"
                   }
                 ],
                 "type": {
@@ -43220,7 +43220,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 726,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L726"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L726"
                   }
                 ],
                 "type": {
@@ -43238,7 +43238,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 766,
                         "character": 12,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L766"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L766"
                       }
                     ],
                     "type": {
@@ -43269,7 +43269,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 720,
                 "character": 17,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L720"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L720"
               }
             ]
           },
@@ -43299,7 +43299,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 741,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L741"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L741"
                   }
                 ],
                 "type": {
@@ -43320,7 +43320,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 746,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
                   }
                 ],
                 "type": {
@@ -43359,7 +43359,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 754,
                             "character": 4,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L754"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L754"
                           }
                         ],
                         "type": {
@@ -43388,7 +43388,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 748,
                             "character": 4,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L748"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L748"
                           }
                         ],
                         "type": {
@@ -43408,7 +43408,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 746,
                         "character": 12,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L746"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L746"
                       }
                     ]
                   }
@@ -43433,7 +43433,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 743,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L743"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L743"
                   }
                 ],
                 "type": {
@@ -43460,7 +43460,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 745,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L745"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L745"
                   }
                 ],
                 "type": {
@@ -43478,7 +43478,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 767,
                         "character": 12,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
                       }
                     ],
                     "type": {
@@ -43525,7 +43525,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 739,
                 "character": 17,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L739"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L739"
               }
             ]
           },
@@ -43555,7 +43555,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 760,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L760"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L760"
                   }
                 ],
                 "type": {
@@ -43582,7 +43582,7 @@
                     "fileName": "src/lib/types.ts",
                     "line": 763,
                     "character": 2,
-                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L763"
+                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L763"
                   }
                 ],
                 "type": {
@@ -43600,7 +43600,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 767,
                         "character": 12,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L767"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L767"
                       }
                     ],
                     "type": {
@@ -43647,7 +43647,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 758,
                 "character": 17,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L758"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L758"
               }
             ]
           }
@@ -43665,7 +43665,7 @@
           "fileName": "src/lib/types.ts",
           "line": 103,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L103"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L103"
         }
       ],
       "type": {
@@ -43688,7 +43688,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 105,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L105"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L105"
                 }
               ],
               "type": {
@@ -43707,7 +43707,7 @@
                   "fileName": "src/lib/types.ts",
                   "line": 104,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L104"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L104"
                 }
               ],
               "type": {
@@ -43731,7 +43731,7 @@
               "fileName": "src/lib/types.ts",
               "line": 103,
               "character": 27,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L103"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L103"
             }
           ]
         }
@@ -43748,7 +43748,7 @@
           "fileName": "src/lib/types.ts",
           "line": 102,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L102"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L102"
         }
       ],
       "type": {
@@ -43786,7 +43786,7 @@
                       "fileName": "src/lib/types.ts",
                       "line": 102,
                       "character": 80,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L102"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L102"
                     }
                   ]
                 }
@@ -43807,7 +43807,7 @@
           "fileName": "src/lib/types.ts",
           "line": 717,
           "character": 12,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L717"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L717"
         }
       ],
       "type": {
@@ -43824,7 +43824,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 641,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L641"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L641"
               }
             ],
             "type": {
@@ -43850,7 +43850,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 643,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L643"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L643"
                           }
                         ],
                         "type": {
@@ -43871,7 +43871,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 651,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                           }
                         ],
                         "type": {
@@ -43904,7 +43904,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 656,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L656"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L656"
                                   }
                                 ],
                                 "type": {
@@ -43925,7 +43925,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 658,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L658"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L658"
                                   }
                                 ],
                                 "type": {
@@ -43995,7 +43995,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 653,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L653"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L653"
                                   }
                                 ],
                                 "type": {
@@ -44015,7 +44015,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 651,
                                 "character": 16,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L651"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L651"
                               }
                             ]
                           }
@@ -44042,7 +44042,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 649,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L649"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L649"
                           }
                         ],
                         "type": {
@@ -44079,7 +44079,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 646,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L646"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L646"
                           }
                         ],
                         "type": {
@@ -44100,7 +44100,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 642,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L642"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L642"
                       }
                     ]
                   }
@@ -44125,7 +44125,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 664,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L664"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L664"
                           }
                         ],
                         "type": {
@@ -44176,7 +44176,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 667,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L667"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L667"
                           }
                         ],
                         "type": {
@@ -44197,7 +44197,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 672,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                           }
                         ],
                         "type": {
@@ -44230,7 +44230,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 674,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L674"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L674"
                                   }
                                 ],
                                 "type": {
@@ -44250,7 +44250,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 672,
                                 "character": 16,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L672"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L672"
                               }
                             ]
                           }
@@ -44275,7 +44275,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 670,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L670"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L670"
                           }
                         ],
                         "type": {
@@ -44297,7 +44297,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 663,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L663"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L663"
                       }
                     ]
                   }
@@ -44316,7 +44316,7 @@
                 "fileName": "src/lib/types.ts",
                 "line": 680,
                 "character": 12,
-                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L680"
+                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L680"
               }
             ],
             "type": {
@@ -44342,7 +44342,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 682,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L682"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L682"
                           }
                         ],
                         "type": {
@@ -44363,7 +44363,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 690,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                           }
                         ],
                         "type": {
@@ -44396,7 +44396,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 695,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L695"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L695"
                                   }
                                 ],
                                 "type": {
@@ -44417,7 +44417,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 697,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L697"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L697"
                                   }
                                 ],
                                 "type": {
@@ -44483,7 +44483,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 692,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L692"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L692"
                                   }
                                 ],
                                 "type": {
@@ -44503,7 +44503,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 690,
                                 "character": 16,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L690"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L690"
                               }
                             ]
                           }
@@ -44521,7 +44521,7 @@
                           "summary": [
                             {
                               "kind": "text",
-                              "text": "Optional statement to include in the Sign in with Solana message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
+                              "text": "Optional statement to include in the Sign in with Ethereum message. Must not include new line characters. Most wallets like Phantom **require specifying a statement!**"
                             }
                           ]
                         },
@@ -44530,7 +44530,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 688,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L688"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L688"
                           }
                         ],
                         "type": {
@@ -44554,7 +44554,7 @@
                             },
                             {
                               "kind": "code",
-                              "text": "`window.solana`"
+                              "text": "`window.ethereum`"
                             },
                             {
                               "kind": "text",
@@ -44567,7 +44567,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 685,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L685"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L685"
                           }
                         ],
                         "type": {
@@ -44588,7 +44588,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 681,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L681"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L681"
                       }
                     ]
                   }
@@ -44613,7 +44613,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 703,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L703"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L703"
                           }
                         ],
                         "type": {
@@ -44664,7 +44664,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 706,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L706"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L706"
                           }
                         ],
                         "type": {
@@ -44685,7 +44685,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 711,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                           }
                         ],
                         "type": {
@@ -44718,7 +44718,7 @@
                                     "fileName": "src/lib/types.ts",
                                     "line": 713,
                                     "character": 8,
-                                    "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L713"
+                                    "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L713"
                                   }
                                 ],
                                 "type": {
@@ -44738,7 +44738,7 @@
                                 "fileName": "src/lib/types.ts",
                                 "line": 711,
                                 "character": 16,
-                                "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L711"
+                                "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L711"
                               }
                             ]
                           }
@@ -44754,7 +44754,7 @@
                           "summary": [
                             {
                               "kind": "text",
-                              "text": "Ed25519 signature of the message."
+                              "text": "Ethereum curve (secp256k1) signature of the message."
                             }
                           ]
                         },
@@ -44763,7 +44763,7 @@
                             "fileName": "src/lib/types.ts",
                             "line": 709,
                             "character": 6,
-                            "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L709"
+                            "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L709"
                           }
                         ],
                         "type": {
@@ -44783,7 +44783,7 @@
                         "fileName": "src/lib/types.ts",
                         "line": 702,
                         "character": 4,
-                        "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L702"
+                        "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L702"
                       }
                     ]
                   }
@@ -44807,7 +44807,7 @@
           "fileName": "src/AuthAdminApi.ts",
           "line": 3,
           "character": 6,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/AuthAdminApi.ts#L3"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/AuthAdminApi.ts#L3"
         }
       ],
       "type": {
@@ -44833,7 +44833,7 @@
           "fileName": "src/AuthClient.ts",
           "line": 3,
           "character": 6,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/AuthClient.ts#L3"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/AuthClient.ts#L3"
         }
       ],
       "type": {
@@ -44859,7 +44859,7 @@
           "fileName": "src/lib/types.ts",
           "line": 1337,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/types.ts#L1337"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/types.ts#L1337"
         }
       ],
       "type": {
@@ -44902,7 +44902,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 6,
           "character": 13,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L6"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L6"
         }
       ],
       "type": {
@@ -44929,7 +44929,7 @@
                   "fileName": "src/lib/locks.ts",
                   "line": 10,
                   "character": 2,
-                  "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L10"
+                  "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L10"
                 }
               ],
               "type": {
@@ -44950,7 +44950,7 @@
               "fileName": "src/lib/locks.ts",
               "line": 6,
               "character": 25,
-              "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L6"
+              "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L6"
             }
           ]
         }
@@ -44968,7 +44968,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 41,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L41"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L41"
         }
       ],
       "signatures": [
@@ -45015,7 +45015,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 26,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L26"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L26"
         }
       ],
       "signatures": [
@@ -45062,7 +45062,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 105,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L105"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L105"
         }
       ],
       "signatures": [
@@ -45109,7 +45109,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 135,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L135"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L135"
         }
       ],
       "signatures": [
@@ -45156,7 +45156,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 72,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L72"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L72"
         }
       ],
       "signatures": [
@@ -45203,7 +45203,7 @@
           "fileName": "src/lib/errors.ts",
           "line": 157,
           "character": 16,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/errors.ts#L157"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/errors.ts#L157"
         }
       ],
       "signatures": [
@@ -45250,7 +45250,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 59,
           "character": 22,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L59"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L59"
         }
       ],
       "signatures": [
@@ -45393,7 +45393,7 @@
                       "fileName": "src/lib/locks.ts",
                       "line": 62,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L62"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L62"
                     }
                   ],
                   "signatures": [
@@ -45449,7 +45449,7 @@
           "fileName": "src/lib/locks.ts",
           "line": 171,
           "character": 22,
-          "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L171"
+          "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L171"
         }
       ],
       "signatures": [
@@ -45560,7 +45560,7 @@
                       "fileName": "src/lib/locks.ts",
                       "line": 174,
                       "character": 6,
-                      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/lib/locks.ts#L174"
+                      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/lib/locks.ts#L174"
                     }
                   ],
                   "signatures": [
@@ -45643,7 +45643,7 @@
       "fileName": "src/index.ts",
       "line": 1,
       "character": 0,
-      "url": "https://github.com/supabase/auth-js/blob/91474d6/src/index.ts#L1"
+      "url": "https://github.com/supabase/auth-js/blob/aadf02e/src/index.ts#L1"
     }
   ]
 }

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -793,7 +793,7 @@ functions:
       - The magic link's destination URL is determined by the [`SITE_URL`](/docs/guides/auth/redirect-urls#use-wildcards-in-redirect-urls).
       - See [redirect URLs and wildcards](/docs/guides/auth/redirect-urls#use-wildcards-in-redirect-urls) to add additional redirect URLs to your project.
       - Magic links and OTPs share the same implementation. To send users a one-time code instead of a magic link, [modify the magic link email template](/dashboard/project/_/auth/templates) to include `{{ .Token }}` instead of `{{ .ConfirmationURL }}`.
-      - See our [Twilio Phone Auth Guide](/docs/guides/auth/phone-login?showSmsProvider=Twilio) for details about configuring WhatsApp sign in.
+      - See our [Twilio Phone Auth Guide](/docs/guides/auth/phone-login?showSMSProvider=Twilio) for details about configuring WhatsApp sign in.
     examples:
       - id: sign-in-with-email
         name: Sign in with email
@@ -845,8 +845,8 @@ functions:
     title: 'signInWithOAuth()'
     $ref: '@supabase/auth-js.GoTrueClient.signInWithOAuth'
     notes: |
-      - This method is used for signing in using a third-party provider.
-      - Supabase supports many different [third-party providers](/docs/guides/auth#configure-third-party-providers).
+      - This method is used for signing in using [Social Login (OAuth) providers](/docs/guides/auth#configure-third-party-providers).
+      - It works by redirecting your application to the provider's authorization screen, before bringing back the user to your app.
     examples:
       - id: sign-in-using-a-third-party-provider
         name: Sign in using a third-party provider
@@ -871,7 +871,7 @@ functions:
         name: Sign in using a third-party provider with redirect
         isSpotlight: false
         description: |
-          - When the third-party provider successfully authenticates the user, the provider redirects the user to the URL specified in the `redirectTo` parameter. This parameter defaults to the [`SITE_URL`](/docs/guides/auth/redirect-urls#use-wildcards-in-redirect-urls). It does not redirect the user immediately after invoking this method.
+          - When the OAuth provider successfully authenticates the user, they are redirected to the URL specified in the `redirectTo` parameter. This parameter defaults to the [`SITE_URL`](/docs/guides/auth/redirect-urls#use-wildcards-in-redirect-urls). It does not redirect the user immediately after invoking this method.
           - See [redirect URLs and wildcards](/docs/guides/auth/redirect-urls#use-wildcards-in-redirect-urls) to add additional redirect URLs to your project.
         code: |
           ```js
@@ -924,6 +924,10 @@ functions:
   - id: sign-in-with-id-token
     title: 'signInWithIdToken'
     $ref: '@supabase/auth-js.GoTrueClient.signInWithIdToken'
+    notes: |
+      - Use an ID token to sign in.
+      - Especially useful when implementing sign in using native platform dialogs in mobile or desktop apps using Sign in with Apple or Sign in with Google on iOS and Android.
+      - You can also use Google's [One Tap](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap) and [Automatic sign-in](https://developers.google.com/identity/gsi/web/guides/automatic-sign-in-sign-out) via this API.
     examples:
       - id: sign-in-with-id-token
         name: 'Sign In using ID Token'
@@ -1033,12 +1037,109 @@ functions:
               window.location.href = data.url
             }
           ```
+  - id: sign-in-with-web3
+    title: 'signInWithWeb3()'
+    $ref: '@supabase/auth-js.GoTrueClient.signInWithWeb3'
+    notes: |
+      - Uses a Web3 (Ethereum, Solana) wallet to sign a user in.
+      - Read up on the [potential for abuse](/docs/guides/auth/auth-web3#potential-for-abuse) before using it.
+    examples:
+      - id: sign-in-with-solana-window
+        name: Sign in with Solana or Ethereum (Window API)
+        isSpotlight: true
+        code: |
+          ```js
+            // uses window.ethereum for the wallet
+            const { data, error } = await supabase.auth.signInWithWeb3({
+              chain: 'ethereum',
+              statement: 'I accept the Terms of Service at https://example.com/tos'
+            })
+
+            // uses window.solana for the wallet
+            const { data, error } = await supabase.auth.signInWithWeb3({
+              chain: 'solana',
+              statement: 'I accept the Terms of Service at https://example.com/tos'
+            })
+          ```
+      - id: sign-in-with-ethereum-raw
+        name: Sign in with Ethereum (Message and Signature)
+        isSpotlight: true
+        code: |
+          ```js
+            const { data, error } = await supabase.auth.signInWithWeb3({
+              chain: 'ethereum',
+              message: '<sign in with ethereum message>',
+              signature: '<hex of the ethereum signature over the message>',
+            })
+          ```
+      - id: sign-in-with-solana-brave
+        name: Sign in with Solana (Brave)
+        isSpotlight: false
+        code: |
+          ```js
+            const { data, error } = await supabase.auth.signInWithWeb3({
+              chain: 'solana',
+              statement: 'I accept the Terms of Service at https://example.com/tos',
+              wallet: window.braveSolana
+            })
+          ```
+      - id: sign-in-with-solana-wallet-adapter
+        name: Sign in with Solana (Wallet Adapter)
+        isSpotlight: false
+        code: |
+          ```jsx
+            function SignInButton() {
+            const wallet = useWallet()
+
+            return (
+              <>
+                {wallet.connected ? (
+                  <button
+                    onClick={() => {
+                      supabase.auth.signInWithWeb3({
+                        chain: 'solana',
+                        statement: 'I accept the Terms of Service at https://example.com/tos',
+                        wallet,
+                      })
+                    }}
+                  >
+                    Sign in with Solana
+                  </button>
+                ) : (
+                  <WalletMultiButton />
+                )}
+              </>
+            )
+          }
+
+          function App() {
+            const endpoint = clusterApiUrl('devnet')
+            const wallets = useMemo(() => [], [])
+
+            return (
+              <ConnectionProvider endpoint={endpoint}>
+                <WalletProvider wallets={wallets}>
+                  <WalletModalProvider>
+                    <SignInButton />
+                  </WalletModalProvider>
+                </WalletProvider>
+              </ConnectionProvider>
+            )
+          }
+          ```
   - id: get-claims
     title: 'getClaims()'
     $ref: '@supabase/auth-js.GoTrueClient.getClaims'
+    notes: |
+      - Parses the user's [access token](/docs/guides/auth/sessions#access-token-jwt-claims) as a [JSON Web Token (JWT)](/docs/guides/auth/jwts) and returns its components if valid and not expired.
+      - If your project is using asymmetric JWT signing keys, then the verification is done locally usually without a network request using the [WebCrypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API).
+      - A network request is sent to your project's JWT signing key discovery endpoint `https://project-id.supabase.co/auth/v1/.well-known/jwks.json`, which is cached locally. If your environment is ephemeral, such as a Lambda function that is destroyed after every request, a network request will be sent for each new invocation. Supabase provides a network-edge cache providing fast responses for these situations.
+      - If the user's access token is about to expire when calling this function, the user's session will first be refreshed before validating the JWT.
+      - If your project is using a symmetric secret to sign the JWT, it always sends a request similar to `getUser()` to validate the JWT at the server before returning the decoded token. This is also used if the WebCrypto API is not available in the environment. Make sure you polyfill it in such situations.
+      - The returned claims can be customized per project using the [Custom Access Token Hook](/docs/guides/auth/auth-hooks/custom-access-token-hook).
     examples:
       - id: get-claims
-        name: Get user object
+        name: Get JWT claims, header and signature
         code: |
           ```js
           const { data, error } = await supabase.auth.getClaims()
@@ -1059,7 +1160,7 @@ functions:
                 "exp": 1715769600,
                 "iat": 1715766000,
                 "is_anonymous": false,
-                "iss": "https://api.supabase.com/auth/v1",
+                "iss": "https://project-id.supabase.co/auth/v1",
                 "phone": "+13334445555",
                 "role": "authenticated",
                 "session_id": "11111111-1111-1111-1111-111111111111",
@@ -1069,7 +1170,7 @@ functions:
               "header": {
                 "alg": "RS256",
                 "typ": "JWT",
-                "kid": "abcdefgh"
+                "kid": "11111111-1111-1111-1111-111111111111"
               },
               "signature": [/** Uint8Array */],
             },
@@ -1081,15 +1182,29 @@ functions:
     $ref: '@supabase/auth-js.GoTrueClient.signOut'
     notes: |
       - In order to use the `signOut()` method, the user needs to be signed in first.
-      - By default, `signOut()` uses the global scope, which signs out all other sessions that the user is logged into as well.
+      - By default, `signOut()` uses the global scope, which signs out all other sessions that the user is logged into as well. Customize this behavior by passing a scope parameter.
       - Since Supabase Auth uses JWTs for authentication, the access token JWT will be valid until it's expired. When the user signs out, Supabase revokes the refresh token and deletes the JWT from the client-side. This does not revoke the JWT and it will still be valid until it expires.
     examples:
       - id: sign-out
-        name: Sign out
+        name: Sign out (all sessions)
         isSpotlight: true
         code: |
           ```js
           const { error } = await supabase.auth.signOut()
+          ```
+      - id: sign-out-current-session
+        name: Sign out (current session)
+        isSpotlight: false
+        code: |
+          ```js
+          const { error } = await supabase.auth.signOut('local')
+          ```
+      - id: sign-out-other-sessions
+        name: Sign out (other sessions)
+        isSpotlight: false
+        code: |
+          ```js
+          const { error } = await supabase.auth.signOut('others')
           ```
   - id: verify-otp
     title: 'verifyOtp()'
@@ -1218,7 +1333,7 @@ functions:
           }
           ```
       - id: verify-sms-one-time-password(otp)
-        name: Verify Sms One-Time Password (OTP)
+        name: Verify SMS One-Time Password (OTP)
         isSpotlight: true
         code: |
           ```js
@@ -1235,10 +1350,13 @@ functions:
     title: 'getSession()'
     $ref: '@supabase/auth-js.GoTrueClient.getSession'
     notes: |
-      - This method retrieves the current local session (i.e local storage).
-      - The session contains a signed JWT and unencoded session data.
-      - Since the unencoded session data is retrieved from the local storage medium, **do not** rely on it as a source of trusted data on the server. It could be tampered with by the sender. If you need verified, trustworthy user data, call [`getUser`](/docs/reference/javascript/auth-getuser) instead.
-      - If the session has an expired access token, this method will use the refresh token to get a new session.
+      - Since the introduction of [asymmetric JWT signing keys](/docs/guides/auth/signing-keys), this method is considered low-level and we encourage you to use `getClaims()` or `getUser()` instead.
+      - Retrieves the current [user session](/docs/guides/auth/sessions) from the storage medium (local storage, cookies).
+      - The session contains an access token (signed JWT), a refresh token and the user object.
+      - If the session's access token is expired or is about to expire, this method will use the refresh token to refresh the session.
+      - When using in a browser, or you've called `startAutoRefresh()` in your environment (React Native, etc.) this function always returns a valid access token without refreshing the session itself, as this is done in the background. This function returns very fast.
+      - **IMPORTANT SECURITY NOTICE:** If using an insecure storage medium, such as cookies or request headers, the user object returned by this function **must not be trusted**. Always verify the JWT using `getClaims()` or your own JWT verification library to securely establish the user's identity and access. You can also use `getUser()` to fetch the user object directly from the Auth server for this purpose.
+      - When using in a browser, this function is synchronized accross all tabs using the [LockManager](https://developer.mozilla.org/en-US/docs/Web/API/LockManager) API. In other environments make sure you've defined a proper `lock` property, if necessary, to make sure there are no race conditions while the session is being refreshed.
     examples:
       - id: get-the-session-data
         name: Get the session data
@@ -3075,6 +3193,16 @@ functions:
           const { data: user, error } = await supabase.auth.admin.updateUserById(
             '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
             { phone_confirm: true }
+          )
+          ```
+      - id: ban-a-user
+        name: Ban a user for 100 years
+        isSpotlight: false
+        code: |
+          ```js
+          const { data: user, error } = await supabase.auth.admin.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { ban_duration: '100y' }
           )
           ```
   - id: mfa-list-factors-admin

--- a/apps/docs/spec/transforms/api_v1_openapi_deparsed.json
+++ b/apps/docs/spec/transforms/api_v1_openapi_deparsed.json
@@ -1494,6 +1494,9 @@
                               }
                             },
                             "required": ["id", "username"]
+                          },
+                          "favorite": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -1506,7 +1509,8 @@
                           "description",
                           "project",
                           "owner",
-                          "updated_by"
+                          "updated_by",
+                          "favorite"
                         ]
                       }
                     },
@@ -1614,11 +1618,16 @@
                       },
                       "required": ["id", "username"]
                     },
+                    "favorite": {
+                      "type": "boolean"
+                    },
                     "content": {
                       "type": "object",
                       "properties": {
                         "favorite": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "deprecated": true,
+                          "description": "Deprecated: Rely on root-level favorite property instead."
                         },
                         "schema_version": {
                           "type": "string"
@@ -1627,7 +1636,7 @@
                           "type": "string"
                         }
                       },
-                      "required": ["favorite", "schema_version", "sql"]
+                      "required": ["schema_version", "sql"]
                     }
                   },
                   "required": [
@@ -1641,6 +1650,7 @@
                     "project",
                     "owner",
                     "updated_by",
+                    "favorite",
                     "content"
                   ]
                 }
@@ -16006,6 +16016,9 @@
                     }
                   },
                   "required": ["id", "username"]
+                },
+                "favorite": {
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -16018,7 +16031,8 @@
                 "description",
                 "project",
                 "owner",
-                "updated_by"
+                "updated_by",
+                "favorite"
               ]
             }
           },
@@ -16091,11 +16105,16 @@
             },
             "required": ["id", "username"]
           },
+          "favorite": {
+            "type": "boolean"
+          },
           "content": {
             "type": "object",
             "properties": {
               "favorite": {
-                "type": "boolean"
+                "type": "boolean",
+                "deprecated": true,
+                "description": "Deprecated: Rely on root-level favorite property instead."
               },
               "schema_version": {
                 "type": "string"
@@ -16104,7 +16123,7 @@
                 "type": "string"
               }
             },
-            "required": ["favorite", "schema_version", "sql"]
+            "required": ["schema_version", "sql"]
           }
         },
         "required": [
@@ -16118,6 +16137,7 @@
           "project",
           "owner",
           "updated_by",
+          "favorite",
           "content"
         ]
       },

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -69,6 +69,7 @@ allow_list = [
     "[Ll]iveness",
     "[Mm]atryoshka",
     "[Mm]essageBird",
+    "MetaMask",
     "[Mm]icroservices?",
     "[Mm]iddlewares?",
     "[Mm]onorepos?",


### PR DESCRIPTION
Adds docs for Sign in with Ethereum pending launch, the `signInWithWeb3` method in the JS client library and other JS client library doc improvements from reading it whole.