### PR TITLE
Add try catches in post delete analytics bucket clean up

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -265,7 +265,7 @@ export const CreateBucketModal = ({
         </ButtonTooltip>
       </DialogTrigger>
 
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Create a {isStorageV2 ? config.singularName : 'storage'} bucket</DialogTitle>
         </DialogHeader>

--- a/apps/studio/components/interfaces/Storage/CreateSpecializedBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateSpecializedBucketModal.tsx
@@ -227,7 +227,7 @@ export const CreateSpecializedBucketModal = ({
         </ButtonTooltip>
       </DialogTrigger>
 
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Create {config.singularName} bucket</DialogTitle>
         </DialogHeader>

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -127,15 +127,17 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
   const { mutate: deleteAnalyticsBucket, isLoading: isDeletingAnalyticsBucket } =
     useAnalyticsBucketDeleteMutation({
       onSuccess: async () => {
-        await deleteAnalyticsBucketCleanUp({
-          projectRef,
-          bucketId: bucket.id,
-          icebergWrapper,
-          icebergWrapperMeta,
-          s3AccessKey,
-          publication,
-        })
-
+        if (project?.connectionString) {
+          await deleteAnalyticsBucketCleanUp({
+            projectRef,
+            connectionString: project.connectionString,
+            bucketId: bucket.id,
+            icebergWrapper,
+            icebergWrapperMeta,
+            s3AccessKey,
+            publication,
+          })
+        }
         toast.success(`Successfully deleted analytics bucket ${bucket.id}`)
         if (isStorageV2) {
           router.push(`/project/${projectRef}/storage/analytics`)
@@ -171,7 +173,7 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
         if (!open) onClose()
       }}
     >
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Confirm deletion of {bucket.id}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Context

Able to test deletion of analytics bucket locally now and found some issues

- The `mutateAsync`s within `useAnalyticsBucketDeleteCleanUp` needs to be wrapped in individual try catches as any issues with each clean up shouldn't affect the others.
- Add missing `connectionString` param to `mutateAsync` of `useAnalyticsBucketDeleteCleanUp`
- Add `aria-describedby={undefined}` to `DialogContent` components in `CreateBucketModal`, `CreateSpecializedBucketModal` and `DeleteBucketModal` to silence some console warnings