### PR TITLE
docs: fix Javascript sign out syntax

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1197,14 +1197,14 @@ functions:
         isSpotlight: false
         code: |
           ```js
-          const { error } = await supabase.auth.signOut('local')
+          const { error } = await supabase.auth.signOut({ scope: 'local' })
           ```
       - id: sign-out-other-sessions
         name: Sign out (other sessions)
         isSpotlight: false
         code: |
           ```js
-          const { error } = await supabase.auth.signOut('others')
+          const { error } = await supabase.auth.signOut({ scope: 'others' })
           ```
   - id: verify-otp
     title: 'verifyOtp()'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Fix docs  "Sign out (current session)" and  "Sign out (other sessions)" https://supabase.com/docs/reference/javascript/auth-signout
- Current syntax

**Sign out (current session)**
```
const { error } = await supabase.auth.signOut('local')
```

**Sign out (other sessions)**
```
const { error } = await supabase.auth.signOut('others')
```
- Screenshot 
<img width="662" height="160" alt="image" src="https://github.com/user-attachments/assets/2f622d97-8b99-4245-9568-be44bbe94851" />


<img width="645" height="128" alt="image" src="https://github.com/user-attachments/assets/29f2f43e-dba9-4595-8052-d5e183b0ad61" />


## What is the current behavior?

- Current syntax is incorrect, it does a global logout

## What is the new behavior?

- Fix syntax
- I believe this is the correct place to modify it as I couldn't find anywhere else it is stated
