### PR TITLE
fix: allow merge request with stale PR to be closed

### DIFF
--- a/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
+++ b/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
@@ -258,6 +258,9 @@ const MergeRequestsPage: NextPageWithLayout = () => {
                               rowLink={rowLink}
                               external={isPR}
                               rowActions={
+                                // We always want to show the action button to close a merge request
+                                // when user has requested review from dashboard. It doesn't matter
+                                // whether the branch is linked to a GitHub PR.
                                 branch.review_requested_at && (
                                   <DropdownMenu>
                                     <DropdownMenuTrigger asChild>

--- a/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
+++ b/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
@@ -258,7 +258,7 @@ const MergeRequestsPage: NextPageWithLayout = () => {
                               rowLink={rowLink}
                               external={isPR}
                               rowActions={
-                                !isPR && (
+                                branch.review_requested_at && (
                                   <DropdownMenu>
                                     <DropdownMenuTrigger asChild>
                                       <Button


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

A merge request may be requested on a branch that has a stale PR. Allows such merge requests to be closed by conditioning on the `review_requested_at` field instead.

## Additional context

Add any other context or screenshots.
