### PR TITLE
Chore/contextual errors for table editor

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -60,17 +60,10 @@ export const SupabaseGrid = ({
     },
     {
       keepPreviousData: true,
-      retryDelay: (retryAttempt, error: any) => {
+      retry: (_, error: any) => {
         const doesNotExistError = error && error.message?.includes('does not exist')
-        const tooManyRequestsError = error.message?.includes('Too Many Requests')
-        const vaultError = error.message?.includes('query vault failed')
-
         if (doesNotExistError) onApplySorts([])
-
-        if (retryAttempt > 3 || doesNotExistError || tooManyRequestsError || vaultError) {
-          return Infinity
-        }
-        return 5000
+        return false
       },
     }
   )

--- a/apps/studio/components/grid/components/common/DropdownControl.tsx
+++ b/apps/studio/components/grid/components/common/DropdownControl.tsx
@@ -1,5 +1,6 @@
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 import { PropsWithChildren } from 'react'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from 'ui'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'ui'
 
 interface DropdownControlProps {
   options: {
@@ -7,6 +8,8 @@ interface DropdownControlProps {
     label: string
     postLabel?: string
     preLabel?: string
+    disabled?: boolean
+    tooltip?: string
   }[]
   onSelect: (value: string | number) => void
   side?: 'bottom' | 'left' | 'top' | 'right' | undefined
@@ -30,13 +33,18 @@ export const DropdownControl = ({
           {options.length === 0 && <p className="dropdown-control__empty-text">No more items</p>}
           {options.map((x) => {
             return (
-              <DropdownMenuItem key={x.value} onClick={() => onSelect(x.value)}>
+              <DropdownMenuItemTooltip
+                key={x.value}
+                disabled={x.disabled}
+                tooltip={{ content: { side: 'right', text: x.tooltip } }}
+                onClick={() => onSelect(x.value)}
+              >
                 <div className="flex items-center gap-2">
                   {x.preLabel && <span className="grow text-foreground-lighter">{x.preLabel}</span>}
                   <span>{x.label}</span>
                   {x.postLabel && <span className="text-foreground-lighter">{x.postLabel}</span>}
                 </div>
-              </DropdownMenuItem>
+              </DropdownMenuItemTooltip>
             )
           })}
         </div>

--- a/apps/studio/components/grid/components/grid/GridError.tsx
+++ b/apps/studio/components/grid/components/grid/GridError.tsx
@@ -5,6 +5,7 @@ import { InlineLink } from 'components/ui/InlineLink'
 import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
+import { Button } from 'ui'
 import { Admonition } from 'ui-patterns'
 
 export const GridError = ({ error }: { error?: any }) => {
@@ -60,6 +61,8 @@ const ForeignTableMissingVaultKeyError = () => {
 }
 
 const InvalidSyntaxError = ({ error }: { error?: any }) => {
+  const { onApplyFilters } = useTableFilter()
+
   return (
     <Admonition
       type="warning"
@@ -73,9 +76,13 @@ const InvalidSyntaxError = ({ error }: { error?: any }) => {
       <p className="!mb-2">
         Verify that your filter values are correct before applying the filters again.
       </p>
-      <p className="text-sm text-foreground-lighter prose max-w-full !mb-0">
+      <p className="text-sm text-foreground-lighter prose max-w-full !mb-4">
         Error: <code className="text-xs">{error.message}</code>
       </p>
+
+      <Button type="default" onClick={() => onApplyFilters([])}>
+        Remove filters
+      </Button>
     </Admonition>
   )
 }

--- a/apps/studio/components/grid/components/grid/GridError.tsx
+++ b/apps/studio/components/grid/components/grid/GridError.tsx
@@ -1,0 +1,100 @@
+import { useParams } from 'common'
+import { useTableFilter } from 'components/grid/hooks/useTableFilter'
+import AlertError from 'components/ui/AlertError'
+import { InlineLink } from 'components/ui/InlineLink'
+import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
+import { Admonition } from 'ui-patterns'
+
+export const GridError = ({ error }: { error?: any }) => {
+  const { filters } = useTableFilter()
+  const snap = useTableEditorTableStateSnapshot()
+
+  const tableEntityType = snap.originalTable?.entity_type
+  const isForeignTable = tableEntityType === ENTITY_TYPE.FOREIGN_TABLE
+
+  const isForeignTableMissingVaultKeyError =
+    isForeignTable && error?.message?.includes('query vault failed')
+
+  const isInvalidSyntaxError =
+    filters.length > 0 && error?.message?.includes('invalid input syntax')
+
+  if (isForeignTableMissingVaultKeyError) {
+    return <ForeignTableMissingVaultKeyError />
+  } else if (isInvalidSyntaxError) {
+    return <InvalidSyntaxError error={error} />
+  }
+
+  return <GeneralError error={error} />
+}
+
+const ForeignTableMissingVaultKeyError = () => {
+  const { ref } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+  const isBranch = project?.parent_project_ref !== undefined
+
+  return (
+    <Admonition
+      type="warning"
+      className="pointer-events-auto"
+      title="Failed to retrieve rows from foreign table"
+    >
+      <p>
+        The key that's used to retrieve data from your foreign table is either incorrect or missing.
+        Verify the key in your{' '}
+        <InlineLink href={`/project/${ref}/integrations?category=wrapper`}>
+          wrapper's settings
+        </InlineLink>{' '}
+        or in <InlineLink href={`/project/${ref}/integrations/vault/overview`}>Vault</InlineLink>.
+      </p>
+      {isBranch && (
+        <p>
+          Note: Vault keys from the main project do not sync to branches. You may add them manually
+          into <InlineLink href={`/project/${ref}/integrations/vault/overview`}>Vault</InlineLink>{' '}
+          if you want to query foreign tables while on a branch.
+        </p>
+      )}
+    </Admonition>
+  )
+}
+
+const InvalidSyntaxError = ({ error }: { error?: any }) => {
+  return (
+    <Admonition
+      type="warning"
+      className="pointer-events-auto"
+      title="Invalid input syntax provided in filter value"
+    >
+      <p className="!mb-0">
+        Unable to retrieve results as the provided value in your filter doesn't match it's column
+        data type.
+      </p>
+      <p className="!mb-2">
+        Verify that your filter values are correct before applying the filters again.
+      </p>
+      <p className="text-sm text-foreground-lighter prose max-w-full !mb-0">
+        Error: <code className="text-xs">{error.message}</code>
+      </p>
+    </Admonition>
+  )
+}
+
+const GeneralError = ({ error }: { error: any }) => {
+  const { filters } = useTableFilter()
+
+  return (
+    <AlertError
+      className="pointer-events-auto"
+      error={error}
+      subject="Failed to retrieve rows from table"
+    >
+      {filters.length > 0 && (
+        <p>
+          Verify that the filter values are correct, as the error may stem from an incorrectly
+          applied filter
+        </p>
+      )}
+    </AlertError>
+  )
+}

--- a/apps/studio/components/grid/components/header/filter/FilterPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverPrimitive.tsx
@@ -109,7 +109,7 @@ export const FilterPopoverPrimitive = ({
             ))}
             {localFilters.length == 0 && (
               <div className="space-y-1 px-3">
-                <h5 className="text-foreground-light">No filters applied to this view</h5>
+                <h5 className="text-xs text-foreground-light">No filters applied to this view</h5>
                 <p className="text-xs text-foreground-lighter">
                   Add a column below to filter the view
                 </p>
@@ -118,7 +118,7 @@ export const FilterPopoverPrimitive = ({
           </div>
           <PopoverSeparator_Shadcn_ />
           <div className="px-3 flex flex-row justify-between">
-            <Button icon={<Plus />} type="text" onClick={onAddFilter}>
+            <Button icon={<Plus />} type="dashed" onClick={onAddFilter}>
               Add filter
             </Button>
             <Button

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -74,7 +74,7 @@ export const SortPopoverPrimitive = ({
   const columns = useMemo(() => {
     if (!snap?.table?.columns) return []
     return snap.table.columns.filter((x) => {
-      if (x.dataType === 'json' || x.dataType === 'jsonb') return false
+      // if (x.dataType === 'json' || x.dataType === 'jsonb') return false
       const found = localSorts.find((y) => y.column == x.name)
       return !found
     })
@@ -82,7 +82,18 @@ export const SortPopoverPrimitive = ({
 
   // Format the columns for the dropdown
   const dropdownOptions = useMemo(() => {
-    return columns?.map((x) => ({ value: x.name, label: x.name })) || []
+    return (
+      columns?.map((x) => ({
+        value: x.name,
+        label: x.name,
+        postLabel: x.dataType,
+        disabled: x.dataType === 'json' || x.dataType === 'jsonb',
+        tooltip:
+          x.dataType === 'json' || x.dataType === 'jsonb'
+            ? 'Sorting on JSON-based columns is currently not supported'
+            : '',
+      })) || []
+    )
   }, [columns])
 
   // Add a new sort

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -74,7 +74,6 @@ export const SortPopoverPrimitive = ({
   const columns = useMemo(() => {
     if (!snap?.table?.columns) return []
     return snap.table.columns.filter((x) => {
-      // if (x.dataType === 'json' || x.dataType === 'jsonb') return false
       const found = localSorts.find((y) => y.column == x.name)
       return !found
     })
@@ -196,7 +195,7 @@ export const SortPopoverPrimitive = ({
       ))}
       {localSorts.length === 0 && (
         <div className="space-y-1 px-3">
-          <h5 className="text-foreground-light">No sorts applied to this view</h5>
+          <h5 className="text-xs text-foreground-light">No sorts applied to this view</h5>
           <p className="text-xs text-foreground-lighter">Add a column below to sort the view</p>
         </div>
       )}
@@ -212,7 +211,7 @@ export const SortPopoverPrimitive = ({
           >
             <Button
               asChild
-              type="text"
+              type="dashed"
               iconRight={<ChevronDown size="14" className="text-foreground-light" />}
               className="sb-grid-dropdown__item-trigger"
               data-testid="table-editor-pick-column-to-sort-button"

--- a/apps/studio/components/grid/components/header/sort/SortRow.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortRow.tsx
@@ -5,7 +5,7 @@ import { useDrag, useDrop } from 'react-dnd'
 
 import type { DragItem, Sort } from 'components/grid/types'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
-import { Button, Toggle } from 'ui'
+import { Button, Switch } from 'ui'
 
 export interface SortRowProps {
   index: number
@@ -113,17 +113,14 @@ const SortRow = ({ index, columnName, sort, onDelete, onToggle, onDrag }: SortRo
           <span className="text-xs text-foreground-lighter">
             {index > 0 ? 'then by' : 'sort by'}
           </span>
-          {column.name}
+          <span className="text-xs">{column.name}</span>
         </span>
       </div>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-x-1.5">
         <label className="text-xs text-foreground-lighter">ascending:</label>
-        <Toggle
-          size="tiny"
-          layout="flex"
+        <Switch
           defaultChecked={sort.ascending}
-          // @ts-ignore
-          onChange={(e: boolean) => onToggle(columnName, e)}
+          onCheckedChange={(e: boolean) => onToggle(columnName, e)}
         />
       </div>
       <Button

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -236,9 +236,7 @@ export async function getTableRows(
 
     return { rows }
   } catch (error) {
-    throw new Error(
-      `Error fetching table rows: ${error instanceof Error ? error.message : 'Unknown error'}`
-    )
+    throw new Error(error instanceof Error ? error.message : 'Unknown error')
   }
 }
 


### PR DESCRIPTION
## Context

On the topic of enabling users to self debug issues, opting to provide contextual errors in the table editor especially when applying filters.

A common issue users run into is when providing a filter value that doesn't match the column data type, understandably with the current error UI it looks like it's something wrong with the dashboard. Opting to show actionable feedback to users when running into errors - we can incrementally expand this (We've already got one for foreign tables).

## Before

<img width="1168" height="327" alt="image" src="https://github.com/user-attachments/assets/b87c1e46-fbf2-4ab2-9dd7-0a03f522f611" />

## Changes involved

- Add error UI for "invalid input syntax" errors
  - Added a "remove filters" CTA as well to allow users to quickly reset back to a working state
  <img width="1167" height="317" alt="image" src="https://github.com/user-attachments/assets/81cd8196-b87a-4369-bf43-bc87b783916d" />
- Add error UI for "could not identify ordering operator" errors
  - Added a "remove sorts" CTA as well to allow users to quickly reset back to a working state.
  <img width="1168" height="299" alt="image" src="https://github.com/user-attachments/assets/0e4be8dd-8bd6-47ab-8c07-3c3d0cbb43d0" />
- Also opting to set `retry` to false when fetching table rows
  - I reckon we don't need to retry the network request if the request is failing, and just immediately show the error to users. Otherwise atm it looks like the dashboard is really slow as it retries 3 times before finally showing the error
- Opt to not hide JSON columns from sort dropdown
  - We currently are, which can be confusing - opting to show a tooltip instead
    <img width="660" height="234" alt="image" src="https://github.com/user-attachments/assets/ef589bf5-4804-4a8d-b153-9bdb81fe0b2d" />

