### PR TITLE
Add region code to region selection in project and replica creation

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -148,7 +148,7 @@ export const RegionSelector = ({
                   value={value.name}
                   className="w-full [&>:nth-child(2)]:w-full"
                 >
-                  <div className="flex flex-row items-center justify-between w-full">
+                  <div className="flex flex-row items-center justify-between w-full gap-x-2">
                     <div className="flex items-center gap-x-3">
                       <img
                         alt="region icon"
@@ -163,13 +163,13 @@ export const RegionSelector = ({
                       </div>
                     </div>
 
-                    <div>
-                      {recommendedSpecificRegions.has(value.code) && (
+                    {recommendedSpecificRegions.has(value.code) && (
+                      <div>
                         <Badge variant="success" className="mr-1">
                           Recommended
                         </Badge>
-                      )}
-                    </div>
+                      </div>
+                    )}
                   </div>
                 </SelectItem_Shadcn_>
               )

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -155,7 +155,12 @@ export const RegionSelector = ({
                         className="w-5 rounded-sm"
                         src={`${BASE_PATH}/img/regions/${value.code}.svg`}
                       />
-                      <span className="text-foreground">{value.name}</span>
+                      <div className="flex items-center gap-x-2">
+                        <span className="text-foreground">{value.name}</span>
+                        <span className="text-xs text-foreground-lighter font-mono">
+                          {value.code}
+                        </span>
+                      </div>
                     </div>
 
                     <div>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
@@ -447,7 +447,10 @@ const DeployNewReplicaPanel = ({
                   />
                 )}
               >
-                {region.name}
+                <p className="flex items-center gap-x-2">
+                  <span>{region.name}</span>
+                  <span className="text-xs text-foreground-lighter font-mono">{region.region}</span>
+                </p>
               </Listbox.Option>
             ))}
           </Listbox>


### PR DESCRIPTION
## Context

Addresses an issue whereby we'd typically use the region code in any incident announcements (e.g "Project and branch lifecycle workflows affected in ap-south-1") but users wouldn't know what `ap-south-1` refers to.

Opting to consolidate this information by also displaying the region code in the dashboard for clarity and easier reference


## Changes

- Adds the region code to region selectors in project creation + read replica creation UI

<img width="476" height="310" alt="image" src="https://github.com/user-attachments/assets/50f98f1a-5c08-44a7-ac36-3dd91038f624" />

<img width="445" height="345" alt="image" src="https://github.com/user-attachments/assets/7964078f-46f0-4f2e-93f0-d08d2e1dba41" />
