### PR TITLE
Silence text model error in diff editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -705,6 +705,11 @@ export const SQLEditor = () => {
                           padding: { top: 4 },
                           lineNumbersMinChars: 3,
                         }}
+                        // [Joshen] These ones are meant to solve a UI issue that seems to only be happening locally
+                        // Happens when you use the inline assistant in the SQL Editor and accept the suggestion
+                        // Error: TextModel got disposed before DiffEditorWidget model got reset
+                        keepCurrentModifiedModel={true}
+                        keepCurrentOriginalModel={true}
                       />
                       {showWidget && (
                         <ResizableAIWidget


### PR DESCRIPTION
## Context

Alternative to this PR [here](https://github.com/supabase/supabase/pull/39697) RE "Error: TextModel got disposed before DiffEditorWidget model got reset" error happening only locally.

Saw this comment in this [thread](https://github.com/suren-atoyan/monaco-react/issues/647#issuecomment-2897027817) that suggests this fix, which seems to be working

## To reproduce
- Locally, use SQL Editor , prompt assistant , accept answer and see error