### PR TITLE
fix(ai): increase request body size limit

### DIFF
--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -1,7 +1,7 @@
 import pgMeta from '@supabase/pg-meta'
 import { convertToModelMessages, type ModelMessage, stepCountIs, streamText } from 'ai'
 import { source } from 'common-tags'
-import type { NextApiRequest, NextApiResponse, PageConfig } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 import z from 'zod'
 
 import { IS_PLATFORM } from 'common'
@@ -26,7 +26,7 @@ import { executeQuery } from 'lib/api/self-hosted/query'
 
 export const maxDuration = 120
 
-export const config: PageConfig = {
+export const config = {
   api: {
     bodyParser: {
       sizeLimit: '5mb',

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -1,7 +1,7 @@
 import pgMeta from '@supabase/pg-meta'
 import { convertToModelMessages, type ModelMessage, stepCountIs, streamText } from 'ai'
 import { source } from 'common-tags'
-import type { NextApiRequest, NextApiResponse } from 'next'
+import type { NextApiRequest, NextApiResponse, PageConfig } from 'next'
 import z from 'zod'
 
 import { IS_PLATFORM } from 'common'
@@ -26,8 +26,12 @@ import { executeQuery } from 'lib/api/self-hosted/query'
 
 export const maxDuration = 120
 
-export const config = {
-  api: { bodyParser: true },
+export const config: PageConfig = {
+  api: {
+    bodyParser: {
+      sizeLimit: '5mb',
+    },
+  },
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
Currently API request bodies cap at 1MB. For our AI assistant, folks with a large amount of chat context sometimes reach this limit, so this bumps it to 5MB (then we will continue to monitor).