### PR TITLE
Clean up iceberg wrapper when deleting analytics bucket

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageSettings/RevokeCredentialModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/RevokeCredentialModal.tsx
@@ -34,7 +34,7 @@ export const RevokeCredentialModal = ({
   })
 
   return (
-    <Dialog open={visible}>
+    <Dialog open={visible} onOpenChange={onClose}>
       <DialogContent size="small">
         <DialogHeader>
           <DialogTitle>

--- a/apps/studio/data/fdw/fdw-delete-mutation.ts
+++ b/apps/studio/data/fdw/fdw-delete-mutation.ts
@@ -12,7 +12,7 @@ import { FDW } from './fdws-query'
 import { fdwKeys } from './keys'
 
 export type FDWDeleteVariables = {
-  projectRef: string
+  projectRef?: string
   connectionString?: string | null
   wrapper: FDW
   wrapperMeta: WrapperMeta


### PR DESCRIPTION
Branches out of this PR: https://github.com/supabase/supabase/pull/39610

## Context

Cleans up the iceberg FDW when deleting analytics bucket, otherwise will be unable to create another analytics bucket with the same name

Also cleans up S3 access key as well

## To test
Changes can only be tested locally against this PR branch: `joshen/add-skeleton-of-analytics-buckets-to-storage` ([PR](https://github.com/supabase/infrastructure/pull/26697))
- [ ] Ensure that new storage UI feature preview is toggled
- [ ] Create an analytics bucket
- [ ] Delete the analytics bucket
- [ ] Verify that S3 key associated with analytics bucket is also removed under Configuration -> S3
- [ ] Try to create another analytics bucket with the same name