### PR TITLE
refactor(billing): show success toast for 202 accepted response from subscription confirm endpoints

### DIFF
--- a/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
+++ b/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
+import type { components } from 'api-types'
 import { organizationKeys } from 'data/organizations/keys'
 import { subscriptionKeys } from './keys'
 import { usageKeys } from 'data/usage/keys'
@@ -62,6 +63,16 @@ export const useConfirmPendingSubscriptionChangeMutation = ({
   >((vars) => confirmPendingSubscriptionChange(vars), {
     async onSuccess(data, variables, context) {
       const { slug } = variables
+
+      // Handle 202 Accepted - show toast and skip query invalidation
+      if (data && 'message' in data && !('slug' in data)) {
+        const pendingResponse = data as components['schemas']['PendingConfirmationResponse']
+        toast.success(pendingResponse.message, {
+          dismissible: true,
+          duration: 10_000,
+        })
+        return
+      }
 
       // [Kevin] Backend can return stale data as it's waiting for the Stripe-sync to complete. Until that's solved in the backend
       // we are going back to monkey here and delay the invalidation

--- a/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
+++ b/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
@@ -65,7 +65,8 @@ export const useConfirmPendingSubscriptionChangeMutation = ({
       const { slug } = variables
 
       // Handle 202 Accepted - show toast and skip query invalidation
-      if (data && 'message' in data && !('slug' in data)) {
+      // The 200 success response returns void, so if data exists it must be 202
+      if (data && 'message' in data) {
         const pendingResponse = data as components['schemas']['PendingConfirmationResponse']
         toast.success(pendingResponse.message, {
           dismissible: true,

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -7612,6 +7612,9 @@ export interface components {
       }[]
       defaultPaymentMethodId: string | null
     }
+    PendingConfirmationResponse: {
+      message: string
+    }
     PgbouncerConfigResponse: {
       connection_string: string
       db_dns_name: string
@@ -13831,6 +13834,14 @@ export interface operations {
         }
         content?: never
       }
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PendingConfirmationResponse']
+        }
+      }
       /** @description Unauthorized */
       401: {
         headers: {
@@ -16167,6 +16178,14 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['CreateOrganizationResponse']
+        }
+      }
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PendingConfirmationResponse']
         }
       }
       /** @description Failed to confirm subscription changes */


### PR DESCRIPTION
### Summary

When subscription confirmation endpoints need more time to poll for subscription confirmation, the backend now returns a 202 Accepted status with a message instructing users to manually refresh after a few seconds.

This PR adds logic to handle the 202 accepted responses on the frontend. Related backend changes are in a branch having the same name on the backend repository.

### Changes

1. Added type definitions for `PendingConfirmationResponse` schema containing a message field.
2. Updated mutation hooks to detect 202 responses and show success toast with the backend message.

### Testing

Tested with both endpoints returning 202 responses from local backend.