### PR TITLE
fix(docs): Fix anchor link in Compute and Disk doc

### DIFF
--- a/apps/docs/content/guides/platform/compute-and-disk.mdx
+++ b/apps/docs/content/guides/platform/compute-and-disk.mdx
@@ -35,7 +35,7 @@ In paid organizations, Nano Compute are billed at the same price as Micro Comput
 [^2]: Database size for each compute instance is the default recommendation but the actual performance of your database has many contributing factors, including resources available to it and the size of the data contained within it. See the [shared responsibility model](/docs/guides/platform/shared-responsibility-model) for more information.
 [^3]: Compute resources on the Free plan are subject to change.
 
-Compute sizes can be changed by first selecting your project in the dashboard [here](/dashboard/project/_/settings/compute-and-disk) and the upgrade process will [incur downtime](/docs/guides/platform/compute-and-disk#upgrade-downtime).
+Compute sizes can be changed by first selecting your project in the dashboard [here](/dashboard/project/_/settings/compute-and-disk) and the upgrade process will [incur downtime](/docs/guides/platform/compute-and-disk#upgrades).
 
 <Image
   alt="Compute Size Selection"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Current anchor link is invalid
- Links to correct section https://supabase.com/docs/guides/platform/compute-and-disk#upgrades which mentions downtime

> Compute upgrades [#](https://supabase.com/docs/guides/platform/compute-and-disk#upgrades)
> Compute instance changes are usually applied with less than 2 minutes of downtime, but can take longer depending on the underlying Cloud Provider.

## Additional context

- Was added in https://github.com/supabase/supabase/pull/30147/files 
- Which previously had an "Upgrade Downtime" header seen in https://github.com/supabase/supabase/pull/30147/commits/6d841f15406c1b4dd3e17d72e8bdfad945cfef8b#diff-d56135e329552eeffe136d10bd07aebca390edaeea09adc80283e596cdbba6f4R70 