### PR TITLE
fix(studio): query performance tabular nums

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -145,7 +145,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
           const fillWidth = Math.min(percentage, 100)
 
           return (
-            <div className="w-full flex flex-col justify-center text-xs">
+            <div className="w-full flex flex-col justify-center text-xs tabular-nums">
               <div
                 className={`absolute inset-0 bg-foreground transition-all duration-200 z-0`}
                 style={{
@@ -174,7 +174,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
 
         if (col.id === 'total_time') {
           return (
-            <div className="w-full flex flex-col justify-center text-xs">
+            <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums">
               {isTime && typeof value === 'number' && !isNaN(value) && isFinite(value) ? (
                 <p
                   className={cn((value / 1000).toFixed(2) === '0.00' && 'text-foreground-lighter')}
@@ -194,7 +194,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
 
         if (col.id === 'calls') {
           return (
-            <div className="w-full flex flex-col justify-center text-xs">
+            <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums">
               {typeof value === 'number' && !isNaN(value) && isFinite(value) ? (
                 <p className={cn(value === 0 && 'text-foreground-lighter')}>
                   {value.toLocaleString()}
@@ -208,7 +208,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
 
         if (col.id === 'max_time' || col.id === 'mean_time' || col.id === 'min_time') {
           return (
-            <div className="w-full flex flex-col justify-center text-xs">
+            <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums">
               {typeof value === 'number' && !isNaN(value) && isFinite(value) ? (
                 <p className={cn(value.toFixed(0) === '0' && 'text-foreground-lighter')}>
                   {Math.round(value).toLocaleString()}ms
@@ -222,7 +222,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
 
         if (col.id === 'rows_read') {
           return (
-            <div className="w-full flex flex-col justify-center text-xs">
+            <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums">
               {typeof value === 'number' && !isNaN(value) && isFinite(value) ? (
                 <p className={cn(value === 0 && 'text-foreground-lighter')}>
                   {value.toLocaleString()}
@@ -241,7 +241,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
 
         if (col.id === 'cache_hit_rate') {
           return (
-            <div className="w-full flex flex-col justify-center text-xs">
+            <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums">
               {typeof value === 'string' ? (
                 <p
                   className={cn(

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -145,7 +145,7 @@ export const QueryPerformanceGrid = ({ queryPerformanceQuery }: QueryPerformance
           const fillWidth = Math.min(percentage, 100)
 
           return (
-            <div className="w-full flex flex-col justify-center text-xs tabular-nums">
+            <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums">
               <div
                 className={`absolute inset-0 bg-foreground transition-all duration-200 z-0`}
                 style={{


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

As per some design feedback, moving the numerical values back to right aligned on the Query Performance grid. Also added `tabular-nums` to help with parsability. 
