### PR TITLE
feat(auth): add account changes notifications template schemas

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -32,6 +32,9 @@ const CONFIRMATION: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_CONFIRMATION: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'authentication',
+  },
 }
 
 const INVITE: FormSchema = {
@@ -63,6 +66,9 @@ const INVITE: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_INVITE: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'authentication',
+  },
 }
 
 const MAGIC_LINK: FormSchema = {
@@ -94,6 +100,9 @@ const MAGIC_LINK: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_MAGIC_LINK: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'authentication',
+  },
 }
 
 const EMAIL_CHANGE: FormSchema = {
@@ -126,6 +135,9 @@ const EMAIL_CHANGE: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_EMAIL_CHANGE: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'authentication',
+  },
 }
 
 const RECOVERY: FormSchema = {
@@ -157,6 +169,9 @@ const RECOVERY: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_RECOVERY: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'authentication',
+  },
 }
 const REAUTHENTICATION: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
@@ -185,6 +200,9 @@ const REAUTHENTICATION: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_REAUTHENTICATION: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'authentication',
+  },
 }
 
 // Notifications
@@ -214,6 +232,9 @@ const PASSWORD_CHANGED_NOTIFICATION: FormSchema = {
       'Subject heading is required.'
     ),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 const EMAIL_CHANGED_NOTIFICATION: FormSchema = {
@@ -241,6 +262,9 @@ const EMAIL_CHANGED_NOTIFICATION: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 const PHONE_CHANGED_NOTIFICATION: FormSchema = {
@@ -269,6 +293,9 @@ const PHONE_CHANGED_NOTIFICATION: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 const IDENTITY_LINKED_NOTIFICATION: FormSchema = {
@@ -296,6 +323,9 @@ const IDENTITY_LINKED_NOTIFICATION: FormSchema = {
   validationSchema: object().shape({
     MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: string().required('Subject heading is required.'),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 const IDENTITY_UNLINKED_NOTIFICATION: FormSchema = {
@@ -325,6 +355,9 @@ const IDENTITY_UNLINKED_NOTIFICATION: FormSchema = {
       'Subject heading is required.'
     ),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 const MFA_FACTOR_ENROLLED_NOTIFICATION: FormSchema = {
@@ -354,6 +387,9 @@ const MFA_FACTOR_ENROLLED_NOTIFICATION: FormSchema = {
       'Subject heading is required.'
     ),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 const MFA_FACTOR_UNENROLLED_NOTIFICATION: FormSchema = {
@@ -383,6 +419,9 @@ const MFA_FACTOR_UNENROLLED_NOTIFICATION: FormSchema = {
       'Subject heading is required.'
     ),
   }),
+  misc: {
+    emailTemplateType: 'security',
+  },
 }
 
 export const TEMPLATES_SCHEMAS = [

--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -1,6 +1,4 @@
 import { object, string } from 'yup'
-
-import { DOCS_URL } from 'lib/constants'
 import type { FormSchema } from 'types'
 
 const JSON_SCHEMA_VERSION = 'http://json-schema.org/draft-07/schema#'
@@ -32,13 +30,8 @@ const CONFIRMATION: FormSchema = {
     },
   },
   validationSchema: object().shape({
-    MAILER_SUBJECTS_CONFIRMATION: string().required('"Subject heading is required.'),
+    MAILER_SUBJECTS_CONFIRMATION: string().required('Subject heading is required.'),
   }),
-  misc: {
-    iconKey: 'email-icon2',
-    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
-[Learn more](${DOCS_URL}/guides/auth/social-login/auth-apple#configure-your-services-id)`,
-  },
 }
 
 const INVITE: FormSchema = {
@@ -68,13 +61,8 @@ const INVITE: FormSchema = {
     },
   },
   validationSchema: object().shape({
-    MAILER_SUBJECTS_INVITE: string().required('"Subject heading is required.'),
+    MAILER_SUBJECTS_INVITE: string().required('Subject heading is required.'),
   }),
-  misc: {
-    iconKey: 'email-icon2',
-    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
-[Learn more](${DOCS_URL}/guides/auth/social-login/auth-apple#configure-your-services-id)`,
-  },
 }
 
 const MAGIC_LINK: FormSchema = {
@@ -104,13 +92,8 @@ const MAGIC_LINK: FormSchema = {
     },
   },
   validationSchema: object().shape({
-    MAILER_SUBJECTS_MAGIC_LINK: string().required('"Subject heading is required.'),
+    MAILER_SUBJECTS_MAGIC_LINK: string().required('Subject heading is required.'),
   }),
-  misc: {
-    iconKey: 'email-icon2',
-    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
-[Learn more](${DOCS_URL}/guides/auth/social-login/auth-apple#configure-your-services-id)`,
-  },
 }
 
 const EMAIL_CHANGE: FormSchema = {
@@ -141,13 +124,8 @@ const EMAIL_CHANGE: FormSchema = {
     },
   },
   validationSchema: object().shape({
-    MAILER_SUBJECTS_EMAIL_CHANGE: string().required('"Subject heading is required.'),
+    MAILER_SUBJECTS_EMAIL_CHANGE: string().required('Subject heading is required.'),
   }),
-  misc: {
-    iconKey: 'email-icon2',
-    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
-[Learn more](${DOCS_URL}/guides/auth/social-login/auth-apple#configure-your-services-id)`,
-  },
 }
 
 const RECOVERY: FormSchema = {
@@ -177,13 +155,8 @@ const RECOVERY: FormSchema = {
     },
   },
   validationSchema: object().shape({
-    MAILER_SUBJECTS_RECOVERY: string().required('"Subject heading is required.'),
+    MAILER_SUBJECTS_RECOVERY: string().required('Subject heading is required.'),
   }),
-  misc: {
-    iconKey: 'email-icon2',
-    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
-[Learn more](${DOCS_URL}/guides/auth/social-login/auth-apple#configure-your-services-id)`,
-  },
 }
 const REAUTHENTICATION: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
@@ -210,13 +183,206 @@ const REAUTHENTICATION: FormSchema = {
     },
   },
   validationSchema: object().shape({
-    MAILER_SUBJECTS_REAUTHENTICATION: string().required('"Subject heading is required.'),
+    MAILER_SUBJECTS_REAUTHENTICATION: string().required('Subject heading is required.'),
   }),
-  misc: {
-    iconKey: 'email-icon2',
-    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
-[Learn more](${DOCS_URL}/guides/auth/social-login/auth-apple#configure-your-services-id)`,
+}
+
+// Notifications
+const PASSWORD_CHANGED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'PASSWORD_CHANGED_NOTIFICATION',
+  type: 'object',
+  title: 'Password changed notification',
+  purpose: 'Notify a user when their password has been changed',
+  properties: {
+    MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_PASSWORD_CHANGED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
   },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: string().required(
+      'Subject heading is required.'
+    ),
+  }),
+}
+
+const EMAIL_CHANGED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'EMAIL_CHANGED_NOTIFICATION',
+  type: 'object',
+  title: 'Email changed notification',
+  purpose: 'Notify a user when their email address has been changed',
+  properties: {
+    MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_EMAIL_CHANGED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's new email address
+- \`{{ .OldEmail }}\` : The user's old email address
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: string().required('Subject heading is required.'),
+  }),
+}
+
+const PHONE_CHANGED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'PHONE_CHANGED_NOTIFICATION',
+  type: 'object',
+  title: 'Phone changed notification',
+  purpose: 'Notify a user when the phone number has been changed',
+  properties: {
+    MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_PHONE_CHANGED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .Phone }}\` : The user's new phone number
+- \`{{ .OldPhone }}\` : The user's old phone number
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: string().required('Subject heading is required.'),
+  }),
+}
+
+const IDENTITY_LINKED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'IDENTITY_LINKED_NOTIFICATION',
+  type: 'object',
+  title: 'Identity linked notification',
+  purpose: 'Notify a user when a new identity has been linked to their account',
+  properties: {
+    MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_IDENTITY_LINKED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .Provider }}\` : The provider of the newly linked identity
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: string().required('Subject heading is required.'),
+  }),
+}
+
+const IDENTITY_UNLINKED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'IDENTITY_UNLINKED_NOTIFICATION',
+  type: 'object',
+  title: 'Identity unlinked notification',
+  purpose: 'Notify a user when an identity has been unlinked from their account',
+  properties: {
+    MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_IDENTITY_UNLINKED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .Provider }}\` : The provider of the unlinked identity
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: string().required(
+      'Subject heading is required.'
+    ),
+  }),
+}
+
+const MFA_FACTOR_ENROLLED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'MFA_FACTOR_ENROLLED_NOTIFICATION',
+  type: 'object',
+  title: 'MFA factor enrolled notification',
+  purpose: 'Notify a user when a new MFA factor has been enrolled for their account',
+  properties: {
+    MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_MFA_FACTOR_ENROLLED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .FactorType }}\` : The type of the newly enrolled MFA factor
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: string().required(
+      'Subject heading is required.'
+    ),
+  }),
+}
+
+const MFA_FACTOR_UNENROLLED_NOTIFICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'MFA_FACTOR_UNENROLLED_NOTIFICATION',
+  type: 'object',
+  title: 'MFA factor unenrolled notification',
+  purpose: 'Notify a user when an MFA factor has been unenrolled from their account',
+  properties: {
+    MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_MFA_FACTOR_UNENROLLED_NOTIFICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: ` 
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .FactorType }}\` : The type of the newly enrolled MFA factor
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: string().required(
+      'Subject heading is required.'
+    ),
+  }),
 }
 
 export const TEMPLATES_SCHEMAS = [
@@ -226,4 +392,12 @@ export const TEMPLATES_SCHEMAS = [
   EMAIL_CHANGE,
   RECOVERY,
   REAUTHENTICATION,
+  // Notifications
+  PASSWORD_CHANGED_NOTIFICATION,
+  EMAIL_CHANGED_NOTIFICATION,
+  PHONE_CHANGED_NOTIFICATION,
+  IDENTITY_LINKED_NOTIFICATION,
+  IDENTITY_UNLINKED_NOTIFICATION,
+  MFA_FACTOR_ENROLLED_NOTIFICATION,
+  MFA_FACTOR_UNENROLLED_NOTIFICATION,
 ]

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -1,37 +1,37 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { useIsSecurityNotificationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { ScaffoldSection, ScaffoldSectionTitle } from 'components/layouts/Scaffold'
 import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
+import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
+import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
+  Button,
   Card,
   CardContent,
+  CardFooter,
+  Form_Shadcn_,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Switch,
   Tabs_Shadcn_,
   TabsContent_Shadcn_,
   TabsList_Shadcn_,
   TabsTrigger_Shadcn_,
-  Switch,
-  FormControl_Shadcn_,
-  CardFooter,
-  Button,
-  Form_Shadcn_,
-  FormField_Shadcn_,
 } from 'ui'
+import { z } from 'zod'
 import { TEMPLATES_SCHEMAS } from '../AuthTemplatesValidation'
 import EmailRateLimitsAlert from '../EmailRateLimitsAlert'
 import { slugifyTitle } from './EmailTemplates.utils'
 import TemplateEditor from './TemplateEditor'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
-import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
-import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { toast } from 'sonner'
-import { useEffect } from 'react'
 
 const notificationEnabledKeys = TEMPLATES_SCHEMAS.filter(
   (t) => t.misc?.emailTemplateType === 'security'
@@ -130,7 +130,7 @@ export const EmailTemplates = () => {
           {isSecurityNotificationsEnabled ? (
             <div className="space-y-8">
               <div>
-                <ScaffoldSectionTitle className="mb-4">Authenticaton</ScaffoldSectionTitle>
+                <ScaffoldSectionTitle className="mb-4">Authentication</ScaffoldSectionTitle>
                 <Card>
                   {TEMPLATES_SCHEMAS.filter(
                     (t) => t.misc?.emailTemplateType === 'authentication'
@@ -151,8 +151,6 @@ export const EmailTemplates = () => {
                           </div>
 
                           <div className="flex items-center gap-4 group">
-                            <Switch checked disabled />
-
                             <ChevronRight
                               size={16}
                               className="text-foreground-muted group-hover:text-foreground transition-colors"
@@ -178,45 +176,46 @@ export const EmailTemplates = () => {
                           `MAILER_NOTIFICATIONS_${template.id?.replace('_NOTIFICATION', '')}_ENABLED` as keyof typeof authConfig
 
                         return (
-                          <CardContent key={`${template.id}`} className="p-0">
-                            <div className="flex items-center justify-between hover:bg-surface-200 transition-colors py-4 px-6 w-full h-full">
+                          <CardContent
+                            key={`${template.id}`}
+                            className="p-0 flex items-center justify-between hover:bg-surface-200 transition-colors w-full h-full"
+                          >
+                            <Link
+                              href={`/project/${projectRef}/auth/templates/${templateSlug}`}
+                              className="flex flex-col flex-1 py-4 px-6"
+                            >
+                              <h3 className="text-sm text-foreground">{template.title}</h3>
+                              {template.purpose && (
+                                <p className="text-sm text-foreground-lighter">
+                                  {template.purpose}
+                                </p>
+                              )}
+                            </Link>
+
+                            <div className="flex items-center gap-4 group h-full pl-2">
+                              <FormField_Shadcn_
+                                control={notificationsForm.control}
+                                name={templateEnabledKey}
+                                render={({ field }) => (
+                                  <FormControl_Shadcn_>
+                                    <Switch
+                                      checked={field.value}
+                                      onCheckedChange={field.onChange}
+                                      disabled={!canUpdateConfig}
+                                    />
+                                  </FormControl_Shadcn_>
+                                )}
+                              />
+
                               <Link
                                 href={`/project/${projectRef}/auth/templates/${templateSlug}`}
-                                className="flex flex-col flex-1"
+                                className="py-6 pr-6"
                               >
-                                <h3 className="text-sm text-foreground">{template.title}</h3>
-                                {template.purpose && (
-                                  <p className="text-sm text-foreground-lighter">
-                                    {template.purpose}
-                                  </p>
-                                )}
-                              </Link>
-
-                              <div className="flex items-center gap-4 group">
-                                <FormField_Shadcn_
-                                  control={notificationsForm.control}
-                                  name={templateEnabledKey}
-                                  render={({ field }) => (
-                                    <FormControl_Shadcn_>
-                                      <Switch
-                                        checked={field.value}
-                                        onCheckedChange={field.onChange}
-                                        disabled={!canUpdateConfig}
-                                        onClick={(e) => e.stopPropagation()}
-                                      />
-                                    </FormControl_Shadcn_>
-                                  )}
+                                <ChevronRight
+                                  size={16}
+                                  className="text-foreground-muted hover:text-foreground transition-colors"
                                 />
-
-                                <Link
-                                  href={`/project/${projectRef}/auth/templates/${templateSlug}`}
-                                >
-                                  <ChevronRight
-                                    size={16}
-                                    className="text-foreground-muted hover:text-foreground transition-colors"
-                                  />
-                                </Link>
-                              </div>
+                              </Link>
                             </div>
                           </CardContent>
                         )

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -248,18 +248,20 @@ export const EmailTemplates = () => {
             <Card>
               <Tabs_Shadcn_ defaultValue={slugifyTitle(TEMPLATES_SCHEMAS[0].title)}>
                 <TabsList_Shadcn_ className="pt-2 px-6 gap-5 mb-0 overflow-x-scroll no-scrollbar mb-4">
-                  {TEMPLATES_SCHEMAS.map((template) => {
-                    return (
-                      <TabsTrigger_Shadcn_
-                        key={`${template.id}`}
-                        value={slugifyTitle(template.title)}
-                      >
-                        {template.title}
-                      </TabsTrigger_Shadcn_>
-                    )
-                  })}
+                  {TEMPLATES_SCHEMAS.filter(
+                    (t) => t.misc?.emailTemplateType === 'authentication'
+                  ).map((template) => (
+                    <TabsTrigger_Shadcn_
+                      key={`${template.id}`}
+                      value={slugifyTitle(template.title)}
+                    >
+                      {template.title}
+                    </TabsTrigger_Shadcn_>
+                  ))}
                 </TabsList_Shadcn_>
-                {TEMPLATES_SCHEMAS.map((template) => {
+                {TEMPLATES_SCHEMAS.filter(
+                  (t) => t.misc?.emailTemplateType === 'authentication'
+                ).map((template) => {
                   const panelId = slugifyTitle(template.title)
                   return (
                     <TabsContent_Shadcn_ key={panelId} value={panelId} className="mt-0">

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -123,12 +123,12 @@ export const EmailTemplates = () => {
       {isSuccess && (
         <div className="my-12">
           {builtInSMTP ? (
-            <div className="mb-4">
+            <div className="mb-12">
               <EmailRateLimitsAlert />
             </div>
           ) : null}
           {isSecurityNotificationsEnabled ? (
-            <div className="space-y-8">
+            <div className="space-y-12">
               <div>
                 <ScaffoldSectionTitle className="mb-4">Authentication</ScaffoldSectionTitle>
                 <Card>

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
@@ -1,6 +1,7 @@
+import { Check, MailWarning } from 'lucide-react'
+
 import { Markdown } from 'components/interfaces/Markdown'
 import { ValidateSpamResponse } from 'data/auth/validate-spam-mutation'
-import { Check, MailWarning } from 'lucide-react'
 import { Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
 
 interface SpamValidationProps {

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -38,7 +38,7 @@ interface TemplateEditorProps {
   template: FormSchema
 }
 
-const TemplateEditor = ({ template }: TemplateEditorProps) => {
+export const TemplateEditor = ({ template }: TemplateEditorProps) => {
   const { ref: projectRef } = useParams()
   const { can: canUpdateConfig } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,
@@ -383,5 +383,3 @@ const TemplateEditor = ({ template }: TemplateEditorProps) => {
     </Form_Shadcn_>
   )
 }
-
-export default TemplateEditor

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -1,9 +1,12 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 import { useIsSecurityNotificationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { TEMPLATES_SCHEMAS } from 'components/interfaces/Auth/AuthTemplatesValidation'
 import { slugifyTitle } from 'components/interfaces/Auth/EmailTemplates/EmailTemplates.utils'
-import TemplateEditor from 'components/interfaces/Auth/EmailTemplates/TemplateEditor'
+import { TemplateEditor } from 'components/interfaces/Auth/EmailTemplates/TemplateEditor'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
@@ -12,9 +15,6 @@ import { DocsButton } from 'components/ui/DocsButton'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { DOCS_URL } from 'lib/constants'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
 import { Button, Card } from 'ui'
 import { Admonition, GenericSkeletonLoader } from 'ui-patterns'
@@ -33,6 +33,16 @@ const RedirectToTemplates = () => {
     'custom_config_gotrue'
   )
 
+  // Find template whose slug matches the URL slug
+  const template =
+    templateId && typeof templateId === 'string'
+      ? TEMPLATES_SCHEMAS.find((template) => slugifyTitle(template.title) === templateId)
+      : null
+
+  // Convert templateId slug to one lowercase word to match docs anchor tag
+  const templateIdForDocs =
+    typeof templateId === 'string' ? templateId.replace(/-/g, '').toLowerCase() : ''
+
   useEffect(() => {
     if (isPermissionsLoaded && !isSecurityNotificationsEnabled) {
       router.replace(`/project/${ref}/auth/templates/`)
@@ -43,18 +53,12 @@ const RedirectToTemplates = () => {
     return <NoPermission isFullPage resourceText="access your project's email settings" />
   }
 
-  if (!isSecurityNotificationsEnabled) {
+  if (!isSecurityNotificationsEnabled || !templateId) {
     return null
   }
 
-  // Find template whose slug matches the URL slug
-  const template =
-    templateId && typeof templateId === 'string'
-      ? TEMPLATES_SCHEMAS.find((template) => slugifyTitle(template.title) === templateId)
-      : null
-
   // Show error if templateId is invalid or template is not found
-  if (!template || !templateId || typeof templateId !== 'string') {
+  if (!template) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <Admonition
@@ -70,9 +74,6 @@ const RedirectToTemplates = () => {
       </div>
     )
   }
-
-  // Convert templateId slug to one lowercase word to match docs anchor tag
-  const templateIdForDocs = templateId.replace(/-/g, '').toLowerCase()
 
   return (
     <PageLayout

--- a/apps/studio/types/form.ts
+++ b/apps/studio/types/form.ts
@@ -32,5 +32,6 @@ export interface FormSchema {
       title?: string
       description?: string
     }
+    emailTemplateType?: 'authentication' | 'security'
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Feature: new email templates
- Resolves DEPR-138
- Resolves AUTH-824

## What is the current behavior?

- Only the existing authentication email templates are available

## What is the new behavior?

- Account changes notifications email templates (`security`) are also available (to people within the feature preview)
- Email template schemas have been expanded to note the `emailTemplateType`: `authentication` or `security`

| Before | After |
| --- | --- |
| <img width="1280" height="1322" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/6bef59a8-f63e-4d4e-a0d9-a60df82757e5" /> | <img width="1280" height="1322" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/dad80d04-cc53-428f-a5db-8eaa6278ab8c" /> |

## To test

- [ ] For users not under the feature preview, do the existing `authentication` templates render and work as expected?
- [ ] When the feature preview is on, can you see the new `security` templates?
  - [ ] Can you enable and disable them from the root page?
- [ ] [We deleted](https://github.com/supabase/supabase/pull/39899#discussion_r2472227920) the `misc` properties because they seemed to be unused. Are they truely safe to delete?
