### PR TITLE
feat: allow skipping retries on specific pathnames

### DIFF
--- a/apps/studio/data/fetchers.ts
+++ b/apps/studio/data/fetchers.ts
@@ -105,9 +105,14 @@ client.use(
 
         // add code field to body
         body.code = response.status
+
         body.requestId = request.headers.get('X-Request-Id')
+
         const retryAfterHeader = response.headers.get('Retry-After')
         body.retryAfter = retryAfterHeader ? parseInt(retryAfterHeader) : undefined
+
+        const requestUrl = new URL(request.url)
+        body.requestPathname = requestUrl.pathname
 
         return new Response(JSON.stringify(body), {
           headers: response.headers,
@@ -156,9 +161,13 @@ export const handleError = (error: unknown, options: HandleErrorOptions = {}): n
       'requestId' in error && typeof error.requestId === 'string' ? error.requestId : undefined
     const retryAfter =
       'retryAfter' in error && typeof error.retryAfter === 'number' ? error.retryAfter : undefined
+    const requestPathname =
+      'requestPathname' in error && typeof error.requestPathname === 'string'
+        ? error.requestPathname
+        : undefined
 
     if (errorMessage) {
-      throw new ResponseError(errorMessage, errorCode, requestId, retryAfter)
+      throw new ResponseError(errorMessage, errorCode, requestId, retryAfter, requestPathname)
     }
   }
 

--- a/apps/studio/data/query-client.ts
+++ b/apps/studio/data/query-client.ts
@@ -1,6 +1,8 @@
 import { QueryClient, onlineManager } from '@tanstack/react-query'
-import { IS_PLATFORM } from 'lib/constants'
+import { match } from 'path-to-regexp'
 import { useState } from 'react'
+
+import { IS_PLATFORM } from 'lib/constants'
 import { ResponseError } from 'types'
 
 // When running locally we don't need the internet
@@ -8,6 +10,14 @@ import { ResponseError } from 'types'
 if (!IS_PLATFORM) {
   onlineManager.setOnline(true)
 }
+
+const SKIP_RETRY_PATHNAME_MATCHERS = [
+  '/system/projects/:ref/run-lints',
+  '/platform/projects/:ref/run-lints',
+  '/platform/organizations/:slug/usage',
+  '/platform/pg-meta/:ref/query',
+  '/v1/projects/:ref/analytics/endpoints/logs.all',
+].map((pathname) => match(pathname))
 
 let queryClient: QueryClient | undefined
 
@@ -27,6 +37,14 @@ export function getQueryClient() {
               error.code < 500 &&
               // Still retry on 429s (rate limit)
               error.code !== 429
+            ) {
+              return false
+            }
+
+            if (
+              error instanceof ResponseError &&
+              error.requestPathname &&
+              SKIP_RETRY_PATHNAME_MATCHERS.some((matchFn) => matchFn(error.requestPathname!))
             ) {
               return false
             }

--- a/apps/studio/data/query-client.ts
+++ b/apps/studio/data/query-client.ts
@@ -12,7 +12,6 @@ if (!IS_PLATFORM) {
 }
 
 const SKIP_RETRY_PATHNAME_MATCHERS = [
-  '/system/projects/:ref/run-lints',
   '/platform/projects/:ref/run-lints',
   '/platform/organizations/:slug/usage',
   '/platform/pg-meta/:ref/query',

--- a/apps/studio/types/base.ts
+++ b/apps/studio/types/base.ts
@@ -89,12 +89,20 @@ export class ResponseError extends Error {
   code?: number
   requestId?: string
   retryAfter?: number
+  requestPathname?: string
 
-  constructor(message: string | undefined, code?: number, requestId?: string, retryAfter?: number) {
+  constructor(
+    message: string | undefined,
+    code?: number,
+    requestId?: string,
+    retryAfter?: number,
+    requestPathname?: string
+  ) {
     super(message || 'API error happened while trying to communicate with the server.')
     this.code = code
     this.requestId = requestId
     this.retryAfter = retryAfter
+    this.requestPathname = requestPathname
   }
 }
 


### PR DESCRIPTION
**Changes:**
- Tracks request pathname on `ResponseError`.
- Introduces a set of pathnames that retries should be skipped on (requested by API team).

**To test (locally):**

- [ ] Add a random `throw new Error('whatever')` into one of the listed API routes (I did `/run-lints`) on your local infra setup, then make sure the FE doesn't retry when requesting that route in the network console.
- [ ] Also adding another random throw to a good API route to test that retries are continuing to work.