### PR TITLE
fix vertical scroll in mobile schema selector

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -133,6 +133,7 @@ export const TableEditorMenu = () => {
               setSelectedSchema(name)
             }}
             onSelectCreateSchema={() => snap.onAddSchema()}
+            portal={!isMobile}
           />
 
           <div className="grid gap-3 mx-4">


### PR DESCRIPTION
Fixes the vertical scroll in the schema selector dropdown list in the [table editor](https://studio-staging-git-fix-schema-selector-vertical-scroll-supabase.vercel.app/dashboard/project/_/editor) on mobile.

## Before

https://github.com/user-attachments/assets/00e37b78-b194-4ab3-819b-112df6b728f3

## After

https://github.com/user-attachments/assets/c0b37304-68d6-4c55-b56e-0d04c4915b05

