### PR TITLE
Address various console warnings

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
+++ b/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
@@ -19,7 +19,7 @@ export const APIKeyRow = ({
   apiKey: Extract<APIKeysData[number], { type: 'secret' | 'publishable' }>
   lastSeen?: { timestamp: string }
 }) => {
-  const MotionTableRow = motion(TableRow)
+  const MotionTableRow = motion.create(TableRow)
 
   return (
     <MotionTableRow

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -253,6 +253,7 @@ export const CreateBranchModal = () => {
         onOpenAutoFocus={(e) => {
           if (promptProPlanUpgrade) e.preventDefault()
         }}
+        aria-describedby={undefined}
       >
         <DialogHeader padding="small">
           <DialogTitle>Create a new preview branch</DialogTitle>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/signing-key-row.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/signing-key-row.tsx
@@ -39,7 +39,7 @@ interface SigningKeyRowProps {
   isLoading?: boolean
 }
 
-const MotionTableRow = motion(TableRow)
+const MotionTableRow = motion.create(TableRow)
 
 export const SigningKeyRow = ({
   signingKey,

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -51,7 +51,7 @@ export const ICON_STROKE_WIDTH = 1.5
 export type SidebarBehaviourType = 'expandable' | 'open' | 'closed'
 export const DEFAULT_SIDEBAR_BEHAVIOR = 'expandable'
 
-const SidebarMotion = motion(SidebarPrimitive) as FC<
+const SidebarMotion = motion.create(SidebarPrimitive) as FC<
   ComponentProps<typeof SidebarPrimitive> & {
     transition?: MotionProps['transition']
   }

--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -183,7 +183,12 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                 className="hidden md:flex"
               />
             )}
-            <ResizablePanel order={2} id="panel-right" className="h-full flex flex-col w-full">
+            <ResizablePanel
+              defaultSize={1}
+              order={2}
+              id="panel-right"
+              className="h-full flex flex-col w-full"
+            >
               <ResizablePanelGroup
                 direction="horizontal"
                 className="h-full w-full overflow-x-hidden flex-1 flex flex-row gap-0"
@@ -191,6 +196,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
               >
                 <ResizablePanel
                   id="panel-content"
+                  defaultSize={1}
                   className={cn('w-full xl:min-w-[600px] bg-dash-sidebar')}
                 >
                   <main
@@ -216,6 +222,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                     <ResizableHandle withHandle />
                     <ResizablePanel
                       id="panel-assistant"
+                      defaultSize={30}
                       minSize={30}
                       maxSize={50}
                       className={cn(

--- a/apps/studio/components/ui/Charts/useChartHoverState.tsx
+++ b/apps/studio/components/ui/Charts/useChartHoverState.tsx
@@ -23,14 +23,16 @@ const subscribers = new Set<(state: ChartHoverState) => void>()
 
 // Load initial sync settings from localStorage
 try {
-  const hoverSyncStored = localStorage.getItem(CHART_HOVER_SYNC_STORAGE_KEY)
-  const tooltipSyncStored = localStorage.getItem(CHART_TOOLTIP_SYNC_STORAGE_KEY)
+  if (typeof window !== 'undefined') {
+    const hoverSyncStored = localStorage.getItem(CHART_HOVER_SYNC_STORAGE_KEY)
+    const tooltipSyncStored = localStorage.getItem(CHART_TOOLTIP_SYNC_STORAGE_KEY)
 
-  if (hoverSyncStored !== null) {
-    globalState.syncHover = JSON.parse(hoverSyncStored)
-  }
-  if (tooltipSyncStored !== null) {
-    globalState.syncTooltip = JSON.parse(tooltipSyncStored)
+    if (hoverSyncStored !== null) {
+      globalState.syncHover = JSON.parse(hoverSyncStored)
+    }
+    if (tooltipSyncStored !== null) {
+      globalState.syncTooltip = JSON.parse(tooltipSyncStored)
+    }
   }
 } catch (error) {
   console.warn('Failed to load chart sync settings from localStorage:', error)

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -32,6 +32,7 @@ import Head from 'next/head'
 import { NuqsAdapter } from 'nuqs/adapters/next/pages'
 import { ErrorInfo, useCallback } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
+
 import {
   FeatureFlagProvider,
   getFlags,

--- a/packages/common/configcat.ts
+++ b/packages/common/configcat.ts
@@ -69,6 +69,8 @@ export async function getFlags(userEmail: string = '', customAttributes?: Record
       new configcat.User(userEmail, undefined, undefined, customAttributes)
     )
   } else {
-    return client.getAllValuesAsync()
+    return client.getAllValuesAsync(
+      new configcat.User('anonymous', undefined, undefined, customAttributes)
+    )
   }
 }


### PR DESCRIPTION
## Context

Addresses various console warnings that show up in the developer tools when landing on the dashboard

- Many many configcat warnings (shows up on prod too)
    <img width="466" height="92" alt="image" src="https://github.com/user-attachments/assets/a458bd38-46a3-4810-9bbb-3fbe5fc6b88b" />
  - Addressed by passing in a dummy user when calling `getAllValuesAsync` from configcat

- `motion is deprecated` (shows up on local dev)
    <img width="467" height="43" alt="image" src="https://github.com/user-attachments/assets/02b02fc9-d970-42bb-a057-9e79f1b694ee" />
  - As per the message, just swapping `motion()` to `motion.create()` in a couple of files

- `Failed to load chart sync settings from localStorage` (shows up on local dev and build logs)
    <img width="700" height="77" alt="image" src="https://github.com/user-attachments/assets/aa2173f9-04b5-4f87-8393-c40e0d3294c6" />
  - This one's just because `useChartHoverState` is trying to access local storage before the browser is loaded, just added a check for `window`

- `Warning: Missing Description for DialogContent` (shows up on local dev)
    <img width="474" height="86" alt="image" src="https://github.com/user-attachments/assets/7de2056d-ee9d-4a80-acba-0bd01199625a" />
  - Just shows up when opening the create branch modal, just needed to add `aria-describedBy={undefined}` in `DialogContent` (and we should do this whenever we're not rendering a `<DialogDescription>`)

## To test

I'm mainly worried about the feature flags stuff, so just need to test if the flags are still working
A quick way to do so is to open the create branch modal to verify if the "include data" toggle is visible (that UI is behind a feature flag that's set to `true`)
 