### PR TITLE
fix: always retry on 429 errors

### DIFF
--- a/apps/studio/data/query-client.ts
+++ b/apps/studio/data/query-client.ts
@@ -43,7 +43,9 @@ export function getQueryClient() {
             if (
               error instanceof ResponseError &&
               error.requestPathname &&
-              SKIP_RETRY_PATHNAME_MATCHERS.some((matchFn) => matchFn(error.requestPathname!))
+              SKIP_RETRY_PATHNAME_MATCHERS.some((matchFn) => matchFn(error.requestPathname!)) &&
+              // Still retry on 429s (rate limit) so that retry after is respected
+              error.code !== 429
             ) {
               return false
             }


### PR DESCRIPTION
If the API returns a 429 error we should always retry so that we only send another request once the API is ready (`retry-after`).