### PR TITLE
refactor: make MCP docs url configurable

### DIFF
--- a/apps/studio/lib/ai/supabase-mcp.ts
+++ b/apps/studio/lib/ai/supabase-mcp.ts
@@ -24,6 +24,7 @@ export async function createSupabaseMCPClient({
       accessToken,
       apiUrl,
     }),
+    contentApiUrl: process.env.NEXT_PUBLIC_CONTENT_API_URL,
     projectId,
     readOnly: true,
   })


### PR DESCRIPTION
To test:

Prompt the dashboard assistant to search the docs. Try something like "search the Supabase docs and tell me how to sign up a new user using the Dart SDK". It should successfully search the docs and give you an answer.