### PR TITLE
fix: `supabase_admin` user for self-hosted read/write queries

### DIFF
--- a/apps/studio/lib/api/self-hosted/constants.ts
+++ b/apps/studio/lib/api/self-hosted/constants.ts
@@ -5,5 +5,5 @@ export const POSTGRES_PORT = process.env.POSTGRES_PORT || 5432
 export const POSTGRES_HOST = process.env.POSTGRES_HOST || 'db'
 export const POSTGRES_DATABASE = process.env.POSTGRES_DB || 'postgres'
 export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD || 'postgres'
-export const POSTGRES_USER_READ_WRITE = 'postgres'
+export const POSTGRES_USER_READ_WRITE = 'supabase_admin'
 export const POSTGRES_USER_READ_ONLY = 'supabase_read_only_user'


### PR DESCRIPTION
**Changes**
- When calling [executeQuery](https://github.com/supabase/supabase/blob/ad6466b1f303aefa12a2df0e16a07f6d92333f09/apps/studio/lib/api/self-hosted/query.ts#L17) with `readOnly = false`, the connection string now uses `supabase_admin` user instead of `postgres`

I sanity checked by running `pnpm dev:studio-local` and trying to run `INSERT` / `CREATE` operations through the local MCP server's `execute_sql` tool with/without `read_only` mode.

✅ `http://127.0.0.1:8082/api/mcp` can still perform writes
✅ `http://127.0.0.1:8082/api/mcp?read_only` still gives permission denied error when attempting writes

Resolves #39901

Resolves AI-186