### PR TITLE
Fix project filter on homepage

### DIFF
--- a/apps/studio/components/interfaces/HomePageActions.tsx
+++ b/apps/studio/components/interfaces/HomePageActions.tsx
@@ -91,32 +91,22 @@ export const HomePageActions = ({
                   { key: PROJECT_STATUS.ACTIVE_HEALTHY, label: 'Active' },
                   { key: PROJECT_STATUS.INACTIVE, label: 'Paused' },
                 ].map(({ key, label }) => (
-                  <div key={key} className="group flex items-center justify-between py-0.5">
-                    <div className="flex items-center gap-x-2">
-                      <Checkbox_Shadcn_
-                        id={key}
-                        name={key}
-                        checked={filterStatus.includes(key)}
-                        onCheckedChange={() => {
-                          if (filterStatus.includes(key)) {
-                            setFilterStatus(filterStatus.filter((y) => y !== key))
-                          } else {
-                            setFilterStatus(filterStatus.concat([key]))
-                          }
-                        }}
-                      />
-                      <Label_Shadcn_ htmlFor={key} className="capitalize text-xs">
-                        {label}
-                      </Label_Shadcn_>
-                    </div>
-                    <Button
-                      size="tiny"
-                      type="default"
-                      onClick={() => setFilterStatus([key])}
-                      className="transition opacity-0 group-hover:opacity-100 h-auto px-1 py-0.5"
-                    >
-                      Select only
-                    </Button>
+                  <div className="flex items-center gap-x-2 py-1">
+                    <Checkbox_Shadcn_
+                      id={key}
+                      name={key}
+                      checked={filterStatus.includes(key)}
+                      onCheckedChange={() => {
+                        if (filterStatus.includes(key)) {
+                          setFilterStatus(filterStatus.filter((y) => y !== key))
+                        } else {
+                          setFilterStatus(filterStatus.concat([key]))
+                        }
+                      }}
+                    />
+                    <Label_Shadcn_ htmlFor={key} className="capitalize text-xs w-full">
+                      {label}
+                    </Label_Shadcn_>
                   </div>
                 ))}
               </div>

--- a/apps/studio/components/interfaces/HomePageActions.tsx
+++ b/apps/studio/components/interfaces/HomePageActions.tsx
@@ -96,12 +96,10 @@ export const HomePageActions = ({
                       <Checkbox_Shadcn_
                         id={key}
                         name={key}
-                        checked={filterStatus.length === 0 || filterStatus.includes(key)}
+                        checked={filterStatus.includes(key)}
                         onCheckedChange={() => {
                           if (filterStatus.includes(key)) {
                             setFilterStatus(filterStatus.filter((y) => y !== key))
-                          } else if (filterStatus.length === 1) {
-                            setFilterStatus([])
                           } else {
                             setFilterStatus(filterStatus.concat([key]))
                           }


### PR DESCRIPTION
## Context

The project status filter on the homepage had a bit of an odd behaviour which starts of as all checked, but if you select one of the status, it checks that status while unchecking the other

Fixing that odd behaviour such that
- filter statuses are unchecked by default (i.e. all projects will be returned)
- checking a status will then return projects based on the status filter (so if both active healthy and paused are selected, only projects of those 2 status will be returned)

## To test
- [ ] Ensure that the status works for returning the expected projects
- [ ] Just verify that the UX doesn't feel weird too 