### PR TITLE
studio(fix):don’t presume organization on API authorize step

### DIFF
--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -108,24 +108,17 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
     )
   })
 
-  const onDeclineRequest = async () => {
+  const onDeclineRequest = form.handleSubmit((values) => {
     if (!auth_id) {
       return toast.error('Unable to decline request: auth_id is missing ')
     }
 
-    // Guard: ensure organizations are loaded
-    if (!organizations || organizations.length === 0) {
-      return toast.error('Unable to decline request: Organizations not loaded')
-    }
-
-    const slugToUse = selectedOrgSlug || organization_slug || organizations[0]?.slug
-    if (!slugToUse) {
-      return toast.error('Unable to decline request: No organization context available')
-    }
-
     setIsDeclining(true)
-    declineRequest({ id: auth_id, slug: slugToUse }, { onError: () => setIsDeclining(false) })
-  }
+    declineRequest(
+      { id: auth_id, slug: values.selectedOrgSlug },
+      { onError: () => setIsDeclining(false) }
+    )
+  })
 
   useEffect(() => {
     if (isSuccessOrganizations && organizations.length > 0) {

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -108,17 +108,24 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
     )
   })
 
-  const onDeclineRequest = form.handleSubmit((values) => {
+  const onDeclineRequest = async () => {
     if (!auth_id) {
       return toast.error('Unable to decline request: auth_id is missing ')
     }
 
+    // Guard: ensure organizations are loaded
+    if (!organizations || organizations.length === 0) {
+      return toast.error('Unable to decline request: Organizations not loaded')
+    }
+
+    const slugToUse = selectedOrgSlug || organization_slug || organizations[0]?.slug
+    if (!slugToUse) {
+      return toast.error('Unable to decline request: No organization context available')
+    }
+
     setIsDeclining(true)
-    declineRequest(
-      { id: auth_id, slug: values.selectedOrgSlug },
-      { onError: () => setIsDeclining(false) }
-    )
-  })
+    declineRequest({ id: auth_id, slug: slugToUse }, { onError: () => setIsDeclining(false) })
+  }
 
   useEffect(() => {
     if (isSuccessOrganizations && organizations.length > 0) {
@@ -322,7 +329,7 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
         <Button
           type="default"
           loading={isDeclining}
-          disabled={isApproving || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
+          disabled={isApproving || isExpired}
           onClick={onDeclineRequest}
         >
           Decline

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -104,8 +104,6 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
     if (isSuccessOrganizations && organizations.length > 0) {
       if (organization_slug) {
         setSelectedOrgSlug(organizations.find(({ slug }) => slug === organization_slug)?.slug)
-      } else {
-        setSelectedOrgSlug(organizations[0].slug)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -267,7 +265,8 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
             >
               <SelectTrigger_Shadcn_ size="small">
                 <SelectValue_Shadcn_>
-                  {organizations?.find((x) => x.slug === selectedOrgSlug)?.name}
+                  {organizations?.find((x) => x.slug === selectedOrgSlug)?.name ??
+                    'Select an organization'}
                 </SelectValue_Shadcn_>
               </SelectTrigger_Shadcn_>
               <SelectContent_Shadcn_>
@@ -289,7 +288,7 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
         <Button
           type="default"
           loading={isDeclining}
-          disabled={isApproving || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
+          disabled={isApproving || isExpired || !selectedOrgSlug}
           onClick={onDeclineRequest}
         >
           Decline
@@ -303,7 +302,7 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
         ) : (
           <Button
             loading={isApproving}
-            disabled={isDeclining || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
+            disabled={isDeclining || isExpired || !selectedOrgSlug}
             onClick={onApproveRequest}
           >
             Authorize {requester?.name}

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -264,7 +264,7 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
               onValueChange={setSelectedOrgSlug}
             >
               <SelectTrigger_Shadcn_ size="small">
-                <SelectValue_Shadcn_>
+                <SelectValue_Shadcn_ placeholder="Select an organization">
                   {organizations?.find((x) => x.slug === selectedOrgSlug)?.name ??
                     'Select an organization'}
                 </SelectValue_Shadcn_>

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -282,11 +282,13 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
               render={({ field }) => (
                 <FormItem_Shadcn_>
                   <FormLayout
-                    label={
+                    label="Organization to grant API access to"
+                    description={
                       organization_slug
-                        ? 'API access will be granted to pre-selected organization'
-                        : 'Organization to grant API access to'
+                        ? `'This organization has been pre-selected by ${requester?.name}.`
+                        : undefined
                     }
+                    isReactForm
                   >
                     <FormControl_Shadcn_>
                       <Select_Shadcn_

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -1,8 +1,11 @@
+import { zodResolver } from '@hookform/resolvers/zod'
 import dayjs from 'dayjs'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
+import * as z from 'zod'
 
 import { useParams } from 'common'
 import { AuthorizeRequesterDetails } from 'components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails'
@@ -24,6 +27,11 @@ import {
   CardFooter,
   CardHeader,
   CheckIcon,
+  Form_Shadcn_,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  FormItem_Shadcn_,
+  FormMessage_Shadcn_,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
@@ -41,7 +49,19 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
   const { auth_id, organization_slug } = useParams()
   const [isApproving, setIsApproving] = useState(false)
   const [isDeclining, setIsDeclining] = useState(false)
-  const [selectedOrgSlug, setSelectedOrgSlug] = useState<string>()
+
+  const formSchema = z.object({
+    selectedOrgSlug: z.string().min(1, 'Please select an organization'),
+  })
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { selectedOrgSlug: '' },
+    mode: 'onSubmit',
+    reValidateMode: 'onBlur',
+  })
+
+  const selectedOrgSlug = form.watch('selectedOrgSlug')
 
   const {
     data: organizations,
@@ -76,34 +96,35 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
     },
   })
 
-  const onApproveRequest = async () => {
+  const onApproveRequest = form.handleSubmit((values) => {
     if (!auth_id) {
       return toast.error('Unable to approve request: auth_id is missing ')
     }
-    if (!selectedOrgSlug) {
-      return toast.error('Unable to approve request: No organization selected')
-    }
 
     setIsApproving(true)
-    approveRequest({ id: auth_id, slug: selectedOrgSlug }, { onError: () => setIsApproving(false) })
-  }
+    approveRequest(
+      { id: auth_id, slug: values.selectedOrgSlug },
+      { onError: () => setIsApproving(false) }
+    )
+  })
 
-  const onDeclineRequest = async () => {
+  const onDeclineRequest = form.handleSubmit((values) => {
     if (!auth_id) {
       return toast.error('Unable to decline request: auth_id is missing ')
     }
-    if (!selectedOrgSlug) {
-      return toast.error('Unable to decline request: No organization selected')
-    }
 
     setIsDeclining(true)
-    declineRequest({ id: auth_id, slug: selectedOrgSlug }, { onError: () => setIsDeclining(false) })
-  }
+    declineRequest(
+      { id: auth_id, slug: values.selectedOrgSlug },
+      { onError: () => setIsDeclining(false) }
+    )
+  })
 
   useEffect(() => {
     if (isSuccessOrganizations && organizations.length > 0) {
       if (organization_slug) {
-        setSelectedOrgSlug(organizations.find(({ slug }) => slug === organization_slug)?.slug)
+        const preselected = organizations.find(({ slug }) => slug === organization_slug)?.slug
+        if (preselected) form.setValue('selectedOrgSlug', preselected)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -251,44 +272,54 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
             </AlertDescription_Shadcn_>
           </Alert_Shadcn_>
         ) : (
-          <FormLayout
-            label={
-              organization_slug
-                ? 'API access will be granted to pre-selected organization:'
-                : 'Select an organization to grant API access to:'
-            }
-          >
-            <Select_Shadcn_
-              value={selectedOrgSlug}
-              disabled={isExpired || Boolean(organization_slug)}
-              onValueChange={setSelectedOrgSlug}
-            >
-              <SelectTrigger_Shadcn_ size="small">
-                <SelectValue_Shadcn_ placeholder="Select an organization">
-                  {organizations?.find((x) => x.slug === selectedOrgSlug)?.name ??
-                    'Select an organization'}
-                </SelectValue_Shadcn_>
-              </SelectTrigger_Shadcn_>
-              <SelectContent_Shadcn_>
-                {(organizations ?? []).map((organization) => (
-                  <SelectItem_Shadcn_
-                    key={organization?.slug}
-                    value={organization?.slug}
-                    className="text-xs"
+          <Form_Shadcn_ {...form}>
+            <FormField_Shadcn_
+              control={form.control}
+              name="selectedOrgSlug"
+              render={({ field }) => (
+                <FormItem_Shadcn_>
+                  <FormLayout
+                    label={
+                      organization_slug
+                        ? 'API access will be granted to pre-selected organization'
+                        : 'Organization to grant API access to'
+                    }
                   >
-                    {organization.name}
-                  </SelectItem_Shadcn_>
-                ))}
-              </SelectContent_Shadcn_>
-            </Select_Shadcn_>
-          </FormLayout>
+                    <FormControl_Shadcn_>
+                      <Select_Shadcn_
+                        value={field.value || undefined}
+                        disabled={isExpired || Boolean(organization_slug)}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger_Shadcn_ size="small">
+                          <SelectValue_Shadcn_ placeholder="Select an organization" />
+                        </SelectTrigger_Shadcn_>
+                        <SelectContent_Shadcn_>
+                          {(organizations ?? []).map((organization) => (
+                            <SelectItem_Shadcn_
+                              key={organization?.slug}
+                              value={organization?.slug}
+                              className="text-xs"
+                            >
+                              {organization.name}
+                            </SelectItem_Shadcn_>
+                          ))}
+                        </SelectContent_Shadcn_>
+                      </Select_Shadcn_>
+                    </FormControl_Shadcn_>
+                  </FormLayout>
+                  <FormMessage_Shadcn_ />
+                </FormItem_Shadcn_>
+              )}
+            />
+          </Form_Shadcn_>
         )}
       </CardContent>
       <CardFooter className="justify-end space-x-2">
         <Button
           type="default"
           loading={isDeclining}
-          disabled={isApproving || isExpired || !selectedOrgSlug}
+          disabled={isApproving || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
           onClick={onDeclineRequest}
         >
           Decline
@@ -302,7 +333,7 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
         ) : (
           <Button
             loading={isApproving}
-            disabled={isDeclining || isExpired || !selectedOrgSlug}
+            disabled={isDeclining || isExpired || (Boolean(organization_slug) && !selectedOrgSlug)}
             onClick={onApproveRequest}
           >
             Authorize {requester?.name}

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -125,6 +125,9 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
       if (organization_slug) {
         const preselected = organizations.find(({ slug }) => slug === organization_slug)?.slug
         if (preselected) form.setValue('selectedOrgSlug', preselected)
+      } else if (!form.getValues('selectedOrgSlug') && organizations.length === 1) {
+        // If user only has one organization and none pre-selected via URL, default to it
+        form.setValue('selectedOrgSlug', organizations[0].slug)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes DEPR-131

## What is the current behavior?

Our API authorisation step (used for example when connecting to an MCP client like Cursor) currently presumes the organisation based on whatever is first alphabetically. This is the fallback behaviour when no `organization_slug` is provided.

## What is the new behavior?

When no `organization_slug` is provided, we make no assumptions. We make the user actively select the organization they wish to grant access to. Additionally:

- A placeholder “Select an organization” string is supplied
- We don’t disable the buttons. Instead, if the user tries to proceed without selecting an authorization, we tell them what to fix

## Additional context

| Before | After |
| --- | --- |
| <img width="780" height="1020" alt="Authorize API access  Supabase" src="https://github.com/user-attachments/assets/029817d7-49d2-441a-8d56-2cc5d87e1988" /> | <img width="780" height="1020" alt="Authorize API access  Supabase" src="https://github.com/user-attachments/assets/0b56fe6c-04b6-40a2-8b53-643272e4da69" /> |
| Presumes first organisation alphabetically | Forces me to choose an organisation |

## To test

You can use the Connect dialog (`?showConnect=true&connectTab=mcp`) to one-click add Supabase to Cursor. From there, tap _Install_ and then _Connect_. That should bring you to the authorization step in question. Please test:

- [x] Trying to proceed without supplying an organis£ation
- [x] Selecting an organisation and then proceeding

It would also be great if you could test another situation where `organization_slug` is provided:
- [x] Does it render correctly?
- [x] Does it function as per usual?
