### PR TITLE
fix(docs): Clarify auth.admin.generateLink does not send emails or OTPs

### DIFF
--- a/apps/docs/features/docs/__snapshots__/Reference.typeSpec.test.ts.snap
+++ b/apps/docs/features/docs/__snapshots__/Reference.typeSpec.test.ts.snap
@@ -42109,7 +42109,7 @@ exports[`TS type spec parsing > matches snapshot 1`] = `
           }
         },
         "comment": {
-          "shortText": "Generates email links and OTPs to be sent via a custom email provider."
+          "shortText": "Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality."
         }
       },
       "@supabase/auth-js.GoTrueAdminApi.getUserById": {

--- a/apps/docs/spec/enrichments/tsdoc_v2/combined_raw.json
+++ b/apps/docs/spec/enrichments/tsdoc_v2/combined_raw.json
@@ -6309,7 +6309,7 @@
                   "kindString": "Call signature",
                   "flags": {},
                   "comment": {
-                    "shortText": "Generates email links and OTPs to be sent via a custom email provider."
+                    "shortText": "Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality."
                   },
                   "parameters": [
                     {

--- a/apps/docs/spec/enrichments/tsdoc_v2/gotrue.json
+++ b/apps/docs/spec/enrichments/tsdoc_v2/gotrue.json
@@ -4413,7 +4413,7 @@
                 "summary": [
                   {
                     "kind": "text",
-                    "text": "Generates email links and OTPs to be sent via a custom email provider."
+                    "text": "Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality."
                   }
                 ]
               },

--- a/apps/docs/spec/enrichments/tsdoc_v2/gotrue_dereferenced.json
+++ b/apps/docs/spec/enrichments/tsdoc_v2/gotrue_dereferenced.json
@@ -4413,7 +4413,7 @@
                 "summary": [
                   {
                     "kind": "text",
-                    "text": "Generates email links and OTPs to be sent via a custom email provider."
+                    "text": "Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality."
                   }
                 ]
               },

--- a/apps/docs/spec/supabase_dart_v1.yml
+++ b/apps/docs/spec/supabase_dart_v1.yml
@@ -685,7 +685,7 @@ functions:
   - id: generate-link
     title: 'generateLink()'
     notes: |
-      Generates email links and OTPs to be sent via a custom email provider.
+      Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality.
       - The following types can be passed into `generateLink()`: `signup`, `magiclink`, `invite`, `recovery`, `emailChangeCurrent`, `emailChangeNew`, `phoneChange`.
       - `generateLink()` only generates the email link for `email_change_email` if the "Secure email change" setting is enabled under the "Email" provider in your Supabase project.
       - `generateLink()` handles the creation of the user for `signup`, `invite` and `magiclink`.

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -2428,7 +2428,7 @@ functions:
   - id: generate-link
     title: 'generateLink()'
     notes: |
-      Generates email links and OTPs to be sent via a custom email provider.
+      Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality.
       - The following types can be passed into `generateLink()`: `signup`, `magiclink`, `invite`, `recovery`, `emailChangeCurrent`, `emailChangeNew`, `phoneChange`.
       - `generateLink()` only generates the email link for `email_change_email` if the "Secure email change" setting is enabled under the "Email" provider in your Supabase project.
       - `generateLink()` handles the creation of the user for `signup`, `invite` and `magiclink`.

--- a/apps/docs/spec/supabase_kt_v1.yml
+++ b/apps/docs/spec/supabase_kt_v1.yml
@@ -2904,7 +2904,7 @@ functions:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     notes: |
-      Generates email links and OTPs to be sent via a custom email provider.
+      Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality.
     examples:
       - id: generate-a-signup-link
         name: Generate a signup link

--- a/apps/docs/spec/supabase_kt_v2.yml
+++ b/apps/docs/spec/supabase_kt_v2.yml
@@ -4186,7 +4186,7 @@ functions:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     notes: |
-      Generates email links and OTPs to be sent via a custom email provider.
+      Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality.
     params:
       - name: type
         isOptional: false

--- a/apps/docs/spec/supabase_kt_v3.yml
+++ b/apps/docs/spec/supabase_kt_v3.yml
@@ -4271,7 +4271,7 @@ functions:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     notes: |
-      Generates email links and OTPs to be sent via a custom email provider.
+      Generates email links and OTPs. This will not send links or OTPs to the end user. This function is for custom admin functionality.
     params:
       - name: type
         isOptional: false


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- In relation to `auth.admin.generateLink`  it mentions "to be sent via a custom email provider" which can be confusing as this method does not send any emails / OTPs, it just generates them
- Removed that mention and clarified it does not send out emails / OTPs
- I just searched for the phrased and replaced them all, so I'm not 100% sure what each file does. If there are any issues just let me know