### PR TITLE
Hook up connecting tables for analytics buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/index.tsx
@@ -1,16 +1,14 @@
-import { snakeCase, uniq } from 'lodash'
+import { uniq } from 'lodash'
 import { SquarePlus } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 
 import { useIsNewStorageUIEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { INTEGRATIONS } from 'components/interfaces/Integrations/Landing/Integrations.constants'
-import { WRAPPER_HANDLERS } from 'components/interfaces/Integrations/Wrappers/Wrappers.constants'
 import { WrapperMeta } from 'components/interfaces/Integrations/Wrappers/Wrappers.types'
 import {
   convertKVStringArrayToJson,
   formatWrapperTables,
-  wrapperMetaComparator,
 } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
 import { BUCKET_TYPES } from 'components/interfaces/Storage/Storage.constants'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
@@ -27,7 +25,6 @@ import {
   DatabaseExtension,
   useDatabaseExtensionsQuery,
 } from 'data/database-extensions/database-extensions-query'
-import { useFDWsQuery } from 'data/fdw/fdws-query'
 import { AnalyticsBucket } from 'data/storage/analytics-buckets-query'
 import { useIcebergNamespacesQuery } from 'data/storage/iceberg-namespaces-query'
 import { useIcebergWrapperCreateMutation } from 'data/storage/iceberg-wrapper-create-mutation'
@@ -55,46 +52,27 @@ import { DecryptedReadOnlyInput } from './DecryptedReadOnlyInput'
 import { NamespaceRow } from './NamespaceRow'
 import { NamespaceWithTables } from './NamespaceWithTables'
 import { SimpleConfigurationDetails } from './SimpleConfigurationDetails'
+import { useAnalyticsBucketWrapperInstance } from './useAnalyticsBucketWrapperInstance'
 import { useIcebergWrapperExtension } from './useIcebergWrapper'
 
 export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) => {
+  const config = BUCKET_TYPES['analytics']
   const [modal, setModal] = useState<'delete' | null>(null)
   const isStorageV2 = useIsNewStorageUIEnabled()
   const { data: project } = useSelectedProjectQuery()
+  const { state: extensionState } = useIcebergWrapperExtension()
+
+  /** The wrapper instance is the wrapper that is installed for this Analytics bucket. */
+  const { data: wrapperInstance, isLoading } = useAnalyticsBucketWrapperInstance(bucket.id)
+  const wrapperValues = convertKVStringArrayToJson(wrapperInstance?.server_options ?? [])
+  const integration = INTEGRATIONS.find((i) => i.id === 'iceberg_wrapper' && i.type === 'wrapper')
+  const wrapperMeta = (integration?.type === 'wrapper' && integration.meta) as WrapperMeta
 
   const { data: extensionsData } = useDatabaseExtensionsQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-
-  const { data, isLoading: isFDWsLoading } = useFDWsQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
-
-  /** The wrapper instance is the wrapper that is installed for this Analytics bucket. */
-  const wrapperInstance = useMemo(() => {
-    return data
-      ?.filter((wrapper) =>
-        wrapperMetaComparator(
-          {
-            handlerName: WRAPPER_HANDLERS.ICEBERG,
-            server: {
-              options: [],
-            },
-          },
-          wrapper
-        )
-      )
-      .find((w) => w.name === snakeCase(`${bucket.id}_fdw`))
-  }, [data, bucket.id])
-
-  const { state: extensionState } = useIcebergWrapperExtension()
-
-  const integration = INTEGRATIONS.find((i) => i.id === 'iceberg_wrapper' && i.type === 'wrapper')
-
-  const wrapperValues = convertKVStringArrayToJson(wrapperInstance?.server_options ?? [])
-  const wrapperMeta = (integration?.type === 'wrapper' && integration.meta) as WrapperMeta
+  const wrappersExtension = extensionsData?.find((ext) => ext.name === 'wrappers')
 
   const { data: token, isSuccess: isSuccessToken } = useVaultSecretDecryptedValueQuery(
     {
@@ -102,9 +80,7 @@ export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) =
       connectionString: project?.connectionString,
       id: wrapperValues.vault_token,
     },
-    {
-      enabled: wrapperValues.vault_token !== undefined,
-    }
+    { enabled: wrapperValues.vault_token !== undefined }
   )
 
   const { data: namespacesData, isLoading: isLoadingNamespaces } = useIcebergNamespacesQuery(
@@ -138,11 +114,7 @@ export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) =
     })
   }, [wrapperTables, namespacesData])
 
