### PR TITLE
chore(studio): improve Postgres upgrade experience

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -95,7 +95,7 @@ const InfrastructureInfo = () => {
           <ScaffoldSectionDetail>
             <h4 className="text-base capitalize m-0">Service Versions</h4>
             <p className="text-foreground-light text-sm pr-8 mt-1">
-              Information on your provisioned instance.
+              Service versions and upgrade eligibility for your provisioned instance.
             </p>
           </ScaffoldSectionDetail>
           <ScaffoldSectionContent>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -33,7 +33,7 @@ export const ObjectsToBeDroppedWarning = ({
           <p className="mb-1">
             The following objects are not supported and must be removed before upgrading.{' '}
             <InlineLink
-              className="text-foreground-lighter hover:text-foreground transition-colorsrs"
+              className="text-foreground-lighter hover:text-foreground transition-colors"
               href={`${DOCS_URL}/guides/platform/upgrading#extensions`}
               target="_blank"
               rel="noopener noreferrer"

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -24,36 +24,37 @@ export const ObjectsToBeDroppedWarning = ({
 }: {
   objectsToBeDropped: string[]
 }) => {
+  const { ref } = useParams()
   return (
-    <Alert_Shadcn_
-      variant="warning"
-      title="A new version of Postgres is available for your project"
-    >
-      <AlertTitle_Shadcn_>A new version of Postgres is available</AlertTitle_Shadcn_>
+    <Alert_Shadcn_ title="A newer version of Postgres is available for your project">
+      <AlertTitle_Shadcn_>A newer version of Postgres is available</AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_ className="flex flex-col gap-3">
-        <div>
-          <p className="mb-1">The following objects have to be removed before upgrading:</p>
+        <>
+          <p className="mb-1">
+            The following objects are not supported and must be removed before upgrading.{' '}
+            <InlineLink
+              className="text-foreground-lighter hover:text-foreground transition-colorsrs"
+              href={`${DOCS_URL}/guides/platform/upgrading#extensions`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more
+            </InlineLink>
+          </p>
 
-          <ul className="pl-4">
+          {/* Old */}
+          <ul className="pl-4 pb-3">
             {objectsToBeDropped.map((obj) => (
               <li className="list-disc" key={obj}>
                 {obj}
               </li>
             ))}
           </ul>
-        </div>
-        <p>Check the docs for which objects need to be removed.</p>
-        <div>
-          <Button size="tiny" type="default" asChild>
-            <a
-              href={`${DOCS_URL}/guides/platform/upgrading#extensions`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              View docs
-            </a>
+
+          <Button className="w-fit" size="tiny" type="default" asChild>
+            <Link href={`/project/${ref}/database/functions`}>Manage functions</Link>
           </Button>
-        </div>
+        </>
       </AlertDescription_Shadcn_>
     </Alert_Shadcn_>
   )
@@ -73,15 +74,15 @@ export const UnsupportedExtensionsWarning = ({
         <>
           <p className="mb-1">
             The following extensions are not supported in newer versions of Postgres and must be
-            removed before you can upgrade.{' '}
+            removed before upgrading.{' '}
             <InlineLink
+              className="text-foreground-lighter hover:text-foreground transition-colors"
               href={`${DOCS_URL}/guides/platform/upgrading#upgrading-to-postgres-17`}
               target="_blank"
               rel="noopener noreferrer"
             >
               Learn more
             </InlineLink>
-            .
           </p>
 
           <ul className="border-t border-border-muted flex flex-col divide-y divide-border-muted">
@@ -107,15 +108,13 @@ export const UnsupportedExtensionsWarning = ({
 
 export const UserDefinedObjectsInInternalSchemasWarning = ({ objects }: { objects: string[] }) => {
   return (
-    <Alert_Shadcn_
-      variant="warning"
-      title="A new version of Postgres is available for your project"
-    >
-      <AlertTitle_Shadcn_>A new version of Postgres is available</AlertTitle_Shadcn_>
+    <Alert_Shadcn_ title="A newer version of Postgres is available for your project">
+      <AlertTitle_Shadcn_>A newer version of Postgres is available</AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_ className="flex flex-col gap-3">
         <div>
           <p className="mb-1">
-            You'll need to move these objects out of auth/realtime/storage schemas before upgrading:
+            The following objects must be removed from the auth/realtime/storage schemas before
+            upgrading:
           </p>
 
           <ul className="pl-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes the Postgres upgrade experience clearer. 
- Fixes DEPR-80
- Fixes DEPR-82

## What is the current behavior?

- The `ObjectsToBeDroppedWarning` just links to the docs. It doesn’t make it clear that the user needs to remove the affected function(s).
- The _Service Versions_ section doesn’t make it clear that this is where the user goes to upgrade Postgres
  - This is exacerbated by the fact that the API call to determine upgrade eligibility can take ~10 seconds

## What is the new behavior?

Specifically for the `ObjectsToBeDroppedWarning`:

| Before | After |
| --- | --- |
| <img width="1024" height="762" alt="Infrastructure  Supabase" src="https://github.com/user-attachments/assets/34235dc0-d2ff-4d9e-8e91-7a98b683d001" /> | <img width="1024" height="762" alt="Infrastructure  Supabase" src="https://github.com/user-attachments/assets/3e012bac-abeb-4670-a5e6-4e8a34d5e5b6" /> |

To address upgrade clarity: the description for the _Service Versions_ section has been amended.

## Additional context

This is a follow up from https://github.com/supabase/supabase/pull/38904.

I would prefer that each line in `ObjectsToBeDroppedWarning` links out directly to its corresponding function. For example:

```tsx
<Button size="tiny" type="default" asChild>
  <Link href={`/project/${ref}/database/functions?search=${obj}`}>Manage</Link>
</Button>
```

But the API only returns `objects_to_be_dropped` as an array of strings like:
- function public.test_noop_plv8 is using obsolete language plv8

That requires backend changes to provide the name of the function and name of the extension, not just the string.