### PR TITLE
chore: add feature-flagged placeholder for CLI profiles

### DIFF
--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -142,6 +142,12 @@ supabase stop --no-backup
 
 </Admonition>
 
+<$Show if="!docs:hide_cli_profiles">
+
+<Partial path="cli_profiles.mdx" />
+
+</$Show>
+
 ## Running Supabase locally
 
 The Supabase CLI uses Docker containers to manage the local development stack. Follow the official guide to install and configure [Docker Desktop](https://docs.docker.com/desktop):

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -40,6 +40,7 @@
   "docs:framework_quickstarts": true,
   "docs:full_getting_started": true,
   "docs:full_platform": true,
+  "docs:hide_cli_profiles": true,
   "docs:mobile_tutorials": true,
   "docs:pgtap": true,
   "docs:production_checklist": true,

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -115,6 +115,7 @@
       "type": "boolean",
       "description": "Enable the database roles page"
     },
+
     "docs:auth": {
       "type": "boolean",
       "description": "Enable auth docs"
@@ -142,6 +143,10 @@
     "docs:full_platform": {
       "type": "boolean",
       "description": "Enable full platform documentation"
+    },
+    "docs:hide_cli_profiles": {
+      "type": "boolean",
+      "description": "Hide docs on CLI profiles"
     },
     "docs:mobile_tutorials": {
       "type": "boolean",
@@ -337,6 +342,7 @@
     "docs:framework_quickstarts",
     "docs:full_getting_started",
     "docs:full_platform",
+    "docs:hide_cli_profiles",
     "docs:mobile_tutorials",
     "docs:pgtap",
     "docs:production_checklist",


### PR DESCRIPTION
- new feature flag: `docs:hide_cli_profiles`
- this must be implemented as a "negative" flag (hide instead of enable), because our current temporary hack for creating the Nimbus search index requires that the default state for all flags be true