### PR TITLE
feat: select ‘25 banner styled

### DIFF
--- a/packages/ui-patterns/src/Banners/LW15Banner.tsx
+++ b/packages/ui-patterns/src/Banners/LW15Banner.tsx
@@ -53,11 +53,11 @@ export function LW15Banner() {
       <div className="relative z-10 flex items-center justify-center">
         <div className="w-full flex gap-5 md:gap-10 items-center md:justify-center text-sm">
           <p className="flex gap-1.5 items-center font-mono uppercase tracking-widest text-sm">
-            {announcement.title}
+            {announcement.text}
           </p>
-          <p className="text-sm hidden sm:block">{announcement.desc}</p>
+          <p className="text-sm hidden sm:block">{announcement.launch}</p>
           <Button size="tiny" type="default" className="px-2 !leading-none text-xs" asChild>
-            <Link href={announcement.link}>{announcement.button}</Link>
+            <Link href={announcement.link}>{announcement.cta}</Link>
           </Button>
         </div>
       </div>

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -49,7 +49,7 @@ export function SelectBanner() {
           <p>{descExtended}</p>
         </div>
 
-        <div className="-px-4 border-r border-muted">
+        <div className="flex flex-col justify-center -px-4 border-r border-muted relative after:absolute after:top-0 after:left-full after:w-screen after:h-full after:bg-black after:-z-10">
           <Link
             target="_blank"
             href={selectSiteUrl}

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -7,7 +7,7 @@ export function SelectBanner() {
   const descExtended = 'Guillermo Rauch, Dylan Field, and more'
   const cta = 'Save your seat'
 
-  const baseStyles = 'flex flex-col justify-center border-l border-muted py-8'
+  const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '
   const styles = baseStyles + 'pr-8 text-xs font-mono uppercase tracking-wide text-white/50'
 
   return (
@@ -37,23 +37,28 @@ export function SelectBanner() {
             href={selectSiteUrl}
             className="transition-opacity hover:opacity-80"
           >
-            <img src="/images/select/supabase-select.svg" alt="Supabase Select" className="w-36" />
+            <img
+              src="/images/select/supabase-select.svg"
+              alt="Supabase Select"
+              className="w-36 -translate-y-[3px]"
+            />
           </Link>
         </div>
-        {desc.map((item, index) => (
-          <div key={index} className={`${styles} hidden sm:flex`}>
-            <p>{item}</p>
-          </div>
-        ))}
-        <div className={`${styles} hidden xl:flex`}>
+        <div className={`${styles} hidden md:flex`}>
+          <p>{desc[0]}</p>
+        </div>
+        <div className={`${styles} hidden sm:flex`}>
+          <p>{desc[1]}</p>
+        </div>
+        <div className={`${styles} hidden lg:flex`}>
           <p>{descExtended}</p>
         </div>
 
-        <div className="flex flex-col justify-center -px-4 border-r border-muted relative after:absolute after:top-0 after:left-full after:w-screen after:h-full after:bg-black after:-z-10">
+        <div className="flex flex-col justify-center -px-4 border-x border-muted relative after:absolute after:top-0 after:left-full after:w-screen after:h-full after:bg-black after:-z-10">
           <Link
             target="_blank"
             href={selectSiteUrl}
-            className="inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 h-11 px-8 relative bg-accent-1-foreground/20 border border-dashed border-accent-1-foreground/30 text-sm font-medium hover:bg-accent-1-foreground/80 hover:border-accent-1-foreground/60 transition-all duration-300 text-white"
+            className="bg-brand/50 inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 h-11 px-8 relative bg-accent-1-foreground/20 border border-dashed border-accent-1-foreground/30 text-sm font-medium hover:bg-accent-1-foreground/80 hover:border-accent-1-foreground/60 transition-all duration-300 text-white"
           >
             {cta}
           </Link>

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-// import { Button } from 'ui/src/components/Button'
 
 export function SelectBanner() {
   const selectSiteUrl = 'https://select.supabase.com/'
@@ -8,57 +7,55 @@ export function SelectBanner() {
   const cta = 'Save your seat'
 
   const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '
-  const styles = baseStyles + 'pr-8 text-xs font-mono uppercase tracking-wide text-white/50'
+  const textBlockStyles =
+    baseStyles +
+    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[3px]'
 
   return (
     <div
       className="relative w-full flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden"
       style={{
-        '--grid-color': '#374151',
+        '--grid-color': 'hsl(var(--border-muted))',
         '--line-width': '1px',
         '--offset-from-top': '64px',
-        '--line-spacing': '16px',
+        '--line-spacing': '12px', // Match -3 used elsewhere
         backgroundImage: `
-          /* Top horizontal line - 16px above middle line */
+          /* Top horizontal line: offset from middle line by line spacing */
           linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) - var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) - var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width))),
           /* Middle horizontal line */
           linear-gradient(to bottom, transparent 0, transparent var(--offset-from-top), var(--grid-color) var(--offset-from-top), var(--grid-color) calc(var(--offset-from-top) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-width))),
-          /* Bottom horizontal line - 16px below middle line */
+          /* Bottom horizontal line: offset from middle line by line spacing */
           linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) + var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) + var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)))
         `,
         backgroundSize: '100% 100%',
         backgroundRepeat: 'no-repeat',
       }}
     >
-      <div className="relative z-10 flex gap-5 items-stretch justify-center px-4 border-l border-muted">
-        <div className={`${baseStyles} -px-4`}>
+      <div className="relative z-10 flex gap-5 items-stretch justify-center px-3 border-l border-muted">
+        <div className={`${baseStyles} -px-3`}>
           <Link
             target="_blank"
             href={selectSiteUrl}
             className="transition-opacity hover:opacity-80"
           >
-            <img
-              src="/images/select/supabase-select.svg"
-              alt="Supabase Select"
-              className="w-36 -translate-y-[3px]"
-            />
+            <img src="/images/select/supabase-select.svg" alt="Supabase Select" className="w-36" />
           </Link>
         </div>
-        <div className={`${styles} hidden md:flex`}>
+        <div className={`${textBlockStyles} hidden md:flex`}>
           <p>{desc[0]}</p>
         </div>
-        <div className={`${styles} hidden sm:flex`}>
+        <div className={`${textBlockStyles} hidden sm:flex`}>
           <p>{desc[1]}</p>
         </div>
-        <div className={`${styles} hidden lg:flex`}>
+        <div className={`${textBlockStyles} hidden lg:flex`}>
           <p>{descExtended}</p>
         </div>
 
-        <div className="flex flex-col justify-center -px-4 border-x border-muted relative after:absolute after:top-0 after:left-full after:w-screen after:h-full after:bg-black after:-z-10">
+        <div className="flex flex-col justify-center -px-4 border-x border-muted border-dashed relative after:absolute after:top-0 after:left-full after:w-screen after:h-full after:bg-black after:-z-10">
           <Link
             target="_blank"
             href={selectSiteUrl}
-            className="bg-brand/50 inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 h-11 px-8 relative bg-accent-1-foreground/20 border border-dashed border-accent-1-foreground/30 text-sm font-medium hover:bg-accent-1-foreground/80 hover:border-accent-1-foreground/60 transition-all duration-300 text-white"
+            className="relative before:absolute before:inset-0 before:bg-black before:-z-10 px-4 py-1 h-10 flex items-center justify-center bg-brand/20 hover:bg-brand/50 outline-1 outline-dashed outline-brand/40 hover:outline-brand text-sm text-white font-medium transition-all duration-300"
           >
             {cta}
           </Link>

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -1,27 +1,38 @@
 import Link from 'next/link'
-import { Button } from 'ui/src/components/Button'
-import announcement from './data.json'
+// import { Button } from 'ui/src/components/Button'
 
 export function SelectBanner() {
+  const selectSiteUrl = 'https://select.supabase.com/'
+  const desc = ['Our first user conference', '3rd Oct 2025']
+  const descExtended = 'Guillermo Rauch, Dylan Field, and more'
+  const cta = 'Save your seat'
+
+  const baseStyles = 'flex flex-col justify-center border-l border-muted py-8'
+  const styles = baseStyles + 'pr-8 text-xs font-mono uppercase tracking-wide text-white/50'
+
   return (
-    <div className="relative w-full p-4 flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden ">
-      <div className="relative z-10 flex items-center justify-center">
-        <div className="w-full flex gap-5 md:gap-10 items-center md:justify-center text-sm">
-          <Link target={announcement.target ?? '_self'} href={announcement.link}>
-            <img src="/images/select/supabase-select.svg" alt="Supabase Select" className="w-32" />
-          </Link>
+    <div className="relative w-full flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden ">
+      <div className="relative z-10 flex gap-5 items-stretch justify-center">
+        <Link target="_blank" href={selectSiteUrl} className={baseStyles}>
+          <img src="/images/select/supabase-select.svg" alt="Supabase Select" className="w-36" />
+        </Link>
 
-          <p className="text-sm hidden sm:block">
-            {announcement.desc}
-            <span className="hidden xl:inline">{announcement.verbose}</span>
-          </p>
-
-          <Button size="tiny" type="default" className="px-2 !leading-none text-xs" asChild>
-            <Link target={announcement.target ?? '_self'} href={announcement.link}>
-              {announcement.button}
-            </Link>
-          </Button>
+        {desc.map((item, index) => (
+          <div key={index} className={`${styles} hidden sm:flex`}>
+            <p>{item}</p>
+          </div>
+        ))}
+        <div className={`${styles} hidden xl:flex`}>
+          <p>{descExtended}</p>
         </div>
+
+        <Link
+          target="_blank"
+          href={selectSiteUrl}
+          className="inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 h-11 px-8 relative bg-accent-1-foreground/20 border border-dashed border-accent-1-foreground/30 text-sm font-medium hover:bg-accent-1-foreground/80 hover:border-accent-1-foreground/60 transition-all duration-300 text-white"
+        >
+          {cta}
+        </Link>
       </div>
     </div>
   )

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Link from 'next/link'
 
 export function SelectBanner() {
@@ -17,12 +18,13 @@ export function SelectBanner() {
   return (
     <div
       className="dark relative w-full flex items-center group justify-center text-foreground-contrast bg-black border-b border-muted transition-colors overflow-hidden"
-      style={{
-        '--line-color': 'hsl(var(--border-muted))',
-        '--line-width': '1px',
-        '--offset-from-top': '64px',
-        '--line-spacing': '12px', // Match -3 utility spacing used elsewhere
-        backgroundImage: `
+      style={
+        {
+          '--line-color': 'hsl(var(--border-muted))',
+          '--line-width': '1px',
+          '--offset-from-top': '64px',
+          '--line-spacing': '12px', // Match -3 utility spacing used elsewhere
+          backgroundImage: `
           /* Top horizontal line: offset from middle line by line spacing */
           linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) - var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) - var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width))),
           /* Middle horizontal line */
@@ -30,9 +32,10 @@ export function SelectBanner() {
           /* Bottom horizontal line: offset from middle line by line spacing */
           linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) + var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) + var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)))
         `,
-        backgroundSize: '100% 100%',
-        backgroundRepeat: 'no-repeat',
-      }}
+          backgroundSize: '100% 100%',
+          backgroundRepeat: 'no-repeat',
+        } as React.CSSProperties
+      }
     >
       <div className="relative z-10 flex gap-5 items-stretch justify-center px-3 border-l border-muted">
         <div className={`${baseStyles} -px-3`}>

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -63,50 +63,21 @@ export function SelectBanner() {
             {cta}
             {/* Crosshairs */}
             <div className="absolute pointer-events-none inset-0 z-10">
-              {/* Top-left crosshair */}
-              <div className="absolute top-0 left-0">
+              {['top-left', 'top-right', 'bottom-left', 'bottom-right'].map((position) => (
                 <div
-                  className="absolute -left-px -top-[3px] w-px h-[5px]"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-                <div
-                  className="absolute -left-[3px] -top-px w-[5px] h-px"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-              </div>
-              {/* Top-right crosshair */}
-              <div className="absolute top-0 right-0">
-                <div
-                  className="absolute -right-px -top-[3px] w-px h-[5px]"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-                <div
-                  className="absolute -right-[3px] -top-px w-[5px] h-px"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-              </div>
-              {/* Bottom-left crosshair */}
-              <div className="absolute bottom-0 left-0">
-                <div
-                  className="absolute -left-px -bottom-[3px] w-px h-[5px]"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-                <div
-                  className="absolute -left-[3px] -bottom-px w-[5px] h-px"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-              </div>
-              {/* Bottom-right crosshair */}
-              <div className="absolute bottom-0 right-0">
-                <div
-                  className="absolute -right-px -bottom-[3px] w-px h-[5px]"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-                <div
-                  className="absolute -right-[3px] -bottom-px w-[5px] h-px"
-                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
-                />
-              </div>
+                  key={position}
+                  className={`absolute ${position === 'top-left' ? 'top-0 left-0' : position === 'top-right' ? 'top-0 right-0' : position === 'bottom-left' ? 'bottom-0 left-0' : 'bottom-0 right-0'}`}
+                >
+                  <div
+                    className={`absolute ${position.includes('left') ? '-left-px' : '-right-px'} ${position.includes('top') ? '-top-[3px]' : '-bottom-[3px]'} w-px h-[5px]`}
+                    style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                  />
+                  <div
+                    className={`absolute ${position.includes('left') ? '-left-[3px]' : '-right-[3px]'} ${position.includes('top') ? '-top-px' : '-bottom-px'} w-[5px] h-px`}
+                    style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                  />
+                </div>
+              ))}
             </div>
           </Link>
         </div>

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -12,11 +12,11 @@ export function SelectBanner() {
   const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '
   const textBlockStyles =
     baseStyles +
-    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[2px]'
+    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[4px]'
 
   return (
     <div
-      className="relative w-full flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden"
+      className="dark relative w-full flex items-center group justify-center text-foreground-contrast bg-black border-b border-muted transition-colors overflow-hidden"
       style={{
         '--line-color': 'hsl(var(--border-muted))',
         '--line-width': '1px',

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -11,12 +11,35 @@ export function SelectBanner() {
   const styles = baseStyles + 'pr-8 text-xs font-mono uppercase tracking-wide text-white/50'
 
   return (
-    <div className="relative w-full flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden ">
-      <div className="relative z-10 flex gap-5 items-stretch justify-center">
-        <Link target="_blank" href={selectSiteUrl} className={baseStyles}>
-          <img src="/images/select/supabase-select.svg" alt="Supabase Select" className="w-36" />
-        </Link>
-
+    <div
+      className="relative w-full flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden"
+      style={{
+        '--grid-color': '#374151',
+        '--line-width': '1px',
+        '--offset-from-top': '64px',
+        '--line-spacing': '16px',
+        backgroundImage: `
+          /* Top horizontal line - 16px above middle line */
+          linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) - var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) - var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width))),
+          /* Middle horizontal line */
+          linear-gradient(to bottom, transparent 0, transparent var(--offset-from-top), var(--grid-color) var(--offset-from-top), var(--grid-color) calc(var(--offset-from-top) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-width))),
+          /* Bottom horizontal line - 16px below middle line */
+          linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) + var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) + var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)))
+        `,
+        backgroundSize: '100% 100%',
+        backgroundRepeat: 'no-repeat',
+      }}
+    >
+      <div className="relative z-10 flex gap-5 items-stretch justify-center px-4 border-l border-muted">
+        <div className={`${baseStyles} -px-4`}>
+          <Link
+            target="_blank"
+            href={selectSiteUrl}
+            className="transition-opacity hover:opacity-80"
+          >
+            <img src="/images/select/supabase-select.svg" alt="Supabase Select" className="w-36" />
+          </Link>
+        </div>
         {desc.map((item, index) => (
           <div key={index} className={`${styles} hidden sm:flex`}>
             <p>{item}</p>
@@ -26,13 +49,15 @@ export function SelectBanner() {
           <p>{descExtended}</p>
         </div>
 
-        <Link
-          target="_blank"
-          href={selectSiteUrl}
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 h-11 px-8 relative bg-accent-1-foreground/20 border border-dashed border-accent-1-foreground/30 text-sm font-medium hover:bg-accent-1-foreground/80 hover:border-accent-1-foreground/60 transition-all duration-300 text-white"
-        >
-          {cta}
-        </Link>
+        <div className="-px-4 border-r border-muted">
+          <Link
+            target="_blank"
+            href={selectSiteUrl}
+            className="inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 h-11 px-8 relative bg-accent-1-foreground/20 border border-dashed border-accent-1-foreground/30 text-sm font-medium hover:bg-accent-1-foreground/80 hover:border-accent-1-foreground/60 transition-all duration-300 text-white"
+          >
+            {cta}
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -3,11 +3,7 @@ import Link from 'next/link'
 
 export function SelectBanner() {
   const selectSiteUrl = 'https://select.supabase.com/'
-  const desc = [
-    'Our first user conference',
-    '3rd Oct 2025',
-    'Guillermo Rauch, Dylan Field, and more',
-  ]
+  const desc = ['Our first user conference', 'Oct 3 2025', 'Guillermo Rauch, Dylan Field, and more']
   const cta = 'Save your seat'
 
   const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -12,7 +12,7 @@ export function SelectBanner() {
   const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '
   const textBlockStyles =
     baseStyles +
-    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[4px]'
+    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[5px]'
 
   return (
     <div
@@ -21,7 +21,7 @@ export function SelectBanner() {
         '--line-color': 'hsl(var(--border-muted))',
         '--line-width': '1px',
         '--offset-from-top': '64px',
-        '--line-spacing': '12px', // Match -3 used elsewhere
+        '--line-spacing': '12px', // Match -3 utility spacing used elsewhere
         backgroundImage: `
           /* Top horizontal line: offset from middle line by line spacing */
           linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) - var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) - var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width))),

