### PR TITLE
Improve member invite UI

### DIFF
--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -8,13 +8,14 @@ import { useOrganizationAcceptInvitationMutation } from 'data/organization-membe
 import { useOrganizationInvitationTokenQuery } from 'data/organization-members/organization-invitation-token-query'
 import { useProfile } from 'lib/profile'
 import { ResponseError } from 'types'
-import { Button, Loading, cn } from 'ui'
+import { Button, cn } from 'ui'
+import { Admonition, GenericSkeletonLoader } from 'ui-patterns'
 import { OrganizationInviteError } from './OrganizationInviteError'
 
 export const OrganizationInvite = () => {
   const router = useRouter()
   const { profile } = useProfile()
-  const { slug, token, name } = useParams()
+  const { slug, token } = useParams()
 
   const { data, error, isSuccess, isError, isLoading } = useOrganizationInvitationTokenQuery(
     { slug, token },
@@ -25,9 +26,10 @@ export const OrganizationInvite = () => {
   )
   const hasError =
     isError || (isSuccess && (data.token_does_not_exist || data.expired_token || !data.email_match))
-  const isNotSignedInError = error?.message.includes('No authorization token was found')
+  const inviteHasBeenAccepted =
+    error?.code === 401 && error?.message.includes('Failed to retrieve organization')
 
-  const organizationName = isSuccess ? data?.organization_name : 'an organization'
+  const organizationName = isSuccess ? data?.organization_name : 'An organization'
   const loginRedirectLink = `/sign-in?returnTo=${encodeURIComponent(`/join?token=${token}&slug=${slug}`)}`
 
   const { mutate: joinOrganization, isLoading: isJoining } =
@@ -47,57 +49,88 @@ export const OrganizationInvite = () => {
   }
 
   return (
-    <Loading active={profile !== undefined && isLoading}>
-      <div className="flex flex-col gap-2 px-6 py-8">
-        <p className="text-sm text-foreground">You have been invited to join </p>
-        <p className="text-3xl text-foreground">{organizationName}</p>
-        {isSuccess && slug && (
-          <p className="text-xs text-foreground-lighter">{`organization slug: ${slug}`}</p>
-        )}
-      </div>
-
-      <div className={cn('border-t border-muted', hasError ? 'bg-alternative' : 'bg-transparent')}>
-        {profile === undefined && (
-          <div className="flex flex-col gap-3 py-4">
-            <p className="text-xs text-foreground-lighter">
-              You will need to sign in to accept this invitation
+    <div
+      className={cn(
+        'mx-auto overflow-hidden rounded-md border',
+        'border-muted bg-alternative text-center shadow',
+        'md:w-[400px]'
+      )}
+    >
+      {isLoading ? (
+        <div className="p-5">
+          <GenericSkeletonLoader />
+        </div>
+      ) : inviteHasBeenAccepted ? (
+        <>
+          <Admonition
+            type="default"
+            title="Invalid invitation"
+            description="This organization invite is no longer valid as it has either been accepted or declined"
+            className="mb-0 border-0 rounded-none text-left"
+          />
+          <div className="p-4 border-muted border-t">
+            <Button type="default" asChild>
+              <Link href="/">Back to dashboard</Link>
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex flex-col gap-y-1 px-6 py-6">
+            <p className="text-sm text-foreground-light">You have been invited to join </p>
+            <p className={cn('text-foreground', !!profile ? 'text-2xl' : 'text-3xl')}>
+              {organizationName}
             </p>
-            <div className="flex justify-center gap-3">
-              <Button asChild type="default">
-                <Link href={loginRedirectLink}>Sign in</Link>
-              </Button>
-              <Button asChild type="default">
-                <Link href={loginRedirectLink}>Create an account</Link>
-              </Button>
+            {isSuccess && slug && (
+              <p className="text-xs text-foreground-lighter">{`Organization slug: ${slug}`}</p>
+            )}
+          </div>
+          <div
+            className={cn('border-t border-muted', hasError ? 'bg-alternative' : 'bg-transparent')}
+          >
+            {profile === undefined && (
+              <div className="flex flex-col gap-y-4 p-4">
+                <p className="text-sm text-foreground">
+                  Sign in or create an account first to view this invitation
+                </p>
+                <div className="flex justify-center gap-3">
+                  <Button asChild type="default">
+                    <Link href={loginRedirectLink}>Sign in</Link>
+                  </Button>
+                  <Button asChild type="default">
+                    <Link href={loginRedirectLink}>Create an account</Link>
+                  </Button>
+                </div>
+              </div>
+            )}
+            <div className={cn('flex flex-col gap-4', !isLoading && !hasError && 'px-6 py-4')}>
+              {!!profile && hasError && (
+                <OrganizationInviteError
+                  data={data}
+                  error={error as unknown as ResponseError}
+                  isError={isError}
+                />
+              )}
+              {isSuccess && !hasError && (
+                <div className="flex flex-row items-center justify-center gap-3">
+                  <Button type="default" disabled={isJoining} asChild>
+                    <Link href="/projects">Decline</Link>
+                  </Button>
+                  <Button
+                    type="primary"
+                    loading={isJoining}
+                    disabled={isJoining}
+                    onClick={handleJoinOrganization}
+                    icon={<CheckSquare />}
+                  >
+                    Join organization
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
-        )}
-        <div className={cn('flex flex-col gap-4', !isLoading && !hasError && 'px-6 py-4')}>
-          {hasError && !isNotSignedInError && (
-            <OrganizationInviteError
-              data={data}
-              error={error as unknown as ResponseError}
-              isError={isError}
-            />
-          )}
-          {isSuccess && !hasError && (
-            <div className="flex flex-row items-center justify-center gap-3">
-              <Button type="default" disabled={isJoining} asChild>
-                <Link href="/projects">Decline</Link>
-              </Button>
-              <Button
-                type="primary"
-                loading={isJoining}
-                disabled={isJoining}
-                onClick={handleJoinOrganization}
-                icon={<CheckSquare />}
-              >
-                Join organization
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-    </Loading>
+        </>
+      )}
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -22,6 +22,7 @@ export const OrganizationInvite = () => {
     {
       retry: false,
       refetchOnWindowFocus: false,
+      enabled: !!profile,
     }
   )
   const hasError =

--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInviteError.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInviteError.tsx
@@ -9,7 +9,7 @@ import { cn } from 'ui'
 
 interface OrganizationInviteError {
   data?: OrganizationInviteByToken
-  error?: ResponseError
+  error?: ResponseError | null
   isError: boolean
 }
 

--- a/apps/studio/components/ui/ActionCard.tsx
+++ b/apps/studio/components/ui/ActionCard.tsx
@@ -29,8 +29,10 @@ export const ActionCard = (card: {
         >
           {card.icon}
         </div>
-        <div className="flex flex-col gap-0 w-full">
-          <h3 className="text-sm text-foreground mb-0">{card.title}</h3>
+        <div className="flex-grow flex flex-col gap-0 min-w-0">
+          <h3 title={card.title} className="text-sm text-foreground mb-0 truncate max-w-full">
+            {card.title}
+          </h3>
           {typeof card.description === 'string' ? (
             <pre className="text-xs text-foreground-light font-sans">{card.description}</pre>
           ) : (

--- a/apps/studio/pages/join.tsx
+++ b/apps/studio/pages/join.tsx
@@ -1,39 +1,48 @@
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 
 import { OrganizationInvite } from 'components/interfaces/OrganizationInvite/OrganizationInvite'
+import { BASE_PATH } from 'lib/constants'
+import { useTheme } from 'next-themes'
+import { useEffect, useMemo, useState } from 'react'
 import { NextPageWithLayout } from 'types'
 import { cn } from 'ui'
 
 const JoinOrganizationPage: NextPageWithLayout = () => {
-  const router = useRouter()
+  const { resolvedTheme } = useTheme()
+  const isDarkMode = resolvedTheme?.includes('dark')
+
+  const [mounted, setMounted] = useState(false)
+
+  const imgUrl = useMemo(
+    () =>
+      isDarkMode ? `${BASE_PATH}/img/supabase-dark.svg` : `${BASE_PATH}/img/supabase-light.svg`,
+    [isDarkMode]
+  )
+
+  useEffect(() => setMounted(true), [])
 
   return (
-    <div
-      className={cn(
-        'flex h-full min-h-screen bg-studio',
-        'w-full flex-col place-items-center',
-        'items-center justify-center gap-8 px-5'
-      )}
-    >
+    <>
       <Link href="/projects" className="flex items-center justify-center gap-4">
-        <img
-          src={`${router.basePath}/img/supabase-logo.svg`}
-          alt="Supabase"
-          className="block h-[24px] cursor-pointer rounded"
-        />
-      </Link>
-      <div
-        className={cn(
-          'mx-auto overflow-hidden rounded-md border',
-          'border-muted bg-alternative text-center shadow',
-          'md:w-[400px]'
+        {mounted && (
+          <img src={imgUrl} alt="Supabase" className="block h-[24px] cursor-pointer rounded" />
         )}
-      >
-        <OrganizationInvite />
-      </div>
-    </div>
+      </Link>
+      <OrganizationInvite />
+    </>
   )
 }
+
+JoinOrganizationPage.getLayout = (page) => (
+  <div
+    className={cn(
+      'flex h-full min-h-screen bg-studio',
+      'w-full flex-col place-items-center',
+      'items-center justify-center gap-8 px-5'
+    )}
+  >
+    {page}
+  </div>
+)
 
 export default JoinOrganizationPage


### PR DESCRIPTION
Fixes FE-1795
Fixes FE-1840

## Context

Changes here addresses some confusion with 2 states in the organization member invite flow (obscure errors from the users' POV)
- Seeing an invite when not logged in yet
  <img width="394" height="277" alt="image" src="https://github.com/user-attachments/assets/3941bd2f-af09-4a85-bc93-28128d20f900" />
- Seeing an invite that's already been accepted
  <img width="384" height="216" alt="image" src="https://github.com/user-attachments/assets/957e0eb1-6f1d-400e-ac57-544a6b2b19ed" />

## Changes involved

Generally did a skim of the whole flow and made the following changes:
- Added better loading states to reduce layout shift
- Only load invite token query if user is logged in (based on `profile`)
- Tweaked UI when user is not logged in yet (Don't show the unnecessary error)
  <img width="483" height="314" alt="not-signed-in" src="https://github.com/user-attachments/assets/8d7b5d5f-3f42-45ca-bdc0-223f4647c427" />
- Tweaked UI when invite has already been accepted / declined
  - Invites get deleted in the BE when they get accepted or declined so FE doesn't have context on which organization the invite was for. Opting for a clearer copy + CTA to head back to dashboard
  <img width="551" height="359" alt="Screenshot 2025-09-19 at 14 24 36" src="https://github.com/user-attachments/assets/93a6090a-aad3-4c16-8004-b9d3c186bf8d" />

## To test
- [ ] Smoke test inviting an organization member, and accepting that invite
