### PR TITLE
docs: add example for handling OAuth redirects in SvelteKit SSR guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -461,6 +461,36 @@ export const actions: Actions = {
 
 </StepHikeCompact.Code>
 
+<StepHikeCompact.Details title="Handling OAuth Providers">
+
+If you're using OAuth providers such as GitHub or Google, you can redirect users to the provider’s authorization page by returning the `data.url` from the `signInWithOAuth` method.
+
+This can be added to the same `+page.server.ts` file as a separate action:
+
+```ts name=src/routes/auth/+page.server.ts
+import { redirect } from '@sveltejs/kit'
+
+export const actions = {
+  oauth: async ({ locals: { supabase } }) => {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'github',
+    })
+
+    if (error) {
+      console.error(error)
+      throw redirect(303, '/auth/error')
+    }
+
+    // Redirect the user to the OAuth provider's login page
+    throw redirect(303, data.url)
+  },
+}
+```
+
+</$CodeTabs>
+
+</StepHikeCompact.Code>
+
 </StepHikeCompact.Step>
 
 <StepHikeCompact.Step step={10}>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The current SvelteKit Server-Side Authentication guide does not include an example for handling OAuth providers (e.g., GitHub, Google).  
As a result, new users may be unsure how to handle redirects using `signInWithOAuth`.

## What is the new behavior?

This PR adds a short example showing how to handle OAuth sign-ins by redirecting to `data.url` after calling `signInWithOAuth`.  
The example is placed after Step 9 (“Create a login page”) in the SvelteKit SSR Auth guide.

```ts
const { data, error } = await supabase.auth.signInWithOAuth({
  provider: 'github',
})

if (error) {
  console.error(error)
  throw redirect(303, '/auth/error')
}

throw redirect(303, data.url)

