### PR TITLE
fix: use Next Link for proper prefixing

### DIFF
--- a/apps/studio/components/interfaces/Organization/HeaderBanner.tsx
+++ b/apps/studio/components/interfaces/Organization/HeaderBanner.tsx
@@ -99,7 +99,7 @@ export const HeaderBanner = ({
           </span>
         </div>
         {link && (
-          <a
+          <Link
             href={link}
             className={cn(
               'lg:block hidden',
@@ -108,7 +108,7 @@ export const HeaderBanner = ({
             )}
           >
             View Details
-          </a>
+          </Link>
         )}
       </div>
     </motion.div>


### PR DESCRIPTION
<a> does not automatically use the `/dashboard` prefix on prod/staging, leading to wrong links for org restriction banner