### PR TITLE
Rename SvelteKit setup guide's environment variables name in docs

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -66,8 +66,8 @@ hideToc: true
       <$CodeTabs>
 
         ```text name=.env
-        VITE_PUBLIC_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
-        VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<SUBSTITUTE_SUPABASE_PUBLISHABLE_KEY>
+        PUBLIC_VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+        PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY=<SUBSTITUTE_SUPABASE_PUBLISHABLE_KEY>
         ```
 
       </$CodeTabs>
@@ -89,16 +89,16 @@ hideToc: true
 
         ```js name=src/lib/supabaseClient.js
           import { createClient } from '@supabase/supabase-js';
-        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
+        import { PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
 
-        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY)
+        export const supabase = createClient(PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY)
         ```
 
         ```ts name=src/lib/supabaseClient.ts
           import { createClient } from '@supabase/supabase-js';
-        import { VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
+        import { PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY } from '$env/static/public';
 
-        export const supabase = createClient(VITE_PUBLIC_SUPABASE_URL, VITE_PUBLIC_SUPABASE_PUBLISHABLE_KEY)
+        export const supabase = createClient(PUBLIC_VITE_SUPABASE_URL, PUBLIC_VITE_SUPABASE_PUBLISHABLE_KEY)
         ```
 
       </$CodeTabs>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update - Fix #39456

## What is the current behavior?

#39456

## What is the new behavior?

Renamed `.env` variables
