### PR TITLE
fix,perf(policies search)

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
@@ -1,7 +1,7 @@
 import type { PostgresPolicy } from '@supabase/postgres-meta'
 import { isEmpty } from 'lodash'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
@@ -11,11 +11,15 @@ import {
 } from 'components/interfaces/Auth/Policies/PolicyTableRow'
 import { ProtectedSchemaWarning } from 'components/interfaces/Database/ProtectedSchemaWarning'
 import { NoSearchResults } from 'components/ui/NoSearchResults'
+import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 import { useDatabasePolicyDeleteMutation } from 'data/database-policies/database-policy-delete-mutation'
 import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import type { ResponseError } from 'types'
 import { Button, Card, CardContent } from 'ui'
 import ConfirmModal from 'ui-patterns/Dialogs/ConfirmDialog'
+
+const EMPTY_POLICIES: PostgresPolicy[] = []
 
 interface PoliciesProps {
   search?: string
@@ -23,6 +27,11 @@ interface PoliciesProps {
   tables: PolicyTableRowProps['table'][]
   hasTables: boolean
   isLocked: boolean
+  policies: PostgresPolicy[]
+  isLoadingPolicies: boolean
+  isPoliciesError: boolean
+  policiesError?: ResponseError | Error
+  visibleTableIds: Set<number>
   onSelectCreatePolicy: (table: string) => void
   onSelectEditPolicy: (policy: PostgresPolicy) => void
   onResetSearch?: () => void
@@ -34,12 +43,18 @@ export const Policies = ({
   tables,
   hasTables,
   isLocked,
+  policies,
+  isLoadingPolicies,
+  isPoliciesError,
+  policiesError,
+  visibleTableIds,
   onSelectCreatePolicy,
   onSelectEditPolicy: onSelectEditPolicyAI,
   onResetSearch,
 }: PoliciesProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
+  const { data: postgrestConfig } = useProjectPostgrestConfigQuery({ projectRef: project?.ref })
 
   const [selectedTableToToggleRLS, setSelectedTableToToggleRLS] = useState<{
     id: number
@@ -66,27 +81,28 @@ export const Policies = ({
     },
   })
 
-  const closeConfirmModal = () => {
+  const closeConfirmModal = useCallback(() => {
     setSelectedPolicyToDelete({})
     setSelectedTableToToggleRLS(undefined)
-  }
+  }, [])
 
-  const onSelectToggleRLS = (table: {
-    id: number
-    schema: string
-    name: string
-    rls_enabled: boolean
-  }) => {
-    setSelectedTableToToggleRLS(table)
-  }
+  const onSelectToggleRLS = useCallback(
+    (table: { id: number; schema: string; name: string; rls_enabled: boolean }) => {
+      setSelectedTableToToggleRLS(table)
+    },
+    []
+  )
 
-  const onSelectEditPolicy = (policy: any) => {
-    onSelectEditPolicyAI(policy)
-  }
+  const onSelectEditPolicy = useCallback(
+    (policy: PostgresPolicy) => {
+      onSelectEditPolicyAI(policy)
+    },
+    [onSelectEditPolicyAI]
+  )
 
-  const onSelectDeletePolicy = (policy: any) => {
+  const onSelectDeletePolicy = useCallback((policy: PostgresPolicy) => {
     setSelectedPolicyToDelete(policy)
-  }
+  }, [])
 
   // Methods that involve some API
   const onToggleRLS = async () => {
@@ -116,6 +132,40 @@ export const Policies = ({
     })
   }
 
+  const exposedSchemas = useMemo(() => {
+    if (!postgrestConfig?.db_schema) return []
+    return postgrestConfig.db_schema
+      .split(',')
+      .map((schema) => schema.trim())
+      .filter((schema) => schema.length > 0)
+  }, [postgrestConfig?.db_schema])
+
+  const policiesByTable = useMemo(() => {
+    const map = new Map<string, PostgresPolicy[]>()
+    policies.forEach((policy) => {
+      const key = `${policy.schema}.${policy.table}`
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(policy)
+      } else {
+        map.set(key, [policy])
+      }
+    })
+
+    map.forEach((policyList) => {
+      policyList.sort((a, b) => a.name.localeCompare(b.name))
+    })
+
+    return map
+  }, [policies])
+
+  const handleCreatePolicy = useCallback(
+    (tableData: PolicyTableRowProps['table']) => {
+      onSelectCreatePolicy(tableData.name)
+    },
+    [onSelectCreatePolicy]
+  )
+
   if (!hasTables) {
     return (
       <Card className="w-full bg-transparent">
@@ -139,18 +189,33 @@ export const Policies = ({
       <div className="flex flex-col gap-y-4 pb-4">
         {isLocked && <ProtectedSchemaWarning schema={schema} entity="policies" />}
         {tables.length > 0 ? (
-          tables.map((table) => (
-            <section key={table.id}>
-              <PolicyTableRow
-                table={table}
-                isLocked={schema === 'realtime' ? true : isLocked}
-                onSelectToggleRLS={onSelectToggleRLS}
-                onSelectCreatePolicy={() => onSelectCreatePolicy(table.name)}
-                onSelectEditPolicy={onSelectEditPolicy}
-                onSelectDeletePolicy={onSelectDeletePolicy}
-              />
-            </section>
-          ))
+          <>
+            {tables.map((table) => {
+              const isVisible = visibleTableIds.has(table.id)
+              return (
+                <section key={table.id} hidden={!isVisible} aria-hidden={!isVisible}>
+                  <PolicyTableRow
+                    table={table}
+                    isLocked={schema === 'realtime' ? true : isLocked}
+                    onSelectToggleRLS={onSelectToggleRLS}
+                    onSelectCreatePolicy={handleCreatePolicy}
+                    onSelectEditPolicy={onSelectEditPolicy}
+                    onSelectDeletePolicy={onSelectDeletePolicy}
+                    policies={
+                      policiesByTable.get(`${table.schema}.${table.name}`) ?? EMPTY_POLICIES
+                    }
+                    isLoadingPolicies={isLoadingPolicies}
+                    isPoliciesError={isPoliciesError}
+                    policiesError={policiesError}
+                    exposedSchemas={exposedSchemas}
+                  />
+                </section>
+              )
+            })}
+            {Boolean(search) && visibleTableIds.size === 0 && (
+              <NoSearchResults searchString={search ?? ''} onResetFilter={onResetSearch} />
+            )}
+          </>
         ) : hasTables ? (
           <NoSearchResults searchString={search ?? ''} onResetFilter={onResetSearch} />
         ) : null}

--- a/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
@@ -6,8 +6,8 @@ import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import {
-  PolicyTableRow,
-  PolicyTableRowProps,
+    PolicyTableRow,
+    PolicyTableRowProps,
 } from 'components/interfaces/Auth/Policies/PolicyTableRow'
 import { ProtectedSchemaWarning } from 'components/interfaces/Database/ProtectedSchemaWarning'
 import { NoSearchResults } from 'components/ui/NoSearchResults'
@@ -165,7 +165,7 @@ export const Policies = ({
                 </section>
               )
             })}
-            {Boolean(search) && visibleTableIds.size === 0 && (
+            {!!search && visibleTableIds.size === 0 && (
               <NoSearchResults searchString={search ?? ''} onResetFilter={onResetSearch} />
             )}
           </>

--- a/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.tsx
@@ -6,8 +6,8 @@ import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import {
-    PolicyTableRow,
-    PolicyTableRowProps,
+  PolicyTableRow,
+  PolicyTableRowProps,
 } from 'components/interfaces/Auth/Policies/PolicyTableRow'
 import { ProtectedSchemaWarning } from 'components/interfaces/Database/ProtectedSchemaWarning'
 import { NoSearchResults } from 'components/ui/NoSearchResults'

--- a/apps/studio/components/interfaces/Auth/Policies/PoliciesDataContext.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PoliciesDataContext.tsx
@@ -1,0 +1,82 @@
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+import type { PropsWithChildren } from 'react'
+import { createContext, useCallback, useContext, useMemo } from 'react'
+
+import type { ResponseError } from 'types'
+
+type TableKey = `${string}.${string}`
+
+interface PoliciesDataContextValue {
+  getPoliciesForTable: (schema: string, table: string) => PostgresPolicy[]
+  isPoliciesLoading: boolean
+  isPoliciesError: boolean
+  policiesError?: ResponseError | Error
+  exposedSchemas: Set<string>
+}
+
+const PoliciesDataContext = createContext<PoliciesDataContextValue | null>(null)
+
+export const usePoliciesData = () => {
+  const context = useContext(PoliciesDataContext)
+  if (!context) throw new Error('usePoliciesData must be used within PoliciesDataProvider')
+  return context
+}
+
+interface PoliciesDataProviderProps {
+  policies: PostgresPolicy[]
+  isPoliciesLoading: boolean
+  isPoliciesError: boolean
+  policiesError?: ResponseError | Error
+  exposedSchemas: string[]
+}
+
+export const PoliciesDataProvider = ({
+  children,
+  policies,
+  isPoliciesLoading,
+  isPoliciesError,
+  policiesError,
+  exposedSchemas,
+}: PropsWithChildren<PoliciesDataProviderProps>) => {
+  const policiesByTable = useMemo(() => {
+    const map = new Map<TableKey, PostgresPolicy[]>()
+
+    for (const policy of policies) {
+      const key = `${policy.schema}.${policy.table}` satisfies TableKey
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(policy)
+      } else {
+        map.set(key, [policy])
+      }
+    }
+
+    for (const list of map.values()) {
+      list.sort((a, b) => a.name.localeCompare(b.name))
+    }
+
+    return map
+  }, [policies])
+
+  const getPoliciesForTable = useCallback(
+    (schema: string, table: string) => policiesByTable.get(`${schema}.${table}`) ?? [],
+    [policiesByTable]
+  )
+
+  const exposedSchemasSet = useMemo(() => new Set(exposedSchemas), [exposedSchemas])
+
+  const contextValue = useMemo(
+    () => ({
+      getPoliciesForTable,
+      isPoliciesLoading,
+      isPoliciesError,
+      policiesError,
+      exposedSchemas: exposedSchemasSet,
+    }),
+    [getPoliciesForTable, isPoliciesLoading, isPoliciesError, policiesError, exposedSchemasSet]
+  )
+
+  return (
+    <PoliciesDataContext.Provider value={contextValue}>{children}</PoliciesDataContext.Provider>
+  )
+}

--- a/apps/studio/components/interfaces/Auth/Policies/PoliciesDataContext.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PoliciesDataContext.tsx
@@ -6,7 +6,7 @@ import type { ResponseError } from 'types'
 
 type TableKey = `${string}.${string}`
 
-interface PoliciesDataContextValue {
+type PoliciesDataContextValue = {
   getPoliciesForTable: (schema: string, table: string) => PostgresPolicy[]
   isPoliciesLoading: boolean
   isPoliciesError: boolean
@@ -22,7 +22,7 @@ export const usePoliciesData = () => {
   return context
 }
 
-interface PoliciesDataProviderProps {
+type PoliciesDataProviderProps = {
   policies: PostgresPolicy[]
   isPoliciesLoading: boolean
   isPoliciesError: boolean

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.types.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.types.ts
@@ -1,0 +1,6 @@
+export type PolicyTable = {
+  id: number
+  schema: string
+  name: string
+  rls_enabled: boolean
+}

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
@@ -8,7 +8,7 @@ import { EditorTablePageLink } from 'data/prefetchers/project.$ref.editor.$id'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { AiIconAnimation, Badge, CardTitle } from 'ui'
-import type { PolicyTable } from './index'
+import type { PolicyTable } from './PolicyTableRow.types'
 
 interface PolicyTableRowHeaderProps {
   table: PolicyTable

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
@@ -8,22 +8,13 @@ import { EditorTablePageLink } from 'data/prefetchers/project.$ref.editor.$id'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { AiIconAnimation, Badge, CardTitle } from 'ui'
+import type { PolicyTable } from './index'
 
 interface PolicyTableRowHeaderProps {
-  table: {
-    id: number
-    schema: string
-    name: string
-    rls_enabled: boolean
-  }
+  table: PolicyTable
   isLocked: boolean
-  onSelectToggleRLS: (table: {
-    id: number
-    schema: string
-    name: string
-    rls_enabled: boolean
-  }) => void
-  onSelectCreatePolicy: () => void
+  onSelectToggleRLS: (table: PolicyTable) => void
+  onSelectCreatePolicy: (table: PolicyTable) => void
 }
 
 export const PolicyTableRowHeader = ({
@@ -91,7 +82,7 @@ export const PolicyTableRowHeader = ({
             <ButtonTooltip
               type="default"
               disabled={!canToggleRLS || !canCreatePolicies}
-              onClick={() => onSelectCreatePolicy()}
+              onClick={() => onSelectCreatePolicy(table)}
               tooltip={{
                 content: {
                   side: 'bottom',

--- a/apps/studio/components/interfaces/Realtime/Policies.tsx
+++ b/apps/studio/components/interfaces/Realtime/Policies.tsx
@@ -6,8 +6,8 @@ import { PoliciesDataProvider } from 'components/interfaces/Auth/Policies/Polici
 import { PolicyEditorPanel } from 'components/interfaces/Auth/Policies/PolicyEditorPanel'
 import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
-import { useDatabasePoliciesQuery } from 'data/database-policies/database-policies-query'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
+import { useDatabasePoliciesQuery } from 'data/database-policies/database-policies-query'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 
@@ -48,8 +48,10 @@ export const RealtimePolicies = () => {
     connectionString: project?.connectionString,
   })
   const exposedSchemas = useMemo(() => {
-    if (!postgrestConfig?.db_schema) return []
-    return postgrestConfig.db_schema
+    const dbSchema = postgrestConfig?.db_schema
+    if (!dbSchema) return []
+
+    return dbSchema
       .split(',')
       .map((schema) => schema.trim())
       .filter((schema) => schema.length > 0)


### PR DESCRIPTION
## Overview

Fixes two problems with the policy search:
1. Search field query keeps getting corrupted
2. Search is extremely laggy when user has hundreds of tables

## To test

### Buggy search problem

Try searching in staging and again in the preview site. In staging, when you type fast, only bits and pieces of the searched query are preserved. This should be fixed in preview.

### Laggy search problem

Add 700 tables to your project using the following SQL:

```
DO
$$
DECLARE
  target_schema  text := 'public';
  prefix         text := 'rnd';
  to_create      int  := 700;
  created        int  := 0;
  tbl_name       text;
BEGIN
  -- Ensure schema exists (no-op for public)
  EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I;', target_schema);

  WHILE created < to_create LOOP
    -- Random-ish, reasonably short, valid identifier
    tbl_name := prefix || '_' || substr(
      md5(random()::text || clock_timestamp()::text || created::text),
      1, 10
    );

    BEGIN
      EXECUTE format(
        'CREATE TABLE %I.%I (
           id   BIGSERIAL PRIMARY KEY,
           name TEXT NOT NULL
         );',
        target_schema, tbl_name
      );
      created := created + 1;
    EXCEPTION
      WHEN duplicate_table THEN
        -- Rare collision: try again without incrementing 'created'
        CONTINUE;
    END;
  END LOOP;
END;
$$;
```

Take a performance profile while searching in both staging and preview. Notice the lag on staging and the number of extremely long tasks. (Lag is especially obvious when you backspace to clear your search.) Compare preview -- should be faster and much fewer, shorter long tasks.

## Breakdown by commit

[fix(policies search): replace useUrlState with nuqs](https://github.com/supabase/supabase/pull/39790/commits/8b329ee854a11b354825e678a38d7316b0130fa8) 
There is a bug when typing quickly into the search field on the policies
page: because useUrlState naively uses router.replace, which is
asynchronous, the search term can get corrupted, e.g., searching for
"dummy" might end up with a final value of "dum". Switched to nuqs for
better handling.

[perf(policies page): memoize and optimize for projects with many tables](https://github.com/supabase/supabase/pull/39790/commits/7c69ff15b2acf315b620cec399af93917ececfb0)
A project with hundreds of tables will have extremely slow search
performance for the policies page, because of heavy rerendering. Made
some optimizations:
- Memoized to reduce rerendering
- Hid filtered-out tables instead of unmounting, so we don't have to
remount when the search is cleared

[refactor(policies page): pass policies info through context](https://github.com/supabase/supabase/pull/39790/commits/e5e5c15b2b85fc580cad63890f49518cdb713593)
Avoid having a mess of props by creating a PoliciesDataContext to share
policy information.
