### PR TITLE
chore/projects pagination part 08

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -45,11 +45,15 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
 
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const { data: permissions } = usePermissionsQuery()
-  const { data } = useProjectsQuery()
   const { data: members } = useOrganizationMembersQuery({ slug })
-  const { data: allRoles } = useOrganizationRolesV2Query({ slug })
 
+  const { data: allRoles } = useOrganizationRolesV2Query({ slug })
+  const hasProjectScopedRoles = (allRoles?.project_scoped_roles ?? []).length > 0
+
+  // [Joshen] We only need this data if the org has project scoped roles
+  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
   const allProjects = data?.projects ?? []
+
   const memberIsUser = member.gotrue_id == profile?.gotrue_id
   const orgScopedRoles = allRoles?.org_scoped_roles ?? []
   const projectScopedRoles = allRoles?.project_scoped_roles ?? []

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -35,14 +35,16 @@ export const MemberRow = ({ member }: MemberRowProps) => {
   const { profile } = useProfile()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
 
-  const { data } = useProjectsQuery()
-  const projects = data?.projects ?? []
   const { data: roles, isLoading: isLoadingRoles } = useOrganizationRolesV2Query({
     slug: selectedOrganization?.slug,
   })
+  const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
+
+  // [Joshen] We only need this data if the org has project scoped roles
+  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
+  const projects = data?.projects ?? []
 
   const orgProjects = projects?.filter((p) => p.organization_id === selectedOrganization?.id)
-  const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
   const isInvitedUser = Boolean(member.invited_id)
   const isEmailUser = member.username === member.primary_email
   const isFlyUser = Boolean(member.primary_email?.endsWith('customer.fly.io'))

--- a/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -1,6 +1,7 @@
 import { Search } from 'lucide-react'
 import { useState } from 'react'
 
+import { useParams } from 'common'
 import {
   ScaffoldActionsContainer,
   ScaffoldActionsGroup,
@@ -10,13 +11,27 @@ import {
   ScaffoldTitle,
 } from 'components/layouts/Scaffold'
 import { DocsButton } from 'components/ui/DocsButton'
+import { useOrganizationRolesV2Query } from 'data/organization-members/organization-roles-query'
+import { useProjectsInfiniteQuery } from 'data/projects/projects-infinite-query'
 import { DOCS_URL } from 'lib/constants'
+import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { InviteMemberButton } from './InviteMemberButton'
 import MembersView from './MembersView'
 
 export const TeamSettings = () => {
+  const { slug } = useParams()
   const [searchString, setSearchString] = useState('')
+
+  const { data: roles } = useOrganizationRolesV2Query({ slug })
+  const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
+
+  // [Joshen] Using the infinite query to get total count. We're using useProjectsInfiniteQuery
+  // here instead of useOrgProjectsInfiniteQuery because the UI here are using useProjectsQuery
+  // which returns all projects the user has access to (not scoped to org)
+  const { data } = useProjectsInfiniteQuery({})
+  const totalCount = data?.pages[0].pagination.count ?? 0
+  const threshold = 1000
 
   return (
     <ScaffoldContainerLegacy>
@@ -38,6 +53,16 @@ export const TeamSettings = () => {
             <InviteMemberButton />
           </ScaffoldActionsGroup>
         </ScaffoldActionsContainer>
+
+        {hasProjectScopedRoles && totalCount > threshold && (
+          <Admonition
+            type="warning"
+            className="mb-0"
+            title="This page may not render properly due to the number of projects your account has access to"
+            description="We're actively looking into optimizing this page and will make things available as soon as we can!"
+          />
+        )}
+
         <ScaffoldSectionContent className="w-full">
           <MembersView searchString={searchString} />
         </ScaffoldSectionContent>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -39,8 +39,12 @@ export const UpdateRolesConfirmationModal = ({
   const { slug } = useParams()
   const queryClient = useQueryClient()
   const { data: organization } = useSelectedOrganizationQuery()
+
   const { data: allRoles } = useOrganizationRolesV2Query({ slug: organization?.slug })
-  const { data } = useProjectsQuery()
+  const hasProjectScopedRoles = (allRoles?.project_scoped_roles ?? []).length > 0
+
+  // [Joshen] We only need this data if the org has project scoped roles
+  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
   const projects = data?.projects ?? []
 
   // [Joshen] Separate saving state instead of using RQ due to several successive steps

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -62,10 +62,14 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
   const { data: organization } = useSelectedOrganizationQuery()
   const isOptedIntoProjectLevelPermissions = useHasAccessToProjectLevelPermissions(slug as string)
 
-  const { data } = useProjectsQuery()
-  const projects = data?.projects ?? []
-  const { data: permissions } = usePermissionsQuery()
   const { data: allRoles, isSuccess: isSuccessRoles } = useOrganizationRolesV2Query({ slug })
+  const hasProjectScopedRoles = (allRoles?.project_scoped_roles ?? []).length > 0
+
+  // [Joshen] We only need this data if the org has project scoped roles
+  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
+  const projects = data?.projects ?? []
+
+  const { data: permissions } = usePermissionsQuery()
 
   // [Joshen] We use the org scoped roles as the source for available roles
   const orgScopedRoles = allRoles?.org_scoped_roles ?? []


### PR DESCRIPTION
Branches out of https://github.com/supabase/supabase/pull/39353

## Context

The last few finals which we need to remove `useProjectsQuery` for are all the in organization Teams page, but we can't remove them atm as we're blocked on an API change that's required on the roles endpoint.

Note that `useProjectsQuery` is only used in the organization teams page if org is using project scoped roles

The changes here are hence to optimize the UX on this page while we're waiting on the API changes
- Only trigger `useProjectsQuery` if the organization has project scoped roles enabled
  - We don't need that data otherwise
- Show a warning that the page may not load, if the organization has project scoped roles + user has access to > 1,000 projects
  - This 1,000 threshold is an arbitrary value to be honest and I'm okay to increase that if we deem its too low
  <img width="1216" height="272" alt="image" src="https://github.com/user-attachments/assets/ff8ee121-c0e0-4fe0-83c5-e0b66de84cdf" />

No functionality changed in this PR, just optimizing when to ping the unpaginated projects endpoint

## Other Considerations

I've considered as well to just use the paginated endpoint here, but we can't do that now as:
- The /roles endpoint returns project ids instead of refs
  - e.g `const roles = [{ id: 1, project_ids: [1, 2, 3] }]`
- But the new paginated org projects endpoint doesn't return project `id`s - we can only use the paginated projects endpoint (which includes the `id` but returns all projects a user has access to across all orgs)
  - We need the projects with their IDs to get their corresponding `ref` for each project ID that the role is applied for (this is being addressed in the API ticket), to show in the UI which projects the user has each role for 
    <img width="365" height="153" alt="image" src="https://github.com/user-attachments/assets/8a059269-e250-4faf-b079-12831150e7d2" />
- But the pagination limit is only 100, and we've had users reach out before when I initially swapped the projects home page to use the paginated endpoint without infinite loading support that they couldn't find their projects
  - So doing so is bound to affect a significant number of users