### PR TITLE
docs: document automatic presence enablement in Python client

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -6832,6 +6832,7 @@ functions:
     title: on().subscribe()
     notes: |
       - By default, Broadcast and Presence are enabled for all projects.
+      - Presence is automatically enabled when you attach presence callbacks (`on_presence_sync()`, `on_presence_join()`, or `on_presence_leave()`). If you add presence callbacks to an already joined channel, the channel will automatically resubscribe with presence enabled.
       - By default, listening to database changes is disabled for new projects due to database performance and security concerns. You can turn it on by managing Realtime's [replication](/docs/guides/api#realtime-api-overview).
       - You can receive the "previous" data for updates and deletes by setting the table's `REPLICA IDENTITY` to `FULL` (e.g., `ALTER TABLE your_table REPLICA IDENTITY FULL;`).
       - Row level security is not applied to delete statements. When RLS is enabled and replica identity is set to full, only the primary key is sent to clients.


### PR DESCRIPTION
## Summary

Updates documentation to reflect the automatic presence enablement behavior introduced in [supabase-py PR #1229](https://github.com/supabase/supabase-py/pull/1229).

The Python client now automatically enables presence when presence callbacks (`on_presence_sync()`, `on_presence_join()`, or `on_presence_leave()`) are attached to a channel. This improves developer experience by eliminating the need to manually configure presence settings.

## Changes

### Updated Files
- **apps/docs/spec/supabase_py_v2.yml**: Updated `subscribe()` method notes
  - Added note explaining automatic presence enablement when callbacks are attached
  - Documented automatic resubscription behavior when callbacks are added to already-joined channels
  - Maintains existing documentation structure and formatting

## Behavioral Change

Previously, developers needed to manually configure presence settings. Now:
- Attaching presence callbacks automatically enables presence
- Adding callbacks to an already-joined channel triggers automatic resubscription

## Related PR

Source PR: https://github.com/supabase/supabase-py/pull/1229

## Test Plan

- [ ] Documentation builds successfully
- [ ] Updated notes appear correctly in the subscribe() method documentation
- [ ] Presence examples remain accurate with the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)