### PR TITLE
feat(support form): add commit sha

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
+++ b/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
@@ -22,18 +22,22 @@ import { CATEGORY_OPTIONS } from './Support.constants'
 export const NO_PROJECT_MARKER = 'no-project'
 export const NO_ORG_MARKER = 'no-org'
 
-export const formatMessage = (
-  message: string,
-  attachments: string[],
+export const formatMessage = ({
+  message,
+  attachments,
+  error,
+  commit,
+}: {
+  message: string
+  attachments: string[]
   error: string | null | undefined
-) => {
-  const errorString = error != null ? `\nError: ${error}` : ''
-  if (attachments.length > 0) {
-    const attachmentsImg = attachments.map((url) => `\n${url}`)
-    return `${message}\n${attachmentsImg.join('')}${errorString}`
-  } else {
-    return `${message}${errorString}`
-  }
+  commit: string | undefined
+}) => {
+  const errorString = error != null ? `\n\nError: ${error}` : ''
+  const attachmentsString =
+    attachments.length > 0 ? `\n\nAttachments:\n${attachments.join('\n')}` : ''
+  const commitString = commit != undefined ? `\n\n---\nSupabase Studio version:  SHA ${commit}` : ''
+  return `${message}${errorString}${attachmentsString}${commitString}`
 }
 
 export function getPageIcon(page: Page) {

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -7,6 +7,7 @@ import { CLIENT_LIBRARIES } from 'common/constants'
 import { getProjectAuthConfig } from 'data/auth/auth-config-query'
 import { useSendSupportTicketMutation } from 'data/feedback/support-ticket-send'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
+import { useDeploymentCommitQuery } from 'data/utils/deployment-commit-query'
 import { detectBrowser } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
 import { DialogSectionSeparator, Form_Shadcn_, Separator } from 'ui'
@@ -53,6 +54,10 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
 
   const attachmentUpload = useAttachmentUpload()
 
+  const { data: commit } = useDeploymentCommitQuery({
+    staleTime: 1000 * 60 * 10, // 10 minutes
+  })
+
   const { mutate: submitSupportTicket } = useSendSupportTicketMutation({
     onSuccess: (_, variables) => {
       dispatch({
@@ -89,7 +94,12 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
         values.category === SupportCategories.PROBLEM && selectedLibrary !== undefined
           ? selectedLibrary.key
           : '',
-      message: formatMessage(values.message, attachments, initialError),
+      message: formatMessage({
+        message: values.message,
+        attachments,
+        error: initialError,
+        commit: commit?.commitSha,
+      }),
       verified: true,
       tags: ['dashboard-support-form'],
       siteUrl: '',

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { IS_PLATFORM, useFlag } from 'common'
@@ -40,13 +40,26 @@ export function useCheckLatestDeploy() {
   const [isToastShown, setIsToastShown] = useState(false)
 
   const { data: commit } = useDeploymentCommitQuery({
-    enabled: IS_PLATFORM && showRefreshToast,
+    enabled: IS_PLATFORM,
     staleTime: 1000 * 60 * 10, // 10 minutes
   })
 
+  const commitLoggedRef = useRef(false)
   useEffect(() => {
-    // if the fetched commit is undefined is undefined
-    if (!commit || commit.commitTime === 'unknown') {
+    if (commit && !commitLoggedRef.current) {
+      const commitTime =
+        commit.commitTime === 'unknown'
+          ? 'unknown time'
+          : dayjs(commit.commitTime).format('YYYY-MM-DD HH:mm:ss')
+      console.log(
+        `Supabase Studio is running commit ${commit.commitSha} deployed at ${commitTime}.`
+      )
+      commitLoggedRef.current = true
+    }
+  }, [commit])
+
+  useEffect(() => {
+    if (!showRefreshToast || !commit || commit.commitTime === 'unknown') {
       return
     }
 
@@ -78,5 +91,5 @@ export function useCheckLatestDeploy() {
       position: 'bottom-right',
     })
     setIsToastShown(true)
-  }, [commit, isToastShown, currentCommitTime])
+  }, [commit, showRefreshToast, isToastShown, currentCommitTime])
 }


### PR DESCRIPTION
Knowing the commit SHA will help us debug issues by matching them to Git timeline. Added the commit SHA in two places:

1. Automatically as part of the message on support requests
2. Logged within the console, so we can ask the user to double-check when checking if issues persist/are fixed