### PR TITLE
fix(docs): Remove @rneui/themed from React Native quickstart guide to resolve dependency conflicts

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react-native.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react-native.mdx
@@ -54,7 +54,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npx expo install @supabase/supabase-js @react-native-async-storage/async-storage @rneui/themed react-native-url-polyfill
+      cd my-app && npx expo install @supabase/supabase-js @react-native-async-storage/async-storage react-native-url-polyfill
       ```
 
     </StepHikeCompact.Code>
@@ -122,9 +122,8 @@ hideToc: true
 
       ```tsx name=components/Auth.tsx
       import React, { useState } from 'react'
-      import { Alert, StyleSheet, View } from 'react-native'
+      import { Alert, StyleSheet, View, TextInput, TouchableOpacity, Text } from 'react-native'
       import { supabase } from '../lib/supabase'
-      import { Button, Input } from '@rneui/themed'
 
       export default function Auth() {
         const [email, setEmail] = useState('')
@@ -160,19 +159,20 @@ hideToc: true
         return (
           <View style={styles.container}>
             <View style={[styles.verticallySpaced, styles.mt20]}>
-              <Input
-                label="Email"
-                leftIcon={{ type: 'font-awesome', name: 'envelope' }}
+              <Text style={styles.label}>Email</Text>
+              <TextInput
+                style={styles.input}
                 onChangeText={(text) => setEmail(text)}
                 value={email}
                 placeholder="email@address.com"
                 autoCapitalize={'none'}
+                keyboardType="email-address"
               />
             </View>
             <View style={styles.verticallySpaced}>
-              <Input
-                label="Password"
-                leftIcon={{ type: 'font-awesome', name: 'lock' }}
+              <Text style={styles.label}>Password</Text>
+              <TextInput
+                style={styles.input}
                 onChangeText={(text) => setPassword(text)}
                 value={password}
                 secureTextEntry={true}
@@ -181,10 +181,22 @@ hideToc: true
               />
             </View>
             <View style={[styles.verticallySpaced, styles.mt20]}>
-              <Button title="Sign in" disabled={loading} onPress={() => signInWithEmail()} />
+              <TouchableOpacity
+                style={[styles.button, loading && styles.buttonDisabled]}
+                disabled={loading}
+                onPress={() => signInWithEmail()}
+              >
+                <Text style={styles.buttonText}>Sign in</Text>
+              </TouchableOpacity>
             </View>
             <View style={styles.verticallySpaced}>
-              <Button title="Sign up" disabled={loading} onPress={() => signUpWithEmail()} />
+              <TouchableOpacity
+                style={[styles.button, loading && styles.buttonDisabled]}
+                disabled={loading}
+                onPress={() => signUpWithEmail()}
+              >
+                <Text style={styles.buttonText}>Sign up</Text>
+              </TouchableOpacity>
             </View>
           </View>
         )
@@ -202,6 +214,34 @@ hideToc: true
         },
         mt20: {
           marginTop: 20,
+        },
+        label: {
+          fontSize: 16,
+          fontWeight: 'bold',
+          marginBottom: 5,
+          color: '#333',
+        },
+        input: {
+          borderWidth: 1,
+          borderColor: '#ddd',
+          padding: 10,
+          fontSize: 16,
+          borderRadius: 6,
+          backgroundColor: '#fff',
+        },
+        button: {
+          backgroundColor: '#007AFF',
+          padding: 15,
+          borderRadius: 6,
+          alignItems: 'center',
+        },
+        buttonDisabled: {
+          backgroundColor: '#ccc',
+        },
+        buttonText: {
+          color: '#fff',
+          fontSize: 16,
+          fontWeight: 'bold',
         },
       })
       ```

--- a/apps/docs/content/guides/auth/quickstarts/react-native.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react-native.mdx
@@ -20,7 +20,7 @@ hideToc: true
 
      ```sql name=SQL_EDITOR
       select * from auth.users;
-      ````
+      ```
 
     </StepHikeCompact.Code>
 


### PR DESCRIPTION
## Problem

The React Native quickstart guide includes `@rneui/themed` in the installation command, which causes npm dependency conflicts with new Expo projects:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer react-native-safe-area-context@"^3.1.9 || ^4.0.0" from @rneui/base@4.0.0-rc.7
npm error Could not resolve dependency with react-native-safe-area-context@5.6.1
```

## Solution

- **Removed** `@rneui/themed` from the installation command as it's outdated (last updated 2023) and causes peer dependency conflicts
- **Replaced** `@rneui/themed` components with React Native built-in components:
  - `Input` → `TextInput` with proper styling and labels
  - `Button` → `TouchableOpacity` with `Text`
- **Added** proper styling for form elements including disabled states
- **Maintained** the same functionality and user experience

## Changes

- Updated Step 3: Removed `@rneui/themed` from npm install command
- Updated Auth component: Replaced external UI library with React Native built-ins
- Added comprehensive styling for the new components
- Improved accessibility with proper keyboard types and labels

## Testing

Users can now follow the quickstart guide without encountering dependency conflicts. The authentication flow works identically to the previous version.

Fixes #[issue-number-if-exists]