### PR TITLE
docs: Add SvelteKit SSR OAuth example

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -420,6 +420,29 @@ export const actions: Actions = {
       redirect(303, '/private')
     }
   },
+  oauth: async ({ url, locals: { supabase } }) => {
+    const provider = url.searchParams.get("provider")
+
+    if (provider) {
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: provider,
+        options: {
+          redirectTo: `${url.origin}/auth/callback`,
+        },
+      })
+
+      if (error) {
+        console.error(error)
+        return redirect(303, '/auth/error')
+      }
+
+      if (data.url) {
+        return redirect(303, data.url)
+      }
+    }
+
+    return redirect(303, '/auth/error');
+  },
 }
 ```
 
@@ -435,7 +458,28 @@ export const actions: Actions = {
   </label>
   <button>Login</button>
   <button formaction="?/signup">Sign up</button>
+  <button formaction="?/oauth&provider=github">
+  Login with GitHub
+  </button>
+
+  <button formaction="?/oauth&provider=google">
+    Login with Google
+  </button>
 </form>
+```
+
+```svelte name=src/routes/auth/callback/+server.ts
+import { redirect } from '@sveltejs/kit'
+
+export const GET = async ({ url, locals: { supabase } }) => {
+  const code = url.searchParams.get('code')
+  
+  if (code) {
+    await supabase.auth.exchangeCodeForSession(code)
+  }
+
+  throw redirect(303, '/private')
+}
 ```
 
 ```svelte name=src/routes/auth/+layout.svelte


### PR DESCRIPTION
Closes #23618

## Description

This PR adds a complete code example for handling server-side OAuth (social logins) to the SvelteKit SSR documentation guide. The previous version of the guide only covered email/password authentication and was missing instructions on how to handle the OAuth callback flow, which was confusing for users.

This change adds a clear, step-by-step example that covers:
- The frontend button to trigger the login.
- The server-side action that calls `signInWithOAuth`.
- The new `auth/callback` server route that handles `exchangeCodeForSession`.

This directly addresses the problem raised in the linked issue by providing the missing documentation.