### PR TITLE
[FE-1926] chore: show sign in error

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import z from 'zod'
 
+import { useAuthError } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useMfaChallengeAndVerifyMutation } from 'data/profile/mfa-challenge-and-verify-mutation'
@@ -85,6 +86,22 @@ export const SignInMfaForm = ({ context = 'sign-in' }: SignInMfaFormProps) => {
       }
     }
   }, [factors?.totp, isSuccessFactors, router, queryClient])
+
+  const error = useAuthError()
+
+  if (error) {
+    return (
+      <AlertError
+        error={error}
+        subject="Error while signing in"
+        additionalActions={
+          <Button asChild type="warning" className="w-min">
+            <Link href="/sign-in">Back to sign in</Link>
+          </Button>
+        }
+      />
+    )
+  }
 
   return (
     <>

--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -15,6 +15,7 @@ export interface AlertErrorProps {
   error?: { message: string } | null
   className?: string
   showIcon?: boolean
+  additionalActions?: React.ReactNode
 }
 
 // [Joshen] To standardize the language for all error UIs
@@ -26,6 +27,7 @@ export const AlertError = ({
   className,
   showIcon = true,
   children,
+  additionalActions,
 }: PropsWithChildren<AlertErrorProps>) => {
   const subjectString = subject?.replace(/ /g, '%20')
   let href = `/support/new?category=dashboard_bug`
@@ -51,9 +53,12 @@ export const AlertError = ({
           </p>
         </div>
         {children}
-        <Button asChild type="warning" className="w-min">
-          <Link href={href}>Contact support</Link>
-        </Button>
+        <div className="flex gap-2">
+          {additionalActions}
+          <Button asChild type="warning" className="w-min">
+            <Link href={href}>Contact support</Link>
+          </Button>
+        </div>
       </AlertDescription_Shadcn_>
     </Alert_Shadcn_>
   )


### PR DESCRIPTION
Currently errors while signing in result in an ephemeral toast. For example:
<img width="419" height="125" alt="Screenshot 2025-10-09 at 17 27 42" src="https://github.com/user-attachments/assets/e3ce6388-21b9-43c7-8dbf-b250d403b6f8" />

This PR adds an inline error message along with actions that the user can take:
<img width="528" height="472" alt="Screenshot 2025-10-09 at 17 27 28" src="https://github.com/user-attachments/assets/5aeaaa0c-68f6-4ad1-be56-246395366e6d" />

To test:

- [ ] Ensure sign in works as normal (happy path)
- [ ] Test error message actions. You can fake an error while logged out by visiting a path like: `/sign-in-mfa?error=server_error&error_code=unexpected_failure&error_description=Error+getting+user+email+from+external+provider&method=snapchat&returnTo=%2Forganizations#error=server_error&error_code=unexpected_failure&error_description=Error+getting+user+email+from+external+provider`