### PR TITLE
feat: add navigator lock debugging to track down some rare issue

### DIFF
--- a/apps/docs/lib/userAuth.ts
+++ b/apps/docs/lib/userAuth.ts
@@ -1,5 +1,10 @@
-import { gotrueClient } from 'common'
+import * as Sentry from '@sentry/nextjs'
+import { gotrueClient, setCaptureException } from 'common'
 import { useEffect } from 'react'
+
+setCaptureException((e: any) => {
+  Sentry.captureException(e)
+})
 
 export const auth = gotrueClient
 

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -1,6 +1,11 @@
+import * as Sentry from '@sentry/nextjs'
 import type { JwtPayload } from '@supabase/supabase-js'
 import { getAccessToken, type User } from 'common/auth'
-import { gotrueClient } from 'common/gotrue'
+import { gotrueClient, setCaptureException } from 'common/gotrue'
+
+setCaptureException((e: any) => {
+  Sentry.captureException(e)
+})
 
 export const auth = gotrueClient
 export { getAccessToken }


### PR DESCRIPTION
Spits out console errors if an Auth lock can't be taken for over 2s. It also kindly asks for the tab / thing that's holding the lock to identify itself.

Hopefully we track down a rare bug.