### PR TITLE
fix: remove docs rewrites from www preview

### DIFF
--- a/apps/www/lib/rewrites.js
+++ b/apps/www/lib/rewrites.js
@@ -1,4 +1,4 @@
-module.exports = [
+const rewrites = [
   {
     source: '/:path*',
     destination: `/:path*`,
@@ -11,21 +11,16 @@ module.exports = [
     source: '/dashboard/:path*',
     destination: `${process.env.NEXT_PUBLIC_STUDIO_URL}/:path*`,
   },
-  {
-    source: '/docs',
-    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
-  },
-  {
-    // redirect /docs/
-    // trailing slash caused by docusaurus issue with multizone
-    source: '/docs/',
-    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
-  },
-  {
-    source: '/docs/:path*',
-    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/:path*`,
-  },
-
+  ...(process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+    ? [
+        { source: '/docs', destination: `${process.env.NEXT_PUBLIC_DOCS_URL}` },
+        {
+          source: '/docs/',
+          destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
+        },
+        { source: '/docs/:path*', destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/:path*` },
+      ]
+    : []),
   {
     source: '/ui',
     destination: `${process.env.NEXT_PUBLIC_UI_LIBRARY_URL}`,
@@ -70,8 +65,7 @@ module.exports = [
     source: '/llms/:path(.*\\.txt$)',
     destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/llms/:path`,
   },
-  {
-    source: '/feed.xml',
-    destination: `/rss.xml`,
-  },
+  { source: '/feed.xml', destination: `/rss.xml` },
 ]
+
+module.exports = rewrites


### PR DESCRIPTION
Preview sites are being crawled because the rewrite causes the docs production content (which naturally has `index, follow`) to be served under the www preview domain. We shouldn’t be rewriting in any environment except production.