### PR TITLE
Fix spelling mistake from 'talke' to 'talk' in data/contributing/supa…

### DIFF
--- a/apps/www/data/open-source/contributing/supasquad.tsx
+++ b/apps/www/data/open-source/contributing/supasquad.tsx
@@ -168,7 +168,7 @@ export const data = {
           </div>
         ),
         subheading:
-          "Help our users who are building with AI + Supabase. If you've vibed a bunch of projects but understand what's happening under the hood, we'd love to talke with you .",
+          "Help our users who are building with AI + Supabase. If you've vibed a bunch of projects but understand what's happening under the hood, we'd love to talk with you .",
       },
 
       {


### PR DESCRIPTION
Fixed a spelling error in  the file,  "talke" was corrected to "talk".
No changes to Supabase functionality or code.
Attached is a screenshot to support this request.

<img width="1457" height="491" alt="Screenshot 2025-09-24 at 11 25 08" src="https://github.com/user-attachments/assets/8654f8f1-edaa-439b-a3ab-f175d6d60470" />
