### PR TITLE
Reinstate ignoreBuildErrors as false for studio prod

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -531,8 +531,9 @@ const nextConfig = {
     pagesBufferLength: 100,
   },
   typescript: {
-    // Typechecking is run via GitHub Action only for efficiency.
-    ignoreBuildErrors: true,
+    // On previews, typechecking is run via GitHub Action only for efficiency
+    // On production, we turn it on to catch errors from typecheck due to conflicting PRs getting into prod
+    ignoreBuildErrors: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? false : true,
   },
   eslint: {
     // We are already running linting via GH action, this will skip linting during production build on Vercel


### PR DESCRIPTION
Reinstating `ignoreBuildErrors` to `false` for dashboard production

Now that we're running typechecking outside of the build, reckon we can flip this back to `false` to catch any errors arising from the typecheck