### PR TITLE
perf: use getClaims for API endpoint auth

### DIFF
--- a/apps/studio/lib/api/apiAuthenticate.test.ts
+++ b/apps/studio/lib/api/apiAuthenticate.test.ts
@@ -3,9 +3,9 @@ import { apiAuthenticate } from './apiAuthenticate'
 
 const mocks = vi.hoisted(() => {
   return {
-    getAuthUser: vi.fn().mockResolvedValue({
-      user: {
-        id: 'test-gotrue-id',
+    getUserClaims: vi.fn().mockResolvedValue({
+      claims: {
+        sub: 'test-gotrue-id',
         email: 'test@example.com',
       },
       error: null,
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock('lib/gotrue', () => ({
-  getAuthUser: mocks.getAuthUser,
+  getUserClaims: mocks.getUserClaims,
 }))
 
 describe('apiAuthenticate', () => {
@@ -29,9 +29,9 @@ describe('apiAuthenticate', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.getAuthUser.mockResolvedValue({
-      user: {
-        id: 'test-gotrue-id',
+    mocks.getUserClaims.mockResolvedValue({
+      claims: {
+        sub: 'test-gotrue-id',
         email: 'test@example.com',
       },
       error: null,
@@ -45,8 +45,8 @@ describe('apiAuthenticate', () => {
   })
 
   it('should return error when auth user fetch fails', async () => {
-    mocks.getAuthUser.mockResolvedValue({
-      user: null,
+    mocks.getUserClaims.mockResolvedValue({
+      claims: null,
       error: new Error('Auth failed'),
     })
 
@@ -55,8 +55,8 @@ describe('apiAuthenticate', () => {
   })
 
   it('should return error when user does not exist', async () => {
-    mocks.getAuthUser.mockResolvedValue({
-      user: null,
+    mocks.getUserClaims.mockResolvedValue({
+      claims: null,
       error: null,
     })
 

--- a/apps/studio/lib/api/apiWrapper.ts
+++ b/apps/studio/lib/api/apiWrapper.ts
@@ -40,9 +40,6 @@ export default async function apiWrapper(
             message: `Unauthorized: ${response.error.message}`,
           },
         })
-      } else {
-        // Attach user information to request parameters
-        ;(req as any).user = response
       }
     }
 

--- a/apps/studio/lib/api/apiWrappers.test.ts
+++ b/apps/studio/lib/api/apiWrappers.test.ts
@@ -28,14 +28,4 @@ describe('apiWrapper', () => {
     expect(mockHandler).toHaveBeenCalledWith(mockReq, mockRes)
     expect(apiAuthenticate).not.toHaveBeenCalled()
   })
-
-  it('should attach user to request and call handler when authentication succeeds', async () => {
-    const mockUser = { id: '123', email: 'test@example.com' } as any as any
-    vi.mocked(apiAuthenticate).mockResolvedValue(mockUser)
-
-    await apiWrapper(mockReq, mockRes, mockHandler, { withAuth: true })
-
-    expect(mockReq.user).toEqual(mockUser)
-    expect(mockHandler).toHaveBeenCalledWith(mockReq, mockRes)
-  })
 })

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -1,3 +1,4 @@
+import type { JwtPayload } from '@supabase/supabase-js'
 import { getAccessToken, type User } from 'common/auth'
 import { gotrueClient } from 'common/gotrue'
 
@@ -23,18 +24,17 @@ export const validateReturnTo = (
   return safePathPattern.test(returnTo) ? returnTo : fallback
 }
 
-export const getAuthUser = async (token: String): Promise<any> => {
+export const getUserClaims = async (
+  token: String
+): Promise<{ error: any | null; claims: JwtPayload | null }> => {
   try {
-    const {
-      data: { user },
-      error,
-    } = await auth.getUser(token.replace('Bearer ', ''))
+    const { data, error } = await auth.getClaims(token.replace(/bearer /i, ''))
     if (error) throw error
 
-    return { user, error: null }
+    return { claims: data?.claims ?? null, error: null }
   } catch (err) {
     console.error(err)
-    return { user: null, error: err }
+    return { claims: null, error: err }
   }
 }
 


### PR DESCRIPTION
Use getClaims instead of getUser which avoids a network call to ~GoTrue~ Auth to validate the user in case of asymmetric keys - this shaves off a good amount of latency for every API call.