### PR TITLE
Fix default value placeholder for fields with foreign keys

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -100,7 +100,7 @@ const InputField = ({
       <Input
         data-testid={`${field.name}-input`}
         layout="horizontal"
-        placeholder="NULL"
+        placeholder={field.defaultValue !== null ? `Default: ${field.defaultValue}` : 'NULL'}
         label={field.name}
         value={field.value ?? ''}
         descriptionText={
@@ -168,11 +168,10 @@ const InputField = ({
           placeholder={
             field.value === null && field.defaultValue === null
               ? 'NULL'
-              : field.value === ''
+              : field.value === '' ||
+                  (typeof field.defaultValue === 'string' && field.defaultValue.length === 0)
                 ? 'EMPTY'
-                : typeof field.defaultValue === 'string' && field.defaultValue.length === 0
-                  ? 'EMPTY'
-                  : `NULL (Default: ${field.defaultValue})`
+                : `Default: ${field.defaultValue}`
           }
           actions={
             <DropdownMenu>
@@ -216,7 +215,7 @@ const InputField = ({
         }
         labelOptional={field.format}
         disabled={!isEditable || isTruncated}
-        placeholder={field?.defaultValue ?? 'NULL'}
+        placeholder={!!field?.defaultValue ? `Default: ${field.defaultValue}` : 'NULL'}
         error={errors[field.name]}
         onChange={(event: any) => onUpdateField({ [field.name]: event.target.value })}
         actions={


### PR DESCRIPTION
## Context

Got a bug report for the Table Editor, that when adding a new row through the side panel, the placeholder value of the input doesn't show up for a column that has a default value + has a foreign key to another column.

This PR addresses that (ref screenshot below for the column `color_id`) and also standardises the placeholder copy to be `Default: ___`

<img width="687" height="377" alt="image" src="https://github.com/user-attachments/assets/34421a2e-9a07-4b0b-a8fa-77799b56ef08" />
