### PR TITLE
fix(table editor): inconsistent serialization and serializing stale values for filter state

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -1,18 +1,16 @@
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
-import { compact, filter } from 'lodash'
-import { useEffect, useState } from 'react'
+import { compact } from 'lodash'
+import { useEffect } from 'react'
 import { CalculatedColumn, CellKeyboardEvent } from 'react-data-grid'
 
 import type { Filter, SavedState } from 'components/grid/types'
 import { Entity, isTableLike } from 'data/table-editor/table-editor-types'
-import { useUrlState } from 'hooks/ui/useUrlState'
+import { parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
 import { copyToClipboard } from 'ui'
 import { FilterOperatorOptions } from './components/header/filter/Filter.constants'
 import { STORAGE_KEY_PREFIX } from './constants'
 import type { Sort, SupaColumn, SupaTable } from './types'
 import { formatClipboardValue } from './utils/common'
-import { parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
-
 export const LOAD_TAB_FROM_CACHE_PARAM = 'loadFromCache'
 
 export function formatSortURLParams(tableName: string, sort?: string[]): Sort[] {
@@ -228,11 +226,11 @@ export function useSyncTableEditorStateFromLocalStorageWithUrl({
         projectRef,
         tableName: table.name,
         schema: table.schema,
-        sorts: latestUrlParams.sort,
-        filters: latestUrlParams.filter,
+        sorts: urlParams.sort,
+        filters: urlParams.filter,
       })
     }
-  }, [urlParams, table, projectRef])
+  }, [urlParams, updateUrlParams, table, projectRef])
 }
 
 export const handleCopyCell = (

--- a/apps/studio/hooks/misc/useTableEditorFiltersSort.ts
+++ b/apps/studio/hooks/misc/useTableEditorFiltersSort.ts
@@ -1,20 +1,10 @@
-import { useRouter } from 'next/router'
-import { useMemo } from 'react'
+import { parseAsArrayOf, parseAsString, useQueryStates } from 'nuqs'
 
 export const useTableEditorFiltersSort = () => {
-  const router = useRouter()
-
-  const urlParams = useMemo(() => {
-    return new URLSearchParams(router.asPath.split('?')[1])
-  }, [router.asPath])
-
-  const filters = useMemo(() => {
-    return urlParams.getAll('filter')
-  }, [urlParams])
-
-  const sorts = useMemo(() => {
-    return urlParams.getAll('sort')
-  }, [urlParams])
+  const [{ sort, filter }, updateUrlParams] = useQueryStates({
+    sort: parseAsArrayOf(parseAsString).withDefault([]),
+    filter: parseAsArrayOf(parseAsString).withDefault([]),
+  })
 
   type SetParamsArgs = {
     filter?: string[]
@@ -22,24 +12,24 @@ export const useTableEditorFiltersSort = () => {
   }
 
   const setParams = (fn: (prevParams: SetParamsArgs) => SetParamsArgs) => {
-    const prevParams = { filter: filters, sort: sorts }
+    const prevParams = { filter, sort }
     const newParams = fn(prevParams)
 
     const hasFilter = newParams.filter !== undefined
     const hasSort = newParams.sort !== undefined
 
-    router.push({
-      query: {
-        ...router.query,
-        ...(hasFilter ? { filter: newParams.filter } : {}),
-        ...(hasSort ? { sort: newParams.sort } : {}),
+    updateUrlParams(
+      {
+        sort: hasSort ? newParams.sort : [],
+        filter: hasFilter ? newParams.filter : [],
       },
-    })
+      { clearOnDefault: true }
+    )
   }
 
   return {
-    filters,
-    sorts,
+    filters: filter,
+    sorts: sort,
     setParams,
   }
 }


### PR DESCRIPTION
We have some reports of filters getting corrupted as users switch or reload tabs.

Some fixes that might help the issue:
- Making sure we write the latest values to storage (we were writing stale values before)
- Using the same serialization/deserialization logic anywhere that needs to sync with URL state

There's probably more we could do to refactor out some common utils, just want to get a basic fix in this PR to see if it helps with a support ticket.

To test:
1. Use an `in` filter to test against a set of matching values on a table
2. Close and reload studio
3. Go back to the same table, the deserialization should fail and cause an error in prod; this should be fixed in this PR