### PR TITLE
Fix prefilled Support Form subject for failed pausing and restoring states

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PauseFailedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PauseFailedState.tsx
@@ -70,7 +70,7 @@ export const PauseFailedState = () => {
             <div className="border-t border-overlay flex items-center justify-end gap-x-2 py-4 px-8">
               <Button asChild type="default">
                 <Link
-                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Restoration%20failed%20for%20project`}
+                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Pausing%20failed%20for%20project`}
                 >
                   Contact support
                 </Link>

--- a/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
@@ -111,7 +111,7 @@ const RestoringState = () => {
             <div className="border-t border-overlay flex items-center justify-end py-4 px-8 gap-x-2">
               <Button asChild type="default">
                 <Link
-                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Prolonged%20restoration%20for%20project`}
+                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Ongoing%20restoration%20for%20project`}
                 >
                   Contact support
                 </Link>

--- a/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
@@ -111,7 +111,7 @@ const RestoringState = () => {
             <div className="border-t border-overlay flex items-center justify-end py-4 px-8 gap-x-2">
               <Button asChild type="default">
                 <Link
-                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Restoration%20failed%20for%20project`}
+                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Prolonged%20restoration%20for%20project`}
                 >
                   Contact support
                 </Link>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Updating the subject to the correct text (subject used to prefill the Support Form)

## What is the current behavior?

- Currently states "Restoration failed for project" for both FailedPause and Restoring states

## What is the new behavior?

- Changed text to add clarity