### PR TITLE
docs: update webhook authorization handling in Studio UI

### DIFF
--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -57,7 +57,7 @@ When creating or editing webhooks through the Supabase Studio UI, headers named 
 - For Edge Functions with JWT verification enabled: Authorization headers are automatically added with the appropriate service role token
 - For regular HTTP requests or Edge Functions without JWT verification: Authorization headers are automatically removed
 
-If you manually add an Authorization header through the UI, it may not appear in the headers list after saving, but it will still be applied to webhook requests when appropriate. You can reference the filtering logic in the [Studio source code](https://github.com/supabase/supabase/blob/031c5644e7d6d3068206e7ce4ab6905f1634af20/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx#L104).
+If you manually add an Authorization header through the UI, it may not appear in the headers list after saving, but it will still be applied to webhook requests when appropriate. You can reference the filtering logic in the [Studio source code](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx#L104).
 
 </Admonition>
 

--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -57,7 +57,7 @@ When creating or editing webhooks through the Supabase Studio UI, headers named 
 - For Edge Functions with JWT verification enabled: Authorization headers are automatically added with the appropriate service role token
 - For regular HTTP requests or Edge Functions without JWT verification: Authorization headers are automatically removed
 
-If you manually add an Authorization header through the UI, it may not appear in the headers list after saving, but it will still be applied to webhook requests when appropriate. You can reference the filtering logic in the [Studio source code](https://github.com/supabase/supabase/blob/main/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx#L104).
+If you manually add an Authorization header through the UI, it may not appear in the headers list after saving, but it will still be applied to webhook requests when appropriate. You can reference the filtering logic in the [Studio source code](https://github.com/supabase/supabase/blob/031c5644e7d6d3068206e7ce4ab6905f1634af20/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx#L104).
 
 </Admonition>
 

--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -48,6 +48,19 @@ execute function "supabase_functions"."http_request"(
 
 We currently support HTTP webhooks. These can be sent as `POST` or `GET` requests with a JSON payload.
 
+<Admonition type="note">
+
+**Authorization Headers in Studio UI**
+
+When creating or editing webhooks through the Supabase Studio UI, headers named `Authorization` are automatically managed and hidden from the interface for security reasons. This behavior ensures that:
+
+- For Edge Functions with JWT verification enabled: Authorization headers are automatically added with the appropriate service role token
+- For regular HTTP requests or Edge Functions without JWT verification: Authorization headers are automatically removed
+
+If you manually add an Authorization header through the UI, it may not appear in the headers list after saving, but it will still be applied to webhook requests when appropriate. You can reference the filtering logic in the [Studio source code](https://github.com/supabase/supabase/blob/main/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx#L104).
+
+</Admonition>
+
 ## Payload
 
 The payload is automatically generated from the underlying table record:

--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -125,7 +125,18 @@ const HTTPRequestFields = ({
       </FormSection>
       <SidePanel.Separator />
       <FormSection
-        header={<FormSectionLabel className="lg:!col-span-4">HTTP Headers</FormSectionLabel>}
+        header={
+          <FormSectionLabel 
+            className="lg:!col-span-4"
+            description={
+              <p className="text-sm text-foreground-light">
+                Authorization headers are automatically managed: added for Edge Functions with JWT verification, removed otherwise.
+              </p>
+            }
+          >
+            HTTP Headers
+          </FormSectionLabel>
+        }
       >
         <FormSectionContent loading={false} className="lg:!col-span-8">
           <div className="space-y-2">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update (both inline UI docs and primary documentation)

## What is the current behavior?
When users create/edit database webhooks in Studio and add Authorization headers, those headers disappear from the UI after saving. This confuses users who think their headers are lost, but they're actually just hidden by the UI for security reasons. The behavior isn't documented anywhere, leading to confusion and bug reports.
Related to issue #38839 where contributors reported user confusion about "missing" Authorization headers.

## What is the new behavior?
Added inline documentation in the Studio webhook UI explaining that Authorization headers are automatically managed
Added a clear note in the Database Webhooks documentation guide explaining when/why Authorization headers are hidden
Both docs explain the three scenarios: auto-added for Edge Functions with JWT verification, removed otherwise

Feel free to include screenshots if it includes visual changes.
<img width="1765" height="899" alt="Screenshot 2025-09-19 at 10 32 10 AM" src="https://github.com/user-attachments/assets/872bc59d-844b-4e49-9604-72aeb8de5110" />


## Additional context
The Authorization header filtering happens in FormContents.tsx where headers are automatically added/removed based on Edge Function JWT settings. This is actually helpful behavior but was completely undocumented, causing unnecessary confusion.