### PR TITLE
In UI library docs, selecting a line shouldn't select $

### DIFF
--- a/apps/ui-library/components/command.tsx
+++ b/apps/ui-library/components/command.tsx
@@ -67,7 +67,7 @@ export function Command({ name, highlight }: CommandCopyProps) {
             <TabsContent_Shadcn_ key={manager} value={manager} className="m-0">
               <div className="flex items-center">
                 <div className="flex-1 font-mono text-sm text-foreground relative z-10">
-                  <span className="mr-2 text-[#888]">$</span>
+                  <span className="mr-2 text-[#888] select-none">$</span>
                   {commands[manager]}
                 </div>
                 <div className="relative z-10">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to UI Library

## What is the current behavior?

Currently when a user selects the command from the docs, it selects the `$` as well.

<img width="1800" height="500" alt="CleanShot 2025-09-22 at 10 29 01@2x" src="https://github.com/user-attachments/assets/48785640-3ba5-4d96-8c6b-79001b123485" />

## What is the new behavior?

This will ensure that only the command is selected. `$` is excluded from the selection

<img width="2302" height="1098" alt="CleanShot 2025-09-22 at 10 30 35@2x" src="https://github.com/user-attachments/assets/7a05094e-6d21-45b1-915a-fd8b552346e5" />

## Additional context

Here's a demo

https://github.com/user-attachments/assets/eaf7914f-164b-4703-b3fa-78fe5e816b61
