### PR TITLE
chore: missing address stronger wording

### DIFF
--- a/apps/studio/components/interfaces/Organization/restriction.constants.ts
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.ts
@@ -24,6 +24,6 @@ export const RESTRICTION_MESSAGES = {
   MISSING_BILLING_INFO: {
     title: 'Missing Billing Information',
     message:
-      'Please add a billing address. If you are a registered business, please add a tax ID too.',
+      'Please add a billing address to avoid restrictions. If you are a registered business, please add a tax ID too.',
   },
 } as const

--- a/apps/studio/hooks/misc/useOrganizationRestrictions.ts
+++ b/apps/studio/hooks/misc/useOrganizationRestrictions.ts
@@ -44,7 +44,7 @@ export function useOrganizationRestrictions() {
     !org.billing_partner
   ) {
     warnings.push({
-      type: 'warning',
+      type: 'danger',
       title: RESTRICTION_MESSAGES.MISSING_BILLING_INFO.title,
       message: RESTRICTION_MESSAGES.MISSING_BILLING_INFO.message,
       link: `/org/${org?.slug}/billing#address`,


### PR DESCRIPTION
Still 30k paying customers with missing address - changing the language to be a bit harsher + showing as danger instead of warning
