### PR TITLE
ci(dependabot): don't get prompted for major version updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
Major version updates require more preparation and testing, so we only want to update these on our schedule / if actually deprecated, not be prompted as soon as a new major version comes out. We mostly want to keep patch/minor updates so we can be aware of any vulnerability fixes.