-  const wrappersExtension = extensionsData?.find((ext) => ext.name === 'wrappers')
-
-  const config = BUCKET_TYPES['analytics']
-
-  const state = isFDWsLoading
+  const state = isLoading
     ? 'loading'
     : extensionState === 'installed'
       ? wrapperInstance
@@ -200,10 +172,10 @@ export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) =
                         Analytics tables stored in this bucket
                       </ScaffoldSectionDescription>
                     </div>
-                    {namespaces.length > 0 && <ConnectTablesDialog />}
+                    {namespaces.length > 0 && <ConnectTablesDialog bucket={bucket} />}
                   </ScaffoldHeader>
 
-                  {isLoadingNamespaces || isFDWsLoading ? (
+                  {isLoadingNamespaces || isLoading ? (
                     <GenericSkeletonLoader />
                   ) : namespaces.length === 0 ? (
                     <aside className="border border-dashed w-full bg-surface-100 rounded-lg px-4 py-10 flex flex-col gap-y-3 items-center text-center gap-1 text-balance">
@@ -214,7 +186,7 @@ export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) =
                           Stream data from tables for archival, backups, or analytical queries.
                         </p>
                       </div>
-                      <ConnectTablesDialog />
+                      <ConnectTablesDialog bucket={bucket} />
                     </aside>
                   ) : (
                     <div className="flex flex-col gap-y-10">
@@ -244,7 +216,7 @@ export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) =
                     </ScaffoldSectionDescription>
                   </ScaffoldHeader>
 
-                  {isLoadingNamespaces || isFDWsLoading ? (
+                  {isLoadingNamespaces || isLoading ? (
                     <GenericSkeletonLoader />
                   ) : namespaces.length === 0 ? (
                     <Card>

--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/index.tsx
@@ -56,7 +56,7 @@ import { useAnalyticsBucketWrapperInstance } from './useAnalyticsBucketWrapperIn
 import { useIcebergWrapperExtension } from './useIcebergWrapper'
 
 export const AnalyticBucketDetails = ({ bucket }: { bucket: AnalyticsBucket }) => {
-  const config = BUCKET_TYPES['analytics']
+  const config = BUCKET_TYPES.analytics
   const [modal, setModal] = useState<'delete' | null>(null)
   const isStorageV2 = useIsNewStorageUIEnabled()
   const { data: project } = useSelectedProjectQuery()

--- a/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/useAnalyticsBucketWrapperInstance.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticBucketDetails/useAnalyticsBucketWrapperInstance.tsx
@@ -1,0 +1,33 @@
+import { WRAPPER_HANDLERS } from 'components/interfaces/Integrations/Wrappers/Wrappers.constants'
+import { wrapperMetaComparator } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
+import { useFDWsQuery } from 'data/fdw/fdws-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { snakeCase } from 'lodash'
+import { useMemo } from 'react'
+
+export const useAnalyticsBucketWrapperInstance = (id: string) => {
+  const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
+
+  const { data, isLoading: isLoadingFDWs } = useFDWsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  const wrapperInstance = useMemo(() => {
+    return data
+      ?.filter((wrapper) =>
+        wrapperMetaComparator(
+          {
+            handlerName: WRAPPER_HANDLERS.ICEBERG,
+            server: {
+              options: [],
+            },
+          },
+          wrapper
+        )
+      )
+      .find((w) => w.name === snakeCase(`${id}_fdw`))
+  }, [data, id])
+
+  return { data: wrapperInstance, isLoading: isLoadingProject || isLoadingFDWs }
+}

--- a/apps/studio/components/interfaces/Storage/ConnectTablesDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ConnectTablesDialog.tsx
@@ -122,14 +122,15 @@ export const ConnectTablesDialog = ({ bucket }: { bucket: AnalyticsBucket }) => 
         }),
       })
 
+      const keysToDecrypt = Object.entries(wrapperValues)
+        .filter(([name]) =>
+          ['vault_aws_access_key_id', 'vault_aws_secret_access_key'].includes(name)
+        )
+        .map(([_, keyId]) => keyId)
       const decryptedValues = await getDecryptedValues({
         projectRef,
         connectionString: project?.connectionString,
-        ids: Object.entries(wrapperValues)
-          .filter(([k, v]) => {
-            if (['vault_aws_access_key_id', 'vault_aws_secret_access_key'].includes(k)) return v
-          })
-          .map((x) => x[1]),
+        ids: keysToDecrypt,
       })
 
       const warehouseName = bucket.id

--- a/apps/studio/components/interfaces/Storage/ConnectTablesDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ConnectTablesDialog.tsx
@@ -7,7 +7,16 @@ import z from 'zod'
 
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { useCreateDestinationPipelineMutation } from 'data/replication/create-destination-pipeline-mutation'
+import { useCreatePublicationMutation } from 'data/replication/create-publication-mutation'
+import { useReplicationSourcesQuery } from 'data/replication/sources-query'
+import { useStartPipelineMutation } from 'data/replication/start-pipeline-mutation'
+import { AnalyticsBucket } from 'data/storage/analytics-buckets-query'
+import { useIcebergNamespaceCreateMutation } from 'data/storage/iceberg-namespace-create-mutation'
 import { useTablesQuery } from 'data/tables/tables-query'
+import { getDecryptedValues } from 'data/vault/vault-secret-decrypted-value-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import {
   Button,
@@ -25,48 +34,48 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { MultiSelector } from 'ui-patterns/multi-select'
-import { inverseValidBucketNameRegex, validBucketNameRegex } from './CreateBucketModal.utils'
+import { convertKVStringArrayToJson } from '../Integrations/Wrappers/Wrappers.utils'
+import { useAnalyticsBucketWrapperInstance } from './AnalyticBucketDetails/useAnalyticsBucketWrapperInstance'
+import { getCatalogURI } from './StorageSettings/StorageSettings.utils'
 
-const FormSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(1, 'Please provide a name for your bucket')
-      .max(100, 'Bucket name should be below 100 characters')
-      .refine(
-        (value) => !value.endsWith(' '),
-        'The name of the bucket cannot end with a whitespace'
-      )
-      .refine(
-        (value) => value !== 'public',
-        '"public" is a reserved name. Please choose another name'
-      ),
-    tables: z.array(z.string()).min(1, 'At least one table is required'),
-  })
-  .superRefine((data, ctx) => {
-    if (!validBucketNameRegex.test(data.name)) {
-      const [match] = data.name.match(inverseValidBucketNameRegex) ?? []
-      ctx.addIssue({
-        path: ['name'],
-        code: z.ZodIssueCode.custom,
-        message: !!match
-          ? `Bucket name cannot contain the "${match}" character`
-          : 'Bucket name contains an invalid special character',
-      })
-    }
-  })
+/**
+ * [Joshen] So far this is purely just setting up a "Connect from empty state" flow
+ * Doing it bit by bit as this is quite an unknown territory, will adjust as we figure out
+ * limitations, correctness, etc, etc. ETL is also only available on staging so its quite hard
+ * to test things locally (Local set up is technically available but quite high friction)
+ *
+ * What's missing afaict:
+ * - Deleting namespaces
+ * - Removing tables
+ * - Adding more tables
+ * - Error handling due to multiple async processes
+ */
+
+const FormSchema = z.object({
+  tables: z.array(z.string()).min(1, 'At least one table is required'),
+})
 
 const formId = 'connect-tables-form'
+const isEnabled = true // Kill switch if we wanna hold off supporting connecting tables
 
 type ConnectTablesForm = z.infer<typeof FormSchema>
 
-export const ConnectTablesDialog = () => {
-  // Temporary loading state before muteAsync is implemented
-  const isConnecting = false
+export const ConnectTablesDialog = ({ bucket }: { bucket: AnalyticsBucket }) => {
+  const form = useForm<ConnectTablesForm>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { tables: [] },
+  })
+
   const [visible, setVisible] = useState(false)
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
+
+  const { data: wrapperInstance } = useAnalyticsBucketWrapperInstance(bucket.id)
+  const wrapperValues = convertKVStringArrayToJson(wrapperInstance?.server_options ?? [])
+
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef })
+  const { data: apiKeys } = useAPIKeysQuery({ projectRef, reveal: true })
+  const { serviceKey } = getKeys(apiKeys)
 
   const { data: tables } = useTablesQuery({
     projectRef,
@@ -74,17 +83,102 @@ export const ConnectTablesDialog = () => {
     includeColumns: false,
   })
 
-  const form = useForm<ConnectTablesForm>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: { name: '', tables: [] },
-  })
+  const { data: sourcesData } = useReplicationSourcesQuery({ projectRef })
+  const sourceId = sourcesData?.sources.find((s) => s.name === projectRef)?.id
+
+  const { mutateAsync: createNamespace, isLoading: isCreatingNamespace } =
+    useIcebergNamespaceCreateMutation()
+
+  const { mutateAsync: createPublication, isLoading: isCreatingPublication } =
+    useCreatePublicationMutation()
+
+  const { mutateAsync: createDestinationPipeline, isLoading: creatingDestinationPipeline } =
+    useCreateDestinationPipelineMutation({
+      onSuccess: () => {},
+    })
+
+  const { mutateAsync: startPipeline } = useStartPipelineMutation()
+
+  const isConnecting = isCreatingNamespace || creatingDestinationPipeline || isCreatingPublication
 
   const onSubmit: SubmitHandler<ConnectTablesForm> = async (values) => {
+    // [Joshen] Currently creates the destination for the analytics bucket here
+    // Which also involves creating a namespace + publication
+    // Publication name is automatically generated as {bucket.id}_publication
+    // Destination name is automatically generated as {bucket.id}_destination
+
+    if (!projectRef) return console.error('Project ref is required')
+    if (!sourceId) return toast.error('Source ID is required')
+
     try {
-      toast.success(`Connected tables “${values.name}”`)
+      const publicationName = `${bucket.id}_publication`
+      await createPublication({
+        projectRef,
+        sourceId,
+        name: publicationName,
+        tables: values.tables.map((table) => {
+          const [schema, name] = table.split('.')
+          return { schema, name }
+        }),
+      })
+
+      const decryptedValues = await getDecryptedValues({
+        projectRef,
+        connectionString: project?.connectionString,
+        ids: Object.entries(wrapperValues)
+          .filter(([k, v]) => {
+            if (['vault_aws_access_key_id', 'vault_aws_secret_access_key'].includes(k)) return v
+          })
+          .map((x) => x[1]),
+      })
+
+      const warehouseName = bucket.id
+      const catalogToken = serviceKey?.api_key ?? ''
+      const s3AccessKeyId = decryptedValues[wrapperValues['vault_aws_access_key_id']]
+      const s3SecretAccessKey = decryptedValues[wrapperValues['vault_aws_secret_access_key']]
+      const s3Region = projectSettings?.region ?? ''
+
+      const protocol = projectSettings?.app_config?.protocol ?? 'https'
+      const endpoint =
+        projectSettings?.app_config?.storage_endpoint || projectSettings?.app_config?.endpoint
+      const catalogUri = getCatalogURI(project?.ref ?? '', protocol, endpoint)
+      const namespace = `${bucket.id}_namespace`
+      await createNamespace({
+        catalogUri,
+        warehouse: warehouseName,
+        token: catalogToken,
+        namespace,
+      })
+
+      const icebergConfiguration = {
+        projectRef,
+        warehouseName,
+        namespace,
+        catalogToken,
+        s3AccessKeyId,
+        s3SecretAccessKey,
+        s3Region,
+      }
+      const destinationName = `${bucket.id}_destination`
+
+      const { pipeline_id: pipelineId } = await createDestinationPipeline({
+        projectRef,
+        destinationName,
+        destinationConfig: { iceberg: icebergConfiguration },
+        sourceId,
+        pipelineConfig: { publicationName },
+      })
+
+      // Pipeline can start behind the scenes, don't need to await
+      startPipeline({ projectRef, pipelineId })
+      toast.success(`Connected ${values.tables.length} tables to Analytics bucket!`)
       form.reset()
       setVisible(false)
     } catch (error: any) {
+      // [Joshen] JFYI there's several async processes here so if something goes wrong midway - we need to figure out how to roll back cleanly
+      // e.g publication gets created, but namespace creation fails -> should the old publication get deleted?
+      // Another question is probably whether all of these step by step logic should be at the API level instead of client level
+      // Same issue present within DestinationPanel - it's alright for now as we do an Alpha but this needs to be addressed before GA
       toast.error(`Failed to connect tables: ${error.message}`)
     }
   }
