### PR TITLE
Nit tidy up hotkey settings

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/HotkeySettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/HotkeySettings.tsx
@@ -28,39 +28,36 @@ export const HotkeySettings = () => {
         </div>
       }
     >
-      <Panel.Content className="space-y-3">
+      <Panel.Content className="space-y-2">
         <Toggle
           checked={commandMenuEnabled}
           onChange={() => setCommandMenuEnabled(!commandMenuEnabled)}
           label={
-            <div className="flex items-center gap-x-2">
+            <div className="flex items-center gap-x-3">
               <KeyboardShortcut keys={['Meta', 'k']} />
               <span>Command menu</span>
             </div>
           }
-          descriptionText="Toggles the global command menu."
         />
         <Toggle
           checked={aiAssistantEnabled}
           onChange={() => setAiAssistantEnabled(!aiAssistantEnabled)}
           label={
-            <div className="flex items-center gap-x-2">
+            <div className="flex items-center gap-x-3">
               <KeyboardShortcut keys={['Meta', 'i']} />
-              <span>AI Assistant</span>
+              <span>AI Assistant Panel</span>
             </div>
           }
-          descriptionText="Toggles the AI Assistant panel."
         />
         <Toggle
           checked={inlineEditorEnabled}
           onChange={() => setInlineEditorEnabled(!inlineEditorEnabled)}
           label={
-            <div className="flex items-center gap-x-2">
+            <div className="flex items-center gap-x-3">
               <KeyboardShortcut keys={['Meta', 'e']} />
-              <span>Inline SQL Editor</span>
+              <span>Inline SQL Editor Panel</span>
             </div>
           }
-          descriptionText="Toggles the inline SQL editor in a side panel"
         />
       </Panel.Content>
     </Panel>


### PR DESCRIPTION
## Context

Just a tiny nit, realised that the descriptions feel unnecessary since its almost the same as the label so opting to remove them

## Before
<img width="1067" height="372" alt="image" src="https://github.com/user-attachments/assets/a69cc3fc-aeb1-4d6a-a019-61a967181132" />

## After
<img width="1061" height="272" alt="image" src="https://github.com/user-attachments/assets/699b322e-3a19-4805-969b-2ac6fd544a08" />
