### PR TITLE
Add threshold value to persist sort by in auth users

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -55,7 +55,7 @@ import { formatUserColumns, formatUsersData } from './Users.utils'
 import { UsersFooter } from './UsersFooter'
 import { UsersSearch } from './UsersSearch'
 
-const SORT_BY_VALUE_COUNT_THRESHOLD = 10
+const SORT_BY_VALUE_COUNT_THRESHOLD = 10_000
 
 export const UsersV2 = () => {
   const queryClient = useQueryClient()

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -55,7 +55,6 @@ import { formatUserColumns, formatUsersData } from './Users.utils'
 import { UsersFooter } from './UsersFooter'
 import { UsersSearch } from './UsersSearch'
 
-// [Joshen] Arbitary threshold value for what's considered to be a lot of users
 const SORT_BY_VALUE_COUNT_THRESHOLD = 10_000
 
 export const UsersV2 = () => {

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -100,7 +100,7 @@ export const UsersV2 = () => {
     parseAsStringEnum(['all', 'verified', 'unverified', 'anonymous']).withDefault('all')
   )
   const [filterKeywords, setFilterKeywords] = useQueryState('keywords', { defaultValue: '' })
-  const [sortByValue, setSortByValue] = useQueryState('id:asc', { defaultValue: 'id:asc' })
+  const [sortByValue, setSortByValue] = useQueryState('sortBy', { defaultValue: 'id:asc' })
   const [sortColumn, sortOrder] = sortByValue.split(':')
   const [selectedColumns, setSelectedColumns] = useQueryState(
     'columns',
@@ -227,6 +227,9 @@ export const UsersV2 = () => {
   const updateStorageFilter = (value: 'id' | 'email' | 'phone' | 'freeform') => {
     setLocalStorageFilter(value)
     setSpecificFilterColumn(value)
+    if (value !== 'freeform') {
+      updateSortByValue('id:asc')
+    }
   }
 
   const updateSortByValue = (value: string) => {
@@ -342,12 +345,16 @@ export const UsersV2 = () => {
 
   // [Joshen] Load URL state for filter column and sort by only once, if no respective values found in URL params
   useEffect(() => {
-    if (isLocalStorageFilterLoaded && isLocalStorageSortByValueLoaded && isCountLoaded) {
+    if (
+      isLocalStorageFilterLoaded &&
+      isLocalStorageSortByValueLoaded &&
+      isCountLoaded &&
+      isCountWithinThresholdForSortBy
+    ) {
       if (specificFilterColumn === 'id' && localStorageFilter !== 'id') {
         setSpecificFilterColumn(localStorageFilter)
       }
-
-      if (isCountWithinThresholdForSortBy) {
+      if (sortByValue === 'id:asc' && localStorageSortByValue !== 'id:asc') {
         setSortByValue(localStorageSortByValue)
       }
     }

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -146,7 +146,7 @@ export const UsersV2 = () => {
   const [isDeletingUsers, setIsDeletingUsers] = useState(false)
   const [showFreeformWarning, setShowFreeformWarning] = useState(false)
 
-  const { data: countData, isSuccess: isCountLoaded } = useUsersCountQuery(
+  const { data: totalUsersCountData, isSuccess: isCountLoaded } = useUsersCountQuery(
     {
       projectRef,
       connectionString: project?.connectionString,
@@ -160,7 +160,7 @@ export const UsersV2 = () => {
     },
     { keepPreviousData: true }
   )
-  const totalUsers = countData?.count ?? 0
+  const totalUsers = totalUsersCountData?.count ?? 0
   const isCountWithinThresholdForSortBy = totalUsers <= SORT_BY_VALUE_COUNT_THRESHOLD
 
   const {

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -55,7 +55,7 @@ import { formatUserColumns, formatUsersData } from './Users.utils'
 import { UsersFooter } from './UsersFooter'
 import { UsersSearch } from './UsersSearch'
 
-const SORT_BY_VALUE_COUNT_THRESHOLD = 10_000
+const SORT_BY_VALUE_COUNT_THRESHOLD = 10
 
 export const UsersV2 = () => {
   const queryClient = useQueryClient()
@@ -727,9 +727,9 @@ export const UsersV2 = () => {
         onCancel={() => setShowFreeformWarning(false)}
         alert={{
           base: { variant: 'warning' },
-          title: 'Searching across all columns is not recommended',
+          title: 'Searching across all columns is not recommended with many users',
           description:
-            'This may adversely impact your database, in particular if your project has a large number of users - use with caution.',
+            'This may adversely impact your database, in particular if your project has a large number of users - use with caution. Search mode will not be persisted across browser sessions as a safeguard.',
         }}
       >
         <p className="text-foreground-light text-sm">

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -28,6 +28,7 @@ export const LOCAL_STORAGE_KEYS = {
   STORAGE_PREFERENCE: (ref: string) => `storage-explorer-${ref}`,
 
   AUTH_USERS_FILTER: (ref: string) => `auth-users-filter-${ref}`,
+  AUTH_USERS_SORT_BY_VALUE: (ref: string) => `auth-users-sort-by-value-${ref}`,
   AUTH_USERS_COLUMNS_CONFIGURATION: (ref: string) => `supabase-auth-users-columns-${ref}`,
 
   SQL_EDITOR_INTELLISENSE: 'supabase_sql-editor-intellisense-enabled',


### PR DESCRIPTION
## Context

Another small improvement to improve the UX of the Auth Users page for most users

## Changes

- Opt to persist the "Sort by" value in the Auth Users page in local storage, ONLY IF the number of users is within an arbitrary threshold of 10,000. This value will then be loaded whenever the user lands on `/auth/users` (e.g from clicking on the dashboard)
  - This check is intentionally strict so if for some reason the count doesn't successfully load, we won't load the sort by value from local storage
- Also opt to skip the warning dialog when selecting "unified search" if number of users is within that same threshold

## To test
This is probably easier to test locally unless you have > 10,000 users. Can set `SORT_BY_VALUE_COUNT_THRESHOLD` to a low value of 10 for example
- [ ] Verify that sort by value gets persisted + loaded if user count is within threshold
- [ ] Verify that warning dialog for selecting "unified search" doesn't show up if user count is within threshold
- [ ] Verify that sort by value does not persist / loaded if user count is outside of the threshold
- [ ] Verify that warning dialog for selecting "unified search" still shows up if user count is outside threshold