### PR TITLE
docs: fix typo in ssl-enforcement guide

### DIFF
--- a/apps/docs/content/guides/platform/ssl-enforcement.mdx
+++ b/apps/docs/content/guides/platform/ssl-enforcement.mdx
@@ -27,7 +27,7 @@ export SUPABASE_ACCESS_TOKEN="your-access-token"
 export PROJECT_REF="your-project-ref"
 
 # Get current SSL enforcement status
-curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/ssl-enforceemnt" \
+curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/ssl-enforcement" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
 
 # Enable SSL enforcement


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.  

**YES**  

## What kind of change does this PR introduce?  

- [x] Docs update (typo fix)  

## What is the current behavior?  

The example in the SSL enforcement guide uses the incorrect endpoint:  

```
curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/ssl-enforceemnt" \
  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
```

## What is the new behavior?

Corrects the typo (ssl-enforceemnt → ssl-enforcement):

```
curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/ssl-enforcement" \
  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
```