### PR TITLE
Update overview.mdx docs: Article change from 'an' to 'a'

### DIFF
--- a/apps/docs/content/guides/database/overview.mdx
+++ b/apps/docs/content/guides/database/overview.mdx
@@ -85,7 +85,7 @@ You can enable Postgres extensions with the click of a button within the Supabas
 
 PostgreSQL the database was derived from the POSTGRES Project, a package written at the University of California at Berkeley in 1986. This package included a query language called "PostQUEL".
 
-In 1994, Postgres95 was built on top of POSTGRES code, adding an SQL language interpreter as a replacement for PostQUEL.
+In 1994, Postgres95 was built on top of POSTGRES code, adding a SQL language interpreter as a replacement for PostQUEL.
 {/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
 
 Eventually, Postgres95 was renamed to PostgreSQL to reflect the SQL query capability.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The _database overview_ docs use the wrong article _an_ before SQL
> In 1994, Postgres95 was built on top of POSTGRES code, adding an SQL language interpreter as a replacement for PostQUEL.

## What is the new behavior?

> In 1994, Postgres95 was built on top of POSTGRES code, adding a SQL language interpreter as a replacement for PostQUEL.