### PR TITLE
Add quotes to Logflare container definition.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -372,8 +372,8 @@ services:
       DB_SCHEMA: _analytics
       LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
       LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN}
-      LOGFLARE_SINGLE_TENANT: true
-      LOGFLARE_SUPABASE_MODE: true
+      LOGFLARE_SINGLE_TENANT: "true"
+      LOGFLARE_SUPABASE_MODE: "true"
       LOGFLARE_MIN_CLUSTER_SIZE: 1
 
       # Comment variables to use Big Query backend for analytics


### PR DESCRIPTION
As per #33974 and #22304, logflare is _actually_ looking for the words 'true' and 'false' in the environment variables `LOGFLARE_SUNGLE_TENANT` and `LOGFLARE_SUPABASE_MODE`, rather than boolean values. The YAML parser will convert any 'boolean-ish' value to a boolean, unless quoted.

This PR quotes these two words so that the YAML parser doesn't interpret them as booleans.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
As per #33974 and #22304, logflare is _actually_ looking for the words 'true' and 'false' in the environment variables `LOGFLARE_SUNGLE_TENANT` and `LOGFLARE_SUPABASE_MODE`, rather than boolean values. The Compose spec says that these values must be quoted.

## What is the current behavior?

When using podman and the compose file in this repository, the analytics container fails to start as it can't find `gcloud.json`. This search is happening because the `LOGFLARE_SINGLE_TENANT` environment variable doesn't contain _the string value_ 'true'.

- #33974 
- #22304 

## What is the new behavior?

The compose file in this repository can be used with podman compose and the analytics container starts.

## Additional context

N/A
