### PR TITLE
feat(billing): invalidate addons query when custom domain is deleted

### DIFF
--- a/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
@@ -2,6 +2,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
+import { subscriptionKeys } from 'data/subscriptions/keys'
 import type { ResponseError } from 'types'
 import { customDomainKeys } from './keys'
 
@@ -46,6 +47,9 @@ export const useCustomDomainDeleteMutation = ({
           status: '0_no_hostname_configured',
         }
       })
+
+      // Invalidate addons cache since the backend removes the addon when deleting the domain
+      await queryClient.invalidateQueries({ queryKey: subscriptionKeys.addons(projectRef) })
 
       await onSuccess?.(data, variables, context)
     },


### PR DESCRIPTION
### Summary

We added logic on the backend to remove the custom domain add-on when a custom domain is removed.

This PR invalidates the add-ons query so that the user sees a nudge to enable the add-on (instead of a form to add a custom domain) when a custom domain is deleted.

### Test instructions

- Apply this patch

```
diff --git a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
index 06bd6f23fc..de1e438a5a 100644
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -121,9 +121,7 @@ export const CustomDomainConfig = () => {
                 />
               )}

-              {customDomainData.status === '5_services_reconfigured' && (
-                <CustomDomainDelete projectRef={ref} customDomain={customDomainData.customDomain} />
-              )}
+              <CustomDomainDelete projectRef={ref} customDomain={customDomainData.customDomain} />
             </div>
           ) : (
             <CustomDomainConfigFallthrough
diff --git a/apps/studio/data/custom-domains/check-cname-mutation.ts b/apps/studio/data/custom-domains/check-cname-mutation.ts
index a85afaf065..4984f6bb45 100644
--- a/apps/studio/data/custom-domains/check-cname-mutation.ts
+++ b/apps/studio/data/custom-domains/check-cname-mutation.ts
@@ -28,13 +28,15 @@ export async function checkCNAMERecord({ domain }: CheckCNAMERecordVariables) {
       `${BASE_PATH}/api/check-cname?domain=${domain}`
     ).then((res) => res.json())

-    if (res.Answer === undefined) {
-      throw new Error(
-        `Your CNAME record for ${domain} cannot be found - if you've just added the record, do check back in a bit.`
-      )
-    }
+    // if (res.Answer === undefined) {
+    //   throw new Error(
+    //     `Your CNAME record for ${domain} cannot be found - if you've just added the record, do check back in a bit.`
+    //   )
+    // }

-    return res.Answer.some((x) => x.type === 5)
+    return true
+
+    // return res.Answer.some((x) => x.type === 5)
   } catch (error) {
     handleError(error)
   }
   ```
   
 - Enable the custom domain add-on
 - Add a custom domain from project settings (make sure it reflects on the UI)
 - Now delete the custom domain 
- The UI should automatically refresh
- The custom domain configuration should no longer be visible
- You should see this notice to enable the add-on

<img width="1196" height="231" alt="Screenshot 2025-10-29 at 4 31 59 PM" src="https://github.com/user-attachments/assets/c87e6fcc-ae49-4501-9f9e-e47164b11b73" />