### PR TITLE
feat: add toggle password visibility logic and icon

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -18,6 +18,7 @@ import { auth, buildPathWithParams, getReturnToPath } from 'lib/gotrue'
 import { Button, Form_Shadcn_, FormControl_Shadcn_, FormField_Shadcn_, Input_Shadcn_ } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { LastSignInWrapper } from './LastSignInWrapper'
+import { Eye, EyeOff } from 'lucide-react'
 
 const schema = z.object({
   email: z.string().min(1, 'Email is required').email('Must be a valid email'),
@@ -30,6 +31,8 @@ export const SignInForm = () => {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [_, setLastSignIn] = useLastSignIn()
+
+  const [passwordHidden, setPasswordHidden] = useState(true)
 
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const captchaRef = useRef<HCaptcha>(null)
@@ -146,14 +149,26 @@ export const SignInForm = () => {
             render={({ field }) => (
               <FormItemLayout name="password" label="Password">
                 <FormControl_Shadcn_>
-                  <Input_Shadcn_
-                    id="password"
-                    type="password"
-                    autoComplete="current-password"
-                    {...field}
-                    placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;"
-                    disabled={isSubmitting}
-                  />
+                  <div className="relative">
+                    <Input_Shadcn_
+                      id="password"
+                      type={passwordHidden ? 'password' : 'text'}
+                      autoComplete="current-password"
+                      {...field}
+                      placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;"
+                      disabled={isSubmitting}
+                      className="pr-10"
+                    />
+                    <Button
+                      type="default"
+                      title={passwordHidden ? `Show password` : `Hide password`}
+                      aria-label={passwordHidden ? `Show password` : `Hide password`}
+                      className="absolute right-1 top-1 px-1.5"
+                      icon={passwordHidden ? <Eye /> : <EyeOff />}
+                      disabled={isSubmitting}
+                      onClick={() => setPasswordHidden((prev) => !prev)}
+                    />
+                  </div>
                 </FormControl_Shadcn_>
               </FormItemLayout>
             )}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

PR adds toggle password functionality to the sign-in form

## What is the current behavior?

Closes #39396 

Currently, the form lacks the toggle password visibility functionality.

## What is the new behavior?

The password field/input can toggle visibility.

<img width="3234" height="920" alt="Screenshot 2025-10-09 at 18 02 38" src="https://github.com/user-attachments/assets/b3fa788d-a10e-40bd-9a85-f5fe8a779be1" />

<img width="3218" height="844" alt="Screenshot 2025-10-09 at 18 02 46" src="https://github.com/user-attachments/assets/6be093b3-c237-430d-95dc-9d7bd342d6ea" />

## Additional context

N/A
