### PR TITLE
realtime: clarify number of connections used by realtime

### DIFF
--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -66,7 +66,7 @@ The number of connections varies based on your compute add-on size and configura
 
 <Admonition type="note">
 
-The `Authorization Pool Size` can be customized through the `Database connection pool size` parameter in your Realtime configuration. If not specified, the default values shown in the table will be used.
+You can customize `Authorization Pool Size` through the `Database connection pool size` parameter in your Realtime configuration. If not specified, the default values shown in the table will be used.
 
 </Admonition>
 

--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -35,7 +35,7 @@ Realtime uses several database connections to perform several operations. As a u
 
 ### Database connections
 
-Realtime uses several database connections to perform various operations. Some of these connections are configurable through [Realtime Settings](/docs/guides/realtime/settings).
+Realtime uses several database connections to perform various operations. You can configure some of these connections through [Realtime Settings](/docs/guides/realtime/settings).
 
 The connections include:
 

--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -35,18 +35,42 @@ Realtime uses several database connections to perform several operations. As a u
 
 ### Database connections
 
-Realtime uses several database connections to do several operations. Some of them, as a user, you are able to tune them.
+Realtime uses several database connections to perform various operations. Some of these connections are configurable through [Realtime Settings](/docs/guides/realtime/settings).
 
-The connections are:
+The connections include:
 
 - **Migrations**: Two temporary connections to run database migrations when needed
 - **Authorization**: Configurable connection pool to check authorization policies on join
-- **Postgres Changes**: 3 connection pools required
+- **Broadcast from database**: one connection to receive data from replication slot used to broadcast the changes to the clients
+- **Postgres Changes**: Multiple connection pools required
   - **Subscription management**: To manage the subscribers to Postgres Changes
   - **Subscription cleanup**: To cleanup the subscribers to Postgres Changes
   - **WAL pull**: To pull the changes from the database
 
-The number of connections varies based on the instance size and your configuration in [Realtime Settings](/docs/guides/realtime/settings).
+The number of connections varies based on your compute add-on size and configuration. The following table shows the default connection pool sizes for different compute addon variants:
+
+| Compute Addon | Broadcast from database | Database Pool Size | Subscription management | Subscription cleanup | WAL pull |
+| ------------- | ----------------------- | ------------------ | ----------------------- | -------------------- | -------- |
+| Nano          | 1                       | 2                  | 2                       | 2                    | 2        |
+| Micro         | 1                       | 2                  | 2                       | 2                    | 2        |
+| Small         | 1                       | 5                  | 4                       | 4                    | 4        |
+| Medium        | 1                       | 5                  | 4                       | 4                    | 4        |
+| Large         | 1                       | 5                  | 4                       | 4                    | 4        |
+| XL            | 1                       | 10                 | 7                       | 7                    | 7        |
+| 2XL           | 1                       | 10                 | 7                       | 7                    | 7        |
+| 4XL           | 1                       | 10                 | 7                       | 7                    | 7        |
+| 8XL           | 1                       | 15                 | 9                       | 9                    | 9        |
+| 12XL          | 1                       | 15                 | 9                       | 9                    | 9        |
+| 16XL          | 1                       | 15                 | 9                       | 9                    | 9        |
+| >16XL         | 1                       | 15                 | 9                       | 9                    | 9        |
+
+<Admonition type="note">
+
+The Postgres Changes pool size values shown in the table are multiplied by 3 to reflect the actual number of connections used, as these connections serve multiple functions including subscription management, subscription cleanup, and WAL pull operations.
+
+The database pool size can be customized through the `connection_pool` parameter in your Realtime configuration. If not specified, the default values shown in the table will be used.
+
+</Admonition>
 
 ### Replication slots
 

--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -40,9 +40,9 @@ Realtime uses several database connections to perform various operations. Some o
 The connections include:
 
 - **Migrations**: Two temporary connections to run database migrations when needed
