### PR TITLE
Add download backups section to project delete modal

### DIFF
--- a/apps/studio/components/interfaces/Connect/usePoolerConfiguration.ts
+++ b/apps/studio/components/interfaces/Connect/usePoolerConfiguration.ts
@@ -1,0 +1,57 @@
+import { usePgbouncerConfigQuery } from 'data/database/pgbouncer-config-query'
+import { useSupavisorConfigurationQuery } from 'data/database/supavisor-configuration-query'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { IS_PLATFORM } from 'lib/constants'
+import { useMemo } from 'react'
+
+export const usePoolerConfiguration = ({ projectRef }: { projectRef?: string }) => {
+  const { data: org } = useSelectedOrganizationQuery()
+
+  const {
+    data: pgbouncerConfig,
+    error: pgbouncerError,
+    isLoading: isLoadingPgbouncerConfig,
+    isError: isErrorPgbouncerConfig,
+    isSuccess: isSuccessPgBouncerConfig,
+  } = usePgbouncerConfigQuery({ projectRef })
+  const {
+    data: supavisorConfig,
+    error: supavisorConfigError,
+    isLoading: isLoadingSupavisorConfig,
+    isError: isErrorSupavisorConfig,
+    isSuccess: isSuccessSupavisorConfig,
+  } = useSupavisorConfigurationQuery({ projectRef })
+
+  const sharedPoolerPreferred = useMemo(() => {
+    return org?.plan?.id === 'free'
+  }, [org])
+
+  const poolerError = sharedPoolerPreferred ? pgbouncerError : supavisorConfigError
+  const isLoadingPoolerConfig = !IS_PLATFORM
+    ? false
+    : sharedPoolerPreferred
+      ? isLoadingPgbouncerConfig
+      : isLoadingSupavisorConfig
+  const isErrorPoolerConfig = !IS_PLATFORM
+    ? undefined
+    : sharedPoolerPreferred
+      ? isErrorPgbouncerConfig
+      : isErrorSupavisorConfig
+  const isSuccessPoolerConfig = !IS_PLATFORM
+    ? true
+    : sharedPoolerPreferred
+      ? isSuccessPgBouncerConfig
+      : isSuccessSupavisorConfig
+
+  const sharedPoolerConfiguration = supavisorConfig?.find((x) => x.identifier === projectRef)
+  const poolingConfiguration = sharedPoolerPreferred ? sharedPoolerConfiguration : pgbouncerConfig
+
+  return {
+    error: poolerError,
+    isLoading: isLoadingPoolerConfig,
+    isError: isErrorPoolerConfig,
+    isSuccess: isSuccessPoolerConfig,
+    sharedPoolerConfiguration,
+    poolingConfiguration,
+  }
+}

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -12,6 +12,7 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Input } from 'ui'
 import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
