### PR TITLE
docs(mcp): add section on manual authentication

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -24,6 +24,57 @@ Choose your Supabase platform, project, and MCP client and follow the installati
 
 Your AI tool is now connected to your Supabase project or account using remote MCP. Try asking the AI tool to query your database using natural language commands.
 
+## Manual authentication
+
+By default the hosted Supabase MCP server uses [dynamic client registration](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#dynamic-client-registration) to authenticate with your Supabase org. This means that you don't need to manually create a personal access token (PAT) or OAuth app to use the server.
+
+There are some situations where you might want to manually authenticate the MCP server instead:
+
+1. You are using Supabase MCP in a CI environment where browser-based OAuth flows are not possible
+2. Your MCP client does not support dynamic client registration and instead requires an OAuth client ID and secret
+
+### CI environment
+
+To authenticate the MCP server in a CI environment, you can create a personal access token (PAT) with the necessary scopes and pass it as a header to the MCP server.
+
+1. Remember to never connect the MCP server to production data. Supabase MCP is only designed for development and testing purposes. See [Security risks](#security-risks).
+
+1. Navigate to your Supabase [access tokens](https://supabase.com/dashboard/account/tokens) and generate a new token. Name the token based on its purpose, e.g. "My App MCP CI token".
+
+1. Pass the token to the `Authorization` header in your MCP server configuration. For example if you are using [Claude Code](https://docs.claude.com/en/docs/claude-code/github-actions), your MCP server configuration might look like this:
+
+   ```json
+   {
+     "mcpServers": {
+       "supabase": {
+         "type": "http",
+         "url": "https://mcp.supabase.com/mcp?project_ref=${SUPABASE_PROJECT_REF}",
+         "headers": {
+           "Authorization": "Bearer ${SUPABASE_ACCESS_TOKEN}"
+         }
+       }
+     }
+   }
+   ```
+
+   The above example assumes you have environment variables `SUPABASE_ACCESS_TOKEN` and `SUPABASE_PROJECT_REF` set in your CI environment.
+
+   Note that not every MCP client supports custom headers, so check your client's documentation for details.
+
+### Manual OAuth app
+
+If your MCP client requires an OAuth client ID and secret (e.g. Azure API Center), you can manually create an OAuth app in your Supabase account and pass the credentials to the MCP client.
+
+1. Remember to never connect the MCP server to production data. Supabase MCP is only designed for development and testing purposes. See [Security risks](#security-risks).
+
+1. Navigate to your Supabase organization's [OAuth apps](https://supabase.com/dashboard/org/_/apps) and add a new application. Name the app based on its purpose, e.g. "My App MCP".
+
+   Your client should provide you the website URL and callback URL that it expects for the OAuth app. Use these values when creating the OAuth app in Supabase.
+
+   Grant write access to all of the available scopes. In the future, the MCP server will support more fine-grained scopes, but for now all scopes are required.
+
+1. After creating the OAuth app, copy the client ID and client secret to your MCP client.
+
 ## Security risks
 
 Connecting any data source to an LLM carries inherent risks, especially when it stores sensitive data. Supabase is no exception, so it's important to discuss what risks you should be aware of and extra precautions you can take to lower them.

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -39,7 +39,7 @@ To authenticate the MCP server in a CI environment, you can create a personal ac
 
 1. Remember to never connect the MCP server to production data. Supabase MCP is only designed for development and testing purposes. See [Security risks](#security-risks).
 
-1. Navigate to your Supabase [access tokens](https://supabase.com/dashboard/account/tokens) and generate a new token. Name the token based on its purpose, e.g. "My App MCP CI token".
+1. Navigate to your Supabase [access tokens](/dashboard/account/tokens) and generate a new token. Name the token based on its purpose, e.g. "Example App MCP CI token".
 
 1. Pass the token to the `Authorization` header in your MCP server configuration. For example if you are using [Claude Code](https://docs.claude.com/en/docs/claude-code/github-actions), your MCP server configuration might look like this:
 
@@ -67,7 +67,7 @@ If your MCP client requires an OAuth client ID and secret (e.g. Azure API Center
 
 1. Remember to never connect the MCP server to production data. Supabase MCP is only designed for development and testing purposes. See [Security risks](#security-risks).
 
-1. Navigate to your Supabase organization's [OAuth apps](https://supabase.com/dashboard/org/_/apps) and add a new application. Name the app based on its purpose, e.g. "My App MCP".
+1. Navigate to your Supabase organization's [OAuth apps](/dashboard/org/_/apps) and add a new application. Name the app based on its purpose, e.g. "Example App MCP".
 
    Your client should provide you the website URL and callback URL that it expects for the OAuth app. Use these values when creating the OAuth app in Supabase.
 


### PR DESCRIPTION
Adds a "Manual authentication" section to the MCP docs for scenarios when dynamic client registration (DCR) isn't possible:
1. In CI environments (flagged [here](https://github.com/orgs/supabase/discussions/39434#discussioncomment-14711094))
2. If the client supports OAuth but not DCR (e.g. Azure API Center)

## Preview
https://docs-git-docs-mcp-manual-auth-supabase.vercel.app/docs/guides/getting-started/mcp#manual-authentication