### PR TITLE
feat: steal the auth lock if it was not completed in 10s

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -144,10 +144,32 @@ async function debuggableNavigatorLock<R>(
       }
 
       console.error(
-        `Waited for over 10s to acquire an Auth client lock`,
+        `Waited for over 10s to acquire an Auth client lock, will steal the lock to unblock`,
         await navigator.locks.query(),
         stackException
       )
+
+      // quickly steal the lock and release it so that others can acquire it,
+      // while leaving the code that was holding it to continue running
+      navigator.locks
+        .request(
+          name,
+          {
+            steal: true,
+          },
+          async () => {
+            await new Promise((accept) => {
+              setTimeout(accept, 0)
+            })
+
+            console.error('Lock was stolen and now released', stackException)
+          }
+        )
+        .catch((e: any) => {
+          if (captureException) {
+            captureException(e)
+          }
+        })
     })()
   }, 10000)
 


### PR DESCRIPTION
We can't find why the lock sometimes gets blocked up. This code should at least see the dashboard load, as it will steal the lock that's holding everything and then release it so other functions can acquire it properly.