### PR TITLE
feat: Add `disabled` state for PostgREST

### DIFF
--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -40,6 +40,7 @@ export const StatusMessage = ({
   if (status === 'UNHEALTHY') return 'Unhealthy'
   if (status === 'COMING_UP') return 'Coming up...'
   if (status === 'ACTIVE_HEALTHY') return 'Healthy'
+  // isProjectNew has to be after all other statuses
   if (isProjectNew) return 'Coming up...'
   if (status) return status
   return 'Unable to connect'
@@ -62,12 +63,14 @@ export const StatusIcon = ({
   isProjectNew: boolean
   projectStatus?: ProjectServiceStatus
 }) => {
-  if (isLoading) return <LoaderIcon />
-  if (isProjectNew) return <LoaderIcon />
-  if (projectStatus === 'DISABLED') return <AlertIcon />
-  if (projectStatus === 'UNHEALTHY') return <AlertIcon />
-  if (projectStatus === 'COMING_UP') return <LoaderIcon />
+  //
   if (projectStatus === 'ACTIVE_HEALTHY') return <CheckIcon />
+  if (projectStatus === 'DISABLED') return <AlertIcon />
+  if (projectStatus === 'COMING_UP') return <LoaderIcon />
+  if (isLoading) return <LoaderIcon />
+  // isProjectNew has to be above UNHEALTHY because in the first few minutes, some services might be starting up and show as UNHEALTHY
+  if (isProjectNew) return <LoaderIcon />
+  if (projectStatus === 'UNHEALTHY') return <AlertIcon />
   return <AlertIcon />
 }
 
@@ -263,7 +266,10 @@ export const ServiceStatus = () => {
     currentBranch?.status === 'CREATING_PROJECT' ||
     currentBranch?.status === 'RUNNING_MIGRATIONS'
   const isLoadingChecks = services.some((service) => service.isLoading)
-  const allServicesOperational = services.every((service) => service.status === 'ACTIVE_HEALTHY')
+  // We consider a service operational if it's healthy or intentionally disabled
+  const allServicesOperational = services.every(
+    (service) => service.status === 'ACTIVE_HEALTHY' || service.status === 'DISABLED'
+  )
 
   // If the project is less than 5 minutes old, and status is not operational, then it's likely the service is still starting up
   const isProjectNew =

--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -8,7 +8,7 @@ import { InlineLink } from 'components/ui/InlineLink'
 import { useBranchesQuery } from 'data/branches/branches-query'
 import { useEdgeFunctionServiceStatusQuery } from 'data/service-status/edge-functions-status-query'
 import {
-  ProjectServiceStatus,
+  ProjectServiceStatus as APIProjectServiceStatus,
   useProjectServiceStatusQuery,
 } from 'data/service-status/service-status-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
@@ -24,19 +24,19 @@ import {
 
 const SERVICE_STATUS_THRESHOLD = 5 // minutes
 
-const StatusMessage = ({
+export type ProjectServiceStatus = APIProjectServiceStatus | 'DISABLED'
+
+export const StatusMessage = ({
   status,
   isLoading,
-  isHealthy,
   isProjectNew,
 }: {
   isLoading: boolean
-  isHealthy: boolean
   isProjectNew: boolean
   status?: ProjectServiceStatus
 }) => {
-  if (isHealthy) return 'Healthy'
   if (isLoading) return 'Checking status'
+  if (status === 'DISABLED') return 'Disabled'
   if (status === 'UNHEALTHY') return 'Unhealthy'
   if (status === 'COMING_UP') return 'Coming up...'
   if (status === 'ACTIVE_HEALTHY') return 'Healthy'
@@ -53,23 +53,21 @@ const LoaderIcon = () => <Loader2 {...iconProps} className="animate-spin" />
 const AlertIcon = () => <AlertTriangle {...iconProps} />
 const CheckIcon = () => <CheckCircle2 {...iconProps} className="text-brand" />
 
-const StatusIcon = ({
+export const StatusIcon = ({
   isLoading,
-  isHealthy,
   isProjectNew,
   projectStatus,
 }: {
   isLoading: boolean
-  isHealthy: boolean
   isProjectNew: boolean
   projectStatus?: ProjectServiceStatus
 }) => {
-  if (isHealthy) return <CheckIcon />
   if (isLoading) return <LoaderIcon />
+  if (isProjectNew) return <LoaderIcon />
+  if (projectStatus === 'DISABLED') return <AlertIcon />
   if (projectStatus === 'UNHEALTHY') return <AlertIcon />
   if (projectStatus === 'COMING_UP') return <LoaderIcon />
   if (projectStatus === 'ACTIVE_HEALTHY') return <CheckIcon />
-  if (isProjectNew) return <LoaderIcon />
   return <AlertIcon />
 }
 
@@ -126,7 +124,18 @@ export const ServiceStatus = () => {
     {
       refetchInterval: (query) => {
         const data = query.state.data
-        return data?.some((service) => !service.healthy) ? 5000 : false
+        const isServiceUnhealthy = data?.some((service) => {
+          // if the postgrest service has an empty schema, the user chose to turn off postgrest during project creation
+          if (service.name === 'rest' && (service.info as any)?.db_schema === '') {
+            return false
+          }
+          if (service.status === 'ACTIVE_HEALTHY') {
+            return false
+          }
+          return true
+        })
+
+        return isServiceUnhealthy ? 5000 : false
       },
     }
   )
@@ -155,7 +164,6 @@ export const ServiceStatus = () => {
     error?: string
     docsUrl?: string
     isLoading: boolean
-    isHealthy: boolean
     status: ProjectServiceStatus
     logsUrl: string
   }[] = [
@@ -164,7 +172,6 @@ export const ServiceStatus = () => {
       error: undefined,
       docsUrl: undefined,
       isLoading: isLoading,
-      isHealthy: !!dbStatus?.healthy,
       status: dbStatus?.status ?? 'UNHEALTHY',
       logsUrl: '/logs/postgres-logs',
     },
@@ -173,8 +180,11 @@ export const ServiceStatus = () => {
       error: restStatus?.error,
       docsUrl: undefined,
       isLoading,
-      isHealthy: !!restStatus?.healthy,
-      status: restStatus?.status ?? 'UNHEALTHY',
+      // If PostgREST has an empty schema, it means it's been disabled
+      status:
+        (restStatus?.info as any)?.db_schema === ''
+          ? 'DISABLED'
+          : restStatus?.status ?? 'UNHEALTHY',
       logsUrl: '/logs/postgrest-logs',
     },
     ...(authEnabled
@@ -184,7 +194,6 @@ export const ServiceStatus = () => {
             error: authStatus?.error,
             docsUrl: undefined,
             isLoading,
-            isHealthy: !!authStatus?.healthy,
             status: authStatus?.status ?? 'UNHEALTHY',
             logsUrl: '/logs/auth-logs',
           },
@@ -197,7 +206,6 @@ export const ServiceStatus = () => {
             error: realtimeStatus?.error,
             docsUrl: undefined,
             isLoading,
-            isHealthy: !!realtimeStatus?.healthy,
             status: realtimeStatus?.status ?? 'UNHEALTHY',
             logsUrl: '/logs/realtime-logs',
           },
@@ -210,7 +218,6 @@ export const ServiceStatus = () => {
             error: storageStatus?.error,
             docsUrl: undefined,
             isLoading,
-            isHealthy: !!storageStatus?.healthy,
             status: storageStatus?.status ?? 'UNHEALTHY',
             logsUrl: '/logs/storage-logs',
           },
@@ -223,7 +230,6 @@ export const ServiceStatus = () => {
             error: undefined,
             docsUrl: `${DOCS_URL}/guides/functions/troubleshooting`,
             isLoading,
-            isHealthy: !!edgeFunctionsStatus?.healthy,
             status: edgeFunctionsStatus?.healthy
               ? 'ACTIVE_HEALTHY'
               : isLoading
@@ -240,7 +246,6 @@ export const ServiceStatus = () => {
             error: undefined,
             docsUrl: undefined,
             isLoading: isBranchesLoading,
-            isHealthy: currentBranch?.status === 'FUNCTIONS_DEPLOYED',
             status: (currentBranch?.status === 'FUNCTIONS_DEPLOYED'
               ? 'ACTIVE_HEALTHY'
               : currentBranch?.status === 'FUNCTIONS_FAILED' ||
@@ -258,7 +263,7 @@ export const ServiceStatus = () => {
     currentBranch?.status === 'CREATING_PROJECT' ||
     currentBranch?.status === 'RUNNING_MIGRATIONS'
   const isLoadingChecks = services.some((service) => service.isLoading)
-  const allServicesOperational = services.every((service) => service.isHealthy)
+  const allServicesOperational = services.every((service) => service.status === 'ACTIVE_HEALTHY')
 
   // If the project is less than 5 minutes old, and status is not operational, then it's likely the service is still starting up
   const isProjectNew =
@@ -316,7 +321,6 @@ export const ServiceStatus = () => {
             <div className="flex gap-x-2">
               <StatusIcon
                 isLoading={service.isLoading}
-                isHealthy={!!service.isHealthy}
                 isProjectNew={isProjectNew}
                 projectStatus={service.status}
               />
@@ -325,7 +329,6 @@ export const ServiceStatus = () => {
                 <p className="text-foreground-light flex items-center gap-1">
                   <StatusMessage
                     isLoading={service.isLoading}
-                    isHealthy={!!service.isHealthy}
                     isProjectNew={isProjectNew}
                     status={service.status}
                   />

--- a/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { AlertTriangle, CheckCircle2, ChevronRight, Loader2 } from 'lucide-react'
+import { ChevronRight, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
 import { useParams } from 'common'
@@ -7,14 +7,12 @@ import { InlineLink } from 'components/ui/InlineLink'
 import { SingleStat } from 'components/ui/SingleStat'
 import { useBranchesQuery } from 'data/branches/branches-query'
 import { useEdgeFunctionServiceStatusQuery } from 'data/service-status/edge-functions-status-query'
-import {
-  ProjectServiceStatus,
-  useProjectServiceStatusQuery,
-} from 'data/service-status/service-status-query'
+import { useProjectServiceStatusQuery } from 'data/service-status/service-status-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
 import { InfoIcon, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Popover_Shadcn_, cn } from 'ui'
+import { ProjectServiceStatus, StatusIcon, StatusMessage } from '../Home/ServiceStatus'
 
 const SERVICE_STATUS_THRESHOLD = 5 // minutes
 
@@ -35,49 +33,6 @@ const SERVICE_STATUS_THRESHOLD = 5 // minutes
  * threshold check (we’d show “Coming up” instead of “unhealthy” if the project is within 5
  * minutes of when it was created). Might be related to decoupling "ready" state vs "health checks"
  */
-
-const StatusMessage = ({
-  status,
-  isLoading,
-  isHealthy,
-  isProjectNew,
-}: {
-  isLoading: boolean
-  isHealthy: boolean
-  isProjectNew: boolean
-  status?: ProjectServiceStatus
-}) => {
-  if (isHealthy || status === 'ACTIVE_HEALTHY') return 'Healthy'
-  if (isLoading) return 'Checking status'
-  if (status === 'UNHEALTHY') return 'Unhealthy'
-  if (isProjectNew || status === 'COMING_UP') return 'Coming up...'
-  if (status) return status
-  return 'Unable to connect'
-}
-
-const iconProps = {
-  size: 18,
-  strokeWidth: 1.5,
-}
-const LoaderIcon = () => <Loader2 {...iconProps} className="animate-spin" />
-const AlertIcon = () => <AlertTriangle {...iconProps} />
-const CheckIcon = () => <CheckCircle2 {...iconProps} className="text-brand" />
-
-const StatusIcon = ({
-  isLoading,
-  isHealthy,
-  isProjectNew,
-  projectStatus,
-}: {
-  isLoading: boolean
-  isHealthy: boolean
-  isProjectNew: boolean
-  projectStatus?: ProjectServiceStatus
-}) => {
-  if (isHealthy || projectStatus === 'ACTIVE_HEALTHY') return <CheckIcon />
-  if (isLoading || isProjectNew || projectStatus === 'COMING_UP') return <LoaderIcon />
-  return <AlertIcon />
-}
 
 export const ServiceStatus = () => {
   const { ref } = useParams()
@@ -113,8 +68,21 @@ export const ServiceStatus = () => {
   const { data: status, isPending: isLoading } = useProjectServiceStatusQuery(
     { projectRef: ref },
     {
-      refetchInterval: (query) =>
-        query.state.data?.some((service) => !service.healthy) ? 5000 : false,
+      refetchInterval: (query) => {
+        const data = query.state.data
+        const isServiceUnhealthy = data?.some((service) => {
+          // if the postgrest service has an empty schema, the user chose to turn off postgrest during project creation
+          if (service.name === 'rest' && (service.info as any)?.db_schema === '') {
+            return false
+          }
+          if (service.status === 'ACTIVE_HEALTHY') {
+            return false
+          }
+          return true
+        })
+
+        return isServiceUnhealthy ? 5000 : false
+      },
     }
   )
   const { data: edgeFunctionsStatus } = useEdgeFunctionServiceStatusQuery(
@@ -141,7 +109,6 @@ export const ServiceStatus = () => {
     error?: string
     docsUrl?: string
     isLoading: boolean
-    isHealthy: boolean
     status: ProjectServiceStatus
     logsUrl: string
   }[] = [
@@ -150,7 +117,6 @@ export const ServiceStatus = () => {
       error: undefined,
       docsUrl: undefined,
       isLoading: isLoading,
-      isHealthy: !!dbStatus?.healthy,
       status: dbStatus?.status ?? 'UNHEALTHY',
       logsUrl: '/logs/postgres-logs',
     },
@@ -159,8 +125,11 @@ export const ServiceStatus = () => {
       error: restStatus?.error,
       docsUrl: undefined,
       isLoading,
-      isHealthy: !!restStatus?.healthy,
-      status: restStatus?.status ?? 'UNHEALTHY',
+      // If PostgREST has an empty schema, it means it's been disabled
+      status:
+        (restStatus?.info as any)?.db_schema === ''
+          ? 'DISABLED'
+          : restStatus?.status ?? 'UNHEALTHY',
       logsUrl: '/logs/postgrest-logs',
     },
     ...(authEnabled
@@ -170,7 +139,6 @@ export const ServiceStatus = () => {
             error: authStatus?.error,
             docsUrl: undefined,
             isLoading,
-            isHealthy: !!authStatus?.healthy,
             status: authStatus?.status ?? 'UNHEALTHY',
             logsUrl: '/logs/auth-logs',
           },
@@ -183,7 +151,6 @@ export const ServiceStatus = () => {
             error: realtimeStatus?.error,
             docsUrl: undefined,
             isLoading,
-            isHealthy: !!realtimeStatus?.healthy,
             status: realtimeStatus?.status ?? 'UNHEALTHY',
             logsUrl: '/logs/realtime-logs',
           },
@@ -196,7 +163,6 @@ export const ServiceStatus = () => {
             error: storageStatus?.error,
             docsUrl: undefined,
             isLoading,
-            isHealthy: !!storageStatus?.healthy,
             status: storageStatus?.status ?? 'UNHEALTHY',
             logsUrl: '/logs/storage-logs',
           },
@@ -209,7 +175,6 @@ export const ServiceStatus = () => {
             error: undefined,
             docsUrl: `${DOCS_URL}/guides/functions/troubleshooting`,
             isLoading,
-            isHealthy: !!edgeFunctionsStatus?.healthy,
             status: edgeFunctionsStatus?.healthy
               ? 'ACTIVE_HEALTHY'
               : isLoading
@@ -226,10 +191,7 @@ export const ServiceStatus = () => {
             error: undefined,
             docsUrl: undefined,
             isLoading: isBranchesLoading,
-            isHealthy: isBranch
-              ? currentBranch?.status === 'FUNCTIONS_DEPLOYED'
-              : !isMigrationLoading,
-            status: (isBranch
+            status: isBranch
               ? currentBranch?.status === 'FUNCTIONS_DEPLOYED'
                 ? 'ACTIVE_HEALTHY'
                 : currentBranch?.status === 'FUNCTIONS_FAILED' ||
@@ -238,7 +200,7 @@ export const ServiceStatus = () => {
                   : 'COMING_UP'
               : isMigrationLoading
                 ? 'COMING_UP'
-                : 'ACTIVE_HEALTHY') as ProjectServiceStatus,
+                : ('ACTIVE_HEALTHY' as ProjectServiceStatus),
             logsUrl: isBranch ? '/branches' : '/logs/database-logs',
           },
         ]
@@ -246,7 +208,7 @@ export const ServiceStatus = () => {
   ]
 
   const isLoadingChecks = services.some((service) => service.isLoading)
-  const allServicesOperational = services.every((service) => service.isHealthy)
+  const allServicesOperational = services.every((service) => service.status === 'ACTIVE_HEALTHY')
 
   // Check if project or branch is in a startup state
   const isProjectNew =
@@ -258,7 +220,7 @@ export const ServiceStatus = () => {
         isMigrationLoading))
 
   const anyUnhealthy = services.some(
-    (service) => !service.isHealthy && service.status !== 'COMING_UP'
+    (service) => service.status !== 'ACTIVE_HEALTHY' && service.status !== 'COMING_UP'
   )
   const anyComingUp = services.some((service) => service.status === 'COMING_UP')
   // Spinner only while the overall project is in COMING_UP; otherwise show 6-dot grid
@@ -289,9 +251,9 @@ export const ServiceStatus = () => {
                       'w-1.5 h-1.5 rounded-full',
                       service.isLoading ||
                         service.status === 'COMING_UP' ||
-                        (isProjectNew && !service.isHealthy)
+                        (isProjectNew && service.status !== 'ACTIVE_HEALTHY')
                         ? 'bg-foreground-lighter animate-pulse'
-                        : service.isHealthy
+                        : service.status === 'ACTIVE_HEALTHY'
                           ? 'bg-brand'
                           : 'bg-selection'
                     )}
@@ -314,7 +276,6 @@ export const ServiceStatus = () => {
             <div className="flex gap-x-2">
               <StatusIcon
                 isLoading={service.isLoading}
-                isHealthy={!!service.isHealthy}
                 isProjectNew={isProjectNew}
                 projectStatus={service.status}
               />
@@ -323,7 +284,6 @@ export const ServiceStatus = () => {
                 <p className="text-foreground-light flex items-center gap-1">
                   <StatusMessage
                     isLoading={service.isLoading}
-                    isHealthy={!!service.isHealthy}
                     isProjectNew={isProjectNew}
                     status={service.status}
                   />

--- a/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
@@ -208,7 +208,10 @@ export const ServiceStatus = () => {
   ]
 
   const isLoadingChecks = services.some((service) => service.isLoading)
-  const allServicesOperational = services.every((service) => service.status === 'ACTIVE_HEALTHY')
+  // We consider a service operational if it's healthy or intentionally disabled
+  const allServicesOperational = services.every(
+    (service) => service.status === 'ACTIVE_HEALTHY' || service.status === 'DISABLED'
+  )
 
   // Check if project or branch is in a startup state
   const isProjectNew =
@@ -219,9 +222,7 @@ export const ServiceStatus = () => {
         currentBranch?.status === 'RUNNING_MIGRATIONS' ||
         isMigrationLoading))
 
-  const anyUnhealthy = services.some(
-    (service) => service.status !== 'ACTIVE_HEALTHY' && service.status !== 'COMING_UP'
-  )
+  const anyUnhealthy = services.some((service) => service.status === 'UNHEALTHY')
   const anyComingUp = services.some((service) => service.status === 'COMING_UP')
   // Spinner only while the overall project is in COMING_UP; otherwise show 6-dot grid
   const showSpinnerIcon = project?.status === 'COMING_UP'

--- a/apps/studio/data/service-status/service-status-query.ts
+++ b/apps/studio/data/service-status/service-status-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 
+import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { serviceStatusKeys } from './keys'
@@ -7,6 +8,13 @@ import { serviceStatusKeys } from './keys'
 export type ProjectServiceStatusVariables = {
   projectRef?: string
 }
+
+// Omit the 'healthy' field as it's equivalent to status = 'ACTIVE_HEALTHY'
+export type ServiceHealthResponse = Omit<
+  components['schemas']['V1ServiceHealthResponse'],
+  'healthy'
+>
+export type ProjectServiceStatus = ServiceHealthResponse['status']
 
 export async function getProjectServiceStatus(
   { projectRef }: ProjectServiceStatusVariables,
@@ -25,11 +33,11 @@ export async function getProjectServiceStatus(
   })
 
   if (error) handleError(error)
-  return data
+
+  return data as ServiceHealthResponse[]
 }
 
 export type ProjectServiceStatusData = Awaited<ReturnType<typeof getProjectServiceStatus>>
-export type ProjectServiceStatus = ProjectServiceStatusData[0]['status']
 export type ProjectServiceStatusError = ResponseError
 
 export const useProjectServiceStatusQuery = <TData = ProjectServiceStatusData>(


### PR DESCRIPTION
When the user has disabled PostgREST, show the PostgREST service as disabled on the home page.

When the PostgREST service is disabled in settings, we set exposed schemas to none. This effectively means PostgREST is inaccessible and disabled.

I've also ommitted the `isHealthy` flag from the API type since it's just a shorthard for `status = ACTIVE_HEALTHY` and makes the logic more complicated.

You can test this PR by disabling Data API in https://studio-staging-git-feat-disabled-postgrest-supabase.vercel.app/dashboard/project/_/settings/api.

This PR relied on https://github.com/supabase/platform/pull/26711 which adds the exposed schemas to `info` object.

<img width="507" height="619" alt="Screenshot 2025-12-18 at 14 25 48" src="https://github.com/user-attachments/assets/f95c417e-b494-4f8a-8088-01cb912c62b2" />
<img width="364" height="467" alt="Screenshot 2025-12-18 at 14 26 08" src="https://github.com/user-attachments/assets/bdfa868e-8319-4c71-a46b-30ba4990bf98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated service status UI into shared components for consistent icons and messages across the app.
  * Simplified status-driven rendering so visuals and labels reflect explicit service states instead of prior mixed flags.

* **Bug Fixes**
  * Correctly treats intentionally disabled services as "disabled" (not unhealthy) and updates overall operational indicators and refresh behavior accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->