### PR TITLE
Add self-remediation for orphan prefixes and refactor delete objects to be a singular request

### DIFF
--- a/apps/studio/data/storage/bucket-prefix-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-prefix-delete-mutation.ts
@@ -1,0 +1,35 @@
+import { executeSql } from 'data/sql/execute-sql-query'
+
+/**
+ * [Joshen] JFYI this is solely being used in storage-explorer.tsx and hence doesn't have a useMutation hook
+ * It's solely supposed to aid users to self-remediate a known issue with orphan prefixes so the condition to
+ * clean the prefix from the storage.prefixes is intentionally strict here (e.g only level 1, since we've only
+ * seen this bug happening at the top level folder)
+ */
+
+type DeleteBucketPrefixParams = {
+  projectRef?: string
+  connectionString?: string
+  bucketId?: string
+  prefix?: string
+}
+export const deleteBucketPrefix = async (
+  { projectRef, connectionString, bucketId, prefix }: DeleteBucketPrefixParams,
+  signal?: AbortSignal
+) => {
+  if (!projectRef) throw new Error('projectRef is required')
+  if (!connectionString) throw new Error('connectionString is required')
+  if (!bucketId) throw new Error('bucketId is required')
+  if (!prefix) throw new Error('prefix is required')
+
+  const sql = /* SQL */ `
+delete from storage.prefixes where bucket_id = '${bucketId}' and name = '${prefix}' and level = 1;
+`.trim()
+
+  const { result } = await executeSql(
+    { projectRef, connectionString, sql, queryKey: ['delete-bucket-prefix'] },
+    signal
+  )
+
+  return result
+}

