### PR TITLE
Chore/attempt to address ts build issue

### DIFF
--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -45,7 +45,7 @@
     "ui": "workspace:*",
     "ui-patterns": "workspace:*",
     "unist-util-visit": "^5.0.0",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@shikijs/compat": "^1.1.7",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -120,7 +120,7 @@
     "uuid": "^9.0.1",
     "valtio": "catalog:",
     "yaml": "^2.4.5",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@graphiql/toolkit": "^0.9.1",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -142,7 +142,7 @@
     "uuid": "^9.0.1",
     "valtio": "catalog:",
     "yup": "^1.4.0",
-    "zod": "^3.25.76",
+    "zod": "catalog:",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -25,7 +25,7 @@
         "name": "next"
       }
     ],
-    "skipDefaultLibCheck": true
+    "noErrorTruncation": true
   },
   "include": [
     "next-env.d.ts",

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -24,7 +24,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "skipDefaultLibCheck": true
   },
   "include": [
     "next-env.d.ts",

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -84,7 +84,7 @@
     "ui-patterns": "workspace:*",
     "unist-util-visit": "^5.0.0",
     "vaul": "^0.9.6",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@react-router/dev": "^7.1.5",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -99,7 +99,7 @@
     "react-hook-form": "^7.45.0",
     "tsconfig": "workspace:*",
     "uuid": "^9.0.1",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "license": "MIT"
 }

--- a/packages/ai-commands/package.json
+++ b/packages/ai-commands/package.json
@@ -20,7 +20,7 @@
     "js-tiktoken": "^1.0.10",
     "jsonrepair": "^3.5.0",
     "openai": "^4.75.1",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@ai-sdk/openai": "^2.0.0",

--- a/packages/pg-meta/package.json
+++ b/packages/pg-meta/package.json
@@ -16,7 +16,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -521,7 +521,7 @@
     "ui": "workspace:*",
     "unist-util-visit": "^5.0.0",
     "valtio": "catalog:",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     vite:
       specifier: ^6.2.7
       version: 6.3.5
+    zod:
+      specifier: ^3.25.76
+      version: 3.25.76
 
 overrides:
   '@supabase/supabase-js>@supabase/auth-js': 2.72.0-rc.11
@@ -290,7 +293,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@shikijs/compat':
@@ -573,7 +576,7 @@ importers:
         specifier: ^2.4.5
         version: 2.4.5
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@graphiql/toolkit':
@@ -1054,7 +1057,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
       zxcvbn:
         specifier: ^4.4.2
@@ -1430,7 +1433,7 @@ importers:
         specifier: ^0.9.6
         version: 0.9.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@react-router/dev':
@@ -1747,7 +1750,7 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
 
   e2e/studio:
@@ -1786,7 +1789,7 @@ importers:
         specifier: ^4.75.1
         version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@ai-sdk/openai':
@@ -2021,7 +2024,7 @@ importers:
   packages/pg-meta:
     dependencies:
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@types/pg':
@@ -2420,7 +2423,7 @@ importers:
         specifier: 'catalog:'
         version: 1.12.0(@types/react@18.3.3)(react@18.3.1)
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@testing-library/dom':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,12 +8,13 @@ catalog:
   '@supabase/auth-js': 2.72.0-rc.11
   '@supabase/supabase-js': ^2.47.14
   '@supabase/realtime-js': ^2.11.3
-  next: ^15.5.2
+  'next': ^15.5.2
   'react': '^18.3.0'
   'react-dom': '^18.3.0'
   '@types/react': '^18.3.0'
   '@types/react-dom': '^18.3.0'
   'valtio': '^1.12.0'
   'vite': '^6.2.7'
+  'zod': '^3.25.76'
 
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Context

We've recently enabled type checking as part of our production builds on Vercel [in this PR](https://github.com/supabase/supabase/pull/38715) in order to catch TS errors from merges. However we've since observed build errors of "Type instantiation is excessively deep and possibly infinite." happening intermittently which unless we're attentive to our production builds in Vercel, it'll easily get overlooked and fixes wouldn't have made it through to production until the next successful build.

## Hypothesis

This one's quite hard to track as no matter how many times I try to run `npx tsc --noEmit` I just can't seem to reproduce that error? There's no specific line or file that shows up from the build logs too which makes it hard to pinpoint. But a number of articles mentioned `zod` as a potential candidate contributing to this problem (more specifically having multiple versions of `zod` installed).

We use `zod` in several different packages that the dashboard depends on (e.g ui-patterns, packages) - they technically all have version `^3.25.76` defined in their respective `package.json` files, but am opting to standardize the version through pnpm's catalog.

Separately, am going to set `noErrorTruncation` as `true` for dashboard's `tsconfig.json` so that if this happens again we'll be able to get more details from the error

There's also articles talking about `z.infer` being the possible culprit, or even react query's nested query keys too but reckon we only investigate those as we get more details, otherwise kinda flying blind

## Changes involved

- Standardize version of `zod` package to `^3.25.76` via pnpm catalog in `pnpm-workspace.yaml`
- Set `noErrorTruncation` to `true` in dashboard's `tsconfig.json` -> `compilerOptions`