### PR TITLE
Add perms check for storage migration callout

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
@@ -1,13 +1,13 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import dayjs from 'dayjs'
+import { useState } from 'react'
 import { toast } from 'sonner'
 
-import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectStorageConfigUpdateUpdateMutation } from 'data/config/project-storage-config-update-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useState } from 'react'
 import {
   Button,
   Dialog,

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageListV2MigrationCallout.tsx
@@ -1,9 +1,12 @@
 import dayjs from 'dayjs'
 import { toast } from 'sonner'
 
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectStorageConfigUpdateUpdateMutation } from 'data/config/project-storage-config-update-mutation'
+import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useState } from 'react'
 import {
   Button,
@@ -67,6 +70,10 @@ export const StorageListV2MigratingCallout = () => {
 
 const StorageListV2MigrationDialog = () => {
   const { ref } = useParams()
+  const { can: canUpdateStorageSettings } = useAsyncCheckPermissions(
+    PermissionAction.STORAGE_ADMIN_WRITE,
+    '*'
+  )
 
   const [open, setOpen] = useState(false)
 
@@ -86,7 +93,20 @@ const StorageListV2MigrationDialog = () => {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button type="primary">Upgrade Storage</Button>
+        <ButtonTooltip
+          type="primary"
+          disabled={!canUpdateStorageSettings}
+          tooltip={{
+            content: {
+              side: 'bottom',
+              text: !canUpdateStorageSettings
+                ? 'You need additional permissions to upgrade storage'
+                : undefined,
+            },
+          }}
+        >
+          Upgrade Storage
+        </ButtonTooltip>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>


### PR DESCRIPTION
## Context

As per PR title - just adding permissions checking for the storage migration callout (which is equivalent to the perms for updating storage config). Will show a tooltip with the button disabled if the user doesn't have sufficient perms

<img width="383" height="167" alt="image" src="https://github.com/user-attachments/assets/1a5b8647-c5de-40e6-aa62-31e82ba83800" />
