### PR TITLE
chore: Add labeler action and documentation config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,4 +2,4 @@
 # https://github.com/marketplace/actions/labeler
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 'apps/docs'
+  - any-glob-to-any-file: 'apps/docs/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# Add 'documentation' to any change in apps/docs
+# https://github.com/marketplace/actions/labeler
+documentation:
+- changed-files:
+  - any-glob-to-any-file: 'apps/docs'

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -1,0 +1,13 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v6


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adding labeller action to more clearly identify and group PRs, starting with documentation.