### PR TITLE
Ensure CSV chunk uploads handle rate limit 409s

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -893,7 +893,9 @@ export const insertRowsViaSpreadsheet = async (
 
         const insertQuery = new Query().from(table.name, table.schema).insert(formattedData).toSql()
         try {
-          await executeWithRetry(() => executeSql({ projectRef, connectionString, sql: insertQuery }));
+          await executeWithRetry(() =>
+            executeSql({ projectRef, connectionString, sql: insertQuery })
+          )
         } catch (error) {
           console.warn(error)
           insertError = error

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -41,6 +41,7 @@ import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePanelEditor.types'
 import { checkIfRelationChanged } from './TableEditor/ForeignKeysManagement/ForeignKeysManagement.utils'
 import type { ImportContent } from './TableEditor/TableEditor.types'
+import { executeWithRetry } from 'data/table-rows/table-rows-query'
 
 const BATCH_SIZE = 1000
 const CHUNK_SIZE = 1024 * 1024 * 0.1 // 0.1MB
@@ -892,7 +893,7 @@ export const insertRowsViaSpreadsheet = async (
 
         const insertQuery = new Query().from(table.name, table.schema).insert(formattedData).toSql()
         try {
-          await executeSql({ projectRef, connectionString, sql: insertQuery })
+          await executeWithRetry(() => executeSql({ projectRef, connectionString, sql: insertQuery }));
         } catch (error) {
           console.warn(error)
           insertError = error

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -54,7 +54,8 @@ export async function executeWithRetry<T>(
     try {
       return await fn()
     } catch (error: any) {
-      if (error?.status === 429 && attempt < maxRetries) {
+      // Our custom ResponseError's use 'code' instead of 'status'
+      if ((error?.status ?? error?.code) === 429 && attempt < maxRetries) {
         // Get retry delay from headers or use exponential backoff (1s, then 2s, then 4s)
         const retryAfter = error.headers?.get('retry-after')
         const delayMs = retryAfter ? parseInt(retryAfter) * 1000 : baseDelay * Math.pow(2, attempt)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

CSV uploads will partially fail when hitting backend rate limit without way to recover. 

## What is the new behavior?

Each CSV chunk will now attempt to retry inserts using the provided backoff from the API. 

## Additional context

Reusing existing utility that's used for rate limited downloads
