### PR TITLE
chore: prevent extraneous tsconfig errors in tests

### DIFF
--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,10 +1,19 @@
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
+// eslint-disable-next-line no-restricted-exports
 export default defineConfig({
   test: {
+    // Exclude examples from test discovery (does not affect tsconfig scanning)
     exclude: ['examples/**/*', '**/node_modules/**'],
     setupFiles: ['vitest.setup.ts'],
   },
-  plugins: [tsconfigPaths({ root: import.meta.dirname })],
+  // Restrict tsconfig-paths to only use this app's tsconfig
+  plugins: [
+    tsconfigPaths({
+      root: import.meta.dirname,
+      // Prevent scanning tsconfig files in subfolders like examples/**
+      projects: ['tsconfig.json'],
+    }),
+  ],
 })


### PR DESCRIPTION
Tests get spammed with unnecessary tsconfig errors because the Vitest config tries to use tsconfig files from the examples directory. Excluding those from tsConfigPaths for cleaner test output.