### PR TITLE
chore: invalidate entitlements

### DIFF
--- a/apps/studio/data/entitlements/entitlements-query.ts
+++ b/apps/studio/data/entitlements/entitlements-query.ts
@@ -2,6 +2,7 @@ import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { ResponseError } from 'types/base'
 import type { components } from 'api-types'
+import { organizationKeys } from 'data/organizations/keys'
 
 export type EntitlementsVariables = {
   slug: string
@@ -31,7 +32,7 @@ export const useEntitlementsQuery = <TData = EntitlementsData>(
   { enabled = true, ...options }: UseQueryOptions<EntitlementsData, EntitlementsError, TData> = {}
 ) => {
   return useQuery<EntitlementsData, EntitlementsError, TData>({
-    queryKey: ['entitlements', slug],
+    queryKey: [organizationKeys.entitlements(slug)],
     queryFn: ({ signal }) => getEntitlements({ slug }, signal),
     enabled: enabled && typeof slug !== 'undefined',
     ...options,

--- a/apps/studio/data/entitlements/entitlements-query.ts
+++ b/apps/studio/data/entitlements/entitlements-query.ts
@@ -35,6 +35,6 @@ export const useEntitlementsQuery = <TData = EntitlementsData>(
     queryFn: ({ signal }) => getEntitlements({ slug }, signal),
     enabled: enabled && typeof slug !== 'undefined',
     ...options,
-    staleTime: 1 * 60 * 1000,
+    staleTime: 30 * 60 * 1000,
   })
 }

--- a/apps/studio/data/organizations/keys.ts
+++ b/apps/studio/data/organizations/keys.ts
@@ -4,6 +4,7 @@ export const organizationKeys = {
   members: (slug?: string) => ['organizations', slug, 'members'] as const,
   mfa: (slug?: string) => ['organizations', slug, 'mfa'] as const,
   paymentMethods: (slug: string | undefined) => ['organizations', slug, 'payment-methods'] as const,
+  entitlements: (slug: string | undefined) => ['entitlements', slug] as const,
   roles: (slug: string | undefined) => ['organizations', slug, 'roles'] as const,
   freeProjectLimitCheck: (slug: string | undefined) =>
     ['organizations', slug, 'free-project-limit-check'] as const,

--- a/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
+++ b/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
@@ -76,6 +76,7 @@ export const useOrgSubscriptionUpdateMutation = ({
           queryClient.invalidateQueries(invoicesKeys.orgUpcomingPreview(slug)),
           queryClient.invalidateQueries(organizationKeys.detail(slug)),
           queryClient.invalidateQueries(organizationKeys.list()),
+          queryClient.invalidateQueries(organizationKeys.entitlements(slug)),
         ])
 
         if (variables.paymentMethod) {


### PR DESCRIPTION
This PR adds invalidation to the entitlements query when the Organization's plan is updated and changes the staleTime to 30 minutes.