### PR TITLE
fix(table editor): don't show dialog separator for hidden context menu items

### DIFF
--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -75,16 +75,20 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
         <Copy size={12} />
         <span className="ml-2 text-xs">Copy row</span>
       </Item>
-      <DialogSectionSeparator className="my-1.5" />
-      <Item onClick={onEditRowClick} hidden={!snap.editable} data="edit">
-        <Edit size={12} />
-        <span className="ml-2 text-xs">Edit row</span>
-      </Item>
-      <DialogSectionSeparator className="my-1.5" />
-      <Item onClick={onDeleteRow} hidden={!snap.editable} data="delete">
-        <Trash size={12} />
-        <span className="ml-2 text-xs">Delete row</span>
-      </Item>
+      {snap.editable && (
+        <>
+          <DialogSectionSeparator className="my-1.5" />
+          <Item onClick={onEditRowClick} data="edit">
+            <Edit size={12} />
+            <span className="ml-2 text-xs">Edit row</span>
+          </Item>
+          <DialogSectionSeparator className="my-1.5" />
+          <Item onClick={onDeleteRow} data="delete">
+            <Trash size={12} />
+            <span className="ml-2 text-xs">Delete row</span>
+          </Item>
+        </>
+      )}
     </Menu>
   )
 }


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="180" height="126" alt="CleanShot 2025-10-23 at 14 20 03" src="https://github.com/user-attachments/assets/fd37c594-fb9e-44d7-a55e-6eba0f6ff9e2" /> | <img width="161" height="90" alt="CleanShot 2025-10-23 at 14 20 21" src="https://github.com/user-attachments/assets/1ed0f1f2-4ace-4f88-a21c-1ae95a08b1b4" /> |