### PR TITLE
docs: fix broken link in Studio README

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -34,7 +34,7 @@ Project settings are managed outside of the Dashboard. If you use docker compose
 ### Developer Quickstart
 
 > [!NOTE]  
-> **Supabase internal use:** To develop on Studio locally with the backend services, see the instructions in the [internal `infrastructure` repo](https://github.com/supabase/infrastructure/blob/develop/docs/contributing.md).
+> **Supabase internal use:** To develop on Studio locally with the backend services, see the instructions in the [main `infrastructure` repo](https://github.com/supabase/supabase/blob/master/DEVELOPERS.md).
 
 ```bash
 # You'll need to be on Node v20


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The "Develop Studio locally" link in apps/studio/README.md points to a 404 page in the internal `infrastructure` repo: https://github.com/supabase/infrastructure/blob/develop/docs/contributing.md

## What is the new behavior?

The link now points to the correct developer guide in the main Supabase repo: https://github.com/supabase/supabase/blob/master/DEVELOPERS.md

## Additional context

This ensures new contributors can correctly follow instructions to run Studio locally. The reference has been updated from the internal repo to the main Supabase repository.
