### PR TITLE
Add flag for metadata IP logs explorer template

### DIFF
--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -3,7 +3,7 @@ import { useLocalStorage } from '@uidotdev/usehooks'
 import dayjs from 'dayjs'
 import { editor } from 'monaco-editor'
 import { useRouter } from 'next/router'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS, useParams } from 'common'
@@ -37,6 +37,7 @@ import {
 import useLogsQuery from 'hooks/analytics/useLogsQuery'
 import { useLogsUrlState } from 'hooks/analytics/useLogsUrlState'
 import { useCustomContent } from 'hooks/custom-content/useCustomContent'
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useUpgradePrompt } from 'hooks/misc/useUpgradePrompt'
 import { uuidv4 } from 'lib/helpers'
@@ -66,6 +67,12 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const { ref, q, queryId } = useParams()
   const projectRef = ref as string
   const { data: organization } = useSelectedOrganizationQuery()
+  const { logsShowMetadataIpTemplate } = useIsFeatureEnabled(['logs:show_metadata_ip_template'])
+
+  const allTemplates = useMemo(() => {
+    if (logsShowMetadataIpTemplate) return TEMPLATES
+    else return TEMPLATES.filter((x) => x.label !== 'Metadata IP')
+  }, [logsShowMetadataIpTemplate])
 
   const editorRef = useRef<editor.IStandaloneCodeEditor>()
   const [editorId] = useState<string>(uuidv4())
@@ -301,7 +308,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
             defaultTo={timestampEnd || ''}
             onDateChange={handleDateChange}
             onSelectSource={handleInsertSource}
-            templates={TEMPLATES.filter((template) => template.mode === 'custom')}
+            templates={allTemplates.filter((template) => template.mode === 'custom')}
             onSelectTemplate={onSelectTemplate}
             warnings={warnings}
           />

--- a/apps/studio/pages/project/[ref]/logs/explorer/templates.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/templates.tsx
@@ -15,17 +15,23 @@ import { Button, Popover, cn } from 'ui'
 
 export const LogsTemplatesPage: NextPageWithLayout = () => {
   const { ref: projectRef } = useParams()
-  const isTemplatesEnabled = useIsFeatureEnabled('logs:templates')
+  const { logsTemplates: isTemplatesEnabled, logsShowMetadataIpTemplate: showMetadataIpTemplate } =
+    useIsFeatureEnabled(['logs:templates', 'logs:show_metadata_ip_template'])
 
   if (!isTemplatesEnabled) {
     return <UnknownInterface urlBack={`/project/${projectRef}/logs/explorer`} />
   }
 
+  const allTemplates = showMetadataIpTemplate
+    ? TEMPLATES
+    : TEMPLATES.filter((template) => template.label !== 'Metadata IP')
+
   return (
     <div className="mx-auto h-full w-full px-5 py-6">
       <LogsExplorerHeader subtitle="Templates" />
       <div className="grid lg:grid-cols-3 gap-6 mt-4 pb-24">
-        {TEMPLATES.sort((a, b) => a.label!.localeCompare(b.label!))
+        {allTemplates
+          .sort((a, b) => a.label!.localeCompare(b.label!))
           .filter((template) => template.mode === 'custom')
           .map((template, i) => {
             return <Template key={i} projectRef={projectRef} template={template} />

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -64,6 +64,7 @@
 
   "logs:templates": true,
   "logs:collections": true,
+  "logs:show_metadata_ip_template": false,
 
   "organization:show_sso_settings": true,
   "organization:show_security_settings": true,

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -64,7 +64,7 @@
 
   "logs:templates": true,
   "logs:collections": true,
-  "logs:show_metadata_ip_template": false,
+  "logs:show_metadata_ip_template": true,
 
   "organization:show_sso_settings": true,
   "organization:show_security_settings": true,

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -228,6 +228,10 @@
       "type": "boolean",
       "description": "Enable the logs collections page"
     },
+    "logs:show_metadata_ip_template": {
+      "type": "boolean",
+      "description": "Show the Metadata IP template in the logs explorer"
+    },
 
     "organization:show_sso_settings": {
       "type": "boolean",
@@ -411,6 +415,7 @@
     "profile:show_account_deletion",
     "logs:templates",
     "logs:collections",
+    "logs:show_metadata_ip_template",
     "organization:show_sso_settings",
     "project_creation:show_advanced_config",
     "project_homepage:show_instance_size",


### PR DESCRIPTION
## Context

Adds a flag in enabled features to toggle visibility of the "Metadata IP" template in logs explorer

## To test

- [ ] Verify behaviour locally when flag is off
- [ ] Verify on staging preview that things are status quo