### PR TITLE
Give password protection visibility within auth protection

### DIFF
--- a/apps/studio/components/interfaces/Auth/ProtectionAuthSettingsForm/ProtectionAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/ProtectionAuthSettingsForm/ProtectionAuthSettingsForm.tsx
@@ -1,6 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Eye, EyeOff } from 'lucide-react'
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -18,6 +19,7 @@ import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
+  Badge,
   Button,
   Card,
   CardContent,
@@ -266,6 +268,29 @@ export const ProtectionAuthSettingsForm = () => {
                 </CardContent>
               </>
             )}
+
+            <CardContent>
+              <FormField_Shadcn_
+                control={protectionForm.control}
+                name="PASSWORD_HIBP_ENABLED"
+                render={({ field }) => (
+                  <FormItemLayout
+                    layout="flex-row-reverse"
+                    label="Prevent use of leaked passwords"
+                    description="Rejects the use of known or easy to guess passwords on sign up or password change. "
+                  >
+                    <div className="flex items-center gap-2">
+                      <Badge variant={field.value ? 'success' : 'default'}>
+                        {field.value ? 'Enabled' : 'Disabled'}
+                      </Badge>
+                      <Link href={`/project/${projectRef}/auth/providers?provider=Email`}>
+                        <Button type="default">Configure email provider</Button>
+                      </Link>
+                    </div>
+                  </FormItemLayout>
+                )}
+              />
+            </CardContent>
 
             <CardFooter className="justify-end space-x-2">
               {protectionForm.formState.isDirty && (


### PR DESCRIPTION

<img width="1240" height="472" alt="image" src="https://github.com/user-attachments/assets/984b737a-b307-4c54-8475-e654b32dbc4c" />


We've had feedback that finding "Prevent use of leaked passwords" has been challenging so this just gives it more visibility within the protection page. The setting just links off to email provider as the two are tied together. 