### PR TITLE
feat(studio): add query perf symlink to reports

### DIFF
--- a/apps/studio/components/layouts/ReportsLayout/ReportsMenu.tsx
+++ b/apps/studio/components/layouts/ReportsLayout/ReportsMenu.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Plus } from 'lucide-react'
+import { Plus, ArrowUpRight } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useMemo, useState } from 'react'
@@ -146,6 +146,12 @@ const ReportsMenu = () => {
               },
             ]
           : []),
+        {
+          name: 'Query Performance',
+          key: 'query-performance',
+          url: `/project/${ref}/advisors/query-performance${preservedQueryParams}`,
+          rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
+        },
         ...(postgrestReportEnabled
           ? [
               {
@@ -250,8 +256,14 @@ const ReportsMenu = () => {
                             : 'hover:bg-surface-200'
                         )}
                       >
-                        <Link href={subItem.url} className="flex-grow h-7 flex items-center pl-3">
-                          {subItem.name}
+                        <Link
+                          href={subItem.url}
+                          className="flex-grow h-7 flex justify-between items-center pl-3"
+                        >
+                          <span>{subItem.name}</span>
+                          {subItem.rightIcon && (
+                            <span className="shrink-0">{subItem.rightIcon}</span>
+                          )}
                         </Link>
                       </li>
                     ))}

--- a/apps/studio/components/layouts/ReportsLayout/ReportsMenu.tsx
+++ b/apps/studio/components/layouts/ReportsLayout/ReportsMenu.tsx
@@ -149,7 +149,7 @@ const ReportsMenu = () => {
         {
           name: 'Query Performance',
           key: 'query-performance',
-          url: `/project/${ref}/advisors/query-performance${preservedQueryParams}`,
+          url: `/project/${ref}/advisors/query-performance`,
           rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
         },
         ...(postgrestReportEnabled


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Introduces Query Performance as a tab in the Reports submenu. Until we can migrate it over or replace with Query Insights, no harm in improving discoverability of it.

Like so:
<img width="248" height="336" alt="Screenshot 2025-09-17 at 12 23 39" src="https://github.com/user-attachments/assets/d911f416-a45b-4c0c-b672-045315088f53" />

