### PR TITLE
Revert "Add sample rate to fetcher"

### DIFF
--- a/apps/studio/data/feedback/support-ticket-send.ts
+++ b/apps/studio/data/feedback/support-ticket-send.ts
@@ -57,7 +57,7 @@ export async function sendSupportTicket({
 
   if (error) {
     handleError(error, {
-      sampleRate: 1,
+      alwaysCapture: true,
       sentryContext: {
         tags: {
           dashboardSupportForm: true,

--- a/apps/studio/data/fetchers.ts
+++ b/apps/studio/data/fetchers.ts
@@ -135,12 +135,15 @@ export const {
 } = client
 
 type HandleErrorOptions = {
+  alwaysCapture?: boolean
   sentryContext?: Parameters<typeof Sentry.captureException>[1]
-  sampleRate?: number
 }
 
 export const handleError = (error: unknown, options: HandleErrorOptions = {}): never => {
   if (error && typeof error === 'object') {
+    if (options.alwaysCapture) {
+      Sentry.captureException(error, options.sentryContext)
+    }
     const errorMessage =
       'msg' in error && typeof error.msg === 'string'
         ? error.msg
@@ -154,12 +157,6 @@ export const handleError = (error: unknown, options: HandleErrorOptions = {}): n
     const retryAfter =
       'retryAfter' in error && typeof error.retryAfter === 'number' ? error.retryAfter : undefined
 
-    const shouldCapture = Math.random() < (options?.sampleRate ?? 0.2) // 20% sample rate
-
-    if (shouldCapture) {
-      Sentry.captureException(error, options.sentryContext)
-    }
-
     if (errorMessage) {
       throw new ResponseError(errorMessage, errorCode, requestId, retryAfter)
     }
@@ -168,6 +165,10 @@ export const handleError = (error: unknown, options: HandleErrorOptions = {}): n
   if (error !== null && typeof error === 'object' && 'stack' in error) {
     console.error(error.stack)
   }
+
+  // the error doesn't have a message or msg property, so we can't throw it as an error. Log it via Sentry so that we can
+  // add handling for it.
+  Sentry.captureException(error, options.sentryContext)
 
   // throw a generic error if we don't know what the error is. The message is intentionally vague because it might show
   // up in the UI.

--- a/apps/studio/data/permissions/permissions-query.ts
+++ b/apps/studio/data/permissions/permissions-query.ts
@@ -18,6 +18,7 @@ export async function getPermissions(signal?: AbortSignal) {
     // since those may require investigation if they spike
     const sendError = statusCode >= 500 || statusCode === 'unknown'
     handleError(error, {
+      alwaysCapture: sendError,
       sentryContext: {
         tags: {
           permissionsQuery: true,


### PR DESCRIPTION
This PR reverts https://github.com/supabase/supabase/pull/38785 because each API error was being sent to Sentry.