### PR TITLE
fix: increase retry delay for throttled api requests

### DIFF
--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -7,7 +7,6 @@ import {
   type UseQueryOptions,
 } from '@tanstack/react-query'
 
-import { THRESHOLD_COUNT } from '@supabase/pg-meta/src/sql/studio/get-count-estimate'
 import { IS_PLATFORM } from 'common'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import { Filter, Sort, SupaRow, SupaTable } from 'components/grid/types'
@@ -50,7 +49,7 @@ async function sleep(ms: number) {
 export async function executeWithRetry<T>(
   fn: () => Promise<T>,
   maxRetries: number = 3,
-  baseDelay: number = 500
+  baseDelay: number = 1000
 ): Promise<T> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {


### PR DESCRIPTION
Increasing this because of reports that CSV uploads are failing from throttling. (I checked and there are no Retry-After headers, so we should be falling back to the default exponential backoff.)

Also brings the implementation in line with the comment :P Before, the comment claimed we were starting at 1s but we were starting at 500ms.