### PR TITLE
Bump zod to v4

### DIFF
--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -16,7 +16,7 @@
     "typecheck": "contentlayer2 build && tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.1.1",
+    "@hookform/resolvers": "catalog:",
     "contentlayer2": "0.4.6",
     "date-fns": "^2.30.0",
     "eslint-config-supabase": "workspace:*",

--- a/apps/design-system/registry/default/example/calendar-form.tsx
+++ b/apps/design-system/registry/default/example/calendar-form.tsx
@@ -25,8 +25,8 @@ import {
 
 const FormSchema = z.object({
   dob: z.date({
-    required_error: 'A date of birth is required.',
-  }),
+      error: (issue) => issue.input === undefined ? 'A date of birth is required.' : undefined
+}),
 })
 
 export default function CalendarForm() {

--- a/apps/design-system/registry/default/example/calendar-form.tsx
+++ b/apps/design-system/registry/default/example/calendar-form.tsx
@@ -25,8 +25,8 @@ import {
 
 const FormSchema = z.object({
   dob: z.date({
-      error: (issue) => issue.input === undefined ? 'A date of birth is required.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'A date of birth is required.' : undefined),
+  }),
 })
 
 export default function CalendarForm() {

--- a/apps/design-system/registry/default/example/calendar-react-hook-form.tsx
+++ b/apps/design-system/registry/default/example/calendar-react-hook-form.tsx
@@ -25,8 +25,8 @@ import {
 
 const FormSchema = z.object({
   dob: z.date({
-    required_error: 'A date of birth is required.',
-  }),
+      error: (issue) => issue.input === undefined ? 'A date of birth is required.' : undefined
+}),
 })
 
 export default function CalendarForm() {

--- a/apps/design-system/registry/default/example/calendar-react-hook-form.tsx
+++ b/apps/design-system/registry/default/example/calendar-react-hook-form.tsx
@@ -25,8 +25,8 @@ import {
 
 const FormSchema = z.object({
   dob: z.date({
-      error: (issue) => issue.input === undefined ? 'A date of birth is required.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'A date of birth is required.' : undefined),
+  }),
 })
 
 export default function CalendarForm() {

--- a/apps/design-system/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/design-system/registry/default/example/checkbox-form-multiple.tsx
@@ -46,8 +46,8 @@ const items = [
 
 const FormSchema = z.object({
   items: z.array(z.string()).refine((value) => value.some((item) => item), {
-    message: 'You have to select at least one item.',
-  }),
+      error: 'You have to select at least one item.'
+}),
 })
 
 export default function CheckboxReactHookFormMultiple() {

--- a/apps/design-system/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/design-system/registry/default/example/checkbox-form-multiple.tsx
@@ -46,8 +46,8 @@ const items = [
 
 const FormSchema = z.object({
   items: z.array(z.string()).refine((value) => value.some((item) => item), {
-      error: 'You have to select at least one item.'
-}),
+    error: 'You have to select at least one item.',
+  }),
 })
 
 export default function CheckboxReactHookFormMultiple() {

--- a/apps/design-system/registry/default/example/checkbox-form-single.tsx
+++ b/apps/design-system/registry/default/example/checkbox-form-single.tsx
@@ -18,7 +18,7 @@ import {
 } from 'ui'
 
 const FormSchema = z.object({
-  mobile: z.boolean().default(false).optional(),
+  mobile: z.boolean().prefault(false).optional(),
 })
 
 export default function CheckboxReactHookFormSingle() {

--- a/apps/design-system/registry/default/example/combobox-form.tsx
+++ b/apps/design-system/registry/default/example/combobox-form.tsx
@@ -43,8 +43,8 @@ const languages = [
 
 const FormSchema = z.object({
   language: z.string({
-      error: (issue) => issue.input === undefined ? 'Please select a language.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'Please select a language.' : undefined),
+  }),
 })
 
 export default function ComboboxForm() {

--- a/apps/design-system/registry/default/example/combobox-form.tsx
+++ b/apps/design-system/registry/default/example/combobox-form.tsx
@@ -43,8 +43,8 @@ const languages = [
 
 const FormSchema = z.object({
   language: z.string({
-    required_error: 'Please select a language.',
-  }),
+      error: (issue) => issue.input === undefined ? 'Please select a language.' : undefined
+}),
 })
 
 export default function ComboboxForm() {

--- a/apps/design-system/registry/default/example/date-picker-form.tsx
+++ b/apps/design-system/registry/default/example/date-picker-form.tsx
@@ -25,8 +25,8 @@ import {
 
 const FormSchema = z.object({
   dob: z.date({
-    required_error: 'A date of birth is required.',
-  }),
+      error: (issue) => issue.input === undefined ? 'A date of birth is required.' : undefined
+}),
 })
 
 export default function DatePickerForm() {

--- a/apps/design-system/registry/default/example/date-picker-form.tsx
+++ b/apps/design-system/registry/default/example/date-picker-form.tsx
@@ -25,8 +25,8 @@ import {
 
 const FormSchema = z.object({
   dob: z.date({
-      error: (issue) => issue.input === undefined ? 'A date of birth is required.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'A date of birth is required.' : undefined),
+  }),
 })
 
 export default function DatePickerForm() {

--- a/apps/design-system/registry/default/example/form-item-layout-demo.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-demo.tsx
@@ -7,8 +7,8 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 const formSchema = z.object({
   username: z.string().min(2, {
-    message: 'Username must be at least 2 characters.',
-  }),
+      error: 'Username must be at least 2 characters.'
+}),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/form-item-layout-demo.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-demo.tsx
@@ -7,8 +7,8 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 const formSchema = z.object({
   username: z.string().min(2, {
-      error: 'Username must be at least 2 characters.'
-}),
+    error: 'Username must be at least 2 characters.',
+  }),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/form-item-layout-with-checkbox-list.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-checkbox-list.tsx
@@ -6,8 +6,8 @@ import { z } from 'zod'
 
 const FormSchema = z.object({
   items: z.array(z.string()).refine((value) => value.some((item) => item), {
-    message: 'You have to select at least one item.',
-  }),
+      error: 'You have to select at least one item.'
+}),
 })
 
 const items = [

--- a/apps/design-system/registry/default/example/form-item-layout-with-checkbox-list.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-checkbox-list.tsx
@@ -6,8 +6,8 @@ import { z } from 'zod'
 
 const FormSchema = z.object({
   items: z.array(z.string()).refine((value) => value.some((item) => item), {
-      error: 'You have to select at least one item.'
-}),
+    error: 'You have to select at least one item.',
+  }),
 })
 
 const items = [

--- a/apps/design-system/registry/default/example/form-item-layout-with-checkbox.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-checkbox.tsx
@@ -12,7 +12,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
 const FormSchema = z.object({
-  consistent_settings: z.boolean().default(false).optional(),
+  consistent_settings: z.boolean().prefault(false).optional(),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/form-item-layout-with-horizontal.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-horizontal.tsx
@@ -7,8 +7,8 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 const formSchema = z.object({
   username: z.string().min(2, {
-    message: 'Username must be at least 2 characters.',
-  }),
+      error: 'Username must be at least 2 characters.'
+}),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/form-item-layout-with-horizontal.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-horizontal.tsx
@@ -7,8 +7,8 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 const formSchema = z.object({
   username: z.string().min(2, {
-      error: 'Username must be at least 2 characters.'
-}),
+    error: 'Username must be at least 2 characters.',
+  }),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/form-item-layout-with-select.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-select.tsx
@@ -15,11 +15,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
 const FormSchema = z.object({
-  email: z
-    .string({
-      required_error: 'Please select an email to display.',
-    })
-    .email(),
+  email: z.email(),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/form-item-layout-with-switch.tsx
+++ b/apps/design-system/registry/default/example/form-item-layout-with-switch.tsx
@@ -5,7 +5,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
 const FormSchema = z.object({
-  switch_option: z.boolean().default(false).optional(),
+  switch_option: z.boolean().prefault(false).optional(),
 })
 
 export default function FormItemLayoutDemo() {

--- a/apps/design-system/registry/default/example/input-form.tsx
+++ b/apps/design-system/registry/default/example/input-form.tsx
@@ -19,8 +19,8 @@ import {
 
 const FormSchema = z.object({
   username: z.string().min(2, {
-    message: 'Username must be at least 2 characters.',
-  }),
+      error: 'Username must be at least 2 characters.'
+}),
 })
 
 export default function InputForm() {

--- a/apps/design-system/registry/default/example/input-form.tsx
+++ b/apps/design-system/registry/default/example/input-form.tsx
@@ -19,8 +19,8 @@ import {
 
 const FormSchema = z.object({
   username: z.string().min(2, {
-      error: 'Username must be at least 2 characters.'
-}),
+    error: 'Username must be at least 2 characters.',
+  }),
 })
 
 export default function InputForm() {

--- a/apps/design-system/registry/default/example/input-otp-form.tsx
+++ b/apps/design-system/registry/default/example/input-otp-form.tsx
@@ -21,8 +21,8 @@ import {
 
 const FormSchema = z.object({
   pin: z.string().min(6, {
-      error: 'Your one-time password must be 6 characters.'
-}),
+    error: 'Your one-time password must be 6 characters.',
+  }),
 })
 
 export default function InputOTPForm() {

--- a/apps/design-system/registry/default/example/input-otp-form.tsx
+++ b/apps/design-system/registry/default/example/input-otp-form.tsx
@@ -21,8 +21,8 @@ import {
 
 const FormSchema = z.object({
   pin: z.string().min(6, {
-    message: 'Your one-time password must be 6 characters.',
-  }),
+      error: 'Your one-time password must be 6 characters.'
+}),
 })
 
 export default function InputOTPForm() {

--- a/apps/design-system/registry/default/example/radio-group-card-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-card-form.tsx
@@ -19,8 +19,8 @@ import {
 
 const FormSchema = z.object({
   type: z.enum(['all', 'mentions', 'none'], {
-    required_error: 'You need to select a notification type.',
-  }),
+      error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
+}),
 })
 
 export default function RadioGroupForm() {

--- a/apps/design-system/registry/default/example/radio-group-card-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-card-form.tsx
@@ -19,8 +19,9 @@ import {
 
 const FormSchema = z.object({
   type: z.enum(['all', 'mentions', 'none'], {
-      error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
-}),
+    error: (issue) =>
+      issue.input === undefined ? 'You need to select a notification type.' : undefined,
+  }),
 })
 
 export default function RadioGroupForm() {

--- a/apps/design-system/registry/default/example/radio-group-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-form.tsx
@@ -19,8 +19,8 @@ import {
 
 const FormSchema = z.object({
   type: z.enum(['all', 'mentions', 'none'], {
-    required_error: 'You need to select a notification type.',
-  }),
+      error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
+}),
 })
 
 export default function RadioGroupForm() {

--- a/apps/design-system/registry/default/example/radio-group-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-form.tsx
@@ -19,8 +19,9 @@ import {
 
 const FormSchema = z.object({
   type: z.enum(['all', 'mentions', 'none'], {
-      error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
-}),
+    error: (issue) =>
+      issue.input === undefined ? 'You need to select a notification type.' : undefined,
+  }),
 })
 
 export default function RadioGroupForm() {

--- a/apps/design-system/registry/default/example/radio-group-stacked-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-stacked-form.tsx
@@ -19,8 +19,8 @@ import {
 
 const FormSchema = z.object({
   type: z.enum(['all', 'mentions', 'none'], {
-    required_error: 'You need to select a notification type.',
-  }),
+      error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
+}),
 })
 
 export default function RadioGroupForm() {

--- a/apps/design-system/registry/default/example/radio-group-stacked-form.tsx
+++ b/apps/design-system/registry/default/example/radio-group-stacked-form.tsx
@@ -19,8 +19,9 @@ import {
 
 const FormSchema = z.object({
   type: z.enum(['all', 'mentions', 'none'], {
-      error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
-}),
+    error: (issue) =>
+      issue.input === undefined ? 'You need to select a notification type.' : undefined,
+  }),
 })
 
 export default function RadioGroupForm() {

--- a/apps/design-system/registry/default/example/select-form.tsx
+++ b/apps/design-system/registry/default/example/select-form.tsx
@@ -23,11 +23,7 @@ import {
 } from 'ui'
 
 const FormSchema = z.object({
-  email: z
-    .string({
-      required_error: 'Please select an email to display.',
-    })
-    .email(),
+  email: z.email(),
 })
 
 export default function SelectForm() {

--- a/apps/design-system/registry/default/example/switch-form.tsx
+++ b/apps/design-system/registry/default/example/switch-form.tsx
@@ -17,7 +17,7 @@ import {
 } from 'ui'
 
 const FormSchema = z.object({
-  marketing_emails: z.boolean().default(false).optional(),
+  marketing_emails: z.boolean().prefault(false).optional(),
   security_emails: z.boolean(),
 })
 

--- a/apps/design-system/registry/default/example/textarea-form.tsx
+++ b/apps/design-system/registry/default/example/textarea-form.tsx
@@ -21,10 +21,10 @@ const FormSchema = z.object({
   bio: z
     .string()
     .min(10, {
-      message: 'Bio must be at least 10 characters.',
+        error: 'Bio must be at least 10 characters.'
     })
     .max(160, {
-      message: 'Bio must not be longer than 30 characters.',
+        error: 'Bio must not be longer than 30 characters.'
     }),
 })
 

--- a/apps/design-system/registry/default/example/textarea-form.tsx
+++ b/apps/design-system/registry/default/example/textarea-form.tsx
@@ -21,10 +21,10 @@ const FormSchema = z.object({
   bio: z
     .string()
     .min(10, {
-        error: 'Bio must be at least 10 characters.'
+      error: 'Bio must be at least 10 characters.',
     })
     .max(160, {
-        error: 'Bio must not be longer than 30 characters.'
+      error: 'Bio must not be longer than 30 characters.',
     }),
 })
 

--- a/apps/docs/app/api/graphql/route.ts
+++ b/apps/docs/app/api/graphql/route.ts
@@ -85,7 +85,7 @@ function isDevGraphiQL(request: Request) {
 
 const graphQLRequestSchema = z.object({
   query: z.string(),
-  variables: z.record(z.any()).optional(),
+  variables: z.record(z.string(), z.any()).optional(),
   operationName: z.string().optional(),
 })
 

--- a/apps/docs/features/directives/CodeSample.ts
+++ b/apps/docs/features/directives/CodeSample.ts
@@ -53,14 +53,14 @@ const ALLOW_LISTED_GITHUB_ORGS = ['supabase', 'supabase-community'] as [string, 
 const linesSchema = z.array(z.tuple([z.coerce.number(), z.coerce.number()]))
 const linesValidator = z
   .string()
-  .default('[[1, -1]]')
+  .prefault('[[1, -1]]')
   .transform((v, ctx) => {
     try {
       const array = JSON.parse(v)
       return linesSchema.parse(array)
     } catch (e) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: 'Lines should be an array of [number, number] tuples',
       })
       return z.NEVER
@@ -82,14 +82,14 @@ const booleanValidator = z.union([z.boolean(), z.string(), z.undefined()]).trans
 const codeSampleExternalSchema = z.object({
   external: z.coerce.boolean().refine((v) => v === true),
   org: z.enum(ALLOW_LISTED_GITHUB_ORGS, {
-    errorMap: () => ({ message: 'Org must be one of: ' + ALLOW_LISTED_GITHUB_ORGS.join(', ') }),
+    error: () => 'Org must be one of: ' + ALLOW_LISTED_GITHUB_ORGS.join(', '),
   }),
   repo: z.string(),
   commit: z.string(),
   path: z.string().transform((v) => (v.startsWith('/') ? v : `/${v}`)),
   lines: linesValidator,
   meta: z.string().optional(),
-  hideElidedLines: z.coerce.boolean().default(false),
+  hideElidedLines: z.coerce.boolean().prefault(false),
   convertToJs: booleanValidator,
 })
 type ICodeSampleExternal = z.infer<typeof codeSampleExternalSchema> & AdditionalMeta
@@ -102,7 +102,7 @@ const codeSampleInternalSchema = z.object({
   path: z.string().transform((v) => (v.startsWith('/') ? v : `/${v}`)),
   lines: linesValidator,
   meta: z.string().optional(),
-  hideElidedLines: z.coerce.boolean().default(false),
+  hideElidedLines: z.coerce.boolean().prefault(false),
   convertToJs: booleanValidator,
 })
 type ICodeSampleInternal = z.infer<typeof codeSampleInternalSchema> & AdditionalMeta

--- a/apps/docs/features/directives/CodeSample.ts
+++ b/apps/docs/features/directives/CodeSample.ts
@@ -33,7 +33,7 @@
 
 import * as acorn from 'acorn'
 import tsPlugin from 'acorn-typescript'
-import { type DefinitionContent, type BlockContent, type Code, type Root } from 'mdast'
+import { type BlockContent, type Code, type DefinitionContent, type Root } from 'mdast'
 import type { MdxJsxAttributeValueExpression, MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
@@ -41,7 +41,7 @@ import { join } from 'node:path'
 import { removeTypes } from 'remove-types'
 import { type Parent } from 'unist'
 import { visitParents } from 'unist-util-visit-parents'
-import { z, type SafeParseError } from 'zod'
+import { z, type ZodSafeParseError } from 'zod'
 
 import { fetchWithNextOptions } from '~/features/helpers.fetch'
 import { IS_PLATFORM } from '~/lib/constants'
@@ -182,7 +182,7 @@ async function fetchSourceCodeContent(tree: Root, deps: Dependencies) {
 
       if (!result.success) {
         throw new Error(
-          `Invalid $CodeSample directive: ${(result as SafeParseError<ICodeSampleExternal>).error.message}`
+          `Invalid $CodeSample directive: ${(result as ZodSafeParseError<ICodeSampleExternal>).error.message}`
         )
       }
 
@@ -224,7 +224,7 @@ async function fetchSourceCodeContent(tree: Root, deps: Dependencies) {
 
       if (!result.success) {
         throw new Error(
-          `Invalid $CodeSample directive: ${(result as SafeParseError<ICodeSampleInternal>).error.message}`
+          `Invalid $CodeSample directive: ${(result as ZodSafeParseError<ICodeSampleInternal>).error.message}`
         )
       }
 

--- a/apps/docs/features/directives/CodeSample.ts
+++ b/apps/docs/features/directives/CodeSample.ts
@@ -60,7 +60,7 @@ const linesValidator = z
       return linesSchema.parse(array)
     } catch (e) {
       ctx.addIssue({
-        code: "custom",
+        code: 'custom',
         message: 'Lines should be an array of [number, number] tuples',
       })
       return z.NEVER

--- a/apps/docs/features/docs/Troubleshooting.utils.common.mjs
+++ b/apps/docs/features/docs/Troubleshooting.utils.common.mjs
@@ -54,8 +54,7 @@ export const TROUBLESHOOTING_DIRECTORY = join(process.cwd(), 'content/troublesho
  * @property {string} [message]
  */
 
-export const TroubleshootingSchema = z
-  .object({
+export const TroubleshootingSchema = z.strictObject({
     title: z.string(),
     topics: z.array(
       z.enum([
@@ -75,30 +74,25 @@ export const TroubleshootingSchema = z
       ])
     ),
     keywords: z.array(z.string()).optional(),
-    api: z
-      .object({
-        sdk: z.array(z.string()).optional(),
-        management_api: z.array(z.string()).optional(),
-        cli: z.array(z.string()).optional(),
-      })
-      .strict()
+    api: z.strictObject({
+            sdk: z.array(z.string()).optional(),
+            management_api: z.array(z.string()).optional(),
+            cli: z.array(z.string()).optional(),
+          })
       .optional(),
     errors: z
       .array(
-        z
-          .object({
-            http_status_code: z.number().optional(),
-            code: z.string().optional(),
-            message: z.string().optional(),
-          })
-          .strict()
+        z.strictObject({
+                      http_status_code: z.number().optional(),
+                      code: z.string().optional(),
+                      message: z.string().optional(),
+                    })
       )
       .optional(),
-    database_id: z.string().default(`pseudo-${uuidv4()}`),
-    github_url: z.string().url().optional(),
+    database_id: z.string().prefault(`pseudo-${uuidv4()}`),
+    github_url: z.url().optional(),
     date_created: z.date({ coerce: true }).optional(),
   })
-  .strict()
 
 /**
  * @param {unknown} troubleshootingMetadata

--- a/apps/docs/features/docs/Troubleshooting.utils.common.mjs
+++ b/apps/docs/features/docs/Troubleshooting.utils.common.mjs
@@ -55,44 +55,45 @@ export const TROUBLESHOOTING_DIRECTORY = join(process.cwd(), 'content/troublesho
  */
 
 export const TroubleshootingSchema = z.strictObject({
-    title: z.string(),
-    topics: z.array(
-      z.enum([
-        'ai',
-        'auth',
-        'branching',
-        'cli',
-        'database',
-        'functions',
-        'platform',
-        'realtime',
-        'self-hosting',
-        'storage',
-        'studio',
-        'supavisor',
-        'terraform',
-      ])
-    ),
-    keywords: z.array(z.string()).optional(),
-    api: z.strictObject({
-            sdk: z.array(z.string()).optional(),
-            management_api: z.array(z.string()).optional(),
-            cli: z.array(z.string()).optional(),
-          })
-      .optional(),
-    errors: z
-      .array(
-        z.strictObject({
-                      http_status_code: z.number().optional(),
-                      code: z.string().optional(),
-                      message: z.string().optional(),
-                    })
-      )
-      .optional(),
-    database_id: z.string().prefault(`pseudo-${uuidv4()}`),
-    github_url: z.url().optional(),
-    date_created: z.date({ coerce: true }).optional(),
-  })
+  title: z.string(),
+  topics: z.array(
+    z.enum([
+      'ai',
+      'auth',
+      'branching',
+      'cli',
+      'database',
+      'functions',
+      'platform',
+      'realtime',
+      'self-hosting',
+      'storage',
+      'studio',
+      'supavisor',
+      'terraform',
+    ])
+  ),
+  keywords: z.array(z.string()).optional(),
+  api: z
+    .strictObject({
+      sdk: z.array(z.string()).optional(),
+      management_api: z.array(z.string()).optional(),
+      cli: z.array(z.string()).optional(),
+    })
+    .optional(),
+  errors: z
+    .array(
+      z.strictObject({
+        http_status_code: z.number().optional(),
+        code: z.string().optional(),
+        message: z.string().optional(),
+      })
+    )
+    .optional(),
+  database_id: z.string().prefault(`pseudo-${uuidv4()}`),
+  github_url: z.url().optional(),
+  date_created: z.coerce.date().optional(),
+})
 
 /**
  * @param {unknown} troubleshootingMetadata

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -157,6 +157,7 @@
     "simple-git": "^3.24.0",
     "slugify": "^1.6.6",
     "smol-toml": "^1.3.1",
+    "tailwindcss": "^3.4.1",
     "tsconfig": "workspace:*",
     "tsx": "^4.19.3",
     "twoslash": "^0.3.1",

--- a/apps/studio/components/interfaces/Account/Preferences/ProfileInformation.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/ProfileInformation.tsx
@@ -30,7 +30,7 @@ const FormSchema = z.object({
   first_name: z.string().optional(),
   last_name: z.string().optional(),
   username: z.string().optional(),
-  primary_email: z.string().email().optional(),
+  primary_email: z.email().optional(),
 })
 
 const formId = 'profile-information-form'

--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -76,14 +76,14 @@ const FormSchema = z
       if (!data.httpsValues.url.startsWith('https://')) {
         ctx.addIssue({
           path: ['httpsValues', 'url'],
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'The URL must start with https://',
         })
       }
       if (!data.httpsValues.secret) {
         ctx.addIssue({
           path: ['httpsValues', 'secret'],
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'Missing secret value',
         })
       }
@@ -92,19 +92,18 @@ const FormSchema = z
       if (!data.postgresValues.schema) {
         ctx.addIssue({
           path: ['postgresValues', 'schema'],
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'You must select a schema',
         })
       }
       if (!data.postgresValues.functionName) {
         ctx.addIssue({
           path: ['postgresValues', 'functionName'],
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'You must select a Postgres function',
         })
       }
     }
-    return true
   })
 
 export const CreateHookSheet = ({

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
@@ -1,11 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Trash } from 'lucide-react'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
 
 import { useParams } from 'common'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useCreateThirdPartyAuthIntegrationMutation } from 'data/third-party-auth/integration-create-mutation'
 import {
   Button,
@@ -22,7 +22,6 @@ import {
   Separator,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import { InlineLink } from 'components/ui/InlineLink'
 
 interface CreateClerkAuthIntegrationProps {
   visible: boolean
@@ -45,7 +44,7 @@ const FormSchema = z
       !val.domain.match(/https:\/\/[a-z0-9-]+[.]clerk[.]accounts[.]dev\/?$/)
     ) {
       ctx.addIssue({
-        code: z.ZodIssueCode.invalid_string,
+        code: 'custom',
         path: ['domain'],
         message:
           'Production Clerk domains use HTTPS and start with the clerk subdomain (https://clerk.example.com). Development Clerk domains use HTTPS and end with .clerk.accounts.dev (https://example.clerk.accounts.dev).',

--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -48,8 +48,8 @@ import type { PaymentMethod } from '@stripe/stripe-js'
 export const BillingCustomerDataSchema = z.object({
   tax_id_type: z.string(),
   tax_id_value: z.string().min(2, {
-      error: 'Tax ID needs to be set.'
-}),
+    error: 'Tax ID needs to be set.',
+  }),
   tax_id_name: z.string(),
 })
 

--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -48,8 +48,8 @@ import type { PaymentMethod } from '@stripe/stripe-js'
 export const BillingCustomerDataSchema = z.object({
   tax_id_type: z.string(),
   tax_id_value: z.string().min(2, {
-    message: 'Tax ID needs to be set.',
-  }),
+      error: 'Tax ID needs to be set.'
+}),
   tax_id_name: z.string(),
 })
 

--- a/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -25,13 +25,13 @@ interface CreateRolePanelProps {
 }
 
 const FormSchema = z.object({
-  name: z.string().trim().min(1, 'You must provide a name').default(''),
-  isSuperuser: z.boolean().default(false),
-  canLogin: z.boolean().default(false),
-  canCreateRole: z.boolean().default(false),
-  canCreateDb: z.boolean().default(false),
-  isReplicationRole: z.boolean().default(false),
-  canBypassRls: z.boolean().default(false),
+  name: z.string().trim().min(1, 'You must provide a name').prefault(''),
+  isSuperuser: z.boolean().prefault(false),
+  canLogin: z.boolean().prefault(false),
+  canCreateRole: z.boolean().prefault(false),
+  canCreateDb: z.boolean().prefault(false),
+  isReplicationRole: z.boolean().prefault(false),
+  canBypassRls: z.boolean().prefault(false),
 })
 
 const initialValues = {

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
@@ -13,29 +13,23 @@ import { CloudProvider } from 'shared-data'
 
 const baseSchema = z.object({
   storageType: z.enum(['io2', 'gp3']).describe('Type of storage: io2 or gp3'),
-  totalSize: z.number().int('Value must be an integer').describe('Allocated disk size in GB'),
+  totalSize: z.int('Value must be an integer').describe('Allocated disk size in GB'),
   provisionedIOPS: z.number().describe('Provisioned IOPS for storage type'),
   throughput: z.number().optional().describe('Throughput in MB/s for gp3'),
   computeSize: z
     .custom<ComputeInstanceAddonVariantId>((val): val is ComputeInstanceAddonVariantId => true)
     .describe('Compute size'),
-  growthPercent: z
-    .number()
-    .int('Value must be an integer')
+  growthPercent: z.int('Value must be an integer')
     .min(10, 'Growth percent must be at least 10%')
     .max(100, 'Growth percent cannot exceed 100%')
     .optional()
     .nullable(),
-  minIncrementGb: z
-    .number()
-    .int('Value must be an integer')
+  minIncrementGb: z.int('Value must be an integer')
     .min(1, 'Minimum increment must be at least 1 GB')
     .max(200, 'Minimum increment cannot exceed 200 GB')
     .optional()
     .nullable(),
-  maxSizeGb: z
-    .number()
-    .int('Value must be an integer')
+  maxSizeGb: z.int('Value must be an integer')
     .max(60000, 'Maximum size cannot exceed 60TB')
     .optional()
     .nullable(),
@@ -49,7 +43,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
     if (!isFlyProject && totalSize < 8) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: 'Allocated disk size must be at least 8 GB.',
         path: ['totalSize'],
       })
@@ -57,7 +51,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
     if (!isFlyProject && totalSize < defaultTotalSize) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: `Disk size cannot be reduced in size. Reduce your database size and then head to the Infrastructure settings and go through a Postgres version upgrade to right-size your disk.`,
         path: ['totalSize'],
       })
@@ -66,7 +60,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
     // Validate maxSizeGb cannot be lower than totalSize
     if (!isFlyProject && !!maxSizeGb && maxSizeGb < totalSize) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: `Max disk size cannot be lower than the current disk size. Must be at least ${formatNumber(totalSize)} GB.`,
         path: ['maxSizeGb'],
       })
@@ -77,7 +71,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS > DISK_LIMITS[DiskType.IO2].maxIops) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: `IOPS can not exceed ${formatNumber(DISK_LIMITS[DiskType.IO2].maxIops)} for io2 Disk type. Please reach out to support if you need higher IOPS than this.`,
           path: ['provisionedIOPS'],
         })
@@ -87,7 +81,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS < DISK_LIMITS[DiskType.IO2].minIops) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: `Provisioned IOPS must be at least ${formatNumber(DISK_LIMITS[DiskType.IO2].minIops)}`,
           path: ['provisionedIOPS'],
         })
@@ -98,14 +92,14 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
           if (diskSizeRequiredForIopsWithIo2 > totalSize) {
             ctx.addIssue({
-              code: z.ZodIssueCode.custom,
+              code: "custom",
               message: `Larger Disk size of at least ${formatNumber(diskSizeRequiredForIopsWithIo2)} GB required. Current max is ${formatNumber(maxIOPSforDiskSizeWithio2)} IOPS.`,
               path: ['provisionedIOPS'],
             })
           }
         } else {
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: "custom",
             message: `Invalid IOPS value due to small disk size`,
             path: ['provisionedIOPS'],
           })
@@ -114,7 +108,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (throughput !== undefined) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: 'Throughput is not configurable for io2.',
           path: ['throughput'],
         })
@@ -122,7 +116,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (totalSize > DISK_LIMITS[DiskType.IO2].maxStorage) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: `Allocated disksize must not exceed ${formatNumber(DISK_LIMITS[DiskType.IO2].maxStorage)} GB `,
           path: ['totalSize'],
         })
@@ -134,7 +128,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS > DISK_LIMITS[DiskType.GP3].maxIops) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: `IOPS can not exceed ${formatNumber(DISK_LIMITS[DiskType.GP3].maxIops)} for GP3 Disk. Change the Disk type to io2 for higher IOPS support.`,
           path: ['provisionedIOPS'],
         })
@@ -142,7 +136,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS < DISK_LIMITS[DiskType.GP3].minIops) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: `IOPS must be at least ${formatNumber(DISK_LIMITS[DiskType.GP3].minIops)}`,
           path: ['provisionedIOPS'],
         })
@@ -152,13 +146,13 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
             calculateDiskSizeRequiredForIopsWithGp3(provisionedIOPS)
 
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: "custom",
             message: `Larger Disk size of at least ${formatNumber(diskSizeRequiredForIopsWithGp3)} GB required. Current max is ${formatNumber(maxIopsAllowedForDiskSizeWithGp3)} IOPS.`,
             path: ['provisionedIOPS'],
           })
         } else {
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: "custom",
             message: `Invalid IOPS value due to invalid disk size`,
             path: ['provisionedIOPS'],
           })
@@ -170,7 +164,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
         if (throughput > DISK_LIMITS['gp3'].maxThroughput) {
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: "custom",
             message: `Throughput can not exceed ${formatNumber(maxThroughput)} MB/s`,
             path: ['throughput'],
           })
@@ -178,14 +172,14 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
         if (throughput > maxThroughput) {
           const iopsRequiredForThroughput = calculateIopsRequiredForThroughput(throughput)
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: "custom",
             message: `Need at least ${formatNumber(iopsRequiredForThroughput)} IOPS to support ${formatNumber(throughput)} MB/s.`,
             path: ['throughput'],
           })
         }
         if (throughput < DISK_LIMITS[DiskType.GP3].minThroughput) {
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: "custom",
             message: `Throughput must be at least ${formatNumber(DISK_LIMITS[DiskType.GP3].minThroughput)} MB/s`,
             path: ['throughput'],
           })
@@ -194,7 +188,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (totalSize > DISK_LIMITS[DiskType.GP3].maxStorage) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: `Allocated disksize must not exceed ${formatNumber(DISK_LIMITS[DiskType.GP3].maxStorage)} GB`,
           path: ['totalSize'],
         })

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
@@ -19,17 +19,20 @@ const baseSchema = z.object({
   computeSize: z
     .custom<ComputeInstanceAddonVariantId>((val): val is ComputeInstanceAddonVariantId => true)
     .describe('Compute size'),
-  growthPercent: z.int('Value must be an integer')
+  growthPercent: z
+    .int('Value must be an integer')
     .min(10, 'Growth percent must be at least 10%')
     .max(100, 'Growth percent cannot exceed 100%')
     .optional()
     .nullable(),
-  minIncrementGb: z.int('Value must be an integer')
+  minIncrementGb: z
+    .int('Value must be an integer')
     .min(1, 'Minimum increment must be at least 1 GB')
     .max(200, 'Minimum increment cannot exceed 200 GB')
     .optional()
     .nullable(),
-  maxSizeGb: z.int('Value must be an integer')
+  maxSizeGb: z
+    .int('Value must be an integer')
     .max(60000, 'Maximum size cannot exceed 60TB')
     .optional()
     .nullable(),
@@ -43,7 +46,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
     if (!isFlyProject && totalSize < 8) {
       ctx.addIssue({
-        code: "custom",
+        code: 'custom',
         message: 'Allocated disk size must be at least 8 GB.',
         path: ['totalSize'],
       })
@@ -51,7 +54,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
     if (!isFlyProject && totalSize < defaultTotalSize) {
       ctx.addIssue({
-        code: "custom",
+        code: 'custom',
         message: `Disk size cannot be reduced in size. Reduce your database size and then head to the Infrastructure settings and go through a Postgres version upgrade to right-size your disk.`,
         path: ['totalSize'],
       })
@@ -60,7 +63,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
     // Validate maxSizeGb cannot be lower than totalSize
     if (!isFlyProject && !!maxSizeGb && maxSizeGb < totalSize) {
       ctx.addIssue({
-        code: "custom",
+        code: 'custom',
         message: `Max disk size cannot be lower than the current disk size. Must be at least ${formatNumber(totalSize)} GB.`,
         path: ['maxSizeGb'],
       })
@@ -71,7 +74,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS > DISK_LIMITS[DiskType.IO2].maxIops) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: `IOPS can not exceed ${formatNumber(DISK_LIMITS[DiskType.IO2].maxIops)} for io2 Disk type. Please reach out to support if you need higher IOPS than this.`,
           path: ['provisionedIOPS'],
         })
@@ -81,7 +84,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS < DISK_LIMITS[DiskType.IO2].minIops) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: `Provisioned IOPS must be at least ${formatNumber(DISK_LIMITS[DiskType.IO2].minIops)}`,
           path: ['provisionedIOPS'],
         })
@@ -92,14 +95,14 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
           if (diskSizeRequiredForIopsWithIo2 > totalSize) {
             ctx.addIssue({
-              code: "custom",
+              code: 'custom',
               message: `Larger Disk size of at least ${formatNumber(diskSizeRequiredForIopsWithIo2)} GB required. Current max is ${formatNumber(maxIOPSforDiskSizeWithio2)} IOPS.`,
               path: ['provisionedIOPS'],
             })
           }
         } else {
           ctx.addIssue({
-            code: "custom",
+            code: 'custom',
             message: `Invalid IOPS value due to small disk size`,
             path: ['provisionedIOPS'],
           })
@@ -108,7 +111,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (throughput !== undefined) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: 'Throughput is not configurable for io2.',
           path: ['throughput'],
         })
@@ -116,7 +119,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (totalSize > DISK_LIMITS[DiskType.IO2].maxStorage) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: `Allocated disksize must not exceed ${formatNumber(DISK_LIMITS[DiskType.IO2].maxStorage)} GB `,
           path: ['totalSize'],
         })
@@ -128,7 +131,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS > DISK_LIMITS[DiskType.GP3].maxIops) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: `IOPS can not exceed ${formatNumber(DISK_LIMITS[DiskType.GP3].maxIops)} for GP3 Disk. Change the Disk type to io2 for higher IOPS support.`,
           path: ['provisionedIOPS'],
         })
@@ -136,7 +139,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (provisionedIOPS < DISK_LIMITS[DiskType.GP3].minIops) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: `IOPS must be at least ${formatNumber(DISK_LIMITS[DiskType.GP3].minIops)}`,
           path: ['provisionedIOPS'],
         })
@@ -146,13 +149,13 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
             calculateDiskSizeRequiredForIopsWithGp3(provisionedIOPS)
 
           ctx.addIssue({
-            code: "custom",
+            code: 'custom',
             message: `Larger Disk size of at least ${formatNumber(diskSizeRequiredForIopsWithGp3)} GB required. Current max is ${formatNumber(maxIopsAllowedForDiskSizeWithGp3)} IOPS.`,
             path: ['provisionedIOPS'],
           })
         } else {
           ctx.addIssue({
-            code: "custom",
+            code: 'custom',
             message: `Invalid IOPS value due to invalid disk size`,
             path: ['provisionedIOPS'],
           })
@@ -164,7 +167,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
         if (throughput > DISK_LIMITS['gp3'].maxThroughput) {
           ctx.addIssue({
-            code: "custom",
+            code: 'custom',
             message: `Throughput can not exceed ${formatNumber(maxThroughput)} MB/s`,
             path: ['throughput'],
           })
@@ -172,14 +175,14 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
         if (throughput > maxThroughput) {
           const iopsRequiredForThroughput = calculateIopsRequiredForThroughput(throughput)
           ctx.addIssue({
-            code: "custom",
+            code: 'custom',
             message: `Need at least ${formatNumber(iopsRequiredForThroughput)} IOPS to support ${formatNumber(throughput)} MB/s.`,
             path: ['throughput'],
           })
         }
         if (throughput < DISK_LIMITS[DiskType.GP3].minThroughput) {
           ctx.addIssue({
-            code: "custom",
+            code: 'custom',
             message: `Throughput must be at least ${formatNumber(DISK_LIMITS[DiskType.GP3].minThroughput)} MB/s`,
             path: ['throughput'],
           })
@@ -188,7 +191,7 @@ export const CreateDiskStorageSchema = (defaultTotalSize: number, cloudProvider:
 
       if (totalSize > DISK_LIMITS[DiskType.GP3].maxStorage) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: `Allocated disksize must not exceed ${formatNumber(DISK_LIMITS[DiskType.GP3].maxStorage)} GB`,
           path: ['totalSize'],
         })

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -38,7 +38,7 @@ const FormSchema = z.object({
         .string()
         .min(1, 'Please provide a name for your secret')
         .refine((value) => !value.match(/^(SUPABASE_).*/), {
-            error: 'Name must not start with the SUPABASE_ prefix'
+          error: 'Name must not start with the SUPABASE_ prefix',
         }),
       value: z.string().min(1, 'Please provide a value for your secret'),
     })

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -38,7 +38,7 @@ const FormSchema = z.object({
         .string()
         .min(1, 'Please provide a name for your secret')
         .refine((value) => !value.match(/^(SUPABASE_).*/), {
-          message: 'Name must not start with the SUPABASE_ prefix',
+            error: 'Name must not start with the SUPABASE_ prefix'
         }),
       value: z.string().min(1, 'Please provide a value for your secret'),
     })

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -66,7 +66,7 @@ const edgeFunctionSchema = z.object({
   type: z.literal('edge_function'),
   method: z.enum(['GET', 'POST']),
   edgeFunctionName: z.string().trim().min(1, 'Please select one of the listed Edge Functions'),
-  timeoutMs: z.coerce.number().int().gte(1000).lte(5000).default(1000),
+  timeoutMs: z.coerce.number().int().gte(1000).lte(5000).prefault(1000),
   httpHeaders: z.array(z.object({ name: z.string(), value: z.string() })),
   httpBody: z
     .string()
@@ -94,7 +94,7 @@ const httpRequestSchema = z.object({
     .min(1, 'Please provide a URL')
     .regex(urlRegex(), 'Please provide a valid URL')
     .refine((value) => value.startsWith('http'), 'Please include HTTP/HTTPs to your URL'),
-  timeoutMs: z.coerce.number().int().gte(1000).lte(5000).default(1000),
+  timeoutMs: z.coerce.number().int().gte(1000).lte(5000).prefault(1000),
   httpHeaders: z.array(z.object({ name: z.string(), value: z.string() })),
   httpBody: z
     .string()
@@ -158,7 +158,7 @@ const FormSchema = z
     if (!cronPattern.test(data.schedule)) {
       if (!(data.supportsSeconds && secondsPattern.test(data.schedule))) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           message: 'Seconds are supported only in pg_cron v1.5.0+. Please use a valid Cron format.',
           path: ['schedule'],
         })

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -158,7 +158,7 @@ const FormSchema = z
     if (!cronPattern.test(data.schedule)) {
       if (!(data.supportsSeconds && secondsPattern.test(data.schedule))) {
         ctx.addIssue({
-          code: "custom",
+          code: 'custom',
           message: 'Seconds are supported only in pg_cron v1.5.0+. Please use a valid Cron format.',
           path: ['schedule'],
         })

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/SendMessageModal.tsx
@@ -27,7 +27,7 @@ const FormSchema = z.object({
       }
     },
     {
-        error: 'The payload should be a JSON object'
+      error: 'The payload should be a JSON object',
     }
   ),
 })

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/SendMessageModal.tsx
@@ -17,7 +17,7 @@ interface SendMessageModalProps {
 }
 
 const FormSchema = z.object({
-  delay: z.coerce.number().int().gte(0).default(5),
+  delay: z.coerce.number().int().gte(0).prefault(5),
   payload: z.string().refine(
     (val) => {
       try {
@@ -27,7 +27,7 @@ const FormSchema = z.object({
       }
     },
     {
-      message: 'The payload should be a JSON object',
+        error: 'The payload should be a JSON object'
     }
   ),
 })

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -53,10 +53,10 @@ const formUnion = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('datadog'),
     api_key: z.string().min(1, {
-        error: 'API key is required'
+      error: 'API key is required',
     }),
     region: z.string().min(1, {
-        error: 'Region is required'
+      error: 'Region is required',
     }),
   }),
   z.object({
@@ -71,7 +71,7 @@ const formUnion = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('loki'),
     url: z.string().min(1, {
-        error: 'Loki URL is required'
+      error: 'Loki URL is required',
     }),
     headers: z.record(z.string(), z.string()),
     username: z.string().optional(),
@@ -82,7 +82,7 @@ const formUnion = z.discriminatedUnion('type', [
 const formSchema = z
   .object({
     name: z.string().min(1, {
-        error: 'Destination name is required'
+      error: 'Destination name is required',
     }),
     description: z.string().optional(),
   })

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -52,8 +52,12 @@ const formUnion = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('datadog'),
-    api_key: z.string().min(1, { message: 'API key is required' }),
-    region: z.string().min(1, { message: 'Region is required' }),
+    api_key: z.string().min(1, {
+        error: 'API key is required'
+    }),
+    region: z.string().min(1, {
+        error: 'Region is required'
+    }),
   }),
   z.object({
     type: z.literal('elastic'),
@@ -66,7 +70,9 @@ const formUnion = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('loki'),
-    url: z.string().min(1, { message: 'Loki URL is required' }),
+    url: z.string().min(1, {
+        error: 'Loki URL is required'
+    }),
     headers: z.record(z.string(), z.string()),
     username: z.string().optional(),
     password: z.string().optional(),
@@ -76,7 +82,7 @@ const formUnion = z.discriminatedUnion('type', [
 const formSchema = z
   .object({
     name: z.string().min(1, {
-      message: 'Destination name is required',
+        error: 'Destination name is required'
     }),
     description: z.string().optional(),
   })

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -32,8 +32,10 @@ import {
 
 const FORM_ID = 'org-billing-email'
 const formSchema = z.object({
-  billingEmail: z.string().email('Please provide a valid email address').optional(),
-  additionalBillingEmails: z.string().email({ message: 'invalid_email' }).array().default([]),
+  billingEmail: z.email('Please provide a valid email address').optional(),
+  additionalBillingEmails: z.email({
+        error: 'invalid_email'
+  }).array().prefault([]),
 })
 
 const BillingEmail = () => {

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -33,9 +33,12 @@ import {
 const FORM_ID = 'org-billing-email'
 const formSchema = z.object({
   billingEmail: z.email('Please provide a valid email address').optional(),
-  additionalBillingEmails: z.email({
-        error: 'invalid_email'
-  }).array().prefault([]),
+  additionalBillingEmails: z
+    .email({
+      error: 'invalid_email',
+    })
+    .array()
+    .prefault([]),
 })
 
 const BillingEmail = () => {

--- a/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
@@ -54,12 +54,12 @@ const FormSchema = z
   // set the error on both fields
   .refine((data) => data.metadataXmlUrl || data.metadataXmlFile, {
     path: ['metadataXmlUrl'],
-      error: 'Please provide either a metadata XML URL or upload a metadata XML file'
-})
+    error: 'Please provide either a metadata XML URL or upload a metadata XML file',
+  })
   .refine((data) => data.metadataXmlUrl || data.metadataXmlFile, {
     path: ['metadataXmlFile'],
-      error: 'Please provide either a metadata XML URL or upload a metadata XML file'
-})
+    error: 'Please provide either a metadata XML URL or upload a metadata XML file',
+  })
 
 export type SSOConfigFormSchema = z.infer<typeof FormSchema>
 

--- a/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
@@ -53,13 +53,13 @@ const FormSchema = z
   })
   // set the error on both fields
   .refine((data) => data.metadataXmlUrl || data.metadataXmlFile, {
-    message: 'Please provide either a metadata XML URL or upload a metadata XML file',
     path: ['metadataXmlUrl'],
-  })
+      error: 'Please provide either a metadata XML URL or upload a metadata XML file'
+})
   .refine((data) => data.metadataXmlUrl || data.metadataXmlFile, {
-    message: 'Please provide either a metadata XML URL or upload a metadata XML file',
     path: ['metadataXmlFile'],
-  })
+      error: 'Please provide either a metadata XML URL or upload a metadata XML file'
+})
 
 export type SSOConfigFormSchema = z.infer<typeof FormSchema>
 

--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -75,22 +75,14 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
     },
   })
 
-  const getFormSchema = () => {
-    if (selectedId === 'new-folder') {
-      return z
-        .object({
-          name: z.string().min(1, 'Please provide a name for the folder'),
-        })
-        .refine((data) => !snapV2.allFolderNames.includes(data.name), {
-          message: 'This folder name already exists',
-          path: ['name'],
-        })
-    } else {
-      return z.object({})
-    }
-  }
-
-  const FormSchema = getFormSchema()
+  const FormSchema = z
+    .object({
+      name: z.string().min(1, 'Please provide a name for the folder'),
+    })
+    .refine((data) => !snapV2.allFolderNames.includes(data.name), {
+      message: 'This folder name already exists',
+      path: ['name'],
+    })
 
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onSubmit',

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -72,8 +72,8 @@ const formSchema = z
       return true
     },
     {
-      message: 'Must have at least one schema if Data API is enabled',
       path: ['dbSchema'],
+        error: 'Must have at least one schema if Data API is enabled'
     }
   )
 

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -73,7 +73,7 @@ const formSchema = z
     },
     {
       path: ['dbSchema'],
-        error: 'Must have at least one schema if Data API is enabled'
+      error: 'Must have at least one schema if Data API is enabled',
     }
   )
 

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -20,7 +20,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { LastSignInWrapper } from './LastSignInWrapper'
 
 const schema = z.object({
-  email: z.string().min(1, 'Email is required').email('Must be a valid email'),
+  email: z.email('Must be a valid email').min(1, 'Email is required'),
   password: z.string().min(1, 'Password is required'),
 })
 

--- a/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -16,7 +16,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 const WHITELIST_ERRORS = ['No SSO provider assigned for this domain']
 
 const schema = z.object({
-  email: z.string().min(1, 'Email is required').email('Must be a valid email'),
+  email: z.email('Must be a valid email').min(1, 'Email is required'),
 })
 
 const formId = 'sso-sign-in-form'

--- a/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -27,7 +27,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import PasswordConditionsHelper from './PasswordConditionsHelper'
 
 const schema = z.object({
-  email: z.string().min(1, 'Email is required').email('Must be a valid email'),
+  email: z.email('Must be a valid email').min(1, 'Email is required'),
   password: z
     .string()
     .min(1, 'Password is required')

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -83,7 +83,7 @@ const FormSchema = z
       const [match] = data.name.match(inverseValidBucketNameRegex) ?? []
       ctx.addIssue({
         path: ['name'],
-        code: "custom",
+        code: 'custom',
         message: !!match
           ? `Bucket name cannot contain the "${match}" character`
           : 'Bucket name contains an invalid special character',

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -69,21 +69,21 @@ const FormSchema = z
         (value) => value !== 'public',
         '"public" is a reserved name. Please choose another name'
       ),
-    type: z.enum(['STANDARD', 'ANALYTICS']).default('STANDARD'),
-    public: z.boolean().default(false),
-    has_file_size_limit: z.boolean().default(false),
+    type: z.enum(['STANDARD', 'ANALYTICS']).prefault('STANDARD'),
+    public: z.boolean().prefault(false),
+    has_file_size_limit: z.boolean().prefault(false),
     formatted_size_limit: z.coerce
       .number()
       .min(0, 'File size upload limit has to be at least 0')
       .optional(),
-    allowed_mime_types: z.string().trim().default(''),
+    allowed_mime_types: z.string().trim().prefault(''),
   })
   .superRefine((data, ctx) => {
     if (!validBucketNameRegex.test(data.name)) {
       const [match] = data.name.match(inverseValidBucketNameRegex) ?? []
       ctx.addIssue({
         path: ['name'],
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: !!match
           ? `Bucket name cannot contain the "${match}" character`
           : 'Bucket name contains an invalid special character',

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -44,7 +44,7 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
 
   const schema = z.object({
     confirm: z.literal(bucket.name, {
-      errorMap: () => ({ message: `Please enter "${bucket.name}" to confirm` }),
+      error: () => `Please enter "${bucket.name}" to confirm`,
     }),
   })
 

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -47,13 +47,13 @@ export interface EditBucketModalProps {
 
 const BucketSchema = z.object({
   name: z.string(),
-  public: z.boolean().default(false),
-  has_file_size_limit: z.boolean().default(false),
+  public: z.boolean().prefault(false),
+  has_file_size_limit: z.boolean().prefault(false),
   formatted_size_limit: z.coerce
     .number()
     .min(0, 'File size upload limit has to be at least 0')
     .optional(),
-  allowed_mime_types: z.string().trim().default(''),
+  allowed_mime_types: z.string().trim().prefault(''),
 })
 
 const formId = 'edit-storage-bucket-form'

--- a/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
@@ -61,7 +61,7 @@ export const ImportForeignSchemaDialog = ({
           return !schemas?.find((s) => s.name === val)
         },
         {
-            error: 'This schema already exists. Please specify a unique schema name.'
+          error: 'This schema already exists. Please specify a unique schema name.',
         }
       ),
   })

--- a/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
@@ -61,7 +61,7 @@ export const ImportForeignSchemaDialog = ({
           return !schemas?.find((s) => s.name === val)
         },
         {
-          message: 'This schema already exists. Please specify a unique schema name.',
+            error: 'This schema already exists. Please specify a unique schema name.'
         }
       ),
   })

--- a/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
@@ -50,7 +50,7 @@ export const CreateCredentialModal = ({ visible, onOpenChange }: CreateCredentia
 
   const FormSchema = z.object({
     description: z.string().min(3, {
-        error: 'Description must be at least 3 characters long'
+      error: 'Description must be at least 3 characters long',
     }),
   })
   const form = useForm<z.infer<typeof FormSchema>>({

--- a/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
@@ -50,7 +50,7 @@ export const CreateCredentialModal = ({ visible, onOpenChange }: CreateCredentia
 
   const FormSchema = z.object({
     description: z.string().min(3, {
-      message: 'Description must be at least 3 characters long',
+        error: 'Description must be at least 3 characters long'
     }),
   })
   const form = useForm<z.infer<typeof FormSchema>>({

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.schema.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.schema.ts
@@ -47,7 +47,7 @@ export const columnFilterSchema = z.object({
     .pipe(z.enum(REGIONS).array())
     .optional(),
   date: z
-    .string()
+    .any()
     .transform((val) => val.split(RANGE_DELIMITER).map(Number))
     .pipe(z.coerce.date().array())
     .optional(),
@@ -72,7 +72,7 @@ export const timelineChartSchema = z.object({
   ...LEVELS.reduce(
     (acc, level) => ({
       ...acc,
-      [level]: z.number().default(0),
+      [level]: z.number().prefault(0),
     }),
     {} as Record<(typeof LEVELS)[number], z.ZodNumber>
   ),

--- a/apps/studio/hooks/forms/useAIOptInForm.ts
+++ b/apps/studio/hooks/forms/useAIOptInForm.ts
@@ -17,9 +17,7 @@ import type { ResponseError } from 'types'
 
 // Shared schema definition
 export const AIOptInSchema = z.object({
-  aiOptInLevel: z.enum(['disabled', 'schema', 'schema_and_log', 'schema_and_log_and_data'], {
-    required_error: 'AI Opt-in level selection is required',
-  }),
+  aiOptInLevel: z.enum(['disabled', 'schema', 'schema_and_log', 'schema_and_log_and_data']),
 })
 
 export type AIOptInFormValues = z.infer<typeof AIOptInSchema>

--- a/apps/studio/lib/ai/tool-filter.test.ts
+++ b/apps/studio/lib/ai/tool-filter.test.ts
@@ -5,8 +5,8 @@ import { z } from 'zod'
 import {
   TOOL_CATEGORIES,
   TOOL_CATEGORY_MAP,
-  filterToolsByOptInLevel,
   createPrivacyMessageTool,
+  filterToolsByOptInLevel,
   toolSetValidationSchema,
   transformToolResult,
 } from './tool-filter'
@@ -309,7 +309,7 @@ describe('toolSetValidationSchema', () => {
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues).toHaveLength(2) // Two unknown tools
-      expect(result.error.issues[0].message).toContain('Invalid enum value')
+      expect(result.error.issues[0].message).toContain('Invalid key in record')
     }
   })
 

--- a/apps/studio/lib/ai/tool-filter.ts
+++ b/apps/studio/lib/ai/tool-filter.ts
@@ -16,7 +16,7 @@ const basicToolSchema = z.custom<Tool>((value) => typeof value === 'object')
 /**
  * Schema for validating that a tool set only contains known tools.
  */
-export const toolSetValidationSchema = z.record(
+export const toolSetValidationSchema = z.partialRecord(
   z.enum([
     // MCP tools
     'list_tables',

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -534,7 +534,8 @@ const nextConfig = {
     // On previews, typechecking is run via GitHub Action only for efficiency
     // On production, we turn it on to prevent errors from conflicting PRs getting into
     // prod
-    ignoreBuildErrors: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? false : true,
+    // ignoreBuildErrors: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? false : true,
+    ignoreBuildErrors: false,
   },
   eslint: {
     // We are already running linting via GH action, this will skip linting during production build on Vercel

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -44,7 +44,7 @@
     "@hcaptcha/react-hcaptcha": "^1.12.0",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.3",
-    "@hookform/resolvers": "^5.1.0",
+    "@hookform/resolvers": "catalog:",
     "@monaco-editor/react": "^4.6.0",
     "@next/bundle-analyzer": "15.3.1",
     "@number-flow/react": "^0.3.2",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -44,7 +44,7 @@
     "@hcaptcha/react-hcaptcha": "^1.12.0",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.3",
-    "@hookform/resolvers": "^3.1.1",
+    "@hookform/resolvers": "^5.1.0",
     "@monaco-editor/react": "^4.6.0",
     "@next/bundle-analyzer": "15.3.1",
     "@number-flow/react": "^0.3.2",

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -100,8 +100,8 @@ const sizesWithNoCostConfirmationRequired: DesiredInstanceSize[] = ['micro', 'sm
 
 const FormSchema = z.object({
   organization: z.string({
-    required_error: 'Please select an organization',
-  }),
+      error: (issue) => issue.input === undefined ? 'Please select an organization' : undefined
+}),
   projectName: z
     .string()
     .trim()
@@ -109,17 +109,19 @@ const FormSchema = z.object({
     .min(3, 'Project name must be at least 3 characters long.') // Minimum length check
     .max(64, 'Project name must be no longer than 64 characters.'), // Maximum length check
   postgresVersion: z.string({
-    required_error: 'Please enter a Postgres version.',
-  }),
+      error: (issue) => issue.input === undefined ? 'Please enter a Postgres version.' : undefined
+}),
   dbRegion: z.string({
-    required_error: 'Please select a region.',
-  }),
+      error: (issue) => issue.input === undefined ? 'Please select a region.' : undefined
+}),
   cloudProvider: z.string({
-    required_error: 'Please select a cloud provider.',
-  }),
+      error: (issue) => issue.input === undefined ? 'Please select a cloud provider.' : undefined
+}),
   dbPassStrength: z.number(),
   dbPass: z
-    .string({ required_error: 'Please enter a database password.' })
+    .string({
+        error: (issue) => issue.input === undefined ? 'Please enter a database password.' : undefined
+    })
     .min(1, 'Password is required.'),
   instanceSize: z.string(),
   dataApi: z.boolean(),
@@ -295,7 +297,7 @@ const Wizard: NextPageWithLayout = () => {
   FormSchema.superRefine(({ dbPassStrength }, refinementContext) => {
     if (dbPassStrength < DEFAULT_MINIMUM_PASSWORD_STRENGTH) {
       refinementContext.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ['dbPass'],
         message: passwordStrengthWarning || 'Password not secure enough',
       })

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -100,8 +100,8 @@ const sizesWithNoCostConfirmationRequired: DesiredInstanceSize[] = ['micro', 'sm
 
 const FormSchema = z.object({
   organization: z.string({
-      error: (issue) => issue.input === undefined ? 'Please select an organization' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'Please select an organization' : undefined),
+  }),
   projectName: z
     .string()
     .trim()
@@ -109,18 +109,19 @@ const FormSchema = z.object({
     .min(3, 'Project name must be at least 3 characters long.') // Minimum length check
     .max(64, 'Project name must be no longer than 64 characters.'), // Maximum length check
   postgresVersion: z.string({
-      error: (issue) => issue.input === undefined ? 'Please enter a Postgres version.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'Please enter a Postgres version.' : undefined),
+  }),
   dbRegion: z.string({
-      error: (issue) => issue.input === undefined ? 'Please select a region.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'Please select a region.' : undefined),
+  }),
   cloudProvider: z.string({
-      error: (issue) => issue.input === undefined ? 'Please select a cloud provider.' : undefined
-}),
+    error: (issue) => (issue.input === undefined ? 'Please select a cloud provider.' : undefined),
+  }),
   dbPassStrength: z.number(),
   dbPass: z
     .string({
-        error: (issue) => issue.input === undefined ? 'Please enter a database password.' : undefined
+      error: (issue) =>
+        issue.input === undefined ? 'Please enter a database password.' : undefined,
     })
     .min(1, 'Password is required.'),
   instanceSize: z.string(),
@@ -297,7 +298,7 @@ const Wizard: NextPageWithLayout = () => {
   FormSchema.superRefine(({ dbPassStrength }, refinementContext) => {
     if (dbPassStrength < DEFAULT_MINIMUM_PASSWORD_STRENGTH) {
       refinementContext.addIssue({
-        code: "custom",
+        code: 'custom',
         path: ['dbPass'],
         message: passwordStrengthWarning || 'Password not secure enough',
       })

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -75,7 +75,7 @@ async function openAiDb(): Promise<IDBPDatabase<AiAssistantDB>> {
 }
 
 async function getAiState(projectRef: string): Promise<StoredAiAssistantState | undefined> {
-  if (!projectRef) return undefined
+  if (typeof window === 'undefined' || !projectRef) return undefined
   try {
     const db = await openAiDb()
     return await db.get(STORE_NAME, projectRef)

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -17,7 +17,7 @@
     "typecheck": "contentlayer2 build && tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.1.1",
+    "@hookform/resolvers": "catalog:",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-accordion": "*",
     "@radix-ui/react-alert-dialog": "*",

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/components/dynamic-form.tsx
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/components/dynamic-form.tsx
@@ -1,8 +1,5 @@
 'use client'
 
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
-import type { z, ZodTypeAny } from 'zod'
 import { Button } from '@/registry/default/components/ui/button'
 import {
   Form,
@@ -14,7 +11,6 @@ import {
   FormMessage,
 } from '@/registry/default/components/ui/form'
 import { Input } from '@/registry/default/components/ui/input'
-import { Switch } from '@/registry/default/components/ui/switch'
 import {
   Select,
   SelectContent,
@@ -22,7 +18,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/registry/default/components/ui/select'
+import { Switch } from '@/registry/default/components/ui/switch'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+import type { z, ZodTypeAny } from 'zod'
 
 interface DynamicFormProps<T extends z.ZodRawShape = z.ZodRawShape> {
   schema: z.ZodObject<T>
@@ -84,7 +84,8 @@ export function DynamicForm<T extends z.ZodRawShape = z.ZodRawShape>({
 
   const defaultValues = Object.keys(schema.shape).reduce(
     (acc, key) => {
-      const originalFieldSchema = schema.shape[key]
+      // [Joshen] Temp as any here to silence warnings for zod migration to v4
+      const originalFieldSchema = schema.shape[key] as any
       if (typeof originalFieldSchema === 'undefined') {
         throw new Error(
           `Schema error: schema.shape['${key}'] is undefined. Check schema definition.`
@@ -147,11 +148,12 @@ export function DynamicForm<T extends z.ZodRawShape = z.ZodRawShape>({
       const schemaKeys = Object.keys(schema.shape)
       const processedInitialValues = schemaKeys.reduce(
         (acc, key) => {
-          const fieldDefFromSchema = schema.shape[key]
+          // [Joshen] Temp as any here to silence warnings for zod migration to v4
+          const fieldDefFromSchema = schema.shape[key] as any
           if (typeof fieldDefFromSchema === 'undefined') {
             throw new Error(`Schema error in useEffect: schema.shape['${key}'] is undefined.`)
           }
-          const value = initialValues.hasOwnProperty(key) ? initialValues[key] : undefined
+          const value = initialValues.hasOwnProperty(key) ? (initialValues as any)[key] : undefined
           const baseFieldType = unwrapZodType(fieldDefFromSchema)
 
           // Support both old (typeName) and new (type) Zod formats
@@ -404,7 +406,7 @@ export function DynamicForm<T extends z.ZodRawShape = z.ZodRawShape>({
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         {Object.keys(schema.shape).map((fieldName) =>
-          renderField(fieldName, schema.shape[fieldName])
+          renderField(fieldName, (schema.shape as any)[fieldName])
         )}
         <div className="pt-6">
           <Button type="submit" disabled={isLoading}>

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/components/supabase-manager/auth.tsx
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/components/supabase-manager/auth.tsx
@@ -1,10 +1,17 @@
 'use client'
 
+import { Alert, AlertDescription, AlertTitle } from '@/registry/default/components/ui/alert'
+import { Button } from '@/registry/default/components/ui/button'
+import { Skeleton } from '@/registry/default/components/ui/skeleton'
 import { DynamicForm } from '@/registry/default/platform/platform-kit-nextjs/components/dynamic-form'
+import { useSheetNavigation } from '@/registry/default/platform/platform-kit-nextjs/contexts/SheetNavigationContext'
 import {
   useGetAuthConfig,
   useUpdateAuthConfig,
 } from '@/registry/default/platform/platform-kit-nextjs/hooks/use-auth'
+import { AlertTriangle, ChevronRight, Mail, Phone, User } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
+import { z } from 'zod'
 import {
   authEmailProviderSchema,
   authFieldLabels,
@@ -13,13 +20,6 @@ import {
   authGoogleProviderSchema,
   authPhoneProviderSchema,
 } from '../../lib/schemas/auth'
-import { AlertTriangle, ChevronRight, Mail, Phone, User } from 'lucide-react'
-import { useCallback, useMemo } from 'react'
-import { z } from 'zod'
-import { useSheetNavigation } from '@/registry/default/platform/platform-kit-nextjs/contexts/SheetNavigationContext'
-import { Skeleton } from '@/registry/default/components/ui/skeleton'
-import { Button } from '@/registry/default/components/ui/button'
-import { Alert, AlertDescription, AlertTitle } from '@/registry/default/components/ui/alert'
 
 function ProviderSettingsView({
   projectRef,
@@ -29,14 +29,16 @@ function ProviderSettingsView({
   onSuccess,
 }: {
   projectRef: string
-  schema: z.ZodObject<any> | z.ZodEffects<z.ZodObject<any>>
+  schema: z.ZodObject<any>
   title: string
   initialValues: any
   onSuccess: () => void
 }) {
   const { mutate: updateAuthConfig, isPending: isUpdatingConfig } = useUpdateAuthConfig()
 
-  const actualSchema = 'shape' in schema ? schema : (schema._def.schema as z.ZodObject<any>)
+  // [Joshen] Temp as any to silence warnings for zod migration to V4
+  const actualSchema =
+    'shape' in schema ? schema : ((schema as any)._def.schema as z.ZodObject<any>)
 
   const handleUpdateAuthConfig = (formData: z.infer<typeof actualSchema>) => {
     const payload = Object.fromEntries(
@@ -121,7 +123,7 @@ export function AuthManager({ projectRef }: { projectRef: string }) {
     name: string
     icon: React.ReactNode
     description: string
-    schema: z.ZodObject<any> | z.ZodEffects<z.ZodObject<any>>
+    schema: z.ZodObject<any>
   }[] = [
     {
       icon: <Mail className="h-4 w-4 text-muted-foreground" />,
@@ -144,7 +146,7 @@ export function AuthManager({ projectRef }: { projectRef: string }) {
   ]
 
   const handleProviderClick = useCallback(
-    (provider: { name: string; schema: z.ZodObject<any> | z.ZodEffects<z.ZodObject<any>> }) => {
+    (provider: { name: string; schema: z.ZodObject<any> }) => {
       push({
         title: `${provider.name} Provider Settings`,
         component: (

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/components/supabase-manager/database.tsx
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/components/supabase-manager/database.tsx
@@ -1,20 +1,20 @@
 'use client'
 
-import { useState, useMemo, useCallback } from 'react'
-import { z, type ZodTypeAny } from 'zod'
-import { useListTables } from '@/registry/default/platform/platform-kit-nextjs/hooks/use-tables'
-import { useRunQuery } from '@/registry/default/platform/platform-kit-nextjs/hooks/use-run-query'
-import { SqlEditor } from '@/registry/default/platform/platform-kit-nextjs/components/sql-editor'
-import { DynamicForm } from '@/registry/default/platform/platform-kit-nextjs/components/dynamic-form'
-import { toast } from 'sonner'
-import { useSheetNavigation } from '@/registry/default/platform/platform-kit-nextjs/contexts/SheetNavigationContext'
-import { Skeleton } from '@/registry/default/components/ui/skeleton'
-import { Button } from '@/registry/default/components/ui/button'
-import { AlertTriangle, Table, Wand } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/registry/default/components/ui/alert'
+import { Button } from '@/registry/default/components/ui/button'
+import { Skeleton } from '@/registry/default/components/ui/skeleton'
+import { DynamicForm } from '@/registry/default/platform/platform-kit-nextjs/components/dynamic-form'
+import { SqlEditor } from '@/registry/default/platform/platform-kit-nextjs/components/sql-editor'
+import { useSheetNavigation } from '@/registry/default/platform/platform-kit-nextjs/contexts/SheetNavigationContext'
+import { useRunQuery } from '@/registry/default/platform/platform-kit-nextjs/hooks/use-run-query'
+import { useListTables } from '@/registry/default/platform/platform-kit-nextjs/hooks/use-tables'
+import { AlertTriangle, Table, Wand } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { z, type ZodTypeAny } from 'zod'
 
 // Helper to generate a Zod schema from the table's column definitions
-function generateZodSchema(table: any): z.ZodObject<any, any, any> {
+function generateZodSchema(table: any): z.ZodObject<any, any> {
   if (!table || !table.columns) {
     return z.object({})
   }

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/pg-meta/types.ts
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/pg-meta/types.ts
@@ -4,11 +4,11 @@ export const postgresPrimaryKeySchema = z.object({
   schema: z.string(),
   table_name: z.string(),
   name: z.string(),
-  table_id: z.number().int(),
+  table_id: z.int(),
 })
 
 export const postgresRelationshipSchema = z.object({
-  id: z.number().int(),
+  id: z.int(),
   constraint_name: z.string(),
   source_schema: z.string(),
   source_table_name: z.string(),
@@ -19,11 +19,11 @@ export const postgresRelationshipSchema = z.object({
 })
 
 export const postgresColumnSchema = z.object({
-  table_id: z.number().int(),
+  table_id: z.int(),
   schema: z.string(),
   table: z.string(),
   id: z.string().regex(/^(\d+)\.(\d+)$/),
-  ordinal_position: z.number().int(),
+  ordinal_position: z.int(),
   name: z.string(),
   default_value: z.any(),
   data_type: z.string(),
@@ -40,7 +40,7 @@ export const postgresColumnSchema = z.object({
 })
 
 export const postgresTableSchema = z.object({
-  id: z.number().int(),
+  id: z.int(),
   schema: z.string(),
   name: z.string(),
   rls_enabled: z.boolean(),
@@ -51,10 +51,10 @@ export const postgresTableSchema = z.object({
     z.literal('FULL'),
     z.literal('NOTHING'),
   ]),
-  bytes: z.number().int(),
+  bytes: z.int(),
   size: z.string(),
-  live_rows_estimate: z.number().int(),
-  dead_rows_estimate: z.number().int(),
+  live_rows_estimate: z.int(),
+  dead_rows_estimate: z.int(),
   comment: z.string().nullable(),
   columns: z.array(postgresColumnSchema).optional(),
   primary_keys: z.array(postgresPrimaryKeySchema),

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/schemas/auth.ts
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/schemas/auth.ts
@@ -118,7 +118,8 @@ export const authEmailProviderSchema = z
       .describe(
         'Rejects the use of known or easy to guess passwords on sign up or password change. Powered by the HaveIBeenPwned.org Pwned Passwords API.'
       ),
-    password_min_length: z.int()
+    password_min_length: z
+      .int()
       .min(6, 'Must be greater or equal to 6.')
       .describe(
         'Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.'
@@ -136,11 +137,13 @@ export const authEmailProviderSchema = z
       .optional()
       .transform((val) => (val === NO_REQUIRED_CHARACTERS ? '' : val))
       .describe('Passwords that do not have at least one of each will be rejected as weak.'),
-    mailer_otp_exp: z.int()
+    mailer_otp_exp: z
+      .int()
       .min(0, 'Must be more than 0')
       .max(86400, 'Must be no more than 86400')
       .describe('Duration before an email otp / link expires in seconds.'),
-    mailer_otp_length: z.int()
+    mailer_otp_length: z
+      .int()
       .min(6, 'Must be at least 6')
       .max(10, 'Must be no more than 10')
       .optional()
@@ -186,9 +189,7 @@ export const authPhoneProviderSchema = z
       .boolean()
       .optional()
       .describe('Users will need to confirm their phone number before signing in.'),
-    sms_otp_exp: z.int()
-      .optional()
-      .describe('Duration before an SMS OTP expires in seconds.'),
+    sms_otp_exp: z.int().optional().describe('Duration before an SMS OTP expires in seconds.'),
     sms_otp_length: z.int().optional().describe('Number of digits in OTP.'),
     sms_template: z.string().optional().describe('To format the OTP code use `{{ .Code }}`'),
     sms_test_otp: z
@@ -197,9 +198,10 @@ export const authPhoneProviderSchema = z
       .describe(
         'Register phone number and OTP combinations for testing as a comma separated list of <phone number>=<otp> pairs. Example: `18005550123=789012`'
       ),
-    sms_test_otp_valid_until: z.iso.datetime({
-              error: 'Invalid datetime string.'
-        })
+    sms_test_otp_valid_until: z.iso
+      .datetime({
+        error: 'Invalid datetime string.',
+      })
       .optional()
       .describe(
         "Test phone number and OTP combinations won't be active past this date and time (local time zone)."
@@ -234,14 +236,14 @@ export const authGoogleProviderSchema = authGoogleProviderObject
   .superRefine((data, ctx) => {
     if (data.external_google_enabled && !data.external_google_client_id) {
       ctx.addIssue({
-        code: "custom",
+        code: 'custom',
         path: ['external_google_client_id'],
         message: 'At least one Client ID is required when Google sign-in is enabled.',
       })
     }
     if (data.external_google_client_id && data.external_google_client_id.includes(' ')) {
       ctx.addIssue({
-        code: "custom",
+        code: 'custom',
         path: ['external_google_client_id'],
         message: 'Client IDs should not contain spaces.',
       })

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/schemas/auth.ts
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/schemas/auth.ts
@@ -118,9 +118,7 @@ export const authEmailProviderSchema = z
       .describe(
         'Rejects the use of known or easy to guess passwords on sign up or password change. Powered by the HaveIBeenPwned.org Pwned Passwords API.'
       ),
-    password_min_length: z
-      .number()
-      .int()
+    password_min_length: z.int()
       .min(6, 'Must be greater or equal to 6.')
       .describe(
         'Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.'
@@ -138,15 +136,11 @@ export const authEmailProviderSchema = z
       .optional()
       .transform((val) => (val === NO_REQUIRED_CHARACTERS ? '' : val))
       .describe('Passwords that do not have at least one of each will be rejected as weak.'),
-    mailer_otp_exp: z
-      .number()
-      .int()
+    mailer_otp_exp: z.int()
       .min(0, 'Must be more than 0')
       .max(86400, 'Must be no more than 86400')
       .describe('Duration before an email otp / link expires in seconds.'),
-    mailer_otp_length: z
-      .number()
-      .int()
+    mailer_otp_length: z.int()
       .min(6, 'Must be at least 6')
       .max(10, 'Must be no more than 10')
       .optional()
@@ -192,12 +186,10 @@ export const authPhoneProviderSchema = z
       .boolean()
       .optional()
       .describe('Users will need to confirm their phone number before signing in.'),
-    sms_otp_exp: z
-      .number()
-      .int()
+    sms_otp_exp: z.int()
       .optional()
       .describe('Duration before an SMS OTP expires in seconds.'),
-    sms_otp_length: z.number().int().optional().describe('Number of digits in OTP.'),
+    sms_otp_length: z.int().optional().describe('Number of digits in OTP.'),
     sms_template: z.string().optional().describe('To format the OTP code use `{{ .Code }}`'),
     sms_test_otp: z
       .string()
@@ -205,9 +197,9 @@ export const authPhoneProviderSchema = z
       .describe(
         'Register phone number and OTP combinations for testing as a comma separated list of <phone number>=<otp> pairs. Example: `18005550123=789012`'
       ),
-    sms_test_otp_valid_until: z
-      .string()
-      .datetime({ message: 'Invalid datetime string.' })
+    sms_test_otp_valid_until: z.iso.datetime({
+              error: 'Invalid datetime string.'
+        })
       .optional()
       .describe(
         "Test phone number and OTP combinations won't be active past this date and time (local time zone)."
@@ -242,14 +234,14 @@ export const authGoogleProviderSchema = authGoogleProviderObject
   .superRefine((data, ctx) => {
     if (data.external_google_enabled && !data.external_google_client_id) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ['external_google_client_id'],
         message: 'At least one Client ID is required when Google sign-in is enabled.',
       })
     }
     if (data.external_google_client_id && data.external_google_client_id.includes(' ')) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ['external_google_client_id'],
         message: 'Client IDs should not contain spaces.',
       })

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -82,7 +82,7 @@
     "yup": "^1.4.0"
   },
   "devDependencies": {
-    "@hookform/resolvers": "^3.1.1",
+    "@hookform/resolvers": "catalog:",
     "@types/animejs": "^3.1.12",
     "@types/classnames": "^2.3.1",
     "@types/common-tags": "^1.8.4",

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -1,7 +1,7 @@
-const ui = require('./ui.config.js')
 const deepMerge = require('deepmerge')
 const plugin = require('tailwindcss/plugin')
 
+const ui = require('./ui.config.js')
 const color = require('./../ui/build/css/tw-extend/color')
 
 /**

--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -318,7 +318,7 @@ export function update(currentFunc: PGFunction, { name, schema, definition }: PG
 }
 
 export const pgFunctionDeleteZod = z.object({
-  cascade: z.boolean().default(false).optional(),
+  cascade: z.boolean().prefault(false).optional(),
 })
 
 export type PGFunctionDelete = z.infer<typeof pgFunctionDeleteZod>

--- a/packages/pg-meta/src/pg-meta-triggers.ts
+++ b/packages/pg-meta/src/pg-meta-triggers.ts
@@ -91,9 +91,9 @@ export function retrieve(params: TriggerIdentifier): TriggersRetrieveReturn {
 
 export const pgTriggerCreateZod = z.object({
   name: z.string(),
-  schema: z.string().optional().default('public'),
+  schema: z.string().optional().prefault('public'),
   table: z.string(),
-  function_schema: z.string().optional().default('public'),
+  function_schema: z.string().optional().prefault('public'),
   function_name: z.string(),
   function_args: z.array(z.string()).optional(),
   activation: z.enum(['BEFORE', 'AFTER', 'INSTEAD OF']),

--- a/packages/pg-meta/test/schemas.test.ts
+++ b/packages/pg-meta/test/schemas.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeAll, afterAll } from 'vitest'
+import { afterAll, beforeAll, expect, test } from 'vitest'
 import pgMeta from '../src/index'
-import { createTestDatabase, cleanupRoot } from './db/utils'
+import { cleanupRoot, createTestDatabase } from './db/utils'
 
 beforeAll(async () => {
   // Any global setup if needed
@@ -43,7 +43,7 @@ withTestDatabase('list with system schemas', async ({ executeQuery }) => {
 
 withTestDatabase('list without system schemas', async ({ executeQuery }) => {
   const { sql, zod } = await pgMeta.schemas.list({ includeSystemSchemas: false })
-  const rq = await executeQuery<typeof zod._type>(sql)
+  const rq = await executeQuery<typeof zod.type>(sql)
   const res = zod.parse(rq)
 
   expect(res.find(({ name }) => name === 'pg_catalog')).toMatchInlineSnapshot(`undefined`)

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -480,7 +480,7 @@
     }
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.1.1",
+    "@hookform/resolvers": "catalog:",
     "@monaco-editor/react": "^4.6.0",
     "@supabase/sql-to-rest": "^0.1.6",
     "@supabase/supabase-js": "catalog:",

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -85,7 +85,7 @@ const TextConfirmModal = forwardRef<
       confirmValue: z.preprocess(
         (val) => (typeof val === 'string' ? val.trim() : val),
         z.literal(confirmString.trim(), {
-          errorMap: () => ({ message: errorMessage }),
+          error: () => errorMessage,
         })
       ),
     })

--- a/packages/ui-patterns/src/form/FormLayout2.tsx
+++ b/packages/ui-patterns/src/form/FormLayout2.tsx
@@ -61,19 +61,20 @@ const items = [
 export const Page = () => {
   const FormSchema = z.object({
     username: z.string().min(2, {
-        error: 'Username must be at least 2 characters.'
+      error: 'Username must be at least 2 characters.',
     }),
     kevins_input: z.string().min(6, {
-        error: 'Username must be at least 6 characters.'
+      error: 'Username must be at least 6 characters.',
     }),
     email: z.email(),
     consistent_settings: z.boolean().prefault(false).optional(),
     switch_option: z.boolean().prefault(false).optional(),
     items: z.array(z.string()).refine((value) => value.some((item) => item), {
-        error: 'You have to select at least one item.'
+      error: 'You have to select at least one item.',
     }),
     type: z.enum(['all', 'mentions', 'none'], {
-        error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
+      error: (issue) =>
+        issue.input === undefined ? 'You need to select a notification type.' : undefined,
     }),
   })
 

--- a/packages/ui-patterns/src/form/FormLayout2.tsx
+++ b/packages/ui-patterns/src/form/FormLayout2.tsx
@@ -61,23 +61,19 @@ const items = [
 export const Page = () => {
   const FormSchema = z.object({
     username: z.string().min(2, {
-      message: 'Username must be at least 2 characters.',
+        error: 'Username must be at least 2 characters.'
     }),
     kevins_input: z.string().min(6, {
-      message: 'Username must be at least 6 characters.',
+        error: 'Username must be at least 6 characters.'
     }),
-    email: z
-      .string({
-        required_error: 'Please select an email to display.',
-      })
-      .email(),
-    consistent_settings: z.boolean().default(false).optional(),
-    switch_option: z.boolean().default(false).optional(),
+    email: z.email(),
+    consistent_settings: z.boolean().prefault(false).optional(),
+    switch_option: z.boolean().prefault(false).optional(),
     items: z.array(z.string()).refine((value) => value.some((item) => item), {
-      message: 'You have to select at least one item.',
+        error: 'You have to select at least one item.'
     }),
     type: z.enum(['all', 'mentions', 'none'], {
-      required_error: 'You need to select a notification type.',
+        error: (issue) => issue.input === undefined ? 'You need to select a notification type.' : undefined
     }),
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@hookform/resolvers':
+      specifier: ^5.1.0
+      version: 5.1.0
     '@supabase/auth-js':
       specifier: 2.72.0-rc.11
       version: 2.72.0-rc.11
@@ -206,8 +209,8 @@ importers:
   apps/design-system:
     dependencies:
       '@hookform/resolvers':
-        specifier: ^3.1.1
-        version: 3.3.1(react-hook-form@7.47.0(react@18.3.1))
+        specifier: 'catalog:'
+        version: 5.1.0(react-hook-form@7.47.0(react@18.3.1))
       contentlayer2:
         specifier: 0.4.6
         version: 0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1)
@@ -376,7 +379,7 @@ importers:
         version: 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10.3.0
-        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
+        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.49.3
@@ -763,7 +766,7 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3(react@18.3.1)
       '@hookform/resolvers':
-        specifier: ^5.1.0
+        specifier: 'catalog:'
         version: 5.1.0(react-hook-form@7.47.0(react@18.3.1))
       '@monaco-editor/react':
         specifier: ^4.6.0
@@ -785,7 +788,7 @@ importers:
         version: 1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10.3.0
-        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
+        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
       '@std/path':
         specifier: npm:@jsr/std__path@^1.0.8
         version: '@jsr/std__path@1.0.8'
@@ -1197,7 +1200,7 @@ importers:
         version: 2.4.11(typescript@5.5.2)
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -1232,8 +1235,8 @@ importers:
   apps/ui-library:
     dependencies:
       '@hookform/resolvers':
-        specifier: ^3.1.1
-        version: 3.3.1(react-hook-form@7.47.0(react@18.3.1))
+        specifier: 'catalog:'
+        version: 5.1.0(react-hook-form@7.47.0(react@18.3.1))
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1555,7 +1558,7 @@ importers:
         version: 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10
-        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
+        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.49.3
@@ -1699,8 +1702,8 @@ importers:
         version: 1.4.0
     devDependencies:
       '@hookform/resolvers':
-        specifier: ^3.1.1
-        version: 3.3.1(react-hook-form@7.47.0(react@18.3.1))
+        specifier: 'catalog:'
+        version: 5.1.0(react-hook-form@7.47.0(react@18.3.1))
       '@types/animejs':
         specifier: ^3.1.12
         version: 3.1.12
@@ -2297,8 +2300,8 @@ importers:
   packages/ui-patterns:
     dependencies:
       '@hookform/resolvers':
-        specifier: ^3.1.1
-        version: 3.3.1(react-hook-form@7.47.0(react@18.3.1))
+        specifier: 'catalog:'
+        version: 5.1.0(react-hook-form@7.47.0(react@18.3.1))
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.6.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2461,7 +2464,7 @@ importers:
         version: link:../api-types
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -4031,11 +4034,6 @@ packages:
     resolution: {integrity: sha512-fEcPfo4oN345SoqdlCDdSa4ivjaKbk0jTd+oubcgNxnNgAfzysfwWfQUr+51wigiWHQQRiZNd1Ao0M5Y3M2EGg==}
     peerDependencies:
       react: '>= 16'
-
-  '@hookform/resolvers@3.3.1':
-    resolution: {integrity: sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==}
-    peerDependencies:
-      react-hook-form: ^7.0.0
 
   '@hookform/resolvers@5.1.0':
     resolution: {integrity: sha512-A5tY8gxqvvR0lFfropqpy/gUDOxjwT7LZCxJ8lNA9puK7nFNRl/O0egGKxzdF4JSz/pnnT1O8g76P/YMyTBEFw==}
@@ -21210,10 +21208,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@hookform/resolvers@3.3.1(react-hook-form@7.47.0(react@18.3.1))':
-    dependencies:
-      react-hook-form: 7.47.0(react@18.3.1)
-
   '@hookform/resolvers@5.1.0(react-hook-form@7.47.0(react@18.3.1))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -25377,7 +25371,7 @@ snapshots:
 
   '@sentry/core@10.3.0': {}
 
-  '@sentry/nextjs@10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)':
+  '@sentry/nextjs@10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.36.0
@@ -34060,7 +34054,7 @@ snapshots:
     dependencies:
       js-yaml-loader: 1.2.2
 
-  next-router-mock@0.9.13(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1):
+  next-router-mock@0.9.13(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1):
     dependencies:
       next: 15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       react: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,9 @@ importers:
       smol-toml:
         specifier: ^1.3.1
         version: 1.3.1
+      tailwindcss:
+        specifier: ^3.4.1
+        version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -4262,10 +4265,6 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jridgewell/gen-mapping@0.3.5':
-    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
-    engines: {node: '>=6.0.0'}
 
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
@@ -9863,10 +9862,6 @@ packages:
     resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
     engines: {node: '>= 6'}
 
-  chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
-    engines: {node: '>= 8.10.0'}
-
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -12995,10 +12990,6 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jiti@1.20.0:
-    resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
-    hasBin: true
-
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -14955,9 +14946,6 @@ packages:
 
   phenomenon@1.6.0:
     resolution: {integrity: sha512-7h9/fjPD3qNlgggzm88cY58l9sudZ6Ey+UmZsizfhtawO6E3srZQXywaNm2lBwT72TbpHYRPy7ytIHeBUD/G0A==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -20054,8 +20042,8 @@ snapshots:
     dependencies:
       '@contentlayer2/core': 0.4.3(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1)
       '@contentlayer2/utils': 0.4.3
-      chokidar: 3.5.3
-      fast-glob: 3.3.2
+      chokidar: 3.6.0
+      fast-glob: 3.3.3
       gray-matter: 4.0.3
       imagescript: 1.3.0
       micromatch: 4.0.8
@@ -20093,7 +20081,7 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.24.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.36.0
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       hash-wasm: 4.11.0
       inflection: 3.0.0
       memfs: 4.14.1
@@ -21389,12 +21377,6 @@ snapshots:
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
-
-  '@jridgewell/gen-mapping@0.3.5':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -26981,7 +26963,7 @@ snapshots:
 
   '@ts-morph/common@0.23.0':
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       minimatch: 9.0.5
       mkdirp: 3.0.1
       path-browserify: 1.0.1
@@ -28733,18 +28715,6 @@ snapshots:
       htmlparser2: 8.0.2
       parse5: 7.1.2
       parse5-htmlparser2-tree-adapter: 7.0.0
-
-  chokidar@3.5.3:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chokidar@3.6.0:
     dependencies:
@@ -32195,8 +32165,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jiti@1.20.0: {}
-
   jiti@1.21.7: {}
 
   jiti@2.4.2: {}
@@ -34987,8 +34955,6 @@ snapshots:
 
   phenomenon@1.6.0: {}
 
-  picocolors@1.0.1: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -37361,7 +37327,7 @@ snapshots:
 
   sucrase@3.34.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/gen-mapping': 0.3.8
       commander: 4.1.1
       glob: 7.1.6
       lines-and-columns: 1.2.4
@@ -37458,25 +37424,25 @@ snapshots:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       didyoumean: 1.2.2
       dlv: 1.1.3
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.20.0
+      jiti: 1.21.7
       lilconfig: 2.1.0
       micromatch: 4.0.8
       normalize-path: 3.0.0
       object-hash: 3.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       postcss: 8.5.3
       postcss-import: 15.1.0(postcss@8.5.3)
       postcss-js: 4.0.1(postcss@8.5.3)
       postcss-load-config: 4.0.1(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       postcss-nested: 6.0.1(postcss@8.5.3)
       postcss-selector-parser: 6.0.13
-      resolve: 1.22.8
+      resolve: 1.22.10
       sucrase: 3.34.0
     transitivePeerDependencies:
       - ts-node

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,7 +376,7 @@ importers:
         version: 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10.3.0
-        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
+        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.49.3
@@ -763,8 +763,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3(react@18.3.1)
       '@hookform/resolvers':
-        specifier: ^3.1.1
-        version: 3.3.1(react-hook-form@7.47.0(react@18.3.1))
+        specifier: ^5.1.0
+        version: 5.1.0(react-hook-form@7.47.0(react@18.3.1))
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.6.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -785,7 +785,7 @@ importers:
         version: 1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10.3.0
-        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
+        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
       '@std/path':
         specifier: npm:@jsr/std__path@^1.0.8
         version: '@jsr/std__path@1.0.8'
@@ -1197,7 +1197,7 @@ importers:
         version: 2.4.11(typescript@5.5.2)
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -1555,7 +1555,7 @@ importers:
         version: 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^10
-        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
+        version: 10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.49.3
@@ -1839,7 +1839,7 @@ importers:
     devDependencies:
       openapi-typescript:
         specifier: ^7.4.3
-        version: 7.5.2(encoding@0.1.13)(typescript@5.7.3)
+        version: 7.5.2(encoding@0.1.13)(typescript@5.5.2)
       prettier:
         specifier: 3.2.4
         version: 3.2.4
@@ -1948,10 +1948,10 @@ importers:
         version: 0.1.9
       '@tailwindcss/forms':
         specifier: ^0.5.0
-        version: 0.5.6(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)))
+        version: 0.5.6(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.9
-        version: 0.5.10(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)))
+        version: 0.5.10(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2)))
       deepmerge:
         specifier: ^4.2.2
         version: 4.3.1
@@ -1964,16 +1964,16 @@ importers:
     devDependencies:
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3))
+        version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       tailwindcss-animate:
         specifier: ^1.0.6
-        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)))
+        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2)))
 
   packages/eslint-config-supabase:
     dependencies:
       eslint-config-next:
         specifier: 15.3.1
-        version: 15.3.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+        version: 15.3.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.57.0(supports-color@8.1.1))
@@ -2461,7 +2461,7 @@ importers:
         version: link:../api-types
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -4036,6 +4036,11 @@ packages:
     resolution: {integrity: sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==}
     peerDependencies:
       react-hook-form: ^7.0.0
+
+  '@hookform/resolvers@5.1.0':
+    resolution: {integrity: sha512-A5tY8gxqvvR0lFfropqpy/gUDOxjwT7LZCxJ8lNA9puK7nFNRl/O0egGKxzdF4JSz/pnnT1O8g76P/YMyTBEFw==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -8064,6 +8069,9 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
@@ -17378,11 +17386,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   ua-parser-js@1.0.40:
     resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
     hasBin: true
@@ -21209,6 +21212,11 @@ snapshots:
 
   '@hookform/resolvers@3.3.1(react-hook-form@7.47.0(react@18.3.1))':
     dependencies:
+      react-hook-form: 7.47.0(react@18.3.1)
+
+  '@hookform/resolvers@5.1.0(react-hook-form@7.47.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.47.0(react@18.3.1)
 
   '@humanwhocodes/config-array@0.11.14(supports-color@8.1.1)':
@@ -25369,7 +25377,7 @@ snapshots:
 
   '@sentry/core@10.3.0': {}
 
-  '@sentry/nextjs@10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)':
+  '@sentry/nextjs@10.3.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.94.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.36.0
@@ -26114,6 +26122,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@stitches/core@1.2.8': {}
 
   '@stripe/react-stripe-js@3.7.0(@stripe/stripe-js@7.5.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -26305,11 +26315,6 @@ snapshots:
       mini-svg-data-uri: 1.4.4
       tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
 
-  '@tailwindcss/forms@0.5.6(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)))':
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3))
-
   '@tailwindcss/typography@0.5.10(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2)))':
     dependencies:
       lodash.castarray: 4.4.0
@@ -26317,14 +26322,6 @@ snapshots:
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
-
-  '@tailwindcss/typography@0.5.10(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)))':
-    dependencies:
-      lodash.castarray: 4.4.0
-      lodash.isplainobject: 4.0.6
-      lodash.merge: 4.6.2
-      postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3))
 
   '@tanstack/directive-functions-plugin@1.114.12(@types/node@22.13.14)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.4.5)':
     dependencies:
@@ -27508,42 +27505,42 @@ snapshots:
 
   '@types/zxcvbn@4.4.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 8.34.1
       eslint: 8.57.0(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 7.0.3
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.1.0(typescript@5.5.2)
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 7.2.0(supports-color@8.1.1)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.0(supports-color@8.1.1)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.34.1(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.34.1(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.5.2)
       '@typescript-eslint/types': 8.34.1
       debug: 4.4.0(supports-color@8.1.1)
-      typescript: 5.7.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -27557,18 +27554,18 @@ snapshots:
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/visitor-keys': 8.34.1
 
-  '@typescript-eslint/tsconfig-utils@8.34.1(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.34.1(typescript@5.5.2)':
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.5.2
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.34.1(supports-color@8.1.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.34.1(supports-color@8.1.1)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.0(supports-color@8.1.1)
-      ts-api-utils: 2.1.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.1.0(typescript@5.5.2)
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -27576,7 +27573,7 @@ snapshots:
 
   '@typescript-eslint/types@8.34.1': {}
 
-  '@typescript-eslint/typescript-estree@7.2.0(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@7.2.0(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/visitor-keys': 7.2.0
@@ -27585,16 +27582,16 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.0.3(typescript@5.7.3)
+      ts-api-utils: 1.0.3(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.34.1(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.34.1(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.34.1(supports-color@8.1.1)(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.7.3)
+      '@typescript-eslint/project-service': 8.34.1(supports-color@8.1.1)(typescript@5.5.2)
+      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.5.2)
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.0(supports-color@8.1.1)
@@ -27602,19 +27599,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.1.0(typescript@5.5.2)
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.0(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
-      '@typescript-eslint/typescript-estree': 8.34.1(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.34.1(supports-color@8.1.1)(typescript@5.5.2)
       eslint: 8.57.0(supports-color@8.1.1)
-      typescript: 5.7.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -30000,21 +29997,21 @@ snapshots:
       eslint-barrel-file-utils-win32-ia32-msvc: 0.0.10
       eslint-barrel-file-utils-win32-x64-msvc: 0.0.10
 
-  eslint-config-next@15.3.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3):
+  eslint-config-next@15.3.1(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2):
     dependencies:
       '@next/eslint-plugin-next': 15.3.1
       '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0(supports-color@8.1.1))
       eslint-plugin-react: 7.37.5(eslint@8.57.0(supports-color@8.1.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.0(supports-color@8.1.1))
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -30036,13 +30033,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.18.1
       eslint: 8.57.0(supports-color@8.1.1)
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-core-module: 2.16.1
@@ -30053,25 +30050,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.31.0)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -30081,7 +30078,7 @@ snapshots:
       eslint-barrel-file-utils: 0.0.10
       requireindex: 1.2.0
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -30092,7 +30089,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -30104,7 +30101,7 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -34063,7 +34060,7 @@ snapshots:
     dependencies:
       js-yaml-loader: 1.2.2
 
-  next-router-mock@0.9.13(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1):
+  next-router-mock@0.9.13(next@15.5.2(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1):
     dependencies:
       next: 15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       react: 18.3.1
@@ -34620,14 +34617,14 @@ snapshots:
 
   openapi-typescript-helpers@0.0.15: {}
 
-  openapi-typescript@7.5.2(encoding@0.1.13)(typescript@5.7.3):
+  openapi-typescript@7.5.2(encoding@0.1.13)(typescript@5.5.2):
     dependencies:
       '@redocly/openapi-core': 1.27.2(encoding@0.1.13)(supports-color@9.4.0)
       ansi-colors: 4.1.3
       change-case: 5.4.4
       parse-json: 8.1.0
       supports-color: 9.4.0
-      typescript: 5.7.3
+      typescript: 5.5.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - encoding
@@ -35139,14 +35136,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.3
       ts-node: 10.9.2(@types/node@22.13.14)(typescript@5.5.2)
-
-  postcss-load-config@4.0.1(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)):
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 2.4.5
-    optionalDependencies:
-      postcss: 8.5.3
-      ts-node: 10.9.2(@types/node@22.13.14)(typescript@5.7.3)
 
   postcss-nested@6.0.1(postcss@8.5.3):
     dependencies:
@@ -37465,9 +37454,9 @@ snapshots:
 
   tailwind-merge@1.14.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))):
     dependencies:
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3))
+      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
 
   tailwindcss-radix@2.8.0: {}
 
@@ -37491,33 +37480,6 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.5.3)
       postcss-js: 4.0.1(postcss@8.5.3)
       postcss-load-config: 4.0.1(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
-      postcss-nested: 6.0.1(postcss@8.5.3)
-      postcss-selector-parser: 6.0.13
-      resolve: 1.22.8
-      sucrase: 3.34.0
-    transitivePeerDependencies:
-      - ts-node
-
-  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.5.3
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.20.0
-      lilconfig: 2.1.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.1
-      postcss: 8.5.3
-      postcss-import: 15.1.0(postcss@8.5.3)
-      postcss-js: 4.0.1(postcss@8.5.3)
-      postcss-load-config: 4.0.1(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3))
       postcss-nested: 6.0.1(postcss@8.5.3)
       postcss-selector-parser: 6.0.13
       resolve: 1.22.8
@@ -37764,13 +37726,13 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-api-utils@1.0.3(typescript@5.7.3):
+  ts-api-utils@1.0.3(typescript@5.5.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.5.2
 
-  ts-api-utils@2.1.0(typescript@5.7.3):
+  ts-api-utils@2.1.0(typescript@5.5.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.5.2
 
   ts-easing@0.2.0: {}
 
@@ -37807,25 +37769,6 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@22.13.14)(typescript@5.7.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.13.14
-      acorn: 8.14.1
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -38027,8 +37970,6 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@5.5.2: {}
-
-  typescript@5.7.3: {}
 
   ua-parser-js@1.0.40: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^6.2.7
       version: 6.3.5
     zod:
-      specifier: ^3.25.76
-      version: 3.25.76
+      specifier: ^4.0.0
+      version: 4.1.8
 
 overrides:
   '@supabase/supabase-js>@supabase/auth-js': 2.72.0-rc.11
@@ -294,7 +294,7 @@ importers:
         version: 5.0.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
     devDependencies:
       '@shikijs/compat':
         specifier: ^1.1.7
@@ -499,7 +499,7 @@ importers:
         version: 1.19.1(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
       openai:
         specifier: ^4.75.1
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.8)
       openapi-fetch:
         specifier: 0.12.4
         version: 0.12.4
@@ -577,7 +577,7 @@ importers:
         version: 2.4.5
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
     devDependencies:
       '@graphiql/toolkit':
         specifier: ^0.9.1
@@ -707,19 +707,19 @@ importers:
     dependencies:
       '@ai-sdk/amazon-bedrock':
         specifier: ^3.0.0
-        version: 3.0.0(zod@3.25.76)
+        version: 3.0.0(zod@4.1.8)
       '@ai-sdk/openai':
         specifier: ^2.0.0
-        version: 2.0.2(zod@3.25.76)
+        version: 2.0.2(zod@4.1.8)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.0
       '@ai-sdk/provider-utils':
         specifier: ^3.0.0
-        version: 3.0.0(zod@3.25.76)
+        version: 3.0.0(zod@4.1.8)
       '@ai-sdk/react':
         specifier: ^2.0.0
-        version: 2.0.2(react@18.3.1)(zod@3.25.76)
+        version: 2.0.2(react@18.3.1)(zod@4.1.8)
       '@aws-sdk/credential-providers':
         specifier: ^3.804.0
         version: 3.823.0
@@ -842,7 +842,7 @@ importers:
         version: 2.7.30
       ai:
         specifier: ^5.0.0
-        version: 5.0.2(zod@3.25.76)
+        version: 5.0.2(zod@4.1.8)
       ai-commands:
         specifier: workspace:*
         version: link:../../packages/ai-commands
@@ -929,7 +929,7 @@ importers:
         version: 2.4.1(next@15.5.2(@babel/core@7.26.10(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.53.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.75.1
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.8)
       openapi-fetch:
         specifier: 0.12.4
         version: 0.12.4
@@ -1058,7 +1058,7 @@ importers:
         version: 1.4.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -1374,7 +1374,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^5.9.0
-        version: 5.9.0(ws@8.18.3)(zod@3.25.76)
+        version: 5.9.0(ws@8.18.3)(zod@4.1.8)
       openapi-fetch:
         specifier: 0.12.4
         version: 0.12.4
@@ -1434,7 +1434,7 @@ importers:
         version: 0.9.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
     devDependencies:
       '@react-router/dev':
         specifier: ^7.1.5
@@ -1627,7 +1627,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.75.1
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.8)
       parse-numeric-range:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1751,7 +1751,7 @@ importers:
         version: 9.0.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
 
   e2e/studio:
     dependencies:
@@ -1772,7 +1772,7 @@ importers:
         version: 2.49.3
       ai:
         specifier: ^5.0.0
-        version: 5.0.2(zod@3.25.76)
+        version: 5.0.2(zod@4.1.8)
       common-tags:
         specifier: ^1.8.2
         version: 1.8.2
@@ -1787,14 +1787,14 @@ importers:
         version: 3.5.0
       openai:
         specifier: ^4.75.1
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.8)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
     devDependencies:
       '@ai-sdk/openai':
         specifier: ^2.0.0
-        version: 2.0.2(zod@3.25.76)
+        version: 2.0.2(zod@4.1.8)
       '@types/common-tags':
         specifier: ^1.8.4
         version: 1.8.4
@@ -2025,7 +2025,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
     devDependencies:
       '@types/pg':
         specifier: ^8.11.11
@@ -2358,7 +2358,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.75.1
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.8)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -2424,7 +2424,7 @@ importers:
         version: 1.12.0(@types/react@18.3.3)(react@18.3.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.1.8
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.0.0
@@ -18233,6 +18233,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
+
   zustand@4.4.7:
     resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
     engines: {node: '>=12.7.0'}
@@ -18260,55 +18263,55 @@ snapshots:
 
   '@adobe/css-tools@4.4.0': {}
 
-  '@ai-sdk/amazon-bedrock@3.0.0(zod@3.25.76)':
+  '@ai-sdk/amazon-bedrock@3.0.0(zod@4.1.8)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.0(zod@3.25.76)
+      '@ai-sdk/anthropic': 2.0.0(zod@4.1.8)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.0(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.0(zod@4.1.8)
       '@smithy/eventstream-codec': 4.0.4
       '@smithy/util-utf8': 4.0.0
       aws4fetch: 1.0.20
-      zod: 3.25.76
+      zod: 4.1.8
 
-  '@ai-sdk/anthropic@2.0.0(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.0(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.0(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.0(zod@4.1.8)
+      zod: 4.1.8
 
-  '@ai-sdk/gateway@1.0.0(zod@3.25.76)':
+  '@ai-sdk/gateway@1.0.0(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.0(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.0(zod@4.1.8)
+      zod: 4.1.8
 
-  '@ai-sdk/openai@2.0.2(zod@3.25.76)':
+  '@ai-sdk/openai@2.0.2(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.0(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.0(zod@4.1.8)
+      zod: 4.1.8
 
-  '@ai-sdk/provider-utils@3.0.0(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.0(zod@4.1.8)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.5(zod@3.25.76)
+      zod: 4.1.8
+      zod-to-json-schema: 3.24.5(zod@4.1.8)
 
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@2.0.2(react@18.3.1)(zod@3.25.76)':
+  '@ai-sdk/react@2.0.2(react@18.3.1)(zod@4.1.8)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.0(zod@3.25.76)
-      ai: 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.0(zod@4.1.8)
+      ai: 5.0.2(zod@4.1.8)
       react: 18.3.1
       swr: 2.2.5(react@18.3.1)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.1.8
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -28019,13 +28022,13 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@5.0.2(zod@3.25.76):
+  ai@5.0.2(zod@4.1.8):
     dependencies:
-      '@ai-sdk/gateway': 1.0.0(zod@3.25.76)
+      '@ai-sdk/gateway': 1.0.0(zod@4.1.8)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.0(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.0(zod@4.1.8)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.1.8
 
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
@@ -34575,7 +34578,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76):
+  openai@4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.8):
     dependencies:
       '@types/node': 18.18.13
       '@types/node-fetch': 2.6.6
@@ -34586,14 +34589,14 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.1.8
     transitivePeerDependencies:
       - encoding
 
-  openai@5.9.0(ws@8.18.3)(zod@3.25.76):
+  openai@5.9.0(ws@8.18.3)(zod@4.1.8):
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.1.8
 
   openapi-fetch@0.12.4:
     dependencies:
@@ -39209,7 +39212,13 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  zod-to-json-schema@3.24.5(zod@4.1.8):
+    dependencies:
+      zod: 4.1.8
+
   zod@3.25.76: {}
+
+  zod@4.1.8: {}
 
   zustand@4.4.7(@types/react@18.3.3)(immer@10.1.1)(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'e2e/*'
 
 catalog:
+  '@hookform/resolvers': ^5.1.0
   '@types/node': ^22.0.0
   '@supabase/auth-js': 2.72.0-rc.11
   '@supabase/supabase-js': ^2.47.14

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,6 @@ catalog:
   '@types/react-dom': '^18.3.0'
   'valtio': '^1.12.0'
   'vite': '^6.2.7'
-  'zod': '^3.25.76'
+  'zod': '^4.0.0'
 
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Context

In efforts to address "Type instantiation is excessively deep and possibly infinite." - many articles suggest Zod V3 might be the culprit, and that upgrading to V4 may be the solution, so giving that a try in this PR. The previous PR [here](https://github.com/supabase/supabase/pull/38846) standardises the Zod version across all apps and packages in the monorepo to use the same version of Zod which mights this transition slightly easier.

Am mainly using this zod-v3-to-v4 codemod [here](https://github.com/nicoespeon/zod-v3-to-v4) to help with the transition, with some manual eye-balling to make sure there's no weird changes

# Changes involved

- Shifted `zod` and `@hookforms/resolver` to `pnpm-workspace` catalog
  - Bump `zod` to `^4.0.0`
  - Bump `@hookforms/resolver` to `^5.1.0`
- Updated usage of `zod` based on v4 migration using codemod
- Added `tailwindcss` as a dev dependency to `docs`
  - Tbh i'm really not sure why this is needed but without this, `docs` and `www` build were complaining of `Error: Cannot find module 'tailwindcss' errors ([ref](https://vercel.com/supabase/docs/2MXiYUJcTqy67FWSoRGMnuFmXKFR)) while others like `ui-library`, `design-system` were complaining of `Module not found: Can't resolve 'tailwindcss/plugin'` ([ref](https://vercel.com/supabase/ui-library/CHBRyRJygTcaekMKxxoDs9e6TkXB))

## To test
- [ ] General smoke test of the dashboard
  - Specifically also look out for these 2 (had to manually fix outside of the codemod)
    - Moving queries in SQL Editor (to existing folder and new folder)
    - Updating AI opt in levels in org settings
  - And this one too (had to bump `hookforms/resolvers` because of Zod errors were throwing client side exceptions which our unit tests caught)
    - Storage -> Delete bucket modal, verify that error handling (e.g not typing the correct bucket name in the input) is handled as expected, shouldn't be a client side crash
- [ ] General smoke test of the docs
- [ ] General smoke test of the www