### PR TITLE
fix: set 24h format when converting postgres timestamp

### DIFF
--- a/apps/studio/lib/api/self-hosted/migrations.ts
+++ b/apps/studio/lib/api/self-hosted/migrations.ts
@@ -34,7 +34,7 @@ const applyAndTrackMigrationsQuery = (query: string, name?: string) => {
     -- track statements in history table
     insert into supabase_migrations.schema_migrations (version, name, statements)
     values (
-      to_char(current_timestamp, 'YYYYMMDDHHMISS'),
+      to_char(current_timestamp, 'YYYYMMDDHH24MISS'),
       ${quote(name)},
       array[${quote(query)}]
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Need to set explicitly because to_char defaults to 12h.

## Additional context

Add any other context or screenshots.
