### PR TITLE
Add flag for database upgrades

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -36,7 +36,8 @@ const InfrastructureInfo = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
-  const authEnabled = useIsFeatureEnabled('project_auth:all')
+  const { projectAuthAll: authEnabled, projectSettingsDatabaseUpgrades: showDatabaseUpgrades } =
+    useIsFeatureEnabled(['project_auth:all', 'project_settings:database_upgrades'])
 
   const {
     data,
@@ -109,6 +110,7 @@ const InfrastructureInfo = () => {
               </Alert_Shadcn_>
             ) : (
               <>
+                {/* [Joshen] Double check why we need this waterfall loading behaviour here */}
                 {isLoadingUpgradeEligibility && <GenericSkeletonLoader />}
                 {isErrorUpgradeEligibility && (
                   <AlertError error={error} subject="Failed to retrieve Postgres version" />
@@ -187,7 +189,7 @@ const InfrastructureInfo = () => {
                       </>
                     )}
 
-                    {data.eligible ? (
+                    {showDatabaseUpgrades && data.eligible ? (
                       hasReadReplicas ? (
                         <ReadReplicasWarning latestPgVersion={latestPgVersion} />
                       ) : (
@@ -195,7 +197,7 @@ const InfrastructureInfo = () => {
                       )
                     ) : null}
 
-                    {!data.eligible ? (
+                    {showDatabaseUpgrades && !data.eligible ? (
                       hasObjectsToBeDropped ? (
                         <ObjectsToBeDroppedWarning
                           objectsToBeDropped={data.objects_to_be_dropped}

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -91,6 +91,7 @@
   "project_settings:show_disable_legacy_api_keys": true,
   "project_settings:legacy_jwt_keys": true,
   "project_settings:log_drains": true,
+  "project_settings:database_upgrades": true,
 
   "quickstarts:hide_nimbus": true,
 

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -315,6 +315,10 @@
       "type": "boolean",
       "description": "Enable the log drains page in project settings"
     },
+    "project_settings:database_upgrades": {
+      "type": "boolean",
+      "description": "Show database upgrade callouts in the project settings infrastructure page"
+    },
 
     "quickstarts:hide_nimbus": {
       "type": "boolean",
@@ -426,6 +430,7 @@
     "project_settings:show_disable_legacy_api_keys",
     "project_settings:legacy_jwt_keys",
     "project_settings:log_drains",
+    "project_settings:database_upgrades",
     "project_connection:javascript_example",
     "project_connection:dart_example",
     "project_connection:show_app_frameworks",


### PR DESCRIPTION
## Context

Adds a flag in enabled features to toggle the visibility of database upgrade callouts in the project settings -> infrastructure page

## To test

- [ ] This is hard to verify locally unless you've got a project on an old postgres version, but if so just verify the callout doesn't show up if the flag is off
- [ ] Verify on staging preview that things are status quo