### PR TITLE
feat: add assistant variation to table quickstart experiment (2.5 of 3)

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableQuickstart/types.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableQuickstart/types.ts
@@ -37,6 +37,7 @@ export enum QuickstartVariant {
   CONTROL = 'control',
   AI = 'ai',
   TEMPLATES = 'templates',
+  ASSISTANT = 'assistant',
 }
 
 export type TableSuggestion = {


### PR DESCRIPTION
## Summary

Adds a new assistant variation to the [table quickstart A/B test experiment](https://linear.app/supabase/project/experiment-tableeditor-quickstart-df9a55685244/overview). When users in the `ASSISTANT` variant click "Create with Assistant", the AI assistant opens with pre-populated messages to help them design a database table.

## Changes

- Add `ASSISTANT` variant to `QuickstartVariant` enum
- Implement `handleOpenAssistant` function that:
  - Creates a new AI chat with pre-populated messages
  - Opens the assistant panel automatically
- Add "Create with Assistant" action card for users in the assistant variant

## Test Plan

1. Set PostHog `tableQuickstart` flag to `assistant` variant
2. Navigate to the table editor in a project < 7 days old
3. Click "Create with Assistant" card
4. Verify AI assistant opens with pre-populated messages
5. Verify you can create tables / schema by picking up the existing conversation w/ the AI

Resolves GROWTH-523

## Related PRs
- Done: #38933
- Done: #38934
- This PR: #39825
- Final PR: #38932

## Screenshots

<img width="1773" height="713" alt="CleanShot 2025-10-23 at 15 01 58" src="https://github.com/user-attachments/assets/cdb5b078-1e15-410a-bfdd-79e16daa08dc" />

<img width="1758" height="572" alt="CleanShot 2025-10-23 at 15 02 45" src="https://github.com/user-attachments/assets/38dac21c-5d24-48ce-9558-ed0351416705" />