### PR TITLE
Fix #39827

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1198,6 +1198,9 @@ function createStorageExplorerState({
                 try {
                   const data = await getTemporaryAPIKey({ projectRef: state.projectRef })
                   req.setHeader('apikey', data.api_key)
+                  if (!IS_PLATFORM) {
+                    req.setHeader('Authorization', `Bearer ${data.api_key}`)
+                  }
                 } catch (error) {
                   throw error
                 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Studio storage UI failing authentication with resumable endpoint

https://github.com/supabase/supabase/issues/39827

## What is the new behavior?

Before initiating a resumable upload, the TUS upload `onBeforeRequest` handler adds a correct `Authorization` header with the temporary token. Overriding the previous behaviour of a `Basic` token that used the dashboard credentials, with the proper `Bearer` token.

## Additional context

It is still unknown how or why an `Authorization` header with the value of `Basic ${base64(USER:PASSWORD)}` was being set on the TUS resumable upload request. Nowhere in the code is it explicitly performed. We might want to look into default behaviour of the `tus-js-client` looking into browser cookies, still a complete mystery. In any case, this PR fixes the Auth header issue for the storage UI.
