### PR TITLE
chore(studio): vector buckets polish A

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -387,7 +387,7 @@ export const TriggerSheet = ({ selectedTrigger, open, setOpen }: TriggerSheetPro
                       <FormItemLayout layout="vertical" className="px-5">
                         <FormControl_Shadcn_>
                           <div className="flex flex-col gap-y-2">
-                            <p className="text-smn">Function to trigger</p>
+                            <p className="text-sm">Function to trigger</p>
                             {function_name.length === 0 ? (
                               <button
                                 type="button"

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorIndexSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorIndexSheet.tsx
@@ -86,7 +86,11 @@ const formId = 'create-vector-table-form'
 
 export type CreateVectorTableForm = z.infer<typeof FormSchema>
 
-export const CreateVectorIndexSheet = () => {
+interface CreateVectorIndexSheetProps {
+  bucketName: string
+}
+
+export const CreateVectorIndexSheet = ({ bucketName }: CreateVectorIndexSheetProps) => {
   const { ref } = useParams()
   const { mutate: createVectorBucket, isLoading: isCreating } = useVectorBucketCreateMutation()
   const [visible, setVisible] = useState(false)
@@ -95,7 +99,7 @@ export const CreateVectorIndexSheet = () => {
     resolver: zodResolver(FormSchema),
     defaultValues: {
       name: '',
-      targetSchema: 'tdai_data',
+      targetSchema: '',
       dimension: undefined,
       distanceMetric: 'cosine',
       metadataKeys: [],
@@ -176,7 +180,7 @@ export const CreateVectorIndexSheet = () => {
               <X className="h-3 w-3" />
               <span className="sr-only">Close</span>
             </SheetClose>
-            <SheetTitle className="truncate">Create Vector Index</SheetTitle>
+            <SheetTitle className="truncate">Create vector index</SheetTitle>
           </div>
         </SheetHeader>
 
@@ -231,7 +235,7 @@ export const CreateVectorIndexSheet = () => {
                         <Input_Shadcn_
                           id="targetSchema"
                           {...field}
-                          placeholder="tdai_data"
+                          value={bucketName}
                           disabled
                           className="pr-10"
                         />

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
@@ -183,8 +183,6 @@ export const CreateVectorTableSheet = ({ bucketName }: CreateVectorTableSheetPro
           <SheetTitle>Create vector table</SheetTitle>
         </SheetHeader>
 
-        {/* <Separator /> */}
-
         <Form_Shadcn_ {...form}>
           <form
             id={formId}

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
@@ -98,11 +98,11 @@ const formId = 'create-vector-table-form'
 
 export type CreateVectorTableForm = z.infer<typeof FormSchema>
 
-interface CreateVectorIndexSheetProps {
+interface CreateVectorTableSheetProps {
   bucketName: string
 }
 
-export const CreateVectorIndexSheet = ({ bucketName }: CreateVectorIndexSheetProps) => {
+export const CreateVectorTableSheet = ({ bucketName }: CreateVectorTableSheetProps) => {
   const { ref } = useParams()
   const { mutate: createVectorBucket, isLoading: isCreating } = useVectorBucketCreateMutation()
   const [visible, setVisible] = useState(false)

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -95,110 +95,117 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
             <ScaffoldHeader className="pt-0 pb-3">
               <ScaffoldSectionTitle>Tables</ScaffoldSectionTitle>
               <ScaffoldSectionDescription>
-                Vector indexes connected to this bucket.
+                Vector indexes stored in this bucket.
               </ScaffoldSectionDescription>
             </ScaffoldHeader>
-            {allIndexes.length > 0 && (
-              <div className="flex flex-row justify-between">
-                <Input
-                  size="tiny"
-                  placeholder="Search for an index"
-                  value={filterString}
-                  onChange={(e) => setFilterString(e.target.value)}
-                  icon={<Search size={12} />}
-                  className="w-48"
-                />
-                <CreateVectorIndexSheet />
-              </div>
-            )}
 
-            {allIndexes.length > 0 && (
-              <Card>
-                <Table>
-                  <TableHeader>
+            <div className="flex flex-row justify-between">
+              <Input
+                size="tiny"
+                placeholder="Search for a table"
+                value={filterString}
+                onChange={(e) => setFilterString(e.target.value)}
+                icon={<Search size={12} />}
+                className="w-48"
+              />
+              <CreateVectorIndexSheet />
+            </div>
+
+            <Card>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead
+                      className={indexesList.length === 0 ? 'text-foreground-lighter' : undefined}
+                    >
+                      Name
+                    </TableHead>
+                    <TableHead
+                      className={indexesList.length === 0 ? 'text-foreground-lighter' : undefined}
+                    >
+                      Created at
+                    </TableHead>
+                    <TableHead />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {indexesList.length === 0 && filterString.length > 0 && (
                     <TableRow>
-                      <TableHead
-                        className={indexesList.length === 0 ? 'text-foreground-lighter' : undefined}
-                      >
-                        Name
-                      </TableHead>
-                      <TableHead
-                        className={indexesList.length === 0 ? 'text-foreground-lighter' : undefined}
-                      >
-                        Created at
-                      </TableHead>
-                      <TableHead />
+                      <TableCell colSpan={3}>
+                        <p className="text-sm text-foreground">No results found</p>
+                        <p className="text-sm text-foreground-light">
+                          Your search for "{filterString}" did not return any results
+                        </p>
+                      </TableCell>
                     </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {indexesList.length === 0 && filterString.length > 0 && (
-                      <TableRow>
-                        <TableCell colSpan={3}>
-                          <p className="text-sm text-foreground">No results found</p>
-                          <p className="text-sm text-foreground-light">
-                            Your search for "{filterString}" did not return any results
+                  )}
+                  {indexesList.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={3}>
+                        <p className="text-sm text-foreground">No tables yet</p>
+                        <p className="text-sm text-foreground-light">
+                          Publish your first table to get started
+                        </p>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {indexesList.map((index, idx: number) => {
+                    const id = `index-${idx}`
+                    const name = index.indexName
+                    // the creation time is in seconds, convert it to milliseconds
+                    const created = +index.creationTime * 1000
+
+                    return (
+                      <TableRow key={id}>
+                        <TableCell>{name}</TableCell>
+                        <TableCell>
+                          <p className="text-foreground-light">
+                            <TimestampInfo utcTimestamp={created} className="text-sm" />
                           </p>
                         </TableCell>
-                      </TableRow>
-                    )}
-                    {indexesList.map((index, idx: number) => {
-                      const id = `index-${idx}`
-                      const name = index.indexName
-                      // the creation time is in seconds, convert it to milliseconds
-                      const created = +index.creationTime * 1000
-
-                      return (
-                        <TableRow key={id}>
-                          <TableCell>{name}</TableCell>
-                          <TableCell>
-                            <p className="text-foreground-light">
-                              <TimestampInfo utcTimestamp={created} className="text-sm" />
-                            </p>
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex flex-row justify-end gap-2">
-                              <Button
-                                asChild
-                                icon={<Eye size={14} className="text-foreground-lighter" />}
-                                type="default"
+                        <TableCell>
+                          <div className="flex flex-row justify-end gap-2">
+                            <Button
+                              asChild
+                              icon={<Eye size={14} className="text-foreground-lighter" />}
+                              type="default"
+                            >
+                              {/* TODO: Proper URL for table editor */}
+                              <Link
+                                href={`/project/${projectRef}/editor/${encodeURIComponent(name)}`}
                               >
-                                {/* TODO: Proper URL for table editor */}
-                                <Link
-                                  href={`/project/${projectRef}/editor/${encodeURIComponent(name)}`}
+                                Table Editor
+                              </Link>
+                            </Button>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  type="default"
+                                  className="px-1"
+                                  icon={<MoreVertical />}
+                                  onClick={(e) => e.stopPropagation()}
+                                />
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent side="bottom" align="end" className="w-40">
+                                <DropdownMenuItem
+                                  className="flex items-center space-x-2"
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                  }}
                                 >
-                                  Table Editor
-                                </Link>
-                              </Button>
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <Button
-                                    type="default"
-                                    className="px-1"
-                                    icon={<MoreVertical />}
-                                    onClick={(e) => e.stopPropagation()}
-                                  />
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent side="bottom" align="end" className="w-40">
-                                  <DropdownMenuItem
-                                    className="flex items-center space-x-2"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                    }}
-                                  >
-                                    <Trash2 size={12} />
-                                    <p>Delete table</p>
-                                  </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      )
-                    })}
-                  </TableBody>
-                </Table>
-              </Card>
-            )}
+                                  <Trash2 size={12} />
+                                  <p>Delete table</p>
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </Card>
           </ScaffoldSection>
 
           <ScaffoldSection isFullWidth className="flex flex-col gap-y-4">

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -69,8 +69,8 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
   })
 
   // Mock data for development - replace with real data when backend is ready
-  const allIndexes = MOCK_VECTOR_INDEXES
-  // const allIndexes = data?.vectorBuckets ?? []
+  // const allIndexes = MOCK_VECTOR_INDEXES
+  const allIndexes = data?.vectorBuckets ?? []
   const config = BUCKET_TYPES['vectors']
   const [filterString, setFilterString] = useState('')
 

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -29,7 +29,7 @@ import {
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { BUCKET_TYPES } from '../Storage.constants'
-import { CreateVectorIndexSheet } from './CreateVectorIndexSheet'
+import { CreateVectorTableSheet } from './CreateVectorTableSheet'
 
 // Mock data for development - remove when backend is ready
 const MOCK_VECTOR_INDEXES = [
@@ -113,7 +113,7 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                 icon={<Search size={12} />}
                 className="w-48"
               />
-              <CreateVectorIndexSheet bucketName={bucket.vectorBucketName} />
+              <CreateVectorTableSheet bucketName={bucket.vectorBucketName} />
             </div>
 
             <Card>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -28,7 +28,6 @@ import {
   TableRow,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
-import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 import { BUCKET_TYPES } from '../Storage.constants'
 import { CreateVectorIndexSheet } from './CreateVectorIndexSheet'
 
@@ -37,14 +36,20 @@ const MOCK_VECTOR_INDEXES = [
   {
     indexName: 'documents_index',
     creationTime: '1704067200', // Jan 1, 2024
+    dimension: 1536,
+    distanceMetric: 'cosine',
   },
   {
     indexName: 'embeddings_index',
     creationTime: '1704153600', // Jan 2, 2024
+    dimension: 1536,
+    distanceMetric: 'cosine',
   },
   {
     indexName: 'search_index',
     creationTime: '1704240000', // Jan 3, 2024
+    dimension: 1536,
+    distanceMetric: 'cosine',
   },
 ]
 
@@ -64,8 +69,8 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
   })
 
   // Mock data for development - replace with real data when backend is ready
-  // const allIndexes = MOCK_VECTOR_INDEXES
-  const allIndexes = data?.vectorBuckets ?? []
+  const allIndexes = MOCK_VECTOR_INDEXES
+  // const allIndexes = data?.vectorBuckets ?? []
   const config = BUCKET_TYPES['vectors']
   const [filterString, setFilterString] = useState('')
 
@@ -95,7 +100,7 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
             <ScaffoldHeader className="pt-0 pb-3">
               <ScaffoldSectionTitle>Tables</ScaffoldSectionTitle>
               <ScaffoldSectionDescription>
-                Vector indexes stored in this bucket.
+                Vector tables stored in this bucket.
               </ScaffoldSectionDescription>
             </ScaffoldHeader>
 
@@ -116,14 +121,19 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                 <TableHeader>
                   <TableRow>
                     <TableHead
-                      className={indexesList.length === 0 ? 'text-foreground-lighter' : undefined}
+                      className={indexesList.length === 0 ? 'text-foreground-muted' : undefined}
                     >
                       Name
                     </TableHead>
                     <TableHead
-                      className={indexesList.length === 0 ? 'text-foreground-lighter' : undefined}
+                      className={indexesList.length === 0 ? 'text-foreground-muted' : undefined}
                     >
-                      Created at
+                      Dimension
+                    </TableHead>
+                    <TableHead
+                      className={indexesList.length === 0 ? 'text-foreground-muted' : undefined}
+                    >
+                      Distance metric
                     </TableHead>
                     <TableHead />
                   </TableRow>
@@ -160,9 +170,10 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                         <TableRow key={id}>
                           <TableCell>{name}</TableCell>
                           <TableCell>
-                            <p className="text-foreground-light">
-                              <TimestampInfo utcTimestamp={created} className="text-sm" />
-                            </p>
+                            <p className="text-foreground-lighter">{index.dimension}</p>
+                          </TableCell>
+                          <TableCell>
+                            <p className="text-foreground-lighter">{index.distanceMetric}</p>
                           </TableCell>
                           <TableCell>
                             <div className="flex flex-row justify-end gap-2">

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -108,7 +108,7 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                 icon={<Search size={12} />}
                 className="w-48"
               />
-              <CreateVectorIndexSheet />
+              <CreateVectorIndexSheet bucketName={bucket.vectorBucketName} />
             </div>
 
             <Card>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -129,80 +129,82 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {indexesList.length === 0 && filterString.length > 0 && (
-                    <TableRow>
+                  {indexesList.length === 0 ? (
+                    <TableRow className="[&>td]:hover:bg-inherit">
                       <TableCell colSpan={3}>
-                        <p className="text-sm text-foreground">No results found</p>
-                        <p className="text-sm text-foreground-light">
-                          Your search for "{filterString}" did not return any results
-                        </p>
+                        {filterString.length > 0 ? (
+                          <>
+                            <p className="text-sm text-foreground">No results found</p>
+                            <p className="text-sm text-foreground-light">
+                              Your search for "{filterString}" did not return any results
+                            </p>
+                          </>
+                        ) : (
+                          <>
+                            <p className="text-sm text-foreground">No tables yet</p>
+                            <p className="text-sm text-foreground-light">
+                              Create your first table to get started
+                            </p>
+                          </>
+                        )}
                       </TableCell>
                     </TableRow>
-                  )}
-                  {indexesList.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={3}>
-                        <p className="text-sm text-foreground">No tables yet</p>
-                        <p className="text-sm text-foreground-light">
-                          Publish your first table to get started
-                        </p>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {indexesList.map((index, idx: number) => {
-                    const id = `index-${idx}`
-                    const name = index.indexName
-                    // the creation time is in seconds, convert it to milliseconds
-                    const created = +index.creationTime * 1000
+                  ) : (
+                    indexesList.map((index, idx: number) => {
+                      const id = `index-${idx}`
+                      const name = index.indexName
+                      // the creation time is in seconds, convert it to milliseconds
+                      const created = +index.creationTime * 1000
 
-                    return (
-                      <TableRow key={id}>
-                        <TableCell>{name}</TableCell>
-                        <TableCell>
-                          <p className="text-foreground-light">
-                            <TimestampInfo utcTimestamp={created} className="text-sm" />
-                          </p>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex flex-row justify-end gap-2">
-                            <Button
-                              asChild
-                              icon={<Eye size={14} className="text-foreground-lighter" />}
-                              type="default"
-                            >
-                              {/* TODO: Proper URL for table editor */}
-                              <Link
-                                href={`/project/${projectRef}/editor/${encodeURIComponent(name)}`}
+                      return (
+                        <TableRow key={id}>
+                          <TableCell>{name}</TableCell>
+                          <TableCell>
+                            <p className="text-foreground-light">
+                              <TimestampInfo utcTimestamp={created} className="text-sm" />
+                            </p>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-row justify-end gap-2">
+                              <Button
+                                asChild
+                                icon={<Eye size={14} className="text-foreground-lighter" />}
+                                type="default"
                               >
-                                Table Editor
-                              </Link>
-                            </Button>
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button
-                                  type="default"
-                                  className="px-1"
-                                  icon={<MoreVertical />}
-                                  onClick={(e) => e.stopPropagation()}
-                                />
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent side="bottom" align="end" className="w-40">
-                                <DropdownMenuItem
-                                  className="flex items-center space-x-2"
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                  }}
+                                {/* TODO: Proper URL for table editor */}
+                                <Link
+                                  href={`/project/${projectRef}/editor/${encodeURIComponent(name)}`}
                                 >
-                                  <Trash2 size={12} />
-                                  <p>Delete table</p>
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
+                                  Table Editor
+                                </Link>
+                              </Button>
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <Button
+                                    type="default"
+                                    className="px-1"
+                                    icon={<MoreVertical />}
+                                    onClick={(e) => e.stopPropagation()}
+                                  />
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent side="bottom" align="end" className="w-40">
+                                  <DropdownMenuItem
+                                    className="flex items-center space-x-2"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                    }}
+                                  >
+                                    <Trash2 size={12} />
+                                    <p>Delete table</p>
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })
+                  )}
                 </TableBody>
               </Table>
             </Card>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore: more UI improvements to the vector buckets and their details

## What is the current behavior?

- Vector buckets don’t have a proper empty state when there are no tables (AKA indexes)
- The table creation flow had some design inconsistencies with other sheets 

## What is the new behavior?

- UI and copywriting improvements to the above areas
- Minor copywriting improvements more generally
- Renamed references of “index” to “table” since that’s our nomenclature for vector ~indexes~ tables

## Additional context

Based branch: https://github.com/supabase/supabase/pull/39597.

Still to come:

- [ ] Delete bucket modal

## To test

Use `MOCK_VECTOR_INDEXES` for `allIndexes` in `VectorBucketDetails` ([here](https://github.com/supabase/supabase/blob/4394ca48f0ee3c2c0f4717b52ff08f639d65c8e3/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx#L67)) if you need mock table data.
