### PR TITLE
fix: invalidate upgrade eligibility query

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -1,5 +1,4 @@
 import { useParams } from 'common'
-import { useEffect } from 'react'
 import {
   ScaffoldContainer,
   ScaffoldDivider,
@@ -45,7 +44,6 @@ const InfrastructureInfo = () => {
     isLoading: isLoadingUpgradeEligibility,
     isError: isErrorUpgradeEligibility,
     isSuccess: isSuccessUpgradeEligibility,
-    refetch: refetchUpgradeEligibility,
   } = useProjectUpgradeEligibilityQuery({
     projectRef: ref,
   })
@@ -80,13 +78,6 @@ const InfrastructureInfo = () => {
   const hasObjectsToBeDropped = (data?.objects_to_be_dropped ?? []).length > 0
   const hasUnsupportedExtensions = (data?.unsupported_extensions || []).length > 0
   const hasObjectsInternalSchema = (data?.user_defined_objects_in_internal_schemas || []).length > 0
-
-  // Refetch upgrade eligibility when component mounts to ensure we have the latest data
-  useEffect(() => {
-    if (ref && project?.status === 'ACTIVE_HEALTHY') {
-      refetchUpgradeEligibility()
-    }
-  }, [ref, project?.status, refetchUpgradeEligibility])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'common'
+import { useEffect } from 'react'
 import {
   ScaffoldContainer,
   ScaffoldDivider,
@@ -44,6 +45,7 @@ const InfrastructureInfo = () => {
     isLoading: isLoadingUpgradeEligibility,
     isError: isErrorUpgradeEligibility,
     isSuccess: isSuccessUpgradeEligibility,
+    refetch: refetchUpgradeEligibility,
   } = useProjectUpgradeEligibilityQuery({
     projectRef: ref,
   })
@@ -78,6 +80,13 @@ const InfrastructureInfo = () => {
   const hasObjectsToBeDropped = (data?.objects_to_be_dropped ?? []).length > 0
   const hasUnsupportedExtensions = (data?.unsupported_extensions || []).length > 0
   const hasObjectsInternalSchema = (data?.user_defined_objects_in_internal_schemas || []).length > 0
+
+  // Refetch upgrade eligibility when component mounts to ensure we have the latest data
+  useEffect(() => {
+    if (ref && project?.status === 'ACTIVE_HEALTHY') {
+      refetchUpgradeEligibility()
+    }
+  }, [ref, project?.status, refetchUpgradeEligibility])
 
   return (
     <>

--- a/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
@@ -4,6 +4,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
+import { configKeys } from 'data/config/keys'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
 
@@ -57,7 +58,10 @@ export const useDatabaseExtensionEnableMutation = ({
     {
       async onSuccess(data, variables, context) {
         const { projectRef } = variables
-        await queryClient.invalidateQueries(databaseExtensionsKeys.list(projectRef))
+        await Promise.all([
+          queryClient.invalidateQueries(databaseExtensionsKeys.list(projectRef)),
+          queryClient.invalidateQueries(configKeys.upgradeEligibility(projectRef)),
+        ])
         await onSuccess?.(data, variables, context)
       },
       async onError(data, variables, context) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes an issue where removing extensions in order to upgrade Postgres didn’t refetch the upgrade eligibility until the user did a hard refresh of the page.

## What is the current behavior?

Going to [Infrastructure](https://supabase.com/dashboard/project/_/settings/infrastructure) after removing a deprecated extension does not show the new ‘ready’ state for upgrading Postgres to v17. The user must hard refresh to get that. See this recording:

https://github.com/user-attachments/assets/b9a86193-01ed-4ddb-b02c-a3aa8b357456

This is confusing. Each new entry into the Infrastructure page—especially after making changes elsewhere—should refetch upgrade eligibility and render accordingly. 

## What is the new behavior?

No hard refresh is required to see the updated warnings. Visiting the Infrastructure page will always show the most current state. The following changes were made with Cursor’s help to achieve this:

In `database-extension-enable-mutation.ts`:
- Updated the `onSuccess` callback to invalidate both the database extensions list and the upgrade eligibility query

~~In `InfrastructureInfo`:~~
- ~~Extracted the `refetch` function from the useProjectUpgradeEligibilityQuery hook~~
- ~~Added a `useEffect` that refetches the upgrade eligibility data when the component mounts~~

_Update: the `queryClient.invalidateQueries()` should handle refetching alone. Thanks @SaxonF._

## Additional context

This is a follow up to https://github.com/supabase/supabase/pull/38904