### PR TITLE
Fix FormItemLayout mobile responsivity when layout is flex row reverse

### DIFF
--- a/apps/studio/components/interfaces/Organization/GeneralSettings/OrganizationDetailsForm.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/OrganizationDetailsForm.tsx
@@ -85,7 +85,7 @@ export const OrganizationDetailsForm = () => {
         onSubmit={orgDetailsForm.handleSubmit(onUpdateOrganizationDetails)}
       >
         <Card>
-          <CardContent className="pt-6">
+          <CardContent>
             <FormField_Shadcn_
               control={orgDetailsForm.control}
               name="name"
@@ -94,7 +94,7 @@ export const OrganizationDetailsForm = () => {
                   <FormControl_Shadcn_>
                     <Input
                       {...field}
-                      className="w-96 max-w-full"
+                      className="w-full max-w-full md:w-96"
                       disabled={!canUpdateOrganization || isUpdatingDetails}
                     />
                   </FormControl_Shadcn_>
@@ -105,13 +105,14 @@ export const OrganizationDetailsForm = () => {
           <CardContent>
             <FormItemLayout label="Organization slug" layout="flex-row-reverse">
               <PrePostTab
+                className="w-full [&>div:first-child]:flex-grow [&>div:last-child]:px-1.5"
                 postTab={
                   <CopyButton type="text" iconOnly text={selectedOrganization?.slug ?? ''} />
                 }
               >
                 <Input
                   disabled
-                  className="w-64 max-w-full"
+                  className="w-full max-w-full md:w-64"
                   id="slug"
                   value={selectedOrganization?.slug ?? ''}
                 />

--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -45,7 +45,8 @@ const ContainerVariants = cva('relative grid gap-10', {
       horizontal: 'flex flex-col gap-2 md:grid md:grid-cols-12',
       vertical: 'flex flex-col gap-2',
       flex: 'flex flex-row gap-3',
-      'flex-row-reverse': 'flex flex-row gap-6 flex-row-reverse justify-between',
+      'flex-row-reverse':
+        'flex flex-col-reverse gap-2 md:gap-6 md:flex-row-reverse md:justify-between',
     },
     flex: {
       true: '',
@@ -232,7 +233,7 @@ const FlexContainer = cva('', {
     },
     {
       layout: 'flex-row-reverse',
-      className: 'flex flex-col justify-center items-end shrink-0',
+      className: 'flex flex-col justify-center items-start md:items-end shrink-0',
     },
   ],
 })


### PR DESCRIPTION
Using organization settings as the demo here

## Before
<img width="408" height="401" alt="image" src="https://github.com/user-attachments/assets/783995d5-ba87-43d6-92a3-ee82f76693c9" />

## After
<img width="407" height="336" alt="image" src="https://github.com/user-attachments/assets/40c0fc06-40d2-4816-8446-14c44839bdd2" />
