### PR TITLE
Chore/consolidate copy icons

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -16,7 +16,7 @@ import { Shortcuts } from './components/common/Shortcuts'
 import { Footer } from './components/footer/Footer'
 import { Grid } from './components/grid/Grid'
 import { Header, HeaderProps } from './components/header/Header'
-import { RowContextMenu } from './components/menu'
+import { RowContextMenu } from './components/menu/RowContextMenu'
 import { GridProps } from './types'
 
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'

--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -1,4 +1,4 @@
-import { Clipboard, Edit, Trash } from 'lucide-react'
+import { Copy, Edit, Trash } from 'lucide-react'
 import { useCallback } from 'react'
 import { Item, ItemParams, Menu } from 'react-contexify'
 import { toast } from 'sonner'
@@ -14,7 +14,7 @@ export type RowContextMenuProps = {
   rows: SupaRow[]
 }
 
-const RowContextMenu = ({ rows }: RowContextMenuProps) => {
+export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
   const tableEditorSnap = useTableEditorStateSnapshot()
   const snap = useTableEditorTableStateSnapshot()
 
@@ -68,11 +68,11 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
   return (
     <Menu id={ROW_CONTEXT_MENU_ID} animation={false} className="!min-w-36">
       <Item onClick={onCopyCellContent}>
-        <Clipboard size={12} />
+        <Copy size={12} />
         <span className="ml-2 text-xs">Copy cell</span>
       </Item>
       <Item onClick={onCopyRowContent}>
-        <Clipboard size={12} />
+        <Copy size={12} />
         <span className="ml-2 text-xs">Copy row</span>
       </Item>
       <DialogSectionSeparator className="my-1.5" />
@@ -88,4 +88,3 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
     </Menu>
   )
 }
-export default RowContextMenu

--- a/apps/studio/components/grid/components/menu/index.ts
+++ b/apps/studio/components/grid/components/menu/index.ts
@@ -1,2 +1,1 @@
 export { default as ColumnMenu } from './ColumnMenu'
-export { default as RowContextMenu } from './RowContextMenu'

--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { Clipboard, Trash, UserIcon } from 'lucide-react'
+import { Copy, Trash, UserIcon } from 'lucide-react'
 import { Column, useRowSelection } from 'react-data-grid'
 
 import { User } from 'data/auth/users-infinite-query'
@@ -386,7 +386,7 @@ export const formatUserColumns = ({
                   copyToClipboard(value)
                 }}
               >
-                <Clipboard size={12} />
+                <Copy size={12} />
                 <span>Copy {col.id === 'id' ? col.name : col.name.toLowerCase()}</span>
               </ContextMenuItem_Shadcn_>
               <ContextMenuSeparator_Shadcn_ />

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -1,6 +1,6 @@
 import type { PostgresSchema } from '@supabase/postgres-meta'
 import { toPng, toSvg } from 'html-to-image'
-import { Check, Clipboard, Download, Loader2 } from 'lucide-react'
+import { Check, Copy, Download, Loader2 } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useEffect, useMemo, useState } from 'react'
 import ReactFlow, { Background, BackgroundVariant, MiniMap, useReactFlow } from 'reactflow'
