### PR TITLE
tooling: add link checks

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -44,4 +44,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lychee-report
-          path: .lychee/report.json
+          path: ./report.json

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,47 @@
+name: Link Checks
+
+on:
+  pull_request:
+    branches: ['master']
+    paths:
+      - 'apps/docs/**/*.md'
+      - 'apps/docs/**/*.mdx'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+
+jobs:
+  links:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/docs
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --cache --max-cache-age 1d
+            --timeout 20 --max-concurrency 50
+            --exclude "^mailto:" --exclude "^tel:" --exclude "localhost"
+            "apps/docs/**/*.md" "apps/docs/**/*.mdx"
+          format: json
+          output: ./report.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail: true
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: .lychee/report.json

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,22 @@
+accept = [403, 429]
+
+retry_wait = 3
+max_retries = 3
+timeout = 20
+
+exclude = [
+  "^file://",
+  # (auth-walled)
+  "^https://app\\.supabase\\.com/",
+  "^https://portal\\.azure\\.com/",
+  "^https://dashboard\\.clerk\\.com/",
+  "^https://dashboard\\.nexmo\\.com/",
+  "^https://marketplace\\.zoom\\.us/",
+]
+
+headers = [
+  "User-Agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari",
+]
+
+cache = true
+max_cache_age = "1d"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
feature

## What is the current behavior?
The Supabase docs have over 4k links, and a good number are external. However, there is no mechanism in place to check if any of the external links are broken.

## What is the new behavior?

Does a link check and generates a report for broken links.

## Additional context

Add any other context or screenshots.
