### PR TITLE
chore(studio): consistent table rows across pages

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
+++ b/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
@@ -54,21 +54,23 @@ export const APIKeyRow = ({
         </div>
       </TableCell>
 
-      <TableCell className="flex justify-end">
-        <DropdownMenu>
-          <DropdownMenuTrigger className="px-1 focus-visible:outline-none" asChild>
-            <Button
-              type="text"
-              size="tiny"
-              icon={
-                <MoreVertical size="14" className="text-foreground-light hover:text-foreground" />
-              }
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="max-w-40" align="end">
-            <APIKeyDeleteDialog apiKey={apiKey} lastSeen={lastSeen} />
-          </DropdownMenuContent>
-        </DropdownMenu>
+      <TableCell className="py-2">
+        <div className="flex justify-end">
+          <DropdownMenu>
+            <DropdownMenuTrigger className="px-1 focus-visible:outline-none" asChild>
+              <Button
+                type="text"
+                size="tiny"
+                icon={
+                  <MoreVertical size="14" className="text-foreground-light hover:text-foreground" />
+                }
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="max-w-40" align="end">
+              <APIKeyDeleteDialog apiKey={apiKey} lastSeen={lastSeen} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </TableCell>
     </MotionTableRow>
   )

--- a/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
@@ -38,6 +38,7 @@ export function ApiKeyPill({
   const {
     data,
     error,
+    isLoading,
     refetch: refetchApiKey,
   } = useAPIKeyIdQuery(
     {
@@ -116,9 +117,7 @@ export function ApiKeyPill({
           'w-[100px] sm:w-[140px] md:w-[180px] lg:w-[340px] gap-0 font-mono rounded-full',
           isSecret ? 'overflow-hidden' : '',
           show ? 'ring-1 ring-foreground-lighter ring-opacity-50' : 'ring-0 ring-opacity-0',
-          'transition-all',
-          'cursor-text',
-          'relative'
+          'transition-all cursor-text relative'
         )}
         style={{ userSelect: 'all' }}
       >
@@ -139,6 +138,7 @@ export function ApiKeyPill({
             <Button
               type="outline"
               className="rounded-full px-2 pointer-events-auto"
+              loading={show && isLoading}
               icon={show ? <EyeOff strokeWidth={2} /> : <Eye strokeWidth={2} />}
               onClick={onSubmitToggle}
               disabled={isRestricted}

--- a/apps/studio/components/interfaces/APIKeys/CreateSecretAPIKeyDialog.tsx
+++ b/apps/studio/components/interfaces/APIKeys/CreateSecretAPIKeyDialog.tsx
@@ -1,7 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
   Button,
   Dialog,
   DialogContent,
@@ -12,18 +16,13 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   DialogTrigger,
+  Form_Shadcn_,
   FormControl_Shadcn_,
   FormField_Shadcn_,
-  Form_Shadcn_,
   Input_Shadcn_,
-  Alert,
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
-import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import { useAPIKeyCreateMutation } from 'data/api-keys/api-key-create-mutation'
@@ -85,7 +84,7 @@ const CreateSecretAPIKeyDialog = () => {
     <Dialog open={visible} onOpenChange={onClose}>
       <DialogTrigger asChild>
         <Button type="default" className="mt-2" icon={<Plus />}>
-          Add new secret key
+          New secret key
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/CreateCredentialModal.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -86,7 +87,12 @@ export const CreateCredentialModal = ({ visible, onOpenChange }: CreateCredentia
       <Tooltip>
         <TooltipTrigger asChild>
           <DialogTrigger asChild>
-            <Button type="default" disabled={disableCreation} className="pointer-events-auto">
+            <Button
+              type="default"
+              icon={<Plus size={14} />}
+              disabled={disableCreation}
+              className="pointer-events-auto"
+            >
               New access key
             </Button>
           </DialogTrigger>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
@@ -14,7 +14,6 @@ import {
   ScaffoldSectionDescription,
   ScaffoldSectionTitle,
 } from 'components/layouts/Scaffold'
-// import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
 import { DocsButton } from 'components/ui/DocsButton'
 import NoPermission from 'components/ui/NoPermission'
@@ -261,10 +260,8 @@ export const S3Connection = () => {
         ) : (
           <>
             {isLoadingStorageCreds ? (
-              // <div className="p-4">
               <GenericSkeletonLoader />
             ) : (
-              // </div>
               <Card>
                 <Table>
                   <TableHeader>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/S3Connection.tsx
@@ -14,7 +14,7 @@ import {
   ScaffoldSectionDescription,
   ScaffoldSectionTitle,
 } from 'components/layouts/Scaffold'
-import Table from 'components/to-be-cleaned/Table'
+// import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
 import { DocsButton } from 'components/ui/DocsButton'
 import NoPermission from 'components/ui/NoPermission'
@@ -36,6 +36,12 @@ import {
   FormField_Shadcn_,
   Form_Shadcn_,
   Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
   WarningIcon,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -116,7 +122,7 @@ export const S3Connection = () => {
   return (
     <>
       <ScaffoldSection isFullWidth>
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex items-end justify-between mb-6">
           <div>
             <ScaffoldSectionTitle>Connection</ScaffoldSectionTitle>
             <ScaffoldSectionDescription>
@@ -225,7 +231,7 @@ export const S3Connection = () => {
       </ScaffoldSection>
 
       <ScaffoldSection isFullWidth>
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex items-end justify-between mb-6">
           <div>
             <ScaffoldSectionTitle>Access keys</ScaffoldSectionTitle>
             <ScaffoldSectionDescription>
@@ -255,20 +261,28 @@ export const S3Connection = () => {
         ) : (
           <>
             {isLoadingStorageCreds ? (
-              <div className="p-4">
-                <GenericSkeletonLoader />
-              </div>
+              // <div className="p-4">
+              <GenericSkeletonLoader />
             ) : (
-              <div className="overflow-x-auto">
-                <Table
-                  head={[
-                    <Table.th key="description">Description</Table.th>,
-                    <Table.th key="access-key-id">Access key ID</Table.th>,
-                    <Table.th key="created-at">Created at</Table.th>,
-                    <Table.th key="actions" />,
-                  ]}
-                  body={
-                    hasStorageCreds ? (
+              // </div>
+              <Card>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead key="description" className="min-w-40 lg:min-w-64">
+                        Description
+                      </TableHead>
+                      <TableHead key="access-key-id" className="min-w-64 w-full">
+                        Access key ID
+                      </TableHead>
+                      <TableHead key="created-at" className="min-w-48">
+                        Created at
+                      </TableHead>
+                      <TableHead key="actions" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {hasStorageCreds ? (
                       storageCreds.data?.map((cred) => (
                         <StorageCredItem
                           key={cred.id}
@@ -283,18 +297,18 @@ export const S3Connection = () => {
                         />
                       ))
                     ) : (
-                      <Table.tr>
-                        <Table.td colSpan={4} className="!rounded-b-md overflow-hidden">
+                      <TableRow>
+                        <TableCell colSpan={4} className="!rounded-b-md overflow-hidden">
                           <p className="text-sm text-foreground">No access keys created</p>
                           <p className="text-sm text-foreground-light">
                             There are no access keys associated with your project yet
                           </p>
-                        </Table.td>
-                      </Table.tr>
-                    )
-                  }
-                />
-              </div>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </Card>
             )}
           </>
         )}

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageCredItem.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageCredItem.tsx
@@ -10,6 +10,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  TableCell,
+  TableRow,
 } from 'ui'
 
 export const StorageCredItem = ({
@@ -45,20 +47,20 @@ export const StorageCredItem = ({
   }
 
   return (
-    <tr className="h-8 text-ellipsis group">
-      <td>
+    <TableRow className="h-8 text-ellipsis group">
+      <TableCell>
         <span className="text-foreground">{description}</span>
-      </td>
-      <td>
+      </TableCell>
+      <TableCell>
         <div className="flex items-center justify-between">
           <span className="text-ellipsis font-mono cursor-default">{access_key}</span>
           <span className="w-24 text-right opacity-0 group-hover:opacity-100 transition-opacity">
             <CopyButton text={access_key} type="default" />
           </span>
         </div>
-      </td>
-      <td>{daysSince(created_at)}</td>
-      <td className="text-right">
+      </TableCell>
+      <TableCell className="text-foreground-lighter">{daysSince(created_at)}</TableCell>
+      <TableCell className="text-right">
         {canRemoveAccessKey && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -82,7 +84,7 @@ export const StorageCredItem = ({
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- UI cleanup
- Fixes DEPR-119

## What is the current behavior?

- The [S3 Configuration](https://supabase.com/dashboard/project/_/storage/s3) page is using a deprecated table components
  - It’s visually out of date with other table instances on Studio
  - This inconsistency will be exacerbated by incoming Storage sibling pages, which also deal with S3 configuration (or at least present data in a similar way
- The [API Keys](https://supabase.com/dashboard/project/_/settings/api-keys/new) page is similarly out of date with table components and incoming similar Storage UI

## What is the new behavior?

- The S3 Configuration table uses the latest table components
- The API Keys page is updated to match both the latest table components and how we’re presenting secrets in Storage


| Before | After |
| --- | --- |
| <img width="1209" height="873" alt="S3 Configuration  Supabase" src="https://github.com/user-attachments/assets/4ec3b723-1fcd-4563-afca-4b1735343024" /> | <img width="1209" height="873" alt="S3 Configuration  Supabase" src="https://github.com/user-attachments/assets/5f7f0ddf-8f26-40b6-b63d-7d925b3aa877" /> | 
| <img width="1209" height="873" alt="Settings  Supabase" src="https://github.com/user-attachments/assets/15d4b6ef-7083-4c11-8867-5d21a7f56f2f" /> | <img width="1209" height="873" alt="Settings  Supabase" src="https://github.com/user-attachments/assets/567a61d3-121e-4836-af87-cf4431ae4f8d" /> | 

## To test

Please test the following at various breakpoints:

- [ ] Viewing [secret keys](https://supabase.com/dashboard/project/_/settings/api-keys/new)
- [ ] Viewing S3 Configuration [access keys](https://supabase.com/dashboard/project/_/storage/s3)
  - [ ] Viewing 1+ items and their values shown in the table
