### PR TITLE
Fix last backup timestamp info

### DIFF
--- a/apps/studio/components/interfaces/HomeNew/ActivityStats.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ActivityStats.tsx
@@ -89,6 +89,7 @@ export const ActivityStats = () => {
             ) : latestBackup ? (
               <TimestampInfo
                 className="text-base"
+                displayAs="utc"
                 label={dayjs(latestBackup.inserted_at).fromNow()}
                 utcTimestamp={latestBackup.inserted_at}
               />


### PR DESCRIPTION
## Context

Internal report RE the new home page in which the relative times here do not match
<img width="1232" height="358" alt="image" src="https://github.com/user-attachments/assets/0045c72b-605f-4250-8822-7515c973b27c" />

Realised was just missing `displayAs="utc"` - can verify that backup items in the database backups page do the same [here](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx#L104)