### PR TITLE
fix(support form): bug with log snapshot

### DIFF
--- a/apps/studio/components/interfaces/Support/DashboardLogsToggle.tsx
+++ b/apps/studio/components/interfaces/Support/DashboardLogsToggle.tsx
@@ -11,14 +11,15 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import type { SupportFormValues } from './SupportForm.schema'
-import { DASHBOARD_LOG_CATEGORIES, getSanitizedBreadcrumbs } from './dashboard-logs'
+import { DASHBOARD_LOG_CATEGORIES } from './dashboard-logs'
 
 interface DashboardLogsToggleProps {
   form: UseFormReturn<SupportFormValues>
+  sanitizedLog: unknown[]
 }
 
-export function DashboardLogsToggle({ form }: DashboardLogsToggleProps) {
-  const sanitizedLogJson = useMemo(() => JSON.stringify(getSanitizedBreadcrumbs(), null, 2), [])
+export function DashboardLogsToggle({ form, sanitizedLog }: DashboardLogsToggleProps) {
+  const sanitizedLogJson = useMemo(() => JSON.stringify(sanitizedLog, null, 2), [sanitizedLog])
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
 

--- a/apps/studio/components/interfaces/Support/dashboard-logs.ts
+++ b/apps/studio/components/interfaces/Support/dashboard-logs.ts
@@ -26,9 +26,11 @@ export const getSanitizedBreadcrumbs = (): unknown[] => {
 
 export const uploadDashboardLog = async ({
   userId,
+  sanitizedLogs,
   uploadDashboardLogFn,
 }: {
   userId: string | undefined
+  sanitizedLogs: unknown[]
   uploadDashboardLogFn: (
     vars: GenerateAttachmentURLsVariables
   ) => Promise<GenerateAttachmentURLsData>
@@ -40,13 +42,12 @@ export const uploadDashboardLog = async ({
     return []
   }
 
-  const sanitized = getSanitizedBreadcrumbs()
-  if (sanitized.length === 0) return []
+  if (sanitizedLogs.length === 0) return []
 
   try {
     const supportStorageClient = createSupportStorageClient()
     const objectKey = `${userId}/${uuidv4()}.json`
-    const body = new Blob([JSON.stringify(sanitized, null, 2)], {
+    const body = new Blob([JSON.stringify(sanitizedLogs, null, 2)], {
       type: 'application/json',
     })
 


### PR DESCRIPTION
The log snapshot is properly cut off at support form navigation in the preview, but not when it is actually uploaded. That happens because we try to take ownership of the current log snapshot twice, so the second time it falls back to the non-snapshotted logs. Changed to take ownership of the snapshot once when the support form is mounted and then pass it to child components/handlers.