### PR TITLE
fix(ai assistant): remove extra backslash in ui

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { BarChart, FileText, Shield } from 'lucide-react'
+// End of third-party imports
 
 import { useParams } from 'common'
 import { LINTER_LEVELS } from 'components/interfaces/Linter/Linter.constants'
@@ -7,7 +8,7 @@ import { createLintSummaryPrompt } from 'components/interfaces/Linter/Linter.uti
 import { type Lint, useProjectLintsQuery } from 'data/lint/lint-query'
 import { Button, Skeleton } from 'ui'
 import { codeSnippetPrompts, defaultPrompts } from './AIAssistant.prompts'
-import { type SqlSnippet } from './AIAssistant.types'
+import type { SqlSnippet } from './AIAssistant.types'
 
 interface AIOnboardingProps {
   sqlSnippets?: SqlSnippet[]
@@ -137,7 +138,7 @@ export const AIOnboarding = ({
                               onFocusInput?.()
                             }}
                           >
-                            {lint.detail ? lint.detail.replace(/`/g, '') : lint.title}
+                            {lint.detail ? lint.detail.replace(/\\`/g, '') : lint.title}
                           </Button>
                         )
                       })}


### PR DESCRIPTION
In the security lints view within the AI Assistant, escaped backticks aren't being properly replaced, so there's a weird backslash around table names. Fixed this so the table name appears without any wrapping punctuation.

<details>
<summary>
Before
</summary>
<img width="598" height="571" alt="CleanShot 2025-09-29 at 11 08 25" src="https://github.com/user-attachments/assets/cdf90adb-b87b-4a3f-9592-966154a3e384" />
</details>

<details>
<summary>
After
</summary>
<img width="434" height="147" alt="CleanShot 2025-09-29 at 11 07 54" src="https://github.com/user-attachments/assets/6211fd1d-c312-4de7-bb4d-7e3a7b5032fe" />
</details>
