### PR TITLE
fix(studio): use session storage as default cache for tab state

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -131,7 +131,8 @@ export function loadTableEditorStateFromLocalStorage(
   schema?: string | null
 ): SavedState | undefined {
   const storageKey = getStorageKey(STORAGE_KEY_PREFIX, projectRef)
-  const jsonStr = localStorage.getItem(storageKey)
+  // Prefer sessionStorage (scoped to current tab) over localStorage
+  const jsonStr = sessionStorage.getItem(storageKey) ?? localStorage.getItem(storageKey)
   if (!jsonStr) return
   const json = JSON.parse(jsonStr)
   const tableKey = !schema || schema == 'public' ? tableName : `${schema}.${tableName}`
@@ -154,7 +155,7 @@ export function saveTableEditorStateToLocalStorage({
   filters?: string[]
 }) {
   const storageKey = getStorageKey(STORAGE_KEY_PREFIX, projectRef)
-  const savedStr = localStorage.getItem(storageKey)
+  const savedStr = sessionStorage.getItem(storageKey) ?? localStorage.getItem(storageKey)
   const tableKey = !schema || schema == 'public' ? tableName : `${schema}.${tableName}`
 
   const config = {
@@ -171,7 +172,9 @@ export function saveTableEditorStateToLocalStorage({
   } else {
     savedJson = { [tableKey]: config }
   }
+  // Save to both localStorage and sessionStorage so it's consistent to current tab
   localStorage.setItem(storageKey, JSON.stringify(savedJson))
+  sessionStorage.setItem(storageKey, JSON.stringify(savedJson))
 }
 
 export const saveTableEditorStateToLocalStorageDebounced = AwesomeDebouncePromise(


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Because local storage is used to store editor tab state, working across multiple _browser_ tabs can lead to confusing behavior of loading tab state from the previously used tab when clicking around the UI.

## What is the new behavior?

Now tab state is saved to both session storage (scoped to the individual browser tab) as well as local storage and then when reading defaults to session storage. For a new tab that doesn't have anything stored in it's session it will read from local storage which will reflect the most recent tab state.

## Additional context

**To test**: open table editor in multiple browser tabs of the same browser and ensure that when clicking between tabs or other table links that the state is consistent to the individual tab and doesn't affect other tabs.