### PR TITLE
docs: Fix SvelteKit OAuth PCKE flow syntax (#39940)

### DIFF
--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -123,12 +123,12 @@ export const GET = async (event) => {
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      throw redirect(303, `/${next.slice(1)}`);
+      redirect(303, `/${next.slice(1)}`);
     }
   }
 
   // return the user to an error page with instructions
-  throw redirect(303, '/auth/auth-code-error');
+  redirect(303, '/auth/auth-code-error');
 };
 ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The code example for SvelteKit `src/routes/auth/callback/+server.js` uses the outdated `throw redirect()` syntax
#39940 

## What is the new behavior?

It uses just `redirect()` to align with the SvelteKit docs
