### PR TITLE
feat: Add typechecking as a required check for the merge queue

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'master'
+  merge_group:
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:

--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -57,7 +57,7 @@
     "postcss": "^8.5.3",
     "rimraf": "^4.1.3",
     "shiki": "^1.1.7",
-    "tailwindcss": "^3.3.0",
+    "tailwindcss": "catalog:",
     "tsconfig": "workspace:*",
     "tsx": "^4.19.3",
     "typescript": "~5.5.0",

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -531,10 +531,8 @@ const nextConfig = {
     pagesBufferLength: 100,
   },
   typescript: {
-    // On previews, typechecking is run via GitHub Action only for efficiency
-    // On production, we turn it on to prevent errors from conflicting PRs getting into
-    // prod
-    ignoreBuildErrors: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? false : true,
+    // Typechecking is run via GitHub Action only for efficiency.
+    ignoreBuildErrors: true,
   },
   eslint: {
     // We are already running linting via GH action, this will skip linting during production build on Vercel

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -197,7 +197,7 @@
     "prettier": "3.2.4",
     "raw-loader": "^4.0.2",
     "require-in-the-middle": "^7.5.2",
-    "tailwindcss": "^3.4.1",
+    "tailwindcss": "catalog:",
     "tsx": "^4.19.3",
     "typescript": "~5.5.0",
     "vite": "catalog:",

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -106,7 +106,7 @@
     "rimraf": "^4.1.3",
     "shadcn": "^2.10.0",
     "shiki": "^1.1.7",
-    "tailwindcss": "^3.3.0",
+    "tailwindcss": "catalog:",
     "tsconfig": "workspace:*",
     "tsx": "^4.19.3",
     "typescript": "~5.5.0",

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "openapi-typescript": "^7.4.3",
-    "prettier": "3.2.4"
+    "prettier": "3.2.4",
+    "typescript": "~5.5.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,7 +17,7 @@
     "tailwindcss-radix": "^2.0.0"
   },
   "devDependencies": {
-    "tailwindcss": "^3.4.1",
+    "tailwindcss": "catalog:",
     "tailwindcss-animate": "^1.0.6",
     "typescript": "~5.5.0"
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "tailwindcss": "^3.4.1",
-    "tailwindcss-animate": "^1.0.6"
+    "tailwindcss-animate": "^1.0.6",
+    "typescript": "~5.5.0"
   }
 }

--- a/packages/eslint-config-supabase/package.json
+++ b/packages/eslint-config-supabase/package.json
@@ -11,5 +11,8 @@
     "eslint-config-next": "15.3.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-turbo": "^2.0.4"
