### PR TITLE
fix(enabled-features): auth providers settings link

### DIFF
--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsLayout.tsx
@@ -35,6 +35,7 @@ const SettingsLayout = ({ title, children }: PropsWithChildren<SettingsLayoutPro
 
   const {
     projectAuthAll: authEnabled,
+    authenticationShowProviders: authProvidersEnabled,
     projectEdgeFunctionAll: edgeFunctionsEnabled,
     projectStorageAll: storageEnabled,
     billingInvoices: invoicesEnabled,
@@ -43,6 +44,7 @@ const SettingsLayout = ({ title, children }: PropsWithChildren<SettingsLayoutPro
     billingAll,
   } = useIsFeatureEnabled([
     'project_auth:all',
+    'authentication:show_providers',
     'project_edge_function:all',
     'project_storage:all',
     'billing:invoices',
@@ -53,6 +55,7 @@ const SettingsLayout = ({ title, children }: PropsWithChildren<SettingsLayoutPro
 
   const menuRoutes = generateSettingsMenu(ref, project, organization, {
     auth: authEnabled,
+    authProviders: authProvidersEnabled,
     edgeFunctions: edgeFunctionsEnabled,
     storage: storageEnabled,
     invoices: invoicesEnabled,

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -11,6 +11,7 @@ export const generateSettingsMenu = (
   organization?: Organization,
   features?: {
     auth?: boolean
+    authProviders?: boolean
     edgeFunctions?: boolean
     storage?: boolean
     invoices?: boolean
@@ -23,6 +24,7 @@ export const generateSettingsMenu = (
   const buildingUrl = `/project/${ref}`
 
   const authEnabled = features?.auth ?? true
+  const authProvidersEnabled = features?.authProviders ?? true
   const edgeFunctionsEnabled = features?.edgeFunctions ?? true
   const storageEnabled = features?.storage ?? true
   const legacyJwtKeysEnabled = features?.legacyJwtKeys ?? true
@@ -128,7 +130,9 @@ export const generateSettingsMenu = (
               {
                 name: 'Authentication',
                 key: 'auth',
-                url: `/project/${ref}/auth/providers`,
+                url: authProvidersEnabled
+                  ? `/project/${ref}/auth/providers`
+                  : `/project/${ref}/auth/policies`,
                 items: [],
                 rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
               },


### PR DESCRIPTION
When auth providers wasn't being shown, the link would go to a page that doesn't exist.