### PR TITLE
Opt to ignore cannot find module errors in AIEditor

### DIFF
--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -163,6 +163,12 @@ const AIEditor = ({
       }
     }
 
+    // [Joshen] Opting to ignore "Cannot find module" errors here as users are getting
+    // confused with the error highlighting when importing external modules
+    monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+      diagnosticCodesToIgnore: [2792],
+    })
+
     fetch(`${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/deno/lib.deno.d.ts`)
       .then((response) => response.text())
       .then((code) => {


### PR DESCRIPTION
## Context

Opting to ignore "Cannot find module" errors in the `AIEditor` as it's causing confusion amongst users - especially for the dashboard's edge function code editor when users are trying to import external modules (e.g `supabase-js`)

Related issue: https://github.com/supabase/supabase/issues/35601

## Before
<img width="691" height="153" alt="image" src="https://github.com/user-attachments/assets/0263e473-0a47-4e63-90f0-2bd73e5559c0" />


## After
<img width="665" height="120" alt="image" src="https://github.com/user-attachments/assets/c657ac0c-bd3c-4e6c-919a-ca3b847412c6" />
