### PR TITLE
feat: improve UsersV2 page initial load performance

### DIFF
--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -15,7 +15,7 @@ export type UsersVariables = {
   keywords?: string
   filter?: Filter
   providers?: string[]
-  sort?: 'created_at' | 'email' | 'phone' | 'last_sign_in_at'
+  sort?: 'id' | 'created_at' | 'email' | 'phone' | 'last_sign_in_at'
   order?: 'asc' | 'desc'
 }
 


### PR DESCRIPTION
Improves the initial load performance of the UsersV2 endpoint:

1. No more saved column searches and sorts.
2. Default sort is by primary key and not by `created_at` unindexed column
3. If the estimated size of the table is over 10k rows, filtering is a click-away to prevent accidental full-table scans

<img width="1169" height="169" alt="image" src="https://github.com/user-attachments/assets/9fdf88d4-260a-4f7b-9c3d-3351292b9e73" />
