### PR TITLE
fix(studio): cache hit rate on query perf with pg_stat_statements

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -280,11 +280,14 @@ export const QueryPerformanceGrid = ({
         }
 
         if (col.id === 'cache_hit_rate') {
+          const numericValue = typeof value === 'number' ? value : parseFloat(value)
           return (
             <div className="w-full flex flex-col justify-center text-xs text-right tabular-nums font-mono">
-              {typeof value === 'number' && !isNaN(value) && isFinite(value) ? (
-                <p className={cn(value.toFixed(2) === '0.00' && 'text-foreground-lighter')}>
-                  {value.toLocaleString(undefined, {
+              {typeof numericValue === 'number' &&
+              !isNaN(numericValue) &&
+              isFinite(numericValue) ? (
+                <p className={cn(numericValue.toFixed(2) === '0.00' && 'text-foreground-lighter')}>
+                  {numericValue.toLocaleString(undefined, {
                     minimumFractionDigits: 2,
                     maximumFractionDigits: 2,
                   })}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

On the old table the number wasn't rendering due to it being a string. Added a guard.
