### PR TITLE
feat(pgmeta): filter by composite values

### DIFF
--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -166,6 +166,22 @@ function applyFilters(query: string, filters: Filter[]) {
   if (filters.length === 0) return query
   query += ` where ${filters
     .map((filter) => {
+      // Handle composite values
+      if (Array.isArray(filter.column)) {
+        switch (filter.operator) {
+          case 'is':
+          case '~~':
+          case '~~*':
+          case '!~~':
+          case '!~~*':
+            throw new Error(`Cannot use ${filter.operator} operator in a tuple filter`)
+          case 'in':
+            return inTupleFilterSql(filter)
+          default:
+            return defaultTupleFilterSql(filter)
+        }
+      }
+
       switch (filter.operator) {
         case 'in':
           return inFilterSql(filter)
@@ -185,14 +201,59 @@ function applyFilters(query: string, filters: Filter[]) {
 }
 
 function inFilterSql(filter: Filter) {
-  let values
+  let values: Array<unknown>
   if (Array.isArray(filter.value)) {
-    values = filter.value.map((x: any) => filterLiteral(x))
+    values = filter.value.map((x) => filterLiteral(x))
   } else {
     const filterValueTxt = String(filter.value)
-    values = filterValueTxt.split(',').map((x: any) => filterLiteral(x))
+    values = filterValueTxt.split(',').map((x) => filterLiteral(x))
   }
   return `${ident(filter.column)} ${filter.operator} (${values.join(',')})`
+}
+
+function defaultTupleFilterSql(filter: Filter) {
+  if (!Array.isArray(filter.column)) {
+    throw new Error('Use standard applyFilters for single column')
+  }
+  if (!Array.isArray(filter.value)) {
+    throw new Error('Tuple filter value must be an array')
+  }
+  if (filter.value.length !== filter.column.length) {
+    throw new Error('Tuple filter value must have the same length as the column array')
+  }
+
+  const columns = `(${filter.column.map((c) => ident(c)).join(', ')})`
+  const values = `(${filter.value.map((v) => filterLiteral(v)).join(', ')})`
+  return `${columns} ${filter.operator} ${values}`
+}
+
+function inTupleFilterSql(filter: Filter) {
+  if (!Array.isArray(filter.column)) {
+    throw new Error('Use inFilterSql for single columns')
+  }
+  if (!Array.isArray(filter.value)) {
+    throw new Error(`Values for a tuple 'in' filter must be an array`)
+  }
+
+  const columns = `(${filter.column.map((c) => ident(c)).join(', ')})`
+
+  const values = filter.value.map((v) => {
+    if (Array.isArray(v)) {
+      if (v.length !== filter.column.length) {
+        throw new Error(`Tuple value length must match column length`)
+      }
+      return `(${v.map((x) => filterLiteral(x)).join(', ')})`
+    } else {
+      const filterValueTxt = String(v)
+      const currValues = filterValueTxt.split(',')
+      if (currValues.length !== filter.column.length) {
+        throw new Error(`Tuple value length must match column length`)
+      }
+      return `(${currValues.map((x) => filterLiteral(x)).join(', ')})`
+    }
+  })
+
+  return `${columns} ${filter.operator} (${values.join(', ')})`
 }
 
 function isFilterSql(filter: Filter) {

--- a/packages/pg-meta/src/query/Query.utils.ts
+++ b/packages/pg-meta/src/query/Query.utils.ts
@@ -169,16 +169,17 @@ function applyFilters(query: string, filters: Filter[]) {
       // Handle composite values
       if (Array.isArray(filter.column)) {
         switch (filter.operator) {
-          case 'is':
-          case '~~':
-          case '~~*':
-          case '!~~':
-          case '!~~*':
-            throw new Error(`Cannot use ${filter.operator} operator in a tuple filter`)
           case 'in':
             return inTupleFilterSql(filter)
-          default:
+          case '=':
+          case '<>':
+          case '>':
+          case '<':
+          case '>=':
+          case '<=':
             return defaultTupleFilterSql(filter)
+          default:
+            throw new Error(`Cannot use ${filter.operator} operator in a tuple filter`)
         }
       }
 

--- a/packages/pg-meta/src/query/QueryFilter.ts
+++ b/packages/pg-meta/src/query/QueryFilter.ts
@@ -18,7 +18,7 @@ export class QueryFilter implements IQueryFilter, IQueryModifier {
     protected actionOptions?: { returning: boolean; enumArrayColumns?: string[] }
   ) {}
 
-  filter(column: string, operator: FilterOperator, value: any) {
+  filter(column: string | string[], operator: FilterOperator, value: any) {
     this.filters.push({ column, operator, value })
     return this
   }

--- a/packages/pg-meta/src/query/types.ts
+++ b/packages/pg-meta/src/query/types.ts
@@ -20,7 +20,7 @@ export type FilterOperator =
   | 'is'
 
 export interface Filter {
-  column: string
+  column: string | Array<string>
   operator: FilterOperator
   value: any
 }

--- a/packages/pg-meta/test/query/query.test.ts
+++ b/packages/pg-meta/test/query/query.test.ts
@@ -419,6 +419,174 @@ describe('Query.utils', () => {
         const result = QueryUtils.selectQuery(table, '*', { filters: filters })
         expect(result).toContain("where name = 'O''Reilly'")
       })
+
+      test('should error if tuple filter value length does not match column length', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '=', value: [1] }]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError(
+          'Tuple filter value must have the same length as the column array'
+        )
+      })
+
+      test('should error if tuple filter value is not an array', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '=', value: 1 }]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError(
+          'Tuple filter value must be an array'
+        )
+      })
+
+      test('should correctly handle tuple filters with equality operator', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '=', value: [1, 2] }]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe('select * from public.users where (id, version) = (1, 2);')
+      })
+
+      test('should correctly handle tuple filters with greater than operator', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '>', value: [1, 2] }]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe('select * from public.users where (id, version) > (1, 2);')
+      })
+
+      test('should correctly handle tuple filters with greater than or equal operator', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '>=', value: [1, 2] }]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe('select * from public.users where (id, version) >= (1, 2);')
+      })
+
+      test('should correctly handle tuple filters with less than operator', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '<', value: [10, 5] }]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe('select * from public.users where (id, version) < (10, 5);')
+      })
+
+      test('should correctly handle tuple filters with less than or equal operator', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '<=', value: [10, 5] }]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe('select * from public.users where (id, version) <= (10, 5);')
+      })
+
+      test('should correctly handle tuple filters with not equal operator (<>)', () => {
+        const filters: Filter[] = [{ column: ['id', 'version'], operator: '<>', value: [1, 2] }]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe('select * from public.users where (id, version) <> (1, 2);')
+      })
+
+      test('should correctly handle tuple filters with in operator', () => {
+        const filters: Filter[] = [
+          {
+            column: ['id', 'version'],
+            operator: 'in',
+            value: [
+              [1, 2],
+              [3, 4],
+              [5, 6],
+            ],
+          },
+        ]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe(
+          'select * from public.users where (id, version) in ((1, 2), (3, 4), (5, 6));'
+        )
+      })
+
+      test('should error if tuple filters with in operator do not have matching number of array values', () => {
+        const filters: Filter[] = [
+          {
+            column: ['id', 'version'],
+            operator: 'in',
+            value: [[1, 2], [3, 4], [5]],
+          },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
+
+      test('should correctly handle tuple filters with in operator using strings', () => {
+        const filters: Filter[] = [
+          {
+            column: ['id', 'version'],
+            operator: 'in',
+            value: ['one,two', 'three,four', 'five,six'],
+          },
+        ]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe(
+          `select * from public.users where (id, version) in (('one', 'two'), ('three', 'four'), ('five', 'six'));`
+        )
+      })
+
+      test('should error if tuple filters with in operator do not have matching number of stringified values', () => {
+        const filters: Filter[] = [
+          {
+            column: ['id', 'version'],
+            operator: 'in',
+            value: ['one,two', 'three,four', 'five'],
+          },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
+
+      test('should correctly handle tuple filters with string values', () => {
+        const filters: Filter[] = [
+          { column: ['first_name', 'last_name'], operator: '=', value: ['John', 'Doe'] },
+        ]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe(
+          "select * from public.users where (first_name, last_name) = ('John', 'Doe');"
+        )
+      })
+
+      test('should correctly handle mixed tuple and regular filters', () => {
+        const filters: Filter[] = [
+          { column: ['id', 'version'], operator: '>', value: [1, 2] },
+          { column: 'active', operator: '=', value: true },
+        ]
+        const result = QueryUtils.selectQuery(table, '*', { filters: filters })
+        expect(result).toBe(
+          'select * from public.users where (id, version) > (1, 2) and active = true;'
+        )
+      })
+
+      test('should error when trying to use "is" operator as a tuple filter', () => {
+        const filters: Filter[] = [
+          {
+            column: ['id', 'version'],
+            operator: 'is',
+            value: [null, null],
+          },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
+
+      test('should error when trying to use "~~" operator as a tuple filter', () => {
+        const filters: Filter[] = [
+          {
+            column: ['first_name', 'last_name'],
+            operator: '~~',
+            value: ['%John%', '%Doe%'],
+          },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
+
+      test('should error when trying to use "~~*" operator as a tuple filter', () => {
+        const filters: Filter[] = [
+          { column: ['first_name', 'last_name'], operator: '~~*', value: ['%john%', '%doe%'] },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
+
+      test('should error when trying to use "!~~" operator as a tuple filter', () => {
+        const filters: Filter[] = [
+          { column: ['first_name', 'last_name'], operator: '!~~', value: ['%Admin%', '%System%'] },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
+
+      test('should error when trying to use "!~~*" operator as a tuple filter', () => {
+        const filters: Filter[] = [
+          { column: ['first_name', 'last_name'], operator: '!~~*', value: ['%admin%', '%system%'] },
+        ]
+        expect(() => QueryUtils.selectQuery(table, '*', { filters: filters })).toThrowError()
+      })
     })
 
     describe('applySorts', () => {


### PR DESCRIPTION
Current behavior:

Only single columns can be used as filters: `where version = 2`

New behavior:

Composite values can be used as filters: `where (id, version) = (1, 2)`

Motivation:

In order to correct an existing bug when fetching table rows, we need to use cursor pagination on the primary key, but in order to handle composite primary keys, we need to be able to filter by composite values.