### PR TITLE
chore: respect catalog version for postgrest-js

### DIFF
--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -48,6 +48,9 @@ jobs:
           # Update @supabase/realtime-js
           sed -i "s/'@supabase\/realtime-js': .*/'@supabase\/realtime-js': ${{ github.event.inputs.version }}/" pnpm-workspace.yaml
 
+          # Update @supabase/postgrest-js
+          sed -i "s/'@supabase\/postgrest-js': .*/'@supabase\/postgrest-js': ${{ github.event.inputs.version }}/" pnpm-workspace.yaml
+
           echo "Updated pnpm-workspace.yaml:"
           cat pnpm-workspace.yaml
 
@@ -69,6 +72,7 @@ jobs:
             - Updated @supabase/supabase-js to ${{ github.event.inputs.version }}
             - Updated @supabase/auth-js to ${{ github.event.inputs.version }}
             - Updated @supabase/realtime-js to ${{ github.event.inputs.version }}
+            - Updated @supabase/postgest-js to ${{ github.event.inputs.version }}
             - Refreshed pnpm-lock.yaml
 
             This PR was created automatically.

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -47,7 +47,7 @@
     "@radix-ui/react-toggle-group": "*",
     "@radix-ui/react-tooltip": "*",
     "@react-router/fs-routes": "^7.4.0",
-    "@supabase/postgrest-js": "*",
+    "@supabase/postgrest-js": "catalog:",
     "@supabase/supa-mdx-lint": "0.2.6-alpha",
     "@tanstack/react-query": "^5.83.0",
     "@supabase/vue-blocks": "workspace:*",

--- a/apps/ui-library/registry/default/blocks/infinite-query-hook/hooks/use-infinite-query.ts
+++ b/apps/ui-library/registry/default/blocks/infinite-query-hook/hooks/use-infinite-query.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { createClient } from '@/registry/default/fixtures/lib/supabase/client'
-import { PostgrestQueryBuilder } from '@supabase/postgrest-js'
+import { PostgrestQueryBuilder, type PostgrestClientOptions } from '@supabase/postgrest-js'
 import { type SupabaseClient } from '@supabase/supabase-js'
 import { useEffect, useRef, useSyncExternalStore } from 'react'
 
@@ -44,8 +44,16 @@ type SupabaseTableName = keyof DatabaseSchema['Tables']
 // Extracts the table definition from the database type
 type SupabaseTableData<T extends SupabaseTableName> = DatabaseSchema['Tables'][T]['Row']
 
+// Default client options for PostgrestQueryBuilder
+type DefaultClientOptions = PostgrestClientOptions
+
 type SupabaseSelectBuilder<T extends SupabaseTableName> = ReturnType<
-  PostgrestQueryBuilder<DatabaseSchema, DatabaseSchema['Tables'][T], T>['select']
+  PostgrestQueryBuilder<
+    DefaultClientOptions,
+    DatabaseSchema,
+    DatabaseSchema['Tables'][T],
+    T
+  >['select']
 >
 
 // A function that modifies the query. Can be used to sort, filter, etc. If .range is used, it will be overwritten.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@supabase/auth-js':
       specifier: 2.75.1
       version: 2.75.1
+    '@supabase/postgrest-js':
+      specifier: 2.75.1
+      version: 2.75.1
     '@supabase/realtime-js':
       specifier: 2.75.1
       version: 2.75.1
@@ -1343,8 +1346,8 @@ importers:
         specifier: ^7.4.0
         version: 7.4.0(@react-router/dev@7.4.0(@types/node@22.13.14)(babel-plugin-macros@3.1.0)(jiti@2.5.1)(react-router@7.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.19.3)(typescript@5.9.2)(vite@6.3.6(@types/node@22.13.14)(jiti@2.5.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(yaml@2.8.1))(typescript@5.9.2)
       '@supabase/postgrest-js':
-        specifier: '*'
-        version: 1.19.2
+        specifier: 'catalog:'
+        version: 2.75.1
       '@supabase/supa-mdx-lint':
         specifier: 0.2.6-alpha
         version: 0.2.6-alpha
@@ -8849,9 +8852,6 @@ packages:
   '@supabase/postgres-meta@0.64.6':
     resolution: {integrity: sha512-vz5gc6RKNfDVnIfRUmH2ssTMYFI0U3MYOVyQ9R4YkzOS2dKSanjC4rTEDGjlMFwGTCUPW3N3pbY7HJIW81wMyg==}
     engines: {node: '>=16', npm: '>=8'}
-
-  '@supabase/postgrest-js@1.19.2':
-    resolution: {integrity: sha512-MXRbk4wpwhWl9IN6rIY1mR8uZCCG4MZAEji942ve6nMwIqnBgBnZhZlON6zTTs6fgveMnoCILpZv1+K91jN+ow==}
 
   '@supabase/postgrest-js@2.75.1':
     resolution: {integrity: sha512-FiYBD0MaKqGW8eo4Xqu7/100Xm3ddgh+3qHtqS18yQRoglJTFRQCJzY1xkrGS0JFHE2YnbjL6XCiOBXiG8DK4Q==}
@@ -28635,10 +28635,6 @@ snapshots:
       - encoding
       - pg-native
       - supports-color
-
-  '@supabase/postgrest-js@1.19.2':
-    dependencies:
-      '@supabase/node-fetch': 2.6.15
 
   '@supabase/postgrest-js@2.75.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ catalog:
   '@supabase/auth-js': 2.75.1
   '@supabase/realtime-js': 2.75.1
   '@supabase/supabase-js': 2.75.1
+  '@supabase/postgrest-js': 2.75.1
   '@types/node': ^22.0.0
   '@types/react': ^18.3.0
   '@types/react-dom': ^18.3.0


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

`@supabase/postgrest-js` should respect catalog version.

## What is the current behavior?

By keeping version to `*`, it would resolve older version from `pnpm-lock.yaml`, so the lock file would have two different versions for `postgrest-js`.

## What is the new behavior?

`@supabase/postgrest-js` version is set in `catalog`, and the `ui-library` version respects that. It follows the convention already in place for version management.
