### PR TITLE
chore(studio): vector buckets polish C

### DIFF
--- a/apps/studio/components/interfaces/Storage/VectorBuckets/DeleteVectorBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/DeleteVectorBucketModal.tsx
@@ -71,7 +71,7 @@ export const DeleteVectorBucketModal = ({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Confirm deletion of {bucket.name}</DialogTitle>
+          <DialogTitle>Confirm deletion of {bucketName}</DialogTitle>
         </DialogHeader>
 
         <DialogSectionSeparator />

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails.tsx
@@ -132,14 +132,14 @@ export const VectorBucketDetails = ({ bucket }: VectorBucketDetailsProps) => {
                           {filterString.length > 0 ? (
                             <>
                               <p className="text-sm text-foreground">No results found</p>
-                              <p className="text-sm text-foreground-light">
+                              <p className="text-sm text-foreground-lighter">
                                 Your search for "{filterString}" did not return any results
                               </p>
                             </>
                           ) : (
                             <>
                               <p className="text-sm text-foreground">No tables yet</p>
-                              <p className="text-sm text-foreground-light">
+                              <p className="text-sm text-foreground-lighter">
                                 Create your first table to get started
                               </p>
                             </>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorsBuckets.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorsBuckets.tsx
@@ -75,8 +75,16 @@ export const VectorsBuckets = () => {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Created at</TableHead>
+                    <TableHead
+                      className={filteredBuckets.length === 0 ? 'text-foreground-muted' : undefined}
+                    >
+                      Name
+                    </TableHead>
+                    <TableHead
+                      className={filteredBuckets.length === 0 ? 'text-foreground-muted' : undefined}
+                    >
+                      Created at
+                    </TableHead>
                     <TableHead />
                   </TableRow>
                 </TableHeader>
@@ -85,7 +93,7 @@ export const VectorsBuckets = () => {
                     <TableRow>
                       <TableCell colSpan={3}>
                         <p className="text-sm text-foreground">No results found</p>
-                        <p className="text-sm text-foreground-light">
+                        <p className="text-sm text-foreground-lighter">
                           Your search for "{filterString}" did not return any results
                         </p>
                       </TableCell>

--- a/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
@@ -4,9 +4,13 @@ import { VectorBucketDetails } from 'components/interfaces/Storage/VectorBuckets
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
 import { useVectorBucketQuery } from 'data/storage/vector-bucket-query'
+import Link from 'next/link'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import type { NextPageWithLayout } from 'types'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 
 const VectorsBucketPage: NextPageWithLayout = () => {
   const { bucketId } = useParams()
@@ -24,12 +28,27 @@ const VectorsBucketPage: NextPageWithLayout = () => {
     <div className="storage-container flex flex-grow">
       {isError && <StorageBucketsError error={error as any} />}
 
-      {isLoading && <GenericSkeletonLoader className="w-full" />}
+      {isLoading && (
+        <ScaffoldContainer>
+          <ScaffoldSection isFullWidth>
+            <GenericSkeletonLoader />
+          </ScaffoldSection>
+        </ScaffoldContainer>
+      )}
 
       {isSuccess ? (
         !vectorBucket ? (
           <div className="flex h-full w-full items-center justify-center">
-            <p className="text-sm text-foreground-light">Bucket {bucketId} cannot be found</p>
+            <Admonition
+              className="max-w-md"
+              type="default"
+              title="Unable to find bucket"
+              description={`${bucketId ? `The template "${bucketId}"` : 'This template'} doesn’t seem to exist.`}
+            >
+              <Button asChild type="default" className="mt-2">
+                <Link href={`/project/${projectRef}/storage/vectors`}>Head back</Link>
+              </Button>
+            </Admonition>
           </div>
         ) : (
           <VectorBucketDetails bucket={vectorBucket} />

--- a/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
@@ -21,7 +21,7 @@ const VectorsBucketPage: NextPageWithLayout = () => {
   } = useVectorBucketQuery({ projectRef, vectorBucketName: bucketId })
 
   return (
-    <div className="storage-container flex flex-grow p-4">
+    <div className="storage-container flex flex-grow">
       {isError && <StorageBucketsError error={error as any} />}
 
       {isLoading && <GenericSkeletonLoader className="w-full" />}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore: UI more improvements to the vector buckets and their details

## What is the current behavior?

- Vector bucket page load  `GenericSkeletonLoader` is full-width
- The bucket deletion dialog is missing the bucket name
- Empty table states are a bit rough
- Extranous padding

## What is the new behavior?

- All of the above have had minor stylistic improvements

## Additional context

Based branch: https://github.com/supabase/supabase/pull/39597.
