### PR TITLE
Fix deleting project not refreshing list of projects in home page

### DIFF
--- a/apps/studio/data/projects/keys.ts
+++ b/apps/studio/data/projects/keys.ts
@@ -2,13 +2,13 @@ export const projectKeys = {
   list: () => ['all-projects'] as const,
   infiniteListByOrg: (
     slug: string | undefined,
-    params: {
+    params?: {
       limit: number
       sort?: 'name_asc' | 'name_desc' | 'created_asc' | 'created_desc'
       search?: string
       statuses?: string[]
     }
-  ) => ['all-projects-infinite', slug, params] as const,
+  ) => ['all-projects-infinite', slug, params].filter(Boolean),
   status: (projectRef: string | undefined) => ['project', projectRef, 'status'] as const,
   types: (projectRef: string | undefined) => ['project', projectRef, 'types'] as const,
   detail: (projectRef: string | undefined) => ['project', projectRef, 'detail'] as const,

--- a/apps/studio/data/projects/project-delete-mutation.ts
+++ b/apps/studio/data/projects/project-delete-mutation.ts
@@ -2,9 +2,9 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
+import { organizationKeys } from 'data/organizations/keys'
 import type { ResponseError } from 'types'
 import { projectKeys } from './keys'
-import { organizationKeys } from 'data/organizations/keys'
 
 export type ProjectDeleteVariables = {
   projectRef: string
@@ -39,6 +39,10 @@ export const useProjectDeleteMutation = ({
         await queryClient.invalidateQueries(projectKeys.list())
 
         if (variables.organizationSlug) {
+          await queryClient.invalidateQueries(
+            projectKeys.infiniteListByOrg(variables.organizationSlug)
+          )
+
           queryClient.invalidateQueries(
             organizationKeys.freeProjectLimitCheck(variables.organizationSlug)
           )


### PR DESCRIPTION
## Context

Addresses a bug whereby deleting a project doesn't refresh the list of projects when you're redirected back to the list of projects page after a successful delete

## To test
- [ ] Verify that deleting a project refreshes the list of projects after getting redirected