### PR TITLE
chore(studio): split auth templates into subpages

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -9,7 +9,8 @@ const CONFIRMATION: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'CONFIRMATION',
   type: 'object',
-  title: 'Confirm signup',
+  title: 'Confirm sign up',
+  purpose: 'Email verification for new user registrations',
   properties: {
     MAILER_SUBJECTS_CONFIRMATION: {
       title: 'Subject heading',
@@ -20,7 +21,7 @@ const CONFIRMATION: FormSchema = {
       descriptionOptional: 'HTML body of your email',
       type: 'code',
       description: ` 
-- \`{{ .ConfirmationURL }}\` : URL to confirm the e-mail address for the new account
+- \`{{ .ConfirmationURL }}\` : URL to confirm the email address for the new account
 - \`{{ .Token }}\` : The 6-digit numeric email OTP 
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
 - \`{{ .SiteURL }}\` : The URL of the site
@@ -45,6 +46,7 @@ const INVITE: FormSchema = {
   id: 'INVITE',
   type: 'object',
   title: 'Invite user',
+  purpose: "Allows administrators to invite users who don't have accounts yet",
   properties: {
     MAILER_SUBJECTS_INVITE: {
       title: 'Subject heading',
@@ -79,7 +81,8 @@ const MAGIC_LINK: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'MAGIC_LINK',
   type: 'object',
-  title: 'Magic Link',
+  title: 'Magic link',
+  purpose: 'Passwordless login using email links',
   properties: {
     MAILER_SUBJECTS_MAGIC_LINK: {
       title: 'Subject heading',
@@ -114,7 +117,8 @@ const EMAIL_CHANGE: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'EMAIL_CHANGE',
   type: 'object',
-  title: 'Change Email Address',
+  title: 'Change email address',
+  purpose: 'Verification for email address changes',
   properties: {
     MAILER_SUBJECTS_EMAIL_CHANGE: {
       title: 'Subject heading',
@@ -150,7 +154,8 @@ const RECOVERY: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'RECOVERY',
   type: 'object',
-  title: 'Reset Password',
+  title: 'Reset password',
+  purpose: 'Password recovery flow for users who forgot their password',
   properties: {
     MAILER_SUBJECTS_RECOVERY: {
       title: 'Subject heading',
@@ -185,6 +190,8 @@ const REAUTHENTICATION: FormSchema = {
   id: 'REAUTHENTICATION',
   type: 'object',
   title: 'Reauthentication',
+  purpose:
+    'Additional verification for sensitive actions (like changing password, deleting account)',
   properties: {
     MAILER_SUBJECTS_REAUTHENTICATION: {
       title: 'Subject heading',

--- a/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
@@ -3,34 +3,28 @@ import Link from 'next/link'
 import { useParams } from 'common'
 import { InlineLink } from 'components/ui/InlineLink'
 import { DOCS_URL } from 'lib/constants'
-import {
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Alert_Shadcn_,
-  Button,
-  WarningIcon,
-} from 'ui'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 
 export function EmailRateLimitsAlert() {
   const { ref } = useParams()
 
   return (
-    <Alert_Shadcn_ variant="warning">
-      <WarningIcon />
-      <AlertTitle_Shadcn_>Email rate-limits and restrictions</AlertTitle_Shadcn_>
-      <AlertDescription_Shadcn_>
-        You're using the built-in email service. The service has rate limits and it's not meant to
-        be used for production apps. Check the{' '}
+    <Admonition
+      type="warning"
+      title="Set up custom SMTP"
+      className="bg-warning-200 border-warning-400"
+    >
+      <p>
+        You’re using the built-in email service. This service has rate limits and is not meant to be
+        used for production apps.{' '}
         <InlineLink href={`${DOCS_URL}/guides/platform/going-into-prod#auth-rate-limits`}>
-          documentation
+          Learn more
         </InlineLink>{' '}
-        for an up-to-date information on the current rate limits.
-      </AlertDescription_Shadcn_>
-      <AlertDescription_Shadcn_ className="mt-2">
-        <Button asChild type="default">
-          <Link href={`/project/${ref}/auth/smtp`}>Set up custom SMTP server</Link>
-        </Button>
-      </AlertDescription_Shadcn_>
-    </Alert_Shadcn_>
+      </p>
+      <Button asChild type="default" className="mt-2">
+        <Link href={`/project/${ref}/auth/smtp`}>Set up SMTP</Link>
+      </Button>
+    </Admonition>
   )
 }

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -69,11 +69,14 @@ export const EmailTemplates = () => {
                     >
                       <div className="flex flex-col">
                         <h3 className="text-sm text-foreground">{template.title}</h3>
-                        <p className="text-sm text-foreground-lighter">
-                          Email description goes here.
-                        </p>
+                        {template.purpose && (
+                          <p className="text-sm text-foreground-lighter">{template.purpose}</p>
+                        )}
                       </div>
-                      <ChevronRight size={16} className="text-foreground-muted group-hover:text-foreground transition-colors" />
+                      <ChevronRight
+                        size={16}
+                        className="text-foreground-muted group-hover:text-foreground transition-colors"
+                      />
                     </Link>
                   </CardContent>
                 )

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -34,8 +34,6 @@ export const EmailTemplates = () => {
     authConfig &&
     (!authConfig.SMTP_HOST || !authConfig.SMTP_USER || !authConfig.SMTP_PASS)
 
-  console.log({ TEMPLATES_SCHEMAS })
-
   return (
     <ScaffoldSection isFullWidth className="!pt-0">
       {isError && (

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -1,13 +1,25 @@
 import { useParams } from 'common'
+import { useIsSecurityNotificationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { ScaffoldSection } from 'components/layouts/Scaffold'
 import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
-import { Card, Tabs_Shadcn_, TabsContent_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
+import { ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+import {
+  Card,
+  CardContent,
+  Tabs_Shadcn_,
+  TabsContent_Shadcn_,
+  TabsList_Shadcn_,
+  TabsTrigger_Shadcn_,
+} from 'ui'
 import { TEMPLATES_SCHEMAS } from '../AuthTemplatesValidation'
 import EmailRateLimitsAlert from '../EmailRateLimitsAlert'
 import TemplateEditor from './TemplateEditor'
 
 export const EmailTemplates = () => {
+  const isSecurityNotificationsEnabled = useIsSecurityNotificationsEnabled()
   const { ref: projectRef } = useParams()
   const {
     data: authConfig,
@@ -22,8 +34,10 @@ export const EmailTemplates = () => {
     authConfig &&
     (!authConfig.SMTP_HOST || !authConfig.SMTP_USER || !authConfig.SMTP_PASS)
 
+  console.log({ TEMPLATES_SCHEMAS })
+
   return (
-    <div className="w-full">
+    <ScaffoldSection isFullWidth className="!pt-0">
       {isError && (
         <AlertError
           className="mt-12"
@@ -43,32 +57,56 @@ export const EmailTemplates = () => {
               <EmailRateLimitsAlert />
             </div>
           ) : null}
-          <Card>
-            <Tabs_Shadcn_ defaultValue={TEMPLATES_SCHEMAS[0].title.trim().replace(/\s+/g, '-')}>
-              <TabsList_Shadcn_ className="pt-2 px-6 gap-5 mb-0 overflow-x-scroll no-scrollbar mb-4">
-                {TEMPLATES_SCHEMAS.map((template) => {
-                  return (
-                    <TabsTrigger_Shadcn_
-                      key={`${template.id}`}
-                      value={template.title.trim().replace(/\s+/g, '-')}
-                    >
-                      {template.title}
-                    </TabsTrigger_Shadcn_>
-                  )
-                })}
-              </TabsList_Shadcn_>
+          {isSecurityNotificationsEnabled ? (
+            <Card>
               {TEMPLATES_SCHEMAS.map((template) => {
-                const panelId = template.title.trim().replace(/\s+/g, '-')
+                const templateSlug = template.title.trim().replace(/\s+/g, '-').toLowerCase()
                 return (
-                  <TabsContent_Shadcn_ key={panelId} value={panelId} className="mt-0">
-                    <TemplateEditor key={template.title} template={template} />
-                  </TabsContent_Shadcn_>
+                  <CardContent key={`${template.id}`} className="p-0">
+                    <Link
+                      href={`/project/${projectRef}/auth/templates/${templateSlug}`}
+                      className="flex items-center justify-between hover:bg-surface-200 transition-colors py-4 px-6 w-full h-full"
+                    >
+                      <div className="flex flex-col">
+                        <h3 className="text-sm text-foreground">{template.title}</h3>
+                        <p className="text-sm text-foreground-lighter">
+                          Email description goes here.
+                        </p>
+                      </div>
+                      <ChevronRight size={16} className="text-foreground-muted group-hover:text-foreground transition-colors" />
+                    </Link>
+                  </CardContent>
                 )
               })}
-            </Tabs_Shadcn_>
-          </Card>
+            </Card>
+          ) : (
+            <Card>
+              <Tabs_Shadcn_ defaultValue={TEMPLATES_SCHEMAS[0].title.trim().replace(/\s+/g, '-')}>
+                <TabsList_Shadcn_ className="pt-2 px-6 gap-5 mb-0 overflow-x-scroll no-scrollbar mb-4">
+                  {TEMPLATES_SCHEMAS.map((template) => {
+                    return (
+                      <TabsTrigger_Shadcn_
+                        key={`${template.id}`}
+                        value={template.title.trim().replace(/\s+/g, '-')}
+                      >
+                        {template.title}
+                      </TabsTrigger_Shadcn_>
+                    )
+                  })}
+                </TabsList_Shadcn_>
+                {TEMPLATES_SCHEMAS.map((template) => {
+                  const panelId = template.title.trim().replace(/\s+/g, '-')
+                  return (
+                    <TabsContent_Shadcn_ key={panelId} value={panelId} className="mt-0">
+                      <TemplateEditor key={template.title} template={template} />
+                    </TabsContent_Shadcn_>
+                  )
+                })}
+              </Tabs_Shadcn_>
+            </Card>
+          )}
         </div>
       )}
-    </div>
+    </ScaffoldSection>
   )
 }

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -16,6 +16,7 @@ import {
 } from 'ui'
 import { TEMPLATES_SCHEMAS } from '../AuthTemplatesValidation'
 import EmailRateLimitsAlert from '../EmailRateLimitsAlert'
+import { slugifyTitle } from './EmailTemplates.utils'
 import TemplateEditor from './TemplateEditor'
 
 export const EmailTemplates = () => {
@@ -58,7 +59,7 @@ export const EmailTemplates = () => {
           {isSecurityNotificationsEnabled ? (
             <Card>
               {TEMPLATES_SCHEMAS.map((template) => {
-                const templateSlug = template.title.trim().replace(/\s+/g, '-').toLowerCase()
+                const templateSlug = slugifyTitle(template.title)
                 return (
                   <CardContent key={`${template.id}`} className="p-0">
                     <Link
@@ -82,13 +83,13 @@ export const EmailTemplates = () => {
             </Card>
           ) : (
             <Card>
-              <Tabs_Shadcn_ defaultValue={TEMPLATES_SCHEMAS[0].title.trim().replace(/\s+/g, '-')}>
+              <Tabs_Shadcn_ defaultValue={slugifyTitle(TEMPLATES_SCHEMAS[0].title)}>
                 <TabsList_Shadcn_ className="pt-2 px-6 gap-5 mb-0 overflow-x-scroll no-scrollbar mb-4">
                   {TEMPLATES_SCHEMAS.map((template) => {
                     return (
                       <TabsTrigger_Shadcn_
                         key={`${template.id}`}
-                        value={template.title.trim().replace(/\s+/g, '-')}
+                        value={slugifyTitle(template.title)}
                       >
                         {template.title}
                       </TabsTrigger_Shadcn_>
@@ -96,7 +97,7 @@ export const EmailTemplates = () => {
                   })}
                 </TabsList_Shadcn_>
                 {TEMPLATES_SCHEMAS.map((template) => {
-                  const panelId = template.title.trim().replace(/\s+/g, '-')
+                  const panelId = slugifyTitle(template.title)
                   return (
                     <TabsContent_Shadcn_ key={panelId} value={panelId} className="mt-0">
                       <TemplateEditor key={template.title} template={template} />

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Convert template title to URL-friendly slug
+ * Shared function to ensure slug matching works correctly across multiple files
+ * Necessary because TEMPLATES_SCHEMAS does not provide a slug for each template
+ */
+export const slugifyTitle = (title: string) => {
+  return title.trim().replace(/\s+/g, '-').toLowerCase()
+}

--- a/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
+++ b/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
@@ -4,16 +4,22 @@ import { useParams } from 'common'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { useRouter } from 'next/router'
 import AuthLayout from './AuthLayout'
 
 export const AuthEmailsLayout = ({ children }: PropsWithChildren<{}>) => {
   const { ref } = useParams()
+  const router = useRouter()
   const showEmails = useIsFeatureEnabled('authentication:emails')
+
+  // Keep the template tab active when on an individual template page /auth/templates/[templateId]
+  const isOnTemplatePage = router.asPath.includes('/auth/templates')
 
   const navItems = [
     {
       label: 'Templates',
       href: `/project/${ref}/auth/templates`,
+      active: isOnTemplatePage,
     },
     {
       label: 'SMTP Settings',

--- a/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
+++ b/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
@@ -4,22 +4,17 @@ import { useParams } from 'common'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useRouter } from 'next/router'
 import AuthLayout from './AuthLayout'
 
 export const AuthEmailsLayout = ({ children }: PropsWithChildren<{}>) => {
   const { ref } = useParams()
-  const router = useRouter()
+  
   const showEmails = useIsFeatureEnabled('authentication:emails')
-
-  // Keep the template tab active when on an individual template page /auth/templates/[templateId]
-  const isOnTemplatePage = router.asPath.includes('/auth/templates')
 
   const navItems = [
     {
       label: 'Templates',
       href: `/project/${ref}/auth/templates`,
-      active: isOnTemplatePage,
     },
     {
       label: 'SMTP Settings',

--- a/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
+++ b/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
@@ -8,7 +8,7 @@ import AuthLayout from './AuthLayout'
 
 export const AuthEmailsLayout = ({ children }: PropsWithChildren<{}>) => {
   const { ref } = useParams()
-  
+
   const showEmails = useIsFeatureEnabled('authentication:emails')
 
   const navItems = [

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -11,11 +11,12 @@ import { DocsButton } from 'components/ui/DocsButton'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { DOCS_URL } from 'lib/constants'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
-import { Card } from 'ui'
-import { GenericSkeletonLoader } from 'ui-patterns'
+import { Button, Card } from 'ui'
+import { Admonition, GenericSkeletonLoader } from 'ui-patterns'
 
 const TemplatePage: NextPageWithLayout = () => {
   return <RedirectToTemplates />
@@ -63,7 +64,16 @@ const RedirectToTemplates = () => {
   if (!template || !templateId || typeof templateId !== 'string') {
     return (
       <div className="flex h-full w-full items-center justify-center">
-        <p className="text-sm text-foreground-light">Template "{templateId}" cannot be found</p>
+        <Admonition
+          className="max-w-md"
+          type="default"
+          title="Unable to find template"
+          description={`${templateId ? `The template "${templateId}"` : 'This template'} doesn’t seem to exist.`}
+        >
+          <Button asChild type="default" className="mt-2">
+            <Link href={`/project/${ref}/auth/templates`}>Head back</Link>
+          </Button>
+        </Admonition>
       </div>
     )
   }

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -2,6 +2,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 import { useIsSecurityNotificationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { TEMPLATES_SCHEMAS } from 'components/interfaces/Auth/AuthTemplatesValidation'
+import TemplateEditor from 'components/interfaces/Auth/EmailTemplates/TemplateEditor'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
@@ -57,12 +58,12 @@ const RedirectToTemplates = () => {
     })
     return template?.id
   }
-
-  // Convert templateId slug to one lowercase word to match docs anchor tag
-  const templateIdForDocs = templateId.replace(/-/g, '').toLowerCase()
   const template = TEMPLATES_SCHEMAS.find(
     (template) => template.id === templateIdFromSlug(templateId as string)
   )
+
+  // Convert templateId slug to one lowercase word to match docs anchor tag
+  const templateIdForDocs = templateId.replace(/-/g, '').toLowerCase()
 
   return (
     <PageLayout
@@ -88,14 +89,8 @@ const RedirectToTemplates = () => {
           </ScaffoldSection>
         ) : (
           <ScaffoldSection isFullWidth>
-            <ScaffoldHeader>
-              <ScaffoldSectionTitle>Contents</ScaffoldSectionTitle>
-            </ScaffoldHeader>
-            {/* Template content will go here */}
             <Card>
-              <CardContent>
-                <p className="text-foreground-light">Template editor will be implemented here.</p>
-              </CardContent>
+              <TemplateEditor template={template} />
             </Card>
           </ScaffoldSection>
         )}

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -2,6 +2,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 import { useIsSecurityNotificationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { TEMPLATES_SCHEMAS } from 'components/interfaces/Auth/AuthTemplatesValidation'
+import { slugifyTitle } from 'components/interfaces/Auth/EmailTemplates/EmailTemplates.utils'
 import TemplateEditor from 'components/interfaces/Auth/EmailTemplates/TemplateEditor'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
@@ -46,18 +47,10 @@ const RedirectToTemplates = () => {
     return null
   }
 
-  // Convert templateId slug back to template ID for lookup
-  const templateIdFromSlug = (slug: string) => {
-    const template = TEMPLATES_SCHEMAS.find((template) => {
-      const templateSlug = template.title.trim().replace(/\s+/g, '-').toLowerCase()
-      return templateSlug === slug
-    })
-    return template?.id
-  }
-
+  // Find template whose slug matches the URL slug
   const template =
     templateId && typeof templateId === 'string'
-      ? TEMPLATES_SCHEMAS.find((template) => template.id === templateIdFromSlug(templateId))
+      ? TEMPLATES_SCHEMAS.find((template) => slugifyTitle(template.title) === templateId)
       : null
 
   // Show error if templateId is invalid or template is not found

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -4,8 +4,10 @@ import { useIsSecurityNotificationsEnabled } from 'components/interfaces/App/Fea
 import { TEMPLATES_SCHEMAS } from 'components/interfaces/Auth/AuthTemplatesValidation'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import {
   ScaffoldContainer,
+  ScaffoldHeader,
   ScaffoldSection,
   ScaffoldSectionDescription,
   ScaffoldSectionTitle,
@@ -16,6 +18,9 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
 import { GenericSkeletonLoader } from 'ui-patterns'
+import { DocsButton } from 'components/ui/DocsButton'
+import { DOCS_URL } from 'lib/constants'
+import { Button, Card, CardContent } from 'ui'
 
 const TemplatePage: NextPageWithLayout = () => {
   return <RedirectToTemplates />
@@ -59,26 +64,39 @@ const RedirectToTemplates = () => {
   )
 
   return (
-    <ScaffoldContainer bottomPadding>
-      {!isPermissionsLoaded ? (
-        <ScaffoldSection isFullWidth>
-          <GenericSkeletonLoader />
-        </ScaffoldSection>
-      ) : (
-        <ScaffoldSection isFullWidth>
-          <div>
-            <ScaffoldSectionTitle>{template?.title || 'Email template'}</ScaffoldSectionTitle>
-            <ScaffoldSectionDescription>
-              {template?.purpose || 'Configure and customize your email template settings.'}
-            </ScaffoldSectionDescription>
-          </div>
-          {/* Template content will go here */}
-          <div className="mt-6">
-            <p className="text-foreground-light">Template editor will be implemented here.</p>
-          </div>
-        </ScaffoldSection>
-      )}
-    </ScaffoldContainer>
+    <PageLayout
+      title={template?.title || 'Email template'}
+      subtitle={template?.purpose || 'Configure and customize email templates.'}
+      breadcrumbs={[
+        {
+          label: 'Emails',
+          href: `/project/${ref}/auth/templates`,
+        },
+      ]}
+      secondaryActions={[
+        <DocsButton key="docs" href={`${DOCS_URL}/reference/javascript/subscribe`} />,
+      ]}
+    >
+      <ScaffoldContainer bottomPadding>
+        {!isPermissionsLoaded ? (
+          <ScaffoldSection isFullWidth>
+            <GenericSkeletonLoader />
+          </ScaffoldSection>
+        ) : (
+          <ScaffoldSection isFullWidth>
+            <ScaffoldHeader>
+              <ScaffoldSectionTitle>Contents</ScaffoldSectionTitle>
+            </ScaffoldHeader>
+            {/* Template content will go here */}
+            <Card>
+              <CardContent>
+                <p className="text-foreground-light">Template editor will be implemented here.</p>
+              </CardContent>
+            </Card>
+          </ScaffoldSection>
+        )}
+      </ScaffoldContainer>
+    </PageLayout>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -6,12 +6,7 @@ import TemplateEditor from 'components/interfaces/Auth/EmailTemplates/TemplateEd
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
-import {
-  ScaffoldContainer,
-  ScaffoldHeader,
-  ScaffoldSection,
-  ScaffoldSectionTitle,
-} from 'components/layouts/Scaffold'
+import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { DocsButton } from 'components/ui/DocsButton'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -19,7 +14,7 @@ import { DOCS_URL } from 'lib/constants'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
-import { Card, CardContent } from 'ui'
+import { Card } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
 
 const TemplatePage: NextPageWithLayout = () => {
@@ -58,17 +53,28 @@ const RedirectToTemplates = () => {
     })
     return template?.id
   }
-  const template = TEMPLATES_SCHEMAS.find(
-    (template) => template.id === templateIdFromSlug(templateId as string)
-  )
+
+  const template =
+    templateId && typeof templateId === 'string'
+      ? TEMPLATES_SCHEMAS.find((template) => template.id === templateIdFromSlug(templateId))
+      : null
+
+  // Show error if templateId is invalid or template is not found
+  if (!template || !templateId || typeof templateId !== 'string') {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <p className="text-sm text-foreground-light">Template "{templateId}" cannot be found</p>
+      </div>
+    )
+  }
 
   // Convert templateId slug to one lowercase word to match docs anchor tag
   const templateIdForDocs = templateId.replace(/-/g, '').toLowerCase()
 
   return (
     <PageLayout
-      title={template?.title || 'Email template'}
-      subtitle={template?.purpose || 'Configure and customize email templates.'}
+      title={template.title}
+      subtitle={template.purpose || 'Configure and customize email templates.'}
       breadcrumbs={[
         {
           label: 'Emails',

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import { AuthEmailsLayout } from 'components/layouts/AuthLayout/AuthEmailsLayout'
+import { TEMPLATES_SCHEMAS } from 'components/interfaces/Auth/AuthTemplatesValidation'
+import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import {
   ScaffoldContainer,
@@ -27,6 +28,19 @@ const TemplatePage: NextPageWithLayout = () => {
     return <NoPermission isFullPage resourceText="access your project's email settings" />
   }
 
+  // Convert templateId slug back to template ID for lookup
+  const templateIdFromSlug = (slug: string) => {
+    const template = TEMPLATES_SCHEMAS.find((template) => {
+      const templateSlug = template.title.trim().replace(/\s+/g, '-').toLowerCase()
+      return templateSlug === slug
+    })
+    return template?.id
+  }
+
+  const template = TEMPLATES_SCHEMAS.find(
+    (template) => template.id === templateIdFromSlug(templateId as string)
+  )
+
   return (
     <ScaffoldContainer bottomPadding>
       {!isPermissionsLoaded ? (
@@ -36,9 +50,9 @@ const TemplatePage: NextPageWithLayout = () => {
       ) : (
         <ScaffoldSection isFullWidth>
           <div>
-            <ScaffoldSectionTitle>Email Template: {templateId}</ScaffoldSectionTitle>
+            <ScaffoldSectionTitle>{template?.title || 'Email template'}</ScaffoldSectionTitle>
             <ScaffoldSectionDescription>
-              Configure and customize your email template settings.
+              {template?.purpose || 'Configure and customize your email template settings.'}
             </ScaffoldSectionDescription>
           </div>
           {/* Template content will go here */}
@@ -53,7 +67,7 @@ const TemplatePage: NextPageWithLayout = () => {
 
 TemplatePage.getLayout = (page) => (
   <DefaultLayout>
-    <AuthEmailsLayout>{page}</AuthEmailsLayout>
+    <AuthLayout>{page}</AuthLayout>
   </DefaultLayout>
 )
 

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -9,18 +9,17 @@ import {
   ScaffoldContainer,
   ScaffoldHeader,
   ScaffoldSection,
-  ScaffoldSectionDescription,
   ScaffoldSectionTitle,
 } from 'components/layouts/Scaffold'
+import { DocsButton } from 'components/ui/DocsButton'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { DOCS_URL } from 'lib/constants'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
+import { Card, CardContent } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
-import { DocsButton } from 'components/ui/DocsButton'
-import { DOCS_URL } from 'lib/constants'
-import { Button, Card, CardContent } from 'ui'
 
 const TemplatePage: NextPageWithLayout = () => {
   return <RedirectToTemplates />
@@ -59,6 +58,8 @@ const RedirectToTemplates = () => {
     return template?.id
   }
 
+  // Convert templateId slug to one lowercase word to match docs anchor tag
+  const templateIdForDocs = templateId.replace(/-/g, '').toLowerCase()
   const template = TEMPLATES_SCHEMAS.find(
     (template) => template.id === templateIdFromSlug(templateId as string)
   )
@@ -74,7 +75,10 @@ const RedirectToTemplates = () => {
         },
       ]}
       secondaryActions={[
-        <DocsButton key="docs" href={`${DOCS_URL}/reference/javascript/subscribe`} />,
+        <DocsButton
+          key="docs"
+          href={`${DOCS_URL}/guides/local-development/customizing-email-templates#authemailtemplate${templateIdForDocs}`}
+        />,
       ]}
     >
       <ScaffoldContainer bottomPadding>

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -1,15 +1,23 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import { EmailTemplates } from 'components/interfaces/Auth/EmailTemplates/EmailTemplates'
 import { AuthEmailsLayout } from 'components/layouts/AuthLayout/AuthEmailsLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
-import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
+import {
+  ScaffoldContainer,
+  ScaffoldSection,
+  ScaffoldSectionDescription,
+  ScaffoldSectionTitle,
+} from 'components/layouts/Scaffold'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useRouter } from 'next/router'
 import type { NextPageWithLayout } from 'types'
 import { GenericSkeletonLoader } from 'ui-patterns'
 
-const TemplatesPage: NextPageWithLayout = () => {
+const TemplatePage: NextPageWithLayout = () => {
+  const router = useRouter()
+  const { templateId } = router.query
+
   const { can: canReadAuthSettings, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
     PermissionAction.READ,
     'custom_config_gotrue'
@@ -20,22 +28,33 @@ const TemplatesPage: NextPageWithLayout = () => {
   }
 
   return (
-    <ScaffoldContainer>
+    <ScaffoldContainer bottomPadding>
       {!isPermissionsLoaded ? (
         <ScaffoldSection isFullWidth>
           <GenericSkeletonLoader />
         </ScaffoldSection>
       ) : (
-        <EmailTemplates />
+        <ScaffoldSection isFullWidth>
+          <div>
+            <ScaffoldSectionTitle>Email Template: {templateId}</ScaffoldSectionTitle>
+            <ScaffoldSectionDescription>
+              Configure and customize your email template settings.
+            </ScaffoldSectionDescription>
+          </div>
+          {/* Template content will go here */}
+          <div className="mt-6">
+            <p className="text-foreground-light">Template editor will be implemented here.</p>
+          </div>
+        </ScaffoldSection>
       )}
     </ScaffoldContainer>
   )
 }
 
-TemplatesPage.getLayout = (page) => (
+TemplatePage.getLayout = (page) => (
   <DefaultLayout>
     <AuthEmailsLayout>{page}</AuthEmailsLayout>
   </DefaultLayout>
 )
 
-export default TemplatesPage
+export default TemplatePage

--- a/apps/studio/pages/project/[ref]/auth/templates/index.tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/index.tsx
@@ -1,0 +1,41 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+
+import { EmailTemplates } from 'components/interfaces/Auth/EmailTemplates/EmailTemplates'
+import { AuthEmailsLayout } from 'components/layouts/AuthLayout/AuthEmailsLayout'
+import DefaultLayout from 'components/layouts/DefaultLayout'
+import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
+import NoPermission from 'components/ui/NoPermission'
+import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import type { NextPageWithLayout } from 'types'
+import { GenericSkeletonLoader } from 'ui-patterns'
+
+const TemplatesPage: NextPageWithLayout = () => {
+  const { can: canReadAuthSettings, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
+    PermissionAction.READ,
+    'custom_config_gotrue'
+  )
+
+  if (isPermissionsLoaded && !canReadAuthSettings) {
+    return <NoPermission isFullPage resourceText="access your project's email settings" />
+  }
+
+  return (
+    <ScaffoldContainer bottomPadding>
+      {!isPermissionsLoaded ? (
+        <ScaffoldSection isFullWidth>
+          <GenericSkeletonLoader />
+        </ScaffoldSection>
+      ) : (
+        <EmailTemplates />
+      )}
+    </ScaffoldContainer>
+  )
+}
+
+TemplatesPage.getLayout = (page) => (
+  <DefaultLayout>
+    <AuthEmailsLayout>{page}</AuthEmailsLayout>
+  </DefaultLayout>
+)
+
+export default TemplatesPage

--- a/apps/studio/types/form.ts
+++ b/apps/studio/types/form.ts
@@ -9,6 +9,7 @@ export interface FormSchema {
   id?: string
   type: 'object'
   title: string
+  purpose?: string
   properties: {
     [x: string]: {
       title: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

- UI update
- Resolves DEPR-137

## What is the current behavior?

- Email templates are listed as tab items on `/auth/templates/`

## What is the new behavior?

For users with `isSecurityNotificationsEnabled` set to `true`:

- `/auth/templates/` now just shows a list of email templates
- Tapping on any of those list items takes the user to `/auth/templates/[templateId]`

For everyone else:

- No visual changes at all
- They get redirected away from `/auth/templates/[templateId]` should they land there

For everyone:

- Cleaned up the custom SMTP admonition and its copywriting

| `/templates` Before | `/templates` After | `[templateId]` New |
| --- | --- | --- |
| <img width="1280" height="1322" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/81424747-fc72-4ab7-a9ea-f9a3e3f3dcac" /> | <img width="1280" height="1322" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/276c9a12-05f6-454f-bf95-8d293006f8e4" /> | <img width="1280" height="1322" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/ab55d4fd-c54d-4d70-8a68-bec6c86e3145" /> |

## To test

- [ ] Please make sure everything works as expected in `/auth/templates/` for existing users
- [ ] Then turn on the _Security notification templates_ feature preview
  - [ ] Note that the `/auth/templates/` page now lists all the templates with their description (`purpose`)
  - [ ] Note that tapping on any takes you to its respective template page
