### PR TITLE
docs: Specify pnpm version

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -165,5 +165,6 @@
     "vite": "catalog:",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^3.0.5"
-  }
+  },
+    "packageManager": "pnpm@10.16.1"
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds specific pnpm version to allow for new features in 10.16.1