### PR TITLE
Only show the copy button when the value is decrypted.

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/DecryptedReadOnlyInput.tsx
@@ -43,8 +43,8 @@ export const DecryptedReadOnlyInput = ({
   return (
     <Input
       readOnly
-      // if the value is hidden, don't allow copying to clipboard
-      copy={showHidden}
+      // If the value is secure, allow copying to clipboard if the value is revealed. Otherwise, always allow copying
+      copy={!secureEntry || showHidden}
       disabled
       label={
         <div className="flex items-center gap-x-2">

--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/DecryptedReadOnlyInput.tsx
@@ -43,7 +43,8 @@ export const DecryptedReadOnlyInput = ({
   return (
     <Input
       readOnly
-      copy
+      // if the value is hidden, don't allow copying to clipboard
+      copy={showHidden}
       disabled
       label={
         <div className="flex items-center gap-x-2">

--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/DecryptedReadOnlyInput.tsx
@@ -44,7 +44,7 @@ export const DecryptedReadOnlyInput = ({
     <Input
       readOnly
       // If the value is secure, allow copying to clipboard if the value is revealed. Otherwise, always allow copying
-      copy={!secureEntry || showHidden}
+      copy={!secureEntry || (!isDecryptedValueLoading && showHidden)}
       disabled
       label={
         <div className="flex items-center gap-x-2">


### PR DESCRIPTION
This PR changes the copy button in the Analytic Bucket details to be shown only when the value is shown/decrypted.