### PR TITLE
Docs/add secret key base

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -194,6 +194,13 @@ const additionalResources = [
     href: 'https://supabase.com/ui',
     external: true,
   },
+  {
+    title: 'Troubleshooting',
+    description: 'Our troubleshooting guide for solutions to common Supabase issues.',
+    icon: 'troubleshooting',
+    href: '/guides/troubleshooting',
+    external: true,
+  }
 ]
 
 const HomePage = () => (

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -199,8 +199,7 @@ const additionalResources = [
     description: 'Our troubleshooting guide for solutions to common Supabase issues.',
     icon: 'troubleshooting',
     href: '/guides/troubleshooting',
-    external: true,
-  }
+  },
 ]
 
 const HomePage = () => (

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -221,6 +221,7 @@ Update the `./docker/.env` file with your own secrets. In particular, these are 
 - `SMTP_*`: mail server credentials. You can use any SMTP server.
 - `POOLER_TENANT_ID`: the tenant-id that will be used by Supavisor pooler for your connection string
 - `PG_META_CRYPTO_KEY`: encryption key for securing connection strings between Studio and postgres-meta
+- `SECRET_KEY_BASE`: encryption key for securing Realtime and Supavisor communications. (Must be at least 64 characters; generate with `openssl rand -base64 48`)
 
 You will need to [restart](#restarting-all-services) the services for the changes to take effect.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a quick description of `SECRET_KEY_BASE` to address #11520 for now.

## What is the current behavior?

`SECRET_KEY_BASE` is not documented.

## What is the new behavior?

Mention what `SECRET_KEY_BASE` is generally for (Realtime and Supavisor use it via Phoenix internals). Describe how it can be generated as a unique 64-character string.

## Additional context

There were a couple of external contributions recently that sparked an internal discussion:

- https://github.com/supabase/supabase/pull/38526
- https://github.com/supabase/supabase/pull/39301

I'd suggest to keep is simple for now. The `SECRET_KEY_BASE` configuration may change in the future.
