### PR TITLE
Fix database webhooks http headers for edge functions not loading auth headers on first open

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -44,6 +44,7 @@ export const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelP
   // hence why this external state as a temporary workaround
   const [events, setEvents] = useState<string[]>(selectedHook?.events ?? [])
   const [eventsError, setEventsError] = useState<string>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   // For HTTP request
   const [httpHeaders, setHttpHeaders] = useState<HTTPArgument[]>(() => {
@@ -65,6 +66,7 @@ export const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelP
       value,
     }))
   })
+
   const [httpParameters, setHttpParameters] = useState<HTTPArgument[]>(() => {
     if (typeof selectedHook === `undefined`) {
       return [{ id: uuidv4(), name: '', value: '' }]
@@ -90,7 +92,7 @@ export const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelP
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const [isSubmitting, setIsSubmitting] = useState(false)
+
   const { mutate: createDatabaseTrigger } = useDatabaseTriggerCreateMutation({
     onSuccess: (res) => {
       toast.success(`Successfully created new webhook "${res.name}"`)
@@ -102,6 +104,7 @@ export const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelP
       toast.error(`Failed to create webhook: ${error.message}`)
     },
   })
+
   const { mutate: updateDatabaseTrigger } = useDatabaseTriggerUpdateMutation({
     onSuccess: (res) => {
       setIsSubmitting(false)
@@ -131,13 +134,6 @@ export const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelP
       : 'http_request',
     timeout_ms: Number(selectedHook?.function_args?.[4] ?? 5000),
   }
-
-  useEffect(() => {
-    if (visible) {
-      setIsEdited(false)
-      setIsClosingPanel(false)
-    }
-  }, [visible])
 
   const onClosePanel = () => {
     if (isEdited) setIsClosingPanel(true)
@@ -261,6 +257,13 @@ export const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelP
       })
     }
   }
+
+  useEffect(() => {
+    if (visible) {
+      setIsEdited(false)
+      setIsClosingPanel(false)
+    }
+  }, [visible])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -51,7 +51,9 @@ export const FormContents = ({
   const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
 
   const { data: keys = [] } = useAPIKeysQuery({ projectRef: ref, reveal: true })
-  const { data: functions = [] } = useEdgeFunctionsQuery({ projectRef: ref })
+  const { data: functions = [], isSuccess: isSucessEdgeFunctions } = useEdgeFunctionsQuery({
+    projectRef: ref,
+  })
 
   const legacyServiceRole = keys.find((x) => x.name === 'service_role')?.api_key ?? '[YOUR API KEY]'
 
@@ -81,6 +83,8 @@ export const FormContents = ({
   }, [values.function_type])
 
   useEffect(() => {
+    if (!isSucessEdgeFunctions) return
+
     const isEdgeFunctionSelected = isEdgeFunction({ ref, restUrlTld, url: values.http_url })
 
     if (values.http_url && isEdgeFunctionSelected) {
@@ -105,7 +109,7 @@ export const FormContents = ({
       setHttpHeaders(updatedHttpHeaders)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values.http_url])
+  }, [values.http_url, isSucessEdgeFunctions])
 
   return (
     <div>


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase/issues/38848, related to https://github.com/supabase/supabase/pull/38844

## Context

Realised that for database webhooks, when editing a webhook that uses an edge function the authorization header doesn't load when you open the panel for the first time which seemingly looks like the authorization header was being hidden (but its not the case)

To reproduce
- Create a webhook that uses an edge function (Ensure that there's an auth header)
- Refresh the page then edit the webhook, notice that the authorization header is missing
- Close the panel then edit the webhook again, notice that the authorization header is now present

https://github.com/user-attachments/assets/d9b795f8-7d58-4831-8828-2184912e6d77

This was happening as the list of edge functions was not loaded yet in initial loading of HTTP headers in the client state within the useEffect. Just needed to check for `isSuccess` from the `useEdgeFunctionsQuery`