### PR TITLE
Add flag for read replicas

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
@@ -17,6 +17,7 @@ import {
   useReadReplicasStatusesQuery,
 } from 'data/read-replicas/replicas-status-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useIsOrioleDb, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { timeout } from 'lib/helpers'
 import { type AWS_REGIONS_KEYS } from 'shared-data'
@@ -51,6 +52,8 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
   const { ref: projectRef } = useParams()
   const numTransition = useRef<number>()
   const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
+
+  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const [view, setView] = useState<'flow' | 'map'>('flow')
   const [showDeleteAllModal, setShowDeleteAllModal] = useState(false)
@@ -225,7 +228,7 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
         {isError && <AlertError error={error} subject="Failed to retrieve replicas" />}
         {isSuccessReplicas && !isLoadingProject && (
           <>
-            {!diagramOnly && (
+            {!diagramOnly && infrastructureReadReplicas && (
               <div className="z-10 absolute top-4 right-4 flex items-center justify-center gap-x-2">
                 <div className="flex items-center justify-center">
                   <ButtonTooltip

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
@@ -18,7 +18,11 @@ import {
 } from 'data/read-replicas/replicas-status-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useIsOrioleDb, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import {
+  useIsAwsCloudProvider,
+  useIsOrioleDb,
+  useSelectedProjectQuery,
+} from 'hooks/misc/useSelectedProject'
 import { timeout } from 'lib/helpers'
 import { type AWS_REGIONS_KEYS } from 'shared-data'
 import {
@@ -53,6 +57,7 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
   const numTransition = useRef<number>()
   const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
 
+  const isAws = useIsAwsCloudProvider()
   const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const [view, setView] = useState<'flow' | 'map'>('flow')
@@ -272,7 +277,7 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
                     </DropdownMenu>
                   )}
                 </div>
-                {project?.cloud_provider === 'AWS' && (
+                {isAws && (
                   <div className="flex items-center justify-center">
                     <Button
                       type="default"

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -10,6 +10,7 @@ import { Markdown } from 'components/interfaces/Markdown'
 import { REPLICA_STATUS } from 'components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { formatDatabaseID, formatDatabaseRegion } from 'data/read-replicas/replicas.utils'
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { IS_PLATFORM } from 'lib/constants'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import {
@@ -52,6 +53,8 @@ const DatabaseSelector = ({
   const { ref: projectRef } = useParams()
   const [open, setOpen] = useState(false)
   const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
+
+  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const state = useDatabaseSelectorStateSnapshot()
   const selectedDatabaseId = _selectedDatabaseId ?? state.selectedDatabaseId
@@ -203,7 +206,7 @@ const DatabaseSelector = ({
                 })}
               </ScrollArea>
             </CommandGroup_Shadcn_>
-            {IS_PLATFORM && (
+            {IS_PLATFORM && infrastructureReadReplicas && (
               <CommandGroup_Shadcn_ className="border-t">
                 <CommandItem_Shadcn_
                   className="cursor-pointer w-full"

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -62,6 +62,8 @@
   "integrations:show_stripe_wrapper": true,
   "integrations:vercel": true,
 
+  "infrastructure:read_replicas": false,
+
   "logs:templates": true,
   "logs:collections": true,
 

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -62,7 +62,7 @@
   "integrations:show_stripe_wrapper": true,
   "integrations:vercel": true,
 
-  "infrastructure:read_replicas": false,
+  "infrastructure:read_replicas": true,
 
   "logs:templates": true,
   "logs:collections": true,

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -220,6 +220,11 @@
       "description": "Enable the vercel integration section in the organization and project settings pages"
     },
 
+    "infrastructure:read_replicas": {
+      "type": "boolean",
+      "description": "Enable read replicas management"
+    },
+
     "logs:templates": {
       "type": "boolean",
       "description": "Enable the logs templates page"
@@ -410,6 +415,7 @@
     "integrations:partners",
     "integrations:show_stripe_wrapper",
     "integrations:vercel",
+    "infrastructure:read_replicas",
     "profile:show_email",
     "profile:show_information",
     "profile:show_analytics_and_marketing",


### PR DESCRIPTION
## Context

Adds a flag in enabled feature to control read replica management
Handles the new replica button in settings/infrastructure and the "Create new replica" CTA within DatabaseSelector

## To test

- [ ] Verify that changes are working when flag is off locally
- [ ] Verify that staging preview is status quo