### PR TITLE
fix: confirmation modal on paid org creation

### DIFF
--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -581,7 +581,7 @@ export const NewOrgForm = ({
                         </InlineLink>
                         . If you want to upgrade your existing projects,{' '}
                         <InlineLink
-                          href="/org/_/billing"
+                          href="/org/_/billing?panel=subscriptionPlan"
                           className="text-inherit hover:text-foreground transition-colors"
                         >
                           upgrade your existing organization

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -2,10 +2,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Elements } from '@stripe/react-stripe-js'
 import type { PaymentIntentResult, PaymentMethod, StripeElementsOptions } from '@stripe/stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
-import _ from 'lodash'
+import { groupBy } from 'lodash'
 import { HelpCircle } from 'lucide-react'
 import { useTheme } from 'next-themes'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -16,6 +15,10 @@ import { z } from 'zod'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { getStripeElementsAppearanceOptions } from 'components/interfaces/Billing/Payment/Payment.utils'
 import { PaymentConfirmation } from 'components/interfaces/Billing/Payment/PaymentConfirmation'
+import {
+  NewPaymentMethodElement,
+  type PaymentMethodElementRef,
+} from 'components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement'
 import SpendCapModal from 'components/interfaces/Billing/SpendCapModal'
 import { InlineLink } from 'components/ui/InlineLink'
 import Panel from 'components/ui/Panel'
@@ -43,11 +46,7 @@ import {
   Switch,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import {
-  NewPaymentMethodElement,
-  type PaymentMethodElementRef,
-} from '../../Billing/Payment/PaymentMethods/NewPaymentMethodElement'
-import { Admonition } from 'ui-patterns'
+import { UpgradeExistingOrganizationCallout } from './UpgradeExistingOrganizationCallout'
 
 const ORG_KIND_TYPES = {
   PERSONAL: 'Personal',
@@ -129,7 +128,7 @@ export const NewOrgForm = ({
   // in onSubmit below, which isn't a critical functionality imo so am okay for now. But ideally perhaps this data can
   // be computed on the API and returned in /profile or something (since this data is on the account level)
   const projectsByOrg = useMemo(() => {
-    return _.groupBy(projects, 'organization_slug')
+    return groupBy(projects, 'organization_slug')
   }, [projects])
 
   const stripeOptionsPaymentMethod: StripeElementsOptions = useMemo(
@@ -470,15 +469,7 @@ export const NewOrgForm = ({
                       description={
                         <>
                           Which plan fits your organization's needs best?{' '}
-                          <InlineLink
-                            href="https://supabase.com/pricing"
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-inherit hover:text-foreground transition-colors"
-                          >
-                            Learn more
-                          </InlineLink>
-                          .
+                          <InlineLink href="https://supabase.com/pricing">Learn more</InlineLink>.
                         </>
                       }
                     >
@@ -563,35 +554,7 @@ export const NewOrgForm = ({
             )}
 
             {hasFreeOrgWithProjects && form.getValues('plan') !== 'FREE' && (
-              <Panel.Content>
-                <Admonition
-                  type="default"
-                  title="Looking to upgrade an existing project?"
-                  description={
-                    <div>
-                      <p className="text-sm text-foreground-light">
-                        Supabase{' '}
-                        <InlineLink
-                          href="https://supabase.com/docs/guides/platform/billing-on-supabase"
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-inherit hover:text-foreground transition-colors"
-                        >
-                          bills per organization
-                        </InlineLink>
-                        . If you want to upgrade your existing projects,{' '}
-                        <InlineLink
-                          href="/org/_/billing?panel=subscriptionPlan"
-                          className="text-inherit hover:text-foreground transition-colors"
-                        >
-                          upgrade your existing organization
-                        </InlineLink>{' '}
-                        instead.
-                      </p>
-                    </div>
-                  }
-                />
-              </Panel.Content>
+              <UpgradeExistingOrganizationCallout />
             )}
           </div>
         </Panel>

--- a/apps/studio/components/interfaces/Organization/NewOrg/UpgradeExistingOrganizationCallout.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/UpgradeExistingOrganizationCallout.tsx
@@ -1,0 +1,29 @@
+import { InlineLink } from 'components/ui/InlineLink'
+import Panel from 'components/ui/Panel'
+import { Admonition } from 'ui-patterns'
+
+export const UpgradeExistingOrganizationCallout = () => {
+  return (
+    <Panel.Content>
+      <Admonition
+        type="default"
+        title="Looking to upgrade an existing project?"
+        description={
+          <div>
+            <p className="text-sm text-foreground-light">
+              Supabase{' '}
+              <InlineLink href="https://supabase.com/docs/guides/platform/billing-on-supabase">
+                bills per organization
+              </InlineLink>
+              . If you want to upgrade your existing projects,{' '}
+              <InlineLink href="/org/_/billing?panel=subscriptionPlan">
+                upgrade your existing organization
+              </InlineLink>{' '}
+              instead.
+            </p>
+          </div>
+        }
+      />
+    </Panel.Content>
+  )
+}

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -43,7 +43,6 @@ import {
   ProjectCreateVariables,
   useProjectCreateMutation,
 } from 'data/projects/project-create-mutation'
-import { useTrack } from 'lib/telemetry/track'
 import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
@@ -63,6 +62,7 @@ import {
 } from 'lib/constants'
 import passwordStrength from 'lib/password-strength'
 import { generateStrongPassword } from 'lib/project'
+import { useTrack } from 'lib/telemetry/track'
 import { AWS_REGIONS, type CloudProvider } from 'shared-data'
 import type { NextPageWithLayout } from 'types'
 import {
@@ -772,18 +772,12 @@ const Wizard: NextPageWithLayout = () => {
                                     The size for your dedicated database. You can change this later.
                                     Learn more about{' '}
                                     <InlineLink
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-inherit hover:text-foreground transition-colors"
                                       href={`${DOCS_URL}/guides/platform/compute-add-ons`}
                                     >
                                       compute add-ons
                                     </InlineLink>{' '}
                                     and{' '}
                                     <InlineLink
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-inherit hover:text-foreground transition-colors"
                                       href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
                                     >
                                       compute billing


### PR DESCRIPTION
The submit handler is triggered both on initially clicking the "Create organization" button and on the confirmation button, but it always early returns if the customer has other free plan orgs with projects, so it doesn't let the customer submit the form.

How to reproduce:
- Create a free plan org with an active project
- Create a new paid plan organization
- Confirmation modal appears
- Clicking the button just closes the modal and does not create the org as there is an early return in the onSubmit handler

Moved away from ConfirmationModal to an inline info instead

<img width="685" height="206" alt="Screenshot 2025-10-25 at 13 00 16" src="https://github.com/user-attachments/assets/3f6d1636-4aa7-462a-86d0-f81ca3644a02" />
