### PR TITLE
chore: set min release age for pnpm

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq && \
   rm -rf /var/lib/apt/lists/* && \
   update-ca-certificates
 
-RUN npm install -g pnpm@9.15.5
+RUN npm install -g pnpm@10.16.1
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
     "neverBuiltDependencies": ["libpg-query"]
   },
   "engines": {
-    "pnpm": ">=9",
+    "pnpm": ">=10.16",
     "node": ">=22"
   },
   "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
-  "packageManager": "pnpm@9.15.5"
+  "packageManager": "pnpm@10.16.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,5 @@ catalog:
   '@types/react-dom': '^18.3.0'
   'valtio': '^1.12.0'
   'vite': '^6.2.7'
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
Requires setting `ENABLE_EXPERIMENTAL_COREPACK=1`, see: https://vercel.com/docs/builds/configure-a-build#corepack

Set this for the preview build but haven't done it for prod yet