### PR TITLE
Add callout for migration

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
@@ -88,7 +88,7 @@ export function DiskSizeField({
   const mainDiskUsed = Math.round(((diskUtil?.metrics.fs_used_bytes ?? 0) / GB) * 100) / 100
 
   return (
-    <div className="grid @xl:grid-cols-12 gap-5">
+    <div id="disk-size" className="grid @xl:grid-cols-12 gap-5">
       <div className="col-span-4">
         <FormField_Shadcn_
           name="totalSize"

--- a/apps/studio/components/interfaces/Storage/StorageMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageMenu.tsx
@@ -2,14 +2,16 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { CreateBucketModal } from 'components/interfaces/Storage/CreateBucketModal'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
+import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import { useBucketsQuery } from 'data/storage/buckets-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from 'lib/constants'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, Menu } from 'ui'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import {
   InnerSideBarEmptyPanel,
   InnerSideBarFilters,
@@ -24,6 +26,15 @@ export const StorageMenu = () => {
   const { ref, bucketId } = useParams()
   const { data: projectDetails } = useSelectedProjectQuery()
   const snap = useStorageExplorerStateSnapshot()
+
+  const showMigrationCallout = useFlag('storageMigrationCallout')
+  const { data: config } = useProjectStorageConfigQuery(
+    { projectRef: ref },
+    { enabled: showMigrationCallout }
+  )
+  const isListV2UpgradeAvailable =
+    !!config?.capabilities.list_v2 && config.external.upstreamTarget === 'main'
+
   const isBranch = projectDetails?.parent_project_ref !== undefined
 
   const [searchText, setSearchText] = useState<string>('')
@@ -159,7 +170,12 @@ export const StorageMenu = () => {
             {IS_PLATFORM && (
               <Link href={`/project/${ref}/storage/settings`}>
                 <Menu.Item rounded active={page === 'settings'}>
-                  <p className="truncate">Settings</p>
+                  <div className="flex items-center gap-x-2">
+                    <p className="truncate">Settings</p>
+                    {isListV2UpgradeAvailable && (
+                      <InfoTooltip side="right">Upgrade available</InfoTooltip>
+                    )}
+                  </div>
                 </Menu.Item>
               </Link>
             )}

--- a/apps/studio/components/interfaces/Storage/StorageMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageMenu.tsx
@@ -33,7 +33,7 @@ export const StorageMenu = () => {
     { enabled: showMigrationCallout }
   )
   const isListV2UpgradeAvailable =
-    !!config?.capabilities.list_v2 && config.external.upstreamTarget === 'main'
+    !!config && !config.capabilities.list_v2 && config.external.upstreamTarget === 'main'
 
   const isBranch = projectDetails?.parent_project_ref !== undefined
 

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
@@ -20,8 +20,8 @@ import {
 } from 'ui'
 import { Admonition, TimestampInfo } from 'ui-patterns'
 
-// [Joshen] Will be decided by Storage team, temp setting to 1st Jan 2026 UTC (3 months buffer)
-const MIGRATION_DEADLINE = '2026-01-01T00:00:00'
+// [Joshen] Will be decided by Storage team, temp setting to 15th December 2025 UTC (3 months buffer)
+const MIGRATION_DEADLINE = '2025-12-15T00:00:00'
 
 export const StorageListV2MigrationCallout = () => {
   const deadline = dayjs(MIGRATION_DEADLINE).utc(true)
@@ -111,7 +111,6 @@ const StorageListV2MigrationDialog = () => {
         />
 
         <DialogSection className="flex flex-col gap-y-2">
-          {/* [Joshen] Ideally we show the minimum time taken as 24 hours can sound daunting and is likely not applicable to 90% use case */}
           <p className="text-sm">
             Depending on the number of objects in your Storage, the migration can take up to 24
             hours to finish.

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
@@ -2,7 +2,6 @@ import dayjs from 'dayjs'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
-import { DocsButton } from 'components/ui/DocsButton'
 import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectStorageConfigUpdateUpdateMutation } from 'data/config/project-storage-config-update-mutation'
 import { useState } from 'react'
@@ -50,7 +49,6 @@ export const StorageListV2MigrationCallout = () => {
         </p>
       )}
       <div className="flex items-center gap-x-2 mt-3">
-        <DocsButton href="https://supabase.com/docs" />
         <StorageListV2MigrationDialog />
       </div>
     </Admonition>
@@ -63,9 +61,6 @@ export const StorageListV2MigratingCallout = () => {
       <p className="!leading-normal prose max-w-full text-sm !mb-0">
         This notice will be closed once the upgrade has been completed - hang tight!
       </p>
-      <div className="flex items-center gap-x-2 mt-3">
-        <DocsButton href="https://supabase.com/docs" />
-      </div>
     </Admonition>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import { DocsButton } from 'components/ui/DocsButton'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectStorageConfigUpdateUpdateMutation } from 'data/config/project-storage-config-update-mutation'
 import { useState } from 'react'
 import {
@@ -30,11 +31,11 @@ export const StorageListV2MigrationCallout = () => {
   return (
     <Admonition
       type={remainingMonths <= 1 ? 'warning' : 'note'}
-      title="A new version of Storage is available for your project!"
+      title="A new version of Storage is available for your project"
     >
       <p className="!leading-normal prose max-w-full text-sm !mb-0">
-        Get access to Analytics buckets to handle Iceberg files, along with a more efficient{' '}
-        <code>list</code> method for fetching files via the client library.
+        Get access to the List-V2 endpoint for improved performance and the ability to enable
+        Analytics buckets to your storage system
       </p>
       {remainingMonths <= 1 && (
         <p className="!leading-normal prose max-w-full text-sm">
@@ -109,11 +110,28 @@ const StorageListV2MigrationDialog = () => {
           description="We recommend running the update during periods of lower activity, although minimal to no disruption is expected."
         />
 
-        <DialogSection>
+        <DialogSection className="flex flex-col gap-y-2">
+          {/* [Joshen] Ideally we show the minimum time taken as 24 hours can sound daunting and is likely not applicable to 90% use case */}
           <p className="text-sm">
-            This migration should only take a few minutes, but note that it will increase your
-            Postgres disk size by about 5 - 10%. The upgrade is also backwards compatible so no
-            changes to your client applications are required.
+            Depending on the number of objects in your Storage, the migration can take up to 24
+            hours to finish.
+          </p>
+
+          <p className="text-sm">
+            The upgrade will increase your disk size to about 15 - 25% and IOPS will be used to
+            create new efficient indexes as well as denormalising tables.
+          </p>
+
+          <p className="text-sm">
+            Ensure that your database instance has not{' '}
+            <InlineLink href={`/project/${ref}/settings/compute-and-disk#disk-size`}>
+              scaled disk
+            </InlineLink>{' '}
+            within the last 6h and you have at least 60%{' '}
+            <InlineLink href={`/project/${ref}/settings/infrastructure#infrastructure-activity`}>
+              CPU capacity
+            </InlineLink>{' '}
+            before proceeding.
           </p>
         </DialogSection>
 

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
@@ -1,0 +1,131 @@
+import dayjs from 'dayjs'
+import { toast } from 'sonner'
+
+import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
+import { useProjectStorageConfigUpdateUpdateMutation } from 'data/config/project-storage-config-update-mutation'
+import { useState } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+import { Admonition, TimestampInfo } from 'ui-patterns'
+
+// [Joshen] Will be decided by Storage team, temp setting to 1st Jan 2026 UTC (3 months buffer)
+const MIGRATION_DEADLINE = '2026-01-01T00:00:00'
+
+export const StorageListV2MigrationCallout = () => {
+  const deadline = dayjs(MIGRATION_DEADLINE).utc(true)
+  const currentDate = dayjs.utc()
+  const remainingMonths = Math.ceil(deadline.diff(currentDate, 'months', true))
+
+  return (
+    <Admonition
+      type={remainingMonths <= 1 ? 'warning' : 'note'}
+      title="A new version of Storage is available for your project!"
+    >
+      <p className="!leading-normal prose max-w-full text-sm !mb-0">
+        Get access to Analytics buckets to handle Iceberg files, along with a more efficient{' '}
+        <code>list</code> method for fetching files via the client library.
+      </p>
+      {remainingMonths <= 1 && (
+        <p className="!leading-normal prose max-w-full text-sm">
+          Your project's Storage will be automatically upgraded by{' '}
+          <TimestampInfo
+            displayAs="utc"
+            utcTimestamp={MIGRATION_DEADLINE}
+            className="text-sm text-foreground"
+            labelFormat="DD MMM YYYY HH:mm (UTC)"
+          />{' '}
+          if the upgrade is not completed by then.
+        </p>
+      )}
+      <div className="flex items-center gap-x-2 mt-3">
+        <DocsButton href="https://supabase.com/docs" />
+        <StorageListV2MigrationDialog />
+      </div>
+    </Admonition>
+  )
+}
+
+export const StorageListV2MigratingCallout = () => {
+  return (
+    <Admonition type="note" title="Project's storage is currently upgrading">
+      <p className="!leading-normal prose max-w-full text-sm !mb-0">
+        This notice will be closed once the upgrade has been completed - hang tight!
+      </p>
+      <div className="flex items-center gap-x-2 mt-3">
+        <DocsButton href="https://supabase.com/docs" />
+      </div>
+    </Admonition>
+  )
+}
+
+const StorageListV2MigrationDialog = () => {
+  const { ref } = useParams()
+
+  const [open, setOpen] = useState(false)
+
+  const { mutate: updateStorageConfig, isLoading: isUpdating } =
+    useProjectStorageConfigUpdateUpdateMutation({
+      onSuccess: () => {
+        toast.success(`Project's storage will be upgraded shortly!`)
+        setOpen(false)
+      },
+    })
+
+  const onConfirmUpgrade = () => {
+    if (!ref) return console.error('Project ref is required')
+    updateStorageConfig({ projectRef: ref, external: { upstreamTarget: 'canary' } })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="primary">Upgrade Storage</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upgrade your project's Storage</DialogTitle>
+          <DialogDescription>
+            Get access to Analytics buckets and an improved list method
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogSectionSeparator />
+
+        <Admonition
+          type="warning"
+          className="mb-0 rounded-none border-x-0 border-t-0"
+          title="Migration required to optimise the database schema for upgrade"
+          description="We recommend running the update during periods of lower activity, although minimal to no disruption is expected."
+        />
+
+        <DialogSection>
+          <p className="text-sm">
+            This migration should only take a few minutes, but note that it will increase your
+            Postgres disk size by about 5 - 10%. The upgrade is also backwards compatible so no
+            changes to your client applications are required.
+          </p>
+        </DialogSection>
+
+        <DialogFooter>
+          <Button type="default" disabled={isUpdating} onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button type="primary" loading={isUpdating} onClick={() => onConfirmUpgrade()}>
+            Upgrade now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -6,7 +6,7 @@ import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
 
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { ScaffoldSection } from 'components/layouts/Scaffold'
 import AlertError from 'components/ui/AlertError'
 import { InlineLink } from 'components/ui/InlineLink'
@@ -42,6 +42,10 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import {
+  StorageListV2MigratingCallout,
+  StorageListV2MigrationCallout,
+} from './StorageListV2MigrationCallout'
+import {
   STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_CAPPED,
   STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_FREE_PLAN,
   STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED,
@@ -59,6 +63,8 @@ interface StorageSettingsState {
 
 export const StorageSettings = () => {
   const { ref: projectRef } = useParams()
+  const showMigrationCallout = useFlag('storageMigrationCallout')
+
   const { can: canReadStorageSettings, isLoading: isLoadingPermissions } = useAsyncCheckPermissions(
     PermissionAction.STORAGE_ADMIN_READ,
     '*'
@@ -75,6 +81,10 @@ export const StorageSettings = () => {
     isSuccess,
     isError,
   } = useProjectStorageConfigQuery({ projectRef })
+  const isListV2UpgradeAvailable =
+    !!config?.capabilities.list_v2 && config.external.upstreamTarget === 'main'
+  const isListV2Upgrading =
+    !!config?.capabilities.list_v2 && config.external.upstreamTarget === 'canary'
 
   const { data: organization } = useSelectedOrganizationQuery()
   const isFreeTier = organization?.plan.id === 'free'
@@ -222,6 +232,12 @@ export const StorageSettings = () => {
                 error={error}
                 subject="Failed to retrieve project's storage configuration"
               />
+            )}
+            {isSuccess && showMigrationCallout && (
+              <>
+                {isListV2UpgradeAvailable && <StorageListV2MigrationCallout />}
+                {isListV2Upgrading && <StorageListV2MigratingCallout />}
+              </>
             )}
             {isSuccess && (
               <form id={formId} className="" onSubmit={form.handleSubmit(onSubmit)}>
@@ -448,5 +464,3 @@ export const StorageSettings = () => {
     </ScaffoldSection>
   )
 }
-
-export default StorageSettings

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -82,9 +82,9 @@ export const StorageSettings = () => {
     isError,
   } = useProjectStorageConfigQuery({ projectRef })
   const isListV2UpgradeAvailable =
-    !!config?.capabilities.list_v2 && config.external.upstreamTarget === 'main'
+    !!config && !config.capabilities.list_v2 && config.external.upstreamTarget === 'main'
   const isListV2Upgrading =
-    !!config?.capabilities.list_v2 && config.external.upstreamTarget === 'canary'
+    !!config && !config.capabilities.list_v2 && config.external.upstreamTarget === 'canary'
 
   const { data: organization } = useSelectedOrganizationQuery()
   const isFreeTier = organization?.plan.id === 'free'


### PR DESCRIPTION
Note: Changes here will only be visible for projects with > 10M objects in their storage (so most of the project's wouldn't be seeing this) This will be based on whether listV2 is false and their upstream target is main from the storage config

## Context

Changes are to make storage upgrade self-serve for certain projects so that their able to control when to do the upgrade since it involves running a migration on the database schema.

UI is controlled by the feature flag `storageMIgrationCallout` which toggles the visibility of the related UI

## If upgrade is available

- Tooltip will show for Storage settings in the side nav
  <img width="271" height="138" alt="image" src="https://github.com/user-attachments/assets/f5aefe8a-1bea-43c8-b081-bb9f2b4088f5" />
- Callout will show in storage settings
  <img width="1120" height="263" alt="image" src="https://github.com/user-attachments/assets/4aa65b1b-c4e3-4d3d-899e-cb450ba3f06e" />
- Clicking the CTA will show this confirmation dialog
  <img width="533" height="346" alt="image" src="https://github.com/user-attachments/assets/d61b97de-665a-44a0-b47d-6fa7538230ae" />
- In which upgrading will then flip the callout to this state (This callout will disappear once the migration is completed)
  <img width="1108" height="117" alt="image" src="https://github.com/user-attachments/assets/cfb158c3-7a45-4a93-be81-5b1eca42e4d7" />
- Callout will change to a warning if it's not completed and it's one month to the deadline (currently set as 1st Jan 2026 for e.g)
  <img width="1089" height="168" alt="image" src="https://github.com/user-attachments/assets/fbad401c-76d5-44b3-b117-8b82dea90e7a" />
  - Using TimestampInfo for convenience here as well
    <img width="556" height="157" alt="image" src="https://github.com/user-attachments/assets/e5122c71-8a42-424b-b396-3572aa35ad53" />

## Next steps (Can be done separately - non blocking since its behind feature flag)

- [ ] Dashboard Storage Explorer needs to use new List V2 endpoint once project has access to that
  - Currently blocked on API endpoint availability


