### PR TITLE
chore: remove links to obsolete terraform repos

### DIFF
--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -52,11 +52,6 @@ export const community = [
     href: 'https://github.com/supabase-community/supabase-kubernetes',
   },
   {
-    name: 'Terraform',
-    description: 'A community-driven Terraform Provider for Supabase.',
-    href: 'https://github.com/supabase-community/supabase-terraform',
-  },
-  {
     name: 'Traefik',
     description: 'A self-hosted Supabase setup with Traefik as a reverse proxy.',
     href: 'https://github.com/supabase-community/supabase-traefik',
@@ -74,11 +69,6 @@ The following third-party providers have shown consistent support for the self-h
 
 <div className="grid md:grid-cols-12 gap-4 not-prose">
   {[
-    {
-      name: 'Digital Ocean',
-      description: 'Deploys using Terraform.',
-      href: 'https://docs.digitalocean.com/developer-center/hosting-supabase-on-digitalocean/',
-    },
     {
       name: 'StackGres',
       description: 'Deploys using Kubernetes.',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removing links to unmaintained repos containing Terraform configurations for self-hosted.

## What is the current behavior?

There's two separate links to "Terraform" for self-hosted that ultimately point to https://github.com/digitalocean/supabase-on-do

That repo hasn't been actively maintained, unfortunately. Following the README will not result in a successful installation of Supabase's self-hosted stack on DigitalOcean.

## What is the new behavior?

Remove the links to Terraform deployment options for self-hosted for now.

## Additional context

Offering a better path for Terraform-based deployment for self-hosted is currently being planned.
