### PR TITLE
chore: user v2 content count query for search

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -52,8 +52,6 @@ export const SearchList = ({ search }: SearchListProps) => {
   )
   const totalNumber = count ? count.private + count.shared : 0
 
-  console.log({ totalNumber })
-
   const snippets = useMemo(
     // [Joshen] Set folder_id to null to ensure flat list
     () => data?.pages.flatMap((page) => page.content.map((x) => ({ ...x, folder_id: null }))),

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -45,13 +45,14 @@ export const SearchList = ({ search }: SearchListProps) => {
   const { data: count, isLoading: isLoadingCount } = useContentCountQuery(
     {
       projectRef,
-      cumulative: true,
       type: 'sql',
       name: search,
     },
     { keepPreviousData: true }
   )
-  const totalNumber = (count as unknown as { count: number })?.count ?? 0
+  const totalNumber = count ? count.private + count.shared : 0
+
+  console.log({ totalNumber })
 
   const snippets = useMemo(
     // [Joshen] Set folder_id to null to ensure flat list

--- a/apps/studio/data/content/content-count-query.ts
+++ b/apps/studio/data/content/content-count-query.ts
@@ -8,11 +8,10 @@ import { contentKeys } from './keys'
 type GetContentCountVariables =
   operations['ContentController_getContentCountV2']['parameters']['query'] & {
     projectRef?: string
-    cumulative?: boolean
   }
 
 export async function getContentCount(
-  { projectRef, cumulative, type, name }: GetContentCountVariables,
+  { projectRef, type, name }: GetContentCountVariables,
   signal?: AbortSignal
 ) {
   if (typeof projectRef === 'undefined') throw new Error('projectRef is required')
@@ -25,7 +24,7 @@ export async function getContentCount(
         ...(name && { name }),
       },
     },
-    ...(cumulative ? {} : { headers: { Version: '2' } }),
+    headers: { Version: '2' },
     signal,
   })
 
@@ -37,15 +36,14 @@ export type ContentIdData = Awaited<ReturnType<typeof getContentCount>>
 export type ContentIdError = ResponseError
 
 export const useContentCountQuery = <TData = ContentIdData>(
-  { projectRef, cumulative, type, name }: GetContentCountVariables,
+  { projectRef, type, name }: GetContentCountVariables,
   { enabled = true, ...options }: UseQueryOptions<ContentIdData, ContentIdError, TData> = {}
 ) =>
   useQuery<ContentIdData, ContentIdError, TData>(
     contentKeys.count(projectRef, type, {
-      cumulative,
       name,
     }),
-    ({ signal }) => getContentCount({ projectRef, cumulative, type, name }, signal),
+    ({ signal }) => getContentCount({ projectRef, type, name }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
       ...options,

--- a/apps/studio/data/content/keys.ts
+++ b/apps/studio/data/content/keys.ts
@@ -37,7 +37,6 @@ export const contentKeys = {
     projectRef: string | undefined,
     type?: string,
     options?: {
-      cumulative?: boolean
       visibility?: string
       favorite?: boolean
       name?: string


### PR DESCRIPTION
Instead of using two different endpoint versions, we can rely on v2 for all cases.