### PR TITLE
FE-1862 Report Chart: Always show tooltip values

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -214,12 +214,9 @@ const CustomTooltip = ({
       >
         <p className="font-medium">{dayjs(timestamp).format(DateTimeFormats.FULL_SECONDS)}</p>
         <div className="grid gap-0">
-          {payload
-            .reverse()
-            .filter((entry: any) => entry.value !== 0)
-            .map((entry: any, index: number) => (
-              <LabelItem key={`${entry.name}-${index}`} entry={entry} />
-            ))}
+          {payload.reverse().map((entry: any, index: number) => (
+            <LabelItem key={`${entry.name}-${index}`} entry={entry} />
+          ))}
           {active && showTotal && (
             <div className="flex md:flex-col gap-1 md:gap-0 text-foreground mt-1">
               <span className="flex-grow text-foreground-lighter">Total</span>

--- a/apps/studio/data/reports/v2/auth.config.ts
+++ b/apps/studio/data/reports/v2/auth.config.ts
@@ -192,7 +192,7 @@ export function defaultAuthReportFormatter(
   const parsedRawData = rawDataSchema.parse(rawData)
   const result = parsedRawData.result
 
-  if (!result || result.length === 0) return { data: undefined, chartAttributes }
+  if (!result) return { data: undefined, chartAttributes }
 
   const timestamps = new Set<string>(result.map((p: any) => String(p.timestamp)))
   const data = Array.from(timestamps)

--- a/apps/studio/data/reports/v2/auth.config.ts
+++ b/apps/studio/data/reports/v2/auth.config.ts
@@ -192,7 +192,7 @@ export function defaultAuthReportFormatter(
   const parsedRawData = rawDataSchema.parse(rawData)
   const result = parsedRawData.result
 
-  if (!result) return { data: undefined, chartAttributes }
+  if (!result || result.length === 0) return { data: undefined, chartAttributes }
 
   const timestamps = new Set<string>(result.map((p: any) => String(p.timestamp)))
   const data = Array.from(timestamps)


### PR DESCRIPTION
More info in the Linear issue → https://linear.app/supabase/issue/FE-1862/always-show-the-0-field

## BEFORE

![CleanShot 2025-10-01 at 10 54 50](https://github.com/user-attachments/assets/f581d45c-1b46-4cf2-aecc-c06f377d9d7c)

## AFTER

![CleanShot 2025-10-01 at 10 54 10](https://github.com/user-attachments/assets/3be06f9b-ffb1-4cb8-8685-9d4b47e1c000)
