### PR TITLE
Fix new table button not working if on unknown table in table editor

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -96,57 +96,6 @@ export const TableGridEditor = ({
     )
   }
 
-  if (!selectedTable) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <div className="w-[400px]">
-          <Admonition
-            type="default"
-            title={`Unable to find your table with ID ${id}`}
-            description="This table doesn't exist in your database"
-          >
-            {!!tabId ? (
-              <Button
-                type="default"
-                className="mt-2"
-                onClick={() => {
-                  tabs.handleTabClose({
-                    id: tabId,
-                    router,
-                    editor: 'table',
-                    onClearDashboardHistory: () => setLastVisitedTable(undefined),
-                  })
-                }}
-              >
-                Close tab
-              </Button>
-            ) : openTabs.length > 0 ? (
-              <Button
-                asChild
-                type="default"
-                className="mt-2"
-                onClick={() => setLastVisitedTable(undefined)}
-              >
-                <Link href={`/project/${projectRef}/editor/${openTabs[0].split('-')[1]}`}>
-                  Close tab
-                </Link>
-              </Button>
-            ) : (
-              <Button
-                asChild
-                type="default"
-                className="mt-2"
-                onClick={() => setLastVisitedTable(undefined)}
-              >
-                <Link href={`/project/${projectRef}/editor`}>Head back</Link>
-              </Button>
-            )}
-          </Admonition>
-        </div>
-      </div>
-    )
-  }
-
   const isViewSelected = isView(selectedTable) || isMaterializedView(selectedTable)
   const isTableSelected = isTableLike(selectedTable)
   const isForeignTableSelected = isForeignTable(selectedTable)
@@ -154,7 +103,9 @@ export const TableGridEditor = ({
   const canEditViaTableEditor = isTableSelected && !isSchemaLocked
   const editable = !isReadOnly && canEditViaTableEditor
 
-  const gridKey = `${selectedTable.schema}_${selectedTable.name}`
+  const gridKey = !!selectedTable
+    ? `${selectedTable.schema}_${selectedTable.name}`
+    : 'unknown-table'
 
   /** [Joshen] We're going to need to refactor SupabaseGrid eventually to make the code here more readable
    * For context we previously built the SupabaseGrid as a reusable npm component, but eventually decided
@@ -164,43 +115,93 @@ export const TableGridEditor = ({
   return (
     // When any click happens in a table tab, the tab becomes permanent
     <div className="h-full" onClick={() => tabs.makeActiveTabPermanent()}>
-      <TableEditorTableStateContextProvider
-        key={`table-editor-table-${selectedTable.id}`}
-        projectRef={projectRef}
-        table={selectedTable}
-        editable={editable}
-      >
-        <SupabaseGrid
-          key={gridKey}
-          gridProps={{ height: '100%' }}
-          customHeader={
-            (isViewSelected || isTableSelected) && selectedView === 'definition' ? (
-              <div className="flex items-center space-x-2">
-                <p>
-                  SQL Definition of <code className="text-sm">{selectedTable.name}</code>{' '}
-                </p>
-                <p className="text-foreground-light text-sm">(Read only)</p>
-              </div>
-            ) : null
-          }
-        >
-          {(isViewSelected || isTableSelected) && selectedView === 'definition' && (
-            <TableDefinition entity={selectedTable} />
-          )}
-        </SupabaseGrid>
-
-        <SidePanelEditor
+      {!selectedTable ? (
+        <div className="flex items-center justify-center h-full">
+          <div className="w-[400px]">
+            <Admonition
+              type="default"
+              title={`Unable to find your table with ID ${id}`}
+              description="This table doesn't exist in your database"
+            >
+              {!!tabId ? (
+                <Button
+                  type="default"
+                  className="mt-2"
+                  onClick={() => {
+                    tabs.handleTabClose({
+                      id: tabId,
+                      router,
+                      editor: 'table',
+                      onClearDashboardHistory: () => setLastVisitedTable(undefined),
+                    })
+                  }}
+                >
+                  Close tab
+                </Button>
+              ) : openTabs.length > 0 ? (
+                <Button
+                  asChild
+                  type="default"
+                  className="mt-2"
+                  onClick={() => setLastVisitedTable(undefined)}
+                >
+                  <Link href={`/project/${projectRef}/editor/${openTabs[0].split('-')[1]}`}>
+                    Close tab
+                  </Link>
+                </Button>
+              ) : (
+                <Button
+                  asChild
+                  type="default"
+                  className="mt-2"
+                  onClick={() => setLastVisitedTable(undefined)}
+                >
+                  <Link href={`/project/${projectRef}/editor`}>Head back</Link>
+                </Button>
+              )}
+            </Admonition>
+          </div>
+        </div>
+      ) : (
+        <TableEditorTableStateContextProvider
+          key={`table-editor-table-${selectedTable.id}`}
+          projectRef={projectRef}
+          table={selectedTable}
           editable={editable}
-          selectedTable={
-            isTableSelected || isForeignTableSelected ? (selectedTable as TableLike) : undefined
-          }
-          onTableCreated={onTableCreated}
-        />
-        <DeleteConfirmationDialogs
-          selectedTable={isTableSelected ? selectedTable : undefined}
-          onTableDeleted={onTableDeleted}
-        />
-      </TableEditorTableStateContextProvider>
+        >
+          <SupabaseGrid
+            key={gridKey}
+            gridProps={{ height: '100%' }}
+            customHeader={
+              (isViewSelected || isTableSelected) && selectedView === 'definition' ? (
+                <div className="flex items-center space-x-2">
+                  <p>
+                    SQL Definition of <code className="text-sm">{selectedTable.name}</code>{' '}
+                  </p>
+                  <p className="text-foreground-light text-sm">(Read only)</p>
+                </div>
+              ) : null
+            }
+          >
+            {(isViewSelected || isTableSelected) && selectedView === 'definition' && (
+              <TableDefinition entity={selectedTable} />
+            )}
+          </SupabaseGrid>
+
+          <DeleteConfirmationDialogs
+            selectedTable={isTableSelected ? selectedTable : undefined}
+            onTableDeleted={onTableDeleted}
+          />
+        </TableEditorTableStateContextProvider>
+      )}
+
+      <SidePanelEditor
+        editable={editable}
+        selectedTable={
+          isTableSelected || isForeignTableSelected ? (selectedTable as TableLike) : undefined
+        }
+        onTableCreated={onTableCreated}
+      />
     </div>
   )
 }

--- a/apps/studio/data/table-editor/table-editor-query.ts
+++ b/apps/studio/data/table-editor/table-editor-query.ts
@@ -33,7 +33,7 @@ export async function getTableEditor(
     signal
   )
 
-  return (result[0]?.entity ?? undefined) as Entity | undefined
+  return (result[0]?.entity ?? null) as Entity | undefined
 }
 
 export type TableEditorData = Awaited<ReturnType<typeof getTableEditor>>


### PR DESCRIPTION
## Context

Addresses an issue where the "new table" button in the table editor wasn't working if we're on a unknown table (e.g /editor/123, where 123 is a random non existent ID)

Realised this was due to an early return statement in `TableGridEditor.tsx`, just had to shift the Unknown table UI state into the main return statement and also shift `SidePanelEditor` outside of the `TableEditorTableStateContextProvidert

^ This is fine since none of the side panels are using the `table-editor-table` state (we only need to make sure that the TableEditor side panel doesn't use actually since all the other panels cannot be accessed while on the Unknown table UI state.)


## To test
- [ ] Verify that you can create a new table while on an unknown table (e.g `/editor/123`)