### PR TITLE
docs: remove credit top ups pay outstanding invoices

### DIFF
--- a/apps/docs/content/guides/platform/credits.mdx
+++ b/apps/docs/content/guides/platform/credits.mdx
@@ -28,7 +28,6 @@ As an example, if you start a Pro Plan subscription on January 1 and downgrade t
 ## Credit top-ups
 
 You can top up credits at any time, with a maximum of <Price price="2000" /> per top-up. These credits do not expire and are non-refundable.
-  
 You may want to consider this option to avoid issues with recurring payments, gain more control over how often your credit card is charged, and potentially make things easier for your accounting department.
 
 <Admonition type="note">

--- a/apps/docs/content/guides/platform/credits.mdx
+++ b/apps/docs/content/guides/platform/credits.mdx
@@ -28,9 +28,7 @@ As an example, if you start a Pro Plan subscription on January 1 and downgrade t
 ## Credit top-ups
 
 You can top up credits at any time, with a maximum of <Price price="2000" /> per top-up. These credits do not expire and are non-refundable.
-
-If you have any outstanding invoices, we’ll automatically use your credits to pay them off. Any remaining credits will be applied to future invoices.
-
+  
 You may want to consider this option to avoid issues with recurring payments, gain more control over how often your credit card is charged, and potentially make things easier for your accounting department.
 
 <Admonition type="note">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -237,8 +237,8 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
             <DialogDescription className="space-y-2">
               <p className="prose text-sm">
                 On successful payment, an invoice will be issued and you'll be granted credits.
-                Credits will be applied to future invoices only and are not refundable.
-                The topped up credits do not expire.
+                Credits will be applied to future invoices only and are not refundable. The topped
+                up credits do not expire.
               </p>
               <p className="prose text-sm">
                 For larger discounted credit packages, please{' '}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -237,7 +237,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
             <DialogDescription className="space-y-2">
               <p className="prose text-sm">
                 On successful payment, an invoice will be issued and you'll be granted credits.
-                Credits will be applied to outstanding and future invoices and are not refundable.
+                Credits will be applied to future invoices only and are not refundable.
                 The topped up credits do not expire.
               </p>
               <p className="prose text-sm">


### PR DESCRIPTION
Orb changed its API, and it's preventing us from marking outstanding invoices with pending payments as paid.
We're hoping to restore the functionality to pay outstanding invoices with credits soon, but we still don't have an update from Orb. 

For now, we're removing this from the docs temporarily.