### PR TITLE
Fix project card provider undefined

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -28,8 +28,7 @@ export const ProjectCard = ({
   resourceWarnings,
 }: ProjectCardProps) => {
   const { name, ref: projectRef } = project
-  const infraInformation = project.databases.find((x) => x.identifier === project.ref)
-  const desc = `${infraInformation?.cloud_provider} | ${project.region}`
+  const desc = `${project.cloud_provider} | ${project.region}`
 
   const { projectHomepageShowInstanceSize } = useIsFeatureEnabled([
     'project_homepage:show_instance_size',

--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectTableRow.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectTableRow.tsx
@@ -110,7 +110,7 @@ export const ProjectTableRow = ({
       </TableCell>
       <TableCell>
         <span className="lowercase text-sm text-foreground-light">
-          {infraInformation?.cloud_provider} | {project.region || 'N/A'}
+          {project.cloud_provider} | {project.region || 'N/A'}
         </span>
       </TableCell>
       <TableCell>


### PR DESCRIPTION
## Context

Realised that some of the project cards had their provider name as `undefined` (specifically for those projects which aren't active healthy)

<img width="395" height="197" alt="image" src="https://github.com/user-attachments/assets/3297a278-ffdd-4711-9e4f-860c3f236ae6" />

- We're retrieving provider information via `project.databases` but that information is only available if the project is active healthy
- `project` itself contains the cloud provider information so opting to retrieve the information from there within `ProjectCard` and `ProjectTableRow` instead
