### PR TITLE
Add callout for leaked password that its on the pro plan and above

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -22,6 +22,8 @@ export interface Provider {
       descriptionOptional?: string
       units?: string
       isSecret?: boolean
+      isPaid?: boolean
+      link?: string
     }
   }
   validationSchema: any // todo: use Yup type

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -7,6 +7,7 @@ import { Markdown } from 'components/interfaces/Markdown'
 import { DatePicker } from 'components/ui/DatePicker'
 import { BASE_PATH } from 'lib/constants'
 import { Button, Input, InputNumber, Listbox, Toggle } from 'ui'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import type { Enum } from './AuthProvidersForm.types'
 
 interface FormFieldProps {
@@ -223,17 +224,18 @@ const FormField = ({
           id={name}
           name={name}
           disabled={disabled}
-          label={properties.title}
+          label={
+            <div className="flex items-center gap-x-2">
+              <span>{properties.title}</span>
+              {properties.link && (
+                <a href={properties.link} target="_blank" rel="noreferrer noopener">
+                  <InfoTooltip side="bottom">Documentation</InfoTooltip>
+                </a>
+              )}
+            </div>
+          }
           descriptionText={
-            properties.description ? (
-              <ReactMarkdown
-                unwrapDisallowed
-                disallowedElements={['p']}
-                className="form-field-markdown"
-              >
-                {properties.description}
-              </ReactMarkdown>
-            ) : null
+            properties.description ? <Markdown content={properties.description} /> : null
           }
         />
       )
@@ -282,7 +284,7 @@ const FormField = ({
       break
   }
 
-  return <></>
+  return null
 }
 
 export default FormField

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -15,6 +15,7 @@ import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutati
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { BASE_PATH } from 'lib/constants'
 import { Button, Form, Input, Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -33,6 +34,7 @@ const doubleNegativeKeys = ['SMS_AUTOCONFIRM']
 
 export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) => {
   const { ref: projectRef } = useParams()
+  const { data: organization } = useSelectedOrganizationQuery()
   const [urlProvider, setUrlProvider] = useQueryState('provider', { defaultValue: '' })
 
   const [open, setOpen] = useState(false)
@@ -62,6 +64,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
     )
   }
 
+  const isFreePlan = organization?.plan.id === 'free'
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
   const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
@@ -163,7 +166,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       </ResourceItem>
 
       <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetContent className="flex flex-col gap-0">
+        <SheetContent size="content" className="flex flex-col gap-0">
           <SheetHeader className="shrink-0 flex items-center gap-4">
             <img
               src={`${BASE_PATH}/img/icons/${provider.misc.iconKey}.svg`}
@@ -191,25 +194,37 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
                         title={provider.title}
                         isHookSendSMSEnabled={config.HOOK_SEND_SMS_ENABLED}
                       />
-                      {Object.keys(provider.properties).map((x: string) => (
-                        <FormField
-                          key={x}
-                          name={x}
-                          setFieldValue={setFieldValue}
-                          properties={provider.properties[x]}
-                          formValues={values}
-                          disabled={shouldDisableField(x) || !canUpdateConfig}
-                        />
-                      ))}
+
+                      {Object.keys(provider.properties).map((x: string) => {
+                        const properties = {
+                          ...provider.properties[x],
+                          description:
+                            provider.properties[x].isPaid && isFreePlan
+                              ? `${provider.properties[x].description} Only available on [Pro plan](/org/${organization.slug}/billing?panel=subscriptionPlan) and above.`
+                              : provider.properties[x].description,
+                        }
+                        const isDisabledDueToPlan = properties.isPaid && isFreePlan
+
+                        return (
+                          <FormField
+                            key={x}
+                            name={x}
+                            setFieldValue={setFieldValue}
+                            properties={properties}
+                            formValues={values}
+                            disabled={
+                              shouldDisableField(x) || !canUpdateConfig || isDisabledDueToPlan
+                            }
+                          />
+                        )
+                      })}
 
                       {provider?.misc?.alert && (
                         <Admonition
                           type="warning"
                           title={provider.misc.alert.title}
                           description={
-                            <>
-                              <ReactMarkdown>{provider.misc.alert.description}</ReactMarkdown>
-                            </>
+                            <ReactMarkdown>{provider.misc.alert.description}</ReactMarkdown>
                           }
                         />
                       )}

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -37,6 +37,8 @@ const PROVIDER_EMAIL = {
       description:
         'Rejects the use of known or easy to guess passwords on sign up or password change. Powered by the HaveIBeenPwned.org Pwned Passwords API.',
       type: 'boolean',
+      link: 'https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection',
+      isPaid: true,
     },
     PASSWORD_MIN_LENGTH: {
       title: 'Minimum password length',

--- a/apps/studio/components/interfaces/Markdown.tsx
+++ b/apps/studio/components/interfaces/Markdown.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import { InlineLink } from 'components/ui/InlineLink'
 import { ReactMarkdown, ReactMarkdownOptions } from 'react-markdown/lib/react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -16,17 +16,7 @@ const Markdown = ({ className, content = '', extLinks = false, ...props }: Props
       remarkPlugins={[remarkGfm]}
       components={{
         h3: ({ children }) => <h3 className="mb-1">{children}</h3>,
-        a: ({ href, children }) => {
-          if (extLinks) {
-            return (
-              <a href={href} target="_blank" rel="noreferrer noopener">
-                {children}
-              </a>
-            )
-          } else {
-            return <Link href={href ?? '/'}>{children}</Link>
-          }
-        },
+        a: ({ href, children }) => <InlineLink href={href ?? '/'}>{children}</InlineLink>,
       }}
       {...props}
       className={cn('prose text-sm', className)}

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -14,6 +14,7 @@ import { LOCAL_STORAGE_KEYS } from 'common'
 import { getStripeElementsAppearanceOptions } from 'components/interfaces/Billing/Payment/Payment.utils'
 import { PaymentConfirmation } from 'components/interfaces/Billing/Payment/PaymentConfirmation'
 import SpendCapModal from 'components/interfaces/Billing/SpendCapModal'
+import { InlineLink } from 'components/ui/InlineLink'
 import Panel from 'components/ui/Panel'
 import { useOrganizationCreateMutation } from 'data/organizations/organization-create-mutation'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
@@ -571,9 +572,9 @@ const NewOrgForm = ({ onPaymentMethodReset, setupIntent, onPlanSelected }: NewOr
 
       <ConfirmationModal
         size="large"
-        loading={false}
+        loading={newOrgLoading}
         visible={isOrgCreationConfirmationModalVisible}
-        title={<>Confirm organization creation</>}
+        title="Confirm organization creation"
         confirmLabel="Create new organization"
         onCancel={() => setIsOrgCreationConfirmationModalVisible(false)}
         onConfirm={async () => {
@@ -584,13 +585,9 @@ const NewOrgForm = ({ onPaymentMethodReset, setupIntent, onPlanSelected }: NewOr
       >
         <p className="text-sm text-foreground-light">
           Supabase{' '}
-          <Link
-            className="underline"
-            href="/docs/guides/platform/billing-on-supabase"
-            target="_blank"
-          >
+          <InlineLink href="https://supabase.com/docs/guides/platform/billing-on-supabase">
             bills per organization
-          </Link>
+          </InlineLink>
           . If you want to upgrade your existing projects, upgrade your existing organization
           instead.
         </p>
@@ -613,7 +610,7 @@ const NewOrgForm = ({ onPaymentMethodReset, setupIntent, onPlanSelected }: NewOr
                   </div>
                   <div className="text-foreground-light text-xs">
                     {orgProjects.length <= 2 ? (
-                      <span>{orgProjects.join('and ')}</span>
+                      <span>{orgProjects.join(' and ')}</span>
                     ) : (
                       <div>
                         {orgProjects.slice(0, 2).join(', ')} and{' '}


### PR DESCRIPTION
## Context

Realised that "Leaked password protection" is a feature that's only available on the pro plan and above as highlighted in our docs [here](https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection), but its not an information that's obvious from the dashboard which resulted in some users tripping up here

## Changes involved

- Adds a callout to the field's description if it's a paid feature + organization is on the free plan, link goes to the organization billing page with the subscription panel open
  <img width="594" height="139" alt="image" src="https://github.com/user-attachments/assets/5978cacd-3f87-4512-aaa3-4d6adb9f9da4" />
  - This wouldn't show up for an organization that's on Pro plan and above
  <img width="621" height="142" alt="image" src="https://github.com/user-attachments/assets/0984b49e-623f-4e61-ae54-534ce9f8f036" />

- Also added a tooltip inline to the field label if there's a corresponding link to the docs site
  <img width="433" height="115" alt="image" src="https://github.com/user-attachments/assets/ecfe5770-4ca7-4528-95ce-ea7ecf5e9e2d" />

