### PR TITLE
chore(studio): Fix typo in connect interface

### DIFF
--- a/apps/studio/components/interfaces/Connect/content/ionicangular/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/ionicangular/supabasejs/content.tsx
@@ -24,7 +24,7 @@ const ContentFile = ({ projectKeys }: ContentFileProps) => {
           {`
 export const environment = {
   supabaseUrl: '${projectKeys.apiUrl ?? 'your-project-url'}',
-  supabaseKey: '${projectKeys.publishableKey ?? '<prefer publishabke key instead of anon key for mobile apps>'}',
+  supabaseKey: '${projectKeys.publishableKey ?? '<prefer publishable key instead of anon key for mobile apps>'}',
 };
 `}
         </SimpleCodeBlock>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix of a typo on the connect interface on the studio
- `publishabke` --> `publishable`

## What is the current behavior?

A typo in the connect interface
<img width="1036" height="365" alt="image" src="https://github.com/user-attachments/assets/bf4e0c62-8002-41b7-beab-fc82b203079b" />

## What is the new behavior?

Same, but typo is fixed.
