### PR TITLE
fix(studio): comma formatting for auth overview numbers

### DIFF
--- a/apps/studio/components/interfaces/Auth/Overview/OverviewUsage.tsx
+++ b/apps/studio/components/interfaces/Auth/Overview/OverviewUsage.tsx
@@ -59,7 +59,11 @@ export const StatCard = ({
         : 'text-brand'
       : getChangeColor(previous)
   const formattedCurrent =
-    suffix === 'ms' ? current.toFixed(2) : suffix === '%' ? current.toFixed(1) : Math.round(current)
+    suffix === 'ms'
+      ? current.toFixed(2)
+      : suffix === '%'
+        ? current.toFixed(1)
+        : Math.round(current).toLocaleString()
   const signChar = previous > 0 ? '+' : previous < 0 ? '-' : ''
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Was missing trusty `.toLocaleString()`.
