### PR TITLE
Fix org usage hidden UI

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -126,7 +126,7 @@ export const Usage = () => {
           <ScaffoldTitle>Usage</ScaffoldTitle>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <div className="sticky top-0 border-b bg-sidebar z-[1] overflow-hidden">
+      <div className="sticky top-0 border-b bg-sidebar z-[1]">
         <ScaffoldContainer>
           <div className="py-4 flex items-center space-x-4">
             {isLoadingSubscription || isLoadingPermissions ? (


### PR DESCRIPTION
## Context

Tiny fix in org usage page

## Before

<img width="1449" height="349" alt="image" src="https://github.com/user-attachments/assets/4fe6ef52-444c-468e-a53b-4aa1e7822306" />


## After

<img width="1450" height="505" alt="image" src="https://github.com/user-attachments/assets/b13f289f-7f5c-4fd9-bdeb-4fd831d51ad5" />
