### PR TITLE
fix(docs): Correct RLS Policy and Client Setup Steps in Next.js Quickstart

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -11,6 +11,30 @@ hideToc: true
 
     <$Partial path="quickstart_db_setup.mdx" />
 
+    <StepHikeCompact.Details>
+
+    <Admonition type="note">
+
+    Since the Next.js template includes authentication middleware by default, update the RLS policy to allow `authenticated` users instead of `anon`:
+
+    </Admonition>
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+    ```sql SQL_EDITOR
+    -- Update the policy to allow authenticated users
+    drop policy "public can read instruments" on public.instruments;
+    
+    create policy "authenticated users can read instruments"
+    on public.instruments
+    for select to authenticated
+    using (true);
+    ```
+
+    </StepHikeCompact.Code>
+
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={2}>
@@ -60,11 +84,13 @@ hideToc: true
   </StepHikeCompact.Step>
 
 <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Create Supabase client">
+    <StepHikeCompact.Details title="Supabase client">
 
-    Create a new file at `utils/supabase/server.ts` and populate with the following.
+    The `with-supabase` template includes a pre-configured Supabase server client at `utils/supabase/server.ts`.
 
-    This creates a Supabase client, using the credentials from the `env.local` file.
+    This client uses the credentials from the `.env.local` file and is ready to use in Server Components and Route Handlers.
+
+    For reference, here's what the file contains:
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Only anon RLS policy is added, blocking authenticated users.

Server client file instructions are unclear and can cause duplication.

#39652 

## What is the new behavior?

RLS policy now allows authenticated users.

Client setup is clarified—no duplicate instructions.

## BEFORE
<img width="1883" height="863" alt="image" src="https://github.com/user-attachments/assets/b124d2a8-d559-498e-bd9f-b55adc3c29e6" />


## AFTER
<img width="1903" height="854" alt="image" src="https://github.com/user-attachments/assets/928fbd20-f322-46e8-973e-3b5028112230" />


## BEFORE 
<img width="1915" height="800" alt="image" src="https://github.com/user-attachments/assets/43efee8a-a463-4650-a9ad-929702d67332" />

## AFTER
<img width="1856" height="850" alt="image" src="https://github.com/user-attachments/assets/03d0b0f4-0d96-4ceb-bcb9-a4673a825201" />


## Additional context

Add any other context or screenshots.
