### PR TITLE
Fix region empty after selecting cloud provider

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -91,6 +91,8 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
 
+// [Joshen] This page is getting rather big and complex, let's aim to break this down into smaller components
+
 const sizes: DesiredInstanceSize[] = ['micro', 'small', 'medium']
 
 const sizesWithNoCostConfirmationRequired: DesiredInstanceSize[] = ['micro', 'small']
@@ -284,7 +286,7 @@ const Wizard: NextPageWithLayout = () => {
     useOrganizationAvailableRegionsQuery(
       {
         slug: slug,
-        cloudProvider: PROVIDERS[defaultProvider].id,
+        cloudProvider: PROVIDERS[cloudProvider as CloudProvider].id,
         desiredInstanceSize: instanceSize as DesiredInstanceSize,
       },
       {
@@ -295,6 +297,9 @@ const Wizard: NextPageWithLayout = () => {
         refetchOnReconnect: false,
       }
     )
+  const recommendedSmartRegion = smartRegionEnabled
+    ? availableRegionsData?.recommendations.smartGroup.name
+    : undefined
   const regionError =
     smartRegionEnabled && defaultProvider !== 'AWS_NIMBUS'
       ? availableRegionsError
@@ -472,6 +477,12 @@ const Wizard: NextPageWithLayout = () => {
       form.setValue('dbRegion', PROVIDERS[defaultProvider].default_region.displayName)
     }
   }, [regionError])
+
+  useEffect(() => {
+    if (recommendedSmartRegion) {
+      form.setValue('dbRegion', recommendedSmartRegion)
+    }
+  }, [recommendedSmartRegion])
 
   useEffect(() => {
     if (watchedInstanceSize !== instanceSize) {


### PR DESCRIPTION
## Context

Switching cloud providers in the new project page causes the region field to be empty

Realised this was happening as `useOrganizationAvailableRegionsQuery` was a static value depdning on `defaultProvider` for its `cloudProvider` parameter.

Separately the new project page has gotten rather big and complex so I'll look into separately to refactor that page into smaller components

## To test

- [ ] Verify that changing cloud providers should update the db region as per what's returned in the `useOrganizationAvailableRegionsQuery` (i don't think there's any difference from the API atm)
- [ ] Verify that you can create a new project