### PR TITLE
Fix: MCP server configuration for VS Code

### DIFF
--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -77,7 +77,7 @@ export const MCP_CLIENTS: McpClient[] = [
     externalDocsUrl: 'https://code.visualstudio.com/docs/copilot/chat/mcp-servers',
     transformConfig: (config): VSCodeMcpConfig => {
       return {
-        mcpServers: {
+        servers: {
           supabase: {
             type: 'http',
             url: config.mcpServers.supabase.url,

--- a/packages/ui-patterns/src/McpUrlBuilder/types.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/types.ts
@@ -32,8 +32,8 @@ export interface McpClientBaseConfig {
 
 export interface CursorMcpConfig extends McpClientBaseConfig {}
 
-export interface VSCodeMcpConfig extends McpClientBaseConfig {
-  mcpServers: {
+export interface VSCodeMcpConfig {
+  servers: {
     supabase: {
       type: 'http'
       url: string


### PR DESCRIPTION
VS Code uses `servers`, not `mcpServers` (see https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server).

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The MCP config code snippet for VS Code is wrong.

## What is the new behavior?

It is fixed to now use `servers` as in VS Code docs: https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server

## Additional context

--
