### PR TITLE
fix(docker): password auth failed for user supabase_read_only_user

### DIFF
--- a/docker/volumes/db/roles.sql
+++ b/docker/volumes/db/roles.sql
@@ -6,3 +6,4 @@ ALTER USER pgbouncer WITH PASSWORD :'pgpass';
 ALTER USER supabase_auth_admin WITH PASSWORD :'pgpass';
 ALTER USER supabase_functions_admin WITH PASSWORD :'pgpass';
 ALTER USER supabase_storage_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_read_only_user WITH PASSWORD :'pgpass';


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix #39961 

## What is the new behavior?

auth success
