### PR TITLE
fix(billing): hide button for credit top up for orgs billed by a marketplace

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditBalance.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditBalance.tsx
@@ -55,7 +55,7 @@ const CreditBalance = () => {
         {isPermissionsLoaded && !canReadSubscriptions ? (
           <NoPermission resourceText="view this organization's credits" />
         ) : (
-          <FormPanel footer={subscription?.billing_via_partner ? '' : <CreditTopUp slug={slug} />}>
+          <FormPanel footer={subscription?.billing_via_partner ? undefined : <CreditTopUp slug={slug} />}>
             <FormSection>
               <FormSectionContent fullWidth loading={isLoading}>
                 {isError && (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditBalance.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditBalance.tsx
@@ -55,7 +55,9 @@ const CreditBalance = () => {
         {isPermissionsLoaded && !canReadSubscriptions ? (
           <NoPermission resourceText="view this organization's credits" />
         ) : (
-          <FormPanel footer={subscription?.billing_via_partner ? undefined : <CreditTopUp slug={slug} />}>
+          <FormPanel
+            footer={subscription?.billing_via_partner ? undefined : <CreditTopUp slug={slug} />}
+          >
             <FormSection>
               <FormSectionContent fullWidth loading={isLoading}>
                 {isError && (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditBalance.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditBalance.tsx
@@ -55,7 +55,7 @@ const CreditBalance = () => {
         {isPermissionsLoaded && !canReadSubscriptions ? (
           <NoPermission resourceText="view this organization's credits" />
         ) : (
-          <FormPanel footer={<CreditTopUp slug={slug} />}>
+          <FormPanel footer={subscription?.billing_via_partner ? '' : <CreditTopUp slug={slug} />}>
             <FormSection>
               <FormSectionContent fullWidth loading={isLoading}>
                 {isError && (


### PR DESCRIPTION
Do not show the button "Top Up" in the "Credit Balance" section the org's "Billing Page" for orgs that are billed by a marketplace (not just AWS Marketplace, but also Vercel Marketplace). We already prevent credit top ups in the backend but were still showing the button.

**FOR PLATFORM BILLED ORGS**
<img width="1215" height="243" alt="Screenshot 2025-10-02 at 12 24 07" src="https://github.com/user-attachments/assets/6e87ec9d-459a-407f-add5-4aa4c59fafdd" />

**FOR MARKETPLACE BILLED ORGS**
<img width="1223" height="161" alt="Screenshot 2025-10-02 at 12 24 38" src="https://github.com/user-attachments/assets/573ab0b3-9b16-45e8-abe1-f79ff9bf9ecb" />
