### PR TITLE
fix: Bug with Project Selector in support form resets on windows focus

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -467,6 +467,7 @@ export const SupportFormV2 = ({
               <FormItemLayout hideMessage layout="vertical" label="Which project is affected?">
                 <FormControl_Shadcn_>
                   <OrganizationProjectSelector
+                    key={organizationSlug}
                     sameWidthAsTrigger
                     checkPosition="left"
                     slug={organizationSlug}

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -113,11 +113,13 @@ export const OrganizationProjectSelector = ({
   ])
 
   useEffect(() => {
-    if (isSuccessProjects && !isFetching && !isFetchingNextPage && !!onInitialLoad) {
-      onInitialLoad(projects)
+    // isLoadingProjects is true only during initial load. If the variables for the query change (slug), isLoadingProjects
+    // will be true again.
+    if (!isLoadingProjects && isSuccessProjects) {
+      onInitialLoad?.(projects)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSuccessProjects, isFetching, isFetchingNextPage, slug])
+  }, [isLoadingProjects, isSuccessProjects])
 
   return (
     <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>


### PR DESCRIPTION
This PR fixes a bug where the Project Selector would reset the selected project on window focus. The Issue happens because RQ refetches on window focus, a `useEffect` is triggered which sets the selected project to the first project under the org.

Additionally, a key set to `org slug` has been set on `OrganizationProjectSelector` so the projects list is refetched on each org change.