### PR TITLE
feat: support verify_jwt per function in self-hosted docker

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -109,7 +109,10 @@ OPENAI_API_KEY=
 # Functions - Configuration for Functions
 ############
 # NOTE: VERIFY_JWT applies to all functions. Per-function VERIFY_JWT is not supported yet.
+# Implementing Per-function verify_jwt, however, keeping this as default for when per function
+# option is not configured in volumes/functions/config.toml
 FUNCTIONS_VERIFY_JWT=false
+FUNCTIONS_VOLUME_PATH=/home/deno/functions
 
 
 ############

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -317,7 +317,8 @@ services:
     image: supabase/edge-runtime:v1.69.6
     restart: unless-stopped
     volumes:
-      - ./volumes/functions:/home/deno/functions:Z
+      - ./volumes/functions:${FUNCTIONS_VOLUME_PATH}:Z
+      - ./volumes/functions/config.toml:${FUNCTIONS_VOLUME_PATH}/config.toml:Z
     depends_on:
       analytics:
         condition: service_healthy
@@ -329,11 +330,12 @@ services:
       SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
       # TODO: Allow configuring VERIFY_JWT per function. This PR might help: https://github.com/supabase/cli/pull/786
       VERIFY_JWT: "${FUNCTIONS_VERIFY_JWT}"
+      FUNCTIONS_VOLUME_PATH: ${FUNCTIONS_VOLUME_PATH}
     command:
       [
         "start",
         "--main-service",
-        "/home/deno/functions/main"
+        "${FUNCTIONS_VOLUME_PATH}/main"
       ]
 
   analytics:

--- a/docker/volumes/functions/config.toml
+++ b/docker/volumes/functions/config.toml
@@ -1,0 +1,2 @@
+[functions.hello]
+verify_jwt = true

--- a/docker/volumes/functions/main/index.ts
+++ b/docker/volumes/functions/main/index.ts
@@ -1,10 +1,13 @@
 import { serve } from 'https://deno.land/std@0.131.0/http/server.ts'
 import * as jose from 'https://deno.land/x/jose@v4.14.4/index.ts'
+import * as toml from 'https://deno.land/std@0.224.0/toml/mod.ts'
 
 console.log('main function started')
 
 const JWT_SECRET = Deno.env.get('JWT_SECRET')
 const VERIFY_JWT = Deno.env.get('VERIFY_JWT') === 'true'
+const FUNCTIONS_VOLUME_PATH = Deno.env.get('FUNCTIONS_VOLUME_PATH')
+const CONFIG_PATH = `${FUNCTIONS_VOLUME_PATH}/config.toml`
 
 function getAuthToken(req: Request) {
   const authHeader = req.headers.get('authorization')
@@ -30,8 +33,44 @@ async function verifyJWT(jwt: string): Promise<boolean> {
   return true
 }
 
+async function getFuncKeyValue(functionName: string, key: string): Promise<any> {
+  try {
+    // Read the TOML file into a string
+    const fileContent = await Deno.readTextFile(CONFIG_PATH);
+
+    // Parse the string
+    const config = toml.parse(fileContent);
+
+    // You can now access the properties
+    const func_key_value: any = config.functions[functionName][key];
+
+    // Un-comment the line below to output the key value to docker logs console
+    // console.log(`'${key}' value for '${functionName}' is: ${func_key_value}`);
+    return func_key_value;
+
+  } catch (e) {
+    console.error(`Error reading or parsing file: ${e.message}`);
+    return VERIFY_JWT;
+  }
+}
+
 serve(async (req: Request) => {
-  if (req.method !== 'OPTIONS' && VERIFY_JWT) {
+  const url = new URL(req.url)
+  const { pathname } = url
+  const path_parts = pathname.split('/')
+  const service_name = path_parts[1]
+
+  if (!service_name || service_name === '') {
+    const error = { msg: 'missing function name in request' }
+    return new Response(JSON.stringify(error), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const FUNC_VERIFY_JWT = await getFuncKeyValue(service_name, 'verify_jwt');
+  
+  if (req.method !== 'OPTIONS' && FUNC_VERIFY_JWT) {
     try {
       const token = getAuthToken(req)
       const isValidJWT = await verifyJWT(token)
@@ -51,20 +90,7 @@ serve(async (req: Request) => {
     }
   }
 
-  const url = new URL(req.url)
-  const { pathname } = url
-  const path_parts = pathname.split('/')
-  const service_name = path_parts[1]
-
-  if (!service_name || service_name === '') {
-    const error = { msg: 'missing function name in request' }
-    return new Response(JSON.stringify(error), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
-
-  const servicePath = `/home/deno/functions/${service_name}`
+  const servicePath = `${FUNCTIONS_VOLUME_PATH}/${service_name}`
   console.error(`serving the request with ${servicePath}`)
 
   const memoryLimitMb = 150


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

feature

## What is the current behavior?

The self-hosted docker does not support per function jwt verification.

## What is the new behavior?

This allows for configuring per function verify_jwt to true/false in volumes/functions/config.toml.

## Additional context

This PR does not take away the current VERIFY_JWT, instead uses that as fallback(default) for when a function does not exist in config.toml.
