### PR TITLE
Custom domain update link to check TXT record

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -111,7 +111,7 @@ const CustomDomainVerify = () => {
                       <Link
                         target="_blank"
                         rel="noreferrer"
-                        href={`https://whatsmydns.net/#TXT/${customDomain?.hostname}`}
+                        href={`https://whatsmydns.net/#TXT/${customDomain?.ssl.txt_name}`}
                         className="text-brand"
                       >
                         here


### PR DESCRIPTION
## Context

For custom domains, realised that the link for "visit here" to check DNS records doesn't match the `name` of the TXT record  - so this PR fixes that

<img width="2570" height="860" alt="image" src="https://github.com/user-attachments/assets/b5f1b41e-1dbe-46e8-bab0-cc9e53fd0419" />
