### PR TITLE
fix: add PostHog external URL to CSP for feature flags support

### DIFF
--- a/apps/studio/csp.js
+++ b/apps/studio/csp.js
@@ -70,6 +70,8 @@ const SUPABASE_ASSETS_URL =
     ? 'https://frontend-assets.supabase.green'
     : 'https://frontend-assets.supabase.com'
 const POSTHOG_URL = isDevOrStaging ? 'https://ph.supabase.green' : 'https://ph.supabase.com'
+// Required for feature flags and other PostHog features
+const POSTHOG_EXTERNAL_URL = 'https://*.posthog.com'
 
 const USERCENTRICS_URLS = 'https://*.usercentrics.eu'
 const USERCENTRICS_APP_URL = 'https://app.usercentrics.eu'
@@ -102,6 +104,7 @@ module.exports.getCSP = function getCSP() {
     STAPE_URL,
     GOOGLE_MAPS_API_URL,
     POSTHOG_URL,
+    POSTHOG_EXTERNAL_URL,
     ...(!!NIMBUS_PROD_PROJECTS_URL ? [NIMBUS_PROD_PROJECTS_URL, NIMBUS_PROD_PROJECTS_URL_WS] : []),
   ]
   const SCRIPT_SRC_URLS = [
@@ -111,6 +114,7 @@ module.exports.getCSP = function getCSP() {
     SUPABASE_ASSETS_URL,
     STAPE_URL,
     POSTHOG_URL,
+    POSTHOG_EXTERNAL_URL,
   ]
   const FRAME_SRC_URLS = [HCAPTCHA_ASSET_URL, STRIPE_JS_URL, STAPE_URL]
   const IMG_SRC_URLS = [


### PR DESCRIPTION
## Summary
- Adds `POSTHOG_EXTERNAL_URL` (`https://*.posthog.com`) to CSP configuration
- Required for PostHog feature flags and other advanced features to work properly

Resolves GROWTH-493

## Context
PostHog feature flags, toolbar, and session replay features require direct connections to `*.posthog.com` endpoints, even when using our proxy server (`ph.supabase.green`) for main event ingestion. Without this CSP rule, these features are blocked by the browser's Content Security Policy.

## Test plan
- [x] PostHog errors no longer appear in browser console
- [x] Feature flags work correctly in development
- [x] Main event tracking still goes through proxy server