### PR TITLE
chore: untrack `next-env.d.ts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ typings/
 # TypeScript cache
 *.tsbuildinfo
 
+# Next.js declaration files (auto-generated)
+next-env.d.ts
+
 # Optional npm cache directory
 .npm
 

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,7 +31,7 @@
     "preinstall": "npx only-allow pnpm",
     "presync": "pnpm run codegen:graphql",
     "pretest": "pnpm run codegen:examples",
-    "pretypecheck": "pnpm run codegen:graphql",
+    "pretypecheck": "pnpm run codegen:graphql && next typegen",
     "start": "next start",
     "sync": "tsx --conditions=react-server ./resources/rootSync.ts",
     "test": "pnpm supabase start && pnpm run test:local && pnpm supabase stop",

--- a/apps/studio/next-env.d.ts
+++ b/apps/studio/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -16,6 +16,7 @@
     "test:ci": "vitest --run --coverage",
     "test:report": "open coverage/lcov-report/index.html",
     "deploy:staging": "VERCEL_ORG_ID=team_E6KJ1W561hMTjon1QSwOh0WO VERCEL_PROJECT_ID=QmcmhbiAtCMFTAHCuGgQscNbke4TzgWULECctNcKmxWCoT vercel --prod -A .vercel/staging.json",
+    "pretypecheck": "next typegen",
     "typecheck": "tsc --noEmit",
     "prettier:check": "prettier --cache --check .",
     "prettier:write": "prettier --cache --write .",

--- a/apps/www/next-env.d.ts
+++ b/apps/www/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-/// <reference path="./.next/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "lint": "next lint",
     "clean": "rimraf node_modules",
+    "pretypecheck": "next typegen",
     "typecheck": "pnpm run content:build && tsc --noEmit",
     "content:build": "node scripts/generateStaticContent.mjs",
     "prettier": "prettier --cache --write \"./{pages,components,lib,stores,styles,tests}/**/*.{ts,tsx,md,js,jsx,json}\"",


### PR DESCRIPTION
Untracks generated `next-env.d.ts` file.

This file is usually ignored in apps created with `create-next-app`:

https://github.com/vercel/next.js/blob/a4be33e9d1e64e5907a6aac69c8f68696511ddde/packages/create-next-app/templates/app/ts/gitignore#L41

This file has introduced noise/confusion during frontend dev:
- https://supabase.slack.com/archives/C0161K73J1J/p1757946453741679
- https://supabase.slack.com/archives/C0161K73J1J/p1726143171579669

E.g. after a recent Next.js version bump https://github.com/supabase/supabase/pull/38352 a `routes.d.ts` reference gets added to this file during dev.