### PR TITLE
fix: providers sheet should have a minimum width

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -166,7 +166,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       </ResourceItem>
 
       <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetContent size="content" className="flex flex-col gap-0">
+        <SheetContent className="flex flex-col gap-0">
           <SheetHeader className="shrink-0 flex items-center gap-4">
             <img
               src={`${BASE_PATH}/img/icons/${provider.misc.iconKey}.svg`}


### PR DESCRIPTION
Removes the `content` sizing which causes providers without much content to be condensed.

## Before

<img width="264" height="858" alt="before" src="https://github.com/user-attachments/assets/63dffccf-1abc-49e2-b2bd-9e682e93a386" />

## After

<img width="512" height="825" alt="Screenshot 2025-10-03 at 09 10 14" src="https://github.com/user-attachments/assets/08784363-bf58-4b98-8e09-83aa1cb3f1c0" />
