### PR TITLE
fix(docs): change 'countries' to 'characters' to match JS example to data source

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -6571,7 +6571,7 @@ functions:
         code: |
           ```ts
           const { data, error } = await supabase
-            .from('countries')
+            .from('characters')
             .select('name')
             .range(0, 1)
           ```


### PR DESCRIPTION
…data source

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The JavaScript example and the Data source don't reference the same table. The JavaScript example should fetch rows from the 'characters' table, just like the Data source, because the response shows data from 'characters', not from 'countries'.

## What is the new behavior?

The JavaScript example and the Data source match now.

## Additional context

This PR is solving [this issue](https://github.com/supabase/supabase/issues/39791)

Here is a screenshot illustrating the issue:

<img width="704" height="350" alt="mimtch" src="https://github.com/user-attachments/assets/637038d4-d2ff-433e-9ea5-f4eab4292bd0" />
