### PR TITLE
OrganizationProjectSelector to only fetch projects when its opened

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsFilter.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsFilter.tsx
@@ -40,7 +40,7 @@ export const NotificationsFilter = ({ activeTab }: { activeTab: 'inbox' | 'archi
   const { data: organizations } = useOrganizationsQuery()
   const { data } = useProjectsInfiniteQuery(
     { search: search.length === 0 ? search : debouncedSearch },
-    { keepPreviousData: true }
+    { keepPreviousData: true, enabled: open }
   )
   const projects = useMemo(() => data?.pages.flatMap((page) => page.projects), [data?.pages]) || []
   const projectCount = data?.pages[0].pagination.count ?? 0

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -86,7 +86,7 @@ export const OrganizationProjectSelector = ({
     fetchNextPage,
   } = useOrgProjectsInfiniteQuery(
     { slug, search: search.length === 0 ? search : debouncedSearch },
-    { keepPreviousData: true }
+    { enabled: open, keepPreviousData: true }
   )
 
   const projects = useMemo(() => data?.pages.flatMap((page) => page.projects), [data?.pages]) || []


### PR DESCRIPTION
## Context

On the topic of optimizing calls to /projects - change here is just to ensure that we fetch projects from the `OrganizationProjectSelector` component only when its opened, so that we don't have to make a call to the /projects endpoint when landing on project pages (e.g home page)

## To test

- [ ] Verify that there's no call to /projects when landing on the project's home page