@@ -207,7 +207,7 @@ export const SchemaGraph = () => {
             <div className="flex items-center gap-x-2">
               <ButtonTooltip
                 type="outline"
-                icon={copied ? <Check /> : <Clipboard />}
+                icon={copied ? <Check /> : <Copy />}
                 onClick={() => {
                   if (tables) {
                     copyToClipboard(tablesToSQL(tables))

--- a/apps/studio/components/interfaces/Functions/CommandRender.tsx
+++ b/apps/studio/components/interfaces/Functions/CommandRender.tsx
@@ -1,4 +1,4 @@
-import { Check, Clipboard } from 'lucide-react'
+import { Check, Copy } from 'lucide-react'
 import { forwardRef, useState } from 'react'
 
 import { cn, copyToClipboard } from 'ui'
@@ -45,7 +45,7 @@ const Command = ({ item }: any) => {
               {isCopied ? (
                 <Check size={14} strokeWidth={3} className="text-brand" />
               ) : (
-                <Clipboard size={14} />
+                <Copy size={14} />
               )}
             </button>
           </span>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { Check, Clipboard } from 'lucide-react'
+import { Check, Copy } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
@@ -66,7 +66,7 @@ export const EdgeFunctionsListItem = ({ function: item }: EdgeFunctionsListItemP
             ) : (
               <div className="relative">
                 <div className="block">
-                  <Clipboard size={14} strokeWidth={1.5} />
+                  <Copy size={14} strokeWidth={1.5} />
                 </div>
               </div>
             )}

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
@@ -1,6 +1,6 @@
 import parser from 'cron-parser'
 import dayjs from 'dayjs'
-import { Clipboard, Edit, MoreVertical, Play, Trash } from 'lucide-react'
+import { Copy, Edit, MoreVertical, Play, Trash } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useState } from 'react'
 import { toast } from 'sonner'
@@ -295,7 +295,7 @@ export const CronJobTableCell = ({
           onFocusCapture={(e) => e.stopPropagation()}
           onSelect={() => copyToClipboard(formattedValue)}
         >
-          <Clipboard size={12} />
+          <Copy size={12} />
           <span>Copy {col.name.toLowerCase()}</span>
         </ContextMenuItem_Shadcn_>
 

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -1,4 +1,4 @@
-import { Clipboard, Expand } from 'lucide-react'
+import { Copy, Expand } from 'lucide-react'
 import { useState } from 'react'
 import DataGrid, { CalculatedColumn } from 'react-data-grid'
 
@@ -53,7 +53,7 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
             }}
             onFocusCapture={(e) => e.stopPropagation()}
           >
-            <Clipboard size={14} />
+            <Copy size={12} />
             Copy cell content
           </ContextMenuItem_Shadcn_>
           <ContextMenuItem_Shadcn_
@@ -61,7 +61,7 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
             onSelect={() => setExpandCell(true)}
             onFocusCapture={(e) => e.stopPropagation()}
           >
-            <Expand size={14} />
+            <Expand size={12} />
             View cell content
           </ContextMenuItem_Shadcn_>
         </ContextMenuContent_Shadcn_>

--- a/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -1,4 +1,4 @@
-import { Check, Clipboard, MousePointerClick, X } from 'lucide-react'
+import { Check, Copy, MousePointerClick, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
@@ -104,20 +104,16 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
                 type="text"
                 tooltip={{
                   content: {
+                    side: 'left',
                     text: isLoading ? 'Loading log...' : 'Copy as JSON',
                   },
                 }}
+                icon={showCopied ? <Check /> : <Copy />}
                 onClick={() => {
                   setShowCopied(true)
                   copyToClipboard(JSON.stringify(log, null, 2))
                 }}
-              >
-                {showCopied ? (
-                  <Check size={14} strokeWidth={2} />
-                ) : (
-                  <Clipboard size={14} strokeWidth={2} />
-                )}
-              </ButtonTooltip>
+              />
 
               <Button type="text" onClick={onClose}>
                 <X size={14} strokeWidth={2} />

--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { isEqual } from 'lodash'
-import { Clipboard, Eye, EyeOff, Play } from 'lucide-react'
+import { Copy, Eye, EyeOff, Play } from 'lucide-react'
 import { Key, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Item, Menu, useContextMenu } from 'react-contexify'
 import DataGrid, { Column, RenderRowProps, Row } from 'react-data-grid'
@@ -437,7 +437,7 @@ const LogTable = ({
             createPortal(
               <Menu id={LOGS_EXPLORER_CONTEXT_MENU_ID} animation={false}>
                 <Item onClick={onCopyCell}>
-                  <Clipboard size={14} />
+                  <Copy size={14} />
                   <span className="ml-2 text-xs">Copy event message</span>
                 </Item>
               </Menu>,

--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { BookOpen, Check, ChevronDown, Clipboard, ExternalLink, X } from 'lucide-react'
+import { BookOpen, Check, ChevronDown, Copy, ExternalLink, X } from 'lucide-react'
 import Link from 'next/link'
 import { ReactNode, useState } from 'react'
 
@@ -310,7 +310,7 @@ const Field = ({
         ) : (
           <Tooltip>
             <TooltipTrigger>
-              <Clipboard size={14} strokeWidth={1.5} />
+              <Copy size={14} strokeWidth={1.5} />
             </TooltipTrigger>
             <TooltipContent side="bottom">Copy value</TooltipContent>
           </Tooltip>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ColumnContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ColumnContextMenu.tsx
@@ -4,7 +4,7 @@ import 'react-contexify/dist/ReactContexify.css'
 
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { ChevronRight, ChevronsDown, ChevronsUp, Clipboard, Eye, FolderPlus } from 'lucide-react'
+import { ChevronRight, ChevronsDown, ChevronsUp, Copy, Eye, FolderPlus } from 'lucide-react'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import {
   STORAGE_ROW_TYPES,
@@ -62,23 +62,23 @@ export const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
     <Menu id={id} animation="fade">
       {canUpdateFiles && [
         <Item key="create-folder" onClick={({ props }) => onSelectCreateFolder(props.index)}>
-          <FolderPlus size="14" strokeWidth={1} />
+          <FolderPlus size={14} />
           <span className="ml-2 text-xs">New folder</span>
         </Item>,
         <Separator key="create-folder-separator" />,
       ]}
       <Item onClick={({ props }) => onSelectAllItemsInColumn(props.index)}>
-        <Clipboard size="14" strokeWidth={1} />
+        <Copy size={14} />
         <span className="ml-2 text-xs">Select all items</span>
       </Item>
       <Submenu
         label={
           <div className="flex items-center space-x-2">
-            <Eye size="14" strokeWidth={1} />
+            <Eye size={14} />
             <span className="text-xs">View</span>
           </div>
         }
-        arrow={<ChevronRight size="14" strokeWidth={1} />}
+        arrow={<ChevronRight size={14} />}
       >
         <Item onClick={() => setView(STORAGE_VIEWS.COLUMNS)}>
           <span className="ml-2 text-xs">As columns</span>
@@ -90,11 +90,11 @@ export const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
       <Submenu
         label={
           <div className="flex items-center space-x-2">
-            <ChevronsDown size="14" strokeWidth={1} />
+            <ChevronsDown size={14} />
             <span className="ml-2 text-xs">Sort by</span>
           </div>
         }
-        arrow={<ChevronRight size="14" strokeWidth={1} />}
+        arrow={<ChevronRight size={14} />}
       >
         <Item onClick={() => setSortBy(STORAGE_SORT_BY.NAME)}>
           <span className="ml-2 text-xs">Name</span>
@@ -112,11 +112,11 @@ export const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
       <Submenu
         label={
           <div className="flex items-center space-x-2">
-            <ChevronsUp size="14" strokeWidth={1} />
+            <ChevronsUp size={14} />
             <span className="ml-2 text-xs">Sort by order</span>
           </div>
         }
-        arrow={<ChevronRight size="14" strokeWidth={1} />}
+        arrow={<ChevronRight size={14} />}
       >
         <Item onClick={() => setSortByOrder(STORAGE_SORT_BY_ORDER.ASC)}>
           <span className="ml-2 text-xs">Ascending</span>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -2,7 +2,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { find, isEmpty, isEqual } from 'lodash'
 import {
   AlertCircle,
-  Clipboard,
+  Copy,
   Download,
   Edit,
   File,
@@ -183,7 +183,7 @@ export const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = 
           },
           {
             name: 'Copy path to folder',
-            icon: <Clipboard size={14} strokeWidth={1} />,
+            icon: <Copy size={14} strokeWidth={1} />,
             onClick: () => copyPathToFolder(openedFolders, itemWithColumnIndex),
           },
           ...(canUpdateFiles
@@ -204,14 +204,14 @@ export const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = 
                   ? [
                       {
                         name: 'Get URL',
-                        icon: <Clipboard size={14} strokeWidth={1} />,
+                        icon: <Copy size={14} strokeWidth={1} />,
                         onClick: () => onCopyUrl(itemWithColumnIndex.name),
                       },
                     ]
                   : [
                       {
                         name: 'Get URL',
-                        icon: <Clipboard size={14} strokeWidth={1} />,
+                        icon: <Copy size={14} strokeWidth={1} />,
                         children: [
                           {
                             name: 'Expire in 1 week',

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FolderContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FolderContextMenu.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Clipboard, Download, Edit, Trash2 } from 'lucide-react'
+import { Copy, Download, Edit, Trash2 } from 'lucide-react'
 import { Item, Menu, Separator } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
 
@@ -20,22 +20,22 @@ export const FolderContextMenu = ({ id = '' }: FolderContextMenuProps) => {
     <Menu id={id} animation="fade">
       {canUpdateFiles && (
         <Item onClick={({ props }) => setSelectedItemToRename(props.item)}>
-          <Edit size="14" strokeWidth={1} />
+          <Edit size={12} />
           <span className="ml-2 text-xs">Rename</span>
         </Item>
       )}
       <Item onClick={({ props }) => downloadFolder(props.item)}>
-        <Download size="14" strokeWidth={1} />
+        <Download size={12} />
         <span className="ml-2 text-xs">Download</span>
       </Item>
       <Item onClick={({ props }) => copyPathToFolder(openedFolders, props.item)}>
-        <Clipboard size="14" strokeWidth={1} />
+        <Copy size={12} />
         <span className="ml-2 text-xs">Copy path to folder</span>
       </Item>
       {canUpdateFiles && [
         <Separator key="separator" />,
         <Item key="delete" onClick={({ props }) => setSelectedItemsToDelete([props.item])}>
-          <Trash2 size="14" strokeWidth={1} stroke="red" />
+          <Trash2 size={12} />
           <span className="ml-2 text-xs">Delete</span>
         </Item>,
       ]}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { ChevronRight, Clipboard, Download, Edit, Move, Trash2 } from 'lucide-react'
+import { ChevronRight, Copy, Download, Edit, Move, Trash2 } from 'lucide-react'
 import { Item, Menu, Separator, Submenu } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
 
@@ -51,18 +51,18 @@ export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
     <Menu id={id} animation="fade">
       {isPublic ? (
         <Item onClick={({ props }) => onHandleClick('copy', props.item)}>
-          <Clipboard size="14" strokeWidth={1} />
+          <Copy size={14} />
           <span className="ml-2 text-xs">Get URL</span>
         </Item>
       ) : (
         <Submenu
           label={
             <div className="flex items-center space-x-2">
-              <Clipboard size="14" />
+              <Copy size={14} />
               <span className="text-xs">Get URL</span>
             </div>
           }
-          arrow={<ChevronRight size="14" strokeWidth={1} />}
+          arrow={<ChevronRight size={14} />}
         >
           <Item
             onClick={({ props }) => onHandleClick('copy', props.item, URL_EXPIRY_DURATION.WEEK)}
@@ -86,20 +86,20 @@ export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
       )}
       {canUpdateFiles && [
         <Item key="rename-file" onClick={({ props }) => onHandleClick('rename', props.item)}>
-          <Edit size="14" strokeWidth={1} />
+          <Edit size={14} strokeWidth={1} />
           <span className="ml-2 text-xs">Rename</span>
         </Item>,
         <Item key="move-file" onClick={({ props }) => onHandleClick('move', props.item)}>
-          <Move size="14" strokeWidth={1} />
+          <Move size={14} strokeWidth={1} />
           <span className="ml-2 text-xs">Move</span>
         </Item>,
         <Item key="download-file" onClick={({ props }) => onHandleClick('download', props.item)}>
-          <Download size="14" strokeWidth={1} />
+          <Download size={14} strokeWidth={1} />
           <span className="ml-2 text-xs">Download</span>
         </Item>,
         <Separator key="file-separator" />,
         <Item key="delete-file" onClick={({ props }) => setSelectedItemsToDelete([props.item])}>
-          <Trash2 size="14" strokeWidth={1} stroke="red" />
+          <Trash2 size={14} strokeWidth={1} stroke="red" />
           <span className="ml-2 text-xs">Delete</span>
         </Item>,
       ]}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -1,7 +1,7 @@
 import { Transition } from '@headlessui/react'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { isEmpty } from 'lodash'
-import { AlertCircle, ChevronDown, Clipboard, Download, Loader, Trash2, X } from 'lucide-react'
+import { AlertCircle, ChevronDown, Copy, Download, Loader, Trash2, X } from 'lucide-react'
 import SVG from 'react-inlinesvg'
 
 import { useParams } from 'common'
@@ -202,7 +202,7 @@ export const PreviewPane = () => {
           <div className="flex space-x-2 border-b border-overlay pb-4">
             <Button
               type="default"
-              icon={<Download size={16} strokeWidth={2} />}
+              icon={<Download />}
               disabled={file.isCorrupted}
               onClick={async () => await downloadFile({ projectRef, bucketId, file })}
             >
@@ -211,7 +211,7 @@ export const PreviewPane = () => {
             {selectedBucket.public ? (
               <Button
                 type="outline"
-                icon={<Clipboard size={16} strokeWidth={2} />}
+                icon={<Copy />}
                 onClick={() => onCopyUrl(file.name)}
                 disabled={file.isCorrupted}
               >
@@ -222,7 +222,7 @@ export const PreviewPane = () => {
                 <DropdownMenuTrigger asChild>
                   <Button
                     type="outline"
-                    icon={<Clipboard size={16} strokeWidth={2} />}
+                    icon={<Copy />}
                     iconRight={<ChevronDown />}
                     disabled={file.isCorrupted}
                   >

--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -1,5 +1,5 @@
 import saveAs from 'file-saver'
-import { Clipboard, Copy, Download, Edit, Lock, MoreVertical, Trash } from 'lucide-react'
+import { Copy, Download, Edit, Lock, MoreVertical, Trash } from 'lucide-react'
 import Link from 'next/link'
 import Papa from 'papaparse'
 import { toast } from 'sonner'
@@ -309,7 +309,7 @@ const EntityListItem: ItemRenderer<Entity, EntityListItemProps> = ({
                   copyToClipboard(entity.name)
                 }}
               >
-                <Clipboard size={12} />
+                <Copy size={12} />
                 <span>Copy name</span>
               </DropdownMenuItem>
 
@@ -341,7 +341,7 @@ const EntityListItem: ItemRenderer<Entity, EntityListItemProps> = ({
                     }
                   }}
                 >
-                  <Clipboard size={12} />
+                  <Copy size={12} />
                   <span>Copy table schema</span>
                 </DropdownMenuItem>
               )}

--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { Check, Clipboard } from 'lucide-react'
+import { Check, Copy } from 'lucide-react'
 import { ComponentProps, forwardRef, useEffect, useState } from 'react'
 
 import { Button, cn, copyToClipboard } from 'ui'
@@ -62,11 +62,7 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
           props.className
         )}
         icon={
-          showCopied ? (
-            <Check strokeWidth={2} className="text-brand" />
-          ) : (
-            props.icon ?? <Clipboard />
-          )
+          showCopied ? <Check strokeWidth={2} className="text-brand" /> : props.icon ?? <Copy />
         }
       >
         {!iconOnly && <>{children ?? (showCopied ? copiedLabel : copyLabel)}</>}

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -1,5 +1,5 @@
 import saveAs from 'file-saver'
-import { ChevronDown, Clipboard, Download } from 'lucide-react'
+import { ChevronDown, Copy, Download } from 'lucide-react'
 import { markdownTable } from 'markdown-table'
 import Papa from 'papaparse'
 import { useMemo } from 'react'
@@ -111,11 +111,11 @@ export const DownloadResultsButton = ({
           <p>Download CSV</p>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={copyAsMarkdown} className="gap-x-2">
-          <Clipboard size={14} />
+          <Copy size={14} />
           <p>Copy as markdown</p>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={copyAsJSON} className="gap-x-2">
-          <Clipboard size={14} />
+          <Copy size={14} />
           <p>Copy as JSON</p>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/studio/components/ui/Logs/LogsExplorerHeader.tsx
+++ b/apps/studio/components/ui/Logs/LogsExplorerHeader.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Check, Clipboard, ExternalLink, List, X } from 'lucide-react'
+import { BookOpen, Check, Copy, ExternalLink, List, X } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -163,7 +163,7 @@ const Field = ({
         ) : (
           <Tooltip>
             <TooltipTrigger>
-              <Clipboard size={14} strokeWidth={1.5} />
+              <Copy size={14} />
             </TooltipTrigger>
             <TooltipContent side="bottom" className="font-sans">
               Copy value

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -1189,7 +1189,7 @@ export default {
             group-hover:border-foreground-muted`,
           active: `
             font-semibold
-            bg-sidebar-accent dark:bg-surface-200
+            bg-sidebar-accent
             text-foreground-lighter
             z-10 rounded-md
           `,

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -1182,20 +1182,16 @@ export default {
           rounded: `rounded-md`,
         },
         pills: {
-          base: `
-            px-3 py-1
-          `,
+          base: `px-3 py-1`,
           normal: `
             font-normal
             border-default
             group-hover:border-foreground-muted`,
           active: `
             font-semibold
-            bg-surface-400 dark:bg-surface-200
+            bg-sidebar-accent dark:bg-surface-200
             text-foreground-lighter
-            z-10
-
-            rounded-md
+            z-10 rounded-md
           `,
         },
       },

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -1191,7 +1191,7 @@ export default {
             group-hover:border-foreground-muted`,
           active: `
             font-semibold
-            bg-surface-200
+            bg-surface-400 dark:bg-surface-200
             text-foreground-lighter
             z-10
 


### PR DESCRIPTION
## Context

This just consolidate all icons for "Copy" actions to use the Copy icon instead of the Clipboard icon

Also addresses a separate issue in the Product Menu -> The background color of the `Menu.Item` in light mode when `active` has barely any differentiation (if any?) against the background color of the side panel (with `bg-surface-200`). Opting to use `bg-surface-400` in light mode when active but i reckon we might need to revisit the light mode colors nonetheless

## Before
<img width="280" height="165" alt="image" src="https://github.com/user-attachments/assets/1c394586-9c2e-4ebf-a178-80e935a4de0b" />

## After
<img width="298" height="143" alt="image" src="https://github.com/user-attachments/assets/2129493d-213e-4f60-9c4d-589a1d7a88c9" />

