### PR TITLE
Mitigate SQL Editor "Unable to find snippet" issue

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -1,8 +1,8 @@
 import Editor, { Monaco, OnMount } from '@monaco-editor/react'
-import { debounce } from 'lodash'
 import { useRouter } from 'next/router'
-import { MutableRefObject, useEffect, useRef } from 'react'
+import { MutableRefObject, useEffect, useRef, useState } from 'react'
 
+import { useDebounce } from '@uidotdev/usehooks'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -51,15 +51,19 @@ const MonacoEditor = ({
   const { profile } = useProfile()
   const { ref, content } = useParams()
   const { data: project } = useSelectedProjectQuery()
+
   const snapV2 = useSqlEditorV2StateSnapshot()
   const tabsSnap = useTabsStateSnapshot()
-
   const aiSnap = useAiAssistantStateSnapshot()
 
   const [intellisenseEnabled] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.SQL_EDITOR_INTELLISENSE,
     true
   )
+
+  // [Joshen] Lodash debounce doesn't seem to be working here, so opting to use useDebounce
+  const [value, setValue] = useState('')
+  const debouncedValue = useDebounce(value, 1000)
 
   const snippet = snapV2.snippets[id]
   const disableEdit =
@@ -162,33 +166,31 @@ const MonacoEditor = ({
     onMount?.(editor)
   }
 
-  const debouncedSetSql = debounce((id, value) => snapV2.setSql(id, value), 1000)
-
   function handleEditorChange(value: string | undefined) {
-    // make active tab permanent
     tabsSnap.makeActiveTabPermanent()
-
-    const snippetCheck = snapV2.snippets[id]
-
     if (id && value) {
-      if (snippetCheck) {
-        debouncedSetSql(id, value)
-      } else {
-        if (ref && profile !== undefined && project !== undefined) {
-          const snippet = createSqlSnippetSkeletonV2({
-            id,
-            name: untitledSnippetTitle,
-            sql: value,
-            owner_id: profile?.id,
-            project_id: project?.id,
-          })
-          snapV2.addSnippet({ projectRef: ref, snippet })
-          snapV2.addNeedsSaving(snippet.id)
-          router.push(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
-        }
+      if (!!snippet) {
+        setValue(value)
+      } else if (ref && !!profile && !!project) {
+        const snippet = createSqlSnippetSkeletonV2({
+          id,
+          name: untitledSnippetTitle,
+          sql: value,
+          owner_id: profile?.id,
+          project_id: project?.id,
+        })
+        snapV2.addSnippet({ projectRef: ref, snippet })
+        router.push(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
       }
     }
   }
+
+  useEffect(() => {
+    if (debouncedValue.length > 0 && snippet) {
+      snapV2.setSql(id, value)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedValue])
 
   // if an SQL query is passed by the content parameter, set the editor value to its content. This
   // is usually used for sending the user to SQL editor from other pages with SQL.

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -36,17 +36,19 @@ const SqlEditor: NextPageWithLayout = () => {
 
   // [Refactor] There's an unnecessary request getting triggered when we start typing while on /new
   // the URL ID gets updated and we attempt to fetch content for a snippet that's not been created yet
+  const canFetchContentBasedOnId = Boolean(
+    id !== 'new' && typeof snapV2.addSnippet === 'function' && !snippet?.isNotSavedInDatabaseYet
+  )
   const { data, error, isError } = useContentIdQuery(
     { projectRef: ref, id },
     {
       // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
       // the snapV2 valtio store for some reason hence why the added typeof check here
       retry: false,
-      enabled: Boolean(
-        id !== 'new' && typeof snapV2.addSnippet === 'function' && !snippet?.isNotSavedInDatabaseYet
-      ),
+      enabled: canFetchContentBasedOnId,
     }
   )
+
   const snippetMissing =
     isError && error.code === 404 && error.message.includes('Content not found')
   const invalidId = isError && error.code === 400 && error.message.includes('Invalid uuid')

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -36,14 +36,14 @@ const SqlEditor: NextPageWithLayout = () => {
 
   // [Refactor] There's an unnecessary request getting triggered when we start typing while on /new
   // the URL ID gets updated and we attempt to fetch content for a snippet that's not been created yet
+  // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
+  // the snapV2 valtio store for some reason hence why the added typeof check here
   const canFetchContentBasedOnId = Boolean(
     id !== 'new' && typeof snapV2.addSnippet === 'function' && !snippet?.isNotSavedInDatabaseYet
   )
   const { data, error, isError } = useContentIdQuery(
     { projectRef: ref, id },
     {
-      // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
-      // the snapV2 valtio store for some reason hence why the added typeof check here
       retry: false,
       enabled: canFetchContentBasedOnId,
     }


### PR DESCRIPTION
## Context

We've been receiving multiple reports of users running into "Unable to find snippet ID..." errors in the SQL Editor after typing for a bit.
<img width="270" height="111" alt="image" src="https://github.com/user-attachments/assets/e37ed8ff-2894-4b30-a11c-94983a6ad3a1" />

## Investigation
- This _may_ very well be due to the replication lag problems that dashboard has been facing, but I noticed there's some inefficiencies on the dashboard that we can improve on
- Noticed that lodash's `debounce` in `MonacoEditor` wasn't working as expected ([ref](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx#L165))
  - If you add a `console.log` in `setSql` in the `sql-editor-v2` valtio store, it's getting triggered even if I'm continuously typing ([ref](https://github.com/supabase/supabase/blob/master/apps/studio/state/sql-editor-v2.ts#L118))
  - I'm not too sure why this is happening to be very honest, and I haven't checked in other parts of the dashboard that we're using lodash's `debounce`
- The fact that we're trying to save the snippet once the user starts typing is also probably what's causing the issue ([ref](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx#L186))

## Changes involved
- Opting to use `useDebounce` instead with a local state to track the input from the MonacoEditor
  - We then have a `useEffect` depending on the debounced value to fire `setSql`
- In `handleEditorChange`, opting to _not_ upsert the snippet to the DB immediately when creating a new snippet
  - Let debounce handle the snippet saving which I think makes more sense
- With these changes at the very least, users won't run into the "Unable to find snippet" error _while_ typing, but after the debounce

## To test
Understandably this doesn't happen all the time, especially locally but probably just good to verify running queries on a "New" tab that everything works as expected. Do this multiple times just to stress test things

## What else we might be able to do
- Another idea that i'm thinking on exploring in this PR as well, is the error handling itself
- e.g if fetching content from a "new" snippet and it errors out, don't block the UI - show a toast or silently try again in the background
- but I'll need to figure out how to differentiate that from an actual non-existing snippet