### PR TITLE
changing pgmq repo address to current repo

### DIFF
--- a/apps/docs/content/guides/queues.mdx
+++ b/apps/docs/content/guides/queues.mdx
@@ -3,7 +3,7 @@ title: Supabase Queues
 subtitle: 'Durable Message Queues with Guaranteed Delivery in Postgres'
 ---
 
-Supabase Queues is a Postgres-native durable Message Queue system with guaranteed delivery built on the [pgmq database extension](https://github.com/tembo-io/pgmq). It offers developers a seamless way to persist and process Messages in the background while improving the resiliency and scalability of their applications and services.
+Supabase Queues is a Postgres-native durable Message Queue system with guaranteed delivery built on the [pgmq database extension](https://github.com/pgmq/pgmq). It offers developers a seamless way to persist and process Messages in the background while improving the resiliency and scalability of their applications and services.
 
 Queues couples the reliability of Postgres with the simplicity Supabase's platform and developer experience, enabling developers to manage Background Tasks with zero configuration.
 
@@ -31,4 +31,4 @@ Queues couples the reliability of Postgres with the simplicity Supabase's platfo
 
 - [Quickstart](/docs/guides/queues/quickstart)
 - [API Reference](/docs/guides/queues/api)
-- [`pgmq` GitHub Repository](https://github.com/tembo-io/pgmq)
+- [`pgmq` GitHub Repository](https://github.com/pgmq/pgmq)

--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -62,10 +62,10 @@ const supabaseIntegrations: IntegrationDefinition[] = [
       <Layers className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
     ),
     description: 'Lightweight message queue in Postgres',
-    docsUrl: 'https://github.com/tembo-io/pgmq',
+    docsUrl: 'https://github.com/pgmq/pgmq',
     author: {
       name: 'pgmq',
-      websiteUrl: 'https://github.com/tembo-io/pgmq',
+      websiteUrl: 'https://github.com/pgmq/pgmq',
     },
     navigation: [
       {

--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
@@ -292,7 +292,7 @@ export const QueuesSettings = () => {
               </FormPanelContent>
 
               <FormPanelFooter className="flex px-8 py-4 flex items-center justify-between">
-                <DocsButton href="https://github.com/tembo-io/pgmq?tab=readme-ov-file#sql-examples" />
+                <DocsButton href="https://github.com/pgmq/pgmq?tab=readme-ov-file#sql-examples" />
                 <div className="flex items-center gap-x-2">
                   <Button
                     type="default"

--- a/apps/www/_blog/2024-12-05-supabase-queues.mdx
+++ b/apps/www/_blog/2024-12-05-supabase-queues.mdx
@@ -31,9 +31,9 @@ Supabase Queues is a Postgres-native, durable Message Queue with guaranteed deli
 
 <Admonition>
 
-Supabase Queues is built on the [pgmq](https://github.com/tembo-io/pgmq) extension by the team at [Tembo](https://github.com/tembo-io).
+Supabase Queues is built on the [pgmq](https://github.com/pgmq/pgmq) extension by the team at [Tembo](https://github.com/tembo-io).
 
-It's a Supabase policy to [support existing tools](/docs/guides/getting-started/architecture#support-existing-tools) wherever possible, and the Tembo team have generously licensed their extension with the OSI-compatible [PostgreSQL license](https://github.com/tembo-io/pgmq?tab=PostgreSQL-1-ov-file).
+It's a Supabase policy to [support existing tools](/docs/guides/getting-started/architecture#support-existing-tools) wherever possible, and the Tembo team have generously licensed their extension with the OSI-compatible [PostgreSQL license](https://github.com/pgmq/pgmq?tab=PostgreSQL-1-ov-file).
 
 We're very thankful to all the contributors and we look forward to working with the Tembo community.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

docs update
## What is the current behavior?

referenced old pgmq repo from tembo

## What is the new behavior?

now points to [pgmq](https://github.com/pgmq/pgmq)

