### PR TITLE
Add realtime button A/B test with three variants (GROWTH-524)

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
-import { useFlag, useParams } from 'common'
+import { useParams } from 'common'
 import { RefreshButton } from 'components/grid/components/header/RefreshButton'
 import { getEntityLintDetails } from 'components/interfaces/TableGridEditor/TableEntity.utils'
 import { APIDocsButton } from 'components/ui/APIDocsButton'
@@ -22,12 +22,12 @@ import {
   isView as isTableLikeView,
 } from 'data/table-editor/table-editor-types'
 import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
-import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useRealtimeExperiment, RealtimeButtonVariant } from 'hooks/misc/useRealtimeExperiment'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
+import { useTrack } from 'lib/telemetry/track'
 import { DOCS_URL } from 'lib/constants'
 import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
@@ -54,7 +54,7 @@ export interface GridHeaderActionsProps {
 export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const { data: org } = useSelectedOrganizationQuery()
+  const track = useTrack()
 
   const [showWarning, setShowWarning] = useQueryState(
     'showWarning',
@@ -69,7 +69,6 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const isView = isTableLikeView(table)
   const isMaterializedView = isTableLikeMaterializedView(table)
 
-  const triggersInsteadOfRealtime = useFlag<boolean>('triggersInsteadOfRealtime')
   const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
   const { isSchemaLocked } = useIsProtectedSchema({ schema: table.schema })
 
@@ -108,10 +107,22 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const realtimeEnabledTables = realtimePublication?.tables ?? []
   const isRealtimeEnabled = realtimeEnabledTables.some((t: any) => t.id === table?.id)
 
+  const { activeVariant: activeRealtimeVariant } = useRealtimeExperiment({
+    projectInsertedAt: project?.inserted_at,
+    isTable,
+    isRealtimeEnabled,
+  })
+
   const { mutate: updatePublications, isLoading: isTogglingRealtime } =
     useDatabasePublicationUpdateMutation({
       onSuccess: () => {
         setShowEnableRealtime(false)
+
+        track(isRealtimeEnabled ? 'table_realtime_disabled' : 'table_realtime_enabled', {
+          method: 'ui',
+          schema_name: table.schema,
+          table_name: table.name,
+        })
       },
       onError: (error) => {
         toast.error(`Failed to toggle realtime for ${table.name}: ${error.message}`)
@@ -162,33 +173,21 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
       table.schema
     )
 
-  const { mutate: sendEvent } = useSendEventMutation()
-
   const manageTriggersHref = `/project/${ref}/database/triggers?schema=${table.schema}`
 
   const toggleRealtime = async () => {
-    if (!project) return console.error('Project is required')
-    if (!realtimePublication) return console.error('Unable to find realtime publication')
+    if (!project || !realtimePublication) return
 
-    const exists = realtimeEnabledTables.some((x: any) => x.id == table.id)
+    const exists = realtimeEnabledTables.some((x) => x.id === table.id)
     const tables = !exists
       ? [`${table.schema}.${table.name}`].concat(
-          realtimeEnabledTables.map((t: any) => `${t.schema}.${t.name}`)
+          realtimeEnabledTables.map((t) => `${t.schema}.${t.name}`)
         )
-      : realtimeEnabledTables
-          .filter((x: any) => x.id != table.id)
-          .map((x: any) => `${x.schema}.${x.name}`)
+      : realtimeEnabledTables.filter((x) => x.id !== table.id).map((x) => `${x.schema}.${x.name}`)
 
-    sendEvent({
-      action: 'realtime_toggle_table_clicked',
-      properties: {
-        newState: exists ? 'disabled' : 'enabled',
-        origin: 'tableGridHeader',
-      },
-      groups: {
-        project: project?.ref ?? 'Unknown',
-        organization: org?.slug ?? 'Unknown',
-      },
+    track('realtime_toggle_table_clicked', {
+      newState: exists ? 'disabled' : 'enabled',
+      origin: 'tableGridHeader',
     })
 
     updatePublications({
@@ -217,17 +216,10 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
       payload: payload,
     })
 
-    sendEvent({
-      action: 'table_rls_enabled',
-      properties: {
-        method: 'table_editor',
-        schema_name: table.schema,
-        table_name: table.name,
-      },
-      groups: {
-        project: projectRef,
-        ...(org?.slug && { organization: org.slug }),
-      },
+    track('table_rls_enabled', {
+      method: 'table_editor',
+      schema_name: table.schema,
+      table_name: table.name,
     })
   }
 
@@ -344,7 +336,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
             )
           ) : null}
 
-          {isTable && triggersInsteadOfRealtime ? (
+          {isTable && activeRealtimeVariant === RealtimeButtonVariant.TRIGGERS ? (
             <Button
               asChild
               type={'default'}
@@ -367,6 +359,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
               </Link>
             </Button>
           ) : (
+            activeRealtimeVariant !== RealtimeButtonVariant.HIDE_BUTTON &&
             realtimeEnabled && (
               <ButtonTooltip
                 type="default"

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -24,11 +24,11 @@ import {
 import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useRealtimeExperiment, RealtimeButtonVariant } from 'hooks/misc/useRealtimeExperiment'
+import { RealtimeButtonVariant, useRealtimeExperiment } from 'hooks/misc/useRealtimeExperiment'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
-import { useTrack } from 'lib/telemetry/track'
 import { DOCS_URL } from 'lib/constants'
+import { useTrack } from 'lib/telemetry/track'
 import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import {
@@ -105,7 +105,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
     (publication) => publication.name === 'supabase_realtime'
   )
   const realtimeEnabledTables = realtimePublication?.tables ?? []
-  const isRealtimeEnabled = realtimeEnabledTables.some((t: any) => t.id === table?.id)
+  const isRealtimeEnabled = realtimeEnabledTables.some((t) => t.id === table?.id)
 
   const { activeVariant: activeRealtimeVariant } = useRealtimeExperiment({
     projectInsertedAt: project?.inserted_at,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -25,6 +25,7 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useConfirmOnClose, type ConfirmOnCloseModalProps } from 'hooks/ui/useConfirmOnClose'
 import { useUrlState } from 'hooks/ui/useUrlState'
+import { useTrack } from 'lib/telemetry/track'
 import { useGetImpersonatedRoleState } from 'state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { createTabId, useTabsStateSnapshot } from 'state/tabs'
@@ -132,6 +133,7 @@ export const SidePanelEditor = ({
   const queryClient = useQueryClient()
   const { data: project } = useSelectedProjectQuery()
   const { data: org } = useSelectedOrganizationQuery()
+  const track = useTrack()
 
   const [isEdited, setIsEdited] = useState<boolean>(false)
 
@@ -397,6 +399,12 @@ export const SidePanelEditor = ({
           publish_delete: true,
           tables: realtimeTables,
         })
+
+        track(enabled ? 'table_realtime_enabled' : 'table_realtime_disabled', {
+          method: 'ui',
+          schema_name: table.schema,
+          table_name: table.name,
+        })
         return
       }
       if (realtimePublication.tables === null) {
@@ -425,6 +433,12 @@ export const SidePanelEditor = ({
           connectionString: project.connectionString,
           tables: realtimeTables,
         })
+
+        track(enabled ? 'table_realtime_enabled' : 'table_realtime_disabled', {
+          method: 'ui',
+          schema_name: table.schema,
+          table_name: table.name,
+        })
         return
       }
       const isAlreadyEnabled = realtimePublication.tables.some((x) => x.id == table.id)
@@ -446,6 +460,12 @@ export const SidePanelEditor = ({
         projectRef: project.ref,
         connectionString: project.connectionString,
         tables: realtimeTables,
+      })
+
+      track(enabled ? 'table_realtime_enabled' : 'table_realtime_disabled', {
+        method: 'ui',
+        schema_name: table.schema,
+        table_name: table.name,
       })
     } catch (error: any) {
       toast.error(`Failed to update realtime for ${table.name}: ${error.message}`)

--- a/apps/studio/hooks/misc/useRealtimeExperiment.ts
+++ b/apps/studio/hooks/misc/useRealtimeExperiment.ts
@@ -64,10 +64,8 @@ export function useRealtimeExperiment({
   const isNewProject = useMemo(() => {
     if (!projectInsertedAt) return false
 
-    // Validate date format
     const insertedDate = dayjs.utc(projectInsertedAt)
     if (!insertedDate.isValid()) {
-      console.warn('[useRealtimeExperiment] Invalid project inserted_at date:', projectInsertedAt)
       return false
     }
 
@@ -102,8 +100,7 @@ export function useRealtimeExperiment({
         table_has_realtime_enabled: isRealtimeEnabled,
         days_since_project_creation: daysSinceCreation,
       })
-    } catch (error) {
-      console.error('[useRealtimeExperiment] Failed to track exposure:', error)
+    } catch {
       hasTrackedExposure.current = false
     }
   }, [isTable, isNewProject, realtimeButtonVariant, projectInsertedAt, isRealtimeEnabled, track])

--- a/apps/studio/hooks/misc/useRealtimeExperiment.ts
+++ b/apps/studio/hooks/misc/useRealtimeExperiment.ts
@@ -3,6 +3,7 @@ import utc from 'dayjs/plugin/utc'
 import { useEffect, useMemo, useRef } from 'react'
 
 import { usePHFlag } from 'hooks/ui/useFlag'
+import { IS_PLATFORM } from 'lib/constants'
 import { useTrack } from 'lib/telemetry/track'
 
 dayjs.extend(utc)
@@ -74,6 +75,7 @@ export function useRealtimeExperiment({
   }, [projectInsertedAt])
 
   const activeVariant = useMemo(() => {
+    if (!IS_PLATFORM) return null
     if (!isTable || !isNewProject) return null
     if (!realtimeButtonVariant || realtimeButtonVariant === RealtimeButtonVariant.CONTROL) {
       return null
@@ -82,6 +84,7 @@ export function useRealtimeExperiment({
   }, [isTable, isNewProject, realtimeButtonVariant])
 
   useEffect(() => {
+    if (!IS_PLATFORM) return
     if (hasTrackedExposure.current) return
     if (!isTable || !isNewProject || !projectInsertedAt) return
     if (!realtimeButtonVariant) return

--- a/apps/studio/hooks/misc/useRealtimeExperiment.ts
+++ b/apps/studio/hooks/misc/useRealtimeExperiment.ts
@@ -1,0 +1,112 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import { useEffect, useMemo, useRef } from 'react'
+
+import { usePHFlag } from 'hooks/ui/useFlag'
+import { useTrack } from 'lib/telemetry/track'
+
+dayjs.extend(utc)
+
+/**
+ * Days after project creation to be considered "new" for experiment targeting
+ */
+export const NEW_PROJECT_THRESHOLD_DAYS = 7
+
+export enum RealtimeButtonVariant {
+  CONTROL = 'control',
+  HIDE_BUTTON = 'hide-button',
+  TRIGGERS = 'triggers',
+}
+
+interface UseRealtimeExperimentOptions {
+  /**
+   * Project creation timestamp
+   */
+  projectInsertedAt?: string
+  /**
+   * Whether the current context is a table (not a view/foreign table)
+   */
+  isTable?: boolean
+  /**
+   * Whether realtime is currently enabled for the table
+   */
+  isRealtimeEnabled?: boolean
+}
+
+interface UseRealtimeExperimentResult {
+  /**
+   * The active variant for this user/project, or null if not in experiment
+   */
+  activeVariant: RealtimeButtonVariant | null
+  /**
+   * Whether this project is considered "new" for experiment targeting
+   */
+  isNewProject: boolean
+}
+
+/**
+ * Hook to manage the realtime button A/B experiment logic.
+ * Handles variant determination, exposure tracking, and date validation.
+ *
+ * @param options Configuration for experiment targeting
+ * @returns Experiment state including active variant and project age
+ */
+export function useRealtimeExperiment({
+  projectInsertedAt,
+  isTable = false,
+  isRealtimeEnabled = false,
+}: UseRealtimeExperimentOptions): UseRealtimeExperimentResult {
+  const track = useTrack()
+  const realtimeButtonVariant = usePHFlag<RealtimeButtonVariant>('realtimeButtonVariant')
+  const hasTrackedExposure = useRef(false)
+
+  const isNewProject = useMemo(() => {
+    if (!projectInsertedAt) return false
+
+    // Validate date format
+    const insertedDate = dayjs.utc(projectInsertedAt)
+    if (!insertedDate.isValid()) {
+      console.warn('[useRealtimeExperiment] Invalid project inserted_at date:', projectInsertedAt)
+      return false
+    }
+
+    return dayjs.utc().diff(insertedDate, 'day') < NEW_PROJECT_THRESHOLD_DAYS
+  }, [projectInsertedAt])
+
+  const activeVariant = useMemo(() => {
+    if (!isTable || !isNewProject) return null
+    if (!realtimeButtonVariant || realtimeButtonVariant === RealtimeButtonVariant.CONTROL) {
+      return null
+    }
+    return realtimeButtonVariant
+  }, [isTable, isNewProject, realtimeButtonVariant])
+
+  useEffect(() => {
+    if (hasTrackedExposure.current) return
+    if (!isTable || !isNewProject || !projectInsertedAt) return
+    if (!realtimeButtonVariant) return
+
+    hasTrackedExposure.current = true
+
+    try {
+      const insertedDate = dayjs.utc(projectInsertedAt)
+      if (!insertedDate.isValid()) return
+
+      const daysSinceCreation = dayjs.utc().diff(insertedDate, 'day')
+
+      track('realtime_experiment_exposed', {
+        variant: realtimeButtonVariant,
+        table_has_realtime_enabled: isRealtimeEnabled,
+        days_since_project_creation: daysSinceCreation,
+      })
+    } catch (error) {
+      console.error('[useRealtimeExperiment] Failed to track exposure:', error)
+      hasTrackedExposure.current = false
+    }
+  }, [isTable, isNewProject, realtimeButtonVariant, projectInsertedAt, isRealtimeEnabled, track])
+
+  return {
+    activeVariant,
+    isNewProject,
+  }
+}

--- a/apps/studio/hooks/ui/useFlag.ts
+++ b/apps/studio/hooks/ui/useFlag.ts
@@ -8,7 +8,32 @@ const isObjectEmpty = (obj: Object) => {
   return Object.keys(obj).length === 0
 }
 
-// TODO(Alaister): move this to packages/common/feature-flags.tsx and rename to useFlag
+/**
+ * Hook to retrieve a PostHog feature flag value.
+ *
+ * @returns `undefined | false | T` where:
+ * - `undefined` = PostHog store is still loading OR flag doesn't exist (treat as "don't show")
+ * - `false` = Flag is explicitly set to false (typically means "disabled" or "control" for experiments)
+ * - `T` = The actual flag value (string, boolean, or custom type like variant names)
+ *
+ * @example Experiment usage convention:
+ * ```typescript
+ * const variant = usePHFlag<ExperimentVariant | false>('experimentName')
+ *
+ * // undefined = loading/doesn't exist, don't render anything yet
+ * if (variant === undefined) return null
+ *
+ * // false = explicitly disabled, show control
+ * if (variant === false) return <Control />
+ *
+ * // Otherwise, variant has a value, show experiment
+ * return <Experiment variant={variant} />
+ * ```
+ *
+ * @todo TODO(Alaister): move this to packages/common/feature-flags.tsx and rename to useFlag
+ * @todo TODO(sean): Refactor to have explicit loading/disabled/value states
+ *       See https://linear.app/supabase/issue/GROWTH-539
+ */
 export function usePHFlag<T = string | boolean>(name: string) {
   const flagStore = useFeatureFlags()
   // [Joshen] Prepend PH flags with "PH" in local storage for easier identification of PH flags

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -423,6 +423,58 @@ export interface RealtimeToggleTableClickedEvent {
 }
 
 /**
+ * Realtime was enabled on a table.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/editor
+ */
+export interface TableRealtimeEnabledEvent {
+  action: 'table_realtime_enabled'
+  properties: {
+    /**
+     * The method used to enable realtime
+     */
+    method: 'ui' | 'sql_editor' | 'api'
+    /**
+     * Schema name
+     */
+    schema_name: string
+    /**
+     * Table name
+     */
+    table_name: string
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * Realtime was disabled on a table.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/editor
+ */
+export interface TableRealtimeDisabledEvent {
+  action: 'table_realtime_disabled'
+  properties: {
+    /**
+     * The method used to disable realtime
+     */
+    method: 'ui' | 'sql_editor' | 'api'
+    /**
+     * Schema name
+     */
+    schema_name: string
+    /**
+     * Table name
+     */
+    table_name: string
+  }
+  groups: TelemetryGroups
+}
+
+/**
  * User clicked the quickstart card in the SQL editor.
  *
  * @group Events
@@ -1547,6 +1599,32 @@ export interface HomeAdvisorAskAssistantClickedEvent {
 }
 
 /**
+ * User was exposed to the realtime experiment (shown or not shown the Enable Realtime button).
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/editor
+ */
+export interface RealtimeExperimentExposedEvent {
+  action: 'realtime_experiment_exposed'
+  properties: {
+    /**
+     * The experiment variant shown to the user
+     */
+    variant: 'control' | 'hide-button' | 'triggers'
+    /**
+     * Whether the table already has realtime enabled
+     */
+    table_has_realtime_enabled: boolean
+    /**
+     * Days since project creation (to segment by new user cohorts)
+     */
+    days_since_project_creation: number
+  }
+  groups: TelemetryGroups
+}
+
+/**
  * User clicked on an issue card in the Advisor section of HomeV2.
  *
  * @group Events
@@ -2266,6 +2344,8 @@ export type TelemetryEvent =
   | RealtimeInspectorFiltersAppliedEvent
   | RealtimeInspectorDatabaseRoleUpdatedEvent
   | RealtimeToggleTableClickedEvent
+  | TableRealtimeEnabledEvent
+  | TableRealtimeDisabledEvent
   | SqlEditorQuickstartClickedEvent
   | SqlEditorTemplateClickedEvent
   | SqlEditorResultDownloadCsvClickedEvent
@@ -2337,6 +2417,7 @@ export type TelemetryEvent =
   | HomeAdvisorAskAssistantClickedEvent
   | HomeAdvisorIssueCardClickedEvent
   | HomeAdvisorFixIssueClickedEvent
+  | RealtimeExperimentExposedEvent
   | HomeProjectUsageServiceClickedEvent
   | HomeProjectUsageChartClickedEvent
   | HomeCustomReportBlockAddedEvent


### PR DESCRIPTION
## What changed

We're running an A/B test on the Enable Realtime button in Table Editor to see if we can improve onboarding for new users. The experiment has three variants and only runs for projects created in the last 7 days.

**Variants:**
- `control` - Shows the normal Enable Realtime button (baseline)
- `hide-button` - Hides the button entirely
- `triggers` - Replaces button with "Manage triggers" link

Implementation uses a PostHog flag `realtimeButtonVariant` that returns one of those three values. Old projects (>7 days) always see the normal button regardless of flag value.

## Why limit to new projects

We only want to test behavior changes on users who haven't already learned the current flow. Changing UI on existing users would contaminate the data and annoy people. Projects older than 7 days are excluded from the experiment entirely - they always see the button, no tracking.

## What got added

**Experiment logic:**
- Check project age on load, only expose flag if ≤7 days old
- Track exposure once per session when viewing a table with all data loaded
- Hide or replace button based on variant (applies to grid header + side panel)

**New telemetry events:**
- `realtime_experiment_exposed` - Fires once when user sees table editor (includes variant, project age, current realtime state)
- `table_realtime_enabled` - Fires on successful enable (replaces old tracking)
- `table_realtime_disabled` - Fires on successful disable (new)

Refactored `realtime_toggle_table_clicked` and `table_rls_enabled` to use `useTrack()` hook instead of `useSendEventMutation()`.

**Constants and types:**
- `RealtimeButtonVariant` enum with three variants
- `NEW_PROJECT_THRESHOLD_DAYS = 7` for consistent project age checks
- TypeScript interfaces for all three new events

## Testing

Verified:
- Control variant shows button normally
- Hide variant removes button from both locations
- Triggers variant shows "Manage triggers" link
- Old projects always see button regardless of flag
- Exposure tracking fires once per session, only for new projects
- Enable/disable events fire on successful mutation
- All variants work in grid header and side panel

[GROWTH-524](https://linear.app/supabase/issue/GROWTH-524)