### PR TITLE
fix: add time zone to commit time and add to support message

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/SortDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/SortDropdown.tsx
@@ -46,7 +46,7 @@ export const SortDropdown = ({
               <>
                 Sorting cannot be changed when searching on a specific column. If you'd like to sort
                 on other columns, change the search to{' '}
-                <span className="text-warning">all columns</span> from the header.
+                <span className="text-warning">unified search</span> from the search dropdown.
               </>
             ),
           },

--- a/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
+++ b/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
@@ -15,6 +15,7 @@ import {
   type DocsSearchResultSection as PageSection,
 } from 'common'
 import { getProjectDetail } from 'data/projects/project-detail-query'
+import dayjs from 'dayjs'
 import { DOCS_URL } from 'lib/constants'
 import type { Organization } from 'types'
 import { CATEGORY_OPTIONS } from './Support.constants'
@@ -31,12 +32,15 @@ export const formatMessage = ({
   message: string
   attachments?: string[]
   error: string | null | undefined
-  commit: string | undefined
+  commit: { commitSha: string; commitTime: string } | undefined
 }) => {
   const errorString = error != null ? `\n\nError: ${error}` : ''
   const attachmentsString =
     attachments.length > 0 ? `\n\nAttachments:\n${attachments.join('\n')}` : ''
-  const commitString = commit != undefined ? `\n\n---\nSupabase Studio version:  SHA ${commit}` : ''
+  const commitString =
+    commit != undefined
+      ? `\n\n---\nSupabase Studio version: SHA ${commit.commitSha} deployed at ${commit.commitTime === 'unknown' ? 'unknown time' : dayjs(commit.commitTime).format('YYYY-MM-DD HH:mm:ss Z')}`
+      : ''
   return `${message}${errorString}${attachmentsString}${commitString}`
 }
 

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -98,7 +98,7 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
         message: values.message,
         attachments,
         error: initialError,
-        commit: commit?.commitSha,
+        commit,
       }),
       verified: true,
       tags: ['dashboard-support-form'],

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import dayjs from 'dayjs'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 // End of third-party imports
 
@@ -62,19 +63,25 @@ const mockProjects = [
   },
 ]
 
-const { mockCommitSha, mockUseDeploymentCommitQuery } = vi.hoisted(() => {
+const { mockCommitSha, mockCommitTime, mockUseDeploymentCommitQuery } = vi.hoisted(() => {
   const sha = 'mock-studio-commit-sha'
+  const commitTime = '2024-01-01T00:00:00Z'
 
   const createCommitResponse = () => ({
     commitSha: sha,
-    commitTime: '2024-01-01T00:00:00Z',
+    commitTime,
   })
 
   return {
     mockCommitSha: sha,
+    mockCommitTime: commitTime,
     mockUseDeploymentCommitQuery: vi.fn().mockReturnValue({ data: createCommitResponse() }),
   }
 })
+
+const supportVersionInfo = `\n\n---\nSupabase Studio version: SHA ${mockCommitSha} deployed at ${dayjs(
+  mockCommitTime
+).format('YYYY-MM-DD HH:mm:ss Z')}`
 
 vi.mock('react-inlinesvg', () => ({
   __esModule: true,
@@ -268,7 +275,7 @@ describe('SupportFormPage', () => {
 
   beforeEach(() => {
     mockUseDeploymentCommitQuery.mockReturnValue({
-      data: { commitSha: mockCommitSha, commitTime: '2024-01-01T00:00:00Z' },
+      data: { commitSha: mockCommitSha, commitTime: mockCommitTime },
     })
     Object.defineProperty(window.navigator, 'userAgent', {
       value:
@@ -696,8 +703,7 @@ describe('SupportFormPage', () => {
       browserInformation: 'Chrome',
     })
     const expectedMessage =
-      'Requests return status 500 when calling the RPC endpoint\n\n---\nSupabase Studio version:  SHA ' +
-      mockCommitSha
+      'Requests return status 500 when calling the RPC endpoint' + supportVersionInfo
     expect(payload.message).toBe(expectedMessage)
 
     await waitFor(() => {
@@ -787,9 +793,7 @@ describe('SupportFormPage', () => {
       additionalRedirectUrls: 'https://project-2.supabase.dev/redirect',
       browserInformation: 'Chrome',
     })
-    const expectedMessage =
-      'MFA challenge fails with an unknown error code\n\n---\nSupabase Studio version:  SHA ' +
-      mockCommitSha
+    const expectedMessage = 'MFA challenge fails with an unknown error code' + supportVersionInfo
     expect(payload.message).toBe(expectedMessage)
 
     await waitFor(() => {
@@ -891,8 +895,8 @@ describe('SupportFormPage', () => {
       browserInformation: 'Chrome',
     })
     expect(payload.message).toBe(
-      'Connections time out after 30 seconds\n\nError: Connection timeout detected\n\n---\nSupabase Studio version:  SHA ' +
-        mockCommitSha
+      'Connections time out after 30 seconds\n\nError: Connection timeout detected' +
+        supportVersionInfo
     )
 
     await waitFor(() => {
@@ -1108,8 +1112,7 @@ describe('SupportFormPage', () => {
     const payload = submitSpy.mock.calls[0]?.[0]
     expect(payload.subject).toBe('Cannot access settings')
     expect(payload.message).toBe(
-      'Settings page shows 500 error - updated description\n\n---\nSupabase Studio version:  SHA ' +
-        mockCommitSha
+      'Settings page shows 500 error - updated description' + supportVersionInfo
     )
 
     await waitFor(() => {
@@ -1332,9 +1335,7 @@ describe('SupportFormPage', () => {
       tags: ['dashboard-support-form'],
       browserInformation: 'Chrome',
     })
-    const expectedMessage =
-      'I need help accessing my Supabase account\n\n---\nSupabase Studio version:  SHA ' +
-      mockCommitSha
+    const expectedMessage = 'I need help accessing my Supabase account' + supportVersionInfo
     expect(payload.message).toBe(expectedMessage)
 
     await waitFor(() => {

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -50,7 +50,7 @@ export function useCheckLatestDeploy() {
       const commitTime =
         commit.commitTime === 'unknown'
           ? 'unknown time'
-          : dayjs(commit.commitTime).format('YYYY-MM-DD HH:mm:ss')
+          : dayjs(commit.commitTime).format('YYYY-MM-DD HH:mm:ss Z')
       console.log(
         `Supabase Studio is running commit ${commit.commitSha} deployed at ${commitTime}.`
       )


### PR DESCRIPTION
The time zone isn't getting logged on the commit times, which makes it confusing what the actual time is. Also added it to the support message alongside the version number, to help quickly rule out outdated version issues.