### PR TITLE
Hide GettingStarted if mature

### DIFF
--- a/apps/studio/components/interfaces/HomeNew/Home.tsx
+++ b/apps/studio/components/interfaces/HomeNew/Home.tsx
@@ -23,7 +23,7 @@ import { ProjectUsageSection } from './ProjectUsageSection'
 export const HomeV2 = () => {
   const { enableBranching } = useParams()
   const snap = useAppStateSnapshot()
-  const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
+  const { data: project } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
   const { mutate: sendEvent } = useSendEventMutation()
 
@@ -109,7 +109,7 @@ export const HomeV2 = () => {
                   if (
                     id === 'getting-started' &&
                     !isMatureProject &&
-                    !isLoadingProject &&
+                    project &&
                     gettingStartedState !== 'hidden'
                   ) {
                     return (

--- a/apps/studio/components/interfaces/HomeNew/Home.tsx
+++ b/apps/studio/components/interfaces/HomeNew/Home.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useEffect, useRef } from 'react'
@@ -22,9 +23,11 @@ import { ProjectUsageSection } from './ProjectUsageSection'
 export const HomeV2 = () => {
   const { enableBranching } = useParams()
   const snap = useAppStateSnapshot()
-  const { data: project } = useSelectedProjectQuery()
+  const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
   const { mutate: sendEvent } = useSendEventMutation()
+
+  const isMatureProject = dayjs(project?.inserted_at).isBefore(dayjs().subtract(10, 'day'))
 
   const hasShownEnableBranchingModalRef = useRef(false)
   const isPaused = project?.status === PROJECT_STATUS.INACTIVE
@@ -103,8 +106,13 @@ export const HomeV2 = () => {
                       </SortableSection>
                     )
                   }
-                  if (id === 'getting-started') {
-                    return gettingStartedState === 'hidden' ? null : (
+                  if (
+                    id === 'getting-started' &&
+                    !isMatureProject &&
+                    !isLoadingProject &&
+                    gettingStartedState !== 'hidden'
+                  ) {
+                    return (
                       <SortableSection key={id} id={id}>
                         <GettingStartedSection
                           value={gettingStartedState}


### PR DESCRIPTION
The GettingStarted section is primarily an onboarding experience that is relevant to new projects. It includes quite a few requests to gather the necessary information to check whether each task is complete or not. Ideally we have a programmatic, non time based way to determine whether the section is still relevant, but for the time being this PR applies a limit of 10 days so that mature projects will not see it when we launch the new home.