### PR TITLE
docs: Set default priority in sitemap and lower auth-helper priority

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
@@ -2,7 +2,7 @@
 id: 'auth-ui'
 title: 'Auth UI'
 description: 'A prebuilt, customizable React component for authenticating users.'
-sitemapPriority: 0.5
+sitemapPriority: 0.3
 ---
 
 <Admonition type="caution">

--- a/apps/docs/content/guides/auth/auth-helpers/flutter-auth-ui.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/flutter-auth-ui.mdx
@@ -2,7 +2,7 @@
 id: 'flutter-auth-ui'
 title: 'Flutter Auth UI'
 description: 'Prebuilt, customizable Flutter widgets for authenticating users.'
-sitemapPriority: 0.5
+sitemapPriority: 0.3
 ---
 
 Flutter Auth UI is a Flutter package containing pre-built widgets for authenticating users.

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -3,7 +3,7 @@ id: 'nextjs-pages'
 title: 'Supabase Auth with Next.js Pages Directory'
 description: 'Authentication helpers for Next.js API routes, middleware, and SSR in the Pages Directory.'
 sidebar_label: 'Next.js (pages)'
-sitemapPriority: 0.5
+sitemapPriority: 0.3
 ---
 
 <Admonition type="caution">

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
@@ -3,7 +3,7 @@ id: 'nextjs'
 title: 'Supabase Auth with the Next.js App Router'
 description: 'Authentication and Authorization helpers for creating an authenticated Supabase client with the Next.js 13 App Router.'
 sidebar_label: 'Next.js'
-sitemapPriority: 0.5
+sitemapPriority: 0.3
 ---
 
 <Admonition type="caution">

--- a/apps/docs/content/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/remix.mdx
@@ -3,7 +3,7 @@ id: 'remix'
 title: 'Supabase Auth with Remix'
 description: 'Authentication helpers for loaders and actions in Remix.'
 sidebar_label: 'Remix'
-sitemapPriority: 0.5
+sitemapPriority: 0.3
 ---
 
 <Admonition type="caution">

--- a/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
@@ -3,7 +3,7 @@ id: 'sveltekit'
 title: 'Supabase Auth with SvelteKit'
 description: 'Convenience helpers for implementing user authentication in SvelteKit.'
 sidebar_label: 'SvelteKit'
-sitemapPriority: 0.5
+sitemapPriority: 0.3
 ---
 
 <Admonition type="caution">

--- a/apps/docs/internals/files/cli.ts
+++ b/apps/docs/internals/files/cli.ts
@@ -13,11 +13,11 @@ const cliSpec = yaml.load(fs.readFileSync(`spec/cli_v1_commands.yaml`, 'utf8')) 
  * @returns {Array<{link: string}>} - An array of CLI page links.
  */
 export function generateCLIPages() {
-  let cliPages: Array<{ link: string }> = []
+  let cliPages: Array<{ link: string; priority: number }> = []
 
   cliSpec.commands.map((section: any) => {
     const slug = (flatCLISections as any[]).find((item: any) => item.id === section.id)?.slug
-    if (slug) cliPages.push({ link: `reference/cli/${slug}` })
+    if (slug) cliPages.push({ link: `reference/cli/${slug}`, priority: 0.8 })
   })
   return cliPages
 }

--- a/apps/docs/internals/files/reference-lib.ts
+++ b/apps/docs/internals/files/reference-lib.ts
@@ -33,6 +33,7 @@ export async function generateReferencePages() {
               link: isLatestVersion
                 ? `reference/${libPath}/${section.slug}`
                 : `reference/${libPath}/${version}/${section.slug}`,
+              priority: 0.8,
             })) ?? []
           )
         })

--- a/apps/docs/internals/generate-sitemap.ts
+++ b/apps/docs/internals/generate-sitemap.ts
@@ -25,7 +25,7 @@ async function generate() {
 
       return {
         link: filePath.replace(/^content\//, '').replace(/\.mdx$/, ''),
-        priority: sitemapPriority,
+        priority: sitemapPriority ?? 0.8,
       }
     })
   )
@@ -40,7 +40,7 @@ async function generate() {
     })
   )
 
-  const allPages = (contentPages as Array<{ link: string; priority?: number }>).concat(
+  const allPages = (contentPages as Array<{ link: string; priority: number }>).concat(
     troubleshootingPages,
     referencePages,
     cliPages
@@ -51,11 +51,12 @@ async function generate() {
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
         ${allPages
           .map(({ link, priority }) => {
+            const finalPriority = priority ?? 0.8
             return `
               <url>
                   <loc>${`https://supabase.com/docs/${link}`}</loc>
                   <changefreq>weekly</changefreq>
-                  ${priority ? `<priority>${priority}</priority>` : ''}
+                  <priority>${finalPriority}</priority>
               </url>
             `
           })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

In an attempt to get various external parties to de-prioritise the auth-helpers library, I noticed that the sitemap generation only adds priority to certain pages, meaning that auth-helpers content wasn't given any lower priority than [the default of 0.5](https://www.sitemaps.org/protocol.html).

So this PR changes the sitemap generation to give a default value if not set and lowers the priority of auth-helpers. I left the troubleshooting content as is, but in my opinion, this should be lower than 1.