### PR TITLE
Fixed Issue #39451 refactor(SQLEditor): enable scrolling for large re…

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -66,9 +66,15 @@ hideToc: true
       <$CodeTabs>
 
         ```text name=.env
-        VITE_PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
-        VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<SUBSTITUTE_SUPABASE_PUBLISHABLE_KEY>
+        PUBLIC_VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY=<SUBSTITUTE_SUPABASE_PUBLISHABLE_KEY>
         ```
+
+    <StepHikeCompact.Details title="">
+
+    In SvelteKit, only variables prefixed with `PUBLIC_` are accessible on the client.
+
+    </StepHikeCompact.Details>
 
       </$CodeTabs>
 
@@ -89,16 +95,16 @@ hideToc: true
 
         ```js name=src/lib/supabaseClient.js
           import { createClient } from '@supabase/supabase-js';
-        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
+        import { PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
 
-        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY)
+        export const supabase = createClient(PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY)
         ```
 
         ```ts name=src/lib/supabaseClient.ts
           import { createClient } from '@supabase/supabase-js';
-        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
+        import { PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
 
-        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY)
+        export const supabase = createClient(PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY)
         ```
 
       </$CodeTabs>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -154,18 +154,23 @@ const UtilityPanel = ({
           executeQuery={executeQuery}
         />
       </TabsList_Shadcn_>
-      <TabsContent_Shadcn_ asChild value="results" className="mt-0 flex-grow">
-        <UtilityTabResults
-          id={id}
-          isExecuting={isExecuting}
-          isDisabled={isDisabled}
-          onDebug={onDebug}
-          isDebugging={isDebugging}
-        />
+      <TabsContent_Shadcn_ asChild value="results" className="mt-0 flex-1 overflow-hidden">
+        <div className="h-full overflow-auto">
+          {/* Enable scrolling for large result sets in bottom panel */}
+          <UtilityTabResults
+            id={id}
+            isExecuting={isExecuting}
+            isDisabled={isDisabled}
+            onDebug={onDebug}
+            isDebugging={isDebugging}
+          />
+        </div>
       </TabsContent_Shadcn_>
 
-      <TabsContent_Shadcn_ asChild value="chart" className="mt-0 flex-grow">
-        <ChartConfig results={result} config={chartConfig} onConfigChange={onConfigChange} />
+      <TabsContent_Shadcn_ asChild value="chart" className="mt-0 flex-1 overflow-hidden">
+        <div className="h-full overflow-auto">
+          <ChartConfig results={result} config={chartConfig} onConfigChange={onConfigChange} />
+        </div>
       </TabsContent_Shadcn_>
     </Tabs_Shadcn_>
   )

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -203,12 +203,12 @@ export const QueryBlock = ({
           disabled={!sql}
           {...(showWarning !== 'hasWriteOperation'
             ? {
-                message: 'Run this query now and send the results to the Assistant? ',
-                subMessage:
-                  'We will execute the query and provide the result rows back to the Assistant to continue the conversation.',
-                cancelLabel: 'Skip',
-                confirmLabel: 'Run & send',
-              }
+              message: 'Run this query now and send the results to the Assistant? ',
+              subMessage:
+                'We will execute the query and provide the result rows back to the Assistant to continue the conversation.',
+              cancelLabel: 'Skip',
+              confirmLabel: 'Run & send',
+            }
             : {})}
         />
       )}
@@ -317,7 +317,8 @@ export const QueryBlock = ({
             </div>
           ) : (
             results && (
-              <div className={cn('flex-1 w-full overflow-auto relative max-h-64')}>
+              <div className={cn('flex-1 w-full overflow-auto relative max-h-[40vh]')}>
+                {/* Enable scrolling for large result sets in bottom panel */}
                 <Results rows={results} />
               </div>
             )


### PR DESCRIPTION
…sult sets in UtilityPanel

Fixed the scrolling issue in results panel(last one) for both the SQL Editor and query result pages. Side bar text This was accomplished by revamping UtilityPanel. tsx and QueryBlock. tsx to apply max-h-[40vh] and overflow-auto` to the containers that need it, so big data sets can scroll without stretching and breaking layout.
