### PR TITLE
docs: clarify site url and redirect urls configuration

### DIFF
--- a/apps/docs/content/guides/auth/general-configuration.mdx
+++ b/apps/docs/content/guides/auth/general-configuration.mdx
@@ -14,7 +14,7 @@ This section covers the [general configuration options](/dashboard/project/_/aut
 - [Email Templates](/dashboard/project/_/auth/templates) to configure what emails your users receive.
 - [Custom SMTP](/dashboard/project/_/auth/smtp) to configure how emails are sent.
 - [Multi-Factor](/dashboard/project/_/auth/mfa) to require users to provide additional verification factors to authenticate.
-- [URL Configuration](/dashboard/project/_/auth/url-configuration) to configure site URL and redirect URLs for authentication.
+- [URL Configuration](/dashboard/project/_/auth/url-configuration) to configure site URL and redirect URLs for authentication. Read more [here](/docs/guides/auth/redirect-urls).
 - [Attack Protection](/dashboard/project/_/auth/protection) to configure security settings to protect your project from attacks.
 - [Auth Hooks (BETA)](/dashboard/project/_/auth/auth-hooks) to use Postgres functions or HTTP endpoints to customize the behavior of Supabase Auth to meet your needs.
 - [Audit Logs (BETA)](/dashboard/project/_/auth/audit-logs) to track and monitor auth events in your project.

--- a/apps/docs/content/guides/auth/general-configuration.mdx
+++ b/apps/docs/content/guides/auth/general-configuration.mdx
@@ -14,7 +14,7 @@ This section covers the [general configuration options](/dashboard/project/_/aut
 - [Email Templates](/dashboard/project/_/auth/templates) to configure what emails your users receive.
 - [Custom SMTP](/dashboard/project/_/auth/smtp) to configure how emails are sent.
 - [Multi-Factor](/dashboard/project/_/auth/mfa) to require users to provide additional verification factors to authenticate.
-- [URL Configuration](/dashboard/project/_/auth/url-configuration) to configure site URL and redirect URLs for authentication. Read more [here](/docs/guides/auth/redirect-urls).
+- [URL Configuration](/dashboard/project/_/auth/url-configuration) to configure site URL and redirect URLs for authentication. Read more [in the redirect URLs documentation](/docs/guides/auth/redirect-urls).
 - [Attack Protection](/dashboard/project/_/auth/protection) to configure security settings to protect your project from attacks.
 - [Auth Hooks (BETA)](/dashboard/project/_/auth/auth-hooks) to use Postgres functions or HTTP endpoints to customize the behavior of Supabase Auth to meet your needs.
 - [Audit Logs (BETA)](/dashboard/project/_/auth/audit-logs) to track and monitor auth events in your project.

--- a/apps/docs/content/guides/auth/redirect-urls.mdx
+++ b/apps/docs/content/guides/auth/redirect-urls.mdx
@@ -7,13 +7,17 @@ subtitle: 'Set up redirect urls with Supabase Auth.'
 
 ## Overview
 
-Supabase Auth allows your application to receive a [user session](/docs/guides/auth/sessions) on web pages or in mobile apps that only you allow.
+Supabase Auth allows you to control how the [user sessions](/docs/guides/auth/sessions) are handled by your application.
 
-When using [passwordless sign-ins](/docs/reference/javascript/auth-signinwithotp) or [third-party providers](/docs/reference/javascript/auth-signinwithoauth#sign-in-using-a-third-party-provider-with-redirect), the Supabase client library methods provide a `redirectTo` parameter to specify where to redirect the user to after authentication. By default, the user will be redirected to the [`SITE_URL`](/docs/guides/auth/redirect-urls) but you can modify the `SITE_URL` or add additional redirect URLs to the allow list. Once you've added necessary URLs to the allow list, you can specify the URL you want the user to be redirected to in the `redirectTo` parameter.
+When using [passwordless sign-ins](/docs/reference/javascript/auth-signinwithotp) or [third-party providers](/docs/reference/javascript/auth-signinwithoauth#sign-in-using-a-third-party-provider-with-redirect), the Supabase client library provides a `redirectTo` parameter to specify where to redirect the user after authentication. The URL in `redirectTo` should match the [Redirect URLs](/dashboard/project/_/auth/url-configuration) list configuration.
 
-When using [Sign in with Web3](/docs/guides/auth/auth-web3) the message signed by the user in the Web3 wallet application will indicate the URL on which the signature took place. Supabase Auth will reject messages that are signed for URLs that have not been allowed.
+To configure allowed redirect URLs, go to the [URL Configuration](/dashboard/project/_/auth/url-configuration) page. Once you've added necessary URLs, you can use the URL you want the user to be redirected to in the `redirectTo` parameter.
 
-To edit the allow list, go to the [URL Configuration](/dashboard/project/_/auth/url-configuration) page. In local development or self-hosted projects, use the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls).
+The Site URL in [URL Configuration](/dashboard/project/_/auth/url-configuration) defines the **default redirect URL** when no `redirectTo` is specified in the code. Change this from `http://localhost:3000` to your production URL (e.g., https://example.com). This setting is critical for email confirmation and password reset.
+
+When using [Sign in with Web3](/docs/guides/auth/auth-web3), the message signed by the user in the Web3 wallet application will indicate the URL on which the signature took place. Supabase Auth will reject messages that are signed for URLs that are not on the allowed list.
+
+In local development or self-hosted projects, use the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls). See below for more information on configuring `SITE_URL` when deploying to Vercel or Netlify.
 
 ## Use wildcards in redirect URLs
 

--- a/apps/docs/content/guides/auth/redirect-urls.mdx
+++ b/apps/docs/content/guides/auth/redirect-urls.mdx
@@ -13,11 +13,11 @@ When using [passwordless sign-ins](/docs/reference/javascript/auth-signinwithotp
 
 To configure allowed redirect URLs, go to the [URL Configuration](/dashboard/project/_/auth/url-configuration) page. Once you've added necessary URLs, you can use the URL you want the user to be redirected to in the `redirectTo` parameter.
 
-The Site URL in [URL Configuration](/dashboard/project/_/auth/url-configuration) defines the **default redirect URL** when no `redirectTo` is specified in the code. Change this from `http://localhost:3000` to your production URL (e.g., https://example.com). This setting is critical for email confirmation and password reset.
+The Site URL in [URL Configuration](/dashboard/project/_/auth/url-configuration) defines the **default redirect URL** when no `redirectTo` is specified in the code. Change this from `http://localhost:3000` to your production URL (e.g., https://example.com). This setting is critical for email confirmations and password resets.
 
 When using [Sign in with Web3](/docs/guides/auth/auth-web3), the message signed by the user in the Web3 wallet application will indicate the URL on which the signature took place. Supabase Auth will reject messages that are signed for URLs that are not on the allowed list.
 
-In local development or self-hosted projects, use the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls). See below for more information on configuring `SITE_URL` when deploying to Vercel or Netlify.
+In local development or self-hosted projects, use the [configuration file](/docs/guides/local-development/cli/config#auth.additional_redirect_urls). See below for more information on configuring `SITE_URL` when deploying to Vercel or Netlify.
 
 ## Use wildcards in redirect URLs
 

--- a/apps/docs/content/troubleshooting/why-am-i-being-redirected-to-the-wrong-url-when-using-auth-redirectto-option-_vqIeO.mdx
+++ b/apps/docs/content/troubleshooting/why-am-i-being-redirected-to-the-wrong-url-when-using-auth-redirectto-option-_vqIeO.mdx
@@ -11,4 +11,4 @@ In order for the provided `redirectTo` option to work you must set the exact URL
 
 ![image](/docs/img/troubleshooting/224379580-fa77bd31-bb58-47e6-90ce-64e140f32579.png)
 
-For more information on formats for redirect URL settings see the documentation here: https://supabase.com/docs/guides/auth/overview#redirect-urls-and-wildcards
+For more information on formats for redirect URL settings see the documentation here: https://supabase.com/docs/guides/auth/redirect-urls

--- a/apps/docs/content/troubleshooting/why-am-i-being-redirected-to-the-wrong-url-when-using-auth-redirectto-option-_vqIeO.mdx
+++ b/apps/docs/content/troubleshooting/why-am-i-being-redirected-to-the-wrong-url-when-using-auth-redirectto-option-_vqIeO.mdx
@@ -11,4 +11,4 @@ In order for the provided `redirectTo` option to work you must set the exact URL
 
 ![image](/docs/img/troubleshooting/224379580-fa77bd31-bb58-47e6-90ce-64e140f32579.png)
 
-For more information on formats for redirect URL settings see the documentation here: https://supabase.com/docs/guides/auth/redirect-urls
+For more information on formats for redirect URL settings see the documentation here: https://supabase.com/docs/guides/auth/redirect-urls#use-wildcards-in-redirect-urls


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This is an update to the section describing redirect urls in Auth.

## What is the current behavior?

While useful, the current contents can be somewhat unclear for someone not familiar with Auth. If the user misinterprets or misses how to configure Site URL in particular, it can be a struggle trying to make email confirmations work.

## What is the new behavior?

I made an attempt to partially rewrite for clarity. I've also added a paragraph describing that Site URL works as a default setting when no `redirectTo` is used in the code. I'm hoping I interpreted it the right way.

## Additional context

Struggle described as seen in users' questions. This PR also fixes broken/inaccurate links, including a link to Redirect URLs from the troubleshooting article.
