### PR TITLE
Contextual error for invalid input syntax in table editor

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -5,6 +5,7 @@ import { ref as valtioRef } from 'valtio'
 import { handleCopyCell } from 'components/grid/SupabaseGrid.utils'
 import { formatForeignKeys } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils'
 import AlertError from 'components/ui/AlertError'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -14,6 +15,7 @@ import { useCsvFileDrop } from 'hooks/ui/useCsvFileDrop'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Button, cn } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import type { Filter, GridProps, SupaRow } from '../../types'
 import { useOnRowsChange } from './Grid.utils'
@@ -58,6 +60,8 @@ export const Grid = memo(
 
       const { data: org } = useSelectedOrganizationQuery()
       const { data: project } = useSelectedProjectQuery()
+      const isBranch = project?.parent_project_ref !== undefined
+      console.log({ isBranch })
 
       const onRowsChange = useOnRowsChange(rows)
 
@@ -76,6 +80,9 @@ export const Grid = memo(
       const tableEntityType = snap.originalTable?.entity_type
       const isForeignTable = tableEntityType === ENTITY_TYPE.FOREIGN_TABLE
       const isTableEmpty = (rows ?? []).length === 0
+
+      const isForeignTableMissingVaultKeyError =
+        isForeignTable && isError && error.message.includes('query vault failed')
 
       const { mutate: sendEvent } = useSendEventMutation()
 
@@ -149,20 +156,51 @@ export const Grid = memo(
               className="absolute top-9 p-2 w-full z-[1] pointer-events-none"
             >
               {isLoading && <GenericSkeletonLoader />}
-              {isError && (
-                <AlertError
-                  className="pointer-events-auto"
-                  error={error}
-                  subject="Failed to retrieve rows from table"
-                >
-                  {filters.length > 0 && (
+              {isError ? (
+                isForeignTableMissingVaultKeyError ? (
+                  <Admonition
+                    type="warning"
+                    className="pointer-events-auto"
+                    title="Failed to retrieve rows from foreign table"
+                  >
                     <p>
-                      Verify that the filter values are correct, as the error may stem from an
-                      incorrectly applied filter
+                      The key that's used to retrieve data from your foreign table is either
+                      incorrect or missing. Verify the key in your{' '}
+                      <InlineLink href={`/project/${project?.ref}/integrations?category=wrapper`}>
+                        wrapper's settings
+                      </InlineLink>{' '}
+                      or in{' '}
+                      <InlineLink href={`/project/${project?.ref}/integrations/vault/overview`}>
+                        Vault
+                      </InlineLink>
+                      .
                     </p>
-                  )}
-                </AlertError>
-              )}
+                    {isBranch && (
+                      <p>
+                        Note: Vault keys from the main project do not sync to branches. You may add
+                        them manually into{' '}
+                        <InlineLink href={`/project/${project?.ref}/integrations/vault/overview`}>
+                          Vault
+                        </InlineLink>{' '}
+                        if you want to query foreign tables while on a branch.
+                      </p>
+                    )}
+                  </Admonition>
+                ) : (
+                  <AlertError
+                    className="pointer-events-auto"
+                    error={error}
+                    subject="Failed to retrieve rows from table"
+                  >
+                    {filters.length > 0 && (
+                      <p>
+                        Verify that the filter values are correct, as the error may stem from an
+                        incorrectly applied filter
+                      </p>
+                    )}
+                  </AlertError>
+                )
+              ) : null}
               {isSuccess && (
                 <>
                   {(filters ?? []).length === 0 ? (


### PR DESCRIPTION
## Context

On the topic of enabling users to self debug issues, opting to provide contextual errors in the table editor especially when applying filters.

A common issue users run into is when providing a filter value that doesn't match the column data type, understandably with the current error UI it looks like it's something wrong with the dashboard. Opting to show actionable feedback to users when running into errors - we can incrementally expand this (We've already got one for foreign tables) but just targeting "invalid input syntax" errors in this PR. Added a "remove filters" CTA as well to allow users to quickly reset back to a working state.

Also opting to set `retry` to false when fetching table rows - i reckon we don't need to retry the network request if the request is failing, and just immediately show the error to users. Otherwise atm it looks like the dashboard is really slow as it retries 3 times before finally showing the error

## Before

<img width="1168" height="327" alt="image" src="https://github.com/user-attachments/assets/b87c1e46-fbf2-4ab2-9dd7-0a03f522f611" />


## After

<img width="1167" height="317" alt="image" src="https://github.com/user-attachments/assets/81cd8196-b87a-4369-bf43-bc87b783916d" />
