### PR TITLE
chore: Migrate RQ functions to use object syntax style

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.utils.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.utils.tsx
@@ -69,7 +69,7 @@ export function useOnRowsChange(rows: SupaRow[]) {
         if (previousRows) {
           queryClient.setQueriesData(queryKey, previousRows)
         }
-        queryClient.invalidateQueries(queryKey)
+        queryClient.invalidateQueries({ queryKey })
       })
 
       toast.error(error?.message ?? error)

--- a/apps/studio/components/grid/components/grid/Grid.utils.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.utils.tsx
@@ -28,7 +28,7 @@ export function useOnRowsChange(rows: SupaRow[]) {
 
       const queryKey = tableRowKeys.tableRows(projectRef, { table: { id: table.id } })
 
-      await queryClient.cancelQueries(queryKey)
+      await queryClient.cancelQueries({ queryKey })
 
       const previousRowsQueries = queryClient.getQueriesData<TableRowsData>({ queryKey })
 

--- a/apps/studio/components/grid/components/grid/Grid.utils.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.utils.tsx
@@ -30,9 +30,9 @@ export function useOnRowsChange(rows: SupaRow[]) {
 
       await queryClient.cancelQueries(queryKey)
 
-      const previousRowsQueries = queryClient.getQueriesData<TableRowsData>(queryKey)
+      const previousRowsQueries = queryClient.getQueriesData<TableRowsData>({ queryKey })
 
-      queryClient.setQueriesData<TableRowsData>(queryKey, (old) => {
+      queryClient.setQueriesData<TableRowsData>({ queryKey }, (old) => {
         return {
           rows:
             old?.rows.map((row) => {
@@ -67,7 +67,7 @@ export function useOnRowsChange(rows: SupaRow[]) {
 
       previousRowsQueries.forEach(([queryKey, previousRows]) => {
         if (previousRows) {
-          queryClient.setQueriesData(queryKey, previousRows)
+          queryClient.setQueriesData({ queryKey }, previousRows)
         }
         queryClient.invalidateQueries({ queryKey })
       })

--- a/apps/studio/components/grid/components/header/RefreshButton.tsx
+++ b/apps/studio/components/grid/components/header/RefreshButton.tsx
@@ -16,7 +16,7 @@ export const RefreshButton = ({ tableId, isRefetching }: RefreshButtonProps) => 
   const queryKey = tableRowKeys.tableRowsAndCount(ref, tableId)
 
   async function onClick() {
-    await queryClient.invalidateQueries(queryKey)
+    await queryClient.invalidateQueries({ queryKey })
   }
 
   return (

--- a/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -128,7 +128,9 @@ const SecondStep = ({
     },
     onSuccess: async () => {
       if (lastVisitedOrganization) {
-        await queryClient.invalidateQueries(organizationKeys.members(lastVisitedOrganization))
+        await queryClient.invalidateQueries({
+          queryKey: organizationKeys.members(lastVisitedOrganization),
+        })
       }
       toast.success(`Successfully added a second factor authentication`)
       onClose()

--- a/apps/studio/components/interfaces/Account/TOTPFactors/DeleteFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/DeleteFactorModal.tsx
@@ -29,7 +29,9 @@ const DeleteFactorModal = ({
   const { mutate: unenroll, isLoading } = useMfaUnenrollMutation({
     onSuccess: async () => {
       if (lastVisitedOrganization) {
-        await queryClient.invalidateQueries(organizationKeys.members(lastVisitedOrganization))
+        await queryClient.invalidateQueries({
+          queryKey: organizationKeys.members(lastVisitedOrganization),
+        })
       }
       toast.success(`Successfully deleted factor`)
       onClose()

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
@@ -125,7 +125,7 @@ export const PolicyEditorPanel = memo(function ({
   const { mutate: executeMutation, isLoading: isExecuting } = useExecuteSqlMutation({
     onSuccess: async () => {
       // refresh all policies
-      await queryClient.invalidateQueries(databasePoliciesKeys.list(ref))
+      await queryClient.invalidateQueries({ queryKey: databasePoliciesKeys.list(ref) })
       toast.success('Successfully created new policy')
       onSelectCancel()
     },

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -296,7 +296,9 @@ export const UsersV2 = () => {
         userIds.map((id) => deleteUser({ projectRef, userId: id, skipInvalidation: true }))
       )
       // [Joshen] Skip invalidation within RQ to prevent multiple requests, then invalidate once at the end
-      await Promise.all([queryClient.invalidateQueries(authKeys.usersInfinite(projectRef))])
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
+      ])
       toast.success(
         `Successfully deleted the selected ${selectedUsers.size} user${selectedUsers.size > 1 ? 's' : ''}`
       )

--- a/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
@@ -74,9 +74,9 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
             paymentMethodId: result.setupIntent.payment_method,
           })
 
-          await queryClient.invalidateQueries(
-            organizationKeys.paymentMethods(selectedOrganization.slug)
-          )
+          await queryClient.invalidateQueries({
+            queryKey: organizationKeys.paymentMethods(selectedOrganization.slug),
+          })
 
           queryClient.setQueriesData(
             organizationKeys.paymentMethods(selectedOrganization.slug),
@@ -97,9 +97,9 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
         }
       } else {
         if (selectedOrganization) {
-          await queryClient.invalidateQueries(
-            organizationKeys.paymentMethods(selectedOrganization.slug)
-          )
+          await queryClient.invalidateQueries({
+            queryKey: organizationKeys.paymentMethods(selectedOrganization.slug),
+          })
         }
       }
 

--- a/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
@@ -79,7 +79,7 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
           })
 
           queryClient.setQueriesData(
-            organizationKeys.paymentMethods(selectedOrganization.slug),
+            { queryKey: organizationKeys.paymentMethods(selectedOrganization.slug) },
             (prev: any) => {
               if (!prev) return prev
               return {

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -186,7 +186,9 @@ export const CreateBranchModal = () => {
     onSuccess: async (data) => {
       toast.success(`Successfully created preview branch "${data.name}"`)
       if (projectRef) {
-        await Promise.all([queryClient.invalidateQueries(projectKeys.detail(projectRef))])
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectRef) }),
+        ])
       }
       sendEvent({
         action: 'branch_create_button_clicked',

--- a/apps/studio/components/interfaces/Database/Privileges/Privileges.utils.ts
+++ b/apps/studio/components/interfaces/Database/Privileges/Privileges.utils.ts
@@ -343,8 +343,10 @@ export function useApplyPrivilegeOperations(callback?: () => void) {
       }
 
       await Promise.all([
-        queryClient.invalidateQueries(privilegeKeys.tablePrivilegesList(project.ref)),
-        queryClient.invalidateQueries(privilegeKeys.columnPrivilegesList(project.ref)),
+        queryClient.invalidateQueries({ queryKey: privilegeKeys.tablePrivilegesList(project.ref) }),
+        queryClient.invalidateQueries({
+          queryKey: privilegeKeys.columnPrivilegesList(project.ref),
+        }),
       ])
 
       setIsLoading(false)

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -185,7 +185,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
 
   const onSuccessfulPayment = async () => {
     onTopUpDialogVisibilityChange(false)
-    await queryClient.invalidateQueries(subscriptionKeys.orgSubscription(slug))
+    await queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgSubscription(slug) })
     toast.success(
       'Successfully topped up balance. It may take a minute to reflect in your account.'
     )

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -61,7 +61,7 @@ export const ProjectClaimConfirm = ({
         window.location.href = url.toString()
       } catch {
         // invalidate the org projects to force them to be refetched
-        queryClient.invalidateQueries(projectKeys.list())
+        queryClient.invalidateQueries({ queryKey: projectKeys.list() })
         router.push(`/org/${selectedOrganization.slug}`)
       }
     } catch (error: any) {

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -146,8 +146,8 @@ export const UpdateRolesConfirmationModal = ({
       }
 
       await Promise.all([
-        queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),
-        queryClient.invalidateQueries(organizationKeysV1.members(slug)),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.rolesV2(slug) }),
+        queryClient.invalidateQueries({ queryKey: organizationKeysV1.members(slug) }),
       ])
       toast.success(`Successfully updated role for ${member.username}`)
       onClose(true)

--- a/apps/studio/components/interfaces/QueryPerformance/hooks/useIndexInvalidation.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/hooks/useIndexInvalidation.ts
@@ -43,7 +43,9 @@ export function useIndexInvalidation() {
 
   return useCallback(() => {
     queryPerformanceQuery.runQuery()
-    queryClient.invalidateQueries(databaseKeys.indexAdvisorFromQuery(project?.ref, ''))
-    queryClient.invalidateQueries(databaseIndexesKeys.list(project?.ref))
+    queryClient.invalidateQueries({
+      queryKey: databaseKeys.indexAdvisorFromQuery(project?.ref, ''),
+    })
+    queryClient.invalidateQueries({ queryKey: databaseIndexesKeys.list(project?.ref) })
   }, [queryPerformanceQuery, queryClient, project?.ref])
 }

--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -274,15 +274,15 @@ const Reports = () => {
       (x) => x.provider === 'infra-monitoring' || x.provider === 'daily-stats'
     )
     monitoringCharts?.forEach((x) => {
-      queryClient.invalidateQueries(
-        analyticsKeys.infraMonitoring(ref, {
+      queryClient.invalidateQueries({
+        queryKey: analyticsKeys.infraMonitoring(ref, {
           attribute: x.attribute,
           startDate,
           endDate,
           interval: config?.interval,
           databaseIdentifier: state.selectedDatabaseId,
-        })
-      )
+        }),
+      })
     })
     setTimeout(() => setIsRefreshing(false), 1000)
   }

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -165,7 +165,7 @@ export const SQLEditor = () => {
       refetchEntityDefinitions()
 
       // revalidate lint query
-      queryClient.invalidateQueries(lintKeys.lint(ref))
+      queryClient.invalidateQueries({ queryKey: lintKeys.lint(ref) })
     },
     onError(error: any, vars) {
       if (id) {

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropAllReplicasConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropAllReplicasConfirmationModal.tsx
@@ -42,8 +42,8 @@ const DropAllReplicasConfirmationModal = ({
       toast.success(`Tearing down all read replicas`)
 
       await Promise.all([
-        queryClient.invalidateQueries(replicaKeys.list(projectRef)),
-        queryClient.invalidateQueries(replicaKeys.loadBalancers(projectRef)),
+        queryClient.invalidateQueries({ queryKey: replicaKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: replicaKeys.loadBalancers(projectRef) }),
       ])
 
       onSuccess()

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/RestartReplicaConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/RestartReplicaConfirmationModal.tsx
@@ -29,7 +29,7 @@ export const RestartReplicaConfirmationModal = ({
       toast.success(`Restarting read replica (ID: ${formattedId})`)
 
       // [Joshen] Temporarily optimistic rendering until API supports immediate status update
-      queryClient.setQueriesData<any>(replicaKeys.list(ref), (old: Database[]) => {
+      queryClient.setQueriesData<any>({ queryKey: replicaKeys.list(ref) }, (old: Database[]) => {
         const updatedReplicas = old.map((x) => {
           if (x.identifier === selectedReplica?.identifier) {
             return { ...x, status: REPLICA_STATUS.RESTARTING }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -269,21 +269,23 @@ const SidePanelEditor = ({
       }
 
       await Promise.all([
-        queryClient.invalidateQueries(tableEditorKeys.tableEditor(project?.ref, selectedTable?.id)),
-        queryClient.invalidateQueries(
-          databaseKeys.foreignKeyConstraints(project?.ref, selectedTable?.schema)
-        ),
-        queryClient.invalidateQueries(
-          databaseKeys.tableDefinition(project?.ref, selectedTable?.id)
-        ),
-        queryClient.invalidateQueries(entityTypeKeys.list(project?.ref)),
+        queryClient.invalidateQueries({
+          queryKey: tableEditorKeys.tableEditor(project?.ref, selectedTable?.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: databaseKeys.foreignKeyConstraints(project?.ref, selectedTable?.schema),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: databaseKeys.tableDefinition(project?.ref, selectedTable?.id),
+        }),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(project?.ref) }),
       ])
 
       // We need to invalidate tableRowsAndCount after tableEditor
       // to ensure the query sent is correct
-      await queryClient.invalidateQueries(
-        tableRowKeys.tableRowsAndCount(project?.ref, selectedTable?.id)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRowsAndCount(project?.ref, selectedTable?.id),
+      })
 
       setIsEdited(false)
       snap.closeSidePanel()
@@ -435,8 +437,10 @@ const SidePanelEditor = ({
         if (isRealtimeEnabled) await updateTableRealtime(table, isRealtimeEnabled)
 
         await Promise.all([
-          queryClient.invalidateQueries(tableKeys.list(project?.ref, table.schema, includeColumns)),
-          queryClient.invalidateQueries(entityTypeKeys.list(project?.ref)),
+          queryClient.invalidateQueries({
+            queryKey: tableKeys.list(project?.ref, table.schema, includeColumns),
+          }),
+          queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(project?.ref) }),
         ])
 
         toast.success(
@@ -461,8 +465,10 @@ const SidePanelEditor = ({
         if (isRealtimeEnabled) await updateTableRealtime(table, true)
 
         await Promise.all([
-          queryClient.invalidateQueries(tableKeys.list(project?.ref, table.schema, includeColumns)),
-          queryClient.invalidateQueries(entityTypeKeys.list(project?.ref)),
+          queryClient.invalidateQueries({
+            queryKey: tableKeys.list(project?.ref, table.schema, includeColumns),
+          }),
+          queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(project?.ref) }),
         ])
 
         toast.success(`Table ${table.name} is good to go!`, { id: toastId })
@@ -574,9 +580,9 @@ const SidePanelEditor = ({
       }
     }
 
-    await queryClient.invalidateQueries(
-      tableRowKeys.tableRowsAndCount(project?.ref, selectedTable?.id)
-    )
+    await queryClient.invalidateQueries({
+      queryKey: tableRowKeys.tableRowsAndCount(project?.ref, selectedTable?.id),
+    })
     toast.success(`Successfully imported ${rowCount} rows of data into ${selectedTable.name}`, {
       id: toastId,
     })

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -19,6 +19,7 @@ import { executeSql } from 'data/sql/execute-sql-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
 import { prefetchTableEditor } from 'data/table-editor/table-editor-query'
 import { tableRowKeys } from 'data/table-rows/keys'
+import { executeWithRetry } from 'data/table-rows/table-rows-query'
 import { tableKeys } from 'data/tables/keys'
 import { createTable as createTableMutation } from 'data/tables/table-create-mutation'
 import { deleteTable as deleteTableMutation } from 'data/tables/table-delete-mutation'
@@ -42,7 +43,6 @@ import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePanelEditor.types'
 import { checkIfRelationChanged } from './TableEditor/ForeignKeysManagement/ForeignKeysManagement.utils'
 import type { ImportContent } from './TableEditor/TableEditor.types'
-import { executeWithRetry } from 'data/table-rows/table-rows-query'
 
 const BATCH_SIZE = 1000
 const CHUNK_SIZE = 1024 * 1024 * 0.1 // 0.1MB
@@ -399,7 +399,7 @@ export const duplicateTable = async (
         : '',
     ].join('\n'),
   })
-  await queryClient.invalidateQueries(tableKeys.list(projectRef, sourceTableSchema))
+  await queryClient.invalidateQueries({ queryKey: tableKeys.list(projectRef, sourceTableSchema) })
 
   // Duplicate foreign key constraints over
   if (foreignKeyRelations.length > 0) {
@@ -868,16 +868,20 @@ export const updateTable = async ({
   })
 
   await Promise.all([
-    queryClient.invalidateQueries(tableEditorKeys.tableEditor(projectRef, table.id)),
-    queryClient.invalidateQueries(databaseKeys.foreignKeyConstraints(projectRef, table.schema)),
-    queryClient.invalidateQueries(databaseKeys.tableDefinition(projectRef, table.id)),
-    queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
-    queryClient.invalidateQueries(tableKeys.list(projectRef, table.schema, true)),
+    queryClient.invalidateQueries({ queryKey: tableEditorKeys.tableEditor(projectRef, table.id) }),
+    queryClient.invalidateQueries({
+      queryKey: databaseKeys.foreignKeyConstraints(projectRef, table.schema),
+    }),
+    queryClient.invalidateQueries({ queryKey: databaseKeys.tableDefinition(projectRef, table.id) }),
+    queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
+    queryClient.invalidateQueries({ queryKey: tableKeys.list(projectRef, table.schema, true) }),
   ])
 
   // We need to invalidate tableRowsAndCount after tableEditor
   // to ensure the query sent is correct
-  await queryClient.invalidateQueries(tableRowKeys.tableRowsAndCount(projectRef, table.id))
+  await queryClient.invalidateQueries({
+    queryKey: tableRowKeys.tableRowsAndCount(projectRef, table.id),
+  })
 
   return {
     table: await prefetchTableEditor(queryClient, {

--- a/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
@@ -38,7 +38,7 @@ export default function ViewEntityAutofixSecurityModal({
     onSuccess: async () => {
       toast.success('View security changed successfully')
       setIsAutofixViewSecurityModalOpen(false)
-      await queryClient.invalidateQueries(lintKeys.lint(project?.ref))
+      await queryClient.invalidateQueries({ queryKey: lintKeys.lint(project?.ref) })
     },
     onError: (error) => {
       toast.error(`Failed to autofix view security: ${error.message}`)

--- a/apps/studio/data/__templates/README.md
+++ b/apps/studio/data/__templates/README.md
@@ -30,7 +30,7 @@ For getting a single item based on parameter(s). `id` is used in this example bu
 For updating a resource. This can easily be adapted to work for create, delete, or any verb that is needed. You may need to modify the `invalidateQueries` section depending on your use case. For example removing:
 
 ```ts
-queryClient.invalidateQueries({ queryKey:resourceKeys.resource(projectRef, id))
+queryClient.invalidateQueries({ queryKey: resourceKeys.resource(projectRef, id) })
 ```
 
 if you are creating a new resource.

--- a/apps/studio/data/__templates/README.md
+++ b/apps/studio/data/__templates/README.md
@@ -30,7 +30,7 @@ For getting a single item based on parameter(s). `id` is used in this example bu
 For updating a resource. This can easily be adapted to work for create, delete, or any verb that is needed. You may need to modify the `invalidateQueries` section depending on your use case. For example removing:
 
 ```ts
-queryClient.invalidateQueries(resourceKeys.resource(projectRef, id))
+queryClient.invalidateQueries({ queryKey:resourceKeys.resource(projectRef, id))
 ```
 
 if you are creating a new resource.

--- a/apps/studio/data/__templates/resource-query.ts
+++ b/apps/studio/data/__templates/resource-query.ts
@@ -58,9 +58,10 @@ export const useResourcePrefetch = ({ projectRef, id }: ResourceVariables) => {
 
   return useCallback(() => {
     if (projectRef && id) {
-      client.prefetchQuery(resourceKeys.resource(projectRef, id), ({ signal }) =>
-        getResource({ projectRef, id }, signal)
-      )
+      client.prefetchQuery({
+        queryKey: resourceKeys.resource(projectRef, id),
+        queryFn: ({ signal }) => getResource({ projectRef, id }, signal),
+      })
     }
   }, [projectRef, id])
 }

--- a/apps/studio/data/__templates/resource-update-mutation.ts
+++ b/apps/studio/data/__templates/resource-update-mutation.ts
@@ -40,8 +40,8 @@ export const useResourceUpdateMutation = ({
       const { projectRef, id } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(resourceKeys.list(projectRef)),
-        queryClient.invalidateQueries(resourceKeys.resource(projectRef, id)),
+        queryClient.invalidateQueries({ queryKey: resourceKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: resourceKeys.resource(projectRef, id) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/__templates/resources-query.ts
+++ b/apps/studio/data/__templates/resources-query.ts
@@ -53,9 +53,10 @@ export const useResourcesPrefetch = ({ projectRef }: ResourcesVariables) => {
 
   return useCallback(() => {
     if (projectRef) {
-      client.prefetchQuery(resourceKeys.list(projectRef), ({ signal }) =>
-        getResources({ projectRef }, signal)
-      )
+      client.prefetchQuery({
+        queryKey: resourceKeys.list(projectRef),
+        queryFn: ({ signal }) => getResources({ projectRef }, signal),
+      })
     }
   }, [projectRef])
 }

--- a/apps/studio/data/access-tokens/access-tokens-create-mutation.ts
+++ b/apps/studio/data/access-tokens/access-tokens-create-mutation.ts
@@ -35,7 +35,7 @@ export const useAccessTokenCreateMutation = ({
   return useMutation<AccessTokenCreateData, ResponseError, AccessTokenCreateVariables>({
     mutationFn: (vars) => createAccessToken(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(accessTokenKeys.list())
+      await queryClient.invalidateQueries({ queryKey: accessTokenKeys.list() })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/access-tokens/access-tokens-delete-mutation.ts
+++ b/apps/studio/data/access-tokens/access-tokens-delete-mutation.ts
@@ -33,7 +33,7 @@ export const useAccessTokenDeleteMutation = ({
   return useMutation<AccessTokenDeleteData, ResponseError, AccessTokenDeleteVariables>({
     mutationFn: (vars) => deleteAccessToken(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(accessTokenKeys.list())
+      await queryClient.invalidateQueries({ queryKey: accessTokenKeys.list() })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/analytics/project-log-requests-count-query.ts
+++ b/apps/studio/data/analytics/project-log-requests-count-query.ts
@@ -51,7 +51,8 @@ export function prefetchProjectLogRequestsCount(
   client: QueryClient,
   { projectRef }: ProjectLogRequestsCountVariables
 ) {
-  return client.fetchQuery(analyticsKeys.usageApiRequestsCount(projectRef), ({ signal }) =>
-    getProjectLogRequestsCountStats({ projectRef }, signal)
-  )
+  return client.fetchQuery({
+    queryKey: analyticsKeys.usageApiRequestsCount(projectRef),
+    queryFn: ({ signal }) => getProjectLogRequestsCountStats({ projectRef }, signal),
+  })
 }

--- a/apps/studio/data/analytics/project-log-stats-query.ts
+++ b/apps/studio/data/analytics/project-log-stats-query.ts
@@ -71,7 +71,8 @@ export function prefetchProjectLogStats(
   client: QueryClient,
   { projectRef, interval }: ProjectLogStatsVariables
 ) {
-  return client.fetchQuery(analyticsKeys.usageApiCounts(projectRef, interval), ({ signal }) =>
-    getProjectLogStats({ projectRef, interval }, signal)
-  )
+  return client.fetchQuery({
+    queryKey: analyticsKeys.usageApiCounts(projectRef, interval),
+    queryFn: ({ signal }) => getProjectLogStats({ projectRef, interval }, signal),
+  })
 }

--- a/apps/studio/data/analytics/utils.ts
+++ b/apps/studio/data/analytics/utils.ts
@@ -20,15 +20,15 @@ export const useInvalidateAnalyticsQuery = () => {
       databaseIdentifier?: string
     }
   ) => {
-    queryClient.invalidateQueries(
-      analyticsKeys.infraMonitoring(ref, {
+    queryClient.invalidateQueries({
+      queryKey: analyticsKeys.infraMonitoring(ref, {
         attribute,
         startDate,
         endDate,
         interval,
         databaseIdentifier,
-      })
-    )
+      }),
+    })
   }
 
   return { invalidateInfraMonitoringQuery }

--- a/apps/studio/data/api-keys/[id]/api-key-id-update-mutation.ts
+++ b/apps/studio/data/api-keys/[id]/api-key-id-update-mutation.ts
@@ -52,7 +52,7 @@ export const useResourceUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, id } = variables
 
-      await queryClient.invalidateQueries(apiKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: apiKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/api-keys/api-key-create-mutation.ts
+++ b/apps/studio/data/api-keys/api-key-create-mutation.ts
@@ -68,7 +68,7 @@ export const useAPIKeyCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(apiKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: apiKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/api-keys/api-key-delete-mutation.ts
+++ b/apps/studio/data/api-keys/api-key-delete-mutation.ts
@@ -40,7 +40,7 @@ export const useAPIKeyDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(apiKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: apiKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/api-keys/legacy-api-key-toggle-mutation.ts
+++ b/apps/studio/data/api-keys/legacy-api-key-toggle-mutation.ts
@@ -40,7 +40,7 @@ export const useToggleLegacyAPIKeysMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(apiKeysKeys.status(projectRef))
+      await queryClient.invalidateQueries({ queryKey: apiKeysKeys.status(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/api-settings/create-and-expose-api-schema-mutation.ts
+++ b/apps/studio/data/api-settings/create-and-expose-api-schema-mutation.ts
@@ -70,8 +70,8 @@ export const useCreateAndExposeAPISchemaMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await Promise.all([
-        queryClient.invalidateQueries(databaseKeys.schemas(projectRef)),
-        queryClient.invalidateQueries(configKeys.postgrest(projectRef)),
+        queryClient.invalidateQueries({ queryKey: databaseKeys.schemas(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: configKeys.postgrest(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/auth/auth-config-query.ts
+++ b/apps/studio/data/auth/auth-config-query.ts
@@ -49,9 +49,10 @@ export const useAuthConfigPrefetch = ({ projectRef }: AuthConfigVariables) => {
 
   return useCallback(() => {
     if (projectRef) {
-      client.prefetchQuery(authKeys.authConfig(projectRef), ({ signal }) =>
-        getProjectAuthConfig({ projectRef }, signal)
-      )
+      client.prefetchQuery({
+        queryKey: authKeys.authConfig(projectRef),
+        queryFn: ({ signal }) => getProjectAuthConfig({ projectRef }, signal),
+      })
     }
   }, [client, projectRef])
 }

--- a/apps/studio/data/auth/auth-config-update-mutation.ts
+++ b/apps/studio/data/auth/auth-config-update-mutation.ts
@@ -41,7 +41,7 @@ export const useAuthConfigUpdateMutation = ({
     mutationFn: (vars) => updateAuthConfig(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(authKeys.authConfig(projectRef))
+      await queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/auth/auth-hooks-update-mutation.ts
+++ b/apps/studio/data/auth/auth-hooks-update-mutation.ts
@@ -37,7 +37,7 @@ export const useAuthHooksUpdateMutation = ({
     mutationFn: (vars) => updateAuthHooks(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(authKeys.authConfig(projectRef))
+      await queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/auth/user-create-mutation.ts
+++ b/apps/studio/data/auth/user-create-mutation.ts
@@ -44,7 +44,9 @@ export const useUserCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await Promise.all([queryClient.invalidateQueries(authKeys.usersInfinite(projectRef))])
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
+      ])
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/auth/user-delete-mutation.ts
+++ b/apps/studio/data/auth/user-delete-mutation.ts
@@ -37,7 +37,9 @@ export const useUserDeleteMutation = ({
       const { projectRef, skipInvalidation = false } = variables
 
       if (!skipInvalidation) {
-        await Promise.all([queryClient.invalidateQueries(authKeys.usersInfinite(projectRef))])
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
+        ])
       }
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/auth/user-invite-mutation.ts
+++ b/apps/studio/data/auth/user-invite-mutation.ts
@@ -36,7 +36,9 @@ export const useUserInviteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await Promise.all([queryClient.invalidateQueries(authKeys.usersInfinite(projectRef))])
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
+      ])
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/auth/user-update-mutation.ts
+++ b/apps/studio/data/auth/user-update-mutation.ts
@@ -38,7 +38,7 @@ export const useUserUpdateMutation = ({
     mutationFn: (vars) => updateUser(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(authKeys.usersInfinite(projectRef))
+      await queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -43,9 +43,9 @@ export const useUsersInfiniteQuery = <TData = UsersData>(
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
-  return useInfiniteQuery<UsersData, UsersError, TData>(
-    authKeys.usersInfinite(projectRef, { keywords, filter, providers, sort, order }),
-    ({ signal, pageParam }) => {
+  return useInfiniteQuery<UsersData, UsersError, TData>({
+    queryKey: authKeys.usersInfinite(projectRef, { keywords, filter, providers, sort, order }),
+    queryFn: ({ signal, pageParam }) => {
       return executeSql(
         {
           projectRef,
@@ -66,21 +66,19 @@ export const useUsersInfiniteQuery = <TData = UsersData>(
         signal
       )
     },
-    {
-      enabled: enabled && typeof projectRef !== 'undefined' && isActive,
-      getNextPageParam(lastPage, pages) {
-        const hasNextPage = lastPage.result.length >= USERS_PAGE_LIMIT
-        if (column) {
-          const lastItem = lastPage.result[lastPage.result.length - 1]
-          if (hasNextPage && lastItem) return lastItem[column]
-          return undefined
-        } else {
-          const page = pages.length
-          if (!hasNextPage) return undefined
-          return page
-        }
-      },
-      ...options,
-    }
-  )
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    getNextPageParam(lastPage, pages) {
+      const hasNextPage = lastPage.result.length >= USERS_PAGE_LIMIT
+      if (column) {
+        const lastItem = lastPage.result[lastPage.result.length - 1]
+        if (hasNextPage && lastItem) return lastItem[column]
+        return undefined
+      } else {
+        const page = pages.length
+        if (!hasNextPage) return undefined
+        return page
+      }
+    },
+    ...options,
+  })
 }

--- a/apps/studio/data/banned-ips/banned-ips-delete-mutations.ts
+++ b/apps/studio/data/banned-ips/banned-ips-delete-mutations.ts
@@ -36,7 +36,7 @@ export const useBannedIPsDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(BannedIPKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: BannedIPKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/branches/branch-create-mutation.ts
+++ b/apps/studio/data/branches/branch-create-mutation.ts
@@ -56,7 +56,7 @@ export const useBranchCreateMutation = ({
     mutationFn: (vars) => createBranch(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(branchKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: branchKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/branches/branch-delete-mutation.ts
+++ b/apps/studio/data/branches/branch-delete-mutation.ts
@@ -36,7 +36,7 @@ export const useBranchDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { branchRef, projectRef } = variables
       setTimeout(() => {
-        queryClient.invalidateQueries(branchKeys.list(projectRef))
+        queryClient.invalidateQueries({ queryKey: branchKeys.list(projectRef) })
       }, 5000)
 
       const branches: BranchesData | undefined = queryClient.getQueryData(

--- a/apps/studio/data/branches/branch-merge-mutation.ts
+++ b/apps/studio/data/branches/branch-merge-mutation.ts
@@ -3,9 +3,9 @@ import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
-import { branchKeys } from './keys'
-import { getBranchDiff } from './branch-diff-query'
 import { upsertMigration } from '../database/migration-upsert-mutation'
+import { getBranchDiff } from './branch-diff-query'
+import { branchKeys } from './keys'
 
 export type BranchMergeVariables = {
   branchProjectRef: string
@@ -67,7 +67,7 @@ export const useBranchMergeMutation = ({
     mutationFn: (vars) => mergeBranch(vars),
     async onSuccess(data, variables, context) {
       const { baseProjectRef } = variables
-      await queryClient.invalidateQueries(branchKeys.list(baseProjectRef))
+      await queryClient.invalidateQueries({ queryKey: branchKeys.list(baseProjectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/branches/branch-push-mutation.ts
+++ b/apps/studio/data/branches/branch-push-mutation.ts
@@ -35,7 +35,7 @@ export const useBranchPushMutation = ({
     mutationFn: (vars) => pushBranch(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(branchKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: branchKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/branches/branch-reset-mutation.ts
+++ b/apps/studio/data/branches/branch-reset-mutation.ts
@@ -35,7 +35,7 @@ export const useBranchResetMutation = ({
     mutationFn: (vars) => resetBranch(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(branchKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: branchKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/branches/branch-update-mutation.ts
+++ b/apps/studio/data/branches/branch-update-mutation.ts
@@ -52,7 +52,7 @@ export const useBranchUpdateMutation = ({
     mutationFn: (vars) => updateBranch(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(branchKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: branchKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/disk-attributes-update-mutation.ts
+++ b/apps/studio/data/config/disk-attributes-update-mutation.ts
@@ -58,7 +58,7 @@ export const useUpdateDiskAttributesMutation = ({
     mutationFn: (vars) => updateDiskAttributes(vars),
     async onSuccess(data, variables, context) {
       const { ref } = variables
-      await queryClient.invalidateQueries(configKeys.diskAttributes(ref))
+      await queryClient.invalidateQueries({ queryKey: configKeys.diskAttributes(ref) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/disk-autoscale-config-update-mutation.ts
+++ b/apps/studio/data/config/disk-autoscale-config-update-mutation.ts
@@ -57,7 +57,7 @@ export const useUpdateDiskAutoscaleConfigMutation = ({
     mutationFn: (vars) => updateDiskAutoscaleConfig(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(configKeys.diskAutoscaleConfig(projectRef))
+      await queryClient.invalidateQueries({ queryKey: configKeys.diskAutoscaleConfig(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/jwt-secret-update-mutation.ts
+++ b/apps/studio/data/config/jwt-secret-update-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
 import type { ResponseError } from 'types'
@@ -47,7 +46,9 @@ export const useJwtSecretUpdateMutation = ({
     mutationFn: (vars) => updateJwtSecret(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(configKeys.jwtSecretUpdatingStatus(projectRef))
+      await queryClient.invalidateQueries({
+        queryKey: configKeys.jwtSecretUpdatingStatus(projectRef),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/project-compliance-config-mutation.ts
+++ b/apps/studio/data/config/project-compliance-config-mutation.ts
@@ -41,7 +41,7 @@ export const useComplianceConfigUpdateMutation = ({
     mutationFn: (vars) => updateComplianceConfig(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(configKeys.settingsV2(projectRef))
+      await queryClient.invalidateQueries({ queryKey: configKeys.settingsV2(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/project-disk-resize-mutation.ts
+++ b/apps/studio/data/config/project-disk-resize-mutation.ts
@@ -44,7 +44,7 @@ export const useProjectDiskResizeMutation = ({
     mutationFn: (vars) => resizeProjectDisk(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      queryClient.setQueriesData(usageKeys.usage(projectRef), (prev: any) => {
+      queryClient.setQueriesData({ queryKey: usageKeys.usage(projectRef) }, (prev: any) => {
         if (!prev) return prev
         return { ...prev, disk_volume_size_gb: variables.volumeSize }
       })

--- a/apps/studio/data/config/project-postgrest-config-update-mutation.ts
+++ b/apps/studio/data/config/project-postgrest-config-update-mutation.ts
@@ -63,7 +63,7 @@ export const useProjectPostgrestConfigUpdateMutation = ({
     mutationFn: (vars) => updateProjectPostgrestConfig(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      queryClient.invalidateQueries(configKeys.postgrest(projectRef))
+      queryClient.invalidateQueries({ queryKey: configKeys.postgrest(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/project-storage-config-update-mutation.ts
+++ b/apps/studio/data/config/project-storage-config-update-mutation.ts
@@ -1,10 +1,10 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { components } from 'api-types'
 import { handleError, patch } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { configKeys } from './keys'
-import { components } from 'api-types'
 
 type StorageConfigUpdatePayload = components['schemas']['UpdateStorageConfigBody']
 
@@ -51,7 +51,7 @@ export const useProjectStorageConfigUpdateUpdateMutation = ({
     mutationFn: (vars) => updateProjectStorageConfigUpdate(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(configKeys.storage(projectRef))
+      await queryClient.invalidateQueries({ queryKey: configKeys.storage(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/config/project-temp-disable-read-only-mutation.ts
+++ b/apps/studio/data/config/project-temp-disable-read-only-mutation.ts
@@ -32,7 +32,10 @@ export const useDisableReadOnlyModeMutation = ({
   return useMutation<DisableReadOnlyModeData, ResponseError, TempDisableReadOnlyModeVariables>({
     mutationFn: (vars) => tempDisableReadOnlyMode(vars),
     async onSuccess(data, variables, context) {
-      setTimeout(() => queryClient.invalidateQueries(usageKeys.resourceWarnings()), 2000)
+      setTimeout(
+        () => queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings() }),
+        2000
+      )
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/content/content-delete-mutation.ts
+++ b/apps/studio/data/content/content-delete-mutation.ts
@@ -41,8 +41,8 @@ export const useContentDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await Promise.all([
-        queryClient.invalidateQueries(contentKeys.allContentLists(projectRef)),
-        queryClient.invalidateQueries(contentKeys.infiniteList(projectRef)),
+        queryClient.invalidateQueries({ queryKey: contentKeys.allContentLists(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: contentKeys.infiniteList(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/content/content-infinite-query.ts
+++ b/apps/studio/data/content/content-infinite-query.ts
@@ -50,14 +50,12 @@ export const useContentInfiniteQuery = <TData = ContentData>(
   { projectRef, type, name, limit, sort }: GetContentVariables,
   { enabled = true, ...options }: UseInfiniteQueryOptions<ContentData, ContentError, TData> = {}
 ) => {
-  return useInfiniteQuery<ContentData, ContentError, TData>(
-    contentKeys.infiniteList(projectRef, { type, name, limit, sort }),
-    ({ signal, pageParam }) =>
+  return useInfiniteQuery<ContentData, ContentError, TData>({
+    queryKey: contentKeys.infiniteList(projectRef, { type, name, limit, sort }),
+    queryFn: ({ signal, pageParam }) =>
       getContent({ projectRef, type, name, limit, sort, cursor: pageParam }, signal),
-    {
-      enabled: enabled && typeof projectRef !== 'undefined',
-      getNextPageParam: (lastPage) => lastPage.cursor,
-      ...options,
-    }
-  )
+    enabled: enabled && typeof projectRef !== 'undefined',
+    getNextPageParam: (lastPage) => lastPage.cursor,
+    ...options,
+  })
 }

--- a/apps/studio/data/content/content-insert-mutation.ts
+++ b/apps/studio/data/content/content-insert-mutation.ts
@@ -56,7 +56,7 @@ export const useContentInsertMutation = ({
     mutationFn: (args) => insertContent(args),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(contentKeys.allContentLists(projectRef))
+      await queryClient.invalidateQueries({ queryKey: contentKeys.allContentLists(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/content/content-upsert-mutation.ts
+++ b/apps/studio/data/content/content-upsert-mutation.ts
@@ -52,8 +52,8 @@ export const useContentUpsertMutation = ({
       const { projectRef } = variables
       if (invalidateQueriesOnSuccess) {
         await Promise.all([
-          queryClient.invalidateQueries(contentKeys.allContentLists(projectRef)),
-          queryClient.invalidateQueries(contentKeys.infiniteList(projectRef)),
+          queryClient.invalidateQueries({ queryKey: contentKeys.allContentLists(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: contentKeys.infiniteList(projectRef) }),
         ])
       }
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/content/sql-folder-contents-query.ts
+++ b/apps/studio/data/content/sql-folder-contents-query.ts
@@ -57,15 +57,14 @@ export const useSQLSnippetFolderContentsQuery = <TData = SQLSnippetFolderContent
     TData
   > = {}
 ) =>
-  useInfiniteQuery<SQLSnippetFolderContentsData, SQLSnippetFolderContentsError, TData>(
-    contentKeys.folderContents(projectRef, folderId, { name, sort }),
-    ({ signal, pageParam }) =>
+  useInfiniteQuery<SQLSnippetFolderContentsData, SQLSnippetFolderContentsError, TData>({
+    queryKey: contentKeys.folderContents(projectRef, folderId, { name, sort }),
+    queryFn: ({ signal, pageParam }) =>
       getSQLSnippetFolderContents({ projectRef, folderId, cursor: pageParam, name, sort }, signal),
-    {
-      enabled: enabled && typeof projectRef !== 'undefined' && typeof folderId !== 'undefined',
-      getNextPageParam(lastPage) {
-        return lastPage.cursor
-      },
-      ...options,
-    }
-  )
+
+    enabled: enabled && typeof projectRef !== 'undefined' && typeof folderId !== 'undefined',
+    getNextPageParam(lastPage) {
+      return lastPage.cursor
+    },
+    ...options,
+  })

--- a/apps/studio/data/content/sql-folder-create-mutation.ts
+++ b/apps/studio/data/content/sql-folder-create-mutation.ts
@@ -48,7 +48,7 @@ export const useSQLSnippetFolderCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       if (invalidateQueriesOnSuccess) {
-        await queryClient.invalidateQueries(contentKeys.folders(projectRef))
+        await queryClient.invalidateQueries({ queryKey: contentKeys.folders(projectRef) })
       }
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/content/sql-folder-update-mutation.ts
+++ b/apps/studio/data/content/sql-folder-update-mutation.ts
@@ -49,7 +49,7 @@ export const useSQLSnippetFolderCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       if (invalidateQueriesOnSuccess) {
-        await queryClient.invalidateQueries(contentKeys.folders(projectRef))
+        await queryClient.invalidateQueries({ queryKey: contentKeys.folders(projectRef) })
       }
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/content/sql-folders-delete-mutation.ts
+++ b/apps/studio/data/content/sql-folders-delete-mutation.ts
@@ -44,7 +44,7 @@ export const useSQLSnippetFoldersDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       if (invalidateQueriesOnSuccess) {
-        await queryClient.invalidateQueries(contentKeys.folders(projectRef))
+        await queryClient.invalidateQueries({ queryKey: contentKeys.folders(projectRef) })
       }
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/content/sql-folders-query.ts
+++ b/apps/studio/data/content/sql-folders-query.ts
@@ -62,15 +62,13 @@ export const useSQLSnippetFoldersQuery = <TData = SQLSnippetFoldersData>(
     ...options
   }: UseInfiniteQueryOptions<SQLSnippetFoldersData, SQLSnippetFoldersError, TData> = {}
 ) =>
-  useInfiniteQuery<SQLSnippetFoldersData, SQLSnippetFoldersError, TData>(
-    contentKeys.folders(projectRef, { name, sort }),
-    ({ signal, pageParam }) =>
+  useInfiniteQuery<SQLSnippetFoldersData, SQLSnippetFoldersError, TData>({
+    queryKey: contentKeys.folders(projectRef, { name, sort }),
+    queryFn: ({ signal, pageParam }) =>
       getSQLSnippetFolders({ projectRef, cursor: pageParam, name, sort }, signal),
-    {
-      enabled: enabled && typeof projectRef !== 'undefined',
-      getNextPageParam(lastPage) {
-        return lastPage.cursor
-      },
-      ...options,
-    }
-  )
+    enabled: enabled && typeof projectRef !== 'undefined',
+    getNextPageParam(lastPage) {
+      return lastPage.cursor
+    },
+    ...options,
+  })

--- a/apps/studio/data/content/sql-snippets-query.ts
+++ b/apps/studio/data/content/sql-snippets-query.ts
@@ -63,15 +63,13 @@ export const useSqlSnippetsQuery = <TData = SqlSnippetsData>(
     ...options
   }: UseInfiniteQueryOptions<SqlSnippetsData, SqlSnippetsError, TData> = {}
 ) =>
-  useInfiniteQuery<SqlSnippetsData, SqlSnippetsError, TData>(
-    contentKeys.sqlSnippets(projectRef, { sort, name, visibility, favorite }),
-    ({ signal, pageParam: cursor }) =>
+  useInfiniteQuery<SqlSnippetsData, SqlSnippetsError, TData>({
+    queryKey: contentKeys.sqlSnippets(projectRef, { sort, name, visibility, favorite }),
+    queryFn: ({ signal, pageParam: cursor }) =>
       getSqlSnippets({ projectRef, cursor, sort, name, visibility, favorite }, signal),
-    {
-      enabled: enabled && typeof projectRef !== 'undefined',
-      getNextPageParam(lastPage) {
-        return lastPage.cursor
-      },
-      ...options,
-    }
-  )
+    enabled: enabled && typeof projectRef !== 'undefined',
+    getNextPageParam(lastPage) {
+      return lastPage.cursor
+    },
+    ...options,
+  })

--- a/apps/studio/data/custom-domains/custom-domains-activate-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-activate-mutation.ts
@@ -34,7 +34,7 @@ export const useCustomDomainActivateMutation = ({
     mutationFn: (vars) => activateCustomDomain(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(customDomainKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: customDomainKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/custom-domains/custom-domains-create-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-create-mutation.ts
@@ -39,7 +39,7 @@ export const useCustomDomainCreateMutation = ({
     mutationFn: (vars) => createCustomDomain(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(customDomainKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: customDomainKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
@@ -40,7 +40,7 @@ export const useCustomDomainDeleteMutation = ({
       // we manually setQueriesData here instead of using
       // the standard invalidateQueries is the custom domains
       // endpoint doesn't immediately return the new state
-      queryClient.setQueriesData(customDomainKeys.list(projectRef), () => {
+      queryClient.setQueriesData({ queryKey: customDomainKeys.list(projectRef) }, () => {
         return {
           customDomain: null,
           status: '0_no_hostname_configured',

--- a/apps/studio/data/custom-domains/custom-domains-reverify-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-reverify-mutation.ts
@@ -34,7 +34,7 @@ export const useCustomDomainReverifyMutation = ({
     mutationFn: (vars) => reverifyCustomDomain(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(customDomainKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: customDomainKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-columns/database-column-delete-mutation.ts
+++ b/apps/studio/data/database-columns/database-column-delete-mutation.ts
@@ -53,22 +53,28 @@ export const useDatabaseColumnDeleteMutation = ({
       const { projectRef, column } = variables
       await Promise.all([
         // refetch all entities in the sidebar because deleting a column may regenerate a view (and change its id)
-        queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
-        queryClient.invalidateQueries(
-          databaseKeys.foreignKeyConstraints(projectRef, column.schema)
-        ),
-        queryClient.invalidateQueries(tableEditorKeys.tableEditor(projectRef, column.table_id)),
-        queryClient.invalidateQueries(databaseKeys.tableDefinition(projectRef, column.table_id)),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
+        queryClient.invalidateQueries({
+          queryKey: databaseKeys.foreignKeyConstraints(projectRef, column.schema),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: tableEditorKeys.tableEditor(projectRef, column.table_id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: databaseKeys.tableDefinition(projectRef, column.table_id),
+        }),
         // invalidate all views from this schema, not sure if this is needed since you can't actually delete a column
         // which has a view dependent on it
-        queryClient.invalidateQueries(viewKeys.listBySchema(projectRef, column.schema)),
+        queryClient.invalidateQueries({
+          queryKey: viewKeys.listBySchema(projectRef, column.schema),
+        }),
       ])
 
       // We need to invalidate tableRowsAndCount after tableEditor
       // to ensure the query sent is correct
-      await queryClient.invalidateQueries(
-        tableRowKeys.tableRowsAndCount(projectRef, column.table_id)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRowsAndCount(projectRef, column.table_id),
+      })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-create-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-create-mutation.ts
@@ -46,9 +46,15 @@ export const useDatabaseCronJobCreateMutation = ({
       const { projectRef, searchTerm, identifier } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(databaseCronJobsKeys.listInfinite(projectRef, searchTerm)),
+        queryClient.invalidateQueries({
+          queryKey: databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
+        }),
         ...(!!identifier
-          ? [queryClient.invalidateQueries(databaseCronJobsKeys.job(projectRef, identifier))]
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: databaseCronJobsKeys.job(projectRef, identifier),
+              }),
+            ]
           : []),
       ])
 

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-delete-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-delete-mutation.ts
@@ -43,7 +43,9 @@ export const useDatabaseCronJobDeleteMutation = ({
     mutationFn: (vars) => deleteDatabaseCronJob(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, searchTerm } = variables
-      await queryClient.invalidateQueries(databaseCronJobsKeys.listInfinite(projectRef, searchTerm))
+      await queryClient.invalidateQueries({
+        queryKey: databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-infinite-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-infinite-query.ts
@@ -93,9 +93,9 @@ export const useCronJobsInfiniteQuery = <TData = DatabaseCronJobsInfiniteData>(
     TData
   > = {}
 ) =>
-  useInfiniteQuery<DatabaseCronJobsInfiniteData, DatabaseCronJobsInfiniteError, TData>(
-    databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
-    ({ pageParam }) => {
+  useInfiniteQuery<DatabaseCronJobsInfiniteData, DatabaseCronJobsInfiniteError, TData>({
+    queryKey: databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
+    queryFn: ({ pageParam }) => {
       return getDatabaseCronJobs({
         projectRef,
         connectionString,
@@ -103,15 +103,13 @@ export const useCronJobsInfiniteQuery = <TData = DatabaseCronJobsInfiniteData>(
         page: pageParam,
       })
     },
-    {
-      staleTime: 0,
-      enabled: enabled && typeof projectRef !== 'undefined',
-      getNextPageParam(lastPage, pages) {
-        const page = pages.length
-        const hasNextPage = lastPage.length >= CRON_JOBS_PAGE_LIMIT
-        if (!hasNextPage) return undefined
-        return page
-      },
-      ...options,
-    }
-  )
+    staleTime: 0,
+    enabled: enabled && typeof projectRef !== 'undefined',
+    getNextPageParam(lastPage, pages) {
+      const page = pages.length
+      const hasNextPage = lastPage.length >= CRON_JOBS_PAGE_LIMIT
+      if (!hasNextPage) return undefined
+      return page
+    },
+    ...options,
+  })

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-runs-infinite-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-runs-infinite-query.ts
@@ -61,9 +61,9 @@ export const useCronJobRunsInfiniteQuery = <TData = DatabaseCronJobRunData>(
     ...options
   }: UseInfiniteQueryOptions<DatabaseCronJobRunData, DatabaseCronJobError, TData> = {}
 ) =>
-  useInfiniteQuery<DatabaseCronJobRunData, DatabaseCronJobError, TData>(
-    databaseCronJobsKeys.runsInfinite(projectRef, jobId, { status }),
-    ({ pageParam }) => {
+  useInfiniteQuery<DatabaseCronJobRunData, DatabaseCronJobError, TData>({
+    queryKey: databaseCronJobsKeys.runsInfinite(projectRef, jobId, { status }),
+    queryFn: ({ pageParam }) => {
       return getDatabaseCronJobRuns({
         projectRef,
         connectionString,
@@ -71,15 +71,13 @@ export const useCronJobRunsInfiniteQuery = <TData = DatabaseCronJobRunData>(
         afterTimestamp: pageParam,
       })
     },
-    {
-      staleTime: 0,
-      enabled: enabled && typeof projectRef !== 'undefined',
+    staleTime: 0,
+    enabled: enabled && typeof projectRef !== 'undefined',
 
-      getNextPageParam(lastPage) {
-        const hasNextPage = lastPage.length <= CRON_JOB_RUNS_PAGE_SIZE
-        if (!hasNextPage) return undefined
-        return last(lastPage)?.start_time
-      },
-      ...options,
-    }
-  )
+    getNextPageParam(lastPage) {
+      const hasNextPage = lastPage.length <= CRON_JOB_RUNS_PAGE_SIZE
+      if (!hasNextPage) return undefined
+      return last(lastPage)?.start_time
+    },
+    ...options,
+  })

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
@@ -45,7 +45,9 @@ export const useDatabaseCronJobToggleMutation = ({
     mutationFn: (vars) => toggleDatabaseCronJob(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, searchTerm } = variables
-      await queryClient.invalidateQueries(databaseCronJobsKeys.listInfinite(projectRef, searchTerm))
+      await queryClient.invalidateQueries({
+        queryKey: databaseCronJobsKeys.listInfinite(projectRef, searchTerm),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
@@ -59,8 +59,8 @@ export const useDatabaseExtensionDisableMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await Promise.all([
-        queryClient.invalidateQueries(databaseExtensionsKeys.list(projectRef)),
-        queryClient.invalidateQueries(configKeys.upgradeEligibility(projectRef)),
+        queryClient.invalidateQueries({ queryKey: databaseExtensionsKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: configKeys.upgradeEligibility(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
@@ -3,8 +3,8 @@ import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { executeSql } from 'data/sql/execute-sql-query'
 import { configKeys } from 'data/config/keys'
+import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
 
@@ -58,8 +58,8 @@ export const useDatabaseExtensionEnableMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await Promise.all([
-        queryClient.invalidateQueries(databaseExtensionsKeys.list(projectRef)),
-        queryClient.invalidateQueries(configKeys.upgradeEligibility(projectRef)),
+        queryClient.invalidateQueries({ queryKey: databaseExtensionsKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: configKeys.upgradeEligibility(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/database-functions/database-functions-create-mutation.ts
+++ b/apps/studio/data/database-functions/database-functions-create-mutation.ts
@@ -46,7 +46,7 @@ export const useDatabaseFunctionCreateMutation = ({
     mutationFn: (vars) => createDatabaseFunction(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseKeys.databaseFunctions(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseKeys.databaseFunctions(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-functions/database-functions-delete-mutation.ts
+++ b/apps/studio/data/database-functions/database-functions-delete-mutation.ts
@@ -47,7 +47,7 @@ export const useDatabaseFunctionDeleteMutation = ({
     mutationFn: (vars) => deleteDatabaseFunction(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseKeys.databaseFunctions(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseKeys.databaseFunctions(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-functions/database-functions-update-mutation.ts
+++ b/apps/studio/data/database-functions/database-functions-update-mutation.ts
@@ -49,7 +49,7 @@ export const useDatabaseFunctionUpdateMutation = ({
     mutationFn: (vars) => updateDatabaseFunction(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseKeys.databaseFunctions(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseKeys.databaseFunctions(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -55,7 +55,7 @@ export const useDatabaseIndexCreateMutation = ({
     mutationFn: (vars) => createDatabaseIndex(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseIndexesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseIndexesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -46,7 +46,7 @@ export const useDatabaseIndexDeleteMutation = ({
     mutationFn: (vars) => deleteDatabaseIndex(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseIndexesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseIndexesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-policies/database-policy-create-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-create-mutation.ts
@@ -58,7 +58,7 @@ export const useDatabasePolicyCreateMutation = ({
     mutationFn: (vars) => createDatabasePolicy(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databasePoliciesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databasePoliciesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-policies/database-policy-delete-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-delete-mutation.ts
@@ -52,7 +52,7 @@ export const useDatabasePolicyDeleteMutation = ({
     mutationFn: (vars) => deleteDatabasePolicy(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databasePoliciesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databasePoliciesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-policies/database-policy-update-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-update-mutation.ts
@@ -59,7 +59,7 @@ export const useDatabasePolicyUpdateMutation = ({
     mutationFn: (vars) => updateDatabasePolicy(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databasePoliciesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databasePoliciesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-publications/database-publications-create-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-create-mutation.ts
@@ -70,7 +70,7 @@ export const useDatabasePublicationCreateMutation = ({
     mutationFn: (vars) => createDatabasePublication(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databasePublicationsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databasePublicationsKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-publications/database-publications-update-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-update-mutation.ts
@@ -69,7 +69,7 @@ export const useDatabasePublicationUpdateMutation = ({
     mutationFn: (vars) => updateDatabasePublication(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databasePublicationsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databasePublicationsKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
@@ -52,9 +52,9 @@ export const useDatabaseQueueMessageArchiveMutation = ({
     mutationFn: (vars) => archiveDatabaseQueueMessage(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, queryName } = variables
-      await queryClient.invalidateQueries(
-        databaseQueuesKeys.getMessagesInfinite(projectRef, queryName)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queryName),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
@@ -52,9 +52,9 @@ export const useDatabaseQueueMessageDeleteMutation = ({
     mutationFn: (vars) => deleteDatabaseQueueMessage(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, queueName } = variables
-      await queryClient.invalidateQueries(
-        databaseQueuesKeys.getMessagesInfinite(projectRef, queueName)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queueName),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
@@ -81,9 +81,9 @@ export const useQueueMessagesInfiniteQuery = <TData = DatabaseQueueData>(
     ...options
   }: UseInfiniteQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
 ) =>
-  useInfiniteQuery<DatabaseQueueData, DatabaseQueueError, TData>(
-    databaseQueuesKeys.getMessagesInfinite(projectRef, queueName, { status }),
-    ({ pageParam }) => {
+  useInfiniteQuery<DatabaseQueueData, DatabaseQueueError, TData>({
+    queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queueName, { status }),
+    queryFn: ({ pageParam }) => {
       return getDatabaseQueue({
         projectRef,
         connectionString,
@@ -92,15 +92,13 @@ export const useQueueMessagesInfiniteQuery = <TData = DatabaseQueueData>(
         status,
       })
     },
-    {
-      staleTime: 0,
-      enabled: enabled && typeof projectRef !== 'undefined',
+    staleTime: 0,
+    enabled: enabled && typeof projectRef !== 'undefined',
 
-      getNextPageParam(lastPage) {
-        const hasNextPage = lastPage.length <= QUEUE_MESSAGES_PAGE_SIZE
-        if (!hasNextPage) return undefined
-        return last(lastPage)?.enqueued_at
-      },
-      ...options,
-    }
-  )
+    getNextPageParam(lastPage) {
+      const hasNextPage = lastPage.length <= QUEUE_MESSAGES_PAGE_SIZE
+      if (!hasNextPage) return undefined
+      return last(lastPage)?.enqueued_at
+    },
+    ...options,
+  })

--- a/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
@@ -54,9 +54,9 @@ export const useDatabaseQueueMessageReadMutation = ({
     mutationFn: (vars) => readDatabaseQueueMessage(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, queryName } = variables
-      await queryClient.invalidateQueries(
-        databaseQueuesKeys.getMessagesInfinite(projectRef, queryName)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queryName),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
@@ -54,9 +54,9 @@ export const useDatabaseQueueMessageSendMutation = ({
     mutationFn: (vars) => sendDatabaseQueueMessage(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, queueName } = variables
-      await queryClient.invalidateQueries(
-        databaseQueuesKeys.getMessagesInfinite(projectRef, queueName)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queueName),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queues-create-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-create-mutation.ts
@@ -2,9 +2,9 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
+import { tableKeys } from 'data/tables/keys'
 import type { ResponseError } from 'types'
 import { databaseQueuesKeys } from './keys'
-import { tableKeys } from 'data/tables/keys'
 
 export type DatabaseQueueCreateVariables = {
   projectRef: string
@@ -61,8 +61,8 @@ export const useDatabaseQueueCreateMutation = ({
     mutationFn: (vars) => createDatabaseQueue(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseQueuesKeys.list(projectRef))
-      queryClient.invalidateQueries(tableKeys.list(projectRef, 'pgmq'))
+      await queryClient.invalidateQueries({ queryKey: databaseQueuesKeys.list(projectRef) })
+      queryClient.invalidateQueries({ queryKey: tableKeys.list(projectRef, 'pgmq') })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queues-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-delete-mutation.ts
@@ -42,7 +42,7 @@ export const useDatabaseQueueDeleteMutation = ({
     mutationFn: (vars) => deleteDatabaseQueue(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseQueuesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseQueuesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queues-purge-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-purge-mutation.ts
@@ -42,9 +42,9 @@ export const useDatabaseQueuePurgeMutation = ({
     mutationFn: (vars) => purgeDatabaseQueue(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, queueName } = variables
-      await queryClient.invalidateQueries(
-        databaseQueuesKeys.getMessagesInfinite(projectRef, queueName)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queueName),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
@@ -1,11 +1,11 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import minify from 'pg-minify'
+import { toast } from 'sonner'
 
+import { databaseKeys } from 'data/database/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 import { databaseQueuesKeys } from './keys'
-import { databaseKeys } from 'data/database/keys'
 
 export type DatabaseQueueExposePostgrestVariables = {
   projectRef: string
@@ -258,9 +258,11 @@ export const useDatabaseQueueToggleExposeMutation = ({
     mutationFn: (vars) => toggleQueuesExposurePostgrest(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseQueuesKeys.exposePostgrestStatus(projectRef))
+      await queryClient.invalidateQueries({
+        queryKey: databaseQueuesKeys.exposePostgrestStatus(projectRef),
+      })
       // [Joshen] Schemas can be invalidated without waiting
-      queryClient.invalidateQueries(databaseKeys.schemas(projectRef))
+      queryClient.invalidateQueries({ queryKey: databaseKeys.schemas(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-triggers/database-trigger-create-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-create-mutation.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import pgMeta from '@supabase/pg-meta'
+import { PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { executeSql } from 'data/sql/execute-sql-query'
+import { toast } from 'sonner'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
-import { executeSql } from 'data/sql/execute-sql-query'
-import { PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 export type DatabaseTriggerCreateVariables = {
   projectRef: string
@@ -45,7 +45,7 @@ export const useDatabaseTriggerCreateMutation = ({
     mutationFn: (vars) => createDatabaseTrigger(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseTriggerKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseTriggerKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
@@ -1,10 +1,9 @@
-import type { PostgresTrigger } from '@supabase/postgres-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import pgMeta from '@supabase/pg-meta'
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { executeSql } from 'data/sql/execute-sql-query'
+import { toast } from 'sonner'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
-import { executeSql } from 'data/sql/execute-sql-query'
 
 export type DatabaseTriggerDeleteVariables = {
   trigger: {
@@ -50,7 +49,7 @@ export const useDatabaseTriggerDeleteMutation = ({
     mutationFn: (vars) => deleteDatabaseTrigger(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseTriggerKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseTriggerKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import pgMeta from '@supabase/pg-meta'
+import { PGTriggerUpdate } from '@supabase/pg-meta/src/pg-meta-triggers'
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { executeSql } from 'data/sql/execute-sql-query'
+import { toast } from 'sonner'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
-import { executeSql } from 'data/sql/execute-sql-query'
-import { PGTriggerUpdate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 export type DatabaseTriggerUpdateVariables = {
   originalTrigger: {
@@ -52,7 +52,7 @@ export const useDatabaseTriggerUpdateMutation = ({
     mutationFn: (vars) => updateDatabaseTrigger(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseTriggerKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseTriggerKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { PGTrigger, PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
+import { PostgresTrigger } from '@supabase/postgres-meta'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { quoteLiteral } from 'lib/pg-format'
 import type { ResponseError } from 'types'
 import { databaseTriggerKeys } from './keys'
-import { PostgresTrigger } from '@supabase/postgres-meta'
-import { PGTrigger, PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
 
 // [Joshen] Writing this query within FE as the PATCH endpoint from pg-meta only supports updating
 // trigger name and enabled mode. So we'll delete and create the trigger, within a single transaction
@@ -67,7 +67,7 @@ export const useDatabaseTriggerUpdateMutation = ({
     mutationFn: (vars) => updateDatabaseTrigger(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseTriggerKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseTriggerKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database/database-password-reset-mutation.ts
+++ b/apps/studio/data/database/database-password-reset-mutation.ts
@@ -37,7 +37,7 @@ export const useDatabasePasswordResetMutation = ({
   return useMutation<DatabasePasswordResetData, ResponseError, DatabasePasswordResetVariables>({
     mutationFn: (vars) => resetDatabasePassword(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(projectKeys.detail(variables.ref))
+      await queryClient.invalidateQueries({ queryKey: projectKeys.detail(variables.ref) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/database/foreign-key-constraints-query.ts
+++ b/apps/studio/data/database/foreign-key-constraints-query.ts
@@ -146,7 +146,9 @@ export function prefetchForeignKeyConstraints(
   client: QueryClient,
   { projectRef, connectionString, schema }: ForeignKeyConstraintsVariables
 ) {
-  return client.fetchQuery(databaseKeys.foreignKeyConstraints(projectRef, schema), ({ signal }) =>
-    getForeignKeyConstraints({ projectRef, connectionString, schema }, signal)
-  )
+  return client.fetchQuery({
+    queryKey: databaseKeys.foreignKeyConstraints(projectRef, schema),
+    queryFn: ({ signal }) =>
+      getForeignKeyConstraints({ projectRef, connectionString, schema }, signal),
+  })
 }

--- a/apps/studio/data/database/migration-upsert-mutation.ts
+++ b/apps/studio/data/database/migration-upsert-mutation.ts
@@ -53,7 +53,7 @@ export const useMigrationUpsertMutation = ({
     mutationFn: (vars) => upsertMigration(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(databaseKeys.migrations(projectRef))
+      await queryClient.invalidateQueries({ queryKey: databaseKeys.migrations(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database/pgbouncer-config-update-mutation.ts
+++ b/apps/studio/data/database/pgbouncer-config-update-mutation.ts
@@ -58,7 +58,7 @@ export const usePgbouncerConfigurationUpdateMutation = ({
     mutationFn: (vars) => updatePgbouncerConfiguration(vars),
     async onSuccess(data, variables, context) {
       const { ref } = variables
-      await queryClient.invalidateQueries(databaseKeys.pgbouncerConfig(ref))
+      await queryClient.invalidateQueries({ queryKey: databaseKeys.pgbouncerConfig(ref) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/database/schemas-query.ts
+++ b/apps/studio/data/database/schemas-query.ts
@@ -53,7 +53,8 @@ export function prefetchSchemas(
   client: QueryClient,
   { projectRef, connectionString }: SchemasVariables
 ) {
-  return client.fetchQuery(databaseKeys.schemas(projectRef), ({ signal }) =>
-    getSchemas({ projectRef, connectionString }, signal)
-  )
+  return client.fetchQuery({
+    queryKey: databaseKeys.schemas(projectRef),
+    queryFn: ({ signal }) => getSchemas({ projectRef, connectionString }, signal),
+  })
 }

--- a/apps/studio/data/database/supavisor-configuration-update-mutation.ts
+++ b/apps/studio/data/database/supavisor-configuration-update-mutation.ts
@@ -49,7 +49,7 @@ export const useSupavisorConfigurationUpdateMutation = ({
     mutationFn: (vars) => updateSupavisorConfiguration(vars),
     async onSuccess(data, variables, context) {
       const { ref } = variables
-      await queryClient.invalidateQueries(databaseKeys.poolingConfiguration(ref))
+      await queryClient.invalidateQueries({ queryKey: databaseKeys.poolingConfiguration(ref) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/edge-functions/edge-functions-delete-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-functions-delete-mutation.ts
@@ -39,7 +39,8 @@ export const useEdgeFunctionDeleteMutation = ({
     mutationFn: (vars) => deleteEdgeFunction(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(edgeFunctionsKeys.list(projectRef), {
+      await queryClient.invalidateQueries({
+        queryKey: edgeFunctionsKeys.list(projectRef),
         refetchType: 'all',
       })
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/edge-functions/edge-functions-deploy-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-functions-deploy-mutation.ts
@@ -63,9 +63,9 @@ export const useEdgeFunctionDeployMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, slug } = variables
       await Promise.all([
-        queryClient.invalidateQueries(edgeFunctionsKeys.list(projectRef)),
-        queryClient.invalidateQueries(edgeFunctionsKeys.detail(projectRef, slug)),
-        queryClient.invalidateQueries(edgeFunctionsKeys.body(projectRef, slug)),
+        queryClient.invalidateQueries({ queryKey: edgeFunctionsKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: edgeFunctionsKeys.detail(projectRef, slug) }),
+        queryClient.invalidateQueries({ queryKey: edgeFunctionsKeys.body(projectRef, slug) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/edge-functions/edge-functions-update-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-functions-update-mutation.ts
@@ -49,8 +49,8 @@ export const useEdgeFunctionUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, slug } = variables
       await Promise.all([
-        queryClient.invalidateQueries(edgeFunctionsKeys.detail(projectRef, slug)),
-        queryClient.invalidateQueries(edgeFunctionsKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: edgeFunctionsKeys.detail(projectRef, slug) }),
+        queryClient.invalidateQueries({ queryKey: edgeFunctionsKeys.list(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/entity-types/entity-types-infinite-query.ts
+++ b/apps/studio/data/entity-types/entity-types-infinite-query.ts
@@ -176,9 +176,9 @@ export function prefetchEntityTypes(
     filterTypes,
   }: Omit<EntityTypesVariables, 'page'>
 ) {
-  return client.prefetchInfiniteQuery(
-    entityTypeKeys.list(projectRef, { schemas, search, sort, limit, filterTypes }),
-    ({ signal, pageParam }) =>
+  return client.prefetchInfiniteQuery({
+    queryKey: entityTypeKeys.list(projectRef, { schemas, search, sort, limit, filterTypes }),
+    queryFn: ({ signal, pageParam }) =>
       getEntityTypes(
         {
           projectRef,
@@ -191,6 +191,6 @@ export function prefetchEntityTypes(
           filterTypes,
         },
         signal
-      )
-  )
+      ),
+  })
 }

--- a/apps/studio/data/entity-types/entity-types-infinite-query.ts
+++ b/apps/studio/data/entity-types/entity-types-infinite-query.ts
@@ -132,9 +132,9 @@ export const useEntityTypesQuery = <TData = EntityTypesData>(
     ...options
   }: UseInfiniteQueryOptions<EntityTypesData, EntityTypesError, TData> = {}
 ) => {
-  return useInfiniteQuery<EntityTypesData, EntityTypesError, TData>(
-    entityTypeKeys.list(projectRef, { schemas, search, sort, limit, filterTypes }),
-    ({ signal, pageParam }) =>
+  return useInfiniteQuery<EntityTypesData, EntityTypesError, TData>({
+    queryKey: entityTypeKeys.list(projectRef, { schemas, search, sort, limit, filterTypes }),
+    queryFn: ({ signal, pageParam }) =>
       getEntityTypes(
         {
           projectRef,
@@ -148,22 +148,20 @@ export const useEntityTypesQuery = <TData = EntityTypesData>(
         },
         signal
       ),
-    {
-      enabled: enabled && typeof projectRef !== 'undefined',
-      getNextPageParam(lastPage, pages) {
-        const page = pages.length
-        const currentTotalCount = page * limit
-        const totalCount = lastPage.data.count
+    enabled: enabled && typeof projectRef !== 'undefined',
+    getNextPageParam(lastPage, pages) {
+      const page = pages.length
+      const currentTotalCount = page * limit
+      const totalCount = lastPage.data.count
 
-        if (currentTotalCount >= totalCount) {
-          return undefined
-        }
+      if (currentTotalCount >= totalCount) {
+        return undefined
+      }
 
-        return page
-      },
-      ...options,
-    }
-  )
+      return page
+    },
+    ...options,
+  })
 }
 
 export function prefetchEntityTypes(

--- a/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
@@ -49,7 +49,7 @@ export const useEnumeratedTypeCreateMutation = ({
     mutationFn: (vars) => createEnumeratedType(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(enumeratedTypesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: enumeratedTypesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
@@ -39,7 +39,7 @@ export const useEnumeratedTypeDeleteMutation = ({
     mutationFn: (vars) => deleteEnumeratedType(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(enumeratedTypesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: enumeratedTypesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
@@ -75,7 +75,7 @@ export const useEnumeratedTypeUpdateMutation = ({
     mutationFn: (vars) => updateEnumeratedType(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(enumeratedTypesKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: enumeratedTypesKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/fdw/fdw-create-mutation.ts
+++ b/apps/studio/data/fdw/fdw-create-mutation.ts
@@ -253,10 +253,10 @@ export const useFDWCreateMutation = ({
       const { projectRef } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(fdwKeys.list(projectRef), { refetchType: 'all' }),
-        queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
-        queryClient.invalidateQueries(foreignTableKeys.list(projectRef)),
-        queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: fdwKeys.list(projectRef), refetchType: 'all' }),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: foreignTableKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/fdw/fdw-delete-mutation.ts
+++ b/apps/studio/data/fdw/fdw-delete-mutation.ts
@@ -110,10 +110,10 @@ export const useFDWDeleteMutation = ({
       const { projectRef } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(fdwKeys.list(projectRef), { refetchType: 'all' }),
-        queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
-        queryClient.invalidateQueries(foreignTableKeys.list(projectRef)),
-        queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: fdwKeys.list(projectRef), refetchType: 'all' }),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: foreignTableKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/fdw/fdw-import-foreign-schema-mutation.ts
+++ b/apps/studio/data/fdw/fdw-import-foreign-schema-mutation.ts
@@ -56,10 +56,10 @@ export const useFDWImportForeignSchemaMutation = ({
       const { projectRef } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(fdwKeys.list(projectRef), { refetchType: 'all' }),
-        queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
-        queryClient.invalidateQueries(foreignTableKeys.list(projectRef)),
-        queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: fdwKeys.list(projectRef), refetchType: 'all' }),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: foreignTableKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/fdw/fdw-update-mutation.ts
+++ b/apps/studio/data/fdw/fdw-update-mutation.ts
@@ -80,10 +80,10 @@ export const useFDWUpdateMutation = ({
       const { projectRef } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(fdwKeys.list(projectRef), { refetchType: 'all' }),
-        queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
-        queryClient.invalidateQueries(foreignTableKeys.list(projectRef)),
-        queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: fdwKeys.list(projectRef), refetchType: 'all' }),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: foreignTableKeys.list(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/integrations/github-connection-create-mutation.ts
+++ b/apps/studio/data/integrations/github-connection-create-mutation.ts
@@ -35,9 +35,9 @@ export const useGitHubConnectionCreateMutation = ({
     mutationFn: (vars) => createGitHubConnection(vars),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(
-          integrationKeys.githubConnectionsList(variables.organizationId)
-        ),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.githubConnectionsList(variables.organizationId),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/integrations/github-connection-delete-mutation.ts
+++ b/apps/studio/data/integrations/github-connection-delete-mutation.ts
@@ -35,9 +35,9 @@ export const useGitHubConnectionDeleteMutation = ({
     mutationFn: (args) => deleteConnection(args),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(
-          integrationKeys.githubConnectionsList(variables.organizationId)
-        ),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.githubConnectionsList(variables.organizationId),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/integrations/github-connection-update-mutation.ts
+++ b/apps/studio/data/integrations/github-connection-update-mutation.ts
@@ -41,9 +41,9 @@ export const useGitHubConnectionUpdateMutation = ({
     mutationFn: (args) => updateConnection(args),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(
-          integrationKeys.githubConnectionsList(variables.organizationId)
-        ),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.githubConnectionsList(variables.organizationId),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/integrations/integrations-vercel-connections-create-mutation.ts
+++ b/apps/studio/data/integrations/integrations-vercel-connections-create-mutation.ts
@@ -52,14 +52,16 @@ export const useIntegrationVercelConnectionsCreateMutation = ({
     mutationFn: (vars) => createIntegrationVercelConnections(vars),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(integrationKeys.integrationsList()),
-        queryClient.invalidateQueries(integrationKeys.integrationsListWithOrg(variables.orgSlug)),
-        queryClient.invalidateQueries(
-          integrationKeys.vercelProjectList(variables.organizationIntegrationId)
-        ),
-        queryClient.invalidateQueries(
-          integrationKeys.vercelConnectionsList(variables.organizationIntegrationId)
-        ),
+        queryClient.invalidateQueries({ queryKey: integrationKeys.integrationsList() }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.integrationsListWithOrg(variables.orgSlug),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.vercelProjectList(variables.organizationIntegrationId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.vercelConnectionsList(variables.organizationIntegrationId),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/integrations/integrations-vercel-installed-connection-delete-mutation.ts
+++ b/apps/studio/data/integrations/integrations-vercel-installed-connection-delete-mutation.ts
@@ -41,14 +41,16 @@ export const useIntegrationsVercelInstalledConnectionDeleteMutation = ({
     mutationFn: (args) => deleteConnection(args),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(integrationKeys.integrationsList()),
-        queryClient.invalidateQueries(integrationKeys.integrationsListWithOrg(variables.orgSlug)),
-        queryClient.invalidateQueries(
-          integrationKeys.vercelProjectList(variables.organization_integration_id)
-        ),
-        queryClient.invalidateQueries(
-          integrationKeys.vercelConnectionsList(variables.organization_integration_id)
-        ),
+        queryClient.invalidateQueries({ queryKey: integrationKeys.integrationsList() }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.integrationsListWithOrg(variables.orgSlug),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.vercelProjectList(variables.organization_integration_id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.vercelConnectionsList(variables.organization_integration_id),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/integrations/vercel-connection-update-mutate.ts
+++ b/apps/studio/data/integrations/vercel-connection-update-mutate.ts
@@ -47,9 +47,9 @@ export const useVercelConnectionUpdateMutation = ({
   return useMutation<UpdateVercelConnectionData, ResponseError, UpdateConnectionPayload>({
     mutationFn: (vars) => updateVercelConnection(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(
-        integrationKeys.vercelConnectionsList(variables.organizationIntegrationId)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: integrationKeys.vercelConnectionsList(variables.organizationIntegrationId),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/integrations/vercel-integration-create-mutation.ts
+++ b/apps/studio/data/integrations/vercel-integration-create-mutation.ts
@@ -56,9 +56,11 @@ export const useVercelIntegrationCreateMutation = ({
     mutationFn: (vars) => createVercelIntegration(vars),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(integrationKeys.integrationsList()),
-        queryClient.invalidateQueries(integrationKeys.integrationsListWithOrg(variables.orgSlug)),
-        queryClient.invalidateQueries(integrationKeys.vercelProjectList(data.id)),
+        queryClient.invalidateQueries({ queryKey: integrationKeys.integrationsList() }),
+        queryClient.invalidateQueries({
+          queryKey: integrationKeys.integrationsListWithOrg(variables.orgSlug),
+        }),
+        queryClient.invalidateQueries({ queryKey: integrationKeys.vercelProjectList(data.id) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/invoices/invoice-payment-link-mutation.ts
+++ b/apps/studio/data/invoices/invoice-payment-link-mutation.ts
@@ -48,7 +48,9 @@ export const useInvoicePaymentLinkGetMutation = ({
     mutationFn: (vars) => updateInvoicePaymentLink(vars),
     async onError(error, variables, context) {
       // In case of an error, there is a good chance that the invoice status has changed, so we invalidate the cache to reflect the updated status
-      await Promise.all([queryClient.invalidateQueries(invoicesKeys.listAndCount(variables.slug))])
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: invoicesKeys.listAndCount(variables.slug) }),
+      ])
 
       if (onError === undefined) {
         toast.error(error.message)

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-key-create-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-key-create-mutation.ts
@@ -48,7 +48,7 @@ export const useJWTSigningKeyCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(jwtSigningKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: jwtSigningKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-key-delete-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-key-delete-mutation.ts
@@ -40,7 +40,7 @@ export const useJWTSigningKeyDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(jwtSigningKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: jwtSigningKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-key-update-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-key-update-mutation.ts
@@ -44,7 +44,7 @@ export const useJWTSigningKeyUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(jwtSigningKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: jwtSigningKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/jwt-signing-keys/legacy-jwt-signing-key-create-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/legacy-jwt-signing-key-create-mutation.ts
@@ -47,9 +47,9 @@ export const useLegacyJWTSigningKeyCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(jwtSigningKeysKeys.legacy(projectRef))
+      await queryClient.invalidateQueries({ queryKey: jwtSigningKeysKeys.legacy(projectRef) })
       // invalidate the keys as well since migration creates 2 new keys and the UI needs to be refreshed
-      await queryClient.invalidateQueries(jwtSigningKeysKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: jwtSigningKeysKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/lint/create-lint-rule-mutation.ts
+++ b/apps/studio/data/lint/create-lint-rule-mutation.ts
@@ -41,8 +41,8 @@ export const useLintRuleCreateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await Promise.all([
-        queryClient.invalidateQueries(lintKeys.lintRules(projectRef)),
-        queryClient.invalidateQueries(lintKeys.lint(projectRef)),
+        queryClient.invalidateQueries({ queryKey: lintKeys.lintRules(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/lint/delete-lint-rule-mutation.ts
+++ b/apps/studio/data/lint/delete-lint-rule-mutation.ts
@@ -35,8 +35,8 @@ export const useLintRuleDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await Promise.all([
-        queryClient.invalidateQueries(lintKeys.lintRules(projectRef)),
-        queryClient.invalidateQueries(lintKeys.lint(projectRef)),
+        queryClient.invalidateQueries({ queryKey: lintKeys.lintRules(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/log-drains/create-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/create-log-drain-mutation.ts
@@ -46,7 +46,7 @@ export const useCreateLogDrainMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(logDrainsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: logDrainsKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/log-drains/delete-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/delete-log-drain-mutation.ts
@@ -37,7 +37,7 @@ export const useDeleteLogDrainMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(logDrainsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: logDrainsKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/log-drains/update-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/update-log-drain-mutation.ts
@@ -51,7 +51,7 @@ export const useUpdateLogDrainMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      await queryClient.invalidateQueries(logDrainsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: logDrainsKeys.list(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -161,25 +161,23 @@ export const useUnifiedLogsInfiniteQuery = <TData = UnifiedLogsData>(
     ...options
   }: UseInfiniteQueryOptions<UnifiedLogsData, UnifiedLogsError, TData> = {}
 ) => {
-  return useInfiniteQuery<UnifiedLogsData, UnifiedLogsError, TData>(
-    logsKeys.unifiedLogsInfinite(projectRef, search),
-    ({ signal, pageParam }) => {
+  return useInfiniteQuery<UnifiedLogsData, UnifiedLogsError, TData>({
+    queryKey: logsKeys.unifiedLogsInfinite(projectRef, search),
+    queryFn: ({ signal, pageParam }) => {
       return getUnifiedLogs({ projectRef, search, pageParam }, signal)
     },
-    {
-      enabled: enabled && typeof projectRef !== 'undefined',
-      keepPreviousData: true,
-      getPreviousPageParam: (firstPage) => {
-        if (!firstPage.prevCursor) return null
-        const result = { cursor: firstPage.prevCursor, direction: 'prev' }
-        return result
-      },
-      getNextPageParam(lastPage) {
-        if (!lastPage.nextCursor || lastPage.data.length === 0) return null
-        return { cursor: lastPage.nextCursor, direction: 'next' }
-      },
-      ...UNIFIED_LOGS_QUERY_OPTIONS,
-      ...options,
-    }
-  )
+    enabled: enabled && typeof projectRef !== 'undefined',
+    keepPreviousData: true,
+    getPreviousPageParam: (firstPage) => {
+      if (!firstPage.prevCursor) return null
+      const result = { cursor: firstPage.prevCursor, direction: 'prev' }
+      return result
+    },
+    getNextPageParam(lastPage) {
+      if (!lastPage.nextCursor || lastPage.data.length === 0) return null
+      return { cursor: lastPage.nextCursor, direction: 'next' }
+    },
+    ...UNIFIED_LOGS_QUERY_OPTIONS,
+    ...options,
+  })
 }

--- a/apps/studio/data/network-restrictions/network-retrictions-apply-mutation.ts
+++ b/apps/studio/data/network-restrictions/network-retrictions-apply-mutation.ts
@@ -51,7 +51,7 @@ export const useNetworkRestrictionsApplyMutation = ({
     mutationFn: (vars) => applyNetworkRestrictions(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(networkRestrictionKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: networkRestrictionKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/notifications/notifications-v2-archive-all-mutation.ts
+++ b/apps/studio/data/notifications/notifications-v2-archive-all-mutation.ts
@@ -25,7 +25,7 @@ export const useNotificationsArchiveAllMutation = ({
   return useMutation<NotificationsArchiveAllData, ResponseError>({
     mutationFn: () => archiveAllNotifications(),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(notificationKeys.list())
+      await queryClient.invalidateQueries({ queryKey: notificationKeys.list() })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/notifications/notifications-v2-query.ts
+++ b/apps/studio/data/notifications/notifications-v2-query.ts
@@ -68,18 +68,16 @@ export const useNotificationsV2Query = <TData = NotificationsData>(
     ...options
   }: UseInfiniteQueryOptions<NotificationsData, NotificationsError, TData> = {}
 ) => {
-  return useInfiniteQuery<NotificationsData, NotificationsError, TData>(
-    notificationKeys.listV2({ status, filters, limit }),
-    ({ signal, pageParam }) =>
+  return useInfiniteQuery<NotificationsData, NotificationsError, TData>({
+    queryKey: notificationKeys.listV2({ status, filters, limit }),
+    queryFn: ({ signal, pageParam }) =>
       getNotifications({ status, filters, limit, page: pageParam }, signal),
-    {
-      enabled: enabled,
-      getNextPageParam(lastPage, pages) {
-        const page = pages.length
-        if ((lastPage ?? []).length < limit) return undefined
-        return page
-      },
-      ...options,
-    }
-  )
+    enabled: enabled,
+    getNextPageParam(lastPage, pages) {
+      const page = pages.length
+      if ((lastPage ?? []).length < limit) return undefined
+      return page
+    },
+    ...options,
+  })
 }

--- a/apps/studio/data/notifications/notifications-v2-update-mutation.ts
+++ b/apps/studio/data/notifications/notifications-v2-update-mutation.ts
@@ -34,7 +34,7 @@ export const useNotificationsV2UpdateMutation = ({
   return useMutation<NotificationsUpdateData, ResponseError, NotificationsUpdateVariables>({
     mutationFn: (vars) => updateNotifications(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(['notifications'])
+      await queryClient.invalidateQueries({ queryKey: ['notifications'] })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/oauth-secrets/client-secret-create-mutation.ts
+++ b/apps/studio/data/oauth-secrets/client-secret-create-mutation.ts
@@ -32,7 +32,7 @@ export const useClientSecretCreateMutation = ({
     mutationFn: (vars) => createClientSecret(vars),
     async onSuccess(data, variables, context) {
       const { slug, appId } = variables
-      await queryClient.invalidateQueries(clientSecretKeys.list(slug, appId))
+      await queryClient.invalidateQueries({ queryKey: clientSecretKeys.list(slug, appId) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/oauth-secrets/client-secret-delete-mutation.ts
+++ b/apps/studio/data/oauth-secrets/client-secret-delete-mutation.ts
@@ -33,7 +33,7 @@ export const useClientSecretDeleteMutation = ({
     mutationFn: (vars) => deleteClientSecret(vars),
     async onSuccess(data, variables, context) {
       const { slug, appId } = variables
-      await queryClient.invalidateQueries(clientSecretKeys.list(slug, appId))
+      await queryClient.invalidateQueries({ queryKey: clientSecretKeys.list(slug, appId) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/oauth/authorized-app-revoke-mutation.ts
+++ b/apps/studio/data/oauth/authorized-app-revoke-mutation.ts
@@ -38,7 +38,7 @@ export const useAuthorizedAppRevokeMutation = ({
     mutationFn: (vars) => revokeAuthorizedApp(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(oauthAppKeys.authorizedApps(slug))
+      await queryClient.invalidateQueries({ queryKey: oauthAppKeys.authorizedApps(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/oauth/oauth-app-create-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-create-mutation.ts
@@ -57,7 +57,7 @@ export const useOAuthAppCreateMutation = ({
     mutationFn: (vars) => createOAuthApp(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(oauthAppKeys.oauthApps(slug))
+      await queryClient.invalidateQueries({ queryKey: oauthAppKeys.oauthApps(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/oauth/oauth-app-delete-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-delete-mutation.ts
@@ -38,7 +38,7 @@ export const useOAuthAppDeleteMutation = ({
     mutationFn: (vars) => deleteOAuthApp(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(oauthAppKeys.oauthApps(slug))
+      await queryClient.invalidateQueries({ queryKey: oauthAppKeys.oauthApps(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/oauth/oauth-app-update-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-update-mutation.ts
@@ -2,9 +2,9 @@ import type { OAuthScope } from '@supabase/shared-types/out/constants'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, put } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
-import { handleError, put } from 'data/fetchers'
 
 export type OAuthAppUpdateVariables = {
   id: string
@@ -61,7 +61,7 @@ export const useOAuthAppUpdateMutation = ({
     mutationFn: (vars) => updateOAuthApp(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(oauthAppKeys.oauthApps(slug))
+      await queryClient.invalidateQueries({ queryKey: oauthAppKeys.oauthApps(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/organization-members/organization-invitation-create-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-create-mutation.ts
@@ -58,8 +58,8 @@ export const useOrganizationCreateInvitationMutation = ({
       const { slug } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),
-        queryClient.invalidateQueries(organizationKeysV1.members(slug)),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.rolesV2(slug) }),
+        queryClient.invalidateQueries({ queryKey: organizationKeysV1.members(slug) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/organization-members/organization-invitation-delete-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-delete-mutation.ts
@@ -51,8 +51,8 @@ export const useOrganizationDeleteInvitationMutation = ({
 
       if (!skipInvalidation) {
         await Promise.all([
-          queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),
-          queryClient.invalidateQueries(organizationKeysV1.members(slug)),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.rolesV2(slug) }),
+          queryClient.invalidateQueries({ queryKey: organizationKeysV1.members(slug) }),
         ])
       }
 

--- a/apps/studio/data/organization-members/organization-member-role-assign-mutation.ts
+++ b/apps/studio/data/organization-members/organization-member-role-assign-mutation.ts
@@ -61,8 +61,8 @@ export const useOrganizationMemberAssignRoleMutation = ({
 
       if (!skipInvalidation) {
         await Promise.all([
-          queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),
-          queryClient.invalidateQueries(organizationKeysV1.members(slug)),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.rolesV2(slug) }),
+          queryClient.invalidateQueries({ queryKey: organizationKeysV1.members(slug) }),
         ])
       }
 

--- a/apps/studio/data/organization-members/organization-member-role-unassign-mutation.ts
+++ b/apps/studio/data/organization-members/organization-member-role-unassign-mutation.ts
@@ -62,8 +62,8 @@ export const useOrganizationMemberUnassignRoleMutation = ({
 
       if (!skipInvalidation) {
         await Promise.all([
-          queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),
-          queryClient.invalidateQueries(organizationKeysV1.members(slug)),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.rolesV2(slug) }),
+          queryClient.invalidateQueries({ queryKey: organizationKeysV1.members(slug) }),
         ])
       }
 

--- a/apps/studio/data/organization-members/organization-member-role-update-mutation.ts
+++ b/apps/studio/data/organization-members/organization-member-role-update-mutation.ts
@@ -61,8 +61,8 @@ export const useOrganizationMemberUpdateRoleMutation = ({
 
       if (!skipInvalidation) {
         await Promise.all([
-          queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),
-          queryClient.invalidateQueries(organizationKeysV1.members(slug)),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.rolesV2(slug) }),
+          queryClient.invalidateQueries({ queryKey: organizationKeysV1.members(slug) }),
         ])
       }
 

--- a/apps/studio/data/organizations/organization-create-mutation.ts
+++ b/apps/studio/data/organizations/organization-create-mutation.ts
@@ -76,7 +76,7 @@ export const useOrganizationCreateMutation = ({
           }
         )
 
-        await queryClient.invalidateQueries(permissionKeys.list())
+        await queryClient.invalidateQueries({ queryKey: permissionKeys.list() })
       }
 
       await onSuccess?.(data, variables, context)
@@ -156,7 +156,7 @@ export const useAwsManagedOrganizationCreateMutation = ({
           }
         )
 
-        await queryClient.invalidateQueries(permissionKeys.list())
+        await queryClient.invalidateQueries({ queryKey: permissionKeys.list() })
       }
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/organizations/organization-customer-profile-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-customer-profile-update-mutation.ts
@@ -62,14 +62,17 @@ export const useOrganizationCustomerProfileUpdateMutation = ({
       const { address, slug, billing_name } = variables
 
       // We do not invalidate here as GET endpoint data is stale for 1-2 seconds, so we handle state manually
-      queryClient.setQueriesData(organizationKeys.customerProfile(slug), (prev: any) => {
-        if (!prev) return prev
-        return {
-          ...prev,
-          billing_name,
-          address,
+      queryClient.setQueriesData(
+        { queryKey: organizationKeys.customerProfile(slug) },
+        (prev: any) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            billing_name,
+            address,
+          }
         }
-      })
+      )
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/organizations/organization-delete-mutation.ts
+++ b/apps/studio/data/organizations/organization-delete-mutation.ts
@@ -34,8 +34,8 @@ export const useOrganizationDeleteMutation = ({
     mutationFn: (vars) => deleteOrganization(vars),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(organizationKeys.list()),
-        queryClient.invalidateQueries(permissionKeys.list()),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.list() }),
+        queryClient.invalidateQueries({ queryKey: permissionKeys.list() }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/organizations/organization-member-delete-mutation.ts
+++ b/apps/studio/data/organizations/organization-member-delete-mutation.ts
@@ -47,8 +47,8 @@ export const useOrganizationMemberDeleteMutation = ({
       const { slug } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(organizationKeys.members(slug)),
-        queryClient.invalidateQueries(organizationKeys.roles(slug)),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.members(slug) }),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.roles(slug) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/organizations/organization-payment-method-default-mutation.ts
+++ b/apps/studio/data/organizations/organization-payment-method-default-mutation.ts
@@ -52,14 +52,17 @@ export const useOrganizationPaymentMethodMarkAsDefaultMutation = ({
     async onSuccess(data, variables, context) {
       const { slug, paymentMethodId } = variables
       // We do not invalidate payment methods here as endpoint data is stale for 1-2 seconds, so we handle state manually
-      queryClient.setQueriesData(organizationKeys.paymentMethods(slug), (prev: any) => {
-        if (!prev) return prev
-        return {
-          ...prev,
-          defaultPaymentMethodId: paymentMethodId,
-          data: prev.data.map((pm: any) => ({ ...pm, is_default: pm.id === paymentMethodId })),
+      queryClient.setQueriesData(
+        { queryKey: organizationKeys.paymentMethods(slug) },
+        (prev: any) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            defaultPaymentMethodId: paymentMethodId,
+            data: prev.data.map((pm: any) => ({ ...pm, is_default: pm.id === paymentMethodId })),
+          }
         }
-      })
+      )
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/organizations/organization-payment-method-delete-mutation.ts
+++ b/apps/studio/data/organizations/organization-payment-method-delete-mutation.ts
@@ -52,7 +52,7 @@ export const useOrganizationPaymentMethodDeleteMutation = ({
     mutationFn: (vars) => deletePaymentMethod(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(organizationKeys.paymentMethods(slug))
+      await queryClient.invalidateQueries({ queryKey: organizationKeys.paymentMethods(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/organizations/organizations-query.ts
+++ b/apps/studio/data/organizations/organizations-query.ts
@@ -64,5 +64,5 @@ export const useOrganizationsQuery = <TData = OrganizationsData>({
 }
 
 export function invalidateOrganizationsQuery(client: QueryClient) {
-  return client.invalidateQueries(organizationKeys.list())
+  return client.invalidateQueries({ queryKey: organizationKeys.list() })
 }

--- a/apps/studio/data/privileges/column-privileges-grant-mutation.ts
+++ b/apps/studio/data/privileges/column-privileges-grant-mutation.ts
@@ -60,7 +60,7 @@ export const useColumnPrivilegesGrantMutation = ({
       const { projectRef } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(privilegeKeys.columnPrivilegesList(projectRef)),
+        queryClient.invalidateQueries({ queryKey: privilegeKeys.columnPrivilegesList(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/privileges/column-privileges-revoke-mutation.ts
+++ b/apps/studio/data/privileges/column-privileges-revoke-mutation.ts
@@ -58,7 +58,7 @@ export const useColumnPrivilegesRevokeMutation = ({
       const { projectRef } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(privilegeKeys.columnPrivilegesList(projectRef)),
+        queryClient.invalidateQueries({ queryKey: privilegeKeys.columnPrivilegesList(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/privileges/table-privileges-grant-mutation.ts
+++ b/apps/studio/data/privileges/table-privileges-grant-mutation.ts
@@ -4,8 +4,8 @@ import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
-import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 import { privilegeKeys } from './keys'
+import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 
 export type TablePrivilegesGrant = Parameters<
   typeof pgMeta.tablePrivileges.grant
@@ -53,7 +53,7 @@ export const useTablePrivilegesGrantMutation = ({
 
       await Promise.all([
         invalidateTablePrivilegesQuery(queryClient, projectRef),
-        queryClient.invalidateQueries(privilegeKeys.columnPrivilegesList(projectRef)),
+        queryClient.invalidateQueries({ queryKey: privilegeKeys.columnPrivilegesList(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/privileges/table-privileges-revoke-mutation.ts
+++ b/apps/studio/data/privileges/table-privileges-revoke-mutation.ts
@@ -4,8 +4,8 @@ import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
-import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 import { privilegeKeys } from './keys'
+import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 
 export type TablePrivilegesRevoke = Parameters<
   typeof pgMeta.tablePrivileges.revoke
@@ -53,7 +53,7 @@ export const useTablePrivilegesRevokeMutation = ({
 
       await Promise.all([
         invalidateTablePrivilegesQuery(queryClient, projectRef),
-        queryClient.invalidateQueries(privilegeKeys.columnPrivilegesList(projectRef)),
+        queryClient.invalidateQueries({ queryKey: privilegeKeys.columnPrivilegesList(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts
+++ b/apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts
@@ -41,8 +41,10 @@ export const useMfaChallengeAndVerifyMutation = ({
       const refreshFactors = variables.refreshFactors ?? true
 
       await Promise.all([
-        ...(refreshFactors ? [queryClient.invalidateQueries(profileKeys.mfaFactors())] : []),
-        queryClient.invalidateQueries(profileKeys.aaLevel()),
+        ...(refreshFactors
+          ? [queryClient.invalidateQueries({ queryKey: profileKeys.mfaFactors() })]
+          : []),
+        queryClient.invalidateQueries({ queryKey: profileKeys.aaLevel() }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/profile/mfa-unenroll-mutation.ts
+++ b/apps/studio/data/profile/mfa-unenroll-mutation.ts
@@ -29,8 +29,8 @@ export const useMfaUnenrollMutation = ({
     async onSuccess(data, variables, context) {
       // when a factor is unenrolled, the aaLevel is bumped down if it's the last factor
       await Promise.all([
-        queryClient.invalidateQueries(profileKeys.mfaFactors()),
-        queryClient.invalidateQueries(profileKeys.aaLevel()),
+        queryClient.invalidateQueries({ queryKey: profileKeys.mfaFactors() }),
+        queryClient.invalidateQueries({ queryKey: profileKeys.aaLevel() }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/profile/profile-create-mutation.ts
+++ b/apps/studio/data/profile/profile-create-mutation.ts
@@ -30,9 +30,9 @@ export const useProfileCreateMutation = ({
     mutationFn: () => createProfile(),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(profileKeys.profile()),
-        queryClient.invalidateQueries(organizationKeys.list()),
-        queryClient.invalidateQueries(permissionKeys.list()),
+        queryClient.invalidateQueries({ queryKey: profileKeys.profile() }),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.list() }),
+        queryClient.invalidateQueries({ queryKey: permissionKeys.list() }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/profile/profile-unlink-identity-mutation.ts
+++ b/apps/studio/data/profile/profile-unlink-identity-mutation.ts
@@ -29,7 +29,7 @@ export const useUnlinkIdentityMutation = ({
     async onSuccess(data, variables, context) {
       await Promise.all([
         auth.refreshSession(),
-        queryClient.invalidateQueries(profileKeys.identities()),
+        queryClient.invalidateQueries({ queryKey: profileKeys.identities() }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/profile/profile-update-email-mutation.ts
+++ b/apps/studio/data/profile/profile-update-email-mutation.ts
@@ -37,7 +37,7 @@ export const useEmailUpdateMutation = ({
     async onSuccess(data, variables, context) {
       await Promise.all([
         auth.refreshSession(),
-        queryClient.invalidateQueries(profileKeys.profile()),
+        queryClient.invalidateQueries({ queryKey: profileKeys.profile() }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/profile/profile-update-mutation.ts
+++ b/apps/studio/data/profile/profile-update-mutation.ts
@@ -46,7 +46,7 @@ export const useProfileUpdateMutation = ({
   return useMutation<ProfileUpdateData, ResponseError, ProfileUpdateVariables>({
     mutationFn: (vars) => updateProfile(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(profileKeys.profile())
+      await queryClient.invalidateQueries({ queryKey: profileKeys.profile() })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/projects/org-projects-infinite-query.ts
+++ b/apps/studio/data/projects/org-projects-infinite-query.ts
@@ -72,6 +72,7 @@ export const useOrgProjectsInfiniteQuery = <TData = OrgProjectsInfiniteData>(
     queryKey: projectKeys.infiniteListByOrg(slug, { limit, sort, search, statuses }),
     queryFn: ({ signal, pageParam }) =>
       getOrganizationProjects({ slug, limit, page: pageParam, sort, search, statuses }, signal),
+    enabled: enabled && profile !== undefined && typeof slug !== 'undefined',
     staleTime: 30 * 60 * 1000, // 30 minutes
     getNextPageParam(lastPage, pages) {
       const page = pages.length

--- a/apps/studio/data/projects/org-projects-infinite-query.ts
+++ b/apps/studio/data/projects/org-projects-infinite-query.ts
@@ -98,8 +98,8 @@ export const useInvalidateProjectsInfiniteQuery = () => {
   const invalidateProjectsQuery = () => {
     // [Joshen] Temporarily for completeness while we still have UIs depending on the old endpoint (Org teams)
     // Can be removed once we completely deprecate projects-query (Old unpaginated endpoint)
-    queryClient.invalidateQueries(projectKeys.list())
-    return queryClient.invalidateQueries([INFINITE_PROJECTS_KEY_PREFIX])
+    queryClient.invalidateQueries({ queryKey: projectKeys.list() })
+    return queryClient.invalidateQueries({ queryKey: [INFINITE_PROJECTS_KEY_PREFIX] })
   }
   return { invalidateProjectsQuery }
 }

--- a/apps/studio/data/projects/org-projects-infinite-query.ts
+++ b/apps/studio/data/projects/org-projects-infinite-query.ts
@@ -68,24 +68,21 @@ export const useOrgProjectsInfiniteQuery = <TData = OrgProjectsInfiniteData>(
   }: UseInfiniteQueryOptions<OrgProjectsInfiniteData, OrgProjectsInfiniteError, TData> = {}
 ) => {
   const { profile } = useProfile()
-  return useInfiniteQuery<OrgProjectsInfiniteData, OrgProjectsInfiniteError, TData>(
-    projectKeys.infiniteListByOrg(slug, { limit, sort, search, statuses }),
-    ({ signal, pageParam }) =>
+  return useInfiniteQuery<OrgProjectsInfiniteData, OrgProjectsInfiniteError, TData>({
+    queryKey: projectKeys.infiniteListByOrg(slug, { limit, sort, search, statuses }),
+    queryFn: ({ signal, pageParam }) =>
       getOrganizationProjects({ slug, limit, page: pageParam, sort, search, statuses }, signal),
-    {
-      enabled: enabled && profile !== undefined && typeof slug !== 'undefined',
-      staleTime: 30 * 60 * 1000, // 30 minutes
-      getNextPageParam(lastPage, pages) {
-        const page = pages.length
-        const currentTotalCount = page * limit
-        const totalCount = lastPage.pagination.count
+    staleTime: 30 * 60 * 1000, // 30 minutes
+    getNextPageParam(lastPage, pages) {
+      const page = pages.length
+      const currentTotalCount = page * limit
+      const totalCount = lastPage.pagination.count
 
-        if (currentTotalCount >= totalCount) return undefined
-        return page
-      },
-      ...options,
-    }
-  )
+      if (currentTotalCount >= totalCount) return undefined
+      return page
+    },
+    ...options,
+  })
 }
 
 export const getComputeSize = (project: OrgProject) => {

--- a/apps/studio/data/projects/project-create-mutation.ts
+++ b/apps/studio/data/projects/project-create-mutation.ts
@@ -99,8 +99,10 @@ export const useProjectCreateMutation = ({
     mutationFn: (vars) => createProject(vars),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(projectKeys.list()),
-        queryClient.invalidateQueries(projectKeys.infiniteListByOrg(variables.organizationSlug)),
+        queryClient.invalidateQueries({ queryKey: projectKeys.list() }),
+        queryClient.invalidateQueries({
+          queryKey: projectKeys.infiniteListByOrg(variables.organizationSlug),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/projects/project-delete-mutation.ts
+++ b/apps/studio/data/projects/project-delete-mutation.ts
@@ -36,19 +36,25 @@ export const useProjectDeleteMutation = ({
     mutationFn: (vars) => deleteProject(vars),
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries(projectKeys.list()),
-        queryClient.invalidateQueries(projectKeys.detail(data.ref)),
+        queryClient.invalidateQueries({ queryKey: projectKeys.list() }),
+        queryClient.invalidateQueries({ queryKey: projectKeys.detail(data.ref) }),
       ])
 
       if (variables.organizationSlug) {
         await Promise.all([
-          queryClient.invalidateQueries(projectKeys.infiniteListByOrg(variables.organizationSlug)),
-          queryClient.invalidateQueries(organizationKeys.detail(variables.organizationSlug)),
-          queryClient.invalidateQueries(projectKeys.orgProjects(variables.organizationSlug)),
+          queryClient.invalidateQueries({
+            queryKey: projectKeys.infiniteListByOrg(variables.organizationSlug),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: organizationKeys.detail(variables.organizationSlug),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: projectKeys.orgProjects(variables.organizationSlug),
+          }),
 
-          queryClient.invalidateQueries(
-            organizationKeys.freeProjectLimitCheck(variables.organizationSlug)
-          ),
+          queryClient.invalidateQueries({
+            queryKey: organizationKeys.freeProjectLimitCheck(variables.organizationSlug),
+          }),
         ])
       }
 

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -84,7 +84,7 @@ export const useSetProjectPostgrestStatus = () => {
 
   const setProjectPostgrestStatus = (ref: Project['ref'], status: Project['postgrestStatus']) => {
     return queryClient.setQueriesData<Project>(
-      projectKeys.detail(ref),
+      { queryKey: projectKeys.detail(ref) },
       (old) => {
         if (!old) return old
         return { ...old, postgrestStatus: status }
@@ -111,7 +111,7 @@ export const useSetProjectStatus = () => {
     // Org projects infinite query
     if (slug) {
       queryClient.setQueriesData<{ pageParams: any; pages: OrgProjectsResponse[] } | undefined>(
-        projectKeys.infiniteListByOrg(slug),
+        { queryKey: projectKeys.infiniteListByOrg(slug) },
         (old) => {
           if (!old) return old
           return {
@@ -132,7 +132,7 @@ export const useSetProjectStatus = () => {
 
     // Projects infinite query
     queryClient.setQueriesData<{ pageParams: any; pages: OrgProjectsResponse[] } | undefined>(
-      projectKeys.infiniteList(),
+      { queryKey: projectKeys.infiniteList() },
       (old) => {
         if (!old) return old
         return {
@@ -152,7 +152,7 @@ export const useSetProjectStatus = () => {
 
     // Project details query
     queryClient.setQueriesData<Project>(
-      projectKeys.detail(ref),
+      { queryKey: projectKeys.detail(ref) },
       (old) => {
         if (!old) return old
         return { ...old, status }
@@ -163,7 +163,7 @@ export const useSetProjectStatus = () => {
     // [Joshen] Temporarily for completeness while we still have UIs depending on the old endpoint (Org teams)
     // Can be removed once we completely deprecate projects-query (Old unpaginated endpoint)
     queryClient.setQueriesData<PaginatedProjectsResponse | undefined>(
-      projectKeys.list(),
+      { queryKey: projectKeys.list() },
       (old) => {
         if (!old) return old
 

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -73,7 +73,7 @@ export const useInvalidateProjectDetailsQuery = () => {
   const queryClient = useQueryClient()
 
   const invalidateProjectDetailsQuery = (ref: string) => {
-    return queryClient.invalidateQueries(projectKeys.detail(ref))
+    return queryClient.invalidateQueries({ queryKey: projectKeys.detail(ref) })
   }
 
   return { invalidateProjectDetailsQuery }

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -64,9 +64,10 @@ export const useProjectDetailQuery = <TData = ProjectDetailData>(
   })
 
 export function prefetchProjectDetail(client: QueryClient, { ref }: ProjectDetailVariables) {
-  return client.fetchQuery(projectKeys.detail(ref), ({ signal }) =>
-    getProjectDetail({ ref }, signal)
-  )
+  return client.fetchQuery({
+    queryKey: projectKeys.detail(ref),
+    queryFn: ({ signal }) => getProjectDetail({ ref }, signal),
+  })
 }
 
 export const useInvalidateProjectDetailsQuery = () => {

--- a/apps/studio/data/projects/project-transfer-mutation.ts
+++ b/apps/studio/data/projects/project-transfer-mutation.ts
@@ -46,11 +46,11 @@ export const useProjectTransferMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, targetOrganizationSlug } = variables
       await Promise.all([
-        queryClient.invalidateQueries(
-          projectKeys.projectTransferPreview(projectRef, targetOrganizationSlug)
-        ),
-        queryClient.invalidateQueries(projectKeys.detail(projectRef)),
-        queryClient.invalidateQueries(projectKeys.list()),
+        queryClient.invalidateQueries({
+          queryKey: projectKeys.projectTransferPreview(projectRef, targetOrganizationSlug),
+        }),
+        queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: projectKeys.list() }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/projects/project-update-mutation.ts
+++ b/apps/studio/data/projects/project-update-mutation.ts
@@ -42,8 +42,8 @@ export const useProjectUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { ref } = variables
       await Promise.all([
-        queryClient.invalidateQueries(projectKeys.list()),
-        queryClient.invalidateQueries(projectKeys.detail(ref)),
+        queryClient.invalidateQueries({ queryKey: projectKeys.list() }),
+        queryClient.invalidateQueries({ queryKey: projectKeys.detail(ref) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/projects/projects-infinite-query.ts
+++ b/apps/studio/data/projects/projects-infinite-query.ts
@@ -53,22 +53,21 @@ export const useProjectsInfiniteQuery = <TData = ProjectsInfiniteData>(
   }: UseInfiniteQueryOptions<ProjectsInfiniteData, ProjectsInfiniteError, TData> = {}
 ) => {
   const { profile } = useProfile()
-  return useInfiniteQuery<ProjectsInfiniteData, ProjectsInfiniteError, TData>(
-    projectKeys.infiniteList({ limit, sort, search }),
-    ({ signal, pageParam }) => getProjects({ limit, page: pageParam, sort, search }, signal),
-    {
-      enabled: enabled && profile !== undefined,
-      staleTime: 30 * 60 * 1000, // 30 minutes
-      getNextPageParam(lastPage, pages) {
-        const page = pages.length
-        const currentTotalCount = page * limit
-        // @ts-ignore [Joshen] API type issue for Version 2 endpoints
-        const totalCount = lastPage.pagination.count
+  return useInfiniteQuery<ProjectsInfiniteData, ProjectsInfiniteError, TData>({
+    queryKey: projectKeys.infiniteList({ limit, sort, search }),
+    queryFn: ({ signal, pageParam }) =>
+      getProjects({ limit, page: pageParam, sort, search }, signal),
+    enabled: enabled && profile !== undefined,
+    staleTime: 30 * 60 * 1000, // 30 minutes
+    getNextPageParam(lastPage, pages) {
+      const page = pages.length
+      const currentTotalCount = page * limit
+      // @ts-ignore [Joshen] API type issue for Version 2 endpoints
+      const totalCount = lastPage.pagination.count
 
-        if (currentTotalCount >= totalCount) return undefined
-        return page
-      },
-      ...options,
-    }
-  )
+      if (currentTotalCount >= totalCount) return undefined
+      return page
+    },
+    ...options,
+  })
 }

--- a/apps/studio/data/read-replicas/replica-remove-mutation.ts
+++ b/apps/studio/data/read-replicas/replica-remove-mutation.ts
@@ -42,8 +42,8 @@ export const useReadReplicaRemoveMutation = ({
 
       if (invalidateReplicaQueries) {
         await Promise.all([
-          queryClient.invalidateQueries(replicaKeys.list(projectRef)),
-          queryClient.invalidateQueries(replicaKeys.loadBalancers(projectRef)),
+          queryClient.invalidateQueries({ queryKey: replicaKeys.list(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: replicaKeys.loadBalancers(projectRef) }),
         ])
       }
 

--- a/apps/studio/data/read-replicas/replica-setup-mutation.ts
+++ b/apps/studio/data/read-replicas/replica-setup-mutation.ts
@@ -55,7 +55,7 @@ export const useReadReplicaSetUpMutation = ({
     mutationFn: (vars) => setUpReadReplica(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(replicaKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: replicaKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/realtime/realtime-config-mutation.ts
+++ b/apps/studio/data/realtime/realtime-config-mutation.ts
@@ -69,7 +69,7 @@ export const useRealtimeConfigurationUpdateMutation = ({
     mutationFn: (vars) => updateRealtimeConfiguration(vars),
     async onSuccess(data, variables, context) {
       const { ref } = variables
-      await queryClient.invalidateQueries(realtimeKeys.configuration(ref))
+      await queryClient.invalidateQueries({ queryKey: realtimeKeys.configuration(ref) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.ts
@@ -133,8 +133,8 @@ export const useCreateDestinationPipelineMutation = ({
         const { projectRef } = variables
 
         await Promise.all([
-          queryClient.invalidateQueries(replicationKeys.destinations(projectRef)),
-          queryClient.invalidateQueries(replicationKeys.pipelines(projectRef)),
+          queryClient.invalidateQueries({ queryKey: replicationKeys.destinations(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: replicationKeys.pipelines(projectRef) }),
         ])
 
         await onSuccess?.(data, variables, context)

--- a/apps/studio/data/replication/create-publication-mutation.ts
+++ b/apps/studio/data/replication/create-publication-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { replicationKeys } from './keys'
-import { handleError, post } from 'data/fetchers'
 
 export type CreatePublicationParams = {
   projectRef: string
@@ -49,7 +49,9 @@ export const useCreatePublicationMutation = ({
     mutationFn: (vars) => createPublication(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, sourceId } = variables
-      await queryClient.invalidateQueries(replicationKeys.publications(projectRef, sourceId))
+      await queryClient.invalidateQueries({
+        queryKey: replicationKeys.publications(projectRef, sourceId),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/replication/create-tenant-source-mutation.ts
+++ b/apps/studio/data/replication/create-tenant-source-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { replicationKeys } from './keys'
-import { handleError, post } from 'data/fetchers'
 
 export type CreateTenantSourceParams = {
   projectRef: string
@@ -39,7 +39,7 @@ export const useCreateTenantSourceMutation = ({
     mutationFn: (vars) => createTenantSource(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(replicationKeys.sources(projectRef))
+      await queryClient.invalidateQueries({ queryKey: replicationKeys.sources(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/replication/delete-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/delete-destination-pipeline-mutation.ts
@@ -50,14 +50,20 @@ export const useDeleteDestinationPipelineMutation = ({
         const { projectRef, destinationId, pipelineId } = variables
 
         await Promise.all([
-          queryClient.invalidateQueries(replicationKeys.destinations(projectRef)),
-          queryClient.invalidateQueries(replicationKeys.pipelines(projectRef)),
-          queryClient.invalidateQueries(replicationKeys.pipelineById(projectRef, pipelineId)),
-          queryClient.invalidateQueries(replicationKeys.pipelinesStatus(projectRef, pipelineId)),
-          queryClient.invalidateQueries(
-            replicationKeys.pipelinesReplicationStatus(projectRef, pipelineId)
-          ),
-          queryClient.invalidateQueries(replicationKeys.destinationById(projectRef, destinationId)),
+          queryClient.invalidateQueries({ queryKey: replicationKeys.destinations(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: replicationKeys.pipelines(projectRef) }),
+          queryClient.invalidateQueries({
+            queryKey: replicationKeys.pipelineById(projectRef, pipelineId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: replicationKeys.pipelinesStatus(projectRef, pipelineId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: replicationKeys.pipelinesReplicationStatus(projectRef, pipelineId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: replicationKeys.destinationById(projectRef, destinationId),
+          }),
         ])
 
         await onSuccess?.(data, variables, context)

--- a/apps/studio/data/replication/rollback-table-mutation.ts
+++ b/apps/studio/data/replication/rollback-table-mutation.ts
@@ -62,10 +62,12 @@ export const useRollbackTableMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, pipelineId } = variables
       await Promise.all([
-        queryClient.invalidateQueries(replicationKeys.pipelinesStatus(projectRef, pipelineId)),
-        queryClient.invalidateQueries(
-          replicationKeys.pipelinesReplicationStatus(projectRef, pipelineId)
-        ),
+        queryClient.invalidateQueries({
+          queryKey: replicationKeys.pipelinesStatus(projectRef, pipelineId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: replicationKeys.pipelinesReplicationStatus(projectRef, pipelineId),
+        }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/replication/start-pipeline-mutation.ts
+++ b/apps/studio/data/replication/start-pipeline-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { replicationKeys } from './keys'
-import { handleError, post } from 'data/fetchers'
 
 export type StartPipelineParams = {
   projectRef: string
@@ -43,7 +43,9 @@ export const useStartPipelineMutation = ({
     mutationFn: (vars) => startPipeline(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, pipelineId } = variables
-      await queryClient.invalidateQueries(replicationKeys.pipelinesStatus(projectRef, pipelineId))
+      await queryClient.invalidateQueries({
+        queryKey: replicationKeys.pipelinesStatus(projectRef, pipelineId),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/replication/stop-pipeline-mutation.ts
+++ b/apps/studio/data/replication/stop-pipeline-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, post } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { replicationKeys } from './keys'
-import { handleError, post } from 'data/fetchers'
 
 export type StopPipelineParams = {
   projectRef: string
@@ -40,7 +40,9 @@ export const useStopPipelineMutation = ({
     mutationFn: (vars) => stopPipeline(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, pipelineId } = variables
-      await queryClient.invalidateQueries(replicationKeys.pipelinesStatus(projectRef, pipelineId))
+      await queryClient.invalidateQueries({
+        queryKey: replicationKeys.pipelinesStatus(projectRef, pipelineId),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -138,11 +138,15 @@ export const useUpdateDestinationPipelineMutation = ({
 
         await Promise.all([
           // Invalidate lists
-          queryClient.invalidateQueries(replicationKeys.destinations(projectRef)),
-          queryClient.invalidateQueries(replicationKeys.pipelines(projectRef)),
+          queryClient.invalidateQueries({ queryKey: replicationKeys.destinations(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: replicationKeys.pipelines(projectRef) }),
           // Invalidate item-level caches used by the editor panel
-          queryClient.invalidateQueries(replicationKeys.destinationById(projectRef, destinationId)),
-          queryClient.invalidateQueries(replicationKeys.pipelineById(projectRef, pipelineId)),
+          queryClient.invalidateQueries({
+            queryKey: replicationKeys.destinationById(projectRef, destinationId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: replicationKeys.pipelineById(projectRef, pipelineId),
+          }),
         ])
 
         await onSuccess?.(data, variables, context)

--- a/apps/studio/data/replication/update-pipeline-version-mutation.ts
+++ b/apps/studio/data/replication/update-pipeline-version-mutation.ts
@@ -49,16 +49,18 @@ export const useUpdatePipelineVersionMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, pipelineId } = variables
       // Ensure the version dot updates promptly
-      await queryClient.invalidateQueries(replicationKeys.pipelinesVersion(projectRef, pipelineId))
+      await queryClient.invalidateQueries({
+        queryKey: replicationKeys.pipelinesVersion(projectRef, pipelineId),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(error, variables, context) {
       const { projectRef, pipelineId } = variables
       if (error?.code === 404) {
         // Default image changed meanwhile. Refresh version info so UI reflects latest state.
-        await queryClient.invalidateQueries(
-          replicationKeys.pipelinesVersion(projectRef, pipelineId)
-        )
+        await queryClient.invalidateQueries({
+          queryKey: replicationKeys.pipelinesVersion(projectRef, pipelineId),
+        })
       } else if (onError === undefined) {
         toast.error(`Failed to update pipeline version: ${error.message}`)
       } else {

--- a/apps/studio/data/secrets/secrets-create-mutation.ts
+++ b/apps/studio/data/secrets/secrets-create-mutation.ts
@@ -37,7 +37,7 @@ export const useSecretsCreateMutation = ({
     mutationFn: (vars) => createSecrets(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(secretsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: secretsKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/secrets/secrets-delete-mutation.ts
+++ b/apps/studio/data/secrets/secrets-delete-mutation.ts
@@ -37,7 +37,7 @@ export const useSecretsDeleteMutation = ({
     mutationFn: (vars) => deleteSecrets(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(secretsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: secretsKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/sql/abort-query-mutation.ts
+++ b/apps/studio/data/sql/abort-query-mutation.ts
@@ -32,7 +32,7 @@ export const useQueryAbortMutation = ({
     mutationFn: (vars) => abortQuery(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(sqlKeys.ongoingQueries(projectRef))
+      await queryClient.invalidateQueries({ queryKey: sqlKeys.ongoingQueries(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -72,7 +72,7 @@ export const useExecuteSqlMutation = ({
       if (contextualInvalidation && projectRef && isMutationSQL) {
         const databaseRelatedKeys = queryClient
           .getQueryCache()
-          .findAll(['projects', projectRef])
+          .findAll({ queryKey: ['projects', projectRef] })
           .map((x) => x.queryKey)
           .filter((x) => !INVALIDATION_KEYS_IGNORE.some((a) => x.includes(a)))
         await Promise.all(

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -75,7 +75,9 @@ export const useExecuteSqlMutation = ({
           .findAll(['projects', projectRef])
           .map((x) => x.queryKey)
           .filter((x) => !INVALIDATION_KEYS_IGNORE.some((a) => x.includes(a)))
-        await Promise.all(databaseRelatedKeys.map((key) => queryClient.invalidateQueries(key)))
+        await Promise.all(
+          databaseRelatedKeys.map((key) => queryClient.invalidateQueries({ queryKey: key }))
+        )
       }
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { handleError, put } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { sslEnforcementKeys } from './keys'
-import { handleError, put } from 'data/fetchers'
 
 export type SSLEnforcementUpdateVariables = {
   projectRef: string
@@ -47,7 +47,7 @@ export const useSSLEnforcementUpdateMutation = ({
     mutationFn: (vars) => updateSSLEnforcement(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(sslEnforcementKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: sslEnforcementKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/sso/sso-config-create-mutation.ts
+++ b/apps/studio/data/sso/sso-config-create-mutation.ts
@@ -37,7 +37,7 @@ export const useSSOConfigCreateMutation = ({
     mutationFn: (vars) => createSSOConfig(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(orgSSOKeys.orgSSOConfig(slug))
+      await queryClient.invalidateQueries({ queryKey: orgSSOKeys.orgSSOConfig(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/sso/sso-config-update-mutation.ts
+++ b/apps/studio/data/sso/sso-config-update-mutation.ts
@@ -37,7 +37,7 @@ export const useSSOConfigUpdateMutation = ({
     mutationFn: (vars) => updateSSOConfig(vars),
     async onSuccess(data, variables, context) {
       const { slug } = variables
-      await queryClient.invalidateQueries(orgSSOKeys.orgSSOConfig(slug))
+      await queryClient.invalidateQueries({ queryKey: orgSSOKeys.orgSSOConfig(slug) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/bucket-create-mutation.ts
+++ b/apps/studio/data/storage/bucket-create-mutation.ts
@@ -55,7 +55,7 @@ export const useBucketCreateMutation = ({
     mutationFn: (vars) => createBucket(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageKeys.buckets(projectRef))
+      await queryClient.invalidateQueries({ queryKey: storageKeys.buckets(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -46,7 +46,7 @@ export const useBucketDeleteMutation = ({
     mutationFn: (vars) => deleteBucket(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageKeys.buckets(projectRef))
+      await queryClient.invalidateQueries({ queryKey: storageKeys.buckets(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/bucket-empty-mutation.ts
+++ b/apps/studio/data/storage/bucket-empty-mutation.ts
@@ -38,7 +38,7 @@ export const useBucketEmptyMutation = ({
     mutationFn: (vars) => emptyBucket(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageKeys.buckets(projectRef))
+      await queryClient.invalidateQueries({ queryKey: storageKeys.buckets(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/bucket-update-mutation.ts
+++ b/apps/studio/data/storage/bucket-update-mutation.ts
@@ -73,7 +73,7 @@ export const useBucketUpdateMutation = ({
     },
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageKeys.buckets(projectRef))
+      await queryClient.invalidateQueries({ queryKey: storageKeys.buckets(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/iceberg-namespace-create-mutation.ts
+++ b/apps/studio/data/storage/iceberg-namespace-create-mutation.ts
@@ -73,12 +73,16 @@ export const useIcebergNamespaceCreateMutation = ({
   return useMutation<IcebergNamespaceCreateData, ResponseError, CreateIcebergNamespaceVariables>({
     mutationFn: (vars) => createIcebergNamespace(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries(
-        storageKeys.icebergNamespace(variables.catalogUri, variables.warehouse, variables.namespace)
-      )
-      await queryClient.invalidateQueries(
-        storageKeys.icebergNamespaces(variables.catalogUri, variables.warehouse)
-      )
+      await queryClient.invalidateQueries({
+        queryKey: storageKeys.icebergNamespace(
+          variables.catalogUri,
+          variables.warehouse,
+          variables.namespace
+        ),
+      })
+      await queryClient.invalidateQueries({
+        queryKey: storageKeys.icebergNamespaces(variables.catalogUri, variables.warehouse),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/s3-access-key-create-mutation.ts
+++ b/apps/studio/data/storage/s3-access-key-create-mutation.ts
@@ -41,7 +41,9 @@ export function useS3AccessKeyCreateMutation({
     mutationFn: (vars) => createS3AccessKeyCredential(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageCredentialsKeys.credentials(projectRef))
+      await queryClient.invalidateQueries({
+        queryKey: storageCredentialsKeys.credentials(projectRef),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/s3-access-key-delete-mutation.ts
+++ b/apps/studio/data/storage/s3-access-key-delete-mutation.ts
@@ -44,7 +44,9 @@ export function useS3AccessKeyDeleteMutation({
     mutationFn: (vars) => deleteS3AccessKeyCredential(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageCredentialsKeys.credentials(projectRef))
+      await queryClient.invalidateQueries({
+        queryKey: storageCredentialsKeys.credentials(projectRef),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/storage-archive-create-mutation.ts
+++ b/apps/studio/data/storage/storage-archive-create-mutation.ts
@@ -36,7 +36,7 @@ export function useStorageArchiveCreateMutation({
     mutationFn: (vars) => createStorageArchive(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(storageKeys.archive(projectRef))
+      await queryClient.invalidateQueries({ queryKey: storageKeys.archive(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
+++ b/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
@@ -1,13 +1,13 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
 import type { components } from 'api-types'
-import { organizationKeys } from 'data/organizations/keys'
-import { subscriptionKeys } from './keys'
-import { usageKeys } from 'data/usage/keys'
+import { handleError, post } from 'data/fetchers'
 import { invoicesKeys } from 'data/invoices/keys'
+import { organizationKeys } from 'data/organizations/keys'
+import { usageKeys } from 'data/usage/keys'
+import type { ResponseError } from 'types'
+import { subscriptionKeys } from './keys'
 
 export type PendingSubscriptionChangeVariables = {
   payment_intent_id: string
@@ -81,13 +81,13 @@ export const useConfirmPendingSubscriptionChangeMutation = ({
       await new Promise((resolve) => setTimeout(resolve, 2000))
 
       await Promise.all([
-        queryClient.invalidateQueries(subscriptionKeys.orgSubscription(slug)),
-        queryClient.invalidateQueries(subscriptionKeys.orgPlans(slug)),
-        queryClient.invalidateQueries(usageKeys.orgUsage(slug)),
-        queryClient.invalidateQueries(invoicesKeys.orgUpcomingPreview(slug)),
-        queryClient.invalidateQueries(organizationKeys.detail(slug)),
-        queryClient.invalidateQueries(organizationKeys.list()),
-        queryClient.invalidateQueries(organizationKeys.paymentMethods(slug)),
+        queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgSubscription(slug) }),
+        queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgPlans(slug) }),
+        queryClient.invalidateQueries({ queryKey: usageKeys.orgUsage(slug) }),
+        queryClient.invalidateQueries({ queryKey: invoicesKeys.orgUpcomingPreview(slug) }),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.detail(slug) }),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.list() }),
+        queryClient.invalidateQueries({ queryKey: organizationKeys.paymentMethods(slug) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/subscriptions/org-subscription-confirm-pending-create.ts
+++ b/apps/studio/data/subscriptions/org-subscription-confirm-pending-create.ts
@@ -1,12 +1,12 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
 import type { components } from 'api-types'
+import { handleError, post } from 'data/fetchers'
 import { organizationKeys } from 'data/organizations/keys'
-import { permissionKeys } from 'data/permissions/keys'
 import { castOrganizationResponseToOrganization } from 'data/organizations/organizations-query'
+import { permissionKeys } from 'data/permissions/keys'
+import type { ResponseError } from 'types'
 
 export type PendingSubscriptionCreateVariables = {
   payment_intent_id: string
@@ -86,7 +86,7 @@ export const useConfirmPendingSubscriptionCreateMutation = ({
         }
       )
 
-      await queryClient.invalidateQueries(permissionKeys.list())
+      await queryClient.invalidateQueries({ queryKey: permissionKeys.list() })
 
       // todo replace plan in org
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
+++ b/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
@@ -80,17 +80,20 @@ export const useOrgSubscriptionUpdateMutation = ({
         ])
 
         if (variables.paymentMethod) {
-          queryClient.setQueriesData(organizationKeys.paymentMethods(slug), (prev: any) => {
-            if (!prev) return prev
-            return {
-              ...prev,
-              defaultPaymentMethodId: variables.paymentMethod,
-              data: prev.data.map((pm: any) => ({
-                ...pm,
-                is_default: pm.id === variables.paymentMethod,
-              })),
+          queryClient.setQueriesData(
+            { queryKey: organizationKeys.paymentMethods(slug) },
+            (prev: any) => {
+              if (!prev) return prev
+              return {
+                ...prev,
+                defaultPaymentMethodId: variables.paymentMethod,
+                data: prev.data.map((pm: any) => ({
+                  ...pm,
+                  is_default: pm.id === variables.paymentMethod,
+                })),
+              }
             }
-          })
+          )
         }
       }
 

--- a/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
+++ b/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
@@ -1,13 +1,13 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { handleError, put } from 'data/fetchers'
 import { invoicesKeys } from 'data/invoices/keys'
+import { organizationKeys } from 'data/organizations/keys'
+import type { CustomerAddress, CustomerTaxId } from 'data/organizations/types'
 import { usageKeys } from 'data/usage/keys'
 import { toast } from 'sonner'
 import type { ResponseError } from 'types/base'
 import { subscriptionKeys } from './keys'
 import type { SubscriptionTier } from './types'
-import { organizationKeys } from 'data/organizations/keys'
-import type { CustomerAddress, CustomerTaxId } from 'data/organizations/types'
 
 export type OrgSubscriptionUpdateVariables = {
   slug: string
@@ -70,13 +70,13 @@ export const useOrgSubscriptionUpdateMutation = ({
         await new Promise((resolve) => setTimeout(resolve, 2000))
 
         await Promise.all([
-          queryClient.invalidateQueries(subscriptionKeys.orgSubscription(slug)),
-          queryClient.invalidateQueries(subscriptionKeys.orgPlans(slug)),
-          queryClient.invalidateQueries(usageKeys.orgUsage(slug)),
-          queryClient.invalidateQueries(invoicesKeys.orgUpcomingPreview(slug)),
-          queryClient.invalidateQueries(organizationKeys.detail(slug)),
-          queryClient.invalidateQueries(organizationKeys.list()),
-          queryClient.invalidateQueries(organizationKeys.entitlements(slug)),
+          queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgSubscription(slug) }),
+          queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgPlans(slug) }),
+          queryClient.invalidateQueries({ queryKey: usageKeys.orgUsage(slug) }),
+          queryClient.invalidateQueries({ queryKey: invoicesKeys.orgUpcomingPreview(slug) }),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.detail(slug) }),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.list() }),
+          queryClient.invalidateQueries({ queryKey: organizationKeys.entitlements(slug) }),
         ])
 
         if (variables.paymentMethod) {

--- a/apps/studio/data/subscriptions/project-addon-remove-mutation.ts
+++ b/apps/studio/data/subscriptions/project-addon-remove-mutation.ts
@@ -49,7 +49,7 @@ export const useProjectAddonRemoveMutation = ({
       const { projectRef } = variables
       // [Joshen] Only invalidate addons, not subscriptions, as AddOn section in
       // subscription page is using AddOn react query
-      await queryClient.invalidateQueries(subscriptionKeys.addons(projectRef))
+      await queryClient.invalidateQueries({ queryKey: subscriptionKeys.addons(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/subscriptions/project-addon-update-mutation.ts
+++ b/apps/studio/data/subscriptions/project-addon-update-mutation.ts
@@ -54,7 +54,7 @@ export const useProjectAddonUpdateMutation = ({
     mutationFn: (vars) => updateSubscriptionAddon(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(subscriptionKeys.addons(projectRef))
+      await queryClient.invalidateQueries({ queryKey: subscriptionKeys.addons(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/table-editor/table-editor-query.ts
+++ b/apps/studio/data/table-editor/table-editor-query.ts
@@ -58,14 +58,16 @@ export function prefetchTableEditor(
   client: QueryClient,
   { projectRef, connectionString, id }: TableEditorVariables
 ) {
-  return client.fetchQuery(tableEditorKeys.tableEditor(projectRef, id), ({ signal }) =>
-    getTableEditor(
-      {
-        projectRef,
-        connectionString,
-        id,
-      },
-      signal
-    )
-  )
+  return client.fetchQuery({
+    queryKey: tableEditorKeys.tableEditor(projectRef, id),
+    queryFn: ({ signal }) =>
+      getTableEditor(
+        {
+          projectRef,
+          connectionString,
+          id,
+        },
+        signal
+      ),
+  })
 }

--- a/apps/studio/data/table-rows/table-row-create-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-create-mutation.ts
@@ -93,7 +93,9 @@ export const useTableRowCreateMutation = ({
         console.error('Failed to track table data insertion event:', error)
       }
 
-      await queryClient.invalidateQueries(tableRowKeys.tableRowsAndCount(projectRef, table.id))
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRowsAndCount(projectRef, table.id),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/table-rows/table-row-delete-all-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-delete-all-mutation.ts
@@ -76,7 +76,9 @@ export const useTableRowDeleteAllMutation = ({
     mutationFn: (vars) => deleteAllTableRow(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, table } = variables
-      await queryClient.invalidateQueries(tableRowKeys.tableRowsAndCount(projectRef, table.id))
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRowsAndCount(projectRef, table.id),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/table-rows/table-row-delete-mutation.tsx
+++ b/apps/studio/data/table-rows/table-row-delete-mutation.tsx
@@ -76,7 +76,9 @@ export const useTableRowDeleteMutation = ({
     mutationFn: (vars) => deleteTableRow(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, table } = variables
-      await queryClient.invalidateQueries(tableRowKeys.tableRowsAndCount(projectRef, table.id))
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRowsAndCount(projectRef, table.id),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/table-rows/table-row-truncate-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-truncate-mutation.ts
@@ -50,7 +50,9 @@ export const useTableRowTruncateMutation = ({
     mutationFn: (vars) => truncateTableRow(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, table } = variables
-      await queryClient.invalidateQueries(tableRowKeys.tableRowsAndCount(projectRef, table.id))
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRowsAndCount(projectRef, table.id),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/table-rows/table-row-update-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-update-mutation.ts
@@ -78,9 +78,9 @@ export const useTableRowUpdateMutation = ({
     mutationFn: (vars) => updateTableRow(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, table } = variables
-      await queryClient.invalidateQueries(
-        tableRowKeys.tableRows(projectRef, { table: { id: table.id } })
-      )
+      await queryClient.invalidateQueries({
+        queryKey: tableRowKeys.tableRows(projectRef, { table: { id: table.id } }),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -278,12 +278,12 @@ export function prefetchTableRows(
   client: QueryClient,
   { projectRef, connectionString, tableId, ...args }: Omit<TableRowsVariables, 'queryClient'>
 ) {
-  return client.fetchQuery(
-    tableRowKeys.tableRows(projectRef, {
+  return client.fetchQuery({
+    queryKey: tableRowKeys.tableRows(projectRef, {
       table: { id: tableId },
       ...args,
     }),
-    ({ signal }) =>
-      getTableRows({ queryClient: client, projectRef, connectionString, tableId, ...args }, signal)
-  )
+    queryFn: ({ signal }) =>
+      getTableRows({ queryClient: client, projectRef, connectionString, tableId, ...args }, signal),
+  })
 }

--- a/apps/studio/data/tables/table-create-mutation.ts
+++ b/apps/studio/data/tables/table-create-mutation.ts
@@ -50,8 +50,12 @@ export const useTableCreateMutation = ({
       const { projectRef, payload } = variables
 
       await Promise.all([
-        queryClient.invalidateQueries(tableKeys.list(projectRef, payload.schema, true)),
-        queryClient.invalidateQueries(tableKeys.list(projectRef, payload.schema, false)),
+        queryClient.invalidateQueries({
+          queryKey: tableKeys.list(projectRef, payload.schema, true),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: tableKeys.list(projectRef, payload.schema, false),
+        }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/tables/table-delete-mutation.ts
+++ b/apps/studio/data/tables/table-delete-mutation.ts
@@ -55,11 +55,11 @@ export const useTableDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { id, projectRef, schema } = variables
       await Promise.all([
-        queryClient.invalidateQueries(tableEditorKeys.tableEditor(projectRef, id)),
-        queryClient.invalidateQueries(tableKeys.list(projectRef, schema)),
-        queryClient.invalidateQueries(entityTypeKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: tableEditorKeys.tableEditor(projectRef, id) }),
+        queryClient.invalidateQueries({ queryKey: tableKeys.list(projectRef, schema) }),
+        queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
         // invalidate all views from this schema
-        queryClient.invalidateQueries(viewKeys.listBySchema(projectRef, schema)),
+        queryClient.invalidateQueries({ queryKey: viewKeys.listBySchema(projectRef, schema) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/tables/table-update-mutation.ts
+++ b/apps/studio/data/tables/table-update-mutation.ts
@@ -63,9 +63,9 @@ export const useTableUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, schema, id } = variables
       await Promise.all([
-        queryClient.invalidateQueries(tableEditorKeys.tableEditor(projectRef, id)),
-        queryClient.invalidateQueries(tableKeys.list(projectRef, schema)),
-        queryClient.invalidateQueries(lintKeys.lint(projectRef)),
+        queryClient.invalidateQueries({ queryKey: tableEditorKeys.tableEditor(projectRef, id) }),
+        queryClient.invalidateQueries({ queryKey: tableKeys.list(projectRef, schema) }),
+        queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/third-party-auth/integration-create-mutation.ts
+++ b/apps/studio/data/third-party-auth/integration-create-mutation.ts
@@ -51,7 +51,7 @@ export const useCreateThirdPartyAuthIntegrationMutation = ({
       mutationFn: (vars) => createThirdPartyIntegration(vars),
       async onSuccess(data, variables, context) {
         const { projectRef } = variables
-        await queryClient.invalidateQueries(keys.integrations(projectRef))
+        await queryClient.invalidateQueries({ queryKey: keys.integrations(projectRef) })
         await onSuccess?.(data, variables, context)
       },
       async onError(data, variables, context) {

--- a/apps/studio/data/third-party-auth/integration-delete-mutation.ts
+++ b/apps/studio/data/third-party-auth/integration-delete-mutation.ts
@@ -49,7 +49,7 @@ export const useDeleteThirdPartyAuthIntegrationMutation = ({
     mutationFn: (vars) => deleteThirdPartyIntegration(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(keys.integrations(projectRef))
+      await queryClient.invalidateQueries({ queryKey: keys.integrations(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/vault/vault-secret-create-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-create-mutation.ts
@@ -45,7 +45,7 @@ export const useVaultSecretCreateMutation = ({
     mutationFn: (vars) => createVaultSecret(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/vault/vault-secret-delete-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-delete-mutation.ts
@@ -38,7 +38,7 @@ export const useVaultSecretDeleteMutation = ({
     mutationFn: (vars) => deleteVaultSecret(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef))
+      await queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/vault/vault-secret-update-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-update-mutation.ts
@@ -49,7 +49,7 @@ export const useVaultSecretUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { id, projectRef } = variables
       await Promise.all([
-        queryClient.removeQueries(vaultSecretsKeys.getDecryptedValue(projectRef, id)),
+        queryClient.removeQueries({ queryKey: vaultSecretsKeys.getDecryptedValue(projectRef, id) }),
         queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/vault/vault-secret-update-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-update-mutation.ts
@@ -50,7 +50,7 @@ export const useVaultSecretUpdateMutation = ({
       const { id, projectRef } = variables
       await Promise.all([
         queryClient.removeQueries(vaultSecretsKeys.getDecryptedValue(projectRef, id)),
-        queryClient.invalidateQueries(vaultSecretsKeys.list(projectRef)),
+        queryClient.invalidateQueries({ queryKey: vaultSecretsKeys.list(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/hooks/analytics/useLogsPreview.tsx
+++ b/apps/studio/hooks/analytics/useLogsPreview.tsx
@@ -100,9 +100,9 @@ function useLogsPreview({
     fetchNextPage,
     isFetchingNextPage,
     refetch,
-  } = useInfiniteQuery(
+  } = useInfiniteQuery({
     queryKey,
-    async ({ signal, pageParam }) => {
+    queryFn: async ({ signal, pageParam }) => {
       const { data, error } = await get(`/platform/projects/{ref}/analytics/endpoints/logs.all`, {
         params: {
           path: { ref: projectRef },
@@ -119,19 +119,17 @@ function useLogsPreview({
 
       return data as unknown as Logs
     },
-    {
-      refetchOnWindowFocus: false,
-      getNextPageParam(lastPage) {
-        if ((lastPage.result?.length ?? 0) === 0) {
-          return undefined
-        }
-        const len = lastPage.result.length
-        const { timestamp: tsLimit }: LogData = lastPage.result[len - 1]
-        const isoTsLimit = dayjs.utc(Number(tsLimit / 1000)).toISOString()
-        return isoTsLimit
-      },
-    }
-  )
+    refetchOnWindowFocus: false,
+    getNextPageParam(lastPage) {
+      if ((lastPage.result?.length ?? 0) === 0) {
+        return undefined
+      }
+      const len = lastPage.result.length
+      const { timestamp: tsLimit }: LogData = lastPage.result[len - 1]
+      const isoTsLimit = dayjs.utc(Number(tsLimit / 1000)).toISOString()
+      return isoTsLimit
+    },
+  })
 
   const { logData, error, oldestTimestamp } = useMemo(() => {
     let logData: LogData[] = []

--- a/apps/studio/hooks/misc/useLocalStorage.ts
+++ b/apps/studio/hooks/misc/useLocalStorage.ts
@@ -89,7 +89,7 @@ export function useLocalStorageQuery<T>(key: string, initialValue: T) {
     }
 
     queryClient.setQueryData(queryKey, valueToStore)
-    queryClient.invalidateQueries(queryKey)
+    queryClient.invalidateQueries({ queryKey })
   }
 
   return [storedValue, setValue, { isSuccess, isLoading, isError, error }] as const

--- a/apps/studio/pages/project/[ref]/reports/database.tsx
+++ b/apps/studio/pages/project/[ref]/reports/database.tsx
@@ -148,27 +148,27 @@ const DatabaseUsage = () => {
     const { period_start, period_end, interval } = selectedDateRange
     REPORT_ATTRIBUTES.forEach((chart: any) => {
       chart.attributes.forEach((attr: any) => {
-        queryClient.invalidateQueries(
-          analyticsKeys.infraMonitoring(ref, {
+        queryClient.invalidateQueries({
+          queryKey: analyticsKeys.infraMonitoring(ref, {
             attribute: attr.attribute,
             startDate: period_start.date,
             endDate: period_end.date,
             interval,
             databaseIdentifier: state.selectedDatabaseId,
-          })
-        )
+          }),
+        })
       })
     })
     if (isReplicaSelected) {
-      queryClient.invalidateQueries(
-        analyticsKeys.infraMonitoring(ref, {
+      queryClient.invalidateQueries({
+        queryKey: analyticsKeys.infraMonitoring(ref, {
           attribute: 'physical_replication_lag_physical_replica_lag_seconds',
           startDate: period_start.date,
           endDate: period_end.date,
           interval,
           databaseIdentifier: state.selectedDatabaseId,
-        })
-      )
+        }),
+      })
     }
     setTimeout(() => setIsRefreshing(false), 1000)
   }

--- a/apps/studio/pages/project/[ref]/reports/realtime.tsx
+++ b/apps/studio/pages/project/[ref]/reports/realtime.tsx
@@ -1,40 +1,33 @@
-import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, RefreshCw } from 'lucide-react'
-import { useParams } from 'common'
+import { useEffect, useState } from 'react'
 
-import DefaultLayout from 'components/layouts/DefaultLayout'
+import ReportFilterBar from 'components/interfaces/Reports/ReportFilterBar'
 import ReportHeader from 'components/interfaces/Reports/ReportHeader'
 import ReportPadding from 'components/interfaces/Reports/ReportPadding'
+import {
+  DatePickerValue,
+  LogsDatePicker,
+} from 'components/interfaces/Settings/Logs/Logs.DatePickers'
+import DefaultLayout from 'components/layouts/DefaultLayout'
 import ReportsLayout from 'components/layouts/ReportsLayout/ReportsLayout'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
-import {
-  LogsDatePicker,
-  DatePickerValue,
-} from 'components/interfaces/Settings/Logs/Logs.DatePickers'
-import {
-  ResponseSpeedChartRenderer,
-  TopApiRoutesRenderer,
-  TotalRequestsChartRenderer,
-} from 'components/interfaces/Reports/renderers/ApiRenderers'
 import { LazyComposedChartHandler } from 'components/ui/Charts/ComposedChartHandler'
-import ReportWidget from 'components/interfaces/Reports/ReportWidget'
-import ReportFilterBar from 'components/interfaces/Reports/ReportFilterBar'
+import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 
-import { analyticsKeys } from 'data/analytics/keys'
-import { getRealtimeReportAttributes } from 'data/reports/realtime-charts'
-import { useApiReport } from 'data/reports/api-report-query'
-import { useReportDateRange } from 'hooks/misc/useReportDateRange'
 import { REPORT_DATERANGE_HELPER_LABELS } from 'components/interfaces/Reports/Reports.constants'
 import ReportStickyNav from 'components/interfaces/Reports/ReportStickyNav'
 import UpgradePrompt from 'components/interfaces/Settings/Logs/UpgradePrompt'
+import { analyticsKeys } from 'data/analytics/keys'
+import { getRealtimeReportAttributes } from 'data/reports/realtime-charts'
+import { useReportDateRange } from 'hooks/misc/useReportDateRange'
 
-import type { NextPageWithLayout } from 'types'
-import type { MultiAttribute } from 'components/ui/Charts/ComposedChart.utils'
 import { SharedAPIReport } from 'components/interfaces/Reports/SharedAPIReport/SharedAPIReport'
 import { useSharedAPIReport } from 'components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants'
+import type { MultiAttribute } from 'components/ui/Charts/ComposedChart.utils'
+import type { NextPageWithLayout } from 'types'
 
 const RealtimeReport: NextPageWithLayout = () => {
   return (
@@ -100,15 +93,15 @@ const RealtimeUsage = () => {
 
     const { period_start, period_end, interval } = selectedDateRange
     REALTIME_REPORT_ATTRIBUTES.forEach((attr) => {
-      queryClient.invalidateQueries(
-        analyticsKeys.infraMonitoring(ref, {
+      queryClient.invalidateQueries({
+        queryKey: analyticsKeys.infraMonitoring(ref, {
           attribute: attr?.id,
           startDate: period_start.date,
           endDate: period_end.date,
           interval,
           databaseIdentifier: state.selectedDatabaseId,
-        })
-      )
+        }),
+      })
     })
 
     refetch()


### PR DESCRIPTION
Migrate various functions from `react-query` to use the new object syntax style.