### PR TITLE
chore: change terminology of prior post

### DIFF
--- a/apps/www/components/Blog/BlogPostRenderer.tsx
+++ b/apps/www/components/Blog/BlogPostRenderer.tsx
@@ -127,9 +127,11 @@ const BlogPostRenderer = ({
               <div>
                 <p className="text-foreground-lighter text-sm">{label}</p>
               </div>
-              <div>
+              <div className="flex flex-col gap-2">
                 {'title' in post && (
-                  <h4 className="text-foreground text-lg">{(post as { title?: string }).title}</h4>
+                  <h4 className="text-foreground text-lg text-balance">
+                    {(post as { title?: string }).title}
+                  </h4>
                 )}
                 {'formattedDate' in post && (
                   <p className="small">{(post as { formattedDate?: string }).formattedDate}</p>
@@ -306,7 +308,7 @@ const BlogPostRenderer = ({
                               formattedDate: string
                             }
                           }
-                          label="Last post"
+                          label="Previous post"
                         />
                       )}
                     </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor language and spacing tweak.

## What is the current behavior?

We use the word _Last post_ to describe the blog post prior to that of the current one. That comes across as ambiguous, as a native English speaker. It implies “most recent blog post” rather than ”the one before this one”.

## What is the new behavior?

- Changed the language to _Previous post_

Also did some minor design nip-and-tuck whilst I was touching this component:

- Gave a bit more breathing room to the post date
- Made the blog post title visually balanced

## Additional context

Fixes DEPR-73. Before and after:

| Before | After |
| --- | --- |
| <img width="1106" height="750" alt="CleanShot 2025-09-29 at 17 19 28@2x" src="https://github.com/user-attachments/assets/63fb6b57-8408-4df7-8f36-e853096d6ae8" /> | <img width="1126" height="808" alt="CleanShot 2025-09-29 at 17 18 36@2x" src="https://github.com/user-attachments/assets/d57e8223-f0c6-458a-8fcf-a51b515af21a" /> |
