### PR TITLE
fix(studio): troubleshooting links

### DIFF
--- a/apps/studio/components/interfaces/Support/SubjectAndSuggestionsInfo.tsx
+++ b/apps/studio/components/interfaces/Support/SubjectAndSuggestionsInfo.tsx
@@ -40,7 +40,7 @@ export function SubjectAndSuggestionsInfo({
         )}
       />
       <DocsSuggestions searchString={subject} />
-      {subject && INCLUDE_DISCUSSIONS.includes(category) && (
+      {true && (
         <GitHubDiscussionSuggestion subject={subject} />
       )}
     </div>
@@ -54,7 +54,7 @@ interface GitHubDiscussionSuggestionProps {
 function GitHubDiscussionSuggestion({ subject }: GitHubDiscussionSuggestionProps) {
   return (
     <p className="flex items-center gap-x-1 text-foreground-lighter text-sm">
-      <span>Check our </span>
+      Check our
       <Link
         key="gh-discussions"
         href={`https://github.com/orgs/supabase/discussions?discussions_q=${subject}`}
@@ -65,7 +65,7 @@ function GitHubDiscussionSuggestion({ subject }: GitHubDiscussionSuggestionProps
         GitHub discussions
         <ExternalLink size={14} strokeWidth={2} />
       </Link>
-      <span> for a quick answer</span>
+      for a quick answer.
     </p>
   )
 }

--- a/apps/studio/components/interfaces/Support/SubjectAndSuggestionsInfo.tsx
+++ b/apps/studio/components/interfaces/Support/SubjectAndSuggestionsInfo.tsx
@@ -40,7 +40,7 @@ export function SubjectAndSuggestionsInfo({
         )}
       />
       <DocsSuggestions searchString={subject} />
-      {true && (
+      {subject && INCLUDE_DISCUSSIONS.includes(category) && (
         <GitHubDiscussionSuggestion subject={subject} />
       )}
     </div>
@@ -65,7 +65,7 @@ function GitHubDiscussionSuggestion({ subject }: GitHubDiscussionSuggestionProps
         GitHub discussions
         <ExternalLink size={14} strokeWidth={2} />
       </Link>
-      for a quick answer.
+      for a quick answer
     </p>
   )
 }

--- a/apps/studio/components/interfaces/Support/SupportFormPage.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormPage.tsx
@@ -23,8 +23,8 @@ import type { SupportFormValues } from './SupportForm.schema'
 import {
   createInitialSupportFormState,
   type SupportFormActions,
-  type SupportFormState,
   supportFormReducer,
+  type SupportFormState,
 } from './SupportForm.state'
 import { SupportFormV2 } from './SupportFormV2'
 import { useSupportForm } from './useSupportForm'
@@ -125,7 +125,7 @@ function SupportFormHeader() {
       <div className="flex items-center gap-x-3">
         <Button asChild type="default" icon={<Wrench />}>
           <Link
-            href={`${DOCS_URL}/guides/platform/troubleshooting`}
+            href={`${DOCS_URL}/guides/troubleshooting?products=platform`}
             target="_blank"
             rel="noreferrer"
           >

--- a/apps/studio/components/layouts/ProjectLayout/ConnectingState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ConnectingState.tsx
@@ -91,7 +91,7 @@ const ConnectingState = ({ project }: ConnectingStateProps) => {
                 </Button>
                 <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
                   <Link
-                    href={`${DOCS_URL}/guides/platform/troubleshooting#unable-to-connect-to-your-supabase-project`}
+                    href={`${DOCS_URL}/guides/troubleshooting?products=platform#unable-to-connect-to-your-supabase-project`}
                     className="translate-y-[1px]"
                   >
                     Troubleshooting

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -10,6 +10,7 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
+import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import {
   AiIconAnimation,
   Button,
@@ -21,7 +22,6 @@ import {
   Popover_Shadcn_,
 } from 'ui'
 import { SIDEBAR_KEYS } from '../LayoutSidebar/LayoutSidebarProvider'
-import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 
 export const HelpPopover = () => {
   const router = useRouter()
@@ -102,7 +102,7 @@ export const HelpPopover = () => {
             )}
             <ButtonGroupItem size="tiny" icon={<Wrench strokeWidth={1.5} size={14} />} asChild>
               <a
-                href={`${DOCS_URL}/guides/platform/troubleshooting`}
+                href={`${DOCS_URL}/guides/troubleshooting?products=platform`}
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Links to the Troubleshooting page were using an old URL, which in turn was redirected to a very specific “[Diagnose HTTP API issues](https://supabase.com/docs/guides/troubleshooting/http-api-issues)” page.

## What is the new behavior?

We link to the root Troubleshooting page with the [`?products=platform`](https://supabase.com/docs/guides/troubleshooting?products=platform) search param.
