### PR TITLE
fix: usage page project filtering via URL param

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/Activity.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Activity.tsx
@@ -6,7 +6,7 @@ import { dailyUsageToDataPoints } from './Usage.utils'
 
 export interface ActivityProps {
   orgSlug: string
-  projectRef?: string
+  projectRef: string | null
   startDate: string | undefined
   endDate: string | undefined
   subscription: OrgSubscription | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/Activity.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Activity.tsx
@@ -6,7 +6,7 @@ import { dailyUsageToDataPoints } from './Usage.utils'
 
 export interface ActivityProps {
   orgSlug: string
-  projectRef: string | null
+  projectRef?: string | null
   startDate: string | undefined
   endDate: string | undefined
   subscription: OrgSubscription | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/Egress.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Egress.tsx
@@ -1,16 +1,12 @@
 import { DataPoint } from 'data/analytics/constants'
-import {
-  PricingMetric,
-  useOrgDailyStatsQuery,
-  type OrgDailyUsageResponse,
-} from 'data/analytics/org-daily-stats-query'
+import { PricingMetric, type OrgDailyUsageResponse } from 'data/analytics/org-daily-stats-query'
 import type { OrgSubscription } from 'data/subscriptions/types'
 import UsageSection from './UsageSection/UsageSection'
 import { dailyUsageToDataPoints } from './Usage.utils'
 
 export interface EgressProps {
   orgSlug: string
-  projectRef?: string
+  projectRef: string | null
   subscription: OrgSubscription | undefined
   currentBillingCycleSelected: boolean
   orgDailyStats: OrgDailyUsageResponse | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/SizeAndCounts.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/SizeAndCounts.tsx
@@ -10,7 +10,7 @@ import { dailyUsageToDataPoints } from './Usage.utils'
 
 export interface SizeAndCountsProps {
   orgSlug: string
-  projectRef: string | null
+  projectRef?: string | null
   subscription: OrgSubscription | undefined
   currentBillingCycleSelected: boolean
   orgDailyStats: OrgDailyUsageResponse | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/SizeAndCounts.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/SizeAndCounts.tsx
@@ -10,7 +10,7 @@ import { dailyUsageToDataPoints } from './Usage.utils'
 
 export interface SizeAndCountsProps {
   orgSlug: string
-  projectRef?: string
+  projectRef: string | null
   subscription: OrgSubscription | undefined
   currentBillingCycleSelected: boolean
   orgDailyStats: OrgDailyUsageResponse | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
@@ -20,7 +20,7 @@ import { SectionContent } from './SectionContent'
 
 export interface ComputeProps {
   orgSlug: string
-  projectRef?: string
+  projectRef: string | null
   startDate: string | undefined
   endDate: string | undefined
   subscription: OrgSubscription | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
@@ -20,7 +20,7 @@ import { SectionContent } from './SectionContent'
 
 export interface ComputeProps {
   orgSlug: string
-  projectRef: string | null
+  projectRef?: string | null
   startDate: string | undefined
   endDate: string | undefined
   subscription: OrgSubscription | undefined

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -1,7 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import dayjs from 'dayjs'
 import Link from 'next/link'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useParams } from 'common'
 import {
@@ -16,7 +16,6 @@ import NoPermission from 'components/ui/NoPermission'
 import { OrganizationProjectSelector } from 'components/ui/OrganizationProjectSelector'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useOrgDailyStatsQuery } from 'data/analytics/org-daily-stats-query'
-import { OrgProject } from 'data/projects/org-projects-infinite-query'
 import { useProjectDetailQuery } from 'data/projects/project-detail-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -30,34 +29,20 @@ import Compute from './Compute'
 import Egress from './Egress'
 import SizeAndCounts from './SizeAndCounts'
 import { TotalUsage } from './TotalUsage'
-
-// [Joshen] JFYI this component could use nuqs to handle `projectRef` state which will help
-// simplify some of the implementation here.
+import { useQueryState } from 'nuqs'
 
 export const Usage = () => {
   const { slug, projectRef } = useParams()
 
   const [dateRange, setDateRange] = useState<any>()
-  const [selectedProject, setSelectedProject] = useState<OrgProject>()
 
-  const [selectedProjectRefInputValue, setSelectedProjectRefInputValue] = useState<
-    string | undefined
-  >('all-projects')
+  const [selectedProjectRef, setSelectedProjectRef] = useQueryState('projectRef')
   const [openProjectSelector, setOpenProjectSelector] = useState(false)
-
-  // [Alaister] 'all-projects' is not a valid project ref, it's just used as an extra
-  // state for the select input. As such we need to remove it for the selected project ref
-  const selectedProjectRef =
-    selectedProjectRefInputValue === 'all-projects' ? undefined : selectedProjectRefInputValue
 
   const { can: canReadSubscriptions, isLoading: isLoadingPermissions } = useAsyncCheckPermissions(
     PermissionAction.BILLING_READ,
     'stripe.subscriptions'
   )
-
-  const { isSuccess: isSuccessProjectDetail } = useProjectDetailQuery({
-    ref: selectedProjectRef,
-  })
 
   const {
     data: subscription,
@@ -66,6 +51,13 @@ export const Usage = () => {
     isError: isErrorSubscription,
     isSuccess: isSuccessSubscription,
   } = useOrgSubscriptionQuery({ orgSlug: slug })
+
+  const { data: selectedProject } = useProjectDetailQuery(
+    {
+      ref: selectedProjectRef!,
+    },
+    { enabled: selectedProjectRef != null }
+  )
 
   const billingCycleStart = useMemo(() => {
     return dayjs.unix(subscription?.current_period_start ?? 0).utc()
@@ -122,13 +114,6 @@ export const Usage = () => {
     endDate,
   })
 
-  useEffect(() => {
-    if (projectRef && isSuccessProjectDetail) {
-      setSelectedProjectRefInputValue(projectRef)
-    }
-    // [Joshen] Since we're already looking at isSuccess
-  }, [projectRef, isSuccessProjectDetail])
-
   return (
     <>
       <ScaffoldContainer>
@@ -175,10 +160,9 @@ export const Usage = () => {
                   <OrganizationProjectSelector
                     open={openProjectSelector}
                     setOpen={setOpenProjectSelector}
-                    selectedRef={selectedProjectRefInputValue}
+                    selectedRef={selectedProjectRef}
                     onSelect={(project) => {
-                      setSelectedProject(project)
-                      setSelectedProjectRefInputValue(project.ref)
+                      setSelectedProjectRef(project.ref)
                     }}
                     renderTrigger={() => {
                       return (
@@ -190,14 +174,12 @@ export const Usage = () => {
                           className="justify-between w-[180px]"
                           iconRight={<ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />}
                         >
-                          {!selectedProject || selectedProjectRefInputValue === 'all-projects'
-                            ? 'All projects'
-                            : selectedProject?.name}
+                          {!selectedProject ? 'All projects' : selectedProject?.name}
                         </Button>
                       )
                     }}
                     renderRow={(project) => {
-                      const isSelected = selectedProjectRefInputValue === project.ref
+                      const isSelected = selectedProjectRef === project.ref
                       return (
                         <div className="w-full flex items-center justify-between">
                           <span className={cn('truncate', isSelected ? 'max-w-60' : 'max-w-64')}>
@@ -213,15 +195,15 @@ export const Usage = () => {
                           className="cursor-pointer flex items-center justify-between w-full"
                           onSelect={() => {
                             setOpenProjectSelector(false)
-                            setSelectedProjectRefInputValue('all-projects')
+                            setSelectedProjectRef(null)
                           }}
                           onClick={() => {
                             setOpenProjectSelector(false)
-                            setSelectedProjectRefInputValue('all-projects')
+                            setSelectedProjectRef(null)
                           }}
                         >
                           All projects
-                          {selectedProjectRefInputValue === 'all-projects' && <Check size={16} />}
+                          {!selectedProjectRef && <Check size={16} />}
                         </CommandItem_Shadcn_>
                       </CommandGroup_Shadcn_>
                     )}
@@ -270,7 +252,7 @@ export const Usage = () => {
         </ScaffoldContainer>
       )}
 
-      {selectedProjectRef ? (
+      {selectedProject ? (
         <ScaffoldContainer className="mt-5">
           <Admonition
             type="default"

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -52,11 +52,9 @@ export const Usage = () => {
     isSuccess: isSuccessSubscription,
   } = useOrgSubscriptionQuery({ orgSlug: slug })
 
-  const { data: selectedProject } = useProjectDetailQuery(
-    {
-      ref: selectedProjectRef ?? undefined,
-    }
-  )
+  const { data: selectedProject } = useProjectDetailQuery({
+    ref: selectedProjectRef ?? undefined,
+  })
 
   const billingCycleStart = useMemo(() => {
     return dayjs.unix(subscription?.current_period_start ?? 0).utc()

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -54,9 +54,8 @@ export const Usage = () => {
 
   const { data: selectedProject } = useProjectDetailQuery(
     {
-      ref: selectedProjectRef!,
-    },
-    { enabled: selectedProjectRef != null }
+      ref: selectedProjectRef ?? undefined,
+    }
   )
 
   const billingCycleStart = useMemo(() => {

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/AttributeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/AttributeUsage.tsx
@@ -23,7 +23,7 @@ import { ChartMeta } from './UsageSection'
 
 export interface AttributeUsageProps {
   slug: string
-  projectRef?: string
+  projectRef?: string | null
   attribute: CategoryAttribute
   usage?: OrgUsageResponse
   usageMeta?: OrgMetricsUsage

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
@@ -19,7 +19,7 @@ import { CategoryAttribute } from '../Usage.constants'
 
 export interface DatabaseSizeUsageProps {
   slug: string
-  projectRef?: string
+  projectRef?: string | null
   attribute: CategoryAttribute
   subscription?: OrgSubscription
   usage?: OrgUsageResponse

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
@@ -23,7 +23,7 @@ import { CategoryAttribute } from '../Usage.constants'
 
 export interface DiskUsageProps {
   slug: string
-  projectRef?: string
+  projectRef?: string | null
   attribute: CategoryAttribute
   subscription?: OrgSubscription
   usage?: OrgUsageResponse

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/UsageSection.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/UsageSection.tsx
@@ -15,7 +15,7 @@ export interface ChartMeta {
 
 export interface UsageSectionProps {
   orgSlug: string
-  projectRef?: string
+  projectRef?: string | null
   categoryKey: CategoryMetaKey
   subscription?: OrgSubscription
   chartMeta: ChartMeta

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -25,7 +25,7 @@ import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 interface OrganizationProjectSelectorSelectorProps {
   slug?: string
   open?: boolean
-  selectedRef?: string
+  selectedRef: string | null
   searchPlaceholder?: string
   sameWidthAsTrigger?: boolean
   checkPosition?: 'right' | 'left'

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -25,7 +25,7 @@ import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 interface OrganizationProjectSelectorSelectorProps {
   slug?: string
   open?: boolean
-  selectedRef: string | null
+  selectedRef?: string | null
   searchPlaceholder?: string
   sameWidthAsTrigger?: boolean
   checkPosition?: 'right' | 'left'

--- a/apps/studio/data/usage/org-usage-query.ts
+++ b/apps/studio/data/usage/org-usage-query.ts
@@ -8,7 +8,7 @@ import { usageKeys } from './keys'
 
 export type OrgUsageVariables = {
   orgSlug?: string
-  projectRef?: string
+  projectRef?: string | null
   start?: Date
   end?: Date
 }
@@ -24,7 +24,11 @@ export async function getOrgUsage(
   const { data, error } = await get(`/platform/organizations/{slug}/usage`, {
     params: {
       path: { slug: orgSlug },
-      query: { project_ref: projectRef, start: start?.toISOString(), end: end?.toISOString() },
+      query: {
+        project_ref: projectRef ?? undefined,
+        start: start?.toISOString(),
+        end: end?.toISOString(),
+      },
     },
     signal,
   })
@@ -40,7 +44,12 @@ export const useOrgUsageQuery = <TData = OrgUsageData>(
   { enabled = true, ...options }: UseQueryOptions<OrgUsageData, OrgUsageError, TData> = {}
 ) =>
   useQuery<OrgUsageData, OrgUsageError, TData>({
-    queryKey: usageKeys.orgUsage(orgSlug, projectRef, start?.toISOString(), end?.toISOString()),
+    queryKey: usageKeys.orgUsage(
+      orgSlug,
+      projectRef ?? undefined,
+      start?.toISOString(),
+      end?.toISOString()
+    ),
     queryFn: ({ signal }) => getOrgUsage({ orgSlug, projectRef, start, end }, signal),
     enabled: enabled && IS_PLATFORM && typeof orgSlug !== 'undefined',
     staleTime: 1000 * 60 * 60,


### PR DESCRIPTION
When opening the usage page with a projectRef param (filter by project), it lead to some odd behaviour where the project is not preselected and then after picking a project, it would end up showing the initially filtered project from the URL.

PR removes the odd all-projects logic and uses nuqs for URL state mgmt

