### PR TITLE
Support opening table rows for foreign tables in side panel (read only)

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -46,7 +46,7 @@ export const generateRowFields = (
   table: PostgresTable,
   foreignKeys: ForeignKey[]
 ): RowField[] => {
-  const { primary_keys } = table
+  const { primary_keys = [] } = table
   const primaryKeyColumns = primary_keys.map((key) => key.name)
 
   return (table.columns ?? []).map((column) => {

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -8,6 +8,7 @@ import { SupabaseGrid } from 'components/grid/SupabaseGrid'
 import { useLoadTableEditorStateFromLocalStorageIntoUrl } from 'components/grid/SupabaseGrid.utils'
 import {
   Entity,
+  isForeignTable,
   isMaterializedView,
   isTableLike,
   isView,
@@ -147,6 +148,7 @@ export const TableGridEditor = ({
 
   const isViewSelected = isView(selectedTable) || isMaterializedView(selectedTable)
   const isTableSelected = isTableLike(selectedTable)
+  const isForeignTableSelected = isForeignTable(selectedTable)
 
   const canEditViaTableEditor = isTableSelected && !isSchemaLocked
   const editable = !isReadOnly && canEditViaTableEditor
@@ -188,11 +190,11 @@ export const TableGridEditor = ({
 
         <SidePanelEditor
           editable={editable}
-          selectedTable={isTableLike(selectedTable) ? selectedTable : undefined}
+          selectedTable={isTableSelected || isForeignTableSelected ? selectedTable : undefined}
           onTableCreated={onTableCreated}
         />
         <DeleteConfirmationDialogs
-          selectedTable={isTableLike(selectedTable) ? selectedTable : undefined}
+          selectedTable={isTableSelected ? selectedTable : undefined}
           onTableDeleted={onTableDeleted}
         />
       </TableEditorTableStateContextProvider>

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -12,6 +12,7 @@ import {
   isMaterializedView,
   isTableLike,
   isView,
+  TableLike,
 } from 'data/table-editor/table-editor-types'
 import { useAsyncCheckProjectPermissions } from 'hooks/misc/useCheckPermissions'
 import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
@@ -190,7 +191,9 @@ export const TableGridEditor = ({
 
         <SidePanelEditor
           editable={editable}
-          selectedTable={isTableSelected || isForeignTableSelected ? selectedTable : undefined}
+          selectedTable={
+            isTableSelected || isForeignTableSelected ? (selectedTable as TableLike) : undefined
+          }
           onTableCreated={onTableCreated}
         />
         <DeleteConfirmationDialogs


### PR DESCRIPTION
## Context

Realised that clicking "Expand row" in the Table Editor for a row in a foreign table doesn't open the side panel. This PR fixes that (input fields are all read only)