### PR TITLE
Chore/table editor stay on schema after creating table

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from 'data/table-editor/table-editor-types'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
+import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { TableEditorTableStateContextProvider } from 'state/table-editor-table'
@@ -38,6 +39,7 @@ export const TableGridEditor = ({
   const router = useRouter()
   const { ref: projectRef, id } = useParams()
   const { setLastVisitedTable } = useDashboardHistory()
+  const { selectedSchema } = useQuerySchemaState()
 
   const tabs = useTabsStateSnapshot()
 
@@ -61,7 +63,9 @@ export const TableGridEditor = ({
 
   const onTableCreated = useCallback(
     (table: { id: number }) => {
-      router.push(`/project/${projectRef}/editor/${table.id}`)
+      router.push(
+        `/project/${projectRef}/editor/${table.id}${!!selectedSchema ? `?schema=${selectedSchema}` : ''}`
+      )
     },
     [projectRef, router]
   )

--- a/apps/studio/pages/project/[ref]/editor/index.tsx
+++ b/apps/studio/pages/project/[ref]/editor/index.tsx
@@ -10,6 +10,7 @@ import TableEditorLayout from 'components/layouts/TableEditorLayout/TableEditorL
 import { TableEditorMenu } from 'components/layouts/TableEditorLayout/TableEditorMenu'
 import { NewTab } from 'components/layouts/Tabs/NewTab'
 import { useDashboardHistory } from 'hooks/misc/useDashboardHistory'
+import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { editorEntityTypes, useTabsStateSnapshot } from 'state/tabs'
 import type { NextPageWithLayout } from 'types'
 
@@ -17,10 +18,13 @@ const TableEditorPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const tabStore = useTabsStateSnapshot()
+  const { selectedSchema } = useQuerySchemaState()
   const { history, isHistoryLoaded } = useDashboardHistory()
 
   const onTableCreated = (table: { id: number }) => {
-    router.push(`/project/${projectRef}/editor/${table.id}`)
+    router.push(
+      `/project/${projectRef}/editor/${table.id}${!!selectedSchema ? `?schema=${selectedSchema}` : ''}`
+    )
   }
 
   useEffect(() => {

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -306,13 +306,22 @@ function createTabsState(projectRef: string) {
       onClearDashboardHistory: () => void
     }) => {
       const tabBeingClosed = store.tabsMap[id]
-      const tabsAfterClosing = Object.values(store.tabsMap).filter((tab) => tab.id !== id)
 
-      const nextTabId = !editor
-        ? undefined
-        : tabsAfterClosing.filter((tab) => {
-            return editorEntityTypes[editor]?.includes(tab.type)
-          })[0]?.id
+      const editorTabIds = (
+        editor
+          ? Object.values(store.tabsMap).filter((tab) =>
+              editorEntityTypes[editor]?.includes(tab.type)
+            )
+          : []
+      ).map((tab) => tab.id)
+      const tabIndexBeingClosed = editorTabIds.indexOf(id)
+      const isLastTabBeingClosed = tabIndexBeingClosed === editorTabIds.length - 1
+      const nextTabId =
+        editorTabIds.length === 1
+          ? undefined
+          : isLastTabBeingClosed
+            ? editorTabIds[tabIndexBeingClosed - 1]
+            : editorTabIds[tabIndexBeingClosed + 1]
 
       const { [id]: value, ...otherTabs } = store.tabsMap
       store.tabsMap = otherTabs


### PR DESCRIPTION
## Context

Just some minor improvements to the Table Editor that I came across while working on it

## Changes involved

- Creating a new table in a schema outside of the `public` schema should keep the selected schema as that schema (currently goes back to `public`)
  - Selected schema affects the list of tables shown in the Table Editor menu
- Small improvement to tab closing behaviour when closing a tab that's in focus
  - Will open the tab that's adjacent to it instead of defaulting to the first tab

## To test
- [ ] Verify that creating a table in a schema apart from `public` will stay on that schema
- [ ] Verify that tab closing behaviour for the tab that's in focus doesn't feel awkward