### PR TITLE
fix: omit quotes in values when `.env` contents are pasted into input

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -48,6 +48,14 @@ const FormSchema = z.object({
 const defaultValues = {
   secrets: [{ name: '', value: '' }],
 }
+
+const removeWrappingQuotes = (str: string): string => {
+  if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
+    return str.slice(1, -1)
+  }
+  return str
+}
+
 const AddNewSecretForm = () => {
   const { ref: projectRef } = useParams()
   const [showSecretValue, setShowSecretValue] = useState(false)
@@ -102,9 +110,10 @@ const AddNewSecretForm = () => {
       lines.forEach((line) => {
         const [key, ...valueParts] = line.split('=')
         if (key && valueParts.length) {
+          const valueStr = valueParts.join('=').trim()
           pairs.push({
             name: key.trim(),
-            value: valueParts.join('=').trim(),
+            value: removeWrappingQuotes(valueStr),
           })
         }
       })


### PR DESCRIPTION
Fixes FE-1941

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

The current behavior when pasting the contents of a `.env` file into the Functions Secrets Dashboard GUI is to split each line into a key/value pair. The value component of the pasted content is sometimes wrapped in `"` or `'` and in these cases they are preserved as a part of the value. This is not in-line with how most systems handle `.env` files, where quotes at the beginning and end are typically stripped from the values.

This would be fine except for the fact that the strings are also hidden from the user so they may not ever notice the error.

## What is the new behavior?

The new behavior is to strip the `"` and `'` characters if they exist in each value string after it has been trimmed of whitespace.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
