### PR TITLE
fix: make dashboard login button a relative link

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -84,12 +84,7 @@ const TopNavBar: FC = () => {
           <div className="hidden lg:flex items-center justify-end gap-3">
             {!isUserLoading && (
               <Button asChild>
-                <a
-                  href="https://supabase.com/dashboard"
-                  className="h-[30px]"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
+                <a href="/dashboard" className="h-[30px]" target="_blank" rel="noreferrer noopener">
                   {isLoggedIn ? 'Dashboard' : 'Sign up'}
                 </a>
               </Button>


### PR DESCRIPTION
Change the link to a relative one so that it'll automatically reconfigure based on the domain.