+import { DownloadBackupsSection } from './DownloadBackupsSection'
 
 export const DeleteProjectModal = ({
   visible,
@@ -106,8 +107,8 @@ export const DeleteProjectModal = ({
       alert={{
         title: isFree
           ? 'This action cannot be undone.'
-          : `This will permanently delete the ${project?.name}`,
-        description: !isFree ? `All project data will be lost, and cannot be undone` : '',
+          : `This will permanently delete the project "${project?.name}"`,
+        description: !isFree ? `All project data will be lost and cannot be undone` : '',
       }}
       text={
         isFree
@@ -121,6 +122,7 @@ export const DeleteProjectModal = ({
       onCancel={() => {
         if (!isSubmitting) onClose()
       }}
+      className="md:px-0 pb-2"
     >
       {/* 
           [Joshen] This is basically ExitSurvey.tsx, ideally we have one shared component but the one
@@ -128,9 +130,9 @@ export const DeleteProjectModal = ({
           but leaving that for the future.
         */}
       {!isFree && (
-        <>
+        <div className="px-5">
           <div className="space-y-1">
-            <h4 className="text-base">
+            <h4 className="text-sm">
               Help us improve by sharing why you're deleting your project.
             </h4>
           </div>
@@ -174,8 +176,9 @@ export const DeleteProjectModal = ({
               />
             </div>
           </div>
-        </>
+        </div>
       )}
+      <DownloadBackupsSection />
     </TextConfirmModal>
   )
 }

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -101,7 +101,7 @@ export const DeleteProjectModal = ({
     <TextConfirmModal
       visible={visible}
       loading={isSubmitting}
-      size={isFree ? 'small' : 'xlarge'}
+      size={isFree ? 'medium' : 'xlarge'}
       title={`Confirm deletion of ${project?.name}`}
       variant="destructive"
       alert={{
@@ -122,7 +122,7 @@ export const DeleteProjectModal = ({
       onCancel={() => {
         if (!isSubmitting) onClose()
       }}
-      className="md:px-0 pb-2"
+      className="md:px-0 pt-0 pb-2"
     >
       {/* 
           [Joshen] This is basically ExitSurvey.tsx, ideally we have one shared component but the one
@@ -130,7 +130,7 @@ export const DeleteProjectModal = ({
           but leaving that for the future.
         */}
       {!isFree && (
-        <div className="px-5">
+        <div className="px-5 pb-5 border-b">
           <div className="space-y-1">
             <h4 className="text-sm">
               Help us improve by sharing why you're deleting your project.

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DownloadBackupsSection.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DownloadBackupsSection.tsx
@@ -40,7 +40,7 @@ export const DownloadBackupsSection = () => {
   )
 
   return (
-    <Accordion_Shadcn_ collapsible type="single" className="border-t mt-5">
+    <Accordion_Shadcn_ collapsible type="single">
       <AccordionItem_Shadcn_ value="backups" className="border-b-0 px-5">
         <AccordionTrigger_Shadcn_ className="pb-2">
           <p className="text-sm">Download a backup of your database before deleting</p>

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DownloadBackupsSection.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DownloadBackupsSection.tsx
@@ -1,0 +1,78 @@
+import { useParams } from 'common'
+import { getConnectionStrings } from 'components/interfaces/Connect/DatabaseSettings.utils'
+import { usePoolerConfiguration } from 'components/interfaces/Connect/usePoolerConfiguration'
+import { InlineLink } from 'components/ui/InlineLink'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import {
+  Accordion_Shadcn_,
+  AccordionContent_Shadcn_,
+  AccordionItem_Shadcn_,
+  AccordionTrigger_Shadcn_,
+  CodeBlock,
+} from 'ui'
+
+export const DownloadBackupsSection = () => {
+  const { ref: projectRef } = useParams()
+
+  const { data: databases } = useReadReplicasQuery({ projectRef })
+  const primaryDatabase = (databases ?? []).find((db) => db.identifier === projectRef)
+
+  const { sharedPoolerConfiguration } = usePoolerConfiguration({ projectRef })
+  const supavisorConnectionStrings = getConnectionStrings({
+    connectionInfo: {
+      db_host: primaryDatabase?.db_host ?? '',
+      db_name: primaryDatabase?.db_name ?? '',
+      db_port: primaryDatabase?.db_port ?? 0,
+      db_user: primaryDatabase?.db_user ?? '',
+    },
+    poolingInfo: {
+      connectionString: sharedPoolerConfiguration?.connection_string ?? '',
+      db_host: sharedPoolerConfiguration?.db_host ?? '',
+      db_name: sharedPoolerConfiguration?.db_name ?? '',
+      db_port: sharedPoolerConfiguration?.db_port ?? 0,
+      db_user: sharedPoolerConfiguration?.db_user ?? '',
+    },
+    metadata: { projectRef },
+  })
+  const sessionPoolerConnectionString = supavisorConnectionStrings['pooler']['uri'].replace(
+    '6543',
+    '5432'
+  )
+
+  return (
+    <Accordion_Shadcn_ collapsible type="single" className="border-t mt-5">
+      <AccordionItem_Shadcn_ value="backups" className="border-b-0 px-5">
+        <AccordionTrigger_Shadcn_ className="pb-2">
+          <p className="text-sm">Download a backup of your database before deleting</p>
+        </AccordionTrigger_Shadcn_>
+        <AccordionContent_Shadcn_ className="[&>div]:flex [&>div]:flex-col [&>div]:gap-y-3">
+          <p className="text-foreground-light text-sm">
+            We recommend keeping a copy of your database backup prior to deleting. Backups can be
+            retrieved from either the{' '}
+            <InlineLink href={`/project/${projectRef}/database/backups/scheduled`}>
+              database section
+            </InlineLink>
+            , or created via the{' '}
+            <InlineLink href="https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore">
+              Supabase CLI
+            </InlineLink>{' '}
+            with these commands:
+          </p>
+          <div>
+            <CodeBlock
+              focusable={false}
+              hideLineNumbers
+              language="bash"
+              value={`
+supabase db dump --db-url ${sessionPoolerConnectionString} -f roles.sql --role-only &&
+supabase db dump --db-url ${sessionPoolerConnectionString} -f schema.sql &&
+supabase db dump --db-url ${sessionPoolerConnectionString} -f data.sql --use-copy --data-only
+`.trim()}
+              className="language-bash"
+            />
+          </div>
+        </AccordionContent_Shadcn_>
+      </AccordionItem_Shadcn_>
+    </Accordion_Shadcn_>
+  )
+}

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -34,6 +34,7 @@ export interface TextConfirmModalProps {
   confirmLabel?: string
   confirmPlaceholder: string
   confirmString: string
+  className?: string
   text?: string | ReactNode
   onConfirm: () => void
   onCancel: () => void
@@ -67,6 +68,7 @@ const TextConfirmModal = forwardRef<
       confirmLabel = 'Submit',
       confirmPlaceholder,
       confirmString,
+      className,
       alert,
       input,
       label,
@@ -135,7 +137,9 @@ const TextConfirmModal = forwardRef<
           )}
           {children && (
             <>
-              <DialogSection padding={'small'}>{children}</DialogSection>
+              <DialogSection padding="small" className={className}>
+                {children}
+              </DialogSection>
               <DialogSectionSeparator />
             </>
           )}


### PR DESCRIPTION
## Context

Adds a section to call out downloading database backup in the project deletion modal:

<img width="585" height="425" alt="image" src="https://github.com/user-attachments/assets/5d3046b2-49d7-40ae-9e7b-050082b24249" />

<img width="558" height="586" alt="image" src="https://github.com/user-attachments/assets/32924b80-1c97-4d02-a02d-8d9711265519" />

## Changes involved
- I've also created a `usePoolerConfiguration` hook that will be used here + in the Connect UI, make it easier to retrieve connection strings anywhere in the dashboard

## To test
- [ ] Verify that UI looks alright for projects in both free and paid org