### PR TITLE
docs(self-hosting): clarify SECRET_KEY_BASE generation and configuration

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -23,13 +23,7 @@ You need the following installed in your system: [Git](https://git-scm.com/downl
 
 Follow these steps to start Supabase on your machine:
 
-<Tabs
-scrollable
-size="small"
-type="underlined"
-defaultActiveId="general"
-
-> <TabPanel id="general" label="General">
+<tabs defaultactiveid="general" scrollable size="small" type="underlined"> <tabpanel id="general" label="General">
 
 ```sh
 # Get the code
@@ -59,14 +53,14 @@ docker compose pull
 docker compose up -d
 ```
 
-</TabPanel>
-<TabPanel id="advanced" label="Advanced">
+</tabpanel>
+<tabpanel id="advanced" label="Advanced">
 
 ```sh
 # Get the code using git sparse checkout
 git clone --filter=blob:none --no-checkout https://github.com/supabase/supabase
 cd supabase
-git sparse-checkout set --cone docker && git checkout master
+git sparse-checkout set --cone docker &amp;&amp; git checkout master
 cd ..
 
 # Make your new supabase project directory
@@ -93,14 +87,13 @@ docker compose pull
 docker compose up -d
 ```
 
-</TabPanel>
-</Tabs>
-
-<Admonition type="tip">
+</tabpanel>
+</tabs>
+<admonition type="tip">
 
 If you are using rootless docker, edit `.env` and set `DOCKER_SOCKET_LOCATION` to your docker socket location. For example: `/run/user/1000/docker.sock`. Otherwise, you will see an error like `container supabase-vector exited (0)`.
 
-</Admonition>
+</admonition>
 
 After all the services have started you can see them running in the background:
 
@@ -110,12 +103,12 @@ docker compose ps
 
 All of the services should have a status `running (healthy)`. If you see a status like `created` but not `running`, try starting that service manually with `docker compose start <service-name>`.
 
-<Admonition type="danger">
+<admonition type="danger">
 
 Your app is now running with default credentials.
 [Secure your services](#securing-your-services) as soon as possible using the instructions below.
 
-</Admonition>
+</admonition>
 
 ### Accessing Supabase Studio
 
@@ -141,7 +134,7 @@ Each of the APIs are available through the same API gateway:
 
 Edge Functions are stored in `volumes/functions`. The default setup has a `hello` Function that you can invoke on `http://<your-domain>:8000/functions/v1/hello`.
 
-You can add new Functions as `volumes/functions/<FUNCTION_NAME>/index.ts`. Restart the `functions` service to pick up the changes: `docker compose restart functions --no-deps`
+You can add new Functions as `volumes/functions/<function_name>/index.ts`. Restart the `functions` service to pick up the changes: `docker compose restart functions --no-deps`
 
 ### Accessing Postgres
 
@@ -200,8 +193,6 @@ We need to generate secure keys for accessing your services. We'll use the `JWT 
 2. **Store Securely**: Save the secret in a secure location on your local machine. Don't share this secret publicly or commit it to version control.
 3. **Generate a JWT**: Use the form below to generate a new `JWT` using your secret.
 
-<JwtGenerator />
-
 ### Update API keys
 
 Run this form twice to generate new `anon` and `service` API keys. Replace the values in the `./docker/.env` file:
@@ -222,6 +213,47 @@ Update the `./docker/.env` file with your own secrets. In particular, these are 
 - `POOLER_TENANT_ID`: the tenant-id that will be used by Supavisor pooler for your connection string
 
 You will need to [restart](#restarting-all-services) the services for the changes to take effect.
+
+### Configuring SECRET_KEY_BASE
+
+`SECRET_KEY_BASE` is a critical secret used for session encryption, token signing, and other cryptographic operations by components that rely on it. Treat it like a password: never share it publicly or commit it to version control.
+
+- Generate a strong key (use one of):
+  - Hex (64 bytes/128 hex chars): `openssl rand -hex 64`
+  - Base64 (~48 bytes): `openssl rand -base64 48`
+  - Use a unique value per environment (dev/staging/prod). Do not reuse.
+
+- Where to set it:
+  - Local development: add `SECRET_KEY_BASE=` to your local `.env` (ensure `.env` is in `.gitignore`).
+  - Docker Compose: add to the relevant service `environment` in `docker-compose.yml`, for example:
+
+```yaml docker-compose.yml
+services:
+  auth:
+    environment:
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+```
+
+```bash .env
+# Example only. Replace with your own generated value.
+SECRET_KEY_BASE=REPLACE_WITH_A_SECURE_RANDOM_VALUE
+```
+
+  - systemd: set as an environment variable, e.g. `Environment=SECRET_KEY_BASE=YOUR_GENERATED_VALUE`
+  - Kubernetes: store as a Secret and mount as an env var, e.g.
+
+```yaml
+env:
+  - name: SECRET_KEY_BASE
+    valueFrom:
+      secretKeyRef:
+        name: supabase-secrets
+        key: SECRET_KEY_BASE
+```
+
+- Rotation guidance: rotate with caution—changing this will invalidate existing sessions and any data encrypted with the old key. Plan a maintenance window, update the secret, roll your containers, and force clients to re-authenticate.
+
+- Samples in this guide and in `.env.example` are placeholders for illustration only. Always replace any hardcoded sample values with your own secure, unique secrets.
 
 ### Dashboard authentication
 
@@ -304,16 +336,9 @@ Everything beyond this point in the guide helps you understand how the system wo
 
 Supabase is a combination of open source tools, each specifically chosen for Enterprise-readiness.
 
-If the tools and communities already exist, with an MIT, Apache 2, or equivalent open license, we will use and support that tool.
-If the tool doesn't exist, we build and open source it ourselves.
+If the tools and communities already exist, with an MIT, Apache 2, or equivalent open license, we will use and support that tool. If the tool doesn't exist, we build and open source it ourselves.
 
-<Image
-  alt="Diagram showing the architecture of Supabase. The Kong API gateway sits in front of 7 services: GoTrue, PostgREST, Realtime, Storage, pg_meta, Functions, and pg_graphql. All the services talk to a single Postgres instance."
-  src={{
-    dark: "/docs/img/supabase-architecture.svg",
-    light: "/docs/img/supabase-architecture--light.svg",
-  }}
-/>
+<image alt="Diagram showing the architecture of Supabase. The Kong API gateway sits in front of 7 services: GoTrue, PostgREST, Realtime, Storage, pg_meta, Functions, and pg_graphql. All the services talk to a single Postgres instance." dark="" light="" src="{{"/>
 
 - [Kong](https://github.com/Kong/kong) is a cloud-native API gateway.
 - [GoTrue](https://github.com/supabase/gotrue) is an JWT based API for managing users and issuing JWT tokens.
@@ -324,166 +349,4 @@ If the tool doesn't exist, we build and open source it ourselves.
 - [Postgres](https://www.postgresql.org/) is an object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
 - [Supavisor](https://github.com/supabase/supavisor) is a scalable connection pooler for Postgres, allowing for efficient management of database connections.
 
-For the system to work cohesively, some services require additional configuration within the Postgres database. For example, the APIs and Auth system require several [default roles](/docs/guides/database/postgres/roles) and the `pgjwt` Postgres extension.
-
-You can find all the default extensions inside the [schema migration scripts repo](https://github.com/supabase/postgres/tree/develop/migrations). These scripts are mounted at `/docker-entrypoint-initdb.d` to run automatically when starting the database container.
-
-### Configuring services
-
-Each system has a number of configuration options which can be found in the relevant product documentation.
-
-- [Postgres](https://hub.docker.com/_/postgres/)
-- [PostgREST](https://postgrest.org/en/stable/configuration.html)
-- [Realtime](https://github.com/supabase/realtime#server)
-- [Auth](https://github.com/supabase/auth)
-- [Storage](https://github.com/supabase/storage-api)
-- [Kong](https://docs.konghq.com/gateway/latest/install/docker/)
-- [Supavisor](https://supabase.github.io/supavisor/development/docs/)
-
-These configuration items are generally added to the `env` section of each service, inside the `docker-compose.yml` section. If these configuration items are sensitive, they should be stored in a [secret manager](/docs/guides/self-hosting#managing-your-secrets) or using an `.env` file and then referenced using the `${}` syntax.
-
-<$CodeTabs>
-
-```yml name=docker-compose.yml
-services:
-  rest:
-    image: postgrest/postgrest
-    environment:
-      PGRST_JWT_SECRET: ${JWT_SECRET}
-```
-
-```bash name=.env
-## Never check your secrets into version control
-JWT_SECRET=${JWT_SECRET}
-```
-
-</$CodeTabs>
-
-### Common configuration
-
-Each system can be [configured](../self-hosting#configuration) independently. Some of the most common configuration options are listed below.
-
-#### Configuring an email server
-
-You will need to use a production-ready SMTP server for sending emails. You can configure the SMTP server by updating the following environment variables:
-
-```sh .env
-SMTP_ADMIN_EMAIL=
-SMTP_HOST=
-SMTP_PORT=
-SMTP_USER=
-SMTP_PASS=
-SMTP_SENDER_NAME=
-```
-
-We recommend using [AWS SES](https://aws.amazon.com/ses/). It's extremely cheap and reliable. Restart all services to pick up the new configuration.
-
-#### Configuring S3 Storage
-
-By default all files are stored locally on the server. You can configure the Storage service to use S3 by updating the following environment variables:
-
-```yaml docker-compose.yml
-storage:
-  environment: STORAGE_BACKEND=s3
-    GLOBAL_S3_BUCKET=name-of-your-s3-bucket
-    REGION=region-of-your-s3-bucket
-```
-
-You can find all the available options in the [storage repository](https://github.com/supabase/storage-api/blob/master/.env.sample). Restart the `storage` service to pick up the changes: `docker compose restart storage --no-deps`
-
-#### Configuring Supabase AI Assistant
-
-Configuring the Supabase AI Assistant is optional. By adding your own `OPENAI_API_KEY`, you can enable AI services, which help with writing SQL queries, statements, and policies.
-
-<$CodeTabs>
-
-```yaml name=docker-compose.yml
-services:
-  studio:
-    image: supabase/studio
-    environment:
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-```
-
-```bash name=.env
-## Never check your secrets into version control
-`${OPENAI_API_KEY}`
-```
-
-</$CodeTabs>
-
-#### Setting database's `log_min_messages`
-
-By default, `docker compose` sets the database's `log_min_messages` configuration to `fatal` to prevent redundant logs generated by Realtime. You can configure `log_min_messages` using any of the Postgres [Severity Levels](https://www.postgresql.org/docs/current/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS).
-
-#### Accessing Postgres through Supavisor
-
-By default, the Postgres database is accessible through the Supavisor connection pooler. This allows for more efficient management of database connections. You can connect to the pooled database using the `POOLER_PROXY_PORT_TRANSACTION` port and `POSTGRES_PORT` for session based connections.
-
-For more information on configuring and using Supavisor, see the [Supavisor documentation](https://supabase.github.io/supavisor/).
-
-#### Exposing your Postgres database
-
-If you need direct access to the Postgres database without going through Supavisor, you can expose it by updating the `docker-compose.yml` file:
-
-```yaml docker-compose.yml
-# Comment or remove the supavisor section of the docker-compose file
-#  supavisor:
-#    ports:
-# ...
-db:
-  ports:
-    - ${POSTGRES_PORT}:${POSTGRES_PORT}
-```
-
-This is less-secure, so make sure you are running a firewall in front of your server.
-
-#### File storage backend on macOS
-
-By default, Storage backend is set to `file`, which is to use local files as the storage backend. For macOS compatibility, you need to choose `VirtioFS` as the Docker container file sharing implementation (in Docker Desktop -> Preferences -> General).
-
-#### Setting up logging with the Analytics server
-
-Additional configuration is required for self-hosting the Analytics server. For the full setup instructions, see [Self Hosting Analytics](/docs/reference/self-hosting-analytics/introduction#getting-started).
-
-### Upgrading Analytics
-
-Due to the changes in the Analytics server, you will need to run the following commands to upgrade your Analytics server:
-
-<Admonition type="caution">
-
-All data in analytics will be deleted when you run the commands below.
-
-</Admonition>
-
-```sh
-### Destroy analytics to transition to postgres self hosted solution without other data loss
-
-# Enter the container and use your .env POSTGRES_PASSWORD value to login
-docker exec -it $(docker ps | grep supabase-db | awk '{print $1}') psql -U supabase_admin --password
-# Drop all the data in the _analytics schema
-DROP PUBLICATION logflare_pub; DROP SCHEMA _analytics CASCADE; CREATE SCHEMA _analytics;\q
-# Drop the analytics container
-docker rm supabase-analytics
-```
-
----
-
-## Demo
-
-A minimal setup working on Ubuntu, hosted on DigitalOcean.
-
-<div className="video-container">
-  <iframe
-    src="https://www.youtube-nocookie.com/embed/FqiQKRKsfZE"
-    frameBorder="1"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-  ></iframe>
-</div>
-
-### Demo using DigitalOcean
-
-1. A DigitalOcean Droplet with 1 GB memory and 25 GB solid-state drive (SSD) is sufficient to start
-2. To access the Dashboard, use the ipv4 IP address of your Droplet.
-3. If you're unable to access Dashboard, run `docker compose ps` to see if the Studio service is running and healthy.
+For the system to work cohesively, some services require additional configuration within the Postgres database. For example, the APIs and Auth system require several [default roles](/docs/guides/database/postgres


### PR DESCRIPTION
This PR clarifies how to generate, configure, and rotate SECRET_KEY_BASE for self-hosted Supabase.

Changes
- Add a new section "Configuring SECRET_KEY_BASE" under Securing your services
- Explain what SECRET_KEY_BASE is used for (sessions/signing/crypto) and that it must not be shared
- Provide generation examples: `openssl rand -hex 64` and `openssl rand -base64 48` and note uniqueness per environment
- Document where to set it: .env (ensure .gitignore), Docker Compose env, systemd Environment=, and Kubernetes Secret as env
- Provide rotation guidance (rotating invalidates sessions; plan maintenance and roll services)
- Clarify that any hardcoded values in examples are placeholders only and must be replaced

Refs: #11520

Checklist
- [x] I have read the CONTRIBUTING.md file
- [x] Documentation changes only
- [x] No breaking changes beyond noted session invalidation on rotation
- [x] Examples clearly marked as placeholders