### PR TITLE
feat: improved issue select

### DIFF
--- a/apps/studio/components/interfaces/Support/Support.constants.ts
+++ b/apps/studio/components/interfaces/Support/Support.constants.ts
@@ -3,7 +3,7 @@ import { SupportCategories } from '@supabase/shared-types/out/constants'
 export const CATEGORY_OPTIONS = [
   {
     value: SupportCategories.PROBLEM,
-    label: 'Issues with APIs / client libraries',
+    label: 'APIs and client libraries',
     description: "Issues with your project's API and client libraries",
     query: undefined,
   },

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -89,7 +89,7 @@ export const SupportFormV2 = ({
     .object({
       organizationSlug: z.string().min(1, 'Please select an organization'),
       projectRef: z.string().min(1, 'Please select a project'),
-      category: z.string(),
+      category: z.string().min(1, 'Please select an issue type'),
       severity: z.string(),
       library: z.string(),
       subject: z.string().min(1, 'Please add a subject heading'),
@@ -110,7 +110,7 @@ export const SupportFormV2 = ({
   const defaultValues = {
     organizationSlug: '',
     projectRef: 'no-project',
-    category: CATEGORY_OPTIONS[0].value,
+    category: '',
     severity: 'Low',
     library: '',
     subject: '',
@@ -434,7 +434,7 @@ export const SupportFormV2 = ({
             name="category"
             control={form.control}
             render={({ field }) => (
-              <FormItemLayout layout="vertical" label="What areas are you having problems with?">
+              <FormItemLayout layout="vertical" label="What are you having issues with?">
                 <FormControl_Shadcn_>
                   <Select_Shadcn_
                     {...field}
@@ -442,8 +442,10 @@ export const SupportFormV2 = ({
                     onValueChange={field.onChange}
                   >
                     <SelectTrigger_Shadcn_ className="w-full">
-                      <SelectValue_Shadcn_>
-                        {CATEGORY_OPTIONS.find((o) => o.value === field.value)?.label}
+                      <SelectValue_Shadcn_ placeholder="Select an issue">
+                        {field.value
+                          ? CATEGORY_OPTIONS.find((o) => o.value === field.value)?.label
+                          : null}
                       </SelectValue_Shadcn_>
                     </SelectTrigger_Shadcn_>
                     <SelectContent_Shadcn_>
@@ -607,7 +609,7 @@ export const SupportFormV2 = ({
                     onValueChange={field.onChange}
                   >
                     <SelectTrigger_Shadcn_ className="w-full">
-                      <SelectValue_Shadcn_ placeholder="Please select a library" />
+                      <SelectValue_Shadcn_ placeholder="Select a library" />
                     </SelectTrigger_Shadcn_>
                     <SelectContent_Shadcn_>
                       <SelectGroup_Shadcn_>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor improvements to our support form:

- Removed default value for the _What areas are you having problems with?_ dropdown 
- Replaced it with a placeholder and error states (because it’s a required field)
- Improved language for clarity

## What is the current behavior?

We assume the user wants to file a ticket specifically about _Issues with APls / client libraries_:

<img width="1204" height="264" alt="CleanShot 2025-09-17 at 11 47 27@2x" src="https://github.com/user-attachments/assets/912edc50-b492-4ef1-a209-497be82c3d2b" />

## What is the new behavior?

We don't assume (and we make language a bit cleaner):

<img width="1214" height="230" alt="CleanShot 2025-09-17 at 12 13 22@2x" src="https://github.com/user-attachments/assets/7ab32144-cde3-416f-b2bb-e8da843218e0" />


## Additional context

- [Linear](https://linear.app/supabase/issue/DEPR-64/remove-preset-value-for-problem-area)
