### PR TITLE
chore(billing): adjust copy for upcoming invoice section for AWS billed orgs

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
@@ -71,22 +71,18 @@ const BillingBreakdown = () => {
           <p className="prose text-sm">
             {selectedOrganization?.managed_by === MANAGED_BY.AWS_MARKETPLACE ? (
               <>
-                You'll receive two invoices from AWS Marketplace: one on the 3rd of{' '}
-                {billingCycleEnd.format('MMMM')} for your usage in{' '}
-                {billingCycleStart.format('MMMM')} and one on {billingCycleEnd.format('MMMM DD')}{' '}
-                for the fixed subscription fee.
+                AWS Marketplace sends two invoices each month: one for your fixed subscription fee,
+                billed on the day you subscribed, and one for your usage charges from the previous
+                month, billed by the 3rd.
               </>
             ) : (
               <>
                 Your upcoming invoice (excluding credits) will continue to update until the end of
-                your billing cycle on {billingCycleEnd.format('MMMM DD')}.
+                your billing cycle on {billingCycleEnd.format('MMMM DD')}. For a more detailed
+                breakdown, visit the <Link href={`/org/${orgSlug}/usage`}>usage page.</Link>
               </>
             )}
-            <>
-              {' '}
-              For a more detailed breakdown, visit the{' '}
-              <Link href={`/org/${orgSlug}/usage`}>usage page.</Link>
-            </>
+            <></>
           </p>
           <br />
           <p className="text-sm text-foreground-light mt-4">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
@@ -71,9 +71,16 @@ const BillingBreakdown = () => {
           <p className="prose text-sm">
             {selectedOrganization?.managed_by === MANAGED_BY.AWS_MARKETPLACE ? (
               <>
-                AWS Marketplace sends two invoices each month: one for your fixed subscription fee,
-                billed on the day you subscribed, and one for your usage charges from the previous
-                month, billed by the 3rd.
+                <p>
+                  AWS Marketplace sends two invoices each month: one for your fixed subscription
+                  fee, billed on the day you subscribed, and one for your usage charges from the
+                  previous month, billed by the 3rd.
+                </p>
+
+                <p>
+                  For a more detailed breakdown, visit the{' '}
+                  <Link href={`/org/${orgSlug}/usage`}>usage page.</Link>
+                </p>
               </>
             ) : (
               <>
@@ -82,7 +89,6 @@ const BillingBreakdown = () => {
                 breakdown, visit the <Link href={`/org/${orgSlug}/usage`}>usage page.</Link>
               </>
             )}
-            <></>
           </p>
           <br />
           <p className="text-sm text-foreground-light mt-4">


### PR DESCRIPTION
For the "Upcoming Invoice" section on the "Billing Page", we're now using a more generic copy instead of using the exact dates.

**BEFORE**
<img width="476" height="314" alt="Screenshot 2025-10-02 at 11 38 12" src="https://github.com/user-attachments/assets/77fc7c65-99ff-4acb-a907-302fcc21682b" />


**AFTER**
<img width="485" height="258" alt="Screenshot 2025-10-02 at 11 44 45" src="https://github.com/user-attachments/assets/3c8a9a4f-3eb7-44a7-9f4a-1fac4352ccb0" />