### PR TITLE
fix: cron logs query to handle type cast

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -228,8 +228,7 @@ limit ${limit}
 
       return `select id, postgres_logs.timestamp, event_message, parsed.error_severity, parsed.query
 from postgres_logs
-  cross join unnest(metadata) as m
-  cross join unnest(m.parsed) as parsed
+${joins}
 ${pgCronWhere}
 ${orderBy}
 limit ${limit}
@@ -293,7 +292,13 @@ export const maybeShowUpgradePrompt = (from: string | null | undefined, planId?:
 }
 
 export const genCountQuery = (table: LogsTableName, filters: Filters): string => {
-  const where = genWhereStatement(table, filters)
+  let where = genWhereStatement(table, filters)
+  // pg_cron logs are a subset of postgres logs
+  // to calculate the chart, we need to query postgres logs
+  if (table === LogsTableName.PG_CRON) {
+    table = LogsTableName.POSTGRES
+    where = basePgCronWhere
+  }
   const joins = genCrossJoinUnnests(table)
   return `SELECT count(*) as count FROM ${table} ${joins} ${where}`
 }
@@ -320,7 +325,7 @@ const calcChartStart = (params: Partial<LogsEndpointParams>): [Dayjs, string] =>
   return [its.add(-extendValue, trunc), trunc]
 }
 
-const basePgCronWhere = `where ( parsed.application_name = 'pg_cron' or regexp_contains(event_message, 'cron job') )`
+const basePgCronWhere = `where ( parsed.application_name = 'pg_cron' or event_message::text LIKE '%cron job%' )`
 /**
  *
  * generates log event chart query


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Follow up from https://github.com/supabase/supabase/pull/39388#issuecomment-3419806412

## Additional context

To test locally

```
docker build -f apps/studio/Dockerfile . -t supabase/studio:dev
echo 'dev' > supabase/.temp/studio-version
npx supabase@latest start
```

Then add a new cron job in studio
```
create extension pg_cron;

select
  cron.schedule(
    'call-hello-world-every-5-minutes',
    '*/5 * * * *',
    'select hello_world()'
  );
```