### PR TITLE
feat: reduce profile information requests, faster page renders

### DIFF
--- a/apps/studio/data/profile/profile-identities-query.ts
+++ b/apps/studio/data/profile/profile-identities-query.ts
@@ -5,11 +5,16 @@ import { auth } from 'lib/gotrue'
 import { profileKeys } from './keys'
 
 export async function getProfileIdentities() {
-  const { error, data } = await auth.getUser()
+  // getSession() uses a cached user object, which is almost never stale as the
+  // session refresh logic keeps it fresh. If there are claims of data not being
+  // fresh, it's because it was modified on another device / browser and the
+  // session hasn't been refreshed yet.
+  const { error, data } = await auth.getSession()
 
   if (error) throw error
+  if (!data.session) throw new Error('Session not found with getSession()')
 
-  const { identities = [], new_email, email_change_sent_at } = data.user
+  const { identities = [], new_email, email_change_sent_at } = data.session.user
   return { identities, new_email, email_change_sent_at }
 }
 


### PR DESCRIPTION
Uses `auth.getSession()` instead of `getUser()` which uses a cached user object, sufficient for this purpose.