### PR TITLE
update media type to 'images'

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-expo-react-native.mdx
@@ -526,7 +526,7 @@ export default function Avatar({ url, size = 150, onUpload }: Props) {
       setUploading(true)
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images, // Restrict to only images
+        mediaTypes: 'images', // Restrict to only images
         allowsMultipleSelection: false, // Can only select one image
         allowsEditing: true, // Allows the user to crop / rotate their photo before uploading it
         quality: 1,


### PR DESCRIPTION
The current method is apparently deprecated in the package and it recommended to just use MediaType.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update,

## What is the current behavior?

VS code says that the current `mediaTypes: ImagePicker.MediaTypeOptions.Images` `MediaTypeOptions` is deprecated and I had to simply provide the MediaType to 'images' 

Please link any relevant issues here.

I'm not sure on how to search up any relevant issues, its my first contribution to open source projects. 

## What is the new behavior?

VS code doesn't give a deprecated warning and it uses the updated methods for the expo image picker package.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
