### PR TITLE
add dashboard bug to allow support access

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
@@ -20,6 +20,7 @@ export const SUPPORT_ACCESS_CATEGORIES: ExtendedSupportCategories[] = [
   SupportCategories.DATABASE_UNRESPONSIVE,
   SupportCategories.PERFORMANCE_ISSUES,
   SupportCategories.PROBLEM,
+  SupportCategories.DASHBOARD_BUG,
 ]
 
 interface SupportAccessToggleProps {

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -1297,7 +1297,7 @@ describe('SupportFormPage', () => {
       organizationSlug: NO_ORG_MARKER,
       library: '',
       affectedServices: '',
-      allowSupportAccess: false,
+      allowSupportAccess: true,
       verified: true,
       tags: ['dashboard-support-form'],
       browserInformation: 'Chrome',


### PR DESCRIPTION
## Context

Selecting "Dashboard bug" as a category in the support form should show the "Allow support access" toggle, which as per current behavior will default to true