### PR TITLE
Add `next` param to Next.js server-side auth guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -406,7 +406,7 @@ If you have email confirmation turned on (the default), a new user will receive 
 
 Change the email template to support a server-side authentication flow.
 
-Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard. In the `Confirm signup` template, change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email`.
+Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard. In the `Confirm signup` template, change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}`.
 
 </StepHikeCompact.Details>
 
@@ -804,7 +804,7 @@ If you have email confirmation turned on (the default), a new user will receive 
 
 Change the email template to support a server-side authentication flow.
 
-Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard. In the `Confirm signup` template, change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/api/auth/confirm?token_hash={{ .TokenHash }}&type=email`.
+Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard. In the `Confirm signup` template, change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/api/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}`.
 
 </StepHikeCompact.Details>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updating Next.js server-side auth docs to include the `next` query param in the auth email template.

## What is the current behavior?

Both the [app router docs](https://supabase.com/docs/guides/auth/server-side/nextjs?queryGroups=router&router=app) and [pages router docs](https://supabase.com/docs/guides/auth/server-side/nextjs?queryGroups=router&router=pages) for Next.js server-side auth setup build auth confirmation routes which handle a `next` query param:
- [App router code ref](https://github.com/supabase/supabase/blob/e978a084b2fd5afb47aa2347d0759422007bba61/apps/docs/content/guides/auth/server-side/nextjs.mdx?plain=1#L440)
- [Pages router code ref](https://github.com/supabase/supabase/blob/e978a084b2fd5afb47aa2347d0759422007bba61/apps/docs/content/guides/auth/server-side/nextjs.mdx?plain=1#L858)


## What is the new behavior?

Docs now include a `&next={{ .RedirectTo }}` param at the end of the email template URL string, creating a full URL like this:

```
{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}
```

**App router screenshot**
<img width="1624" height="995" alt="Screenshot 2025-10-01 at 4 48 35 PM" src="https://github.com/user-attachments/assets/de2d1a9b-66c0-437d-b9bd-bbd94662c52a" />

**Pages router screenshot**
<img width="1624" height="995" alt="Screenshot 2025-10-01 at 4 48 42 PM" src="https://github.com/user-attachments/assets/e9a07f03-d43a-4102-82ed-53d3536a9b48" />

## Additional context

This change corresponds to a similar update to the Next.js `with-supabase` template: https://github.com/vercel/next.js/pull/84441