### PR TITLE
fix: wait for auth to load before fetching feature flags

### DIFF
--- a/packages/common/feature-flags.tsx
+++ b/packages/common/feature-flags.tsx
@@ -4,7 +4,7 @@ import { FlagValues } from 'flags/react'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 
 import { components } from 'api-types'
-import { useUser } from './auth'
+import { useAuth } from './auth'
 import { getFlags as getDefaultConfigCatFlags } from './configcat'
 import { hasConsented } from './consent-state'
 import { get, post } from './fetchWrappers'
@@ -72,7 +72,8 @@ export const FeatureFlagProvider = ({
     userEmail?: string
   ) => Promise<{ settingKey: string; settingValue: boolean | number | string | null | undefined }[]>
 }>) => {
-  const user = useUser()
+  const { session, isLoading } = useAuth()
+  const userEmail = session?.user?.email
 
   const [store, setStore] = useState<FeatureFlagContextType>({
     API_URL,
@@ -85,7 +86,7 @@ export const FeatureFlagProvider = ({
     let mounted = true
 
     async function processFlags() {
-      if (!enabled) return
+      if (!enabled || isLoading) return
 
       const loadPHFlags =
         (enabled === true || (typeof enabled === 'object' && enabled.ph)) && !!API_URL
@@ -98,8 +99,8 @@ export const FeatureFlagProvider = ({
         loadPHFlags ? getFeatureFlags(API_URL) : Promise.resolve({}),
         loadCCFlags
           ? typeof getConfigCatFlags === 'function'
-            ? getConfigCatFlags(user?.email)
-            : getDefaultConfigCatFlags(user?.email)
+            ? getConfigCatFlags(userEmail)
+            : getDefaultConfigCatFlags(userEmail)
           : Promise.resolve([]),
       ])
 
@@ -139,7 +140,7 @@ export const FeatureFlagProvider = ({
     return () => {
       mounted = false
     }
-  }, [enabled, user?.email])
+  }, [enabled, isLoading, userEmail])
 
   return (
     <FeatureFlagContext.Provider value={store}>


### PR DESCRIPTION
Currently on initial render, we're sending two requests to `/platform/telemetry/feature-flags` because we're not waiting for the user to load:
<img width="644" height="156" alt="Screenshot 2025-10-28 at 16 18 20" src="https://github.com/user-attachments/assets/f0d60e67-3bb2-4d6e-b2e5-21657de3d85a" />

The first request is unauthenticated, followed by another request with the user email attached right after it.

This PR simply waits for the authentication state to finish loading before sending the request.

**To test:**

- [ ] Verify only one request is being sent
- [ ] Ensure feature flags still function as normal