### PR TITLE
Improve logic to calculate time range when log chart is clicked

### DIFF
--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master
         with:
+          fail-on-error: false
           parallel: true
           flag-name: studio-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,5 +74,6 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
+          fail-on-error: false
           parallel-finished: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master
         with:
-          fail-on-error: false
           parallel: true
           flag-name: studio-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +73,5 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
-          fail-on-error: false
           parallel-finished: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/invocations.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/invocations.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import EdgeFunctionDetailsLayout from 'components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout'
 import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import EdgeFunctionDetailsLayout from 'components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout'
 import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'

--- a/apps/studio/pages/project/[ref]/logs/auth-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/auth-logs.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import NoPermission from 'components/ui/NoPermission'

--- a/apps/studio/pages/project/[ref]/logs/cron-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/cron-logs.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/router'
 
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'

--- a/apps/studio/pages/project/[ref]/logs/dedicated-pooler-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/dedicated-pooler-logs.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'common'
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import { Loading } from 'components/ui/Loading'

--- a/apps/studio/pages/project/[ref]/logs/edge-functions-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/edge-functions-logs.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'
 import DefaultLayout from 'components/layouts/DefaultLayout'

--- a/apps/studio/pages/project/[ref]/logs/edge-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/edge-logs.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'
 import DefaultLayout from 'components/layouts/DefaultLayout'

--- a/apps/studio/pages/project/[ref]/logs/etl-replication-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/etl-replication-logs.tsx
@@ -1,5 +1,5 @@
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import type { NextPageWithLayout } from 'types'

--- a/apps/studio/pages/project/[ref]/logs/pg-upgrade-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/pg-upgrade-logs.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'

--- a/apps/studio/pages/project/[ref]/logs/pgcron-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/pgcron-logs.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import type { NextPageWithLayout } from 'types'

--- a/apps/studio/pages/project/[ref]/logs/pooler-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/pooler-logs.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'common'
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import { Loading } from 'components/ui/Loading'

--- a/apps/studio/pages/project/[ref]/logs/postgres-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/postgres-logs.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'

--- a/apps/studio/pages/project/[ref]/logs/postgrest-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/postgrest-logs.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 
 import { LogsTableName } from 'components/interfaces/Settings/Logs/Logs.constants'
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'
 import { LogsTableEmptyState } from 'components/interfaces/Settings/Logs/LogsTableEmptyState'

--- a/apps/studio/pages/project/[ref]/logs/realtime-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/realtime-logs.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import type { NextPageWithLayout } from 'types'
 import DefaultLayout from 'components/layouts/DefaultLayout'

--- a/apps/studio/pages/project/[ref]/logs/storage-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/storage-logs.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 
-import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { LogsPreviewer } from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import type { NextPageWithLayout } from 'types'


### PR DESCRIPTION
- removes export default
- fixes all imports of logspreviewer
- improves calculation of time range for logs bar chart click
- moves calculation to external function to be used elsewhere
- adds tests to this function

