### PR TITLE
Fixes diff editor widget

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -454,7 +454,16 @@ export const SQLEditor = () => {
       setIsAcceptDiffLoading(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sourceSqlDiff, selectedDiffType, handleNewQuery, generateSqlTitle, router, id, snapV2, closeDiff])
+  }, [
+    sourceSqlDiff,
+    selectedDiffType,
+    handleNewQuery,
+    generateSqlTitle,
+    router,
+    id,
+    snapV2,
+    closeDiff,
+  ])
 
   const discardAiHandler = useCallback(() => {
     sendEvent({

--- a/apps/studio/components/interfaces/SQLEditor/useDiffEditorLifecycle.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useDiffEditorLifecycle.ts
@@ -10,6 +10,9 @@ interface UseDiffEditorLifecycleParams {
   onDiffCleared?: () => void
 }
 
+// This one's meant to solve a UI issue that seems to only be happening locally
+// Happens when you use the inline assistant in the SQL Editor and accept the suggestion
+// Error: TextModel got disposed before DiffEditorWidget model got reset
 export const useDiffEditorLifecycle = ({
   editorRef,
   diffEditorRef,

--- a/apps/studio/components/interfaces/SQLEditor/useDiffEditorLifecycle.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useDiffEditorLifecycle.ts
@@ -1,0 +1,57 @@
+import { MutableRefObject, useCallback, useEffect } from 'react'
+
+import { IStandaloneCodeEditor, IStandaloneDiffEditor } from './SQLEditor.types'
+
+interface UseDiffEditorLifecycleParams {
+  editorRef: MutableRefObject<IStandaloneCodeEditor | null>
+  diffEditorRef: MutableRefObject<IStandaloneDiffEditor | null>
+  isDiffOpen: boolean
+  closeDiffState: () => void
+  onDiffCleared?: () => void
+}
+
+export const useDiffEditorLifecycle = ({
+  editorRef,
+  diffEditorRef,
+  isDiffOpen,
+  closeDiffState,
+  onDiffCleared,
+}: UseDiffEditorLifecycleParams) => {
+  const disposeDiffEditorModel = useCallback(() => {
+    const diffEditor = diffEditorRef.current
+    if (!diffEditor) return
+
+    const model = diffEditor.getModel()
+    if (model) {
+      diffEditor.setModel(null)
+
+      const primaryModel = editorRef.current?.getModel()
+      if (model.original && model.original !== primaryModel) {
+        model.original.dispose()
+      }
+      if (model.modified && model.modified !== primaryModel) {
+        model.modified.dispose()
+      }
+    }
+
+    diffEditorRef.current = null
+    onDiffCleared?.()
+  }, [diffEditorRef, editorRef, onDiffCleared])
+
+  const closeDiff = useCallback(() => {
+    disposeDiffEditorModel()
+    closeDiffState()
+  }, [disposeDiffEditorModel, closeDiffState])
+
+  useEffect(() => {
+    if (!isDiffOpen) {
+      disposeDiffEditorModel()
+    }
+
+    return disposeDiffEditorModel
+  }, [isDiffOpen, disposeDiffEditorModel])
+
+  return { closeDiff }
+}
+
+export default useDiffEditorLifecycle

--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 
 import { constructHeaders } from 'data/fetchers'
 import { detectOS } from 'lib/helpers'
+import { useDiffEditorLifecycle } from 'components/interfaces/SQLEditor/useDiffEditorLifecycle'
 import ResizableAIWidget from './ResizableAIWidget'
 
 interface AIEditorProps {
@@ -126,12 +127,29 @@ const AIEditor = ({
     [aiEndpoint, aiMetadata]
   )
 
-  const handleReset = useCallback(() => {
-    setIsDiffMode(false)
+  const handleDiffCleared = useCallback(() => {
+    setIsDiffEditorMounted(false)
     setPromptState((prev) => ({ ...prev, isOpen: false }))
     setPromptInput('')
-    editorRef.current?.focus()
   }, [])
+
+  const { closeDiff } = useDiffEditorLifecycle({
+    editorRef,
+    diffEditorRef,
+    isDiffOpen: isDiffMode,
+    closeDiffState: () => setIsDiffMode(false),
+    onDiffCleared: handleDiffCleared,
+  })
+
+  const handleReset = useCallback(() => {
+    if (isDiffMode) {
+      closeDiff()
+    } else {
+      setPromptState((prev) => ({ ...prev, isOpen: false }))
+      setPromptInput('')
+    }
+    editorRef.current?.focus()
+  }, [isDiffMode, closeDiff])
 
   const handleAcceptDiff = useCallback(() => {
     if (diffValue.modified) {


### PR DESCRIPTION
This error only occurs locally as far as I know but when using the inline assistant for sql editor and ai editor when you accept or reject an answer it throws an error:

```
TextModel got disposed before DiffEditorWidget model got reset

Error: TextModel got disposed before DiffEditorWidget model got reset
```

To test:
- Locally, use SQL Editor , prompt assistant , accept answer and see error
- Switch to branch and do the same 
- Test same on staging
