### PR TITLE
Opt to silently swallow 404 error when creating new snippet

### DIFF
--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
+import { usePrevious } from '@uidotdev/usehooks'
 import { useParams } from 'common/hooks/useParams'
 import { SQLEditor } from 'components/interfaces/SQLEditor/SQLEditor'
 import DefaultLayout from 'components/layouts/DefaultLayout'
@@ -22,6 +23,7 @@ import { Admonition } from 'ui-patterns'
 const SqlEditor: NextPageWithLayout = () => {
   const router = useRouter()
   const { id, ref, content, skip } = useParams()
+  const previousRoute = usePrevious(id)
   const { data: project } = useSelectedProjectQuery()
 
   const editor = useEditorType()
@@ -34,8 +36,6 @@ const SqlEditor: NextPageWithLayout = () => {
 
   const tabId = !!id ? tabs.openTabs.find((x) => x.endsWith(id)) : undefined
 
-  // [Refactor] There's an unnecessary request getting triggered when we start typing while on /new
-  // the URL ID gets updated and we attempt to fetch content for a snippet that's not been created yet
   // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
   // the snapV2 valtio store for some reason hence why the added typeof check here
   const canFetchContentBasedOnId = Boolean(
@@ -53,6 +53,17 @@ const SqlEditor: NextPageWithLayout = () => {
     isError && error.code === 404 && error.message.includes('Content not found')
   const invalidId = isError && error.code === 400 && error.message.includes('Invalid uuid')
 
+  // [Joshen] Atm we suspect that replication lag is causing this to happen whereby a newly created snippet
+  // shows the "Unable to find snippet" error which blocks the whole UI
+  // - For a newly created a snippet (on /new), snippets are marked with 'isNotSavedInDatabaseYet' (ref createSqlSnippetSkeletonV2)
+  // - New snippet is saved after debouncing, in which thereafter 'isNotSavedInDatabaseYet' is marked as false (ref upsertSnippet)
+  // - This then satisfies the condition for 'canFetchContentBasedOnId' and FE tries to fetch the content of the snippet
+  // - But because of replication lag, that request returns a 404 despite the save working correctly
+  // Am opting to silently swallow this error, since the saves are still going through and we're scoping this behaviour down to a
+  // very specific use case too with all these conditionals
+  const snippetMissingImmediatelyAfterCreating =
+    !!snippet && snippetMissing && previousRoute === 'new' && 'isNotSavedInDatabaseYet' in snippet
+
   useEffect(() => {
     if (ref && data && project) {
       // [Joshen] Check if snippet belongs to the current project
@@ -63,6 +74,7 @@ const SqlEditor: NextPageWithLayout = () => {
         router.push(`/project/${ref}/sql/new`)
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref, data, project])
 
   // Load the last visited snippet when landing on /new
@@ -95,9 +107,10 @@ const SqlEditor: NextPageWithLayout = () => {
         name: snippet?.name,
       },
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady, id])
 
-  if (snippetMissing || invalidId) {
+  if ((snippetMissing || invalidId) && !snippetMissingImmediatelyAfterCreating) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="w-[400px]">
@@ -122,7 +135,12 @@ const SqlEditor: NextPageWithLayout = () => {
                 Close tab
               </Button>
             ) : (
-              <Button asChild type="default" className="mt-2">
+              <Button
+                asChild
+                type="default"
+                className="mt-2"
+                onClick={() => setLastVisitedSnippet(undefined)}
+              >
                 <Link href={`/project/${ref}/sql`}>Head back</Link>
               </Button>
             )}

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -55,13 +55,9 @@ const SqlEditor: NextPageWithLayout = () => {
 
   // [Joshen] Atm we suspect that replication lag is causing this to happen whereby a newly created snippet
   // shows the "Unable to find snippet" error which blocks the whole UI
-  // - For a newly created a snippet (on /new), snippets are marked with 'isNotSavedInDatabaseYet' (ref createSqlSnippetSkeletonV2)
-  // - New snippet is saved after debouncing, in which thereafter 'isNotSavedInDatabaseYet' is marked as false (ref upsertSnippet)
-  //   - Note that it only gets marked as false if the upsert happened successfully
-  // - This then satisfies the condition for 'canFetchContentBasedOnId' and FE tries to fetch the content of the snippet
-  // - But because of replication lag, that request returns a 404 despite the save working correctly
-  // Am opting to silently swallow this error, since the saves are still going through and we're scoping this behaviour down to a
-  // very specific use case too with all these conditionals
+  // Am opting to silently swallow this error, since the saves are still going through and we're scoping this behaviour
+  // behaviour down to a very specific use case too with all these conditionals
+  // More details: https://github.com/supabase/supabase/pull/39389
   const snippetMissingImmediatelyAfterCreating =
     !!snippet && snippetMissing && previousRoute === 'new' && 'isNotSavedInDatabaseYet' in snippet
 

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -57,6 +57,7 @@ const SqlEditor: NextPageWithLayout = () => {
   // shows the "Unable to find snippet" error which blocks the whole UI
   // - For a newly created a snippet (on /new), snippets are marked with 'isNotSavedInDatabaseYet' (ref createSqlSnippetSkeletonV2)
   // - New snippet is saved after debouncing, in which thereafter 'isNotSavedInDatabaseYet' is marked as false (ref upsertSnippet)
+  //   - Note that it only gets marked as false if the upsert happened successfully
   // - This then satisfies the condition for 'canFetchContentBasedOnId' and FE tries to fetch the content of the snippet
   // - But because of replication lag, that request returns a 404 despite the save working correctly
   // Am opting to silently swallow this error, since the saves are still going through and we're scoping this behaviour down to a

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -306,7 +306,9 @@ async function upsertSnippet(
     }
 
     let snippet = sqlEditorState.snippets[id]?.snippet
-    if (snippet?.content) snippet.isNotSavedInDatabaseYet = false
+    if (snippet?.content && 'isNotSavedInDatabaseYet' in snippet) {
+      snippet.isNotSavedInDatabaseYet = false
+    }
     sqlEditorState.savingStates[id] = 'IDLE'
   } catch (error) {
     sqlEditorState.savingStates[id] = 'UPDATING_FAILED'


### PR DESCRIPTION
## Context

Related to a previous PR here: https://github.com/supabase/supabase/pull/39364, RE running into "Unable to find snippet ID..." errors in the SQL Editor after typing for a bit. The previous PR mitigates the disruption of running into this bug by preventing it from happening while typing, but there's still a chance that this happens (primarily due to replication lag from our current best understanding)

## Idea

Users should still be able to run their queries on their database irregardless of this issue since our replication lag has no implication on their database, so this PR looks into optimizing the UX for this particular case - in which TLDR am opting to silently ignore the 404 given the following specific conditions
- User is writing a new snippet
  - i.e Route is changing from /new to /[id] + snippet has a client side property `isNotSavedInDatabaseYet`
- Snippet has been saved successfully

Just to trace the flow a little for context:
- For a newly created a snippet (on /new), snippets are marked with 'isNotSavedInDatabaseYet' (ref `createSqlSnippetSkeletonV2` [here](https://github.com/supabase/supabase/blob/master/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts#L41))
  - Existing snippets do not have this property, and I've updated `upsertSnippet` in this PR to only set this property if it exists in the snippet
- New snippet is saved after debouncing, in which thereafter `isNotSavedInDatabaseYet` is marked as false (ref `upsertSnippet` [here](https://github.com/supabase/supabase/blob/master/apps/studio/state/sql-editor-v2.ts#L289))
  - Note that `isNotSavedInDatabaseYet` is only updated if the upsert went through successfully
- This then satisfies the condition for `canFetchContentBasedOnId` and FE tries to fetch the content of the snippet via `useContentIdQuery` in `/sql/[id].tsx`
- But because of replication lag, that request returns a 404 despite the save working correctly
- So in this case, from the user's POV - nothing happened, they continue to write and run their query. Saving is fine so their data still persists either way

^ Added this as a comment in the code as well for future reference

## To test
- [ ] Just verify that you can still create snippets as per usual (Ideally we'd be able to repro the replication lag, which we technically can by hardcoding `useContentIdQuery` locally)