### PR TITLE
docs: automate js libs docs update

### DIFF
--- a/.github/workflows/docs-js-libs-update.yml
+++ b/.github/workflows/docs-js-libs-update.yml
@@ -1,0 +1,70 @@
+name: Update JS Client Libraries Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version that was released (e.g., patch, minor, major, or v2.1.0)"
+        required: true
+        type: string
+      source:
+        description: "Source of the documentation update"
+        required: false
+        type: string
+        default: "manual"
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  update-docs:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          sparse-checkout: |
+            apps/docs
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm i
+
+      - name: Regenerate JS client libraries tsdoc files
+        working-directory: apps/docs/spec
+        run: |
+          echo "Regenerating tsdoc files for JS client libraries..."
+          echo "Source: ${{ github.event.inputs.source }}"
+          echo "Version: ${{ github.event.inputs.version }}"
+          make
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: update js client libraries (${{ github.event.inputs.version }})"
+          title: "docs: update js client libraries (${{ github.event.inputs.version }})"
+          body: |
+            Updates JS client libraries documentation following stable release. 
+            Ran `make` in apps/docs/spec to regenerate tsdoc files.
+
+            **Details:**
+            - **Version:** `${{ github.event.inputs.version }}`
+            - **Source:** `${{ github.event.inputs.source }}`
+            - **Changes:** Regenerated tsdoc files from latest spec files
+
+            🤖 Auto-generated from supabase-js-libs stable release.
+          branch: "gha/update-js-libs-docs-${{ github.run_number }}"
+          base: "master"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add a new workflow that can be triggered either manually or from a `workflow_dispatch` event. Once the new js monorepo is in place, this workflow will be triggered whenever there's a stable release. See [here](https://github.com/supabase/supabase-js-libs/blob/main/.github/workflows/release-stable.yml#L99). Follows example of [mgmt-api](https://github.com/supabase/supabase/blob/master/.github/workflows/docs-mgmt-api-update.yml).
