### PR TITLE
chore: add js libs auto-update workflow

### DIFF
--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -1,0 +1,76 @@
+name: Update JS Libraries
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to update to'
+        required: true
+        type: string
+      source:
+        description: 'Source of the update'
+        required: false
+        type: string
+        default: 'manual'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  update-js-libs:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Update @supabase/*-js packages in pnpm-workspace.yaml
+        run: |
+          # Update @supabase/supabase-js
+          sed -i "s/'@supabase\/supabase-js': .*/'@supabase\/supabase-js': ^${{ github.event.inputs.version }}/" pnpm-workspace.yaml
+          
+          # Update @supabase/auth-js
+          sed -i "s/'@supabase\/auth-js': .*/'@supabase\/auth-js': ^${{ github.event.inputs.version }}/" pnpm-workspace.yaml
+          
+          # Update @supabase/realtime-js
+          sed -i "s/'@supabase\/realtime-js': .*/'@supabase\/realtime-js': ^${{ github.event.inputs.version }}/" pnpm-workspace.yaml
+          
+          echo "Updated pnpm-workspace.yaml:"
+          cat pnpm-workspace.yaml
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'feat: update @supabase/*-js libraries to v${{ github.event.inputs.version }}'
+          title: 'feat: update @supabase/*-js libraries to v${{ github.event.inputs.version }}'
+          body: |
+            This PR updates @supabase/*-js libraries to version ${{ github.event.inputs.version }}.
+            
+            **Source**: ${{ github.event.inputs.source }}
+            
+            **Changes**:
+            - Updated @supabase/supabase-js to ^${{ github.event.inputs.version }}
+            - Updated @supabase/auth-js to ^${{ github.event.inputs.version }}
+            - Updated @supabase/realtime-js to ^${{ github.event.inputs.version }}
+            - Refreshed pnpm-lock.yaml
+            
+            This PR was created automatically.
+          branch: 'gha/auto-update-js-libs-v${{ github.event.inputs.version }}'
+          base: 'master'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,6 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/*'
   - '@supabase/mcp-server-supabase'
   - '@supabase/mcp-utils'
+  - '@supabase/auth-js' 
+  - '@supabase/supabase-js'
+  - '@supabase/realtime-js'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Now that the JS Libs are switching to non-automated releases, whenever we trigger a stable release on the js client libs monorepo, and the release succeeds, it will trigger this workflow, that will update the js client libs on this repository, and create a PR. Context [here](https://github.com/supabase/js-client-libs/blob/main/.github/workflows/release-stable.yml#L135).

It will also help us quickly check specific canaries, by manually triggering this workflow, adding manually the canary we want to test.
