### PR TITLE
fix: binds studio listener to both ipv4 and ipv6

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -95,7 +95,6 @@ ENABLE_PHONE_AUTOCONFIRM=true
 STUDIO_DEFAULT_ORGANIZATION=Default Organization
 STUDIO_DEFAULT_PROJECT=Default Project
 
-STUDIO_PORT=3000
 # replace if you intend to use Studio outside of localhost
 SUPABASE_PUBLIC_URL=http://localhost:8000
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       analytics:
         condition: service_healthy
     environment:
+      # Binds nestjs listener to both IPv4 and IPv6 network interfaces
+      HOSTNAME: "::"
+
       STUDIO_PG_META_URL: http://meta:8080
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       PG_META_CRYPTO_KEY: ${PG_META_CRYPTO_KEY}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Nestjs binds to IPv6 by default. Since kong only resolves IPv4, this is causing errors connecting to upstream.

<img width="566" height="146" alt="Screenshot 2025-10-09 at 11 19 12 AM" src="https://github.com/user-attachments/assets/cbe1245d-da72-4f44-8880-81ca73e9c02e" />

Setting `::` as hostname implicitly binds both IPv4 and IPv6 network interfaces so it works with kong's dns resolution.

Also removes unused STUDIO_PORT configuration from example.env

## Additional context

Before:

```bash
curl http://studio:3000 -v
* Host studio:3000 was resolved.
* IPv6: fd07:b51a:cc66:d003::b
* IPv4: 192.168.117.11
*   Trying 192.168.117.11:3000...
* connect to 192.168.117.11 port 3000 from 192.168.117.13 port 34504 failed: Connection refused
*   Trying [fd07:b51a:cc66:d003::b]:3000...
* Connected to studio (fd07:b51a:cc66:d003::b) port 3000
> GET / HTTP/1.1
> Host: studio:3000
> User-Agent: curl/8.5.0
> Accept: */*
```

After:

```bash
curl http://studio:3000 -v
* Host studio:3000 was resolved.
* IPv6: fd07:b51a:cc66:d003::8
* IPv4: 192.168.117.8
*   Trying 192.168.117.8:3000...
* Connected to studio (192.168.117.8) port 3000
> GET / HTTP/1.1
> Host: studio:3000
> User-Agent: curl/8.5.0
> Accept: */*
```