@@ -102,16 +196,13 @@ export const ConnectTablesDialog = () => {
       }}
     >
       <DialogTrigger asChild>
-        {/* Temporary disabled button in UI until the feature is implemented */}
         <ButtonTooltip
-          disabled
+          disabled={!isEnabled}
           size="tiny"
           type="primary"
           icon={<Plus size={14} />}
-          // onClick={() => setVisible(true)}
-          tooltip={{
-            content: { side: 'bottom', text: 'Coming soon' },
-          }}
+          onClick={() => setVisible(true)}
+          tooltip={{ content: { side: 'bottom', text: !isEnabled ? 'Coming soon' : undefined } }}
         >
           Connect tables
         </ButtonTooltip>
@@ -128,8 +219,8 @@ export const ConnectTablesDialog = () => {
           <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
             <DialogSection className="flex flex-col gap-y-4">
               <p className="text-sm">
-                Select the database tables you would like to send data from. A destination analytics
-                table will be created for each, and data will replicate automatically.
+                Select the database tables to send data from. A destination analytics table will be
+                created for each, and data will replicate automatically.
               </p>
             </DialogSection>
             <DialogSectionSeparator />
@@ -145,9 +236,7 @@ export const ConnectTablesDialog = () => {
                         onValuesChange={field.onChange}
                         disabled={isConnecting}
                       >
-                        <MultiSelector.Trigger>
-                          <MultiSelector.Input placeholder="Select tables" />
-                        </MultiSelector.Trigger>
+                        <MultiSelector.Trigger label="Select tables..." badgeLimit="wrap" />
                         <MultiSelector.Content>
                           <MultiSelector.List>
                             {tables?.map((table) => (


### PR DESCRIPTION
Branches out of https://github.com/supabase/supabase/pull/39610

## Pre-requisite

Heads up that this cannot be tested locally (unless you have ETL set up locally), nor on staging unless your staging project is flagged to be able to use replication - which is quite a bit of a blocker to have this tested. I haven't been able to test the changes here E2E as a result.

As such, am okay for just a code review for now as we'd still need to do an E2E test either way before merging the main branch

## Context

Hooks up connecting tables for Analytics Bucket, which is essentially trying to do the same as what's `DestinationPanel.tsx` doing. The changes here _only_ cover the flow of connecting tables from an empty state (e.g new Analytics Bucket) so there's probably more cases to consider thereafter too (can follow up with subsequent PRs)

In general from the user's POV they're only just selecting which tables they want to send data from
<img width="562" height="551" alt="image" src="https://github.com/user-attachments/assets/6b5408ae-7b76-43ef-9340-ea42f02f29d7" />

But behind the scenes thereafter, we're
- Creating a new publication based on the selected tables (Default name to `{bucketId}_publication`)
- Creating a new namespace (Default name to `{bucketId}_namespace`)
- Creating a new destination pipeline (Default name to `{bucketId}_destination`)
- Starting the newly created pipeline

However, what's missing thereafter still are
- Managing namespaces
  - I suppose we also need to support deleting namespaces? Where can I check what's the endpoint for that?
- Removing / Adding more tables
  - Question: Is this just a matter of updating the publication?
- Error handling due to multiple async processes