### PR TITLE
Auth Report Fixes

### DIFF
--- a/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
@@ -24,6 +24,7 @@ export interface ReportChartV2Props {
   syncId?: string
   filters?: any
   highlightActions?: ChartHighlightAction[]
+  queryKeys?: string[]
 }
 
 export const ReportChartV2 = ({
@@ -37,6 +38,7 @@ export const ReportChartV2 = ({
   syncId,
   filters,
   highlightActions,
+  queryKeys,
 }: ReportChartV2Props) => {
   const { data: org } = useSelectedOrganizationQuery()
   const { plan: orgPlan } = useCurrentOrgPlan()
@@ -53,12 +55,15 @@ export const ReportChartV2 = ({
     error,
     isFetching,
   } = useQuery(
-    [
-      'projects',
-      projectRef,
-      'report-v2',
-      { reportId: report.id, startDate, endDate, interval, filters },
-    ],
+    queryKeys && queryKeys.length > 0
+      ? [
+          'projects',
+          projectRef,
+          'report-v2',
+          ...queryKeys,
+          { startDate, endDate, interval, filters },
+        ]
+      : ['projects', projectRef, 'report-v2', report.id, { startDate, endDate, interval, filters }],
     async () => {
       return await report.dataProvider(projectRef, startDate, endDate, interval, filters)
     },
@@ -66,6 +71,12 @@ export const ReportChartV2 = ({
       enabled: Boolean(projectRef && canFetch && isAvailable && !report.hide),
       refetchOnWindowFocus: false,
       staleTime: 0,
+      select: (data) => {
+        if (report.selectTransform) {
+          return report.selectTransform(data)
+        }
+        return data
+      },
     }
   )
 

--- a/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { ComposedChart } from 'components/ui/Charts/ComposedChart'
 import type { ChartHighlightAction } from 'components/ui/Charts/ChartHighlightActions'
@@ -70,7 +70,6 @@ export const ReportChartV2 = ({
     {
       enabled: Boolean(projectRef && canFetch && isAvailable && !report.hide),
       refetchOnWindowFocus: false,
-      staleTime: 0,
     }
   )
 

--- a/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
@@ -71,12 +71,6 @@ export const ReportChartV2 = ({
       enabled: Boolean(projectRef && canFetch && isAvailable && !report.hide),
       refetchOnWindowFocus: false,
       staleTime: 0,
-      select: (data) => {
-        if (report.selectTransform) {
-          return report.selectTransform(data)
-        }
-        return data
-      },
     }
   )
 

--- a/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
@@ -55,15 +55,13 @@ export const ReportChartV2 = ({
     error,
     isFetching,
   } = useQuery(
-    queryKeys && queryKeys.length > 0
-      ? [
-          'projects',
-          projectRef,
-          'report-v2',
-          ...queryKeys,
-          { startDate, endDate, interval, filters },
-        ]
-      : ['projects', projectRef, 'report-v2', report.id, { startDate, endDate, interval, filters }],
+    [
+      'projects',
+      projectRef,
+      'report-v2',
+      ...(queryKeys && queryKeys.length > 0 ? queryKeys : [report.id]),
+      { startDate, endDate, interval, filters },
+    ],
     async () => {
       return await report.dataProvider(projectRef, startDate, endDate, interval, filters)
     },

--- a/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportChartV2.tsx
@@ -70,6 +70,8 @@ export const ReportChartV2 = ({
     {
       enabled: Boolean(projectRef && canFetch && isAvailable && !report.hide),
       refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      staleTime: 5_000, // Enough for multiple metrics with the same query to share the fetch request.
     }
   )
 

--- a/apps/studio/data/reports/v2/auth.config.ts
+++ b/apps/studio/data/reports/v2/auth.config.ts
@@ -466,7 +466,6 @@ export const createUsageReportConfig = ({
   const groupByProvider = Boolean(filters?.provider && filters.provider.length > 0)
 
   const usageSql = buildUsageAllSQL(interval, filters, startDate, endDate)
-  const usageDataPromise = fetchLogs(projectRef, usageSql, startDate, endDate)
 
   return [
     {
@@ -486,13 +485,12 @@ export const createUsageReportConfig = ({
         const attributes = [
           { attribute: 'ActiveUsers', provider: 'logs', label: 'Active Users', enabled: true },
         ]
-        const sql = usageSql
-        const rawData = await usageDataPromise
+        const rawData = await fetchLogs(projectRef, usageSql, startDate, endDate)
         const transformedData = defaultAuthReportFormatter(rawData, attributes, groupByProvider)
         return {
           data: transformedData.data,
           attributes: transformedData.chartAttributes,
-          query: sql,
+          query: usageSql,
         }
       },
     },
@@ -540,13 +538,12 @@ export const createUsageReportConfig = ({
             enabled: true,
           },
         ]
-        const sql = usageSql
-        const rawData = await usageDataPromise
+        const rawData = await fetchLogs(projectRef, usageSql, startDate, endDate)
         const transformedData = defaultAuthReportFormatter(rawData, attributes, groupByProvider)
         return {
           data: transformedData.data,
           attributes: transformedData.chartAttributes,
-          query: sql,
+          query: usageSql,
         }
       },
     },
@@ -572,13 +569,12 @@ export const createUsageReportConfig = ({
             enabled: true,
           },
         ]
-        const sql = usageSql
-        const rawData = await usageDataPromise
+        const rawData = await fetchLogs(projectRef, usageSql, startDate, endDate)
         const transformedData = defaultAuthReportFormatter(rawData, attributes, groupByProvider)
         return {
           data: transformedData.data,
           attributes: transformedData.chartAttributes,
-          query: sql,
+          query: usageSql,
         }
       },
     },
@@ -604,13 +600,12 @@ export const createUsageReportConfig = ({
             enabled: true,
           },
         ]
-        const sql = usageSql
-        const rawData = await usageDataPromise
+        const rawData = await fetchLogs(projectRef, usageSql, startDate, endDate)
         const transformedData = defaultAuthReportFormatter(rawData, attributes, groupByProvider)
         return {
           data: transformedData.data,
           attributes: transformedData.chartAttributes,
-          query: sql,
+          query: usageSql,
         }
       },
     },

--- a/apps/studio/data/reports/v2/reports.types.ts
+++ b/apps/studio/data/reports/v2/reports.types.ts
@@ -39,4 +39,5 @@ export interface ReportConfig<FiltersType = any> {
   YAxisProps?: YAxisProps
   xAxisKey?: string
   yAxisKey?: string
+  queryKeys?: string[]
 }

--- a/apps/studio/pages/project/[ref]/reports/auth.tsx
+++ b/apps/studio/pages/project/[ref]/reports/auth.tsx
@@ -168,8 +168,6 @@ const AuthUsage = () => {
 
     updateDateRange(newStart, newEnd)
 
-    queryClient.invalidateQueries(['projects', ref, 'report-v2'])
-
     refetch()
     setTimeout(() => setIsRefreshing(false), 1000)
   }

--- a/apps/studio/pages/project/[ref]/reports/auth.tsx
+++ b/apps/studio/pages/project/[ref]/reports/auth.tsx
@@ -25,6 +25,7 @@ import {
   createUsageReportConfig,
   createErrorsReportConfig,
   createLatencyReportConfig,
+  AUTH_REPORT_QUERY_KEYS,
 } from 'data/reports/v2/auth.config'
 import { ReportSettings } from 'components/ui/Charts/ReportSettings'
 import type { ChartHighlightAction } from 'components/ui/Charts/ChartHighlightActions'
@@ -160,6 +161,8 @@ const AuthUsage = () => {
 
     setIsRefreshing(true)
 
+    queryClient.invalidateQueries(AUTH_REPORT_QUERY_KEYS.usage)
+
     refetch()
     setTimeout(() => setIsRefreshing(false), 1000)
   }
@@ -269,6 +272,7 @@ const AuthUsage = () => {
                   syncId={chartSyncId}
                   filters={{ provider: usageProviderFilter }}
                   highlightActions={highlightActions}
+                  queryKeys={metric.queryKeys}
                 />
               ))}
             </div>

--- a/apps/studio/pages/project/[ref]/reports/auth.tsx
+++ b/apps/studio/pages/project/[ref]/reports/auth.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, LogsIcon, RefreshCw } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
 import { ReportChartV2 } from 'components/interfaces/Reports/v2/ReportChartV2'
 import { ReportSectionHeader } from 'components/interfaces/Reports/v2/ReportSectionHeader'

--- a/apps/studio/pages/project/[ref]/reports/auth.tsx
+++ b/apps/studio/pages/project/[ref]/reports/auth.tsx
@@ -25,7 +25,6 @@ import {
   createUsageReportConfig,
   createErrorsReportConfig,
   createLatencyReportConfig,
-  AUTH_REPORT_QUERY_KEYS,
 } from 'data/reports/v2/auth.config'
 import { ReportSettings } from 'components/ui/Charts/ReportSettings'
 import type { ChartHighlightAction } from 'components/ui/Charts/ChartHighlightActions'
@@ -161,7 +160,15 @@ const AuthUsage = () => {
 
     setIsRefreshing(true)
 
-    queryClient.invalidateQueries(AUTH_REPORT_QUERY_KEYS.usage)
+    const duration = dayjs(selectedDateRange.period_end.date).diff(
+      selectedDateRange.period_start.date
+    )
+    const newEnd = dayjs().toISOString()
+    const newStart = dayjs().subtract(duration, 'milliseconds').toISOString()
+
+    updateDateRange(newStart, newEnd)
+
+    queryClient.invalidateQueries(['projects', ref, 'report-v2'])
 
     refetch()
     setTimeout(() => setIsRefreshing(false), 1000)


### PR DESCRIPTION
- moves usage queries to 1 query

Having different queries for each makes it difficult to always have the same number of data points and timestamps in the final data, specially after transformations, by moving it to 1 query we make sure the 4 related charts have the same data, and comparing the different metrics more robust.

- fixes refresh