### PR TITLE
FE-1860: Shared API Report Fixes

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -74,8 +74,8 @@ const ReportWidget = (props: ReportWidgetProps) => {
                       query.content = props.resolvedSql
                     } else {
                       query.q = props.params?.sql
-                      query.its = props.params!.iso_timestamp_start
-                      query.ite = props.params!.iso_timestamp_end
+                      query.its = props.params?.iso_timestamp_start || ''
+                      query.ite = props.params?.iso_timestamp_end || ''
                     }
 
                     router.push({ pathname, query })

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
@@ -219,8 +219,15 @@ const fetchLogs = async ({
 
 const DEFAULT_KEYS = ['shared-api-report']
 
+export type SharedAPIReportFilterBy =
+  | 'auth'
+  | 'realtime'
+  | 'storage'
+  | 'graphql'
+  | 'functions'
+  | 'postgrest'
 type SharedAPIReportParams = {
-  filterBy: 'auth' | 'realtime' | 'storage' | 'graphql' | 'functions' | 'postgrest'
+  filterBy: SharedAPIReportFilterBy
   start: string
   end: string
   projectRef: string
@@ -263,7 +270,16 @@ export const useSharedAPIReport = ({
 
   const queries = useQueries({
     queries: Object.entries(SHARED_API_REPORT_SQL).map(([key, value]) => ({
-      queryKey: [...DEFAULT_KEYS, key, filterByMapSource[filterBy], filters, start, end, ref],
+      queryKey: [
+        ...DEFAULT_KEYS,
+        filterBy,
+        key,
+        filterByMapSource[filterBy],
+        filters,
+        start,
+        end,
+        ref,
+      ],
       enabled: enabled && !!ref && !!filterBy,
       queryFn: () =>
         fetchLogs({
@@ -324,6 +340,22 @@ export const useSharedAPIReport = ({
 
   const isLoadingData = Object.values(isLoading).some(Boolean)
 
+  const SQLMap: Record<SharedAPIReportKey, string> = {
+    totalRequests: SHARED_API_REPORT_SQL.totalRequests.sql(allFilters, filterByMapSource[filterBy]),
+    topRoutes: SHARED_API_REPORT_SQL.topRoutes.sql(allFilters, filterByMapSource[filterBy]),
+    errorCounts: SHARED_API_REPORT_SQL.errorCounts.sql(allFilters, filterByMapSource[filterBy]),
+    topErrorRoutes: SHARED_API_REPORT_SQL.topErrorRoutes.sql(
+      allFilters,
+      filterByMapSource[filterBy]
+    ),
+    responseSpeed: SHARED_API_REPORT_SQL.responseSpeed.sql(allFilters, filterByMapSource[filterBy]),
+    topSlowRoutes: SHARED_API_REPORT_SQL.topSlowRoutes.sql(allFilters, filterByMapSource[filterBy]),
+    networkTraffic: SHARED_API_REPORT_SQL.networkTraffic.sql(
+      allFilters,
+      filterByMapSource[filterBy]
+    ),
+  }
+
   return {
     data,
     error,
@@ -334,5 +366,9 @@ export const useSharedAPIReport = ({
     filters,
     addFilter,
     removeFilters,
+    /**
+     * The SQL queries used to fetch each metric
+     */
+    sql: SQLMap,
   }
 }

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.tsx
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.tsx
@@ -6,7 +6,11 @@ import {
   TopApiRoutesRenderer,
   TotalRequestsChartRenderer,
 } from '../renderers/ApiRenderers'
-import { SharedAPIReportKey } from './SharedAPIReport.constants'
+import {
+  SharedAPIReportFilterBy,
+  SharedAPIReportKey,
+  useSharedAPIReport,
+} from './SharedAPIReport.constants'
 
 type SharedAPIReportWidgetsProps = {
   data: any
@@ -14,6 +18,7 @@ type SharedAPIReportWidgetsProps = {
   isLoading: any
   isRefetching: boolean
   hiddenReports?: SharedAPIReportKey[]
+  sql: Record<SharedAPIReportKey, string>
 }
 
 export function SharedAPIReport({
@@ -22,6 +27,7 @@ export function SharedAPIReport({
   isLoading,
   isRefetching,
   hiddenReports = [],
+  sql,
 }: SharedAPIReportWidgetsProps) {
   return (
     <div className="grid grid-cols-1 gap-4">
@@ -34,6 +40,10 @@ export function SharedAPIReport({
           renderer={TotalRequestsChartRenderer}
           append={TopApiRoutesRenderer}
           appendProps={{ data: data.topRoutes }}
+          queryType="logs"
+          params={{
+            sql: sql.totalRequests,
+          }}
         />
       )}
       {!hiddenReports.includes('errorCounts') && (
@@ -48,6 +58,10 @@ export function SharedAPIReport({
             data: data.topErrorRoutes || [],
           }}
           append={TopApiRoutesRenderer}
+          queryType="logs"
+          params={{
+            sql: sql.errorCounts,
+          }}
         />
       )}
       {!hiddenReports.includes('responseSpeed') && (
@@ -60,6 +74,10 @@ export function SharedAPIReport({
           renderer={ResponseSpeedChartRenderer}
           appendProps={{ data: data.topSlowRoutes || [] }}
           append={TopApiRoutesRenderer}
+          queryType="logs"
+          params={{
+            sql: sql.responseSpeed,
+          }}
         />
       )}
       {!hiddenReports.includes('networkTraffic') && (
@@ -70,6 +88,10 @@ export function SharedAPIReport({
           tooltip="Ingress and egress of requests and responses respectively"
           data={data.networkTraffic || []}
           renderer={NetworkTrafficRenderer}
+          queryType="logs"
+          params={{
+            sql: sql.networkTraffic,
+          }}
         />
       )}
     </div>

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.tsx
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.tsx
@@ -6,11 +6,7 @@ import {
   TopApiRoutesRenderer,
   TotalRequestsChartRenderer,
 } from '../renderers/ApiRenderers'
-import {
-  SharedAPIReportFilterBy,
-  SharedAPIReportKey,
-  useSharedAPIReport,
-} from './SharedAPIReport.constants'
+import { SharedAPIReportKey } from './SharedAPIReport.constants'
 
 type SharedAPIReportWidgetsProps = {
   data: any

--- a/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -220,22 +220,6 @@ export const TopApiRoutesRenderer = (
           >
             {!showMore ? 'Show more' : 'Show less'}
           </Button>
-          <Button
-            type="text"
-            className="text-foreground-lighter"
-            onClick={() => {
-              props.router.push({
-                pathname: `/project/${projectRef}/logs/explorer`,
-                query: {
-                  q: props.params?.sql,
-                  its: props.params!.iso_timestamp_start,
-                  ite: props.params!.iso_timestamp_end,
-                },
-              })
-            }}
-          >
-            Open in Logs Explorer
-          </Button>
         </div>
       </Collapsible.Trigger>
     </Collapsible>

--- a/apps/studio/pages/project/[ref]/reports/auth.tsx
+++ b/apps/studio/pages/project/[ref]/reports/auth.tsx
@@ -62,6 +62,7 @@ const AuthUsage = () => {
     addFilter,
     removeFilters,
     isLoadingData,
+    sql,
   } = useSharedAPIReport({
     filterBy: 'auth',
     start: selectedDateRange?.period_start?.date,
@@ -161,6 +162,10 @@ const AuthUsage = () => {
             error={error}
             isLoading={isLoading}
             isRefetching={isRefetching}
+            sql={sql}
+            filterBy={'auth'}
+            start={selectedDateRange?.period_start?.date}
+            end={selectedDateRange?.period_end?.date}
           />
         </div>
       </ReportStickyNav>

--- a/apps/studio/pages/project/[ref]/reports/auth.tsx
+++ b/apps/studio/pages/project/[ref]/reports/auth.tsx
@@ -163,9 +163,6 @@ const AuthUsage = () => {
             isLoading={isLoading}
             isRefetching={isRefetching}
             sql={sql}
-            filterBy={'auth'}
-            start={selectedDateRange?.period_start?.date}
-            end={selectedDateRange?.period_end?.date}
           />
         </div>
       </ReportStickyNav>

--- a/apps/studio/pages/project/[ref]/reports/postgrest.tsx
+++ b/apps/studio/pages/project/[ref]/reports/postgrest.tsx
@@ -61,6 +61,7 @@ const PostgrestReport = () => {
     addFilter,
     removeFilters,
     isLoadingData,
+    sql,
   } = useSharedAPIReport({
     filterBy: 'postgrest',
     start: selectedDateRange?.period_start?.date,
@@ -151,6 +152,10 @@ const PostgrestReport = () => {
             error={error}
             isLoading={isLoading}
             isRefetching={isRefetching}
+            filterBy={'postgrest'}
+            start={selectedDateRange?.period_start?.date}
+            end={selectedDateRange?.period_end?.date}
+            sql={sql}
           />
         </div>
       </ReportStickyNav>

--- a/apps/studio/pages/project/[ref]/reports/postgrest.tsx
+++ b/apps/studio/pages/project/[ref]/reports/postgrest.tsx
@@ -152,9 +152,6 @@ const PostgrestReport = () => {
             error={error}
             isLoading={isLoading}
             isRefetching={isRefetching}
-            filterBy={'postgrest'}
-            start={selectedDateRange?.period_start?.date}
-            end={selectedDateRange?.period_end?.date}
             sql={sql}
           />
         </div>

--- a/apps/studio/pages/project/[ref]/reports/realtime.tsx
+++ b/apps/studio/pages/project/[ref]/reports/realtime.tsx
@@ -79,6 +79,7 @@ const RealtimeUsage = () => {
     addFilter,
     removeFilters,
     isLoadingData,
+    sql,
   } = useSharedAPIReport({
     filterBy: 'realtime',
     start: selectedDateRange?.period_start?.date,
@@ -218,6 +219,10 @@ const RealtimeUsage = () => {
             isLoading={isLoading}
             isRefetching={isRefetching}
             hiddenReports={['networkTraffic']}
+            sql={sql}
+            filterBy={'realtime'}
+            start={selectedDateRange?.period_start?.date}
+            end={selectedDateRange?.period_end?.date}
           />
         </div>
       </ReportStickyNav>

--- a/apps/studio/pages/project/[ref]/reports/realtime.tsx
+++ b/apps/studio/pages/project/[ref]/reports/realtime.tsx
@@ -220,9 +220,6 @@ const RealtimeUsage = () => {
             isRefetching={isRefetching}
             hiddenReports={['networkTraffic']}
             sql={sql}
-            filterBy={'realtime'}
-            start={selectedDateRange?.period_start?.date}
-            end={selectedDateRange?.period_end?.date}
           />
         </div>
       </ReportStickyNav>


### PR DESCRIPTION
- fixes open in log explorer button
- removes old button, opt for top right button instead
- fixes shared api report not refetching on filterby change
- adds new "sql" prop for components to grab the sql ran to pass on to log explorer link

## To test
- create some users or grab a project with usage
- go to reports / auth
- click open in log explorer in one of the metrics
- SQL makes sense / runs 