### PR TITLE
chore(studio): better new org and project forms

### DIFF
--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -242,9 +242,9 @@ const NewPaymentMethodElement = forwardRef(
     }, [availableTaxIds, stripeAddress])
 
     return (
-      <div className="space-y-4">
-        <p className="text-sm text-foreground-light mb-2">
-          Please ensure CVC and postal codes match what is on file for your card.
+      <div className="space-y-2">
+        <p className="text-sm text-foreground-lighter">
+          Please ensure CVC and postal codes match what’s on file for your card.
         </p>
 
         <PaymentElement
@@ -256,14 +256,14 @@ const NewPaymentMethodElement = forwardRef(
         />
 
         {fullyLoaded && (
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center space-x-2 py-4">
             <Checkbox_Shadcn_
               id="business"
               checked={purchasingAsBusiness}
               onCheckedChange={() => setPurchasingAsBusiness(!purchasingAsBusiness)}
             />
-            <label htmlFor="business" className="text-foreground-light text-sm leading-none">
-              I'm purchasing as a business
+            <label htmlFor="business" className="text-foreground text-sm leading-none">
+              I’m purchasing as a business
             </label>
           </div>
         )}

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -389,6 +389,10 @@ export const NewOrgForm = ({
                         autoFocus
                         type="text"
                         placeholder="Organization name"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
+                        data-bwignore
                         {...field}
                       />
                     </FormControl_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -578,53 +578,62 @@ export const NewOrgForm = ({
         >
           <p className="text-sm text-foreground-light">
             Supabase{' '}
-            <InlineLink href="https://supabase.com/docs/guides/platform/billing-on-supabase">
+            <InlineLink
+              href="https://supabase.com/docs/guides/platform/billing-on-supabase"
+              target="_blank"
+              rel="noreferrer"
+              className="text-inherit hover:text-foreground transition-colors"
+            >
               bills per organization
             </InlineLink>
             . If you want to upgrade your existing projects, upgrade your existing organization
             instead.
           </p>
 
-          <ul className="mt-4 space-y-6">
+          <ul className="mt-4 divide-y divide-border-muted border-t border-t-border-muted">
             {freeOrgs
               .filter((it) => projectsByOrg[it.slug]?.length > 0)
               .map((org) => {
                 const orgProjects = projectsByOrg[org.slug].map((it) => it.name)
 
                 return (
-                  <li key={`org_${org.slug}`}>
-                    <div className="flex justify-between text-sm">
-                      <span>{org.name}</span>
-                      <Button asChild type="primary" size="tiny">
-                        <Link href={`/org/${org.slug}/billing?panel=subscriptionPlan`}>
-                          Change Plan
-                        </Link>
-                      </Button>
+                  <li
+                    key={`org_${org.slug}`}
+                    className="pt-3 [&:not(:last-child)]:pb-3 flex items-center justify-between"
+                  >
+                    <div className="flex flex-col">
+                      <h3 className="text-sm">{org.name}</h3>
+
+                      <div className="text-foreground-lighter text-xs">
+                        {orgProjects.length <= 2 ? (
+                          <span>{orgProjects.join(' and ')}</span>
+                        ) : (
+                          <div>
+                            {orgProjects.slice(0, 2).join(', ')} and{' '}
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="underline decoration-dotted">
+                                  {orgProjects.length - 2} other{' '}
+                                  {orgProjects.length === 3 ? 'project' : 'project'}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <ul className="list-disc list-inside">
+                                  {orgProjects.slice(2).map((project) => (
+                                    <li>{project}</li>
+                                  ))}
+                                </ul>
+                              </TooltipContent>
+                            </Tooltip>
+                          </div>
+                        )}
+                      </div>
                     </div>
-                    <div className="text-foreground-light text-xs">
-                      {orgProjects.length <= 2 ? (
-                        <span>{orgProjects.join(' and ')}</span>
-                      ) : (
-                        <div>
-                          {orgProjects.slice(0, 2).join(', ')} and{' '}
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="underline decoration-dotted">
-                                {orgProjects.length - 2} other{' '}
-                                {orgProjects.length === 3 ? 'project' : 'project'}
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <ul className="list-disc list-inside">
-                                {orgProjects.slice(2).map((project) => (
-                                  <li>{project}</li>
-                                ))}
-                              </ul>
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
-                      )}
-                    </div>
+                    <Button asChild type="default" size="tiny">
+                      <Link href={`/org/${org.slug}/billing?panel=subscriptionPlan`}>
+                        Change plan
+                      </Link>
+                    </Button>
                   </li>
                 )
               })}

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -185,11 +185,11 @@ export const NewOrgForm = ({
 
   useEffect(() => {
     const currentName = form.getValues('name')
-    if (!currentName && organizations?.length === 0 && !user.isLoading) {
+    if (!currentName && isSuccess && organizations?.length === 0 && user.isSuccess) {
       const prefilledOrgName = user.profile?.username ? user.profile.username + `'s Org` : 'My Org'
       form.setValue('name', prefilledOrgName)
     }
-  }, [isSuccess, form, organizations?.length, user.isLoading, user.profile?.username])
+  }, [isSuccess, form, organizations?.length, user.profile?.username, user.isSuccess])
 
   const [newOrgLoading, setNewOrgLoading] = useState(false)
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>()

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -373,7 +373,7 @@ export const NewOrgForm = ({
           footerClasses="rounded-b-md"
         >
           <div className="divide-y divide-border-muted">
-            <Panel.Content className="Form section-block--body has-inputs-centered">
+            <Panel.Content>
               <FormField_Shadcn_
                 control={form.control}
                 name="name"
@@ -395,7 +395,7 @@ export const NewOrgForm = ({
                 )}
               />
             </Panel.Content>
-            <Panel.Content className="Form section-block--body has-inputs-centered">
+            <Panel.Content>
               <FormField_Shadcn_
                 control={form.control}
                 name="kind"
@@ -426,7 +426,7 @@ export const NewOrgForm = ({
             </Panel.Content>
 
             {form.watch('kind') == 'COMPANY' && (
-              <Panel.Content className="Form section-block--body has-inputs-centered">
+              <Panel.Content>
                 <FormField_Shadcn_
                   control={form.control}
                   name="size"

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -8,8 +8,8 @@ import { parseAsString, useQueryStates } from 'nuqs'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
-
 import { loadStripe } from '@stripe/stripe-js'
+import { Form_Shadcn_ } from 'ui'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { getStripeElementsAppearanceOptions } from 'components/interfaces/Billing/Payment/Payment.utils'
 import { PaymentConfirmation } from 'components/interfaces/Billing/Payment/PaymentConfirmation'
@@ -333,334 +333,333 @@ export const NewOrgForm = ({
   }
 
   return (
-    <form onSubmit={onSubmitWithOrgCreation}>
-      <Panel
-        title={
-          <div key="panel-title">
-            <h4>Create a new organization</h4>
-          </div>
-        }
-        footer={
-          <div key="panel-footer" className="flex w-full items-center justify-between">
-            <Button
-              type="default"
-              disabled={newOrgLoading || paymentConfirmationLoading}
-              onClick={() => {
-                if (!!lastVisitedOrganization) router.push(`/org/${lastVisitedOrganization}`)
-                else router.push('/organizations')
-              }}
-            >
-              Cancel
-            </Button>
-            <div className="flex items-center space-x-3">
-              <p className="text-xs text-foreground-lighter">
-                You can rename your organization later
+    <Form_Shadcn_ {...formState}>
+      <form onSubmit={onSubmitWithOrgCreation}>
+        <Panel
+          title={
+            <div key="panel-title">
+              <h3>Create a new organization</h3>
+              <p className="text-sm text-foreground-lighter text-balance">
+                This is your organization within Supabase. You could use the name of your company or
+                department, for example.
               </p>
+            </div>
+          }
+          footer={
+            <div key="panel-footer" className="flex w-full items-center justify-between">
               <Button
-                htmlType="submit"
-                type="primary"
-                loading={newOrgLoading}
-                disabled={newOrgLoading}
+                type="default"
+                disabled={newOrgLoading || paymentConfirmationLoading}
+                onClick={() => {
+                  if (!!lastVisitedOrganization) router.push(`/org/${lastVisitedOrganization}`)
+                  else router.push('/organizations')
+                }}
               >
-                Create organization
+                Cancel
               </Button>
-            </div>
-          </div>
-        }
-        className="overflow-visible"
-      >
-        <Panel.Content>
-          <p className="text-sm">This is your organization within Supabase.</p>
-          <p className="text-sm text-foreground-light">
-            For example, you can use the name of your company or department.
-          </p>
-        </Panel.Content>
-        <Panel.Content className="Form section-block--body has-inputs-centered">
-          <div className="grid grid-cols-3 w-full">
-            <div>
-              <Label_Shadcn_ htmlFor="name">Name</Label_Shadcn_>
-            </div>
-            <div className="col-span-2">
-              <Input_Shadcn_
-                id="name"
-                autoFocus
-                type="text"
-                placeholder="Organization name"
-                value={formState.name}
-                onChange={(e) => updateForm('name', e.target.value)}
-              />
-              <div className="mt-1">
-                <Label_Shadcn_
-                  htmlFor="name"
-                  className="text-foreground-lighter leading-normal text-sm"
+              <div className="flex items-center space-x-3">
+                <p className="text-xs text-foreground-lighter">
+                  You can rename your organization later
+                </p>
+                <Button
+                  htmlType="submit"
+                  type="primary"
+                  loading={newOrgLoading}
+                  disabled={newOrgLoading}
                 >
-                  What's the name of your company or team?
-                </Label_Shadcn_>
+                  Create organization
+                </Button>
               </div>
             </div>
-          </div>
-        </Panel.Content>
-        <Panel.Content className="Form section-block--body has-inputs-centered">
-          <div className="grid grid-cols-3">
-            <div>
-              <Label_Shadcn_ htmlFor="kind">Type</Label_Shadcn_>
-            </div>
-            <div className="col-span-2">
-              <Select_Shadcn_
-                value={formState.kind}
-                onValueChange={(value) => updateForm('kind', value)}
-              >
-                <SelectTrigger_Shadcn_ id="kind" className="w-full">
-                  <SelectValue_Shadcn_ />
-                </SelectTrigger_Shadcn_>
-
-                <SelectContent_Shadcn_>
-                  {Object.entries(ORG_KIND_TYPES).map(([k, v]) => (
-                    <SelectItem_Shadcn_ key={k} value={k}>
-                      {v}
-                    </SelectItem_Shadcn_>
-                  ))}
-                </SelectContent_Shadcn_>
-              </Select_Shadcn_>
-
-              <div className="mt-1">
-                <Label_Shadcn_
-                  htmlFor="kind"
-                  className="text-foreground-lighter leading-normal text-sm"
-                >
-                  What would best describe your organization?
-                </Label_Shadcn_>
-              </div>
-            </div>
-          </div>
-        </Panel.Content>
-
-        {formState.kind == 'COMPANY' && (
-          <Panel.Content className="Form section-block--body has-inputs-centered">
-            <div className="grid grid-cols-3">
-              <div>
-                <Label_Shadcn_ htmlFor="size">Company size</Label_Shadcn_>
-              </div>
-              <div className="col-span-2">
-                <Select_Shadcn_
-                  value={formState.size}
-                  onValueChange={(value) => updateForm('size', value)}
-                >
-                  <SelectTrigger_Shadcn_ id="size" className="w-full">
-                    <SelectValue_Shadcn_ />
-                  </SelectTrigger_Shadcn_>
-
-                  <SelectContent_Shadcn_>
-                    {Object.entries(ORG_SIZE_TYPES).map(([k, v]) => (
-                      <SelectItem_Shadcn_ key={k} value={k}>
-                        {v}
-                      </SelectItem_Shadcn_>
-                    ))}
-                  </SelectContent_Shadcn_>
-                </Select_Shadcn_>
-
-                <div className="mt-2">
-                  <Label_Shadcn_
-                    htmlFor="size"
-                    className="text-foreground-lighter leading-normal text-sm"
-                  >
-                    How many people are in your company?
-                  </Label_Shadcn_>
+          }
+        >
+          <div className="divide-y divide-border-muted">
+            <Panel.Content className="Form section-block--body has-inputs-centered">
+              <div className="grid grid-cols-3 w-full">
+                <div>
+                  <Label_Shadcn_ htmlFor="name">Name</Label_Shadcn_>
+                </div>
+                <div className="col-span-2">
+                  <Input_Shadcn_
+                    id="name"
+                    autoFocus
+                    type="text"
+                    placeholder="Organization name"
+                    value={formState.name}
+                    onChange={(e) => updateForm('name', e.target.value)}
+                  />
+                  <div className="mt-1">
+                    <Label_Shadcn_
+                      htmlFor="name"
+                      className="text-foreground-lighter leading-normal text-sm"
+                    >
+                      What's the name of your company or team?
+                    </Label_Shadcn_>
+                  </div>
                 </div>
               </div>
-            </div>
-          </Panel.Content>
-        )}
-
-        {isBillingEnabled && (
-          <Panel.Content>
-            <div className="grid grid-cols-3">
-              <div className="flex flex-col gap-2">
-                <Label_Shadcn_ htmlFor="plan" className=" text-sm">
-                  Plan
-                </Label_Shadcn_>
-
-                <a
-                  href="https://supabase.com/pricing"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="text-sm flex items-center gap-2 opacity-75 hover:opacity-100 transition"
-                >
-                  Pricing
-                  <ExternalLink size={16} strokeWidth={1.5} />
-                </a>
-              </div>
-              <div className="col-span-2">
-                <Select_Shadcn_
-                  value={formState.plan}
-                  onValueChange={(value) => {
-                    updateForm('plan', value)
-                    onPlanSelected(value)
-                  }}
-                >
-                  <SelectTrigger_Shadcn_ id="plan" className="w-full">
-                    <SelectValue_Shadcn_ />
-                  </SelectTrigger_Shadcn_>
-
-                  <SelectContent_Shadcn_>
-                    {Object.entries(PRICING_TIER_LABELS_ORG).map(([k, v]) => (
-                      <SelectItem_Shadcn_ key={k} value={k} translate="no">
-                        {v}
-                      </SelectItem_Shadcn_>
-                    ))}
-                  </SelectContent_Shadcn_>
-                </Select_Shadcn_>
-
-                <div className="mt-1">
-                  <Label_Shadcn_
-                    htmlFor="plan"
-                    className="text-foreground-lighter leading-normal text-sm"
-                  >
-                    The Plan applies to your new organization.
-                  </Label_Shadcn_>
-                </div>
-              </div>
-            </div>
-          </Panel.Content>
-        )}
-
-        {formState.plan === 'PRO' && (
-          <>
-            <Panel.Content className="border-b border-panel-border-interior-light dark:border-panel-border-interior-dark">
+            </Panel.Content>
+            <Panel.Content className="Form section-block--body has-inputs-centered">
               <div className="grid grid-cols-3">
-                <div className="col-span-1 flex space-x-2 text-sm">
-                  <Label_Shadcn_ htmlFor="spend-cap" className=" leading-normal">
-                    Spend Cap
-                  </Label_Shadcn_>
-
-                  <HelpCircle
-                    size={16}
-                    strokeWidth={1.5}
-                    className="transition opacity-50 cursor-pointer hover:opacity-100"
-                    onClick={() => setShowSpendCapHelperModal(true)}
-                  />
+                <div>
+                  <Label_Shadcn_ htmlFor="kind">Type</Label_Shadcn_>
                 </div>
-                <div className="col-span-2 flex items-center space-x-2">
-                  <Switch
-                    id="spend-cap"
-                    checked={formState.spend_cap}
-                    onCheckedChange={() => updateForm('spend_cap', !formState.spend_cap)}
-                  />
-                  <Label_Shadcn_ htmlFor="spend-cap">
-                    {formState.spend_cap
-                      ? `Usage is limited to the plan's quota.`
-                      : `You pay for overages beyond the plan's quota.`}
-                  </Label_Shadcn_>
+                <div className="col-span-2">
+                  <Select_Shadcn_
+                    value={formState.kind}
+                    onValueChange={(value) => updateForm('kind', value)}
+                  >
+                    <SelectTrigger_Shadcn_ id="kind" className="w-full">
+                      <SelectValue_Shadcn_ />
+                    </SelectTrigger_Shadcn_>
+
+                    <SelectContent_Shadcn_>
+                      {Object.entries(ORG_KIND_TYPES).map(([k, v]) => (
+                        <SelectItem_Shadcn_ key={k} value={k}>
+                          {v}
+                        </SelectItem_Shadcn_>
+                      ))}
+                    </SelectContent_Shadcn_>
+                  </Select_Shadcn_>
+
+                  <div className="mt-1">
+                    <Label_Shadcn_
+                      htmlFor="kind"
+                      className="text-foreground-lighter leading-normal text-sm"
+                    >
+                      What would best describe your organization?
+                    </Label_Shadcn_>
+                  </div>
                 </div>
               </div>
             </Panel.Content>
 
-            <SpendCapModal
-              visible={showSpendCapHelperModal}
-              onHide={() => setShowSpendCapHelperModal(false)}
-            />
-          </>
-        )}
+            {formState.kind == 'COMPANY' && (
+              <Panel.Content className="Form section-block--body has-inputs-centered">
+                <div className="grid grid-cols-3">
+                  <div>
+                    <Label_Shadcn_ htmlFor="size">Company size</Label_Shadcn_>
+                  </div>
+                  <div className="col-span-2">
+                    <Select_Shadcn_
+                      value={formState.size}
+                      onValueChange={(value) => updateForm('size', value)}
+                    >
+                      <SelectTrigger_Shadcn_ id="size" className="w-full">
+                        <SelectValue_Shadcn_ />
+                      </SelectTrigger_Shadcn_>
 
-        {setupIntent && formState.plan !== 'FREE' && (
-          <Panel.Content>
-            <Elements stripe={stripePromise} options={stripeOptionsPaymentMethod}>
-              <Panel.Content>
-                <NewPaymentMethodElement
-                  ref={paymentRef}
-                  email={user.profile?.primary_email}
-                  readOnly={newOrgLoading || paymentConfirmationLoading}
-                />
+                      <SelectContent_Shadcn_>
+                        {Object.entries(ORG_SIZE_TYPES).map(([k, v]) => (
+                          <SelectItem_Shadcn_ key={k} value={k}>
+                            {v}
+                          </SelectItem_Shadcn_>
+                        ))}
+                      </SelectContent_Shadcn_>
+                    </Select_Shadcn_>
+
+                    <div className="mt-2">
+                      <Label_Shadcn_
+                        htmlFor="size"
+                        className="text-foreground-lighter leading-normal text-sm"
+                      >
+                        How many people are in your company?
+                      </Label_Shadcn_>
+                    </div>
+                  </div>
+                </div>
               </Panel.Content>
-            </Elements>
-          </Panel.Content>
+            )}
+
+            {isBillingEnabled && (
+              <Panel.Content>
+                <div className="grid grid-cols-3">
+                  <Label_Shadcn_ htmlFor="plan" className=" text-sm">
+                    Plan
+                  </Label_Shadcn_>
+
+                  <div className="col-span-2">
+                    <Select_Shadcn_
+                      value={formState.plan}
+                      onValueChange={(value) => {
+                        updateForm('plan', value)
+                        onPlanSelected(value)
+                      }}
+                    >
+                      <SelectTrigger_Shadcn_ id="plan" className="w-full">
+                        <SelectValue_Shadcn_ />
+                      </SelectTrigger_Shadcn_>
+
+                      <SelectContent_Shadcn_>
+                        {Object.entries(PRICING_TIER_LABELS_ORG).map(([k, v]) => (
+                          <SelectItem_Shadcn_ key={k} value={k} translate="no">
+                            {v}
+                          </SelectItem_Shadcn_>
+                        ))}
+                      </SelectContent_Shadcn_>
+                    </Select_Shadcn_>
+
+                    <div className="mt-1">
+                      <Label_Shadcn_
+                        htmlFor="plan"
+                        className="text-foreground-lighter leading-normal text-sm"
+                      >
+                        Which plan fits your organization’s needs best?{' '}
+                        <InlineLink
+                          href="https://supabase.com/pricing"
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-inherit hover:text-foreground transition-colors"
+                        >
+                          More information
+                        </InlineLink>
+                        .
+                      </Label_Shadcn_>
+                    </div>
+                  </div>
+                </div>
+              </Panel.Content>
+            )}
+
+            {formState.plan === 'PRO' && (
+              <>
+                <Panel.Content className="border-b border-panel-border-interior-light dark:border-panel-border-interior-dark">
+                  <div className="grid grid-cols-3">
+                    <div className="col-span-1 flex space-x-2 text-sm">
+                      <Label_Shadcn_ htmlFor="spend-cap" className=" leading-normal">
+                        Spend Cap
+                      </Label_Shadcn_>
+
+                      <HelpCircle
+                        size={16}
+                        strokeWidth={1.5}
+                        className="transition opacity-50 cursor-pointer hover:opacity-100"
+                        onClick={() => setShowSpendCapHelperModal(true)}
+                      />
+                    </div>
+                    <div className="col-span-2 flex items-center space-x-2">
+                      <Switch
+                        id="spend-cap"
+                        checked={formState.spend_cap}
+                        onCheckedChange={() => updateForm('spend_cap', !formState.spend_cap)}
+                      />
+                      <Label_Shadcn_ htmlFor="spend-cap">
+                        {formState.spend_cap
+                          ? `Usage is limited to the plan's quota.`
+                          : `You pay for overages beyond the plan's quota.`}
+                      </Label_Shadcn_>
+                    </div>
+                  </div>
+                </Panel.Content>
+
+                <SpendCapModal
+                  visible={showSpendCapHelperModal}
+                  onHide={() => setShowSpendCapHelperModal(false)}
+                />
+              </>
+            )}
+
+            {setupIntent && formState.plan !== 'FREE' && (
+              <Panel.Content>
+                <Elements stripe={stripePromise} options={stripeOptionsPaymentMethod}>
+                  <Panel.Content>
+                    <NewPaymentMethodElement
+                      ref={paymentRef}
+                      email={user.profile?.primary_email}
+                      readOnly={newOrgLoading || paymentConfirmationLoading}
+                    />
+                  </Panel.Content>
+                </Elements>
+              </Panel.Content>
+            )}
+          </div>
+        </Panel>
+
+        <ConfirmationModal
+          size="large"
+          loading={newOrgLoading}
+          visible={isOrgCreationConfirmationModalVisible}
+          title="Confirm organization creation"
+          confirmLabel="Create new organization"
+          onCancel={() => setIsOrgCreationConfirmationModalVisible(false)}
+          onConfirm={async () => {
+            await handleSubmit()
+            setIsOrgCreationConfirmationModalVisible(false)
+          }}
+          variant={'warning'}
+        >
+          <p className="text-sm text-foreground-light">
+            Supabase{' '}
+            <InlineLink href="https://supabase.com/docs/guides/platform/billing-on-supabase">
+              bills per organization
+            </InlineLink>
+            . If you want to upgrade your existing projects, upgrade your existing organization
+            instead.
+          </p>
+
+          <ul className="mt-4 space-y-6">
+            {freeOrgs
+              .filter((it) => projectsByOrg[it.slug]?.length > 0)
+              .map((org) => {
+                const orgProjects = projectsByOrg[org.slug].map((it) => it.name)
+
+                return (
+                  <li key={`org_${org.slug}`}>
+                    <div className="flex justify-between text-sm">
+                      <span>{org.name}</span>
+                      <Button asChild type="primary" size="tiny">
+                        <Link href={`/org/${org.slug}/billing?panel=subscriptionPlan`}>
+                          Change Plan
+                        </Link>
+                      </Button>
+                    </div>
+                    <div className="text-foreground-light text-xs">
+                      {orgProjects.length <= 2 ? (
+                        <span>{orgProjects.join(' and ')}</span>
+                      ) : (
+                        <div>
+                          {orgProjects.slice(0, 2).join(', ')} and{' '}
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="underline decoration-dotted">
+                                {orgProjects.length - 2} other{' '}
+                                {orgProjects.length === 3 ? 'project' : 'project'}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <ul className="list-disc list-inside">
+                                {orgProjects.slice(2).map((project) => (
+                                  <li>{project}</li>
+                                ))}
+                              </ul>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                )
+              })}
+          </ul>
+        </ConfirmationModal>
+
+        {stripePromise && paymentIntentSecret && paymentMethod && (
+          <Elements stripe={stripePromise} options={stripeOptionsConfirm}>
+            <PaymentConfirmation
+              paymentIntentSecret={paymentIntentSecret}
+              onPaymentIntentConfirm={(paymentIntentConfirmation) =>
+                paymentIntentConfirmed(paymentIntentConfirmation)
+              }
+              onLoadingChange={(loading) => setPaymentConfirmationLoading(loading)}
+              onError={(err) => {
+                toast.error(err.message, { duration: 10_000 })
+                setNewOrgLoading(false)
+                resetPaymentMethod()
+              }}
+            />
+          </Elements>
         )}
-      </Panel>
-
-      <ConfirmationModal
-        size="large"
-        loading={newOrgLoading}
-        visible={isOrgCreationConfirmationModalVisible}
-        title="Confirm organization creation"
-        confirmLabel="Create new organization"
-        onCancel={() => setIsOrgCreationConfirmationModalVisible(false)}
-        onConfirm={async () => {
-          await handleSubmit()
-          setIsOrgCreationConfirmationModalVisible(false)
-        }}
-        variant={'warning'}
-      >
-        <p className="text-sm text-foreground-light">
-          Supabase{' '}
-          <InlineLink href="https://supabase.com/docs/guides/platform/billing-on-supabase">
-            bills per organization
-          </InlineLink>
-          . If you want to upgrade your existing projects, upgrade your existing organization
-          instead.
-        </p>
-
-        <ul className="mt-4 space-y-6">
-          {freeOrgs
-            .filter((it) => projectsByOrg[it.slug]?.length > 0)
-            .map((org) => {
-              const orgProjects = projectsByOrg[org.slug].map((it) => it.name)
-
-              return (
-                <li key={`org_${org.slug}`}>
-                  <div className="flex justify-between text-sm">
-                    <span>{org.name}</span>
-                    <Button asChild type="primary" size="tiny">
-                      <Link href={`/org/${org.slug}/billing?panel=subscriptionPlan`}>
-                        Change Plan
-                      </Link>
-                    </Button>
-                  </div>
-                  <div className="text-foreground-light text-xs">
-                    {orgProjects.length <= 2 ? (
-                      <span>{orgProjects.join(' and ')}</span>
-                    ) : (
-                      <div>
-                        {orgProjects.slice(0, 2).join(', ')} and{' '}
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="underline decoration-dotted">
-                              {orgProjects.length - 2} other{' '}
-                              {orgProjects.length === 3 ? 'project' : 'project'}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <ul className="list-disc list-inside">
-                              {orgProjects.slice(2).map((project) => (
-                                <li>{project}</li>
-                              ))}
-                            </ul>
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                    )}
-                  </div>
-                </li>
-              )
-            })}
-        </ul>
-      </ConfirmationModal>
-
-      {stripePromise && paymentIntentSecret && paymentMethod && (
-        <Elements stripe={stripePromise} options={stripeOptionsConfirm}>
-          <PaymentConfirmation
-            paymentIntentSecret={paymentIntentSecret}
-            onPaymentIntentConfirm={(paymentIntentConfirmation) =>
-              paymentIntentConfirmed(paymentIntentConfirmation)
-            }
-            onLoadingChange={(loading) => setPaymentConfirmationLoading(loading)}
-            onError={(err) => {
-              toast.error(err.message, { duration: 10_000 })
-              setNewOrgLoading(false)
-              resetPaymentMethod()
-            }}
-          />
-        </Elements>
-      )}
-    </form>
+      </form>
+    </Form_Shadcn_>
   )
 }

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -370,6 +370,7 @@ export const NewOrgForm = ({
           // Allow address dropdown in Stripe Elements to overflow the panel
           noHideOverflow
           // Prevent resulting rounded corners in footer being clipped by squared corners of bg
+          titleClasses="rounded-t-md"
           footerClasses="rounded-b-md"
         >
           <div className="divide-y divide-border-muted">

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -367,6 +367,10 @@ export const NewOrgForm = ({
               </Button>
             </div>
           }
+          // Allow address dropdown in Stripe Elements to overflow the panel
+          noHideOverflow
+          // Prevent resulting rounded corners in footer being clipped by squared corners of bg
+          footerClasses="rounded-b-md"
         >
           <div className="divide-y divide-border-muted">
             <Panel.Content className="Form section-block--body has-inputs-centered">

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -381,7 +381,7 @@ export const NewOrgForm = ({
                   <FormItemLayout
                     label="Name"
                     layout="horizontal"
-                    description="What's the name of your company or team? You can change this name later."
+                    description="What's the name of your company or team? You can change this later."
                   >
                     <FormControl_Shadcn_>
                       <Input_Shadcn_

--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -29,7 +29,7 @@ export const OrgNotFound = ({ slug }: { slug?: string }) => {
         </Admonition>
       )}
 
-      <h3 className="text-sm">Select an organization to create your new project from</h3>
+      <h3 className="text-sm">Select an organization to create your new project in</h3>
 
       <div className="grid gap-2 grid-cols-2">
         {isOrganizationsLoading && (

--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -147,7 +147,7 @@ export const SecurityOptions = ({
         />
       )}
       <p className="text-xs text-foreground-lighter mt-3">
-        These settings can be changed after the project is created via the project's settings
+        These two security options can be changed after your project is created
       </p>
     </>
   )

--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -13,6 +13,7 @@ interface PanelProps {
   wrapWithLoading?: boolean
   noHideOverflow?: boolean
   titleClasses?: string
+  footerClasses?: string
 }
 
 /**
@@ -41,7 +42,7 @@ function Panel(props: PropsWithChildren<PanelProps>) {
         </div>
       )}
       {props.children}
-      {props.footer && <Footer>{props.footer}</Footer>}
+      {props.footer && <Footer className={props.footerClasses}>{props.footer}</Footer>}
     </div>
   )
 
@@ -56,9 +57,9 @@ function Content({ children, className }: { children: ReactNode; className?: str
   return <div className={cn('px-4 py-4', className)}>{children}</div>
 }
 
-function Footer({ children }: { children: ReactNode; className?: string }) {
+function Footer({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className="bg-surface-100 border-t border-default">
+    <div className={cn('bg-surface-100 border-t border-default', className)}>
       <div className="flex h-12 items-center px-4">{children}</div>
     </div>
   )

--- a/apps/studio/components/ui/PasswordStrengthBar.tsx
+++ b/apps/studio/components/ui/PasswordStrengthBar.tsx
@@ -39,7 +39,7 @@ const PasswordStrengthBar = ({
           ? passwordStrengthMessage
           : 'This is the password to your Postgres database, so it must be strong and hard to guess.'}{' '}
         <span
-          className="text-foreground opacity-50 underline hover:opacity-100 transition cursor-pointer"
+          className="text-inherit underline hover:text-foreground transition-colors cursor-pointer"
           onClick={generateStrongPassword}
         >
           Generate a password

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -751,38 +751,30 @@ const Wizard: NextPageWithLayout = () => {
                           render={({ field }) => (
                             <FormItemLayout
                               layout="horizontal"
-                              label={
-                                <div className="flex flex-col gap-y-4">
-                                  <span>Compute size</span>
-
-                                  <div className="flex flex-col gap-y-2">
-                                    <Link
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      href={`${DOCS_URL}/guides/platform/compute-add-ons`}
-                                    >
-                                      <div className="flex items-center space-x-2 opacity-75 hover:opacity-100 transition">
-                                        <p className="text-sm m-0">Compute add-ons</p>
-                                        <ExternalLink size={16} strokeWidth={1.5} />
-                                      </div>
-                                    </Link>
-                                    <Link
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
-                                    >
-                                      <div className="flex items-center space-x-2 opacity-75 hover:opacity-100 transition">
-                                        <p className="text-sm m-0">Compute billing</p>
-                                        <ExternalLink size={16} strokeWidth={1.5} />
-                                      </div>
-                                    </Link>
-                                  </div>
-                                </div>
-                              }
+                              label="Compute size"
                               description={
                                 <>
                                   <p>
                                     The size for your dedicated database. You can change this later.
+                                    Learn more about{' '}
+                                    <InlineLink
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-inherit hover:text-foreground transition-colors"
+                                      href={`${DOCS_URL}/guides/platform/compute-add-ons`}
+                                    >
+                                      compute add-ons
+                                    </InlineLink>{' '}
+                                    and{' '}
+                                    <InlineLink
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-inherit hover:text-foreground transition-colors"
+                                      href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
+                                    >
+                                      compute billing
+                                    </InlineLink>
+                                    .
                                   </p>
                                 </>
                               }

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -483,11 +483,9 @@ const Wizard: NextPageWithLayout = () => {
           title={
             <div key="panel-title">
               <h3>Create a new project</h3>
-              <p className="text-sm text-foreground-lighter">
-                Your project will have its own dedicated instance and full Postgres database.
-                <br />
-                An API will be set up so you can easily interact with your new database.
-                <br />
+              <p className="text-sm text-foreground-lighter text-balance">
+                Your project will have its own dedicated instance and full Postgres database. An API
+                will be set up so you can easily interact with your new database.
               </p>
             </div>
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI improvements

## What is the current behavior?

In general:
- The styling between New organization and New project were quite different
  - These are important parts to get right for new users
  - They flow on from each other, so inconsistencies are exacerbated

On the [New organization](https://supabase.com/dashboard/new) step specfically:
- The form’s rounded corners were getting clipped because we had `overflow-visible` set
  - Which was necessary for the Stripe address dropdown (for paid plans)
- Elements and copywriting a little scattered throughout
- Duplicative copywriting (e.g. about naming)

On the [New project](https://supabase.com/dashboard/new/_) step specifically:
- Room for improvement in terms of copywriting
- Elements and copywriting a little scattered throughout


## What is the new behavior?

| Before | After |
| --- | --- |
| <img width="1024" height="762" alt="Supabase" src="https://github.com/user-attachments/assets/f3c4d420-837a-4e16-b8be-a2fe0e0763c6" />| <img width="1024" height="762" alt="Supabase" src="https://github.com/user-attachments/assets/f846fda1-bcd8-4252-9e53-565c31f97fd7" /> |
| <img width="1024" height="762" alt="Supabase" src="https://github.com/user-attachments/assets/2defe6fd-ac86-47db-a2bc-4d3565cc3b47" /> | <img width="1024" height="762" alt="Supabase" src="https://github.com/user-attachments/assets/4bdaf2f9-6073-49ae-9c9f-2802a79775a2" /> |
| <img width="1024" height="762" alt="Supabase" src="https://github.com/user-attachments/assets/89a501dc-0917-474b-82e6-09798cae9c3b" /> | <img width="1024" height="762" alt="Supabase" src="https://github.com/user-attachments/assets/edc93e13-5a3c-466c-ad93-957c7162383f" /> |

## Additional context

The [New organization](https://supabase.com/dashboard/new) form was using older form components making it difficult to make changes (e.g. to a field label) without it having knock-on effects. To avoid resorting to hacks, I resorted to refactoring that component to use (I hope) the latest-and-greatest in forms. Please keep this in mind as you test; it’s not just a cosmetic change and therefore needs testing.



## To test

Please test the following. You can use the [Stripe test cards](https://docs.stripe.com/testing) to create a paid org on local.

- [ ] Creating an organization
  - [ ] Free
  - [ ] Pro
    - [ ] When there is already an existing organization (thus triggering the _Confirm organization creation_ dialog)
  - [ ] Team
- [ ] Creating a project