### PR TITLE
docs(swift): add documentation for new Swift SDK features

### DIFF
--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -931,6 +931,42 @@ functions:
             // custom URL opening logic
           }
           ```
+  - id: link-identity-with-id-token
+    title: 'linkIdentityWithIdToken()'
+    notes: |
+      - The **Enable Manual Linking** option must be enabled from your [project's authentication settings](/dashboard/project/_/settings/auth).
+      - The user needs to be signed in to call `linkIdentityWithIdToken()`.
+      - If the candidate identity is already linked to the existing user or another user, `linkIdentityWithIdToken()` will fail.
+      - This method allows you to link an OIDC identity using an ID token obtained from a provider like Apple, Google, etc.
+    examples:
+      - id: link-identity-with-id-token
+        name: Link an OIDC identity using an ID token
+        isSpotlight: true
+        code: |
+          ```swift
+          try await supabase.auth.linkIdentityWithIdToken(
+            credentials: OpenIDConnectCredentials(
+              provider: .apple,
+              idToken: idToken
+            )
+          )
+          ```
+        description: |
+          Link an OpenID Connect identity to the current user using an ID token. This is useful when you've obtained an ID token from a provider's SDK (like Sign in with Apple) and want to link it to the current user's account.
+      - id: link-identity-with-id-token-and-nonce
+        name: Link an OIDC identity with nonce
+        code: |
+          ```swift
+          try await supabase.auth.linkIdentityWithIdToken(
+            credentials: OpenIDConnectCredentials(
+              provider: .apple,
+              idToken: idToken,
+              nonce: nonce
+            )
+          )
+          ```
+        description: |
+          For providers that support nonce verification (like Apple), you can include the nonce used during authentication.
   - id: unlink-identity
     title: 'unlinkIdentity()'
     notes: |
@@ -3749,6 +3785,57 @@ functions:
           ```
         hideCodeBlock: true
         isSpotlight: true
+
+  - id: max-affected
+    title: maxAffected()
+    description: |
+      Set the maximum number of rows that can be affected by the query.
+
+      Only available in PostgREST v13+ and only works with PATCH, DELETE methods and RPC calls.
+    notes: |
+      - This method sets `handling=strict` and `max-affected=<value>` headers for row limit enforcement.
+      - Only use with UPDATE (PATCH), DELETE operations, or RPC calls that modify data.
+      - If the query would affect more rows than specified, PostgREST will return an error.
+      - This is useful for preventing accidental bulk updates or deletes.
+    examples:
+      - id: with-update
+        name: With `update()`
+        code: |
+          ```swift
+          try await supabase
+            .from("users")
+            .update(["status": "active"])
+            .eq("id", value: 1)
+            .maxAffected(1)
+            .execute()
+          ```
+        description: |
+          Ensure that only one row is updated. If the query would update more than one row, an error is returned.
+        isSpotlight: true
+      - id: with-delete
+        name: With `delete()`
+        code: |
+          ```swift
+          try await supabase
+            .from("users")
+            .delete()
+            .in("id", values: [1, 2, 3])
+            .maxAffected(3)
+            .execute()
+          ```
+        description: |
+          Ensure that only three rows are deleted. If the query would delete more than three rows, an error is returned.
+      - id: with-rpc
+        name: With `rpc()`
+        code: |
+          ```swift
+          try await supabase
+            .rpc("delete_inactive_users")
+            .maxAffected(10)
+            .execute()
+          ```
+        description: |
+          Ensure that the RPC call affects at most 10 rows. Useful for limiting the impact of stored procedures.
 
   - id: single
     title: single()


### PR DESCRIPTION
## Summary

This PR adds documentation for two new features introduced in supabase-swift v2.33.1+:

### 1. `maxAffected()` method
- **Source**: [supabase/supabase-swift#795](https://github.com/supabase/supabase-swift/pull/795)
- **Feature**: Allows setting a maximum number of rows that can be affected by a query
- **Use cases**: Preventing accidental bulk updates/deletes, enforcing row limits
- **Availability**: PostgREST v13+ only
- **Compatible with**: UPDATE (PATCH), DELETE, and RPC operations

### 2. `linkIdentityWithIdToken()` method  
- **Source**: [supabase/supabase-swift#776](https://github.com/supabase/supabase-swift/pull/776)
- **Feature**: Link OIDC identities to existing users using ID tokens
- **Use cases**: Sign in with Apple, Google, and other OIDC providers
- **Requirement**: Manual linking must be enabled in project settings

## Files Updated

- `apps/docs/spec/supabase_swift_v2.yml`:
  - Added `maxAffected()` method documentation with 3 examples (update, delete, RPC)
  - Added `linkIdentityWithIdToken()` method documentation with 2 examples (basic and with nonce)

## Documentation Changes

### maxAffected()
- Added method description explaining it sets row limit enforcement headers
- Documented that it only works with PATCH, DELETE, and RPC operations
- Added notes about preventing accidental bulk operations
- Included 3 code examples showing different usage patterns

### linkIdentityWithIdToken()
- Added method description explaining OIDC identity linking with ID tokens
- Documented requirements (manual linking enabled, user must be signed in)
- Added notes about provider SDK integration
- Included 2 code examples (basic usage and with nonce parameter)

## Test Plan

- [x] Documentation follows existing Swift spec file conventions
- [x] All new content added without removing existing content
- [x] Code examples use proper Swift syntax and existing patterns
- [x] Method descriptions are clear and concise
- [x] Notes section provides important context and requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)