### PR TITLE
Add image transformation configuration to CLI spec

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -618,6 +618,17 @@ parameters:
       - name: 'Storage server configuration'
         link: 'https://supabase.com/docs/guides/self-hosting/storage/config'
 
+  - id: 'storage.image_transformation.enabled'
+    title: 'storage.image_transformation.enabled'
+    tags: ['storage']
+    required: false
+    default: 'false'
+    description: |
+      Image transformation API is available to Supabase Pro plan.
+    links:
+      - name: 'Storage server configuration'
+        link: 'https://supabase.com/docs/guides/self-hosting/storage/config'
+
   - id: 'storage.buckets.bucket_name.public'
     title: 'storage.buckets.<bucket_name>.public'
     tags: ['storage']


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Missing information on the available `storage.image_transformation.enabled` option.

## What is the new behavior?

Information added to the spec.

## Additional context

Added configuration for `image_transformation.enabled` option in `storage` section of the CLI spec. The comment is taken from the default `config.toml` generated by `supabase init`.