### PR TITLE
Updated docs to use pnpm for studio

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -40,11 +40,11 @@ Project settings are managed outside of the Dashboard. If you use docker compose
 # You'll need to be on Node v20
 # in /studio
 
-npm i # install dependencies
-npm run dev:secrets:pull # Supabase internal use: if you are working on the platform version of the Studio
-npm run dev # start dev server
-npm run test # run tests
-npm run -- --watch # run tests in watch mode
+pnpmn install # install dependencies
+mise studio  # Supabase internal use: if you are working on the platform version of the Studio
+pnpm run dev # start dev server
+pnpm run test # run tests
+pnpm run test -- --watch # run tests in watch mode
 ```
 
 ## Running within a self-hosted environment


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Getting Started README is out of date, fixing the README to use pnpm as it references deps from the catelog

## What is the current behavior?

npm commands don't work

## What is the new behavior?

pnpm commands work as expected

## Additional context

Just want to ensure that the misc command is correct here!
