### PR TITLE
fix: revert 39818

### DIFF
--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -75,20 +75,17 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
         <Copy size={12} />
         <span className="ml-2 text-xs">Copy row</span>
       </Item>
-      {snap.editable && (
-        <>
-          <DialogSectionSeparator className="my-1.5" />
-          <Item onClick={onEditRowClick} data="edit">
-            <Edit size={12} />
-            <span className="ml-2 text-xs">Edit row</span>
-          </Item>
-          <DialogSectionSeparator className="my-1.5" />
-          <Item onClick={onDeleteRow} data="delete">
-            <Trash size={12} />
-            <span className="ml-2 text-xs">Delete row</span>
-          </Item>
-        </>
-      )}
+
+      <DialogSectionSeparator className="my-1.5" />
+      <Item onClick={onEditRowClick} data="edit">
+        <Edit size={12} />
+        <span className="ml-2 text-xs">Edit row</span>
+      </Item>
+      <DialogSectionSeparator className="my-1.5" />
+      <Item onClick={onDeleteRow} data="delete">
+        <Trash size={12} />
+        <span className="ml-2 text-xs">Delete row</span>
+      </Item>
     </Menu>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Table Editor > Right Click Row

## What is the current behavior?

The right click options on the table editor do not work and console error.

## What is the new behavior?

Reverted back and right click options work

## Additional context

Closes #39872
