### PR TITLE
fix(support form): project selector, test timeout

### DIFF
--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -11,9 +11,9 @@ import { OrganizationProjectSelector } from 'components/ui/OrganizationProjectSe
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import {
   Button,
+  cn,
   CommandGroup_Shadcn_,
   CommandItem_Shadcn_,
-  cn,
   FormControl_Shadcn_,
   FormField_Shadcn_,
 } from 'ui'
@@ -76,6 +76,7 @@ function ProjectSelector({ form, orgSlug, projectRef }: ProjectSelectorProps) {
             <OrganizationProjectSelector
               key={orgSlug}
               sameWidthAsTrigger
+              fetchOnMount
               checkPosition="left"
               slug={!orgSlug || orgSlug === NO_ORG_MARKER ? undefined : orgSlug}
               selectedRef={field.value}

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -507,7 +507,7 @@ describe('SupportFormPage', () => {
       expect(submitSpy).toHaveBeenCalledTimes(1)
     })
     expect(submitSpy.mock.calls[0]?.[0]?.dashboardSentryIssueId).toBe(sentryIssueId)
-  })
+  }, 10_000)
 
   test('includes initial error message from URL in submission payload', async () => {
     const initialError = 'failed to fetch user data'
@@ -551,7 +551,7 @@ describe('SupportFormPage', () => {
 
     const payload = submitSpy.mock.calls[0]?.[0]
     expect(payload?.message).toMatch(initialError)
-  })
+  }, 10_000)
 
   test('submits support request with problem category, library, and affected services', async () => {
     const submitSpy = vi.fn()
@@ -640,7 +640,7 @@ describe('SupportFormPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /success/i })).toBeInTheDocument()
     })
-  })
+  }, 10_000)
 
   test('submits urgent login issues ticket for a different organization', async () => {
     const submitSpy = vi.fn()
@@ -729,7 +729,7 @@ describe('SupportFormPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /success/i })).toBeInTheDocument()
     })
-  })
+  }, 10_000)
 
   test('submits database unresponsive ticket with initial error', async () => {
     const submitSpy = vi.fn()
@@ -829,7 +829,7 @@ describe('SupportFormPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /success/i })).toBeInTheDocument()
     })
-  })
+  }, 10_000)
 
   test('when organization changes, project selector updates to match', async () => {
     renderSupportFormPage()
@@ -968,7 +968,7 @@ describe('SupportFormPage', () => {
         expect(screen.getByRole('heading', { name: /success/i })).toBeInTheDocument()
       })
     }
-  })
+  }, 10_000)
 
   test('shows toast on submission error and allows form re-editing and resubmission', async () => {
     const submitSpy = vi.fn()
@@ -1046,7 +1046,7 @@ describe('SupportFormPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /success/i })).toBeInTheDocument()
     })
-  })
+  }, 10_000)
 
   test('submits support request with attachments and includes attachment URLs in message', async () => {
     const submitSpy = vi.fn()
@@ -1199,7 +1199,7 @@ describe('SupportFormPage', () => {
       url.revokeObjectURL = originalRevokeObjectURL
       vi.mocked(createSupportStorageClient).mockReset()
     }
-  })
+  }, 10_000)
 
   test('can submit form with no organizations and no projects', async () => {
     const submitSpy = vi.fn()
@@ -1266,5 +1266,5 @@ describe('SupportFormPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /success/i })).toBeInTheDocument()
     })
-  })
+  }, 10_000)
 })

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -41,6 +41,7 @@ interface OrganizationProjectSelectorSelectorProps {
   renderActions?: (setOpen: (value: boolean) => void) => ReactNode
   onSelect?: (project: OrgProject) => void
   onInitialLoad?: (projects: OrgProject[]) => void
+  fetchOnMount?: boolean
 }
 
 export const OrganizationProjectSelector = ({
@@ -56,6 +57,7 @@ export const OrganizationProjectSelector = ({
   renderActions,
   onSelect,
   onInitialLoad,
+  fetchOnMount = false,
 }: OrganizationProjectSelectorSelectorProps) => {
   const { data: organization } = useSelectedOrganizationQuery()
   const slug = _slug ?? organization?.slug
@@ -86,7 +88,7 @@ export const OrganizationProjectSelector = ({
     fetchNextPage,
   } = useOrgProjectsInfiniteQuery(
     { slug, search: search.length === 0 ? search : debouncedSearch },
-    { enabled: open, keepPreviousData: true }
+    { enabled: fetchOnMount || open, keepPreviousData: true }
   )
 
   const projects = useMemo(() => data?.pages.flatMap((page) => page.projects), [data?.pages]) || []


### PR DESCRIPTION
[fix(support form): fetch projects on mount](https://github.com/supabase/supabase/commit/6a5dbaa571cf751c4d5b57d31c49ae43154197a8) 

The OrganizationProjectSelector was updated to only fetch when opened to
save on API requests. This causes a problem for the Support Form, which
expects the projects to be fetched immediately so it can fall back to
the first project if no project was passed in the URL.

Added a fetchOnMount prop to OrganizationProjectSelector, which defaults
to false, so we can override this behaviour for the Support Form.

[fix(tests): increase timeout on support form tests](https://github.com/supabase/supabase/commit/d66b390aa3277c78bc34d7bb01e395024a834afe)