### PR TITLE
To update physical backups are enabled when database size > 15GB

### DIFF
--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -26,7 +26,7 @@ Database backups can be categorized into two types: **logical** and **physical**
 To enable physical backups, you have three options:
 
 - Enable [Point-in-Time Recovery (PITR)](#point-in-time-recovery)
-- [Increase your disk size](/docs/guides/platform/database-size) to greater than 15GB
+- [Increase your database size](/docs/guides/platform/database-size) to greater than 15GB
 - [Create a read replica](/docs/guides/platform/read-replicas)
 
 Once a project satisfies at least one of the requirements for physical backups then logical backups are no longer made. However, your project may revert back to logical backups if you remove add-ons.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

To update that physical backups are enabled when db size > 15GB

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
