### PR TITLE
chore: put focus on Discord for community help

### DIFF
--- a/apps/docs/content/troubleshooting/how-do-you-troubleshoot-nextjs---supabase-auth-issues-riMCZV.mdx
+++ b/apps/docs/content/troubleshooting/how-do-you-troubleshoot-nextjs---supabase-auth-issues-riMCZV.mdx
@@ -29,6 +29,6 @@ Our YouTube channel has great videos to help you implement Supabase Auth with Ne
 
 Also, take some time to get familiar with some concepts on authentication with Next.js, such as https://nextjs.org/docs/app/building-your-application/authentication.
 
-We know your requirements vary, and you might run into an edge case. In that scenario, use our amazing community channels ([GitHub](https://github.com/orgs/supabase/discussions), [Discord](https://discord.gg/rxTfewPvys)) to get help troubleshooting the issue. You can post your issues to the `@supabase/ssr` [GitHub repo](https://github.com/supabase/ssr/issues). We always welcome your contributions!
+We know your requirements vary, and you might run into an edge case. In that scenario, join our amazing [Discord community](https://discord.supabase.com) to get help troubleshooting the issue. You can post your issues to the `@supabase/ssr` [GitHub repo](https://github.com/supabase/ssr/issues). We always welcome your contributions!
 
 If none of the above works, don’t hesitate to reach out to [Supabase support](https://supabase.help); consider adding more information, such as your use case, code snippets, a copy of your `package.json`, `middleware.ts` and a HAR file, to help the support team triage your issue.

--- a/apps/www/data/home/content.tsx
+++ b/apps/www/data/home/content.tsx
@@ -1,12 +1,12 @@
-import { MessageCircle } from 'lucide-react'
+import VideoWithHighlights from 'components/VideoWithHighlights'
+import { useSendTelemetryEvent } from 'lib/telemetry'
 import Link from 'next/link'
 import { Button } from 'ui'
-import VideoWithHighlights from 'components/VideoWithHighlights'
 import ProductModules from '../ProductModules'
-import { useSendTelemetryEvent } from 'lib/telemetry'
 
-import tweets from 'shared-data/tweets'
 import MainProducts from 'data/MainProducts'
+import tweets from 'shared-data/tweets'
+import { IconDiscord } from 'ui'
 
 export default () => {
   const sendTelemetryEvent = useSendTelemetryEvent()
@@ -173,36 +173,20 @@ export default () => {
       heading: 'Join the community',
       subheading: 'Discover what our community has to say about their Supabase experience.',
       ctas: (
-        <>
-          <Button asChild size="small" iconRight={<MessageCircle size={14} />} type="default">
-            <Link
-              href={'https://github.com/supabase/supabase/discussions'}
-              target="_blank"
-              tabIndex={-1}
-              onClick={() =>
-                sendTelemetryEvent({
-                  action: 'homepage_github_discussions_button_clicked',
-                })
-              }
-            >
-              GitHub discussions
-            </Link>
-          </Button>
-          <Button asChild type="default" size="small" iconRight={<MessageCircle size={14} />}>
-            <Link
-              href={'https://discord.supabase.com/'}
-              target="_blank"
-              tabIndex={-1}
-              onClick={() =>
-                sendTelemetryEvent({
-                  action: 'homepage_discord_button_clicked',
-                })
-              }
-            >
-              Discord
-            </Link>
-          </Button>
-        </>
+        <Button asChild type="default" size="small" icon={<IconDiscord />}>
+          <Link
+            href={'https://discord.supabase.com/'}
+            target="_blank"
+            tabIndex={-1}
+            onClick={() =>
+              sendTelemetryEvent({
+                action: 'homepage_discord_button_clicked',
+              })
+            }
+          >
+            Join us on Discord
+          </Link>
+        </Button>
       ),
       tweets: tweets.slice(0, 18),
     },

--- a/apps/www/data/solutions/beginners.tsx
+++ b/apps/www/data/solutions/beginners.tsx
@@ -1,15 +1,16 @@
+import { CubeIcon } from '@heroicons/react/outline'
+import { Check, Sparkles, Timer } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { Check, Sparkles, Timer } from 'lucide-react'
-import { CubeIcon } from '@heroicons/react/outline'
-import { Button, cn, Image } from 'ui'
+import { Button, cn, IconDiscord, Image } from 'ui'
 
-import MainProducts from '../MainProducts'
 import { frameworks } from 'components/Hero/HeroFrameworks'
+import MainProducts from '../MainProducts'
 
-import type { TwoColumnsSectionProps } from '~/components/Solutions/TwoColumnsSection'
+import type { MPCSectionProps } from 'components/Solutions/MPCSection'
 import type { PlatformSectionProps } from 'components/Solutions/PlatformSection'
 import type { TwitterSocialSectionProps } from 'components/TwitterSocialSection'
+import type { TwoColumnsSectionProps } from '~/components/Solutions/TwoColumnsSection'
 import {
   FrameworkLink,
   getEditors,
@@ -17,12 +18,11 @@ import {
   type HeroSection,
   type Metadata,
 } from './solutions.utils'
-import type { MPCSectionProps } from 'components/Solutions/MPCSection'
 
-import { PRODUCT_SHORTNAMES } from 'shared-data/products'
-import { tweets } from 'shared-data'
 import { useBreakpoint } from 'common'
 import { useSendTelemetryEvent } from 'lib/telemetry'
+import { tweets } from 'shared-data'
+import { PRODUCT_SHORTNAMES } from 'shared-data/products'
 
 const AuthVisual = dynamic(() => import('components/Products/AuthVisual'))
 const ComputePricingCalculator = dynamic(
@@ -480,22 +480,20 @@ const data: () => {
       heading: 'Fun projects built with Supabase',
       subheading: 'Discover what our community has to say about their Supabase experience.',
       ctas: (
-        <>
-          <Button asChild size="small" type="default">
-            <Link
-              href="https://github.com/supabase/supabase/discussions"
-              target="_blank"
-              tabIndex={-1}
-            >
-              GitHub discussions
-            </Link>
-          </Button>
-          <Button asChild type="default" size="small">
-            <Link href={'https://discord.supabase.com/'} target="_blank" tabIndex={-1}>
-              Discord
-            </Link>
-          </Button>
-        </>
+        <Button asChild type="default" size="small" icon={<IconDiscord />}>
+          <Link
+            href={'https://discord.supabase.com/'}
+            target="_blank"
+            tabIndex={-1}
+            onClick={() =>
+              sendTelemetryEvent({
+                action: 'homepage_discord_button_clicked',
+              })
+            }
+          >
+            Join us on Discord
+          </Link>
+        </Button>
       ),
       tweets: tweets.slice(0, 18),
     },

--- a/apps/www/pages/support-policy.mdx
+++ b/apps/www/pages/support-policy.mdx
@@ -56,7 +56,7 @@ Limited technical support is accessible for Supabase customers utilizing paid Su
 
 Supabase support staff will only address support requests received through the official channels mentioned earlier. However, community channels may exist for peer-to-peer support and discussions. This is support provided by volunteers that contribute to the Supabase community.
 
-For questions related to debugging code, we recommend reaching out on **[GitHub Discussions](https://github.com/supabase/supabase/discussions)** or on **[Discord](https://discord.gg/rxTfewPvys)**. The community is made up of experienced developers who may be able to provide guidance and support with code-related issues.
+For questions related to debugging code, we recommend reaching out to our **[Discord community](https://discord.supabase.com)**. The community is made up of experienced developers who may be able to provide guidance and support with code-related issues.
 
 To get the most helpful response from the community, providing precise and detailed information about your problem and any error messages you may be encountering is important. Be sure to **include any relevant code snippets explaining how to reproduce** the issue in your message.
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -701,17 +701,6 @@ export interface HomepageGitHubButtonClickedEvent {
 }
 
 /**
- * User clicked the GitHub Discussions button in the homepage community section.
- *
- * @group Events
- * @source www
- * @page /
- */
-export interface HomepageGitHubDiscussionsButtonClickedEvent {
-  action: 'homepage_github_discussions_button_clicked'
-}
-
-/**
  * User clicked the Discord button in the homepage community section.
  *
  * @group Events

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2058,7 +2058,6 @@ export type TelemetryEvent =
   | WwwPricingPlanCtaClickedEvent
   | EventPageCtaClickedEvent
   | HomepageGitHubButtonClickedEvent
-  | HomepageGitHubDiscussionsButtonClickedEvent
   | HomepageDiscordButtonClickedEvent
   | HomepageCustomerStoryCardClickedEvent
   | HomepageProjectTemplateCardClickedEvent


### PR DESCRIPTION
## What kind of change does this PR introduce?

Clarifies Discord as our community resource in prominent `www` slots, and one `docs` troubleshooting guide. Resolves DEPR-145.

## What is the current behavior?

All of the above intermingle GitHub Discussions with Discord. This is problematic for two reasons:

1. Discord is our community support channel of choice going forward.
2. Having two options of equal visual prominence is confusing.

## What is the new behavior?

- GitHub Discussions is removed from community calls-to-actions
- Discord is elevated
- We use the canonical `discord.supabase.com` invite link

| Before | After |
| --- | --- |
| <img width="944" height="740" alt="Support Policy" src="https://github.com/user-attachments/assets/0a91eb18-60fe-409e-8104-90efddebc4fc" /> | <img width="944" height="740" alt="Support Policy" src="https://github.com/user-attachments/assets/8c038ca4-4753-4d56-80dc-89e7776eea65" /> |
| <img width="944" height="740" alt="Supabase for Beginners" src="https://github.com/user-attachments/assets/67398c39-85c1-498c-8ed7-fc4b267670d4" /> | <img width="944" height="740" alt="Supabase for Beginners" src="https://github.com/user-attachments/assets/b4fbca05-af7a-44b9-80c7-193a950eee15" /> |
| <img width="944" height="740" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/f524de85-06cf-4b90-a870-f99906e71c8b" /> | <img width="944" height="740" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/cd1dda59-1ef4-4e25-a652-0347b8e47363" /> |
