### PR TITLE
coveralls: fail-on-error false

### DIFF
--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -64,6 +64,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./apps/studio/coverage/lcov.info
           base-path: './apps/studio'
+          fail-on-error: false
 
   finish:
     needs: test


### PR DESCRIPTION
allow ci to continue if coveralls step fails, tests have to pass but coveralls step can fail