### PR TITLE
chore: project daily stats caching / deprecated props

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -23,7 +23,6 @@ import { Dashboards } from 'types'
 import { WarningIcon } from 'ui'
 import { METRIC_THRESHOLDS } from './ReportBlock.constants'
 import { ReportBlockContainer } from './ReportBlockContainer'
-import { startOfDay } from 'date-fns'
 
 interface ChartBlockProps {
   label: string

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -23,6 +23,7 @@ import { Dashboards } from 'types'
 import { WarningIcon } from 'ui'
 import { METRIC_THRESHOLDS } from './ReportBlock.constants'
 import { ReportBlockContainer } from './ReportBlockContainer'
+import { startOfDay } from 'date-fns'
 
 interface ChartBlockProps {
   label: string
@@ -74,10 +75,8 @@ export const ChartBlock = ({
     {
       projectRef: ref as string,
       attribute: attribute as ProjectDailyStatsAttribute,
-      startDate,
-      endDate,
-      interval: interval as AnalyticsInterval,
-      databaseIdentifier,
+      startDate: dayjs(startDate).format('YYYY-MM-DD'),
+      endDate: dayjs(endDate).format('YYYY-MM-DD'),
     },
     { enabled: provider === 'daily-stats' }
   )

--- a/apps/studio/components/interfaces/Reports/v2/ReportChartUpsell.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportChartUpsell.tsx
@@ -1,8 +1,7 @@
+import { LogChartHandler } from 'components/ui/Charts/LogChartHandler'
 import Link from 'next/link'
 import { useRef, useState } from 'react'
 
-import { LogChartHandler } from 'components/ui/Charts/LogChartHandler'
-import { ReportConfig } from 'data/reports/v2/reports.types'
 import { Button, Card, cn } from 'ui'
 
 export function ReportChartUpsell({
@@ -78,7 +77,6 @@ export function ReportChartUpsell({
           label={''}
           startDate={startDate}
           endDate={endDate}
-          interval={'1d'}
           data={demoData as any}
           isLoading={false}
           highlightedValue={0}

--- a/apps/studio/components/ui/Charts/ChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ChartHandler.tsx
@@ -17,6 +17,7 @@ import { Activity, BarChartIcon, Loader2 } from 'lucide-react'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { WarningIcon } from 'ui'
 import type { ChartData } from './Charts.types'
+import dayjs from 'dayjs'
 
 interface ChartHandlerProps {
   id?: string
@@ -75,10 +76,8 @@ const ChartHandler = ({
     {
       projectRef: ref as string,
       attribute: attribute as ProjectDailyStatsAttribute,
-      startDate,
-      endDate,
-      interval: interval as AnalyticsInterval,
-      databaseIdentifier,
+      startDate: dayjs(startDate).format('YYYY-MM-DD'),
+      endDate: dayjs(endDate).format('YYYY-MM-DD'),
     },
     { enabled: provider === 'daily-stats' && data === undefined }
   )

--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -343,8 +343,6 @@ const useAttributeQueries = (
     ref,
     startDate,
     endDate,
-    interval,
-    databaseIdentifier,
     data,
     isVisible
   )

--- a/apps/studio/components/ui/Charts/LogChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/LogChartHandler.tsx
@@ -1,19 +1,19 @@
-import React, { PropsWithChildren, useState, useEffect, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
+import React, { PropsWithChildren, useEffect, useRef, useState } from 'react'
 import { cn, WarningIcon } from 'ui'
 
 import Panel from 'components/ui/Panel'
 import { ComposedChart } from './ComposedChart'
 
 import { AnalyticsInterval } from 'data/analytics/constants'
-import { InfraMonitoringAttribute } from 'data/analytics/infra-monitoring-query'
 import { useInfraMonitoringQueries } from 'data/analytics/infra-monitoring-queries'
-import { ProjectDailyStatsAttribute } from 'data/analytics/project-daily-stats-query'
+import { InfraMonitoringAttribute } from 'data/analytics/infra-monitoring-query'
 import { useProjectDailyStatsQueries } from 'data/analytics/project-daily-stats-queries'
+import { ProjectDailyStatsAttribute } from 'data/analytics/project-daily-stats-query'
 import { useChartHighlight } from './useChartHighlight'
 
-import type { ChartData } from './Charts.types'
 import type { UpdateDateRange } from 'pages/project/[ref]/reports/database'
+import type { ChartData } from './Charts.types'
 import type { MultiAttribute } from './ComposedChart.utils'
 
 interface LogChartHandlerProps {
@@ -22,7 +22,6 @@ interface LogChartHandlerProps {
   attributes: MultiAttribute[]
   startDate: string
   endDate: string
-  interval: string
   customDateFormat?: string
   defaultChartStyle?: 'bar' | 'line' | 'stackedAreaLine'
   hideChartType?: boolean

--- a/apps/studio/components/ui/Charts/LogChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/LogChartHandler.tsx
@@ -5,7 +5,7 @@ import { cn, WarningIcon } from 'ui'
 import Panel from 'components/ui/Panel'
 import { ComposedChart } from './ComposedChart'
 
-import { AnalyticsInterval, DataPoint } from 'data/analytics/constants'
+import { AnalyticsInterval } from 'data/analytics/constants'
 import { InfraMonitoringAttribute } from 'data/analytics/infra-monitoring-query'
 import { useInfraMonitoringQueries } from 'data/analytics/infra-monitoring-queries'
 import { ProjectDailyStatsAttribute } from 'data/analytics/project-daily-stats-query'
@@ -196,8 +196,6 @@ export const useAttributeQueries = (
     ref,
     startDate,
     endDate,
-    interval,
-    databaseIdentifier,
     data,
     isVisible
   )

--- a/apps/studio/data/analytics/project-daily-stats-queries.ts
+++ b/apps/studio/data/analytics/project-daily-stats-queries.ts
@@ -1,14 +1,11 @@
 import { useProjectDailyStatsQuery } from './project-daily-stats-query'
 import type { ProjectDailyStatsAttribute } from './project-daily-stats-query'
-import { AnalyticsInterval } from './constants'
 
 export function useProjectDailyStatsQueries(
   attributes: ProjectDailyStatsAttribute[],
   ref: string | string[] | undefined,
   startDate: string,
   endDate: string,
-  interval: AnalyticsInterval,
-  databaseIdentifier: string | undefined,
   data: any,
   isVisible: boolean
 ) {
@@ -19,8 +16,6 @@ export function useProjectDailyStatsQueries(
         attribute,
         startDate,
         endDate,
-        interval,
-        databaseIdentifier,
       },
       { enabled: data === undefined && isVisible }
     )


### PR DESCRIPTION
Remove deprecated props that have no effect on behaviour and fix the caching (based on date instead of timestamp)