### PR TITLE
Fix missing parenthesis in policy editor

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
@@ -374,6 +374,9 @@ export const PolicyEditorPanel = memo(function ({
                         <p className="font-mono tracking-tighter">
                           {showCheckBlock ? (
                             <>
+                              {supportWithCheck && showCheckBlock && (
+                                <span className="text-[#ffd700]">) </span>
+                              )}
                               <span className="text-[#569cd6]">with check</span>{' '}
                               <span className="text-[#ffd700]">(</span>
                             </>


### PR DESCRIPTION
## Context
One of our users pointed out a missing closing parenthesis in the policy editor UI (purely UI, not functionality) if there's both a using and with check block (for commands "UPDATE" and "ALL") (Notice line 8 in the screenshot)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/70d5b238-5715-456e-9c45-c104e2967a09" />

## Changes involved
Adds the missing parenthesis

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0472921b-b661-4a75-87d0-d1a58f0532cc" />

## To test
- [ ] Swap through the commands in the policy editor - just make sure that the UI code boilerplate generally looks right