--- a/apps/studio/data/storage/bucket-prefix-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-prefix-delete-mutation.ts
@@ -3,8 +3,9 @@ import { executeSql } from 'data/sql/execute-sql-query'
 /**
  * [Joshen] JFYI this is solely being used in storage-explorer.tsx and hence doesn't have a useMutation hook
  * It's solely supposed to aid users to self-remediate a known issue with orphan prefixes so the condition to
- * clean the prefix from the storage.prefixes is intentionally strict here (e.g only level 1, since we've only
- * seen this bug happening at the top level folder)
+ * clean the prefix from the storage.prefixes is intentionally strict here (e.g only level 1)
+ *
+ * We can make this a bit more loose if needed, but ideal case is that this issue is addressed at the storage level
  */
 
 type DeleteBucketPrefixParams = {

--- a/apps/studio/data/storage/bucket-prefix-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-prefix-delete-mutation.ts
@@ -24,7 +24,7 @@ export const deleteBucketPrefix = async (
   if (!prefix) throw new Error('prefix is required')
 
   const sql = /* SQL */ `
-delete from storage.prefixes where bucket_id = '${bucketId}' and name = '${prefix}' and level = 1;
+select storage.delete_prefix('${bucketId}', '${prefix}');
 `.trim()
 
   const { result } = await executeSql(

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -44,6 +44,7 @@ import { getQueryClient } from 'data/query-client'
 import { deleteBucketObject } from 'data/storage/bucket-object-delete-mutation'
 import { downloadBucketObject } from 'data/storage/bucket-object-download-mutation'
 import { listBucketObjects, StorageObject } from 'data/storage/bucket-objects-list-mutation'
+import { deleteBucketPrefix } from 'data/storage/bucket-prefix-delete-mutation'
 import { Bucket } from 'data/storage/buckets-query'
 import { moveStorageObject } from 'data/storage/object-move-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -79,10 +80,12 @@ if (typeof window !== 'undefined') {
 
 function createStorageExplorerState({
   projectRef,
+  connectionString,
   resumableUploadUrl,
   supabaseClient,
 }: {
   projectRef: string
+  connectionString: string
   resumableUploadUrl: string
   supabaseClient?: () => Promise<SupabaseClient<any, 'public', any>>
 }) {
@@ -93,6 +96,7 @@ function createStorageExplorerState({
 
   const state = proxy({
     projectRef,
+    connectionString,
     supabaseClient,
     resumableUploadUrl,
     uploadProgresses: [] as UploadProgress[],
@@ -591,7 +595,18 @@ function createStorageExplorerState({
       try {
         const isDeleteFolder = true
         const files = await state.getAllItemsAlongFolder(folder)
-        await state.deleteFiles({ files: files as any[], isDeleteFolder })
+
+        if (files.length === 0) {
+          // [Joshen] This is to self-remediate orphan prefixes
+          await deleteBucketPrefix({
+            projectRef: state.projectRef,
+            connectionString: state.connectionString,
+            bucketId: state.selectedBucket.id,
+            prefix: folder.name,
+          })
+        } else {
+          await state.deleteFiles({ files: files as any[], isDeleteFolder })
+        }
 
         state.popColumnAtIndex(folder.columnIndex)
         state.popOpenedFoldersAtIndex(folder.columnIndex - 1)
@@ -607,7 +622,6 @@ function createStorageExplorerState({
 
         await state.refetchAllOpenedFolders()
         state.setSelectedItemsToDelete([])
-
         toast.success(`Successfully deleted ${folder.name}`)
       } catch (error: any) {
         toast.error(`Failed to delete folder: ${error.message}`)
@@ -1411,7 +1425,6 @@ function createStorageExplorerState({
       isDeleteFolder?: boolean
     }) => {
       state.setSelectedFilePreview(undefined)
-      let progress = 0
 
       // If every file has the 'prefix' property, then just construct the prefix
       // directly (from delete folder). Otherwise go by the opened folders.
@@ -1429,37 +1442,13 @@ function createStorageExplorerState({
 
       state.clearSelectedItems()
 
-      const toastId = toast(
-        <SonnerProgress progress={0} message={`Deleting ${prefixes.length} file(s)...`} />,
-        { closeButton: false, position: 'top-right' }
-      )
+      const toastId = toast.loading(`Deleting ${prefixes.length} file(s)...`)
 
-      // batch BATCH_SIZE prefixes per request
-      const batches = chunk(prefixes, BATCH_SIZE).map((batch) => () => {
-        progress = progress + batch.length / prefixes.length
-        return deleteBucketObject({
-          projectRef: state.projectRef,
-          bucketId: state.selectedBucket.id,
-          paths: batch as string[],
-        })
+      await deleteBucketObject({
+        projectRef: state.projectRef,
+        bucketId: state.selectedBucket.id,
+        paths: prefixes,
       })
-
-      // make BATCH_SIZE requests at the same time
-      await chunk(batches, BATCH_SIZE).reduce(async (previousPromise, nextBatch) => {
-        await previousPromise
-        await Promise.all(nextBatch.map((batch) => batch()))
-        toast(
-          <SonnerProgress
-            progress={progress * 100}
-            message={`Deleting ${prefixes.length} file(s)...`}
-          />,
-          {
-            id: toastId,
-            closeButton: false,
-            position: 'top-right',
-          }
-        )
-      }, Promise.resolve())
 
       if (!isDeleteFolder) {
         // If parent folders are empty, reinstate .emptyFolderPlaceholder to persist them
@@ -1790,6 +1779,7 @@ type StorageExplorerState = ReturnType<typeof createStorageExplorerState>
 
 const DEFAULT_STATE_CONFIG = {
   projectRef: '',
+  connectionString: '',
   resumableUploadUrl: '',
   supabaseClient: undefined,
 }
@@ -1823,6 +1813,7 @@ export const StorageExplorerStateContextProvider = ({ children }: PropsWithChild
       setState(
         createStorageExplorerState({
           projectRef: project?.ref ?? '',
+          connectionString: project.connectionString ?? '',
           supabaseClient: async () => {
             try {
               const data = await getTemporaryAPIKey({ projectRef: project.ref })

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -602,7 +602,7 @@ function createStorageExplorerState({
             projectRef: state.projectRef,
             connectionString: state.connectionString,
             bucketId: state.selectedBucket.id,
-            prefix: folder.name,
+            prefix: folder.path,
           })
         } else {
           await state.deleteFiles({ files: files as any[], isDeleteFolder })


### PR DESCRIPTION
## Context

There seems to be an issue that's happening in the Dashboard's Storage Explorer, whereby if you try to delete a folder through the UI, there's a chance that the folder that you deleted persists in the UI despite it being empty. And trying to delete that folder again subsequently just shows success toasts but the folder continues to persist

<img width="541" height="194" alt="image" src="https://github.com/user-attachments/assets/b5fa0923-17dc-495c-8c36-b8b05739af1e" />
<img width="1142" height="213" alt="image" src="https://github.com/user-attachments/assets/beaf4da6-7b30-4cc9-b84d-d1cd75b3b82e" />

This happens rather inconsistently and can be reproduced occasionally with just a flat folder (e.g I reproduced this with a folder that contains 70 files, no nested folders)

## Hypothesis

Current assumption is that there might be some race condition happening on the Storage BE side of things (unconfirmed - but given it's inconsistent nature) as the dashboard fires a series of network requests when deleting folders - specifically we're firing a DELETE object request per 2 files. So if there's 70 files, that'll mean 35 requests. I'm actually not sure why we're doing that to be honest 🤦‍♂️

However, this seems to be a known problem from the Storage team ("Orphan prefix") which they've suggested a simple fix would just be to clean that row from the `storage.prefixes` table.

## Changes involved

- Added self-remediate step in `deleteFolder` where if the number of files to be deleted is 0, we'll trigger a function to delete from the `storage.prefixes` table
- Opt to trigger just one singular request when deleting files since DELETE objects accepts an array of strings for `paths`
  - This hopefully aims to mitigate the orphan prefix issue which I haven't been able to reproduce since, but I cannot confirm if it resolves it entirely
  - NOTE: The UI consequence of this change is that there's no longer a progress indicator since it just waits on when the request finishes (that might have been a factor of consideration for the old implementation, but reckon this is still better than almost DDOSing the project's API)

## To test
- [ ] Try to reproduce the Orphan prefix issue by uploading a folder with some files, then deleting the folder
- [ ] If you have the Orphan prefix issue, try deleting the empty folder - it should clear up nicely
- [ ] Verify that you can also still delete multiple files (not just the whole folder)