### PR TITLE
Fix Readme. npm i doesn't work, we have to use pnpm i

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -40,7 +40,7 @@ Project settings are managed outside of the Dashboard. If you use docker compose
 # You'll need to be on Node v20
 # in /studio
 
-npm i # install dependencies
+pnpm i # install dependencies
 npm run dev:secrets:pull # Supabase internal use: if you are working on the platform version of the Studio
 npm run dev # start dev server
 npm run test # run tests


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Readme Fix

## What is the current behavior?

npm i does not work because 
"preinstall": "npx only-allow pnpm" in package.json
