### PR TITLE
chore: minimumReleaseAgeExclude for all supabase js libs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,9 +40,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/*'
   - '@supabase/mcp-server-supabase'
   - '@supabase/mcp-utils'
-  - '@supabase/auth-js'
-  - '@supabase/supabase-js'
-  - '@supabase/realtime-js'
+  - '@supabase/*'
 
 onlyBuiltDependencies:
   - supabase


### PR DESCRIPTION
Needed so that a PR can be created automatically when we release a new version for the Supabase JS libs.

Example of failed workflow: https://github.com/supabase/supabase/actions/runs/18309837456/job/52135594300

```txt
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @supabase/storage-js@2.74.0 
published by Tue Sep 30 2025 10:32:34 GMT+0000 (Coordinated Universal Time) while fetching it 
from [https://registry.npmjs.org/.](https://registry.npmjs.org/) 
Version 2.74.0 satisfies the specs but was released at Mon Oct 06 2025 14:55:09 GMT+0000 
(Coordinated Universal Time)
This error happened while installing the dependencies of @supabase/supabase-js@2.74.0
```