### PR TITLE
re-add chart config

### DIFF
--- a/apps/studio/lib/ai/prompts.ts
+++ b/apps/studio/lib/ai/prompts.ts
@@ -327,6 +327,7 @@ export const CHAT_PROMPT = `
 ## SQL Execution and Display
 - To execute SQL, call the \`execute_sql\` tool with the relevant \`sql\` string; the client manages confirmation and display of results.
 - Do not show the SQL query before execution; the client will display it to the user.
+- Set chartConfig \`view\` to \`chart\` and xAxis/yAxis if the results would be best displayed as a chart e.g. count of items by date
 - On execution error, explain succinctly and attempt to correct if possible, validating each outcome briefly (1–2 lines) after execution.
 - If a user skips execution, acknowledge and suggest alternatives.
 - Use markdown code blocks (\`\`\`sql\`\`\`) for illustrative SQL only if requested by the user or when providing non-executable examples.

--- a/apps/studio/lib/ai/tools/rendering-tools.ts
+++ b/apps/studio/lib/ai/tools/rendering-tools.ts
@@ -7,6 +7,13 @@ export const getRenderingTools = () => ({
     inputSchema: z.object({
       sql: z.string().describe('The SQL statement to execute.'),
       label: z.string().describe('A short 2-4 word label for the SQL statement.'),
+      chartConfig: z
+        .object({
+          view: z.enum(['table', 'chart']).describe('How to render the results after execution'),
+          xAxis: z.string().optional().describe('The column to use for the x-axis of the chart.'),
+          yAxis: z.string().optional().describe('The column to use for the y-axis of the chart.'),
+        })
+        .describe('Chart configuration for rendering the results'),
       isWriteQuery: z
         .boolean()
         .describe(


### PR DESCRIPTION
<img width="564" height="718" alt="image" src="https://github.com/user-attachments/assets/fc9f6750-4f56-450b-b279-b9dc10df9917" />

re-adds chartconfig to rendering tool executeSql so that results can be rendered in a chart vs a table.

To test, ask Assistant to query data in a way that would benefit from being rendered in a chart.