### PR TITLE
fix: fix handling of upgrade failure acknowledgment in ProjectUpgradeFailedBanner

### DIFF
--- a/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
+++ b/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
@@ -21,7 +21,6 @@ export const ProjectUpgradeFailedBanner = () => {
 
   const [hasDismissed, setHasDismissed] = useState(false)
   useEffect(() => {
-    if (typeof window === 'undefined') return
     setHasDismissed(localStorage?.getItem(key) === 'true')
   }, [key])
 

--- a/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
+++ b/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
@@ -2,7 +2,7 @@ import { DatabaseUpgradeStatus } from '@supabase/shared-types/out/events'
 import dayjs from 'dayjs'
 import { X } from 'lucide-react'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useParams } from 'common'
 import { useProjectUpgradingStatusQuery } from 'data/config/project-upgrade-status-query'
@@ -18,9 +18,12 @@ export const ProjectUpgradeFailedBanner = () => {
   const { status, initiated_at, latest_status_at, error } = data?.databaseUpgradeStatus ?? {}
 
   const key = `supabase-upgrade-${ref}-${initiated_at}`
-  const isAcknowledged =
-    typeof window !== 'undefined' ? localStorage?.getItem(key) === 'true' : false
-  const [showMessage, setShowMessage] = useState(!isAcknowledged)
+
+  const [hasDismissed, setHasDismissed] = useState(false)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setHasDismissed(localStorage?.getItem(key) === 'true')
+  }, [key])
 
   const isFailed = status === DatabaseUpgradeStatus.Failed
   const initiatedAt = dayjs
@@ -43,11 +46,11 @@ export const ProjectUpgradeFailedBanner = () => {
   const timestampFilter = `its=${initiatedAtEncoded}&ite=${latestStatusAtEncoded}`
 
   const acknowledgeMessage = () => {
-    setShowMessage(false)
+    setHasDismissed(true)
     localStorage.setItem(key, 'true')
   }
 
-  if (!isFailed || !showMessage) return null
+  if (!isFailed || hasDismissed) return null
 
   return (
     <div className="max-w-7xl">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The key used to read from local storage is effectively undefined initially and not refetched when the key is asynchrously derived from server response

## What is the new behavior?

When the storage key changes, local storage is read, and state is updated.

