### PR TITLE
fix: feature flag command menu & ingerations section

### DIFF
--- a/apps/docs/components/Navigation/Navigation.commands.tsx
+++ b/apps/docs/components/Navigation/Navigation.commands.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight } from 'lucide-react'
 
+import { isFeatureEnabled } from 'common'
 import type { ICommand } from 'ui-patterns/CommandMenu'
 import { useRegisterCommands } from 'ui-patterns/CommandMenu'
 
@@ -89,6 +90,7 @@ const navCommands = [
     value: 'Reference, API, SDK: Go to Dart reference (Flutter)',
     route: '/reference/dart/introduction',
     icon: () => <ArrowRight />,
+    enabled: isFeatureEnabled('sdk:dart'),
   },
   {
     id: 'nav-ref-python',
@@ -96,6 +98,7 @@ const navCommands = [
     value: 'Reference, API, SDK: Go to Python reference',
     route: '/reference/python/introduction',
     icon: () => <ArrowRight />,
+    enabled: isFeatureEnabled('sdk:python'),
   },
   {
     id: 'nav-ref-csharp',
@@ -103,6 +106,7 @@ const navCommands = [
     value: 'Reference, API, SDK: Go to C# reference',
     route: '/reference/csharp/introduction',
     icon: () => <ArrowRight />,
+    enabled: isFeatureEnabled('sdk:csharp'),
   },
   {
     id: 'nav-ref-swift',
@@ -110,6 +114,7 @@ const navCommands = [
     value: 'Reference, API, SDK: Go to Swift reference',
     route: '/reference/swift/introduction',
     icon: () => <ArrowRight />,
+    enabled: isFeatureEnabled('sdk:swift'),
   },
   {
     id: 'nav-ref-kotlin',
@@ -117,6 +122,7 @@ const navCommands = [
     value: 'Reference, API, SDK: Go to Kotlin reference',
     route: '/reference/kotlin/introduction',
     icon: () => <ArrowRight />,
+    enabled: isFeatureEnabled('sdk:kotlin'),
   },
   {
     id: 'nav-ref-cli',
@@ -143,11 +149,14 @@ const navCommands = [
     name: 'Go to Integrations',
     route: 'https://supabase.com/partners/integrations',
     icon: () => <ArrowRight />,
+    enabled: isFeatureEnabled('integrations:partners'),
   },
-] satisfies ICommand[]
+] satisfies Array<ICommand & { enabled?: boolean }>
+
+const filteredNavCommands = navCommands.filter((command) => command.enabled !== false)
 
 const useDocsNavCommands = () => {
-  useRegisterCommands('Go to', navCommands)
+  useRegisterCommands('Go to', filteredNavCommands)
 }
 
 export { useDocsNavCommands }

--- a/apps/docs/components/Navigation/Navigation.types.ts
+++ b/apps/docs/components/Navigation/Navigation.types.ts
@@ -38,4 +38,5 @@ export type NavMenuConstant = Readonly<{
   icon: string
   url?: `/${string}`
   items: ReadonlyArray<Partial<NavMenuSection>>
+  enabled?: boolean
 }>

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -9,6 +9,7 @@ const {
   billingAll: billingEnabled,
   docsCompliance: complianceEnabled,
   'docsSelf-hosting': selfHostingEnabled,
+  integrationsPartners: integrationsEnabled,
   sdkCsharp: sdkCsharpEnabled,
   sdkDart: sdkDartEnabled,
   sdkKotlin: sdkKotlinEnabled,
@@ -19,6 +20,7 @@ const {
   'billing:all',
   'docs:compliance',
   'docs:self-hosting',
+  'integrations:partners',
   'sdk:csharp',
   'sdk:dart',
   'sdk:kotlin',
@@ -128,6 +130,7 @@ export const GLOBAL_MENU_ITEMS: GlobalMenuItems = [
             hasLightIcon: true,
             href: '/guides/integrations' as `/${string}`,
             level: 'integrations',
+            enabled: integrationsEnabled,
           },
         ],
       ],
@@ -2626,6 +2629,7 @@ export const integrations: NavMenuConstant = {
   title: 'Integrations',
   icon: 'integrations',
   url: '/guides/integrations',
+  enabled: integrationsEnabled,
   items: [
     {
       name: 'Overview',

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
@@ -146,6 +146,10 @@ const ContentLink = React.memo(function ContentLink(props: any) {
 const Content = (props) => {
   const { menu, id } = props
 
+  if (menu.enabled === false) {
+    return null
+  }
+
   return (
     <ul className={['relative w-full flex flex-col gap-0 pb-5'].join(' ')}>
       <Link href={menu.url ?? ''}>

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -38,8 +38,9 @@
 
   "feedback:docs": true,
 
-  "integrations:vercel": true,
+  "integrations:partners": true,
   "integrations:show_stripe_wrapper": true,
+  "integrations:vercel": true,
 
   "logs:templates": true,
   "logs:collections": true,

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -130,13 +130,17 @@
       "description": "Enable feedback submission for docs site"
     },
 
-    "integrations:vercel": {
+    "integrations:partners": {
       "type": "boolean",
-      "description": "Enable the vercel integration section in the organization and project settings pages"
+      "description": "Show all third-party-managed integrations"
     },
     "integrations:show_stripe_wrapper": {
       "type": "boolean",
       "description": "Show the Stripe wrapper under project integrations"
+    },
+    "integrations:vercel": {
+      "type": "boolean",
+      "description": "Enable the vercel integration section in the organization and project settings pages"
     },
 
     "logs:templates": {
@@ -291,8 +295,9 @@
     "docs:compliance",
     "docs:self-hosting",
     "feedback:docs",
-    "integrations:vercel",
+    "integrations:partners",
     "integrations:show_stripe_wrapper",
+    "integrations:vercel",
     "profile:show_email",
     "profile:show_information",
     "profile:show_analytics_and_marketing",


### PR DESCRIPTION
- Disabled pages were still showing up as navigation items on the command menu, removing those as well.
- Integrations section was also not fully disabled, removing that.