### PR TITLE
chore(www): update Select banner with live text

### DIFF
--- a/packages/ui-patterns/src/Banners/SelectBanner.tsx
+++ b/packages/ui-patterns/src/Banners/SelectBanner.tsx
@@ -3,8 +3,12 @@ import Link from 'next/link'
 
 export function SelectBanner() {
   const selectSiteUrl = 'https://select.supabase.com/'
-  const desc = ['Our first user conference', 'Oct 3 2025', 'Guillermo Rauch, Dylan Field, and more']
-  const cta = 'Save your seat'
+  const desc = [
+    'Our first user conference',
+    'Oct 3 2025',
+    'Patrick Collison, Dylan Field, and more',
+  ]
+  const cta = 'Watch live'
 
   const baseStyles = 'flex flex-col justify-center border-l border-muted py-8 '
   const textBlockStyles =


### PR DESCRIPTION
## What kind of change does this PR introduce?

Copywriting update

## What is the current behavior?

Select banner links out to page with _Save your seat_

## What is the new behavior?

- Select banner links out to page with _Watch live_
- Add Patrick Collison to lineup

| Before | After |
| --- | --- |
| <img width="1372" height="388" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/1222f3f0-a306-4b87-9fb0-9f9a513b12ff" /> | <img width="1372" height="388" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/5962d4d7-7dfe-4513-b548-1edbc5e43804" /> |

## Additional context

- Please don’t merge until 9:45am PT Friday 3rd October
- I’ll create a follow-up PR after Select to either update the copywriting or remove the banner
- Fixes DEBR-14