### PR TITLE
docs: realtime getting started link

### DIFF
--- a/apps/docs/content/guides/realtime.mdx
+++ b/apps/docs/content/guides/realtime.mdx
@@ -20,7 +20,7 @@ Supabase provides a globally distributed [Realtime](https://github.com/supabase/
 - **Multiplayer games** - Synchronized game state and player interactions
 - **Social features** - Live notifications, reactions, and user activity feeds
 
-Check the [Getting Started](/docs/guides/realtime/getting-started) guide to get started.
+Check the [Getting Started](/docs/guides/realtime/getting_started) guide to get started.
 
 ## Examples
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Realtime](https://supabase.com/docs/guides/realtime)

## What is the current behavior?

The getting started link is broken.

## What is the new behavior?

Link is now working.

Closes #39199 
