### PR TITLE
cleanup(region selector): remove code from selected region

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -89,8 +89,7 @@ export const RegionSelector = ({
     process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
 
   const allSelectableRegions = [...smartRegions, ...regionOptions]
-  const selectedRegion =
-allSelectableRegions.find((region) => {
+  const selectedRegion = allSelectableRegions.find((region) => {
     return !!region.name && region.name === field.value
   })
 

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -90,11 +90,9 @@ export const RegionSelector = ({
 
   const allSelectableRegions = [...smartRegions, ...regionOptions]
   const selectedRegion =
-    field.value !== undefined
-      ? allSelectableRegions.find((region) => {
-          return !!region.name && region.name === field.value
-        })
-      : undefined
+allSelectableRegions.find((region) => {
+    return !!region.name && region.name === field.value
+  })
 
   if (isErrorAvailableRegions) {
     return <AlertError subject="Error loading available regions" error={errorAvailableRegions} />

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -72,7 +72,7 @@ export const RegionSelector = ({
   )
 
   const availableRegions = getAvailableRegions(PROVIDERS[cloudProvider].id)
-  const regionsArray = Object.entries(availableRegions).map(([key, value]) => {
+  const regionsArray = Object.entries(availableRegions).map(([_key, value]) => {
     return {
       code: value.code,
       name: value.displayName,
@@ -87,6 +87,14 @@ export const RegionSelector = ({
   const showNonProdFields =
     process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
     process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+
+  const allSelectableRegions = [...smartRegions, ...regionOptions]
+  const selectedRegion =
+    field.value !== undefined
+      ? allSelectableRegions.find((region) => {
+          return !!region.name && region.name === field.value
+        })
+      : undefined
 
   if (isErrorAvailableRegions) {
     return <AlertError subject="Error loading available regions" error={errorAvailableRegions} />
@@ -118,7 +126,20 @@ export const RegionSelector = ({
             placeholder={
               isLoading ? 'Loading available regions...' : 'Select a region for your project..'
             }
-          />
+          >
+            {field.value !== undefined && (
+              <div className="flex items-center gap-x-3">
+                {selectedRegion?.code && (
+                  <img
+                    alt="region icon"
+                    className="w-5 rounded-sm"
+                    src={`${BASE_PATH}/img/regions/${selectedRegion.code}.svg`}
+                  />
+                )}
+                <span className="text-foreground">{selectedRegion?.name ?? field.value}</span>
+              </div>
+            )}
+          </SelectValue_Shadcn_>
         </SelectTrigger_Shadcn_>
         <SelectContent_Shadcn_>
           {smartRegionEnabled && (


### PR DESCRIPTION
Selector looks a bit busy and you probably know the code if you've already selected it, so removing it from the dropdown as suggested in a previous PR.