### PR TITLE
Remove has configured auth step

### DIFF
--- a/apps/studio/components/interfaces/HomeNew/GettingStarted/GettingStarted.utils.tsx
+++ b/apps/studio/components/interfaces/HomeNew/GettingStarted/GettingStarted.utils.tsx
@@ -37,7 +37,6 @@ export const getCodeWorkflowSteps = ({
     hasCliSetup,
     hasSampleData,
     hasRlsPolicies,
-    hasConfiguredAuth,
     hasAppConnected,
     hasFirstUser,
     hasStorageObjects,
@@ -139,15 +138,6 @@ export const getCodeWorkflowSteps = ({
             ),
         },
       ],
-    },
-    {
-      key: 'setup-auth',
-      status: hasConfiguredAuth ? 'complete' : 'incomplete',
-      title: 'Allow user signups',
-      icon: <User strokeWidth={1} className="text-foreground-muted" size={16} />,
-      description:
-        "It's time to configure your authentication providers and settings for Supabase Auth, so jump into the configuration page and tailor the providers you need.",
-      actions: [{ label: 'Configure', href: `/project/${ref}/auth/providers`, variant: 'default' }],
     },
     {
       key: 'connect-app',
@@ -321,17 +311,6 @@ export const getNoCodeWorkflowSteps = ({
               'Generate RLS policies for my existing tables in the public schema. '
             ),
         },
-      ],
-    },
-    {
-      key: 'setup-auth',
-      status: hasConfiguredAuth ? 'complete' : 'incomplete',
-      title: 'Allow user signups',
-      icon: <User strokeWidth={1} className="text-foreground-muted" size={16} />,
-      description:
-        "It's time to set up authentication so you can start signing up users, configuring providers and settings from the auth dashboard.",
-      actions: [
-        { label: 'Configure auth', href: `/project/${ref}/auth/providers`, variant: 'default' },
       ],
     },
     {

--- a/apps/studio/components/interfaces/HomeNew/GettingStarted/GettingStarted.utils.tsx
+++ b/apps/studio/components/interfaces/HomeNew/GettingStarted/GettingStarted.utils.tsx
@@ -236,7 +236,6 @@ export const getNoCodeWorkflowSteps = ({
     hasTables,
     hasSampleData,
     hasRlsPolicies,
-    hasConfiguredAuth,
     hasAppConnected,
     hasFirstUser,
     hasStorageObjects,

--- a/apps/studio/components/interfaces/HomeNew/GettingStarted/useGettingStartedProgress.ts
+++ b/apps/studio/components/interfaces/HomeNew/GettingStarted/useGettingStartedProgress.ts
@@ -18,7 +18,6 @@ type GettingStartedStatuses = {
   hasCliSetup: boolean
   hasSampleData: boolean
   hasRlsPolicies: boolean
-  hasConfiguredAuth: boolean
   hasAppConnected: boolean
   hasFirstUser: boolean
   hasStorageObjects: boolean
@@ -94,7 +93,6 @@ export const useGettingStartedProgress = (): GettingStartedStatuses => {
     const hasRlsPolicies = (policiesData?.length ?? 0) > 0
     const allowSignupsEnabled = authConfig ? !authConfig.DISABLE_SIGNUP : false
     const emailProviderEnabled = !!authConfig?.EXTERNAL_EMAIL_ENABLED
-    const hasConfiguredAuth = allowSignupsEnabled && emailProviderEnabled
     const hasFirstUser = !!usersCountData && !usersCountData.is_estimate && usersCountData.count > 0
     const hasStorageObjects = (storageTablesData ?? []).some(
       (table) => table.name === 'objects' && Number(table?.live_rows_estimate ?? 0) > 0
@@ -119,7 +117,6 @@ export const useGettingStartedProgress = (): GettingStartedStatuses => {
       hasCliSetup,
       hasSampleData,
       hasRlsPolicies,
-      hasConfiguredAuth,
       hasAppConnected,
       hasFirstUser,
       hasStorageObjects,


### PR DESCRIPTION
By default authentication (sign up/in) is enabled on new projects. In our new getting started section we were showing a step for enabling which could lead to confusion. Reduce steps by removing auth check and lean more into the sign up user step.