### PR TITLE
fix(billing): make balance optional in subscription endpoint response

### DIFF
--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -6407,7 +6407,7 @@ export interface components {
       cached_egress_enabled: boolean
       current_period_end: number
       current_period_start: number
-      customer_balance: number
+      customer_balance?: number
       next_invoice_at: number
       payment_method_type: string
       plan: {


### PR DESCRIPTION
**Summary:**

This PR makes the `customer_balance` attribute optional in the `GetSubscriptionResponse` object since it isn't accessible for project-scoped team members.

This shouldn't cause any type errors since we already have null coalescing checks for it.

More context can be found in the backend PR having the same branch name.
