### PR TITLE
fix(column editor): cannot read properties of null

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -113,7 +113,7 @@ const ColumnForeignKey = ({
         </Button>
       </div>
 
-      {table !== undefined && (
+      {table != undefined && (
         <ForeignKeySelector
           visible={open}
           column={column}


### PR DESCRIPTION
Another instance of types not matching reality, we have a check for undefined, but this is sometimes coming out null.