### PR TITLE
Chore/fix region empty after changing cloud provider

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
@@ -1,0 +1,59 @@
+import { UseFormReturn } from 'react-hook-form'
+
+import Panel from 'components/ui/Panel'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
+import { PROVIDERS } from 'lib/constants'
+import { CreateProjectForm } from 'pages/new/[slug]'
+import {
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectGroup_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+export const CloudProviderSelector = ({ form }: { form: UseFormReturn<CreateProjectForm> }) => {
+  const { infraCloudProviders: validCloudProviders } = useCustomContent(['infra:cloud_providers'])
+
+  return (
+    <Panel.Content>
+      <FormField_Shadcn_
+        control={form.control}
+        name="cloudProvider"
+        render={({ field }) => (
+          <FormItemLayout label="Cloud provider" layout="horizontal">
+            <Select_Shadcn_
+              defaultValue={field.value}
+              onValueChange={(value) => field.onChange(value)}
+            >
+              <FormControl_Shadcn_>
+                <SelectTrigger_Shadcn_>
+                  <SelectValue_Shadcn_ placeholder="Select a cloud provider" />
+                </SelectTrigger_Shadcn_>
+              </FormControl_Shadcn_>
+              <SelectContent_Shadcn_>
+                <SelectGroup_Shadcn_>
+                  {Object.values(PROVIDERS)
+                    .filter((provider) => validCloudProviders?.includes(provider.id) ?? true)
+                    .map((providerObj) => {
+                      const label = providerObj['name']
+                      const value = providerObj['id']
+                      return (
+                        <SelectItem_Shadcn_ key={value} value={value}>
+                          {label}
+                        </SelectItem_Shadcn_>
+                      )
+                    })}
+                </SelectGroup_Shadcn_>
+              </SelectContent_Shadcn_>
+            </Select_Shadcn_>
+          </FormItemLayout>
+        )}
+      />
+    </Panel.Content>
+  )
+}

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -1,3 +1,4 @@
+import { DesiredInstanceSize, instanceSizeSpecs } from 'data/projects/new-project.constants'
 import type { CloudProvider, Region } from 'shared-data'
 import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
 import { SMART_REGION_TO_EXACT_REGION_MAP } from 'shared-data/regions'
@@ -21,4 +22,18 @@ export function getAvailableRegions(cloudProvider: CloudProvider): Region {
     default:
       throw new Error('Invalid cloud provider')
   }
+}
+
+export const instanceLabel = (instance: string | undefined): string => {
+  return instanceSizeSpecs[instance as DesiredInstanceSize]?.label || 'Micro'
+}
+
+/**
+ * When launching new projects, they only get assigned a compute size once successfully launched,
+ * this might assume wrong compute size, but only for projects being rapidly launched after one another on non-default compute sizes.
+ *
+ * Needs to be in the API in the future [kevin]
+ */
+export const monthlyInstancePrice = (instance: string | undefined): number => {
+  return instanceSizeSpecs[instance as DesiredInstanceSize]?.priceMonthly || 10
 }

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -1,0 +1,191 @@
+import { useRouter } from 'next/router'
+import { UseFormReturn } from 'react-hook-form'
+
+import { PopoverSeparator } from '@ui/components/shadcn/ui/popover'
+import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
+import { InlineLink } from 'components/ui/InlineLink'
+import { DesiredInstanceSize, instanceSizeSpecs } from 'data/projects/new-project.constants'
+import { OrgProject } from 'data/projects/org-projects-infinite-query'
+import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { DOCS_URL, PROJECT_STATUS } from 'lib/constants'
+import { CreateProjectForm, sizes } from 'pages/new/[slug]'
+import { Badge, Button, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
+import { instanceLabel, monthlyInstancePrice } from './ProjectCreation.utils'
+
+export const ProjectCreationFooter = ({
+  form,
+  allProjects,
+  canCreateProject,
+  isCreatingNewProject,
+  isSuccessNewProject,
+}: {
+  form: UseFormReturn<CreateProjectForm>
+  allProjects?: OrgProject[]
+  canCreateProject: boolean
+  isCreatingNewProject: boolean
+  isSuccessNewProject: boolean
+}) => {
+  const router = useRouter()
+  const { data: currentOrg } = useSelectedOrganizationQuery()
+  const projectCreationDisabled = useFlag('disableProjectCreationAndUpdate')
+  const [lastVisitedOrganization] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.LAST_VISITED_ORGANIZATION,
+    ''
+  )
+
+  const isFreePlan = currentOrg?.plan?.id === 'free'
+  const canChooseInstanceSize = !isFreePlan
+  const { instanceSize: watchedInstanceSize } = form.watch()
+  const instanceSize = canChooseInstanceSize ? watchedInstanceSize ?? sizes[0] : undefined
+
+  const organizationProjects =
+    allProjects?.filter((project) => project.status !== PROJECT_STATUS.INACTIVE) ?? []
+
+  // [kevin] This will eventually all be provided by a new API endpoint to preview and validate project creation, this is just for kaizen now
+  const monthlyComputeCosts =
+    // current project costs
+    organizationProjects.reduce((prev, acc) => {
+      const primaryDatabase = acc.databases.find((db) => db.identifier === acc.ref)
+      const cost = !!primaryDatabase ? monthlyInstancePrice(primaryDatabase.infra_compute_size) : 0
+      return prev + cost
+    }, 0) +
+    // selected compute size
+    monthlyInstancePrice(instanceSize) -
+    // compute credits
+    10
+
+  const availableComputeCredits = organizationProjects.length === 0 ? 10 : 0
+  const additionalMonthlySpend = isFreePlan
+    ? 0
+    : instanceSizeSpecs[instanceSize as DesiredInstanceSize]!.priceMonthly - availableComputeCredits
+
+  return (
+    <div key="panel-footer" className="grid grid-cols-12 w-full gap-4 items-center">
+      <div className="col-span-4">
+        {!isFreePlan &&
+          !projectCreationDisabled &&
+          canCreateProject &&
+          additionalMonthlySpend > 0 && (
+            <div className="flex justify-between text-sm">
+              <span>Additional costs</span>
+              <div className="text-brand flex gap-1 items-center font-mono font-medium">
+                <span>${additionalMonthlySpend}/m</span>
+                <InfoTooltip side="top" className="max-w-[450px] p-0">
+                  <div className="p-4 text-sm text-foreground-light space-y-1">
+                    <p>
+                      Each project includes a dedicated Postgres instance running on its own server.
+                      You are charged for the{' '}
+                      <InlineLink href={`${DOCS_URL}/guides/platform/billing-on-supabase`}>
+                        Compute resource
+                      </InlineLink>{' '}
+                      of that server, independent of your database usage.
+                    </p>
+                    {monthlyComputeCosts > 0 && (
+                      <p>Compute costs are applied on top of your subscription plan costs.</p>
+                    )}
+                  </div>
+
+                  <Table className="mt-2">
+                    <TableHeader className="[&_th]:h-7">
+                      <TableRow className="py-2">
+                        <TableHead className="w-[170px]">Project</TableHead>
+                        <TableHead>Compute Size</TableHead>
+                        <TableHead className="text-right">Monthly Costs</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody className="[&_td]:py-2">
+                      {organizationProjects.map((project) => {
+                        const primaryDb = project.databases.find(
+                          (db) => db.identifier === project.ref
+                        )
+                        return (
+                          <TableRow key={project.ref} className="text-foreground-light">
+                            <TableCell className="w-[170px] truncate">{project.name}</TableCell>
+                            <TableCell className="text-center">
+                              {instanceLabel(primaryDb?.infra_compute_size)}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              ${monthlyInstancePrice(primaryDb?.infra_compute_size)}
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })}
+
+                      <TableRow>
+                        <TableCell className="w-[170px] flex gap-2">
+                          <span className="truncate">
+                            {form.getValues('projectName')
+                              ? form.getValues('projectName')
+                              : 'New project'}
+                          </span>
+                          <Badge size={'small'} variant={'default'}>
+                            NEW
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-center">{instanceLabel(instanceSize)}</TableCell>
+                        <TableCell className="text-right">
+                          ${monthlyInstancePrice(instanceSize)}
+                        </TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                  <PopoverSeparator />
+                  <Table>
+                    <TableHeader className="[&_th]:h-7">
+                      <TableRow>
+                        <TableHead colSpan={2}>Compute Credits</TableHead>
+                        <TableHead colSpan={1} className="text-right">
+                          -$10
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody className="[&_td]:py-2">
+                      <TableRow className="text-foreground">
+                        <TableCell colSpan={2}>
+                          Total Monthly Compute Costs
+                          {/**
+                           * API currently doesnt output replica information on the projects list endpoint. Until then, we cannot correctly calculate the costs including RRs.
+                           * Will be adjusted in the future [kevin]
+                           */}
+                          {organizationProjects.length > 0 && (
+                            <p className="text-xs text-foreground-lighter">
+                              Excluding Read replicas
+                            </p>
+                          )}
+                        </TableCell>
+                        <TableCell colSpan={1} className="text-right">
+                          ${monthlyComputeCosts}
+                        </TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </InfoTooltip>
+              </div>
+            </div>
+          )}
+      </div>
+
+      <div className="flex items-end col-span-8 space-x-2 ml-auto">
+        <Button
+          type="default"
+          disabled={isCreatingNewProject || isSuccessNewProject}
+          onClick={() => {
+            if (!!lastVisitedOrganization) router.push(`/org/${lastVisitedOrganization}`)
+            else router.push('/organizations')
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          htmlType="submit"
+          loading={isCreatingNewProject || isSuccessNewProject}
+          disabled={!canCreateProject}
+        >
+          Create new project
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import Link from 'next/link'
+import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
@@ -34,11 +35,11 @@ import {
   Switch,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
-import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
-import { useState } from 'react'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 const formId = 'realtime-configuration-form'
+
 export const RealtimeSettings = () => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -48,6 +49,8 @@ export const RealtimeSettings = () => {
     isLoading: isLoadingPermissions,
     isSuccess: isPermissionsLoaded,
   } = useAsyncCheckPermissions(PermissionAction.REALTIME_ADMIN_READ, '*')
+
+  const [isConfirmNextModalOpen, setIsConfirmNextModalOpen] = useState(false)
 
   const { data: maxConn } = useMaxConnectionsQuery({
     projectRef: project?.ref,
@@ -116,400 +119,416 @@ export const RealtimeSettings = () => {
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = (data) => {
     if (!projectRef) return console.error('Project ref is required')
+    setIsConfirmNextModalOpen(true)
+  }
+
+  const onConfirmSave = () => {
+    if (!projectRef) return console.error('Project ref is required')
+    const data = form.getValues()
+
+    // [Joshen] Casting to `Number` here as the values are being set as string when edited in the form
+    // and returned in form.getValues() - I might be missing some easy util function from RHF though
     updateRealtimeConfig({
       ref: projectRef,
       private_only: !data.allow_public,
-      connection_pool: data.connection_pool,
-      max_concurrent_users: data.max_concurrent_users,
-      max_events_per_second: data.max_events_per_second,
-      max_presence_events_per_second: data.max_presence_events_per_second,
-      max_payload_size_in_kb: data.max_payload_size_in_kb,
+      connection_pool: Number(data.connection_pool),
+      max_concurrent_users: Number(data.max_concurrent_users),
+      max_events_per_second: Number(data.max_events_per_second),
+      max_presence_events_per_second: Number(data.max_presence_events_per_second),
+      max_payload_size_in_kb: Number(data.max_payload_size_in_kb),
       suspend: data.suspend,
     })
     setIsConfirmNextModalOpen(false)
   }
-  const [isConfirmNextModalOpen, setIsConfirmNextModalOpen] = useState(false)
 
   return (
-    <ScaffoldSection isFullWidth>
-      <Form_Shadcn_ {...form}>
-        <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-          {isError ? (
-            <AlertError error={error} subject="Failed to retrieve realtime settings" />
-          ) : (
-            <Card>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="suspend"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !pt-2"
-                      header={<FormSectionLabel>Enable Realtime service</FormSectionLabel>}
-                    >
-                      <FormSectionContent
-                        loaders={1}
-                        loading={isLoading || isLoadingPermissions}
-                        className="!gap-y-2"
+    <>
+      <ScaffoldSection isFullWidth>
+        <Form_Shadcn_ {...form}>
+          <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
+            {isError ? (
+              <AlertError error={error} subject="Failed to retrieve realtime settings" />
+            ) : (
+              <Card>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="suspend"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !pt-2"
+                        header={<FormSectionLabel>Enable Realtime service</FormSectionLabel>}
                       >
-                        <FormItemLayout
-                          layout="flex"
-                          label="Enable Realtime service"
-                          description="If enabled, all clients will be able to connect and new connections will be allowed"
+                        <FormSectionContent
+                          loaders={1}
+                          loading={isLoading || isLoadingPermissions}
+                          className="!gap-y-2"
                         >
-                          <FormControl_Shadcn_>
-                            <Switch
-                              checked={!field.value}
-                              onCheckedChange={(checked) => field.onChange(!checked)}
-                              disabled={!canUpdateConfig}
-                            />
-                          </FormControl_Shadcn_>
-                        </FormItemLayout>
-                        <FormMessage_Shadcn_ />
-                        {isSuccessOrganization && isRealtimeDisabed && (
-                          <Admonition showIcon={false} type="default">
-                            <div className="flex items-center gap-x-2">
-                              <div>
-                                <h5 className="text-foreground mb-1">
-                                  Realtime service is disabled
-                                </h5>
-                                <p className="text-foreground-light">
-                                  You will need to enable it to continue using Realtime
-                                </p>
+                          <FormItemLayout
+                            layout="flex"
+                            label="Enable Realtime service"
+                            description="If enabled, all clients will be able to connect and new connections will be allowed"
+                          >
+                            <FormControl_Shadcn_>
+                              <Switch
+                                checked={!field.value}
+                                onCheckedChange={(checked) => field.onChange(!checked)}
+                                disabled={!canUpdateConfig}
+                              />
+                            </FormControl_Shadcn_>
+                          </FormItemLayout>
+                          <FormMessage_Shadcn_ />
+                          {isSuccessOrganization && isRealtimeDisabed && (
+                            <Admonition showIcon={false} type="default">
+                              <div className="flex items-center gap-x-2">
+                                <div>
+                                  <h5 className="text-foreground mb-1">
+                                    Realtime service is disabled
+                                  </h5>
+                                  <p className="text-foreground-light">
+                                    You will need to enable it to continue using Realtime
+                                  </p>
+                                </div>
                               </div>
-                            </div>
-                          </Admonition>
-                        )}
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="allow_public"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !pt-2"
-                      header={<FormSectionLabel>Channel restrictions</FormSectionLabel>}
-                    >
-                      <FormSectionContent
-                        loaders={1}
-                        loading={isLoading || isLoadingPermissions}
-                        className="!gap-y-2"
+                            </Admonition>
+                          )}
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="allow_public"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !pt-2"
+                        header={<FormSectionLabel>Channel restrictions</FormSectionLabel>}
                       >
-                        <FormItemLayout
-                          layout="flex"
-                          label="Allow public access"
-                          description="If disabled, only private channels will be allowed"
+                        <FormSectionContent
+                          loaders={1}
+                          loading={isLoading || isLoadingPermissions}
+                          className="!gap-y-2"
                         >
+                          <FormItemLayout
+                            layout="flex"
+                            label="Allow public access"
+                            description="If disabled, only private channels will be allowed"
+                          >
+                            <FormControl_Shadcn_>
+                              <Switch
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                                disabled={!canUpdateConfig || isRealtimeDisabed}
+                              />
+                            </FormControl_Shadcn_>
+                          </FormItemLayout>
+
+                          {isSuccessPolicies &&
+                            !hasRealtimeMessagesPolicies &&
+                            !allow_public &&
+                            !isRealtimeDisabed && (
+                              <Admonition
+                                showIcon={false}
+                                type="warning"
+                                title="No Realtime RLS policies found"
+                                description={
+                                  <>
+                                    <p className="prose max-w-full text-sm">
+                                      Private mode is {isSettingToPrivate ? 'being ' : ''}
+                                      enabled, but no RLS policies exists on the{' '}
+                                      <code className="text-xs">realtime.messages</code> table. No
+                                      messages will be received by users.
+                                    </p>
+
+                                    <Button asChild type="default" className="mt-2">
+                                      <Link href={`/project/${projectRef}/realtime/policies`}>
+                                        Create policy
+                                      </Link>
+                                    </Button>
+                                  </>
+                                }
+                              />
+                            )}
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="connection_pool"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !py-2"
+                        header={
+                          <FormSectionLabel
+                            description={
+                              <p className="text-foreground-lighter text-sm !mt-1">
+                                Realtime Authorization uses this database pool to check client
+                                access
+                              </p>
+                            }
+                          >
+                            Database connection pool size
+                          </FormSectionLabel>
+                        }
+                      >
+                        <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
                           <FormControl_Shadcn_>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
+                            <Input_Shadcn_
+                              {...field}
+                              type="number"
                               disabled={!canUpdateConfig || isRealtimeDisabed}
+                              value={field.value || ''}
                             />
                           </FormControl_Shadcn_>
-                        </FormItemLayout>
-
-                        {isSuccessPolicies &&
-                          !hasRealtimeMessagesPolicies &&
-                          !allow_public &&
-                          !isRealtimeDisabed && (
+                          <FormMessage_Shadcn_ />
+                          {!!maxConn && field.value > maxConn.maxConnections * 0.5 && (
                             <Admonition
                               showIcon={false}
                               type="warning"
-                              title="No Realtime RLS policies found"
-                              description={
-                                <>
-                                  <p className="prose max-w-full text-sm">
-                                    Private mode is {isSettingToPrivate ? 'being ' : ''}
-                                    enabled, but no RLS policies exists on the{' '}
-                                    <code className="text-xs">realtime.messages</code> table. No
-                                    messages will be received by users.
-                                  </p>
-
-                                  <Button asChild type="default" className="mt-2">
-                                    <Link href={`/project/${projectRef}/realtime/policies`}>
-                                      Create policy
-                                    </Link>
-                                  </Button>
-                                </>
-                              }
+                              title={`Pool size is greater than 50% of the max connections (${maxConn.maxConnections}) on your database`}
+                              description="This may result in instability and unreliability with your database connections."
                             />
                           )}
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="connection_pool"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !py-2"
-                      header={
-                        <FormSectionLabel
-                          description={
-                            <p className="text-foreground-lighter text-sm !mt-1">
-                              Realtime Authorization uses this database pool to check client access
-                            </p>
-                          }
-                        >
-                          Database connection pool size
-                        </FormSectionLabel>
-                      }
-                    >
-                      <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
-                        <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            {...field}
-                            type="number"
-                            disabled={!canUpdateConfig || isRealtimeDisabed}
-                            value={field.value || ''}
-                          />
-                        </FormControl_Shadcn_>
-                        <FormMessage_Shadcn_ />
-                        {!!maxConn && field.value > maxConn.maxConnections * 0.5 && (
-                          <Admonition
-                            showIcon={false}
-                            type="warning"
-                            title={`Pool size is greater than 50% of the max connections (${maxConn.maxConnections}) on your database`}
-                            description="This may result in instability and unreliability with your database connections."
-                          />
-                        )}
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="max_concurrent_users"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !py-2"
-                      header={
-                        <FormSectionLabel
-                          description={
-                            <p className="text-foreground-lighter text-sm !mt-1">
-                              Sets maximum number of concurrent clients that can connect to your
-                              Realtime service
-                            </p>
-                          }
-                        >
-                          Max concurrent clients
-                        </FormSectionLabel>
-                      }
-                    >
-                      <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
-                        <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            {...field}
-                            type="number"
-                            disabled={!canUpdateConfig || isRealtimeDisabed}
-                            value={field.value || ''}
-                          />
-                        </FormControl_Shadcn_>
-                        <FormMessage_Shadcn_ />
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="max_events_per_second"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !py-2"
-                      header={
-                        <FormSectionLabel
-                          description={
-                            <p className="text-foreground-lighter text-sm !mt-1">
-                              Sets maximum number of events per second that can be sent to your
-                              Realtime service
-                            </p>
-                          }
-                        >
-                          Max events per second
-                        </FormSectionLabel>
-                      }
-                    >
-                      <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
-                        <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            {...field}
-                            type="number"
-                            disabled={
-                              !isUsageBillingEnabled || !canUpdateConfig || isRealtimeDisabed
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="max_concurrent_users"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !py-2"
+                        header={
+                          <FormSectionLabel
+                            description={
+                              <p className="text-foreground-lighter text-sm !mt-1">
+                                Sets maximum number of concurrent clients that can connect to your
+                                Realtime service
+                              </p>
                             }
-                            value={field.value || ''}
-                          />
-                        </FormControl_Shadcn_>
-                        <FormMessage_Shadcn_ />
-                        {isSuccessOrganization && !isUsageBillingEnabled && !isRealtimeDisabed && (
-                          <Admonition showIcon={false} type="default">
-                            <div className="flex items-center gap-x-2">
-                              <div>
-                                <h5 className="text-foreground mb-1">
-                                  Spend cap needs to be disabled to configure this value
-                                </h5>
-                                <p className="text-foreground-light">
-                                  {isFreePlan
-                                    ? 'Upgrade to the Pro plan first to disable spend cap'
-                                    : 'You may adjust this setting in the organization billing settings'}
-                                </p>
-                              </div>
-                              <div className="flex-grow flex items-center justify-end">
-                                {isFreePlan ? (
-                                  <UpgradePlanButton source="realtimeSettings" plan="Pro" />
-                                ) : (
-                                  <ToggleSpendCapButton />
-                                )}
-                              </div>
-                            </div>
-                          </Admonition>
-                        )}
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="max_presence_events_per_second"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !py-2"
-                      header={
-                        <FormSectionLabel
-                          description={
-                            <p className="text-foreground-lighter text-sm !mt-1">
-                              Sets maximum number of presence events per second that can be sent to
-                              your Realtime service
-                            </p>
-                          }
-                        >
-                          Max presence events per second
-                        </FormSectionLabel>
-                      }
-                    >
-                      <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
-                        <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            {...field}
-                            type="number"
-                            disabled={
-                              !isUsageBillingEnabled || !canUpdateConfig || isRealtimeDisabed
+                          >
+                            Max concurrent clients
+                          </FormSectionLabel>
+                        }
+                      >
+                        <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
+                          <FormControl_Shadcn_>
+                            <Input_Shadcn_
+                              {...field}
+                              type="number"
+                              disabled={!canUpdateConfig || isRealtimeDisabed}
+                              value={field.value || ''}
+                            />
+                          </FormControl_Shadcn_>
+                          <FormMessage_Shadcn_ />
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="max_events_per_second"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !py-2"
+                        header={
+                          <FormSectionLabel
+                            description={
+                              <p className="text-foreground-lighter text-sm !mt-1">
+                                Sets maximum number of events per second that can be sent to your
+                                Realtime service
+                              </p>
                             }
-                            value={field.value || ''}
-                          />
-                        </FormControl_Shadcn_>
-                        <FormMessage_Shadcn_ />
-                        {isSuccessOrganization && !isUsageBillingEnabled && !isRealtimeDisabed && (
-                          <Admonition showIcon={false} type="default">
-                            <div className="flex items-center gap-x-2">
-                              <div>
-                                <h5 className="text-foreground mb-1">
-                                  Spend cap needs to be disabled to configure this value
-                                </h5>
-                                <p className="text-foreground-light">
-                                  {isFreePlan
-                                    ? 'Upgrade to the Pro plan first to disable spend cap'
-                                    : 'You may adjust this setting in the organization billing settings'}
-                                </p>
-                              </div>
-                              <div className="flex-grow flex items-center justify-end">
-                                {isFreePlan ? (
-                                  <UpgradePlanButton source="realtimeSettings" plan="Pro" />
-                                ) : (
-                                  <ToggleSpendCapButton />
-                                )}
-                              </div>
-                            </div>
-                          </Admonition>
-                        )}
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
-              <CardContent>
-                <FormField_Shadcn_
-                  control={form.control}
-                  name="max_payload_size_in_kb"
-                  render={({ field }) => (
-                    <FormSection
-                      className="!p-0 !py-2"
-                      header={
-                        <FormSectionLabel
-                          description={
-                            <p className="text-foreground-lighter text-sm !mt-1">
-                              Sets maximum number of payload size in KB that can be sent to your
-                              Realtime service
-                            </p>
-                          }
-                        >
-                          Max payload size in KB
-                        </FormSectionLabel>
-                      }
-                    >
-                      <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
-                        <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            {...field}
-                            type="number"
-                            disabled={
-                              !isUsageBillingEnabled || !canUpdateConfig || isRealtimeDisabed
+                          >
+                            Max events per second
+                          </FormSectionLabel>
+                        }
+                      >
+                        <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
+                          <FormControl_Shadcn_>
+                            <Input_Shadcn_
+                              {...field}
+                              type="number"
+                              disabled={
+                                !isUsageBillingEnabled || !canUpdateConfig || isRealtimeDisabed
+                              }
+                              value={field.value || ''}
+                            />
+                          </FormControl_Shadcn_>
+                          <FormMessage_Shadcn_ />
+                          {isSuccessOrganization &&
+                            !isUsageBillingEnabled &&
+                            !isRealtimeDisabed && (
+                              <Admonition showIcon={false} type="default">
+                                <div className="flex items-center gap-x-2">
+                                  <div>
+                                    <h5 className="text-foreground mb-1">
+                                      Spend cap needs to be disabled to configure this value
+                                    </h5>
+                                    <p className="text-foreground-light">
+                                      {isFreePlan
+                                        ? 'Upgrade to the Pro plan first to disable spend cap'
+                                        : 'You may adjust this setting in the organization billing settings'}
+                                    </p>
+                                  </div>
+                                  <div className="flex-grow flex items-center justify-end">
+                                    {isFreePlan ? (
+                                      <UpgradePlanButton source="realtimeSettings" plan="Pro" />
+                                    ) : (
+                                      <ToggleSpendCapButton />
+                                    )}
+                                  </div>
+                                </div>
+                              </Admonition>
+                            )}
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="max_presence_events_per_second"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !py-2"
+                        header={
+                          <FormSectionLabel
+                            description={
+                              <p className="text-foreground-lighter text-sm !mt-1">
+                                Sets maximum number of presence events per second that can be sent
+                                to your Realtime service
+                              </p>
                             }
-                            value={field.value || ''}
-                          />
-                        </FormControl_Shadcn_>
-                        <FormMessage_Shadcn_ />
-                        {isSuccessOrganization && !isUsageBillingEnabled && !isRealtimeDisabed && (
-                          <Admonition showIcon={false} type="default">
-                            <div className="flex items-center gap-x-2">
-                              <div>
-                                <h5 className="text-foreground mb-1">
-                                  Spend cap needs to be disabled to configure this value
-                                </h5>
-                                <p className="text-foreground-light">
-                                  {isFreePlan
-                                    ? 'Upgrade to the Pro plan first to disable spend cap'
-                                    : 'You may adjust this setting in the organization billing settings'}
-                                </p>
-                              </div>
-                              <div className="flex-grow flex items-center justify-end">
-                                {isFreePlan ? (
-                                  <UpgradePlanButton source="realtimeSettings" plan="Pro" />
-                                ) : (
-                                  <ToggleSpendCapButton />
-                                )}
-                              </div>
-                            </div>
-                          </Admonition>
-                        )}
-                      </FormSectionContent>
-                    </FormSection>
-                  )}
-                />
-              </CardContent>
+                          >
+                            Max presence events per second
+                          </FormSectionLabel>
+                        }
+                      >
+                        <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
+                          <FormControl_Shadcn_>
+                            <Input_Shadcn_
+                              {...field}
+                              type="number"
+                              disabled={
+                                !isUsageBillingEnabled || !canUpdateConfig || isRealtimeDisabed
+                              }
+                              value={field.value || ''}
+                            />
+                          </FormControl_Shadcn_>
+                          <FormMessage_Shadcn_ />
+                          {isSuccessOrganization &&
+                            !isUsageBillingEnabled &&
+                            !isRealtimeDisabed && (
+                              <Admonition showIcon={false} type="default">
+                                <div className="flex items-center gap-x-2">
+                                  <div>
+                                    <h5 className="text-foreground mb-1">
+                                      Spend cap needs to be disabled to configure this value
+                                    </h5>
+                                    <p className="text-foreground-light">
+                                      {isFreePlan
+                                        ? 'Upgrade to the Pro plan first to disable spend cap'
+                                        : 'You may adjust this setting in the organization billing settings'}
+                                    </p>
+                                  </div>
+                                  <div className="flex-grow flex items-center justify-end">
+                                    {isFreePlan ? (
+                                      <UpgradePlanButton source="realtimeSettings" plan="Pro" />
+                                    ) : (
+                                      <ToggleSpendCapButton />
+                                    )}
+                                  </div>
+                                </div>
+                              </Admonition>
+                            )}
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
+                <CardContent>
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="max_payload_size_in_kb"
+                    render={({ field }) => (
+                      <FormSection
+                        className="!p-0 !py-2"
+                        header={
+                          <FormSectionLabel
+                            description={
+                              <p className="text-foreground-lighter text-sm !mt-1">
+                                Sets maximum number of payload size in KB that can be sent to your
+                                Realtime service
+                              </p>
+                            }
+                          >
+                            Max payload size in KB
+                          </FormSectionLabel>
+                        }
+                      >
+                        <FormSectionContent loaders={1} loading={isLoading} className="!gap-y-2">
+                          <FormControl_Shadcn_>
+                            <Input_Shadcn_
+                              {...field}
+                              type="number"
+                              disabled={
+                                !isUsageBillingEnabled || !canUpdateConfig || isRealtimeDisabed
+                              }
+                              value={field.value || ''}
+                            />
+                          </FormControl_Shadcn_>
+                          <FormMessage_Shadcn_ />
+                          {isSuccessOrganization &&
+                            !isUsageBillingEnabled &&
+                            !isRealtimeDisabed && (
+                              <Admonition showIcon={false} type="default">
+                                <div className="flex items-center gap-x-2">
+                                  <div>
+                                    <h5 className="text-foreground mb-1">
+                                      Spend cap needs to be disabled to configure this value
+                                    </h5>
+                                    <p className="text-foreground-light">
+                                      {isFreePlan
+                                        ? 'Upgrade to the Pro plan first to disable spend cap'
+                                        : 'You may adjust this setting in the organization billing settings'}
+                                    </p>
+                                  </div>
+                                  <div className="flex-grow flex items-center justify-end">
+                                    {isFreePlan ? (
+                                      <UpgradePlanButton source="realtimeSettings" plan="Pro" />
+                                    ) : (
+                                      <ToggleSpendCapButton />
+                                    )}
+                                  </div>
+                                </div>
+                              </Admonition>
+                            )}
+                        </FormSectionContent>
+                      </FormSection>
+                    )}
+                  />
+                </CardContent>
 
-              {/*
+                {/*
                 [Joshen] The following fields are hidden from the UI temporarily while we figure out what settings to expose to the users
                 - Max bytes per second
                 - Max channels per client
                 - Max joins per second
               */}
 
-              {/* <CardContent>
+                {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_bytes_per_second"
@@ -552,7 +571,7 @@ export const RealtimeSettings = () => {
                   }}
                 />
               </CardContent> */}
-              {/* <CardContent>
+                {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_channels_per_client"
@@ -587,7 +606,7 @@ export const RealtimeSettings = () => {
                   )}
                 />
               </CardContent> */}
-              {/* <CardContent>
+                {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_joins_per_second"
@@ -623,48 +642,49 @@ export const RealtimeSettings = () => {
                 />
               </CardContent> */}
 
-              <CardFooter className="justify-between">
-                <div>
-                  {isPermissionsLoaded && !canUpdateConfig && (
-                    <p className="text-sm text-foreground-light">
-                      You need additional permissions to update realtime settings
-                    </p>
-                  )}
-                </div>
-                <div className="flex items-center gap-x-2">
-                  {form.formState.isDirty && (
-                    <Button type="default" onClick={() => form.reset(data as any)}>
-                      Cancel
+                <CardFooter className="justify-between">
+                  <div>
+                    {isPermissionsLoaded && !canUpdateConfig && (
+                      <p className="text-sm text-foreground-light">
+                        You need additional permissions to update realtime settings
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-x-2">
+                    {form.formState.isDirty && (
+                      <Button type="default" onClick={() => form.reset(data as any)}>
+                        Cancel
+                      </Button>
+                    )}
+                    <Button
+                      type="primary"
+                      htmlType="submit"
+                      form={formId}
+                      disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
+                      loading={isUpdatingConfig}
+                    >
+                      Save changes
                     </Button>
-                  )}
-                  <Button
-                    type="primary"
-                    htmlType="button"
-                    onClick={() => setIsConfirmNextModalOpen(true)}
-                    form={formId}
-                    disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
-                    loading={isUpdatingConfig}
-                  >
-                    Save changes
-                  </Button>
-                </div>
-              </CardFooter>
-            </Card>
-          )}
-          <ConfirmationModal
-            visible={isConfirmNextModalOpen}
-            title="Confirm saving changes"
-            confirmLabel="Save changes"
-            onCancel={() => setIsConfirmNextModalOpen(false)}
-            onConfirm={() => form.handleSubmit(onSubmit)()}
-          >
-            <p className="text-sm text-foreground-light">
-              Saving the changes will disconnect all the clients connected to your project. Are you
-              sure you want to continue?
-            </p>
-          </ConfirmationModal>
-        </form>
-      </Form_Shadcn_>
-    </ScaffoldSection>
+                  </div>
+                </CardFooter>
+              </Card>
+            )}
+          </form>
+        </Form_Shadcn_>
+      </ScaffoldSection>
+
+      <ConfirmationModal
+        visible={isConfirmNextModalOpen}
+        title="Confirm saving changes"
+        confirmLabel="Save changes"
+        onCancel={() => setIsConfirmNextModalOpen(false)}
+        onConfirm={() => onConfirmSave()}
+      >
+        <p className="text-sm text-foreground-light">
+          Saving the changes will disconnect all the clients connected to your project. Are you sure
+          you want to continue?
+        </p>
+      </ConfirmationModal>
+    </>
   )
 }

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -35,9 +35,10 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { useState } from 'react'
 
 const formId = 'realtime-configuration-form'
-
 export const RealtimeSettings = () => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -125,7 +126,9 @@ export const RealtimeSettings = () => {
       max_payload_size_in_kb: data.max_payload_size_in_kb,
       suspend: data.suspend,
     })
+    setIsConfirmNextModalOpen(false)
   }
+  const [isConfirmNextModalOpen, setIsConfirmNextModalOpen] = useState(false)
 
   return (
     <ScaffoldSection isFullWidth>
@@ -636,7 +639,8 @@ export const RealtimeSettings = () => {
                   )}
                   <Button
                     type="primary"
-                    htmlType="submit"
+                    htmlType="button"
+                    onClick={() => setIsConfirmNextModalOpen(true)}
                     form={formId}
                     disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
                     loading={isUpdatingConfig}
@@ -647,6 +651,18 @@ export const RealtimeSettings = () => {
               </CardFooter>
             </Card>
           )}
+          <ConfirmationModal
+            visible={isConfirmNextModalOpen}
+            title="Confirm saving changes"
+            confirmLabel="Save changes"
+            onCancel={() => setIsConfirmNextModalOpen(false)}
+            onConfirm={() => form.handleSubmit(onSubmit)()}
+          >
+            <p className="text-sm text-foreground-light">
+              Saving the changes will disconnect all the clients connected to your project. Are you
+              sure you want to continue?
+            </p>
+          </ConfirmationModal>
         </form>
       </Form_Shadcn_>
     </ScaffoldSection>

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -81,6 +81,7 @@ export const RealtimeSettings = () => {
       onSuccess: () => {
         form.reset(form.getValues())
         toast.success('Successfully updated realtime settings')
+        setIsConfirmNextModalOpen(false)
       },
     })
 
@@ -138,7 +139,6 @@ export const RealtimeSettings = () => {
       max_payload_size_in_kb: Number(data.max_payload_size_in_kb),
       suspend: data.suspend,
     })
-    setIsConfirmNextModalOpen(false)
   }
 
   return (
@@ -677,6 +677,7 @@ export const RealtimeSettings = () => {
         visible={isConfirmNextModalOpen}
         title="Confirm saving changes"
         confirmLabel="Save changes"
+        loading={isUpdatingConfig}
         onCancel={() => setIsConfirmNextModalOpen(false)}
         onConfirm={() => onConfirmSave()}
       >

--- a/apps/studio/data/organizations/keys.ts
+++ b/apps/studio/data/organizations/keys.ts
@@ -1,5 +1,3 @@
-import type { DesiredInstanceSizeForAvailableRegions } from './organization-available-regions-query'
-
 export const organizationKeys = {
   list: () => ['organizations'] as const,
   detail: (slug?: string) => ['organizations', slug] as const,
@@ -22,9 +20,6 @@ export const organizationKeys = {
     ['organizations', slug, 'validate-token', token] as const,
   projectClaim: (slug: string, token: string) =>
     ['organizations', slug, 'project-claim', token] as const,
-  availableRegions: (
-    slug: string | undefined,
-    cloudProvider: string,
-    size?: DesiredInstanceSizeForAvailableRegions
-  ) => ['organizations', slug, 'available-regions', cloudProvider, size] as const,
+  availableRegions: (slug: string | undefined, cloudProvider: string, size?: string) =>
+    ['organizations', slug, 'available-regions', cloudProvider, size] as const,
 }


### PR DESCRIPTION
## Context

Switching cloud providers in the new project page causes the region field to be empty

Realised this was happening as `useOrganizationAvailableRegionsQuery` was a static value depdning on `defaultProvider` for its `cloudProvider` parameter.

Separately the new project page has gotten rather big and complex so I'll look into separately to refactor that page into smaller components

## To test

- [ ] Verify that changing cloud providers should update the db region as per what's returned in the `useOrganizationAvailableRegionsQuery` (i don't think there's any difference from the API atm)
- [ ] Verify that you can create a new project