### PR TITLE
perf: avoid double projects lists query

### DIFF
--- a/apps/studio/data/projects/constants.ts
+++ b/apps/studio/data/projects/constants.ts
@@ -1,0 +1,4 @@
+// [Joshen] Try to keep this value a multiple of 6 (common denominator of 2 and 3) to fit the cards view
+// So that the last row will always be a full row of cards while there's a next page
+// API max rows is 100, I'm just choosing 96 here as the highest value thats a multiple of 6
+export const PROJECT_PAGINATION_DEFAULT_LIMIT = 96

--- a/apps/studio/data/projects/org-projects-infinite-query.ts
+++ b/apps/studio/data/projects/org-projects-infinite-query.ts
@@ -5,11 +5,7 @@ import { get, handleError } from 'data/fetchers'
 import { useProfile } from 'lib/profile'
 import { ResponseError } from 'types'
 import { INFINITE_PROJECTS_KEY_PREFIX, projectKeys } from './keys'
-
-// [Joshen] Try to keep this value a multiple of 6 (common denominator of 2 and 3) to fit the cards view
-// So that the last row will always be a full row of cards while there's a next page
-// API max rows is 100, I'm just choosing 96 here as the highest value thats a multiple of 6
-const DEFAULT_LIMIT = 96
+import { PROJECT_PAGINATION_DEFAULT_LIMIT } from './constants'
 
 interface GetOrgProjectsInfiniteVariables {
   slug?: string
@@ -26,7 +22,7 @@ export type OrgProject = OrgProjectsResponse['projects'][number]
 async function getOrganizationProjects(
   {
     slug,
-    limit = DEFAULT_LIMIT,
+    limit = PROJECT_PAGINATION_DEFAULT_LIMIT,
     page = 0,
     sort = 'name_asc',
     search: _search = '',
@@ -57,7 +53,7 @@ export type OrgProjectsInfiniteError = ResponseError
 export const useOrgProjectsInfiniteQuery = <TData = OrgProjectsInfiniteData>(
   {
     slug,
-    limit = DEFAULT_LIMIT,
+    limit = PROJECT_PAGINATION_DEFAULT_LIMIT,
     sort = 'name_asc',
     search,
     statuses = [],

--- a/apps/studio/data/projects/projects-infinite-query.ts
+++ b/apps/studio/data/projects/projects-infinite-query.ts
@@ -5,8 +5,7 @@ import { get, handleError } from 'data/fetchers'
 import { useProfile } from 'lib/profile'
 import { ResponseError } from 'types'
 import { projectKeys } from './keys'
-
-const DEFAULT_LIMIT = 100
+import { PROJECT_PAGINATION_DEFAULT_LIMIT } from './constants'
 
 interface GetProjectsInfiniteVariables {
   limit?: number
@@ -20,7 +19,7 @@ export type ProjectInfoInfinite =
 
 async function getProjects(
   {
-    limit = DEFAULT_LIMIT,
+    limit = PROJECT_PAGINATION_DEFAULT_LIMIT,
     page = 0,
     sort = 'name_asc',
     search: _search = '',
@@ -46,7 +45,7 @@ export type ProjectsInfiniteData = Awaited<ReturnType<typeof getProjects>>
 export type ProjectsInfiniteError = ResponseError
 
 export const useProjectsInfiniteQuery = <TData = ProjectsInfiniteData>(
-  { limit = DEFAULT_LIMIT, sort = 'name_asc', search }: GetProjectsInfiniteVariables,
+  { limit = PROJECT_PAGINATION_DEFAULT_LIMIT, sort = 'name_asc', search }: GetProjectsInfiniteVariables,
   {
     enabled = true,
     ...options


### PR DESCRIPTION
We call the projects list endpoint in multiple places - in some cases we use 96 as a limit in other cases 100. Given the limit is part of the cache key, this caused us to fire two parallel requests to this rather expensive endpoint.

96 was the limit due to the grid layout - we can use that value