### PR TITLE
Update custom-access-token-hook.mdx

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/custom-access-token-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/custom-access-token-hook.mdx
@@ -285,7 +285,7 @@ as $$
     is_admin boolean;
   begin
     -- Check if the user is marked as admin in the profiles table
-    select is_admin into is_admin from profiles where user_id = (event->>'user_id')::uuid;
+    select p.is_admin into is_admin from public.profiles p where p.user_id = (event->>'user_id')::uuid;
 
     -- Proceed only if the user is an admin
     if is_admin then


### PR DESCRIPTION
Fixed two SQL issues in the custom access token hook function:

1. Added explicit schema reference (public.profiles) to resolve "relation does not exist" error
2. Used table alias to fix "column reference is ambiguous" error in the SELECT query

The hook now properly reads admin status from the profiles table and sets the admin claim in JWT tokens without throwing database errors.

Changes:
- Updated SQL query to use `public.profiles p` with alias
- Changed `select is_admin` to `select p.is_admin` for clarity
- Ensured proper schema access for auth hooks

Tested with login flow and admin claim generation works as expected.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, docs update

## What is the current behavior?

The custom_access_token_hook function fails with two sequential database errors:
ERROR: relation "profiles" does not exist (SQLSTATE 42P01)
ERROR: column reference "is_admin" is ambiguous (SQLSTATE 42702)
This prevents users from logging in as the auth hook crashes during token generation.

<img width="1282" height="669" alt="image" src="https://github.com/user-attachments/assets/a54e9ef4-b070-4b46-b0c3-87eb3b6079dd" />

Please link any relevant issues here.

## What is the new behavior?

The hook now successfully:
- Accesses the profiles table with explicit schema reference
- Queries the is_admin column without ambiguity
- Sets admin claims in JWT tokens for admin users
- Allows normal login flow to complete
