### PR TITLE
fix: handle undefined count when fetching table rows

### DIFF
--- a/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -69,9 +69,10 @@ const Pagination = () => {
     }
   )
 
-  const count = data?.is_estimate ? formatEstimatedCount(data.count) : data?.count.toLocaleString()
-  const maxPages = Math.ceil((data?.count ?? 0) / tableEditorSnap.rowsPerPage)
-  const totalPages = (data?.count ?? 0) > 0 ? maxPages : 1
+  const count = data?.count ?? 0
+  const countString = data?.is_estimate ? formatEstimatedCount(count) : count.toLocaleString()
+  const maxPages = Math.ceil(count / tableEditorSnap.rowsPerPage)
+  const totalPages = count > 0 ? maxPages : 1
 
   const onPreviousPage = () => {
     if (page > 1) {
@@ -202,7 +203,7 @@ const Pagination = () => {
 
           <div className="flex items-center gap-x-2">
             <p className="text-xs text-foreground-light">
-              {`${count} ${data.count === 0 || data.count > 1 ? `records` : 'record'}`}{' '}
+              {`${countString} ${count === 0 || count > 1 ? `records` : 'record'}`}{' '}
               {data.is_estimate ? '(estimated)' : ''}
             </p>
 
@@ -217,7 +218,7 @@ const Pagination = () => {
                     icon={<HelpCircle />}
                     onClick={() => {
                       // Show warning if either NOT a table entity, or table rows estimate is beyond threshold
-                      if (rowsCountEstimate === null || data.count > THRESHOLD_COUNT) {
+                      if (rowsCountEstimate === null || count > THRESHOLD_COUNT) {
                         setIsConfirmFetchExactCountModalOpen(true)
                       } else snap.setEnforceExactCount(true)
                     }}

--- a/apps/studio/data/table-rows/table-rows-count-query.ts
+++ b/apps/studio/data/table-rows/table-rows-count-query.ts
@@ -90,7 +90,7 @@ from approximation;
 }
 
 export type TableRowsCount = {
-  count: number
+  count?: number
   is_estimate?: boolean
 }
 
@@ -144,8 +144,8 @@ export async function getTableRowsCount(
   )
 
   return {
-    count: result[0].count,
-    is_estimate: result[0].is_estimate ?? false,
+    count: result?.[0]?.count,
+    is_estimate: result?.[0]?.is_estimate ?? false,
   } as TableRowsCount
 }
 


### PR DESCRIPTION
count can be undefined in the return from fetching table rows (it uses executeSqlQuery under the hood which has no type safety) so we need to deal with that case