### PR TITLE
fix(settings): add Zod validation to limit project name length to 64 chars

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -50,7 +50,9 @@ const General = () => {
     ref: z.string().optional(),
   })
 
-  const validateForm = (values: any) => {
+  type SettingsFormValues = z.infer<typeof SettingsFormSchema>
+
+  const validateForm = (values: SettingsFormValues) => {
     const result = SettingsFormSchema.safeParse(values)
     if (result.success) return {}
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix the issue with updating the project name in settings. Currently, there’s no proper Zod validation for the name length. Names longer than 64 characters are accepted, causing the UI to break. Added validation to enforce a maximum length of 64 characters.

## What is the current behavior?

https://github.com/user-attachments/assets/239cd8cf-ce5a-401d-9507-835b721f4dfd



## What is the new behavior?

couldn't add the video as there is no option to modify the project name during development


