### PR TITLE
fix: show replica as healthy if it is

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -294,8 +294,7 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
                 <Badge>Restarting</Badge>
               ) : status === REPLICA_STATUS.RESIZING ? (
                 <Badge>Resizing</Badge>
-              ) : initStatus === ReplicaInitializationStatus.Completed &&
-                status === REPLICA_STATUS.ACTIVE_HEALTHY ? (
+              ) : status === REPLICA_STATUS.ACTIVE_HEALTHY ? (
                 <Badge variant="brand">Healthy</Badge>
               ) : (
                 <Badge variant="warning">Unhealthy</Badge>


### PR DESCRIPTION
 If the API returns the statuses as `ACTIVE_HEALTHY`, but omits `replicaInitializationStatus` (valid per the types), replicas will show as unhealthy.

`ReplicaInitializationStatus` only has 3 states, of which the first two are already covered in the ternary. This means we should be able to safely remove this extra check for completed.