### PR TITLE
Fix: infinite re-render on table when computing foreign keys

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -1,6 +1,6 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
 import { isEmpty, isUndefined, noop } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import { DocsButton } from 'components/ui/DocsButton'
@@ -141,14 +141,18 @@ export const TableEditor = ({
     (constraint) => constraint.type === CONSTRAINT_TYPE.PRIMARY_KEY_CONSTRAINT
   )
 
-  const { data: foreignKeyMeta, isSuccess: isSuccessForeignKeyMeta } =
+  const { data: foreignKeyMeta = [], isSuccess: isSuccessForeignKeyMeta } =
     useForeignKeyConstraintsQuery({
       projectRef: project?.ref,
       connectionString: project?.connectionString,
       schema: table?.schema,
     })
-  const foreignKeys = (foreignKeyMeta ?? []).filter(
-    (fk) => fk.source_schema === table?.schema && fk.source_table === table?.name
+  const foreignKeys = useMemo(
+    () =>
+      foreignKeyMeta.filter(
+        (fk) => fk.source_schema === table?.schema && fk.source_table === table?.name
+      ),
+    [foreignKeyMeta, table]
   )
 
   const onUpdateField = (changes: Partial<TableField>) => {
@@ -245,7 +249,7 @@ export const TableEditor = ({
       } else {
         const tableFields = generateTableFieldFromPostgresTable(
           table,
-          foreignKeyMeta || [],
+          foreignKeyMeta,
           isDuplicating,
           isRealtimeEnabled
         )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix for https://github.com/supabase/supabase/issues/39833

## What is the current behavior?

When loading the table editor, this is causing an infinite re-render because of the following:

- This .filter() call creates a new array reference on every single render
- Even if the actual data hasn't changed, foreignKeys is a brand new array each time
- React's useEffect uses shallow comparison on dependencies
- It sees foreignKeys as "different" on every render (new reference) and re-runs the effect

## What is the new behavior?

no more unused re-renders 🙈 

## Additional context


