### PR TITLE
Chore/optimize auth users UI query

### DIFF
--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -44,7 +44,22 @@ export const getUsersSQL = ({
 
   const conditions: string[] = []
   const baseQueryUsers = `
-  select *, coalesce((select array_agg(distinct i.provider) from auth.identities i where i.user_id = auth.users.id), '{}'::text[]) as providers from auth.users
+  select 
+    id,
+    email,
+    banned_until,
+    created_at,
+    confirmed_at,
+    confirmation_sent_at,
+    is_anonymous,
+    is_sso_user,
+    invited_at,
+    last_sign_in_at,
+    phone,
+    raw_app_meta_data,
+    raw_user_meta_data,
+    updated_at,
+    coalesce((select array_agg(distinct i.provider) from auth.identities i where i.user_id = auth.users.id), '{}'::text[]) as providers from auth.users
   `.trim()
 
   if (hasValidKeywords) {

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -43,24 +43,6 @@ export const getUsersSQL = ({
   const hasValidKeywords = keywords && keywords !== ''
 
   const conditions: string[] = []
-  const baseQueryUsers = `
-  select 
-    id,
-    email,
-    banned_until,
-    created_at,
-    confirmed_at,
-    confirmation_sent_at,
-    is_anonymous,
-    is_sso_user,
-    invited_at,
-    last_sign_in_at,
-    phone,
-    raw_app_meta_data,
-    raw_user_meta_data,
-    updated_at,
-    coalesce((select array_agg(distinct i.provider) from auth.identities i where i.user_id = auth.users.id), '{}'::text[]) as providers from auth.users
-  `.trim()
 
   if (hasValidKeywords) {
     // [Joshen] Escape single quotes properly
@@ -96,7 +78,52 @@ export const getUsersSQL = ({
   const sortOn = sort ?? 'created_at'
   const sortOrder = order ?? 'desc'
 
-  return `${baseQueryUsers}${conditions.length > 0 ? ` where ${combinedConditions}` : ''} order by "${sortOn}" ${sortOrder} nulls last limit ${USERS_PAGE_LIMIT} offset ${offset};`
+  const usersQuery = `
+with
+  users_data as (
+    select
+      id,
+      email,
+      banned_until,
+      created_at,
+      confirmed_at,
+      confirmation_sent_at,
+      is_anonymous,
+      is_sso_user,
+      invited_at,
+      last_sign_in_at,
+      phone,
+      raw_app_meta_data,
+      raw_user_meta_data,
+      updated_at
+    from
+      auth.users
+    ${conditions.length > 0 ? ` where ${combinedConditions}` : ''}
+    order by
+      "${sortOn}" ${sortOrder} nulls last
+    limit
+      ${USERS_PAGE_LIMIT}
+    offset
+      ${offset}
+  )
+select
+  *,
+  coalesce(
+    (
+      select
+        array_agg(distinct i.provider)
+      from
+        auth.identities i
+      where
+        i.user_id = users_data.id
+    ),
+    '{}'::text[]
+  ) as providers
+from
+  users_data;
+  `.trim()
+
+  return usersQuery
 }
 
 export type UsersData = { result: User[] }


### PR DESCRIPTION
## Context

Part of an (to-be) ongoing effort to optimize any SQL queries that are being run by the dashboard, with the end goal to not affect primary workloads on the database from using the dashboard.

This will/should eventually also be a point of consideration for future UIs in the dashboard too - that queries must work at scale (or gracefully degrade)

## Changes

Mainly updating how we query the auth.users table for the Auth Users UI
- Only select required columns (avoiding `*`)
  - This should eventually become a rule for all UIs i reckon (or where appropriate)
- Use CTE and only run aggregation within the results block

Costs + execution are seemingly lower with this implementation via `explain analyze` but my understanding of `explain analyze` is a bit shallow to make any clear deductions - more than happy if anyone might be able to provide any feedback 🙏

We could potentially further optimize this by using cursor pagination - but reckon it's not a high priority
- Main thing is that _using_ the UI shouldn't degrade the database
- I don't think anyone be using the UI to scroll through a million rows just to find something, search will be used instead
- Although, if it does end up being a use case, we can investigate using cursor pagination then

## To test
- [ ] Verify that Auth Users UI is still functioning as expected
  - Things like pagination, filters, search