### PR TITLE
fix(studio): remove password managers from inputs

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -191,6 +191,11 @@ const AddNewSecretForm = () => {
                           <Input
                             {...field}
                             type={showSecretValue ? 'text' : 'password'}
+                            // [Danny] Prevent password managers from appearing in field
+                            data-1p-ignore
+                            data-lpignore="true"
+                            data-form-type="other"
+                            data-bwignore
                             actions={
                               <div className="mr-1">
                                 <Button

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -191,7 +191,6 @@ const AddNewSecretForm = () => {
                           <Input
                             {...field}
                             type={showSecretValue ? 'text' : 'password'}
-                            // [Danny] Prevent password managers from appearing in field
                             data-1p-ignore
                             data-lpignore="true"
                             data-form-type="other"

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -269,7 +269,6 @@ export const CreateBucketModal = () => {
                     <FormControl_Shadcn_>
                       <Input_Shadcn_
                         id="name"
-                        // [Danny] Prevent password managers from appearing in field
                         data-1p-ignore
                         data-lpignore="true"
                         data-form-type="other"

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -56,7 +56,7 @@ import { convertFromBytes, convertToBytes } from './StorageSettings/StorageSetti
 
 const FormSchema = z
   .object({
-    name: z
+    bucketName: z
       .string()
       .trim()
       .min(1, 'Please provide a name for your bucket')
@@ -79,10 +79,10 @@ const FormSchema = z
     allowed_mime_types: z.string().trim().default(''),
   })
   .superRefine((data, ctx) => {
-    if (!validBucketNameRegex.test(data.name)) {
-      const [match] = data.name.match(inverseValidBucketNameRegex) ?? []
+    if (!validBucketNameRegex.test(data.bucketName)) {
+      const [match] = data.bucketName.match(inverseValidBucketNameRegex) ?? []
       ctx.addIssue({
-        path: ['name'],
+        path: ['bucketName'],
         code: z.ZodIssueCode.custom,
         message: !!match
           ? `Bucket name cannot contain the "${match}" character`
@@ -120,7 +120,7 @@ export const CreateBucketModal = () => {
   const form = useForm<CreateBucketForm>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      name: '',
+      bucketName: '',
       public: false,
       type: 'STANDARD',
       has_file_size_limit: false,
@@ -130,7 +130,7 @@ export const CreateBucketModal = () => {
   })
   const { formatted_size_limit: formattedSizeLimitError } = form.formState.errors
 
-  const bucketName = snakeCase(form.watch('name'))
+  const bucketName = snakeCase(form.watch('bucketName'))
   const isPublicBucket = form.watch('public')
   const isStandardBucket = form.watch('type') === 'STANDARD'
   const hasFileSizeLimit = form.watch('has_file_size_limit')
@@ -168,7 +168,7 @@ export const CreateBucketModal = () => {
 
       await createBucket({
         projectRef: ref,
-        id: values.name,
+        id: values.bucketName,
         type: values.type,
         isPublic: values.public,
         file_size_limit: fileSizeLimit,
@@ -181,15 +181,15 @@ export const CreateBucketModal = () => {
       })
 
       if (values.type === 'ANALYTICS' && icebergWrapperExtensionState === 'installed') {
-        await createIcebergWrapper({ bucketName: values.name })
+        await createIcebergWrapper({ bucketName: values.bucketName })
       }
 
-      toast.success(`Successfully created bucket ${values.name}`)
+      toast.success(`Successfully created bucket ${values.bucketName}`)
       form.reset()
 
       setSelectedUnit(StorageSizeUnits.MB)
       setVisible(false)
-      router.push(`/project/${ref}/storage/buckets/${values.name}`)
+      router.push(`/project/${ref}/storage/buckets/${values.bucketName}`)
     } catch (error: any) {
       // Handle specific error cases for inline display
       const errorMessage = error.message?.toLowerCase() || ''
@@ -257,17 +257,17 @@ export const CreateBucketModal = () => {
           <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
             <DialogSection className="flex flex-col gap-y-2">
               <FormField_Shadcn_
-                key="name"
-                name="name"
+                key="bucketName"
+                name="bucketName"
                 control={form.control}
                 render={({ field }) => (
                   <FormItemLayout
-                    name="name"
+                    name="bucketName"
                     label="Name of bucket"
                     labelOptional="Buckets cannot be renamed once created."
                   >
                     <FormControl_Shadcn_>
-                      <Input_Shadcn_ id="name" {...field} placeholder="Enter bucket name" />
+                      <Input_Shadcn_ id="bucketName" {...field} placeholder="Enter bucket name" />
                     </FormControl_Shadcn_>
                   </FormItemLayout>
                 )}

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -269,6 +269,7 @@ export const CreateBucketModal = () => {
                     <FormControl_Shadcn_>
                       <Input_Shadcn_
                         id="name"
+                        // [Danny] Prevent password managers from appearing in field
                         data-1p-ignore
                         data-lpignore="true"
                         data-form-type="other"

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -56,7 +56,7 @@ import { convertFromBytes, convertToBytes } from './StorageSettings/StorageSetti
 
 const FormSchema = z
   .object({
-    bucketName: z
+    name: z
       .string()
       .trim()
       .min(1, 'Please provide a name for your bucket')
@@ -79,10 +79,10 @@ const FormSchema = z
     allowed_mime_types: z.string().trim().default(''),
   })
   .superRefine((data, ctx) => {
-    if (!validBucketNameRegex.test(data.bucketName)) {
-      const [match] = data.bucketName.match(inverseValidBucketNameRegex) ?? []
+    if (!validBucketNameRegex.test(data.name)) {
+      const [match] = data.name.match(inverseValidBucketNameRegex) ?? []
       ctx.addIssue({
-        path: ['bucketName'],
+        path: ['name'],
         code: z.ZodIssueCode.custom,
         message: !!match
           ? `Bucket name cannot contain the "${match}" character`
@@ -120,7 +120,7 @@ export const CreateBucketModal = () => {
   const form = useForm<CreateBucketForm>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      bucketName: '',
+      name: '',
       public: false,
       type: 'STANDARD',
       has_file_size_limit: false,
@@ -130,7 +130,7 @@ export const CreateBucketModal = () => {
   })
   const { formatted_size_limit: formattedSizeLimitError } = form.formState.errors
 
-  const bucketName = snakeCase(form.watch('bucketName'))
+  const bucketName = snakeCase(form.watch('name'))
   const isPublicBucket = form.watch('public')
   const isStandardBucket = form.watch('type') === 'STANDARD'
   const hasFileSizeLimit = form.watch('has_file_size_limit')
@@ -168,7 +168,7 @@ export const CreateBucketModal = () => {
 
       await createBucket({
         projectRef: ref,
-        id: values.bucketName,
+        id: values.name,
         type: values.type,
         isPublic: values.public,
         file_size_limit: fileSizeLimit,
@@ -181,15 +181,15 @@ export const CreateBucketModal = () => {
       })
 
       if (values.type === 'ANALYTICS' && icebergWrapperExtensionState === 'installed') {
-        await createIcebergWrapper({ bucketName: values.bucketName })
+        await createIcebergWrapper({ bucketName: values.name })
       }
 
-      toast.success(`Successfully created bucket ${values.bucketName}`)
+      toast.success(`Successfully created bucket ${values.name}`)
       form.reset()
 
       setSelectedUnit(StorageSizeUnits.MB)
       setVisible(false)
-      router.push(`/project/${ref}/storage/buckets/${values.bucketName}`)
+      router.push(`/project/${ref}/storage/buckets/${values.name}`)
     } catch (error: any) {
       // Handle specific error cases for inline display
       const errorMessage = error.message?.toLowerCase() || ''
@@ -257,17 +257,25 @@ export const CreateBucketModal = () => {
           <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
             <DialogSection className="flex flex-col gap-y-2">
               <FormField_Shadcn_
-                key="bucketName"
-                name="bucketName"
+                key="name"
+                name="name"
                 control={form.control}
                 render={({ field }) => (
                   <FormItemLayout
-                    name="bucketName"
+                    name="name"
                     label="Name of bucket"
                     labelOptional="Buckets cannot be renamed once created."
                   >
                     <FormControl_Shadcn_>
-                      <Input_Shadcn_ id="bucketName" {...field} placeholder="Enter bucket name" />
+                      <Input_Shadcn_
+                        id="name"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
+                        data-bwignore
+                        {...field}
+                        placeholder="Enter bucket name"
+                      />
                     </FormControl_Shadcn_>
                   </FormItemLayout>
                 )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

1Password shows an annoying widget and tooltip in the _Bucket name_ field when it has nothing to do with what a user might have in a 1Password vault.

## What is the new behavior?

This 1Password widget no longer shows.

| Before | After |
| --- | --- |
| <img width="1024" height="762" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/d296d1b7-8f1e-4d42-b760-d352a9d8128d" /> | <img width="1024" height="762" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/6a19e13e-2835-45e7-a24f-1e10a054ed2b" /> |

## Additional context

As explained [here](https://flaviocopes.com/how-to-disable-1password-in-an-input-field/), 1Password adds this based on the `name="name"` value. I added the appropriate `ignore` attributes for 1Password and similar password managers. I also did the same for edge function secrets.
