### PR TITLE
Consolidate enabled flag checks to use isOptedIntoProjectLevelPermissions for useProjectsQuery

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -16,6 +16,7 @@ import {
 } from 'data/organizations/organization-members-query'
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
+import { useHasAccessToProjectLevelPermissions } from 'data/subscriptions/org-subscription-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -45,13 +46,12 @@ export const MemberActions = ({ member }: MemberActionsProps) => {
 
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const { data: permissions } = usePermissionsQuery()
-  const { data: members } = useOrganizationMembersQuery({ slug })
-
   const { data: allRoles } = useOrganizationRolesV2Query({ slug })
-  const hasProjectScopedRoles = (allRoles?.project_scoped_roles ?? []).length > 0
+  const { data: members } = useOrganizationMembersQuery({ slug })
+  const isOptedIntoProjectLevelPermissions = useHasAccessToProjectLevelPermissions(slug as string)
 
   // [Joshen] We only need this data if the org has project scoped roles
-  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
+  const { data } = useProjectsQuery({ enabled: isOptedIntoProjectLevelPermissions })
   const allProjects = data?.projects ?? []
 
   const memberIsUser = member.gotrue_id == profile?.gotrue_id

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -1,11 +1,13 @@
 import { ArrowRight, Check, Minus, User, X } from 'lucide-react'
 import Link from 'next/link'
 
+import { useParams } from 'common'
 import PartnerIcon from 'components/ui/PartnerIcon'
 import { ProfileImage } from 'components/ui/ProfileImage'
 import { useOrganizationRolesV2Query } from 'data/organization-members/organization-roles-query'
 import { OrganizationMember } from 'data/organizations/organization-members-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
+import { useHasAccessToProjectLevelPermissions } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { getGitHubProfileImgUrl } from 'lib/github'
 import { useProfile } from 'lib/profile'
@@ -32,8 +34,10 @@ const MEMBER_ORIGIN_TO_MANAGED_BY = {
 } as const
 
 export const MemberRow = ({ member }: MemberRowProps) => {
+  const { slug } = useParams()
   const { profile } = useProfile()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
+  const isOptedIntoProjectLevelPermissions = useHasAccessToProjectLevelPermissions(slug as string)
 
   const { data: roles, isLoading: isLoadingRoles } = useOrganizationRolesV2Query({
     slug: selectedOrganization?.slug,
@@ -41,7 +45,7 @@ export const MemberRow = ({ member }: MemberRowProps) => {
   const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
 
   // [Joshen] We only need this data if the org has project scoped roles
-  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
+  const { data } = useProjectsQuery({ enabled: isOptedIntoProjectLevelPermissions })
   const projects = data?.projects ?? []
 
   const orgProjects = projects?.filter((p) => p.organization_id === selectedOrganization?.id)

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -14,6 +14,7 @@ import {
 import { organizationKeys as organizationKeysV1 } from 'data/organizations/keys'
 import { OrganizationMember } from 'data/organizations/organization-members-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
+import { useHasAccessToProjectLevelPermissions } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import {
@@ -39,12 +40,12 @@ export const UpdateRolesConfirmationModal = ({
   const { slug } = useParams()
   const queryClient = useQueryClient()
   const { data: organization } = useSelectedOrganizationQuery()
+  const isOptedIntoProjectLevelPermissions = useHasAccessToProjectLevelPermissions(slug as string)
 
   const { data: allRoles } = useOrganizationRolesV2Query({ slug: organization?.slug })
-  const hasProjectScopedRoles = (allRoles?.project_scoped_roles ?? []).length > 0
 
   // [Joshen] We only need this data if the org has project scoped roles
-  const { data } = useProjectsQuery({ enabled: hasProjectScopedRoles })
+  const { data } = useProjectsQuery({ enabled: isOptedIntoProjectLevelPermissions && visible })
   const projects = data?.projects ?? []
 
   // [Joshen] Separate saving state instead of using RQ due to several successive steps


### PR DESCRIPTION
## Context

As per PR title, just consolidates all the `enabled` checks for the unpaginated `useProjectsQuery` to check against `isOptedIntoProjectLevelPermissions`