### PR TITLE
Remove stray character in Edge Function invocation call

### DIFF
--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -83,7 +83,7 @@ export const TerminalInstructions = forwardRef<
         return (
           <>
             <span className="text-brand-600">curl</span> -L -X POST '{functionsEndpoint}
-            /hello-world' -H 'Authorization: Bearer [YOUR ANON KEY]' s
+            /hello-world' -H 'Authorization: Bearer [YOUR ANON KEY]'
             {anonKey?.type === 'publishable' ? " -H 'apikey: [YOUR ANON KEY]' " : ''}
             {`--data '{"name":"Functions"}'`}
           </>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

There is a stray `s` which makes curl request invalid if you select text and copy

<img width="684" height="540" alt="image" src="https://github.com/user-attachments/assets/46566c24-37c8-440e-8562-8707128e5b9d" />

Shows when creating a new function via CLI
- Go to https://supabase.com/dashboard/project/_/functions
- Click "Deploy a new function" > "Via CLI"
<img width="650" height="454" alt="image" src="https://github.com/user-attachments/assets/9816253d-ea4f-4d1e-a4ba-fab8eadc3627" />
