### PR TITLE
feat(prompts): add cursor prompt deeplinks to docs

### DIFF
--- a/apps/docs/app/guides/getting-started/ai-prompts/[slug]/AiPrompts.utils.ts
+++ b/apps/docs/app/guides/getting-started/ai-prompts/[slug]/AiPrompts.utils.ts
@@ -28,18 +28,28 @@ function parseMarkdown(markdown: string) {
     }
   })
 
+  return { heading, content: withoutFrontmatter }
+}
+
+/**
+ * Wraps content in a markdown code block.
+ *
+ * Uses `mdast` to ensure proper escaping of backticks within the content.
+ */
+export function wrapInMarkdownCodeBlock(content: string) {
+  const mdast = fromMarkdown(content)
+
   const codeBlock: Code = {
     type: 'code',
     lang: 'markdown',
-    value: markdown,
+    value: content,
   }
   const root: Root = {
     type: 'root',
     children: [codeBlock],
   }
-  const content = toMarkdown(root)
 
-  return { heading, content }
+  return toMarkdown(root)
 }
 
 async function getAiPromptsImpl() {
@@ -105,4 +115,29 @@ export async function generateAiPromptsStaticParams() {
       slug: prompt.filename,
     }
   })
+}
+
+/**
+ * Generates a deep link URL for Cursor that preloads the given prompt text.
+ *
+ * Cursor deep links have a maximum URL length of 8000 characters.
+ * If the generated URL exceeds this length, `url` will be undefined
+ * and an error will be returned.
+ */
+export function generateCursorPromptDeepLink(promptText: string) {
+  // Temporarily reject prompts that contain ".env" due to a bug in Cursor
+  if (promptText.includes('.env')) {
+    return { error: new Error('Prompt text cannot contain the text .env due to a temporary bug') }
+  }
+
+  const url = new URL('cursor://anysphere.cursor-deeplink/prompt')
+  url.searchParams.set('text', promptText)
+  const urlString = url.toString()
+
+  // Cursor has a max URL length of 8000 characters for deep links
+  if (urlString.length > 8000) {
+    return { error: new Error('Prompt text is too long to generate a Cursor deep link.') }
+  }
+
+  return { url: urlString }
 }

--- a/apps/docs/app/guides/getting-started/ai-prompts/[slug]/AiPrompts.utils.ts
+++ b/apps/docs/app/guides/getting-started/ai-prompts/[slug]/AiPrompts.utils.ts
@@ -28,7 +28,7 @@ function parseMarkdown(markdown: string) {
     }
   })
 
-  return { heading, content: withoutFrontmatter }
+  return { heading, content: withoutFrontmatter.trim() }
 }
 
 /**

--- a/apps/docs/app/guides/getting-started/ai-prompts/[slug]/page.tsx
+++ b/apps/docs/app/guides/getting-started/ai-prompts/[slug]/page.tsx
@@ -1,9 +1,12 @@
+import { source } from 'common-tags'
 import { notFound } from 'next/navigation'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
 import {
   generateAiPromptMetadata,
   generateAiPromptsStaticParams,
+  generateCursorPromptDeepLink,
   getAiPrompt,
+  wrapInMarkdownCodeBlock,
 } from './AiPrompts.utils'
 
 export const dynamicParams = false
@@ -19,17 +22,28 @@ export default async function AiPromptsPage(props: { params: Promise<{ slug: str
   }
 
   let { heading, content } = prompt
-  content = `
-## How to use
+  const { url: cursorUrl } = generateCursorPromptDeepLink(content)
 
-Copy the prompt to a file in your repo.
+  content = source`
+    ## How to use
 
-Use the "include file" feature from your AI tool to include the prompt when chatting with your AI assistant. For example, with GitHub Copilot, use \`#<filename>\`, in Cursor, use \`@Files\`, and in Zed, use \`/file\`.
+    Copy the prompt to a file in your repo.
 
-## Prompt
+    Use the "include file" feature from your AI tool to include the prompt when chatting with your AI assistant. For example, with GitHub Copilot, use \`#<filename>\`, in Cursor, use \`@Files\`, and in Zed, use \`/file\`.
 
-${content}
-`.trim()
+    ${
+      cursorUrl
+        ? source`
+            You can also load the prompt directly into your IDE via the following links:
+              - [Open in Cursor](${cursorUrl})
+          `
+        : ''
+    }
+
+    ## Prompt
+
+    ${wrapInMarkdownCodeBlock(content)}
+  `
 
   return (
     <GuideTemplate


### PR DESCRIPTION
Adds Cursor [deeplinks](https://cursor.com/docs/integrations/deeplinks) to our AI Prompts pages.

There's currently a bug in Cursor that prevents text containing `'.env'` to load, so there's some temporary logic to omit the deeplink for prompts that contain this. Cursor deeplinks also max at 8000 characters which one of our prompts exceeds (so we also hide the deeplink there). In the future we can look at trimming this down.

## Preview
https://docs-git-feat-cursor-deeplinks-supabase.vercel.app/docs/guides/getting-started/ai-prompts/code-format-sql