### PR TITLE
Feature: Abililty to duplicate triggers from the dashboard

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -471,7 +471,7 @@ export const TriggerSheet = ({
               type="default"
               htmlType="reset"
               disabled={isCreating || isUpdating}
-              onClick={() => onClose()}
+              onClick={onClose}
             >
               Cancel
             </Button>

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -164,14 +164,14 @@ export const TriggerSheet = ({
       form.clearErrors()
 
       if (isDuplicatingTrigger && selectedTrigger) {
-        form.reset(selectedTrigger)
-
         const initalSelectedTable = tables.find((t) => t.name === selectedTrigger.table)
-        if (initalSelectedTable) {
-          form.setValue('tableId', initalSelectedTable.id.toString())
-          form.setValue('table', initalSelectedTable.name)
-          form.setValue('schema', initalSelectedTable.schema)
-        }
+
+        form.reset({
+          ...selectedTrigger,
+          tableId: initalSelectedTable?.id.toString(),
+          table: initalSelectedTable?.name,
+          schema: initalSelectedTable?.schema,
+        })
       } else if (isEditing) {
         form.reset(selectedTrigger)
       } else if (tables.length > 0) {

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -273,10 +273,12 @@ export const TriggerSheet = ({
                           <Select_Shadcn_
                             defaultValue={field.value}
                             onValueChange={(val) => {
+                              // mark table ID as dirty to trigger validation
+                              field.onChange(val)
                               const table = tables.find((x) => x.id.toString() === val)
                               if (table) {
-                                form.setValue('table', table.name)
-                                form.setValue('schema', table.schema)
+                                form.setValue('table', table.name, { shouldDirty: true })
+                                form.setValue('schema', table.schema, { shouldDirty: true })
                               }
                             }}
                           >

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -188,7 +188,7 @@ export const TriggerSheet = ({
 
   return (
     <>
-      <Sheet open={open} onOpenChange={() => isClosingSidePanel()}>
+      <Sheet open={open} onOpenChange={isClosingSidePanel}>
         <SheetContent size="lg" className="flex flex-col gap-0">
           <SheetHeader>
             <SheetTitle>

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -163,7 +163,16 @@ export const TriggerSheet = ({
     if (open && isSuccess) {
       form.clearErrors()
 
-      if (isEditing || isDuplicatingTrigger) {
+      if (isDuplicatingTrigger && selectedTrigger) {
+        form.reset(selectedTrigger)
+
+        const initalSelectedTable = tables.find((t) => t.name === selectedTrigger.table)
+        if (initalSelectedTable) {
+          form.setValue('tableId', initalSelectedTable.id.toString())
+          form.setValue('table', initalSelectedTable.name)
+          form.setValue('schema', initalSelectedTable.schema)
+        }
+      } else if (isEditing) {
         form.reset(selectedTrigger)
       } else if (tables.length > 0) {
         form.reset({
@@ -183,9 +192,11 @@ export const TriggerSheet = ({
         <SheetContent size="lg" className="flex flex-col gap-0">
           <SheetHeader>
             <SheetTitle>
-              {isEditing
-                ? `Edit database trigger: ${selectedTrigger.name}`
-                : 'Create a new database trigger'}
+              {isDuplicatingTrigger
+                ? 'Duplicate trigger'
+                : isEditing
+                  ? `Edit database trigger: ${selectedTrigger.name}`
+                  : 'Create a new database trigger'}
             </SheetTitle>
           </SheetHeader>
 

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -80,7 +80,12 @@ interface TriggerSheetProps {
   onClose: () => void
 }
 
-export const TriggerSheet = ({ selectedTrigger, isDuplicatingTrigger, open, onClose }: TriggerSheetProps) => {
+export const TriggerSheet = ({
+  selectedTrigger,
+  isDuplicatingTrigger,
+  open,
+  onClose,
+}: TriggerSheetProps) => {
   const { data: project } = useSelectedProjectQuery()
 
   const [showFunctionSelector, setShowFunctionSelector] = useState(false)

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -94,8 +94,8 @@ export const TriggerSheet = ({
 
   const { mutate: createDatabaseTrigger, isLoading: isCreating } = useDatabaseTriggerCreateMutation(
     {
-      onSuccess: (res) => {
-        toast.success(`Successfully created trigger ${res.name}`)
+      onSuccess: () => {
+        toast.success(`Successfully created trigger`)
         onClose()
       },
       onError: (error) => {
@@ -105,8 +105,8 @@ export const TriggerSheet = ({
   )
   const { mutate: updateDatabaseTrigger, isLoading: isUpdating } = useDatabaseTriggerUpdateMutation(
     {
-      onSuccess: (res) => {
-        toast.success(`Successfully updated trigger ${res.name}`)
+      onSuccess: () => {
+        toast.success(`Successfully updated trigger`)
         onClose()
       },
       onError: (error) => {

--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -40,6 +40,7 @@ import {
   TRIGGER_ORIENTATIONS,
   TRIGGER_TYPES,
 } from './Triggers.constants'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 const formId = 'create-trigger'
 
@@ -88,6 +89,7 @@ export const TriggerSheet = ({
 }: TriggerSheetProps) => {
   const { data: project } = useSelectedProjectQuery()
 
+  const [isClosingPanel, setIsClosingPanel] = useState(false)
   const [showFunctionSelector, setShowFunctionSelector] = useState(false)
 
   const { mutate: createDatabaseTrigger, isLoading: isCreating } = useDatabaseTriggerCreateMutation(
@@ -133,6 +135,10 @@ export const TriggerSheet = ({
   })
   const { function_name, function_schema } = form.watch()
 
+  function isClosingSidePanel() {
+    form.formState.isDirty ? setIsClosingPanel(true) : onClose()
+  }
+
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
     if (!project) return console.error('Project is required')
     const { tableId, ...payload } = values
@@ -173,7 +179,7 @@ export const TriggerSheet = ({
 
   return (
     <>
-      <Sheet open={open} onOpenChange={() => onClose()}>
+      <Sheet open={open} onOpenChange={() => isClosingSidePanel()}>
         <SheetContent size="lg" className="flex flex-col gap-0">
           <SheetHeader>
             <SheetTitle>
@@ -460,6 +466,22 @@ export const TriggerSheet = ({
               {isEditing ? 'Save' : 'Create'} trigger
             </Button>
           </SheetFooter>
+
+          <ConfirmationModal
+            visible={isClosingPanel}
+            title="Discard changes"
+            confirmLabel="Discard"
+            onCancel={() => setIsClosingPanel(false)}
+            onConfirm={() => {
+              setIsClosingPanel(false)
+              onClose()
+            }}
+          >
+            <p className="text-sm text-foreground-light">
+              There are unsaved changes. Are you sure you want to close the panel? Your changes will
+              be lost.
+            </p>
+          </ConfirmationModal>
         </SheetContent>
       </Sheet>
 

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { includes, sortBy } from 'lodash'
-import { Check, Edit, Edit2, MoreVertical, Trash, X } from 'lucide-react'
+import { Check, Copy, Edit, Edit2, MoreVertical, Trash, X } from 'lucide-react'
 
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabaseTriggersQuery } from 'data/database-triggers/database-triggers-query'
@@ -13,6 +13,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   TableCell,
   TableRow,
@@ -21,13 +22,15 @@ import {
   TooltipTrigger,
 } from 'ui'
 import { generateTriggerCreateSQL } from './TriggerList.utils'
+import { PostgresTrigger } from '@supabase/postgres-meta'
 
 interface TriggerListProps {
   schema: string
   filterString: string
   isLocked: boolean
-  editTrigger: (trigger: any) => void
-  deleteTrigger: (trigger: any) => void
+  editTrigger: (trigger: PostgresTrigger) => void
+  duplicateTrigger: (trigger: PostgresTrigger) => void
+  deleteTrigger: (trigger: PostgresTrigger) => void
 }
 
 const TriggerList = ({
@@ -35,6 +38,7 @@ const TriggerList = ({
   filterString,
   isLocked,
   editTrigger,
+  duplicateTrigger,
   deleteTrigger,
 }: TriggerListProps) => {
   const { data: project } = useSelectedProjectQuery()
@@ -195,6 +199,11 @@ const TriggerList = ({
                         <Edit size={14} />
                         <p>Edit with Assistant</p>
                       </DropdownMenuItem>
+                      <DropdownMenuItem className="space-x-2" onClick={() => duplicateTrigger(x)}>
+                        <Copy size={14} />
+                        <p>Duplicate trigger</p>
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
                       <DropdownMenuItem className="space-x-2" onClick={() => deleteTrigger(x)}>
                         <Trash stroke="red" size={14} />
                         <p>Delete trigger</p>

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
@@ -37,12 +37,14 @@ import Link from 'next/link'
 interface TriggersListProps {
   createTrigger: () => void
   editTrigger: (trigger: PostgresTrigger) => void
+  duplicateTrigger: (trigger: PostgresTrigger) => void
   deleteTrigger: (trigger: PostgresTrigger) => void
 }
 
 const TriggersList = ({
   createTrigger = noop,
   editTrigger = noop,
+  duplicateTrigger = noop,
   deleteTrigger = noop,
 }: TriggersListProps) => {
   const { data: project } = useSelectedProjectQuery()
@@ -228,6 +230,7 @@ const TriggersList = ({
                   filterString={filterString}
                   isLocked={isSchemaLocked}
                   editTrigger={editTrigger}
+                  duplicateTrigger={duplicateTrigger}
                   deleteTrigger={deleteTrigger}
                 />
               </TableBody>

--- a/apps/studio/pages/project/[ref]/database/triggers.tsx
+++ b/apps/studio/pages/project/[ref]/database/triggers.tsx
@@ -21,6 +21,8 @@ const TriggersPage: NextPageWithLayout = () => {
   const isInlineEditorEnabled = useIsInlineEditorEnabled()
 
   const [selectedTrigger, setSelectedTrigger] = useState<PostgresTrigger>()
+  const [isDuplicatingTrigger, setIsDuplicatingTrigger] = useState<boolean>(false)
+
   const [showCreateTriggerForm, setShowCreateTriggerForm] = useState<boolean>(false)
   const [showDeleteTriggerForm, setShowDeleteTriggerForm] = useState<boolean>(false)
 
@@ -53,9 +55,27 @@ const TriggersPage: NextPageWithLayout = () => {
     }
   }
 
+  const duplicateTrigger = (trigger: PostgresTrigger) => {
+    setIsDuplicatingTrigger(true)
+
+    if (isInlineEditorEnabled) {
+      setSelectedTriggerForEditor(trigger)
+      setEditorPanelOpen(true)
+    } else {
+      setSelectedTrigger(trigger)
+      setShowCreateTriggerForm(true)
+    }
+  }
+
   const deleteTrigger = (trigger: PostgresTrigger) => {
     setSelectedTrigger(trigger)
     setShowDeleteTriggerForm(true)
+  }
+
+  const resetEditorPanel = () => {
+    setIsDuplicatingTrigger(false)
+    setEditorPanelOpen(false)
+    setSelectedTriggerForEditor(undefined)
   }
 
   if (isPermissionsLoaded && !canReadTriggers) {
@@ -75,6 +95,7 @@ const TriggersPage: NextPageWithLayout = () => {
             <TriggersList
               createTrigger={createTrigger}
               editTrigger={editTrigger}
+              duplicateTrigger={duplicateTrigger}
               deleteTrigger={deleteTrigger}
             />
           </div>
@@ -83,7 +104,11 @@ const TriggersPage: NextPageWithLayout = () => {
       <TriggerSheet
         selectedTrigger={selectedTrigger}
         open={showCreateTriggerForm}
-        setOpen={setShowCreateTriggerForm}
+        onClose={() => {
+          setIsDuplicatingTrigger(false)
+          setShowCreateTriggerForm(false)
+        }}
+        isDuplicatingTrigger={isDuplicatingTrigger}
       />
       <DeleteTrigger
         trigger={selectedTrigger}
@@ -93,14 +118,8 @@ const TriggersPage: NextPageWithLayout = () => {
 
       <EditorPanel
         open={editorPanelOpen}
-        onRunSuccess={() => {
-          setEditorPanelOpen(false)
-          setSelectedTriggerForEditor(undefined)
-        }}
-        onClose={() => {
-          setEditorPanelOpen(false)
-          setSelectedTriggerForEditor(undefined)
-        }}
+        onRunSuccess={resetEditorPanel}
+        onClose={resetEditorPanel}
         initialValue={
           selectedTriggerForEditor
             ? generateTriggerCreateSQL(selectedTriggerForEditor)
@@ -111,12 +130,16 @@ execute function function_name();`
         }
         label={
           selectedTriggerForEditor
-            ? `Edit trigger "${selectedTriggerForEditor.name}"`
+            ? isDuplicatingTrigger
+              ? `Duplicate trigger "${selectedTriggerForEditor.name}"`
+              : `Edit trigger "${selectedTriggerForEditor.name}"`
             : 'Create new database trigger'
         }
         initialPrompt={
           selectedTriggerForEditor
-            ? `Update the database trigger "${selectedTriggerForEditor.name}" to...`
+            ? isDuplicatingTrigger
+              ? `Duplicate the database trigger "${selectedTriggerForEditor.name}" to...`
+              : `Update the database trigger "${selectedTriggerForEditor.name}" to...`
             : 'Create a new database trigger that...'
         }
       />

--- a/apps/studio/pages/project/[ref]/database/triggers.tsx
+++ b/apps/studio/pages/project/[ref]/database/triggers.tsx
@@ -58,11 +58,16 @@ const TriggersPage: NextPageWithLayout = () => {
   const duplicateTrigger = (trigger: PostgresTrigger) => {
     setIsDuplicatingTrigger(true)
 
+    const dupTrigger = {
+      ...trigger,
+      name: `${trigger.name}_duplicate`,
+    }
+
     if (isInlineEditorEnabled) {
-      setSelectedTriggerForEditor(trigger)
+      setSelectedTriggerForEditor(dupTrigger)
       setEditorPanelOpen(true)
     } else {
-      setSelectedTrigger(trigger)
+      setSelectedTrigger(dupTrigger)
       setShowCreateTriggerForm(true)
     }
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Ability to duplicate a trigger 

## What is the current behavior?

There is no way to duplicate a trigger

## What is the new behavior?

You can use the sub menu to duplicate a trigger and change its settings

## Additional context

This one was much harder, we need to add the discard state logic as well that was missing plus clean up types

## Demo

https://github.com/user-attachments/assets/f4e76abd-3abd-4ffd-adfc-8d99b399d455

