### PR TITLE
Opt to remove vercel.json

### DIFF
--- a/apps/studio/vercel.json
+++ b/apps/studio/vercel.json
@@ -1,3 +1,0 @@
-{
-  "buildCommand": "pnpm build"
-}


### PR DESCRIPTION
## Context

This is related to addressing the type instantiation errors that we occasionally run into on the `studio` Vercel app production builds. 

Plan moving forward is to run the typecheck outside of the build (we've since also set `ignoreBuildErrors` to `false` in `next.config.js` to avoid that error while experimenting with merge queues - hence why we currently don't run into that build problem atm)

Opting to remove `vercel.json` -> `buildCommand` to set the build command directly from the Vercel projects instead since we only want to run the typecheck on `studio`.

`studio-staging` is currently set to use `pnpm build` while `studio` is currently set to use `pnpm typecheck && pnpm build`

<img width="945" height="76" alt="image" src="https://github.com/user-attachments/assets/5fafd8b3-226f-4a10-9c44-622a52999e9f" />

<img width="880" height="98" alt="image" src="https://github.com/user-attachments/assets/c7375296-c28e-4faa-aca6-ead98b5689c4" />
