### PR TITLE
chart footer tooltip improvs

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -2,7 +2,7 @@
 
 import dayjs from 'dayjs'
 import { useState } from 'react'
-import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { cn, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'ui'
 import { CHART_COLORS, DateTimeFormats } from './Charts.constants'
 import { numberFormatter } from './Charts.utils'
 import { formatBytes } from 'lib/helpers'
@@ -293,12 +293,12 @@ const CustomLabel = ({
   const LabelItem = ({ entry }: { entry: any }) => {
     const attribute = attributes?.find((a) => a.attribute === entry.name)
     const isMax = entry.name === maxValueAttribute?.attribute
-    const isHovered = hoveredLabel === entry.name
     const isHidden = hiddenAttributes?.has(entry.name)
+    const color = isHidden ? 'gray' : entry.color
 
     const Label = () => (
       <div className="flex items-center gap-1">
-        {getIcon(entry.name, entry.color)}
+        {getIcon(entry.name, color)}
         <span className={cn('text-nowrap text-foreground-lighter', isHidden && 'opacity-50')}>
           {attribute?.label || entry.name}
         </span>
@@ -310,17 +310,17 @@ const CustomLabel = ({
     return (
       <button
         key={entry.name}
-        className="flex md:flex-col gap-1 md:gap-0 w-fit text-foreground rounded-lg p-1.5 hover:bg-background-overlay-hover"
+        className="flex md:flex-col gap-1 md:gap-0 w-fit text-foreground rounded-lg  hover:bg-background-overlay-hover"
         onMouseOver={() => handleMouseEnter(entry.name)}
         onMouseOutCapture={handleMouseLeave}
         onClick={(e) => onToggleAttribute?.(entry.name, { exclusive: e.metaKey || e.ctrlKey })}
       >
         {!!attribute?.tooltip ? (
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger className="p-1.5">
               <Label />
             </TooltipTrigger>
-            <TooltipContent side="bottom" align="center" className="max-w-[250px]">
+            <TooltipContent sideOffset={6} side="bottom" align="center" className="max-w-[250px]">
               {attribute.tooltip}
             </TooltipContent>
           </Tooltip>
@@ -334,7 +334,9 @@ const CustomLabel = ({
   return (
     <div className="relative z-10 mx-auto flex flex-col items-center gap-1 text-xs w-full">
       <div className="flex flex-wrap items-center justify-center gap-2">
-        {items?.map((entry, index) => <LabelItem key={`${entry.name}-${index}`} entry={entry} />)}
+        <TooltipProvider delayDuration={800}>
+          {items?.map((entry, index) => <LabelItem key={`${entry.name}-${index}`} entry={entry} />)}
+        </TooltipProvider>
       </div>
     </div>
   )


### PR DESCRIPTION
- adds a bit of delay to the tooltip group
- fixes tooltip trigger only wrapping text, not whole clickable area
- makes the color on disabled attributes gray.

---

- tooltip only triggers if you hover the text

- before (idk why the previews are not working)

https://github.com/user-attachments/assets/9836943d-21fa-4712-aca3-8dd96109c239

- after

https://github.com/user-attachments/assets/dd4ef25a-f4fe-470e-8143-524f0e811bc4


- disabled attribute still shows colored dot
<img width="734" height="724" alt="CleanShot 2025-09-19 at 11 53 19@2x" src="https://github.com/user-attachments/assets/c7fcbeb9-98e5-4595-85fb-4eedfdca9482" />
- after
<img width="816" height="598" alt="CleanShot 2025-09-19 at 12 00 08@2x" src="https://github.com/user-attachments/assets/b4f562bc-f6c1-41c5-a82c-14b99dd67f3b" />


- adds a bit more offset to the tooltip
- be4
<img width="904" height="692" alt="CleanShot 2025-09-19 at 11 54 40@2x" src="https://github.com/user-attachments/assets/f7dd0fd7-be32-4a1d-9946-88a035d5c19d" />
- after
<img width="994" height="856" alt="CleanShot 2025-09-19 at 12 01 39@2x" src="https://github.com/user-attachments/assets/6a8c0513-b925-4711-8c56-092e68d7e638" />