-- **Authorization**: Configurable connection pool to check authorization policies on join
-- **Broadcast from database**: one connection to receive data from replication slot used to broadcast the changes to the clients
-- **Postgres Changes**: Multiple connection pools required
+- **Authorization**: Configurable connection pool to check authorization policies on join that are always started.
+- **Broadcast from database**: One connection to receive data from replication slot used to broadcast the changes to the clients that is always started.
+- **Postgres Changes**: Multiple connection pools required. These pools are only started if you use Postgres Changes.
   - **Subscription management**: To manage the subscribers to Postgres Changes
   - **Subscription cleanup**: To cleanup the subscribers to Postgres Changes
   - **WAL pull**: To pull the changes from the database

--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -66,9 +66,7 @@ The number of connections varies based on your compute add-on size and configura
 
 <Admonition type="note">
 
-The Postgres Changes pool size values shown in the table are multiplied by 3 to reflect the actual number of connections used, as these connections serve multiple functions including subscription management, subscription cleanup, and WAL pull operations.
-
-The database pool size can be customized through the `connection_pool` parameter in your Realtime configuration. If not specified, the default values shown in the table will be used.
+The `Authorization Pool Size` can be customized through the `Database connection pool size` parameter in your Realtime configuration. If not specified, the default values shown in the table will be used.
 
 </Admonition>
 

--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -47,22 +47,22 @@ The connections include:
   - **Subscription cleanup**: To cleanup the subscribers to Postgres Changes
   - **WAL pull**: To pull the changes from the database
 
-The number of connections varies based on your compute add-on size and configuration. The following table shows the default connection pool sizes for different compute addon variants:
+The number of connections varies based on your compute add-on size and configuration. The following table shows the default connection pool sizes for different compute add-on variants:
 
-| Compute Addon | Broadcast from database | Database Pool Size | Subscription management | Subscription cleanup | WAL pull |
-| ------------- | ----------------------- | ------------------ | ----------------------- | -------------------- | -------- |
-| Nano          | 1                       | 2                  | 2                       | 2                    | 2        |
-| Micro         | 1                       | 2                  | 2                       | 2                    | 2        |
-| Small         | 1                       | 5                  | 4                       | 4                    | 4        |
-| Medium        | 1                       | 5                  | 4                       | 4                    | 4        |
-| Large         | 1                       | 5                  | 4                       | 4                    | 4        |
-| XL            | 1                       | 10                 | 7                       | 7                    | 7        |
-| 2XL           | 1                       | 10                 | 7                       | 7                    | 7        |
-| 4XL           | 1                       | 10                 | 7                       | 7                    | 7        |
-| 8XL           | 1                       | 15                 | 9                       | 9                    | 9        |
-| 12XL          | 1                       | 15                 | 9                       | 9                    | 9        |
-| 16XL          | 1                       | 15                 | 9                       | 9                    | 9        |
-| >16XL         | 1                       | 15                 | 9                       | 9                    | 9        |
+| Compute Add-on | Broadcast from database | Authorization Pool Size | Subscription management | Subscription cleanup | WAL pull |
+| -------------- | ----------------------- | ----------------------- | ----------------------- | -------------------- | -------- |
+| Nano           | 1                       | 2                       | 2                       | 2                    | 2        |
+| Micro          | 1                       | 2                       | 2                       | 2                    | 2        |
+| Small          | 1                       | 5                       | 4                       | 4                    | 4        |
+| Medium         | 1                       | 5                       | 4                       | 4                    | 4        |
+| Large          | 1                       | 5                       | 4                       | 4                    | 4        |
+| XL             | 1                       | 10                      | 7                       | 7                    | 7        |
+| 2XL            | 1                       | 10                      | 7                       | 7                    | 7        |
+| 4XL            | 1                       | 10                      | 7                       | 7                    | 7        |
+| 8XL            | 1                       | 15                      | 9                       | 9                    | 9        |
+| 12XL           | 1                       | 15                      | 9                       | 9                    | 9        |
+| 16XL           | 1                       | 15                      | 9                       | 9                    | 9        |
+| >16XL          | 1                       | 15                      | 9                       | 9                    | 9        |
 
 <Admonition type="note">
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

clarify number of connections used by realtime per instance size