### PR TITLE
Fix gap issue

### DIFF
--- a/packages/ui/src/components/shadcn/ui/sidebar.tsx
+++ b/packages/ui/src/components/shadcn/ui/sidebar.tsx
@@ -219,8 +219,8 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            overflowing ? 'absolute top-0' : 'relative', // sidebar custom changes - to contain the absolute sidebar below
-            'duration-100 h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear',
+            overflowing ? 'absolute top-0' : 'relative',
+            'duration-100 h-full w-[--sidebar-width] bg-transparent transition-[width] ease-linear',
             'group-data-[collapsible=offcanvas]:w-0',
             'group-data-[side=right]:rotate-180',
             variant === 'floating' || variant === 'inset'


### PR DESCRIPTION
<img width="988" height="869" alt="image" src="https://github.com/user-attachments/assets/e6836d8f-7707-45c8-aa6c-6854e2ba4d4b" />

When visiting a page that is linked to an id e.g. `/billing#address` there is a small gap that appears at the bottom of the viewport. Strangely this appears to be due to our sidebar and specifically a div used to set width on desktop and its use of svh. 