### PR TITLE
fix: add custom message for 404 storage config errors

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
@@ -125,6 +125,15 @@ export const S3Connection = () => {
           </div>
           <DocsButton href={`${DOCS_URL}/guides/storage/s3/authentication`} />
         </div>
+
+        {isErrorStorageConfig && (
+          <AlertError
+            className="mb-4"
+            subject="Failed to retrieve storage configuration"
+            error={configError}
+          />
+        )}
+
         <Form_Shadcn_ {...form}>
           <form id="s3-connection-form" onSubmit={form.handleSubmit(onSubmit)}>
             {projectIsLoading ? (
@@ -153,15 +162,6 @@ export const S3Connection = () => {
                       </FormItemLayout>
                     )}
                   />
-
-                  {isErrorStorageConfig && (
-                    <div className="px-8 pb-8">
-                      <AlertError
-                        subject="Failed to retrieve storage configuration"
-                        error={configError}
-                      />
-                    </div>
-                  )}
                 </CardContent>
 
                 <CardContent className="py-6">

--- a/apps/studio/data/config/project-storage-config-query.ts
+++ b/apps/studio/data/config/project-storage-config-query.ts
@@ -23,7 +23,13 @@ export async function getProjectStorageConfig(
     signal,
   })
 
-  if (error) handleError(error)
+  if (error) {
+    if (error.code === 404) {
+      handleError({ ...error, message: 'Storage configuration not found.' })
+    } else {
+      handleError(error)
+    }
+  }
   return data
 }
 

--- a/apps/studio/data/config/project-storage-config-query.ts
+++ b/apps/studio/data/config/project-storage-config-query.ts
@@ -2,9 +2,9 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 
 import { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError } from 'types'
 import { configKeys } from './keys'
-import { IS_PLATFORM } from 'lib/constants'
 
 export type ProjectStorageConfigVariables = {
   projectRef?: string
@@ -24,8 +24,10 @@ export async function getProjectStorageConfig(
   })
 
   if (error) {
-    if (error.code === 404) {
-      handleError({ ...error, message: 'Storage configuration not found.' })
+    // [Joshen] This is due to API not returning an error message on this endpoint if a 404 is returned
+    // Should only be a temporary patch, needs to be addressed on the API end
+    if ((error as any).code === 404) {
+      handleError({ ...(error as any), message: 'Storage configuration not found.' })
     } else {
       handleError(error)
     }


### PR DESCRIPTION
## Summary
- Added a specific error message "Storage configuration not found." when the storage config API returns a 404 error code

## Test plan
- [ ] Verify that when the storage configuration API returns a 404, the error message "Storage configuration not found." is displayed
- [ ] Verify that other error codes continue to display their default error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)