### PR TITLE
chore(studio): vector buckets polish B

### DIFF
--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -33,11 +33,17 @@ export interface DeleteBucketModalProps {
   visible: boolean
   bucket: Bucket
   onClose: () => void
+  onDelete?: (bucket: Bucket) => void
 }
 
 const formId = `delete-storage-bucket-form`
 
-export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModalProps) => {
+export const DeleteBucketModal = ({
+  visible,
+  bucket,
+  onClose,
+  onDelete, // Temporary prop for vector buckets specific deletion mutation
+}: DeleteBucketModalProps) => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -103,7 +109,13 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
   const onSubmit: SubmitHandler<z.infer<typeof schema>> = async () => {
     if (!projectRef) return console.error('Project ref is required')
     if (!bucket) return console.error('No bucket is selected')
-    deleteBucket({ projectRef, id: bucket.id, type: bucket.type })
+
+    // Temporary change for vector buckets specific deletion mutation
+    if (onDelete) {
+      onDelete(bucket)
+    } else {
+      deleteBucket({ projectRef, id: bucket.id, type: bucket.type })
+    }
   }
 
   return (

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -34,6 +34,7 @@ import {
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+import { DeleteBucketModal } from '../DeleteBucketModal'
 import { BUCKET_TYPES } from '../Storage.constants'
 import { CreateVectorTableSheet } from './CreateVectorTableSheet'
 
@@ -42,6 +43,7 @@ interface VectorBucketDetailsProps {
 }
 
 export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
+  const [modal, setModal] = useState<'delete' | null>(null)
   const { ref: projectRef } = useParams()
   const router = useRouter()
 
@@ -236,10 +238,7 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                 <Button
                   type="danger"
                   onClick={() => {
-                    deleteBucket({
-                      projectRef: projectRef!,
-                      bucketName: bucket.vectorBucketName,
-                    })
+                    setModal('delete')
                   }}
                 >
                   Delete bucket
@@ -249,6 +248,23 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
           </ScaffoldSection>
         </ScaffoldContainer>
       </PageLayout>
+
+      <DeleteBucketModal
+        visible={modal === `delete`}
+        bucket={{
+          id: bucket.vectorBucketName,
+          name: bucket.vectorBucketName,
+          created_at: bucket.creationTime,
+          updated_at: bucket.creationTime,
+          owner: '',
+          public: false,
+          type: 'STANDARD' as const,
+        }}
+        onClose={() => setModal(null)}
+        onDelete={() =>
+          deleteBucket({ projectRef: projectRef!, bucketName: bucket.vectorBucketName })
+        }
+      />
     </>
   )
 }

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -33,6 +33,7 @@ import {
   TableRow,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { BUCKET_TYPES } from '../Storage.constants'
 import { CreateVectorTableSheet } from './CreateVectorTableSheet'
 
@@ -45,7 +46,11 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
   const router = useRouter()
 
   // Use the correct query for bucket contents
-  const { data, isLoading, error } = useVectorBucketsIndexesQuery({
+  const {
+    data,
+    isLoading: isLoadingIndexes,
+    error,
+  } = useVectorBucketsIndexesQuery({
     projectRef,
     vectorBucketName: bucket.vectorBucketName,
   })
@@ -101,114 +106,118 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
               <CreateVectorTableSheet bucketName={bucket.vectorBucketName} />
             </div>
 
-            <Card>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead
-                      className={filteredList.length === 0 ? 'text-foreground-muted' : undefined}
-                    >
-                      Name
-                    </TableHead>
-                    <TableHead
-                      className={filteredList.length === 0 ? 'text-foreground-muted' : undefined}
-                    >
-                      Dimension
-                    </TableHead>
-                    <TableHead
-                      className={filteredList.length === 0 ? 'text-foreground-muted' : undefined}
-                    >
-                      Distance metric
-                    </TableHead>
-                    <TableHead />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredList.length === 0 ? (
-                    <TableRow className="[&>td]:hover:bg-inherit">
-                      <TableCell colSpan={3}>
-                        {filterString.length > 0 ? (
-                          <>
-                            <p className="text-sm text-foreground">No results found</p>
-                            <p className="text-sm text-foreground-light">
-                              Your search for "{filterString}" did not return any results
-                            </p>
-                          </>
-                        ) : (
-                          <>
-                            <p className="text-sm text-foreground">No tables yet</p>
-                            <p className="text-sm text-foreground-light">
-                              Create your first table to get started
-                            </p>
-                          </>
-                        )}
-                      </TableCell>
+            {isLoadingIndexes ? (
+              <GenericSkeletonLoader />
+            ) : (
+              <Card>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead
+                        className={filteredList.length === 0 ? 'text-foreground-muted' : undefined}
+                      >
+                        Name
+                      </TableHead>
+                      <TableHead
+                        className={filteredList.length === 0 ? 'text-foreground-muted' : undefined}
+                      >
+                        Dimension
+                      </TableHead>
+                      <TableHead
+                        className={filteredList.length === 0 ? 'text-foreground-muted' : undefined}
+                      >
+                        Distance metric
+                      </TableHead>
+                      <TableHead />
                     </TableRow>
-                  ) : (
-                    filteredList.map((index, idx: number) => {
-                      const id = `index-${idx}`
-                      const name = index.indexName
-                      // the creation time is in seconds, convert it to milliseconds
-                      // const created = +index.creationTime * 1000
+                  </TableHeader>
+                  <TableBody>
+                    {filteredList.length === 0 ? (
+                      <TableRow className="[&>td]:hover:bg-inherit">
+                        <TableCell colSpan={3}>
+                          {filterString.length > 0 ? (
+                            <>
+                              <p className="text-sm text-foreground">No results found</p>
+                              <p className="text-sm text-foreground-light">
+                                Your search for "{filterString}" did not return any results
+                              </p>
+                            </>
+                          ) : (
+                            <>
+                              <p className="text-sm text-foreground">No tables yet</p>
+                              <p className="text-sm text-foreground-light">
+                                Create your first table to get started
+                              </p>
+                            </>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      filteredList.map((index, idx: number) => {
+                        const id = `index-${idx}`
+                        const name = index.indexName
+                        // the creation time is in seconds, convert it to milliseconds
+                        // const created = +index.creationTime * 1000
 
-                      return (
-                        <TableRow key={id}>
-                          <TableCell>{name}</TableCell>
-                          <TableCell>
-                            <p className="text-foreground-lighter">{index.dimension}</p>
-                          </TableCell>
-                          <TableCell>
-                            <p className="text-foreground-lighter">{index.distanceMetric}</p>
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex flex-row justify-end gap-2">
-                              <Button
-                                asChild
-                                icon={<Eye size={14} className="text-foreground-lighter" />}
-                                type="default"
-                              >
-                                {/* TODO: Proper URL for table editor */}
-                                <Link
-                                  href={`/project/${projectRef}/editor/${encodeURIComponent(name)}`}
+                        return (
+                          <TableRow key={id}>
+                            <TableCell>{name}</TableCell>
+                            <TableCell>
+                              <p className="text-foreground-lighter">{index.dimension}</p>
+                            </TableCell>
+                            <TableCell>
+                              <p className="text-foreground-lighter">{index.distanceMetric}</p>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex flex-row justify-end gap-2">
+                                <Button
+                                  asChild
+                                  icon={<Eye size={14} className="text-foreground-lighter" />}
+                                  type="default"
                                 >
-                                  Table Editor
-                                </Link>
-                              </Button>
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <Button
-                                    type="default"
-                                    className="px-1"
-                                    icon={<MoreVertical />}
-                                    onClick={(e) => e.stopPropagation()}
-                                  />
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent side="bottom" align="end" className="w-40">
-                                  <DropdownMenuItem
-                                    className="flex items-center space-x-2"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      deleteIndex({
-                                        projectRef: projectRef!,
-                                        bucketName: bucket.vectorBucketName,
-                                        indexName: index.indexName,
-                                      })
-                                    }}
+                                  {/* TODO: Proper URL for table editor */}
+                                  <Link
+                                    href={`/project/${projectRef}/editor/${encodeURIComponent(name)}`}
                                   >
-                                    <Trash2 size={12} />
-                                    <p>Delete table</p>
-                                  </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      )
-                    })
-                  )}
-                </TableBody>
-              </Table>
-            </Card>
+                                    Table Editor
+                                  </Link>
+                                </Button>
+                                <DropdownMenu>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      type="default"
+                                      className="px-1"
+                                      icon={<MoreVertical />}
+                                      onClick={(e) => e.stopPropagation()}
+                                    />
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent side="bottom" align="end" className="w-40">
+                                    <DropdownMenuItem
+                                      className="flex items-center space-x-2"
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        deleteIndex({
+                                          projectRef: projectRef!,
+                                          bucketName: bucket.vectorBucketName,
+                                          indexName: index.indexName,
+                                        })
+                                      }}
+                                    >
+                                      <Trash2 size={12} />
+                                      <p>Delete table</p>
+                                    </DropdownMenuItem>
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })
+                    )}
+                  </TableBody>
+                </Table>
+              </Card>
+            )}
           </ScaffoldSection>
 
           <ScaffoldSection isFullWidth className="flex flex-col gap-y-4">

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorsBuckets.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorsBuckets.tsx
@@ -25,6 +25,7 @@ import {
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
+import { DeleteBucketModal } from '../DeleteBucketModal'
 import { EmptyBucketState } from '../EmptyBucketState'
 import { CreateVectorBucketDialog } from './CreateVectorBucketDialog'
 
@@ -33,6 +34,9 @@ export const VectorsBuckets = () => {
   const router = useRouter()
   const { data, isLoading: isLoadingBuckets } = useVectorBucketsQuery({ projectRef })
   const [filterString, setFilterString] = useState('')
+  const [modal, setModal] = useState<{
+    bucket: { vectorBucketName: string; creationTime: string }
+  } | null>(null)
 
   const bucketsList = data?.vectorBuckets ?? []
 
@@ -128,10 +132,7 @@ export const VectorsBuckets = () => {
                                 <DropdownMenuItem
                                   className="flex items-center space-x-2"
                                   onClick={() => {
-                                    deleteBucket({
-                                      bucketName: name,
-                                      projectRef: projectRef!,
-                                    })
+                                    setModal({ bucket })
                                   }}
                                 >
                                   <Trash2 size={12} />
@@ -149,6 +150,25 @@ export const VectorsBuckets = () => {
             </Card>
           )}
         </ScaffoldSection>
+      )}
+
+      {modal && (
+        <DeleteBucketModal
+          visible={true}
+          bucket={{
+            id: modal.bucket.vectorBucketName,
+            name: modal.bucket.vectorBucketName,
+            created_at: modal.bucket.creationTime,
+            updated_at: modal.bucket.creationTime,
+            owner: '',
+            public: false,
+            type: 'STANDARD' as const,
+          }}
+          onClose={() => setModal(null)}
+          onDelete={() =>
+            deleteBucket({ projectRef: projectRef!, bucketName: modal.bucket.vectorBucketName })
+          }
+        />
       )}
     </>
   )

--- a/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
@@ -7,7 +7,6 @@ import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
 import { useVectorBucketQuery } from 'data/storage/vector-bucket-query'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import type { NextPageWithLayout } from 'types'
-import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 const VectorsBucketPage: NextPageWithLayout = () => {
   const { bucketId } = useParams()
@@ -16,7 +15,6 @@ const VectorsBucketPage: NextPageWithLayout = () => {
   const {
     data: vectorBucket,
     isSuccess,
-    isLoading,
     isError,
     error,
   } = useVectorBucketQuery({ projectRef, vectorBucketName: bucketId })
@@ -25,7 +23,6 @@ const VectorsBucketPage: NextPageWithLayout = () => {
     <div className="storage-container flex flex-grow p-4">
       {isError && <StorageBucketsError error={error as any} />}
 
-      {isLoading && <GenericSkeletonLoader className="w-full" />}
       {isSuccess ? (
         !vectorBucket ? (
           <div className="flex h-full w-full items-center justify-center">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore: UI more improvements to the vector buckets and their details

## What is the current behavior?

- Vector bucket page load  `GenericSkeletonLoader` is full-width
- The bucket deletion action happens instantly after tapping _Delete bucket_
  - On both the ‘outside’ (/storage/vectors) and ‘inside’ (storage/vectors/buckets/test)

## What is the new behavior?

- `GenericSkeletonLoader` is constrained to the loading of indexes, everything else should load instantly (just like analytics buckets)
- The bucket deletion action calls the `DeleteBucketModal`
  - On both the ‘outside’ (/storage/vectors) and ‘inside’ (storage/vectors/buckets/test)

### Known issues to fix

- [ ] I’ve introduced a bit of a regression with the `GenericSkeletonLoader` fix. Although it is now properly constrained to just the tables (indexes), the entire `VectorBucketDetails` is (presumedly) waiting for `isSuccess` from the parent `[bucketId]`. That means a momentary blank screen when going from ‘outside’ (/storage/vectors) to ‘inside’ (storage/vectors/buckets/test). I’m not sure why this is the case given analytics buckets work in the same way (without any flash). See https://github.com/supabase/supabase/pull/39610.
- [ ] I had to edit the `DeleteBucketModal` component to handle the custom delete _vector_ bucket mutation. This goes over my head, but I’m wondering if we can avoid this customisation since analytics buckets deletion works without any customisation.

## Additional context

Based branch: https://github.com/supabase/supabase/pull/39597.

## To test

Use `MOCK_VECTOR_INDEXES` for `allIndexes` in `VectorBucketDetails` ([here](https://github.com/supabase/supabase/blob/4394ca48f0ee3c2c0f4717b52ff08f639d65c8e3/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx#L67)) if you need mock table data.
