### PR TITLE
chore: @supabase/postgres as code owner for pg-meta package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 /packages/shared-data/pricing.ts @roryw10 @supabase/billing
 /packages/shared-data/plans.ts @roryw10 @supabase/billing
 /packages/common/telemetry-constants.ts @supabase/growth-eng
+/packages/pg-meta @supabase/postgres
 
 /apps/studio/ @supabase/Dashboard
 


### PR DESCRIPTION
Sets @supabase/postgres as the code owner for the `packages/pg-meta` package. The goal is:
- Begin to move all dashboard SQL query logic from within `apps/studio` to `packages/pg-meta`
- Have @supabase/postgres team verify any new queries before they're merged in order to evaluate impact on customer projects (e.g. we don't want to unintentionally run a query that puts heavy load on a customer database)