### PR TITLE
fix(docker): realtime logs in self-hosted dashboard

### DIFF
--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -33,7 +33,7 @@ transforms:
       kong: '.appname == "supabase-kong"'
       auth: '.appname == "supabase-auth"'
       rest: '.appname == "supabase-rest"'
-      realtime: '.appname == "supabase-realtime"'
+      realtime: 'starts_with(string!(.appname), "realtime-dev")'
       storage: '.appname == "supabase-storage"'
       functions: '.appname == "supabase-edge-functions"'
       db: '.appname == "supabase-db"'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

realtime logs not present in self-hosted dashboard

<img width="1920" height="963" alt="Screenshot 2025-10-18 185632" src="https://github.com/user-attachments/assets/1d7d9702-f918-4fae-98dd-6e43c4340458" />

## What is the new behavior?
realtime logs are present now

<img width="1920" height="961" alt="image" src="https://github.com/user-attachments/assets/f21acb9a-a17e-4a0b-8966-c96e374faedf" />