--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -2,30 +2,33 @@ import Link from 'next/link'
 
 export function SelectBanner() {
   const selectSiteUrl = 'https://select.supabase.com/'
-  const desc = ['Our first user conference', '3rd Oct 2025']
-  const descExtended = 'Guillermo Rauch, Dylan Field, and more'
+  const desc = [
+    'Our first user conference',
+    '3rd Oct 2025',
+    'Guillermo Rauch, Dylan Field, and more',
+  ]
   const cta = 'Save your seat'
 
   const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '
   const textBlockStyles =
     baseStyles +
-    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[3px]'
+    'pr-8 text-xs font-mono uppercase leading-none tracking-wide text-white/50 [&_p]:mt-[2px]'
 
   return (
     <div
       className="relative w-full flex items-center group justify-center text-foreground-contrast dark:text-white bg-black border-b border-muted transition-colors overflow-hidden"
       style={{
-        '--grid-color': 'hsl(var(--border-muted))',
+        '--line-color': 'hsl(var(--border-muted))',
         '--line-width': '1px',
         '--offset-from-top': '64px',
         '--line-spacing': '12px', // Match -3 used elsewhere
         backgroundImage: `
           /* Top horizontal line: offset from middle line by line spacing */
-          linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) - var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) - var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width))),
+          linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) - var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) - var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) - var(--line-spacing) + var(--line-width))),
           /* Middle horizontal line */
-          linear-gradient(to bottom, transparent 0, transparent var(--offset-from-top), var(--grid-color) var(--offset-from-top), var(--grid-color) calc(var(--offset-from-top) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-width))),
+          linear-gradient(to bottom, transparent 0, transparent var(--offset-from-top), var(--line-color) var(--offset-from-top), var(--line-color) calc(var(--offset-from-top) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-width))),
           /* Bottom horizontal line: offset from middle line by line spacing */
-          linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) + var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) + var(--line-spacing)), var(--grid-color) calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)))
+          linear-gradient(to bottom, transparent 0, transparent calc(var(--offset-from-top) + var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) + var(--line-spacing)), var(--line-color) calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)), transparent calc(var(--offset-from-top) + var(--line-spacing) + var(--line-width)))
         `,
         backgroundSize: '100% 100%',
         backgroundRepeat: 'no-repeat',
@@ -47,17 +50,64 @@ export function SelectBanner() {
         <div className={`${textBlockStyles} hidden sm:flex`}>
           <p>{desc[1]}</p>
         </div>
-        <div className={`${textBlockStyles} hidden lg:flex`}>
-          <p>{descExtended}</p>
+        <div className={`${textBlockStyles} hidden xl:flex`}>
+          <p>{desc[2]}</p>
         </div>
 
         <div className="flex flex-col justify-center -px-4 border-x border-muted border-dashed relative after:absolute after:top-0 after:left-full after:w-screen after:h-full after:bg-black after:-z-10">
           <Link
             target="_blank"
             href={selectSiteUrl}
-            className="relative before:absolute before:inset-0 before:bg-black before:-z-10 px-4 py-1 h-10 flex items-center justify-center bg-brand/20 hover:bg-brand/50 outline-1 outline-dashed outline-brand/40 hover:outline-brand text-sm text-white font-medium transition-all duration-300"
+            className="relative before:absolute before:inset-0 before:bg-black before:-z-10 px-4 py-1 h-10 flex items-center justify-center bg-brand-600/20 hover:bg-brand-600/50 outline-1 outline-dashed outline-brand-600/40 hover:outline-brand-600 text-sm text-white font-medium transition-all duration-200"
           >
             {cta}
+            {/* Crosshairs */}
+            <div className="absolute pointer-events-none inset-0 z-10">
+              {/* Top-left crosshair */}
+              <div className="absolute top-0 left-0">
+                <div
+                  className="absolute -left-px -top-[3px] w-px h-[5px]"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+                <div
+                  className="absolute -left-[3px] -top-px w-[5px] h-px"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+              </div>
+              {/* Top-right crosshair */}
+              <div className="absolute top-0 right-0">
+                <div
+                  className="absolute -right-px -top-[3px] w-px h-[5px]"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+                <div
+                  className="absolute -right-[3px] -top-px w-[5px] h-px"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+              </div>
+              {/* Bottom-left crosshair */}
+              <div className="absolute bottom-0 left-0">
+                <div
+                  className="absolute -left-px -bottom-[3px] w-px h-[5px]"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+                <div
+                  className="absolute -left-[3px] -bottom-px w-[5px] h-px"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+              </div>
+              {/* Bottom-right crosshair */}
+              <div className="absolute bottom-0 right-0">
+                <div
+                  className="absolute -right-px -bottom-[3px] w-px h-[5px]"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+                <div
+                  className="absolute -right-[3px] -bottom-px w-[5px] h-px"
+                  style={{ backgroundColor: 'hsl(var(--brand-600))' }}
+                />
+              </div>
+            </div>
           </Link>
         </div>
       </div>

--- a/packages/ui-patterns/src/Banners/data.json
+++ b/packages/ui-patterns/src/Banners/data.json
@@ -1,8 +1,7 @@
 {
-  "title": "Supabase Select",
-  "desc": "Our first user conference · October 3, San Francisco",
-  "verbose": " · Guillermo Rauch, Dylan Field, and more",
-  "link": "https://select.supabase.com/",
-  "target": "_blank",
-  "button": "Save your seat"
+  "text": "",
+  "launch": "",
+  "launchDate": "2025-07-17T08:00:00.000-07:00",
+  "link": "#",
+  "cta": "Learn more"
 }

--- a/packages/ui-patterns/src/PromoToast/PromoToast.tsx
+++ b/packages/ui-patterns/src/PromoToast/PromoToast.tsx
@@ -46,7 +46,7 @@ const PromoToast = () => {
         poster={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/images/launch-week/lw15/assets/lw15-galaxy.png`}
       />
       <div className="relative z-10 text-foreground-lighter uppercase flex flex-col text-sm w-full mb-2">
-        <span className="mb-1">{announcement.title}</span>
+        <span className="mb-1">{announcement.text}</span>
         <p className="relative z-10 text-foreground flex flex-col text-xl w-full leading-7"></p>
       </div>
 

--- a/packages/ui/src/layout/banners/Announcement.tsx
+++ b/packages/ui/src/layout/banners/Announcement.tsx
@@ -66,7 +66,7 @@ const Announcement = ({
       <div className={cn('relative z-40 w-full', className)}>
         {dismissable && !isLaunchWeekSection && (
           <div
-            className="absolute z-50 right-4 flex h-full items-center opacity-100 text-foreground-contrast dark:text-foreground transition-opacity hover:opacity-100 hover:cursor-pointer"
+            className="absolute z-50 right-4 flex h-full items-center opacity-100 text-foreground-contrast dark:text-foreground transition-opacity hover:opacity-80 hover:cursor-pointer"
             onClick={handleClose}
           >
             <X size={16} />

--- a/packages/ui/src/layout/banners/Announcement.tsx
+++ b/packages/ui/src/layout/banners/Announcement.tsx
@@ -9,8 +9,8 @@ import { X } from 'lucide-react'
 
 export interface AnnouncementProps {
   show: boolean
-  title: string
-  launchDate: string | null
+  text: string
+  launchDate: string
   link: string
   badge?: string
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds some visual styles to the Supabase Select banner introduced yesterday in https://github.com/supabase/supabase/pull/38773

## What is the current behavior?

https://github.com/supabase/supabase/pull/38773 brought in a plain banner; white text on black background irrespective of user theme preference:

<img width="1512" height="522" alt="Database  Open source SQL Database" src="https://github.com/user-attachments/assets/f9ece723-5e02-46ae-ba61-cab27ee5854f" />


## What is the new behavior?

We still force dark mode but I’ve made the banner more closely aligned with the [Supabase Select](https://select.supabase.com/) branding:

https://github.com/user-attachments/assets/1d2bce1b-720d-4e3a-aa0f-24271edd30ec

## Additional context

Since this banner is quite different to the template used in Launch Weeks, I’ve reverted the JSON and prop changes I introduced in https://github.com/supabase/supabase/pull/38773. That means future Launch Weeks can just roll as per usual. So ignore my comments about this yesterday @fsansalvadore! All is back to normal. Except the _Announcement_ component which forces a dark `<X size={16} />`.
