### PR TITLE
feat: Redirect the user after claiming a project

### DIFF
--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -47,16 +47,22 @@ export const ProjectClaimConfirm = ({
 
   const onClaimProject = async () => {
     try {
-      await approveRequest({ id: auth_id!, slug: selectedOrganization.slug })
+      const response = await approveRequest({ id: auth_id!, slug: selectedOrganization.slug })
       await claimProject({
         slug: selectedOrganization.slug,
         token: claimToken!,
       })
 
       toast.success('Project claimed successfully')
-      // invalidate the org projects to force them to be refetched
-      queryClient.invalidateQueries(projectKeys.list())
-      router.push(`/org/${selectedOrganization.slug}`)
+      try {
+        // check if the redirect url is valid. If not, redirect the user to the org dashboard
+        const url = new URL(response.url)
+        window.location.href = url.toString()
+      } catch {
+        // invalidate the org projects to force them to be refetched
+        queryClient.invalidateQueries(projectKeys.list())
+        router.push(`/org/${selectedOrganization.slug}`)
+      }
     } catch (error: any) {
       toast.error(`Failed to claim project ${error.message}`)
     }

--- a/apps/studio/pages/claim-project.tsx
+++ b/apps/studio/pages/claim-project.tsx
@@ -21,7 +21,7 @@ const ClaimProjectPageLayout = ({ children }: PropsWithChildren) => {
   return (
     <>
       <Head>
-        <title>{`Claim project ${appTitle ?? 'Supabase'}`}</title>
+        <title>{`Claim project | ${appTitle ?? 'Supabase'}`}</title>
       </Head>
       {children}
     </>

--- a/apps/studio/pages/claim-project.tsx
+++ b/apps/studio/pages/claim-project.tsx
@@ -21,7 +21,7 @@ const ClaimProjectPageLayout = ({ children }: PropsWithChildren) => {
   return (
     <>
       <Head>
-        <title>Claim project | {appTitle || 'Supabase'}</title>
+        <title>{`Claim project ${appTitle ?? 'Supabase'}`}</title>
       </Head>
       {children}
     </>


### PR DESCRIPTION
This PR adds a redirect after the user claims a project. The redirect will the match the `redirect_uri` parameter from when the source `/v1/oauth/authorize/project-claim` API call. The redirect URL still needs to math the redirect URI in the oAuth app.