### PR TITLE
Address odd bug between data grid contextmenu and overlay

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/DeleteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/DeleteUserModal.tsx
@@ -3,7 +3,6 @@ import { toast } from 'sonner'
 
 import { useUserDeleteMutation } from 'data/auth/user-delete-mutation'
 import { User } from 'data/auth/users-infinite-query'
-import { timeout } from 'lib/helpers'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 interface DeleteUserModalProps {
@@ -29,7 +28,6 @@ export const DeleteUserModal = ({
   })
 
   const handleDeleteUser = async () => {
-    await timeout(200)
     if (!projectRef) return console.error('Project ref is required')
     if (selectedUser?.id === undefined) {
       return toast.error(`Failed to delete user: User ID not found`)

--- a/apps/studio/components/interfaces/Auth/Users/DeleteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/DeleteUserModal.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner'
 
 import { useUserDeleteMutation } from 'data/auth/user-delete-mutation'
 import { User } from 'data/auth/users-infinite-query'
-import { timeout } from 'lib/helpers'
+import { cleanPointerEventsNoneOnBody, timeout } from 'lib/helpers'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 interface DeleteUserModalProps {
@@ -44,8 +44,13 @@ export const DeleteUserModal = ({
       title="Confirm to delete user"
       loading={isDeleting}
       confirmLabel="Delete"
-      onCancel={() => onClose()}
-      onConfirm={() => handleDeleteUser()}
+      onCancel={() => {
+        onClose()
+        cleanPointerEventsNoneOnBody()
+      }}
+      onConfirm={() => {
+        handleDeleteUser()
+      }}
       alert={{
         title: 'Deleting a user is irreversible',
         description:

--- a/apps/studio/components/interfaces/Auth/Users/DeleteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/DeleteUserModal.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner'
 
 import { useUserDeleteMutation } from 'data/auth/user-delete-mutation'
 import { User } from 'data/auth/users-infinite-query'
-import { cleanPointerEventsNoneOnBody, timeout } from 'lib/helpers'
+import { timeout } from 'lib/helpers'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 interface DeleteUserModalProps {
@@ -44,13 +44,8 @@ export const DeleteUserModal = ({
       title="Confirm to delete user"
       loading={isDeleting}
       confirmLabel="Delete"
-      onCancel={() => {
-        onClose()
-        cleanPointerEventsNoneOnBody()
-      }}
-      onConfirm={() => {
-        handleDeleteUser()
-      }}
+      onCancel={() => onClose()}
+      onConfirm={() => handleDeleteUser()}
       alert={{
         title: 'Deleting a user is irreversible',
         description:

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -681,13 +681,13 @@ export const UsersV2 = () => {
         visible={!!selectedUserToDelete}
         selectedUser={selectedUserToDelete}
         onClose={() => {
-          cleanPointerEventsNoneOnBody()
           setSelectedUserToDelete(undefined)
+          cleanPointerEventsNoneOnBody()
         }}
         onDeleteSuccess={() => {
           if (selectedUserToDelete?.id === selectedUser) setSelectedUser(undefined)
           setSelectedUserToDelete(undefined)
-          cleanPointerEventsNoneOnBody()
+          cleanPointerEventsNoneOnBody(500)
         }}
       />
 

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -30,7 +30,7 @@ import { THRESHOLD_COUNT } from 'data/table-rows/table-rows-count-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { isAtBottom } from 'lib/helpers'
+import { cleanPointerEventsNoneOnBody, isAtBottom } from 'lib/helpers'
 import {
   Button,
   cn,
@@ -680,10 +680,14 @@ export const UsersV2 = () => {
       <DeleteUserModal
         visible={!!selectedUserToDelete}
         selectedUser={selectedUserToDelete}
-        onClose={() => setSelectedUserToDelete(undefined)}
+        onClose={() => {
+          cleanPointerEventsNoneOnBody()
+          setSelectedUserToDelete(undefined)
+        }}
         onDeleteSuccess={() => {
           if (selectedUserToDelete?.id === selectedUser) setSelectedUser(undefined)
           setSelectedUserToDelete(undefined)
+          cleanPointerEventsNoneOnBody()
         }}
       />
 

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
@@ -18,7 +18,7 @@ import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
-import { isAtBottom } from 'lib/helpers'
+import { cleanPointerEventsNoneOnBody, isAtBottom } from 'lib/helpers'
 import { Button, cn, LoadingLine, Sheet, SheetContent } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { formatCronJobColumns } from './CronJobs.utils'
@@ -279,6 +279,7 @@ export const CronjobsTab = () => {
               setIsClosingCreateCronJobSheet(false)
               setCronJobForEditing(undefined)
               setCreateCronJobSheetShown(false)
+              cleanPointerEventsNoneOnBody(500)
             }}
             isClosing={isClosingCreateCronJobSheet}
             setIsClosing={setIsClosingCreateCronJobSheet}

--- a/apps/studio/components/interfaces/Integrations/CronJobs/DeleteCronJob.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/DeleteCronJob.tsx
@@ -6,6 +6,7 @@ import { CronJob } from 'data/database-cron-jobs/database-cron-jobs-infinite-que
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { cleanPointerEventsNoneOnBody } from 'lib/helpers'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
 
@@ -53,7 +54,10 @@ export const DeleteCronJob = ({ cronJob, visible, onClose }: DeleteCronJobProps)
       <ConfirmationModal
         variant="destructive"
         visible={visible}
-        onCancel={() => onClose()}
+        onCancel={() => {
+          onClose()
+          cleanPointerEventsNoneOnBody()
+        }}
         onConfirm={handleDelete}
         title={`Delete the cron job`}
         loading={isLoading}
@@ -67,8 +71,11 @@ export const DeleteCronJob = ({ cronJob, visible, onClose }: DeleteCronJobProps)
     <TextConfirmModal
       variant="destructive"
       visible={visible}
-      onCancel={() => onClose()}
       onConfirm={handleDelete}
+      onCancel={() => {
+        onClose()
+        cleanPointerEventsNoneOnBody()
+      }}
       title="Delete this cron job"
       loading={isLoading}
       confirmLabel={`Delete cron job ${cronJob.jobname}`}

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -331,3 +331,20 @@ export const formatCurrency = (amount: number | undefined | null): string | null
     return currencyFormatterDefault.format(amount)
   }
 }
+
+/**
+ * [Joshen] This is to address an incredibly weird bug that's happening between Data Grid + Shadcn ContextMenu + Shadcn Overlay
+ * This trifecta is causing a pointer events none style getting left behind on the body element which makes the dashboard become
+ * unresponsive, hence the attempt to clean things up here
+ *
+ * Timeout is made configurable as I've observed it requires a higher timeout sometimes (e.g when closing the cron job sheet)
+ */
+export const cleanPointerEventsNoneOnBody = (timeoutMs: number = 200) => {
+  if (typeof window !== 'undefined') {
+    setTimeout(() => {
+      if (document.body.style.pointerEvents === 'none') {
+        document.body.style.pointerEvents = ''
+      }
+    }, timeoutMs)
+  }
+}

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -339,7 +339,7 @@ export const formatCurrency = (amount: number | undefined | null): string | null
  *
  * Timeout is made configurable as I've observed it requires a higher timeout sometimes (e.g when closing the cron job sheet)
  */
-export const cleanPointerEventsNoneOnBody = (timeoutMs: number = 200) => {
+export const cleanPointerEventsNoneOnBody = (timeoutMs: number = 300) => {
   if (typeof window !== 'undefined') {
     setTimeout(() => {
       if (document.body.style.pointerEvents === 'none') {


### PR DESCRIPTION
## Context

We received an internal bug report that in the Auth Users UI, if you were to open the delete user confirmation modal through right clicking on the user - once the modal is closed (no matter cancelling or confirming the delete), nothing else in the dashboard is clickable.

## Investigation
- This is very very oddly specifically happening when Data Grid + Context Menu + Dialog (or any component that uses Shadcn Overlay, which includes Sheet) components are being used together (Using a Context Menu from Shadcn in a Data Grid to trigger a Dialog)
- A `pointer-events: none` style is getting applied to the `body` element of the page when the modal gets closed, but that style isn't getting cleaned up - hence why the dashboard becomes unresponsive after
- I can reproduce this not just in the Auth Users UI, but also in the Cron Jobs Table UI which has a similar set up of this 3 things
- I cannot reproduce this in the SQL Editor UI (Side nav snippet list) as it doesn't use Data Grid (Only context menu and dialog)

## Changes involved
- Am opting to simplify and scoping down the fix by removing the `pointer-events` style on the body if it exists when closing the confirmation modal for just the Auth Users DeleteUserModal + CreateCronJobSheet + DeleteCronJob, since its specifically only happening in these 3 areas
- Table Editor is not affected because it's not using the ContextMenu from Shadcn

## To test
- [ ] Verify in Auth Users UI, right click user -> Delete user, close modal, can still click around in the dashboard
- [ ] Verify in Cron UI, right click job -> Edit / Dlete job, close sheet / modal, can still click around in the dashboard