### PR TITLE
Add AI Assistant link variant for table quickstart

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableQuickstart/TableTemplateSelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableQuickstart/TableTemplateSelector.tsx
@@ -1,6 +1,9 @@
+import { Columns3 } from 'lucide-react'
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
-import { Button, cn } from 'ui'
+import { v4 as uuidv4 } from 'uuid'
+import { AiIconAnimation, Button, cn } from 'ui'
+import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { tableTemplates } from './templates'
 import { QuickstartVariant } from './types'
 import { convertTableSuggestionToTableField } from './utils'
@@ -8,7 +11,7 @@ import type { TableSuggestion } from './types'
 import type { TableField } from '../TableEditor.types'
 
 interface TableTemplateSelectorProps {
-  variant: Exclude<QuickstartVariant, QuickstartVariant.CONTROL> // [Sean] this will be used in PR #38934
+  variant: Exclude<QuickstartVariant, QuickstartVariant.CONTROL>
   onSelectTemplate: (tableField: Partial<TableField>) => void
   onDismiss?: () => void
   disabled?: boolean
@@ -16,14 +19,28 @@ interface TableTemplateSelectorProps {
 
 const SUCCESS_MESSAGE_DURATION_MS = 3000
 
+const CONTEXT_PROMPT = `Help me create a table for my Supabase PostgreSQL database. Use these conventions:
+- Use snake_case for all names
+- Include an id column (uuid type, primary key, default: gen_random_uuid())
+- Include created_at and updated_at columns (timestamptz type, default: now())
+- Choose appropriate PostgreSQL data types
+- Consider nullable, unique, and default constraints
+
+Reference: https://supabase.com/docs/guides/database/tables`
+
+const AI_GREETING = `I'd be happy to help you design a table schema! What kind of application are you building? Tell me a bit about what data you need to store.`
+
 export const TableTemplateSelector = ({
-  variant: _variant,
+  variant,
   onSelectTemplate,
   onDismiss,
   disabled,
 }: TableTemplateSelectorProps) => {
-  const [activeCategory, setActiveCategory] = useState<string | null>(null) // null => All
+  const [activeCategory, setActiveCategory] = useState<string | null>(null)
   const [selectedTemplate, setSelectedTemplate] = useState<TableSuggestion | null>(null)
+  const aiSnap = useAiAssistantStateSnapshot()
+
+  const isAssistant = variant === QuickstartVariant.ASSISTANT
 
   const handleSelectTemplate = useCallback(
     (template: TableSuggestion) => {
@@ -40,26 +57,54 @@ export const TableTemplateSelector = ({
     [onSelectTemplate]
   )
 
+  const openAiChatWithGreeting = useCallback(
+    (name: string, contextPrompt: string, greetingMessage: string) => {
+      // Create new chat
+      aiSnap.newChat({ name, open: true })
+
+      // Add hidden context message (user role - sets expectations for AI)
+      aiSnap.saveMessage({
+        id: uuidv4(),
+        role: 'user',
+        createdAt: new Date(),
+        parts: [{ type: 'text', text: contextPrompt }],
+      })
+
+      // Add AI greeting (what user sees first)
+      aiSnap.saveMessage({
+        id: uuidv4(),
+        role: 'assistant',
+        createdAt: new Date(),
+        parts: [{ type: 'text', text: greetingMessage }],
+      })
+    },
+    [aiSnap]
+  )
+
   const categories = useMemo(() => Object.keys(tableTemplates), [])
 
   useEffect(() => {
-    if (activeCategory === null && categories.length > 0) {
+    if (!isAssistant && activeCategory === null && categories.length > 0) {
       setActiveCategory(categories[0])
     }
-  }, [categories, activeCategory])
+  }, [categories, activeCategory, isAssistant])
 
-  const displayed = useMemo(
-    () => (activeCategory ? tableTemplates[activeCategory] || [] : []),
-    [activeCategory]
-  )
+  const displayed = useMemo(() => {
+    if (isAssistant) return []
+    return activeCategory ? tableTemplates[activeCategory] || [] : []
+  }, [activeCategory, isAssistant])
 
   return (
     <div className="rounded-lg border border-default bg-surface-75 p-4">
       <div className="flex items-center justify-between mb-3">
         <div>
-          <h3 className="text-sm font-medium">Start faster with a table template</h3>
+          <h3 className="text-sm font-medium">
+            {isAssistant ? 'Design your table with AI' : 'Start faster with a table template'}
+          </h3>
           <p className="text-xs text-foreground-lighter mt-1">
-            Save time by starting from a ready-made table schema.
+            {isAssistant
+              ? 'Let AI help you create a table schema for your application.'
+              : 'Save time by starting from a ready-made table schema.'}
           </p>
         </div>
         {onDismiss && (
@@ -69,53 +114,115 @@ export const TableTemplateSelector = ({
         )}
       </div>
 
-      <div className="flex flex-wrap gap-2 mb-3">
-        {categories.map((category) => (
+      {isAssistant && (
+        <div className="space-y-3">
           <button
-            key={category}
-            onClick={() => setActiveCategory(category)}
+            onClick={() =>
+              openAiChatWithGreeting('Create database table', CONTEXT_PROMPT, AI_GREETING)
+            }
             disabled={disabled}
             className={cn(
-              'px-2 py-1 rounded-md text-xs capitalize border',
-              activeCategory === category
-                ? 'border-foreground bg-surface-200'
-                : 'border-default hover:border-foreground-muted hover:bg-surface-100',
-              'disabled:opacity-50 disabled:cursor-not-allowed'
+              'flex items-center gap-2 px-3 py-2 rounded-md text-sm border border-default w-full',
+              'hover:border-foreground-muted hover:bg-surface-100',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+              'transition-all'
             )}
           >
-            {category}
+            <AiIconAnimation size={14} />
+            <span>Open AI Assistant</span>
           </button>
-        ))}
-      </div>
 
-      <div className="grid gap-2">
-        {displayed.map((t) => (
-          <button
-            key={`${activeCategory}:${t.tableName}`}
-            onClick={() => handleSelectTemplate(t)}
-            disabled={disabled}
-            className={cn(
-              'text-left p-3 rounded-md border transition-all w-full',
-              selectedTemplate?.tableName === t.tableName
-                ? 'border-foreground bg-surface-200'
-                : 'border-default hover:border-foreground-muted hover:bg-surface-100',
-              'disabled:opacity-50 disabled:cursor-not-allowed'
-            )}
-          >
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <div className="text-sm font-medium font-mono">{t.tableName}</div>
-                {t.rationale && (
-                  <div className="text-sm text-foreground-light mt-1">{t.rationale}</div>
-                )}
-              </div>
-              <div className="flex items-center gap-1 text-sm text-foreground-muted ml-3">
-                <span>{t.fields.length} columns</span>
-              </div>
+          <div>
+            <div className="text-xs text-foreground-light mb-2">Or try these quick ideas:</div>
+            <div className="flex flex-wrap gap-2">
+              {[
+                {
+                  label: 'Recipe app',
+                  greeting: `I'd love to help you create a recipe table! Tell me more about what recipe data you need to store - ingredients, instructions, cooking times, serving sizes?`,
+                },
+                {
+                  label: 'Task manager',
+                  greeting: `Let's design a task management table! What features do you need - priorities, due dates, status tracking, assignments?`,
+                },
+                {
+                  label: 'Blog posts',
+                  greeting: `I'll help you create a blog posts table! What information do you want to capture - author details, categories, tags, publish dates?`,
+                },
+              ].map(({ label, greeting }) => (
+                <button
+                  key={label}
+                  onClick={() =>
+                    openAiChatWithGreeting(`Create ${label} table`, CONTEXT_PROMPT, greeting)
+                  }
+                  disabled={disabled}
+                  className={cn(
+                    'flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border border-default',
+                    'hover:border-foreground-muted hover:bg-surface-100',
+                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                    'transition-all'
+                  )}
+                >
+                  <AiIconAnimation size={12} />
+                  <span>{label}</span>
+                </button>
+              ))}
             </div>
-          </button>
-        ))}
-      </div>
+          </div>
+        </div>
+      )}
+
+      {!isAssistant && (
+        <div className="flex flex-wrap gap-2 mb-3">
+          {categories.map((category) => (
+            <button
+              key={category}
+              onClick={() => setActiveCategory(category)}
+              disabled={disabled}
+              className={cn(
+                'px-2 py-1 rounded-md text-xs capitalize border',
+                activeCategory === category
+                  ? 'border-foreground bg-surface-200'
+                  : 'border-default hover:border-foreground-muted hover:bg-surface-100',
+                'disabled:opacity-50 disabled:cursor-not-allowed'
+              )}
+            >
+              {category}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {displayed.length > 0 && (
+        <div className="grid gap-2">
+          {displayed.map((t) => (
+            <button
+              key={`${activeCategory}:${t.tableName}`}
+              onClick={() => handleSelectTemplate(t)}
+              disabled={disabled}
+              className={cn(
+                'text-left p-3 rounded-md border transition-all w-full',
+                selectedTemplate?.tableName === t.tableName
+                  ? 'border-foreground bg-surface-200'
+                  : 'border-default hover:border-foreground-muted hover:bg-surface-100',
+                'disabled:opacity-50 disabled:cursor-not-allowed'
+              )}
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <div className="text-sm font-medium font-mono">{t.tableName}</div>
+                  {t.rationale && (
+                    <div className="text-sm text-foreground-light mt-1">{t.rationale}</div>
+                  )}
+                </div>
+                <div className="flex items-center gap-1 text-sm text-foreground-muted ml-3">
+                  <Columns3 size={14} aria-hidden="true" />
+                  <span>{t.fields.length}</span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableQuickstart/types.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableQuickstart/types.ts
@@ -43,7 +43,7 @@ export enum TableSource {
 
 export enum QuickstartVariant {
   CONTROL = 'control',
-  AI = 'ai',
+  ASSISTANT = 'assistant',
   TEMPLATES = 'templates',
 }
 


### PR DESCRIPTION
## Summary

Adds a new AI Assistant link variant to the table quickstart feature. Instead of generating tables inline, this variant opens the AI Assistant with pre-populated context so users can describe their app and get help designing a schema.

## How it works

The assistant variant uses a two-message pattern to set up the conversation:

1. First message (hidden from user) provides context about Supabase conventions - things like using snake_case, adding uuid primary keys, including timestamps, etc. This way the AI knows what kind of schema to generate without the user having to spell it out.

2. Second message is the AI's greeting that the user actually sees - something friendly like "What kind of application are you building? Tell me about the data you need to store."

When the user responds, the AI already has all the context it needs to generate a proper Supabase-style schema.

## UI

Added a main "Open AI Assistant" button plus three quick idea buttons for common use cases:
- Recipe app
- Task manager  
- Blog posts

Each quick idea has its own custom greeting to make the conversation feel more natural.

## Changes

- Added `QuickstartVariant.ASSISTANT` to types
- Implemented the assistant link UI in `TableTemplateSelector`
- Cleaned up some unused code

## Related

Continuing exploration of inline AI generation in #38934.

## Testing

- [ ] Assistant variant shows the button and quick ideas
- [ ] Clicking opens AI Assistant with the greeting
- [ ] AI has context about Supabase conventions
- [ ] Quick idea buttons work
- [ ] Other variants (control, templates) still work

## Notes

Need to add "assistant" variant to the `tableQuickstart` PostHog flag.