### PR TITLE
Flatten table editor grid context menu copy action

### DIFF
--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -1,12 +1,12 @@
-import { ChevronRight, Clipboard, Edit, Trash } from 'lucide-react'
+import { Clipboard, Edit, Trash } from 'lucide-react'
 import { useCallback } from 'react'
-import { Item, ItemParams, Menu, Separator, Submenu } from 'react-contexify'
+import { Item, ItemParams, Menu } from 'react-contexify'
 import { toast } from 'sonner'
 
 import type { SupaRow } from 'components/grid/types'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
-import { copyToClipboard } from 'ui'
+import { copyToClipboard, DialogSectionSeparator } from 'ui'
 import { ROW_CONTEXT_MENU_ID } from '.'
 import { formatClipboardValue } from '../../utils/common'
 
@@ -67,27 +67,20 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
 
   return (
     <Menu id={ROW_CONTEXT_MENU_ID} animation={false} className="!min-w-36">
-      <Submenu
-        label={
-          <div className="flex items-center space-x-2">
-            <Clipboard size={12} />
-            <span className="text-xs">Copy</span>
-          </div>
-        }
-        arrow={<ChevronRight size={12} />}
-      >
-        <Item onClick={onCopyCellContent}>
-          <span className="ml-2 text-xs">Copy cell</span>
-        </Item>
-        <Item onClick={onCopyRowContent}>
-          <span className="ml-2 text-xs">Copy row</span>
-        </Item>
-      </Submenu>
+      <Item onClick={onCopyCellContent}>
+        <Clipboard size={12} />
+        <span className="ml-2 text-xs">Copy cell</span>
+      </Item>
+      <Item onClick={onCopyRowContent}>
+        <Clipboard size={12} />
+        <span className="ml-2 text-xs">Copy row</span>
+      </Item>
+      <DialogSectionSeparator className="my-1.5" />
       <Item onClick={onEditRowClick} hidden={!snap.editable} data="edit">
         <Edit size={12} />
         <span className="ml-2 text-xs">Edit row</span>
       </Item>
-      <Separator />
+      <DialogSectionSeparator className="my-1.5" />
       <Item onClick={onDeleteRow} hidden={!snap.editable} data="delete">
         <Trash size={12} />
         <span className="ml-2 text-xs">Delete row</span>


### PR DESCRIPTION
## Context

Opting to flatten the context menu of the table editor grid into a single level menu since copy cell value is a rather common action and this 2nd level UI slows down the UX

## Before

<img width="498" height="163" alt="image" src="https://github.com/user-attachments/assets/edceaf4d-51a0-462d-8454-82fe7e73f54f" />

## After

<img width="283" height="212" alt="image" src="https://github.com/user-attachments/assets/c4035519-6a51-4f35-84d0-87cc5586114c" />

## To test

- [ ] Verify that copy cell and copy row are still working in the table editor