+  },
+  "devDependencies": {
+    "typescript": "~5.5.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,7 +76,7 @@
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "tailwind-merge": "^1.13.2",
-    "tailwindcss": "^3.4.1",
+    "tailwindcss": "catalog:",
     "vaul": "^0.9.9"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     react-dom:
       specifier: ^18.3.0
       version: 18.3.1
+    tailwindcss:
+      specifier: 3.4.1
+      version: 3.4.1
     valtio:
       specifier: ^1.12.0
       version: 1.12.0
@@ -324,7 +327,7 @@ importers:
         specifier: ^1.1.7
         version: 1.6.0
       tailwindcss:
-        specifier: ^3.3.0
+        specifier: 'catalog:'
         version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       tsconfig:
         specifier: workspace:*
@@ -1211,7 +1214,7 @@ importers:
         specifier: ^7.5.2
         version: 7.5.2(supports-color@8.1.1)
       tailwindcss:
-        specifier: ^3.4.1
+        specifier: 'catalog:'
         version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       tsx:
         specifier: ^4.19.3
@@ -1494,7 +1497,7 @@ importers:
         specifier: ^1.1.7
         version: 1.6.0
       tailwindcss:
-        specifier: ^3.3.0
+        specifier: 'catalog:'
         version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       tsconfig:
         specifier: workspace:*
@@ -1966,7 +1969,7 @@ importers:
         version: 2.8.0
     devDependencies:
       tailwindcss:
-        specifier: ^3.4.1
+        specifier: 'catalog:'
         version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       tailwindcss-animate:
         specifier: ^1.0.6
@@ -2243,7 +2246,7 @@ importers:
         specifier: ^1.13.2
         version: 1.14.0
       tailwindcss:
-        specifier: ^3.4.1
+        specifier: 'catalog:'
         version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       vaul:
         specifier: ^0.9.9
@@ -4287,10 +4290,6 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jridgewell/gen-mapping@0.3.5':
-    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
-    engines: {node: '>=6.0.0'}
 
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
@@ -13023,10 +13022,6 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jiti@1.20.0:
-    resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
-    hasBin: true
-
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -14983,9 +14978,6 @@ packages:
 
   phenomenon@1.6.0:
     resolution: {integrity: sha512-7h9/fjPD3qNlgggzm88cY58l9sudZ6Ey+UmZsizfhtawO6E3srZQXywaNm2lBwT72TbpHYRPy7ytIHeBUD/G0A==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -21433,12 +21425,6 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@jridgewell/gen-mapping@0.3.5':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -27022,7 +27008,7 @@ snapshots:
 
   '@ts-morph/common@0.23.0':
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       minimatch: 9.0.5
       mkdirp: 3.0.1
       path-browserify: 1.0.1
@@ -32244,8 +32230,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jiti@1.20.0: {}
-
   jiti@1.21.7: {}
 
   jiti@2.4.2: {}
@@ -35036,8 +35020,6 @@ snapshots:
 
   phenomenon@1.6.0: {}
 
-  picocolors@1.0.1: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -37410,7 +37392,7 @@ snapshots:
 
   sucrase@3.34.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/gen-mapping': 0.3.8
       commander: 4.1.1
       glob: 7.1.6
       lines-and-columns: 1.2.4
@@ -37507,25 +37489,25 @@ snapshots:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       didyoumean: 1.2.2
       dlv: 1.1.3
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.20.0
+      jiti: 1.21.7
       lilconfig: 2.1.0
       micromatch: 4.0.8
       normalize-path: 3.0.0
       object-hash: 3.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       postcss: 8.5.3
       postcss-import: 15.1.0(postcss@8.5.3)
       postcss-js: 4.0.1(postcss@8.5.3)
       postcss-load-config: 4.0.1(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2))
       postcss-nested: 6.0.1(postcss@8.5.3)
       postcss-selector-parser: 6.0.13
-      resolve: 1.22.8
+      resolve: 1.22.10
       sucrase: 3.34.0
     transitivePeerDependencies:
       - ts-node

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1843,6 +1843,9 @@ importers:
       prettier:
         specifier: 3.2.4
         version: 3.2.4
+      typescript:
+        specifier: ~5.5.0
+        version: 5.5.2
 
   packages/build-icons:
     devDependencies:
@@ -1968,6 +1971,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.6
         version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.5.2)))
+      typescript:
+        specifier: ~5.5.0
+        version: 5.5.2
 
   packages/eslint-config-supabase:
     dependencies:
@@ -1980,6 +1986,10 @@ importers:
       eslint-config-turbo:
         specifier: ^2.0.4
         version: 2.0.4(eslint@8.57.0(supports-color@8.1.1))
+    devDependencies:
+      typescript:
+        specifier: ~5.5.0
+        version: 5.5.2
 
   packages/generator:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   'valtio': '^1.12.0'
   'vite': '^6.2.7'
   'zod': '^3.25.76'
+  'tailwindcss': '3.4.1'
 
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:


### PR DESCRIPTION
This PR adds the `typecheck` Github Action as a required check when merging PRs via the merge queue.

This check is added to avoid issues where the master branch and the PR branch have incompatible changes and may result in a bad build. This used to be checked by the Vercel build, but the Vercel build took too long so we removed typechecking as a step.