### PR TITLE
Fix default order by columsn to exclude json columns

### DIFF
--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -35,7 +35,9 @@ export interface GetTableRowsArgs {
 const getDefaultOrderByColumns = (table: SupaTable) => {
   const primaryKeyColumns = table.columns.filter((col) => col?.isPrimaryKey).map((col) => col.name)
   if (primaryKeyColumns.length === 0) {
-    return [table.columns[0]?.name]
+    const eligibleColumnsForSorting = table.columns.filter((x) => !x.dataType.includes('json'))
+    if (eligibleColumnsForSorting.length > 0) return [eligibleColumnsForSorting[0]?.name]
+    else return []
   } else {
     return primaryKeyColumns
   }

--- a/packages/pg-meta/src/query/table-row-query.ts
+++ b/packages/pg-meta/src/query/table-row-query.ts
@@ -77,7 +77,9 @@ export const getDefaultOrderByColumns = (table: Pick<PGTable, 'primary_keys' | '
     return primaryKeyColumns
   }
   if (table.columns && table.columns.length > 0) {
-    return [table.columns[0].name]
+    const eligibleColumnsForSorting = table.columns.filter((x) => !x.data_type.includes('json'))
+    if (eligibleColumnsForSorting.length > 0) return [eligibleColumnsForSorting[0].name]
+    else return []
   }
   return []
 }


### PR DESCRIPTION
## Context

Our current `getDefaultOrderByColumns` picks the first column in the table to sort on if the table has no primary key

However, JSON based columns cannot be sorted on and hence if the table's first column is of JSON type, the user will run into the following error with no way of remediating:

<img width="1152" height="311" alt="image" src="https://github.com/user-attachments/assets/4d57ae3e-a3b2-4bea-89ff-3232ece575de" />

## Changes involved

- Omit json based columns in `getDefaultOrderByColumns`

## To test

- [ ] Create a table with no PK, and just one JSON type column
- [ ] Verify that you can open that table in the table editor