### PR TITLE
docs: clarify ETL destination in replication overview

### DIFF
--- a/apps/docs/content/guides/database/replication.mdx
+++ b/apps/docs/content/guides/database/replication.mdx
@@ -24,6 +24,7 @@ Postgres comes with built-in support for replication via publications and replic
 - [Monitoring replication](/docs/guides/database/replication/monitoring-replication)
 
 <Admonition type="tip">
+
 If you want to set up a read replica, see [Read Replicas](/docs/guides/platform/read-replicas) instead. If you want to sync your data in real time to a client such as a browser or mobile app, see [Realtime](/docs/guides/realtime) instead. For configuring replication to an ETL destination, use the [Dashboard](/dashboard/project/_/database/replication).
 
 

--- a/apps/docs/content/guides/database/replication.mdx
+++ b/apps/docs/content/guides/database/replication.mdx
@@ -27,7 +27,6 @@ Postgres comes with built-in support for replication via publications and replic
 
 If you want to set up a read replica, see [Read Replicas](/docs/guides/platform/read-replicas) instead. If you want to sync your data in real time to a client such as a browser or mobile app, see [Realtime](/docs/guides/realtime) instead. For configuring replication to an ETL destination, use the [Dashboard](/dashboard/project/_/database/replication).
 
-
 </Admonition>
 
 ## Concepts and terms

--- a/apps/docs/content/guides/database/replication.mdx
+++ b/apps/docs/content/guides/database/replication.mdx
@@ -24,8 +24,8 @@ Postgres comes with built-in support for replication via publications and replic
 - [Monitoring replication](/docs/guides/database/replication/monitoring-replication)
 
 <Admonition type="tip">
+If you want to set up a read replica, see [Read Replicas](/docs/guides/platform/read-replicas) instead. If you want to sync your data in real time to a client such as a browser or mobile app, see [Realtime](/docs/guides/realtime) instead. For configuring replication to an ETL destination, use the [Dashboard](/dashboard/project/_/database/replication).
 
-If you want to set up a read replica, see [Read Replicas](/docs/guides/platform/read-replicas) instead. If you want to sync your data in real time to a client such as a browser or mobile app, see [Realtime](/docs/guides/realtime) instead.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
## What is the new behavior?
A clarifying sentence in the CDC Replication docs that points users using ETL products to the ETL dashboard, so the “Replication” label in the UI doesn’t mislead them.

## Additional context
There is already a redirect in the docs (to read replicas / realtime). This change is only textual in docs — no UI changes.
Add any other context or screenshots.
