### PR TITLE
docs: add max_affected() method to Python client reference

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -6076,6 +6076,98 @@ functions:
           }
           ```
         hideCodeBlock: true
+  - id: max-affected
+    title: max_affected()
+    description: |
+      Set the maximum number of rows that can be affected by an update or delete operation.
+      If the query would affect more rows than the specified limit, the operation will fail with an error.
+
+      This uses PostgREST's `Prefer: max-affected` header with `handling=strict`.
+    notes: |
+      - Only available in PostgREST v13+
+      - Only works with PATCH (update) and DELETE methods
+      - The operation will fail if it would affect more rows than specified
+    params:
+      - name: value
+        isOptional: false
+        type: int
+        description: The maximum number of rows that can be affected
+    examples:
+      - id: with-update
+        name: Limit affected rows on update
+        code: |
+          ```python
+          response = (
+              supabase.table("planets")
+              .update({"name": "Updated"})
+              .eq("id", 1)
+              .max_affected(1)
+              .execute()
+          )
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              planets (id int8 primary key, name text);
+
+            insert into
+              planets (id, name)
+            values
+              (1, 'Mercury'),
+              (2, 'Earth');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "id": 1,
+                "name": "Updated"
+              }
+            ],
+            "count": null
+          }
+          ```
+        hideCodeBlock: true
+        isSpotlight: true
+      - id: with-delete
+        name: Limit affected rows on delete
+        code: |
+          ```python
+          response = (
+              supabase.table("planets")
+              .delete()
+              .eq("id", 1)
+              .max_affected(1)
+              .execute()
+          )
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              planets (id int8 primary key, name text);
+
+            insert into
+              planets (id, name)
+            values
+              (1, 'Mercury'),
+              (2, 'Earth');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "id": 1,
+                "name": "Mercury"
+              }
+            ],
+            "count": null
+          }
+          ```
+        hideCodeBlock: true
   - id: using-modifiers
     title: Using Modifiers
     description: |


### PR DESCRIPTION
## Summary

Adds documentation for the new `max_affected()` method introduced in [supabase-py PR #1222](https://github.com/supabase/supabase-py/pull/1222).

This method allows developers to set a maximum limit on the number of rows that can be affected by update or delete operations, providing a safety mechanism against accidentally modifying too many rows.

## Changes

### Updated Files
- **apps/docs/spec/supabase_py_v2.yml**: Added `max_affected()` method documentation
  - Complete method signature with parameter details
  - Usage notes highlighting PostgREST v13+ requirement and PATCH/DELETE method limitation
  - Two comprehensive examples demonstrating update and delete operations
  - Maintains existing file structure and formatting

## Related PR

Source PR: https://github.com/supabase/supabase-py/pull/1222

## Test Plan

- [ ] Documentation builds successfully
- [ ] Examples render correctly in the reference documentation
- [ ] Method appears in the correct section of the Python client docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)