### PR TITLE
connect dialog: add shared pooler to transaction pooler

### DIFF
--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -353,7 +353,7 @@ export const Connect = () => {
             {connectionTypes.length === 1 ? ` via ${connectionTypes[0].label.toLowerCase()}` : null}
           </DialogTitle>
           <DialogDescription>
-            Get the connection strings and environment variables for your app
+            Get the connection strings and environment variables for your app.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
@@ -15,6 +15,7 @@ import {
   Collapsible_Shadcn_,
   CollapsibleContent_Shadcn_,
   CollapsibleTrigger_Shadcn_,
+  Separator,
   WarningIcon,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -25,6 +26,7 @@ interface ConnectionPanelProps {
   badge?: string
   title: string
   description: string
+  contentFooter?: ReactNode
   connectionString: string
   ipv4Status: {
     type: 'error' | 'success'
@@ -105,6 +107,7 @@ export const ConnectionPanel = ({
   badge,
   title,
   description,
+  contentFooter,
   connectionString,
   ipv4Status,
   notice,
@@ -123,161 +126,175 @@ export const ConnectionPanel = ({
 
   const links = ipv4Status.links ?? []
 
+  const isTransactionDedicatedPooler = type === 'transaction' && badge === 'Dedicated Pooler'
+
   return (
     <div className="relative text-sm flex flex-col gap-5 lg:grid lg:grid-cols-12 w-full">
       <div className="col-span-4 flex flex-col">
         <div className="flex items-center gap-x-2 mb-2">
           <h1 className="text-sm">{title}</h1>
-          {!!badge && <Badge>{badge}</Badge>}
+          {!!badge && !isTransactionDedicatedPooler && <Badge>{badge}</Badge>}
         </div>
         <p className="text-sm text-foreground-light mb-4">{description}</p>
+        {contentFooter}
       </div>
       <div className="col-span-8 flex flex-col gap-2">
-        <div className="flex flex-col -space-y-px">
-          {fileTitle && <CodeBlockFileHeader title={fileTitle} />}
-          {type === 'transaction' && isSessionMode ? (
-            <Admonition
-              showIcon={false}
-              type="default"
-              className="[&>h5]:text-xs [&>div]:text-xs"
-              title="Transaction pooler is unavailable as pool mode is set to Session"
-              description="If you'd like to use transaction mode, update your pool mode to Transaction for the connection pooler in your project's Database Settings."
-            >
-              <Button asChild type="default" className="mt-2">
-                <Link
-                  href={`/project/${projectRef}/database/settings#connection-pooler`}
-                  className="text-xs text-light hover:text-foreground"
-                >
-                  Database Settings
-                </Link>
-              </Button>
-            </Admonition>
-          ) : (
-            <>
-              <CodeBlock
-                wrapperClassName={cn(
-                  '[&_pre]:rounded-b-none [&_pre]:px-4 [&_pre]:py-3',
-                  fileTitle && '[&_pre]:rounded-t-none'
-                )}
-                language={lang}
-                value={connectionString}
-                className="[&_code]:text-[12px] [&_code]:text-foreground [&_code]:!whitespace-normal"
-                hideLineNumbers
-                onCopyCallback={onCopyCallback}
-              />
-              {notice && (
-                <div className="border px-4 py-1 w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-light">
-                  {notice?.map((text: string) => (
-                    <p key={text} className="text-xs text-foreground-lighter">
-                      {text}
-                    </p>
-                  ))}
-                </div>
-              )}
-              {parameters.length > 0 && <ConnectionParameters parameters={parameters} />}
-            </>
+        <div className="flex flex-col gap-2">
+          {isTransactionDedicatedPooler && (
+            <div className="text-xs flex items-center text-foreground-light">
+              Using the Dedicated Pooler:
+            </div>
           )}
-          {children}
-        </div>
-        <div className="flex flex-col -space-y-px w-full">
-          {IS_PLATFORM && (
-            <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b">
-              <div className="flex items-center gap-2">
-                <IPv4StatusIcon active={ipv4Status.type === 'success'} />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-xs text-foreground">{ipv4Status.title}</span>
-                {ipv4Status.description &&
-                  (typeof ipv4Status.description === 'string' ? (
-                    <span className="text-xs text-foreground-lighter">
-                      {ipv4Status.description}
-                    </span>
-                  ) : (
-                    ipv4Status.description
-                  ))}
-                {links.length > 0 && (
-                  <div className="flex items-center gap-x-2 mt-2">
-                    {links.map((link) => (
-                      <Button key={link.text} asChild type="default" size="tiny">
-                        <Link href={link.url} className="text-xs text-light hover:text-foreground">
-                          {link.text}
-                        </Link>
-                      </Button>
+          <div className="flex flex-col -space-y-px">
+            {fileTitle && <CodeBlockFileHeader title={fileTitle} />}
+            {type === 'transaction' && isSessionMode ? (
+              <Admonition
+                showIcon={false}
+                type="default"
+                className="[&>h5]:text-xs [&>div]:text-xs"
+                title="Transaction pooler is unavailable as pool mode is set to Session"
+                description="If you'd like to use transaction mode, update your pool mode to Transaction for the connection pooler in your project's Database Settings."
+              >
+                <Button asChild type="default" className="mt-2">
+                  <Link
+                    href={`/project/${projectRef}/database/settings#connection-pooler`}
+                    className="text-xs text-light hover:text-foreground"
+                  >
+                    Database Settings
+                  </Link>
+                </Button>
+              </Admonition>
+            ) : (
+              <>
+                <CodeBlock
+                  wrapperClassName={cn(
+                    '[&_pre]:rounded-b-none [&_pre]:px-4 [&_pre]:py-3',
+                    fileTitle && '[&_pre]:rounded-t-none'
+                  )}
+                  language={lang}
+                  value={connectionString}
+                  className="[&_code]:text-[12px] [&_code]:text-foreground [&_code]:!whitespace-normal"
+                  hideLineNumbers
+                  onCopyCallback={onCopyCallback}
+                />
+                {notice && (
+                  <div className="border px-4 py-1 w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-light">
+                    {notice?.map((text: string) => (
+                      <p key={text} className="text-xs text-foreground-lighter">
+                        {text}
+                      </p>
                     ))}
                   </div>
                 )}
-              </div>
-            </div>
-          )}
-
-          {type === 'session' && (
-            <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b bg-alternative/50">
-              <div className="flex w-6 h-6 rounded items-center justify-center gap-2 flex-shrink-0 bg-surface-100">
-                <WarningIcon />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-xs text-foreground">Only use on a IPv4 network</span>
-                <div className="flex flex-col text-xs text-foreground-lighter">
-                  <p>Session pooler connections are IPv4 proxied for free.</p>
-                  <p>Use Direct Connection if connecting via an IPv6 network.</p>
+                {parameters.length > 0 && <ConnectionParameters parameters={parameters} />}
+              </>
+            )}
+          </div>
+          <div className="flex flex-col -space-y-px w-full">
+            {IS_PLATFORM && (
+              <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b">
+                <div className="flex items-center gap-2">
+                  <IPv4StatusIcon active={ipv4Status.type === 'success'} />
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs text-foreground">{ipv4Status.title}</span>
+                  {ipv4Status.description &&
+                    (typeof ipv4Status.description === 'string' ? (
+                      <span className="text-xs text-foreground-lighter">
+                        {ipv4Status.description}
+                      </span>
+                    ) : (
+                      ipv4Status.description
+                    ))}
+                  {links.length > 0 && (
+                    <div className="flex items-center gap-x-2 mt-2">
+                      {links.map((link) => (
+                        <Button key={link.text} asChild type="default" size="tiny">
+                          <Link
+                            href={link.url}
+                            className="text-xs text-light hover:text-foreground"
+                          >
+                            {link.text}
+                          </Link>
+                        </Button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {IS_PLATFORM && ipv4Status.type === 'error' && (
-            <Collapsible_Shadcn_ className="group -space-y-px">
-              <CollapsibleTrigger_Shadcn_
-                asChild
-                className="group/collapse w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-muted"
-              >
-                <Button
-                  type="default"
-                  size="tiny"
-                  className="text-foreground-lighter !bg-dash-sidebar"
-                  icon={
-                    <ChevronRight
-                      className={cn(
-                        'group-data-[state=open]/collapse:rotate-90 text-foreground-muted transition-transform'
-                      )}
-                    />
-                  }
-                >
-                  Some platforms are IPv4-only:
-                </Button>
-              </CollapsibleTrigger_Shadcn_>
-              <CollapsibleContent_Shadcn_ className="bg-dash-sidebar rounded-b border px-3 py-2">
-                <div className="flex flex-col gap-2">
-                  <p className="text-xs text-foreground-light max-w-xs">
-                    A few major platforms are IPv4-only and may not work with a Direct Connection:
-                  </p>
-                  <div className="flex gap-4">
-                    <div className="text-foreground text-xs">Vercel</div>
-                    <div className="text-foreground text-xs">GitHub Actions</div>
-                    <div className="text-foreground text-xs">Render</div>
-                    <div className="text-foreground text-xs">Retool</div>
+            {type === 'session' && (
+              <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b bg-alternative/50">
+                <div className="flex w-6 h-6 rounded items-center justify-center gap-2 flex-shrink-0 bg-surface-100">
+                  <WarningIcon />
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs text-foreground">Only use on a IPv4 network</span>
+                  <div className="flex flex-col text-xs text-foreground-lighter">
+                    <p>Session pooler connections are IPv4 proxied for free.</p>
+                    <p>Use Direct Connection if connecting via an IPv6 network.</p>
                   </div>
-                  <p className="text-xs text-foreground-lighter max-w-xs">
-                    If you wish to use a Direct Connection with these, please purchase{' '}
-                    <Link
-                      href={`/project/${projectRef}/settings/addons?panel=ipv4`}
-                      className="text-xs text-light hover:text-foreground"
-                    >
-                      IPv4 support
-                    </Link>
-                    .
-                  </p>
-                  <p className="text-xs text-foreground-lighter max-w-xs">
-                    You may also use the{' '}
-                    <span className="text-foreground-light">Session Pooler</span> or{' '}
-                    <span className="text-foreground-light">Transaction Pooler</span> if you are on
-                    a IPv4 network.
-                  </p>
                 </div>
-              </CollapsibleContent_Shadcn_>
-            </Collapsible_Shadcn_>
-          )}
+              </div>
+            )}
+
+            {IS_PLATFORM && ipv4Status.type === 'error' && (
+              <Collapsible_Shadcn_ className="group -space-y-px">
+                <CollapsibleTrigger_Shadcn_
+                  asChild
+                  className="group/collapse w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-muted"
+                >
+                  <Button
+                    type="default"
+                    size="tiny"
+                    className="text-foreground-lighter !bg-dash-sidebar"
+                    icon={
+                      <ChevronRight
+                        className={cn(
+                          'group-data-[state=open]/collapse:rotate-90 text-foreground-muted transition-transform'
+                        )}
+                      />
+                    }
+                  >
+                    Some platforms are IPv4-only:
+                  </Button>
+                </CollapsibleTrigger_Shadcn_>
+                <CollapsibleContent_Shadcn_ className="bg-dash-sidebar rounded-b border px-3 py-2">
+                  <div className="flex flex-col gap-2">
+                    <p className="text-xs text-foreground-light max-w-xs">
+                      A few major platforms are IPv4-only and may not work with a Direct Connection:
+                    </p>
+                    <div className="flex gap-4">
+                      <div className="text-foreground text-xs">Vercel</div>
+                      <div className="text-foreground text-xs">GitHub Actions</div>
+                      <div className="text-foreground text-xs">Render</div>
+                      <div className="text-foreground text-xs">Retool</div>
+                    </div>
+                    <p className="text-xs text-foreground-lighter max-w-xs">
+                      If you wish to use a Direct Connection with these, please purchase{' '}
+                      <Link
+                        href={`/project/${projectRef}/settings/addons?panel=ipv4`}
+                        className="text-xs text-light hover:text-foreground"
+                      >
+                        IPv4 support
+                      </Link>
+                      .
+                    </p>
+                    <p className="text-xs text-foreground-lighter max-w-xs">
+                      You may also use the{' '}
+                      <span className="text-foreground-light">Session Pooler</span> or{' '}
+                      <span className="text-foreground-light">Transaction Pooler</span> if you are
+                      on a IPv4 network.
+                    </p>
+                  </div>
+                </CollapsibleContent_Shadcn_>
+              </Collapsible_Shadcn_>
+            )}
+          </div>
         </div>
+        {isTransactionDedicatedPooler && <Separator className="w-full" />}
+        {children}
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
@@ -139,159 +139,154 @@ export const ConnectionPanel = ({
         {contentFooter}
       </div>
       <div className="col-span-8 flex flex-col gap-2">
-        <div className="flex flex-col gap-2">
-          {isTransactionDedicatedPooler && (
-            <div className="text-xs flex items-center text-foreground-light">
-              Using the Dedicated Pooler:
-            </div>
+        {isTransactionDedicatedPooler && (
+          <div className="text-xs flex items-center text-foreground-light">
+            Using the Dedicated Pooler:
+          </div>
+        )}
+        <div className="flex flex-col -space-y-px">
+          {fileTitle && <CodeBlockFileHeader title={fileTitle} />}
+          {type === 'transaction' && isSessionMode ? (
+            <Admonition
+              showIcon={false}
+              type="default"
+              className="[&>h5]:text-xs [&>div]:text-xs"
+              title="Transaction pooler is unavailable as pool mode is set to Session"
+              description="If you'd like to use transaction mode, update your pool mode to Transaction for the connection pooler in your project's Database Settings."
+            >
+              <Button asChild type="default" className="mt-2">
+                <Link
+                  href={`/project/${projectRef}/database/settings#connection-pooler`}
+                  className="text-xs text-light hover:text-foreground"
+                >
+                  Database Settings
+                </Link>
+              </Button>
+            </Admonition>
+          ) : (
+            <>
+              <CodeBlock
+                wrapperClassName={cn(
+                  '[&_pre]:rounded-b-none [&_pre]:px-4 [&_pre]:py-3',
+                  fileTitle && '[&_pre]:rounded-t-none'
+                )}
+                language={lang}
+                value={connectionString}
+                className="[&_code]:text-[12px] [&_code]:text-foreground [&_code]:!whitespace-normal"
+                hideLineNumbers
+                onCopyCallback={onCopyCallback}
+              />
+              {notice && (
+                <div className="border px-4 py-1 w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-light">
+                  {notice?.map((text: string) => (
+                    <p key={text} className="text-xs text-foreground-lighter">
+                      {text}
+                    </p>
+                  ))}
+                </div>
+              )}
+              {parameters.length > 0 && <ConnectionParameters parameters={parameters} />}
+            </>
           )}
-          <div className="flex flex-col -space-y-px">
-            {fileTitle && <CodeBlockFileHeader title={fileTitle} />}
-            {type === 'transaction' && isSessionMode ? (
-              <Admonition
-                showIcon={false}
-                type="default"
-                className="[&>h5]:text-xs [&>div]:text-xs"
-                title="Transaction pooler is unavailable as pool mode is set to Session"
-                description="If you'd like to use transaction mode, update your pool mode to Transaction for the connection pooler in your project's Database Settings."
-              >
-                <Button asChild type="default" className="mt-2">
-                  <Link
-                    href={`/project/${projectRef}/database/settings#connection-pooler`}
-                    className="text-xs text-light hover:text-foreground"
-                  >
-                    Database Settings
-                  </Link>
-                </Button>
-              </Admonition>
-            ) : (
-              <>
-                <CodeBlock
-                  wrapperClassName={cn(
-                    '[&_pre]:rounded-b-none [&_pre]:px-4 [&_pre]:py-3',
-                    fileTitle && '[&_pre]:rounded-t-none'
-                  )}
-                  language={lang}
-                  value={connectionString}
-                  className="[&_code]:text-[12px] [&_code]:text-foreground [&_code]:!whitespace-normal"
-                  hideLineNumbers
-                  onCopyCallback={onCopyCallback}
-                />
-                {notice && (
-                  <div className="border px-4 py-1 w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-light">
-                    {notice?.map((text: string) => (
-                      <p key={text} className="text-xs text-foreground-lighter">
-                        {text}
-                      </p>
+        </div>
+        <div className="flex flex-col -space-y-px w-full">
+          {IS_PLATFORM && (
+            <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b">
+              <div className="flex items-center gap-2">
+                <IPv4StatusIcon active={ipv4Status.type === 'success'} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs text-foreground">{ipv4Status.title}</span>
+                {ipv4Status.description &&
+                  (typeof ipv4Status.description === 'string' ? (
+                    <span className="text-xs text-foreground-lighter">
+                      {ipv4Status.description}
+                    </span>
+                  ) : (
+                    ipv4Status.description
+                  ))}
+                {links.length > 0 && (
+                  <div className="flex items-center gap-x-2 mt-2">
+                    {links.map((link) => (
+                      <Button key={link.text} asChild type="default" size="tiny">
+                        <Link href={link.url} className="text-xs text-light hover:text-foreground">
+                          {link.text}
+                        </Link>
+                      </Button>
                     ))}
                   </div>
                 )}
-                {parameters.length > 0 && <ConnectionParameters parameters={parameters} />}
-              </>
-            )}
-          </div>
-          <div className="flex flex-col -space-y-px w-full">
-            {IS_PLATFORM && (
-              <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b">
-                <div className="flex items-center gap-2">
-                  <IPv4StatusIcon active={ipv4Status.type === 'success'} />
-                </div>
-                <div className="flex flex-col">
-                  <span className="text-xs text-foreground">{ipv4Status.title}</span>
-                  {ipv4Status.description &&
-                    (typeof ipv4Status.description === 'string' ? (
-                      <span className="text-xs text-foreground-lighter">
-                        {ipv4Status.description}
-                      </span>
-                    ) : (
-                      ipv4Status.description
-                    ))}
-                  {links.length > 0 && (
-                    <div className="flex items-center gap-x-2 mt-2">
-                      {links.map((link) => (
-                        <Button key={link.text} asChild type="default" size="tiny">
-                          <Link
-                            href={link.url}
-                            className="text-xs text-light hover:text-foreground"
-                          >
-                            {link.text}
-                          </Link>
-                        </Button>
-                      ))}
-                    </div>
-                  )}
+              </div>
+            </div>
+          )}
+
+          {type === 'session' && (
+            <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b bg-alternative/50">
+              <div className="flex w-6 h-6 rounded items-center justify-center gap-2 flex-shrink-0 bg-surface-100">
+                <WarningIcon />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs text-foreground">Only use on a IPv4 network</span>
+                <div className="flex flex-col text-xs text-foreground-lighter">
+                  <p>Session pooler connections are IPv4 proxied for free.</p>
+                  <p>Use Direct Connection if connecting via an IPv6 network.</p>
                 </div>
               </div>
-            )}
+            </div>
+          )}
 
-            {type === 'session' && (
-              <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b bg-alternative/50">
-                <div className="flex w-6 h-6 rounded items-center justify-center gap-2 flex-shrink-0 bg-surface-100">
-                  <WarningIcon />
-                </div>
-                <div className="flex flex-col">
-                  <span className="text-xs text-foreground">Only use on a IPv4 network</span>
-                  <div className="flex flex-col text-xs text-foreground-lighter">
-                    <p>Session pooler connections are IPv4 proxied for free.</p>
-                    <p>Use Direct Connection if connecting via an IPv6 network.</p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {IS_PLATFORM && ipv4Status.type === 'error' && (
-              <Collapsible_Shadcn_ className="group -space-y-px">
-                <CollapsibleTrigger_Shadcn_
-                  asChild
-                  className="group/collapse w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-muted"
+          {IS_PLATFORM && ipv4Status.type === 'error' && (
+            <Collapsible_Shadcn_ className="group -space-y-px">
+              <CollapsibleTrigger_Shadcn_
+                asChild
+                className="group/collapse w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-muted"
+              >
+                <Button
+                  type="default"
+                  size="tiny"
+                  className="text-foreground-lighter !bg-dash-sidebar"
+                  icon={
+                    <ChevronRight
+                      className={cn(
+                        'group-data-[state=open]/collapse:rotate-90 text-foreground-muted transition-transform'
+                      )}
+                    />
+                  }
                 >
-                  <Button
-                    type="default"
-                    size="tiny"
-                    className="text-foreground-lighter !bg-dash-sidebar"
-                    icon={
-                      <ChevronRight
-                        className={cn(
-                          'group-data-[state=open]/collapse:rotate-90 text-foreground-muted transition-transform'
-                        )}
-                      />
-                    }
-                  >
-                    Some platforms are IPv4-only:
-                  </Button>
-                </CollapsibleTrigger_Shadcn_>
-                <CollapsibleContent_Shadcn_ className="bg-dash-sidebar rounded-b border px-3 py-2">
-                  <div className="flex flex-col gap-2">
-                    <p className="text-xs text-foreground-light max-w-xs">
-                      A few major platforms are IPv4-only and may not work with a Direct Connection:
-                    </p>
-                    <div className="flex gap-4">
-                      <div className="text-foreground text-xs">Vercel</div>
-                      <div className="text-foreground text-xs">GitHub Actions</div>
-                      <div className="text-foreground text-xs">Render</div>
-                      <div className="text-foreground text-xs">Retool</div>
-                    </div>
-                    <p className="text-xs text-foreground-lighter max-w-xs">
-                      If you wish to use a Direct Connection with these, please purchase{' '}
-                      <Link
-                        href={`/project/${projectRef}/settings/addons?panel=ipv4`}
-                        className="text-xs text-light hover:text-foreground"
-                      >
-                        IPv4 support
-                      </Link>
-                      .
-                    </p>
-                    <p className="text-xs text-foreground-lighter max-w-xs">
-                      You may also use the{' '}
-                      <span className="text-foreground-light">Session Pooler</span> or{' '}
-                      <span className="text-foreground-light">Transaction Pooler</span> if you are
-                      on a IPv4 network.
-                    </p>
+                  Some platforms are IPv4-only:
+                </Button>
+              </CollapsibleTrigger_Shadcn_>
+              <CollapsibleContent_Shadcn_ className="bg-dash-sidebar rounded-b border px-3 py-2">
+                <div className="flex flex-col gap-2">
+                  <p className="text-xs text-foreground-light max-w-xs">
+                    A few major platforms are IPv4-only and may not work with a Direct Connection:
+                  </p>
+                  <div className="flex gap-4">
+                    <div className="text-foreground text-xs">Vercel</div>
+                    <div className="text-foreground text-xs">GitHub Actions</div>
+                    <div className="text-foreground text-xs">Render</div>
+                    <div className="text-foreground text-xs">Retool</div>
                   </div>
-                </CollapsibleContent_Shadcn_>
-              </Collapsible_Shadcn_>
-            )}
-          </div>
+                  <p className="text-xs text-foreground-lighter max-w-xs">
+                    If you wish to use a Direct Connection with these, please purchase{' '}
+                    <Link
+                      href={`/project/${projectRef}/settings/addons?panel=ipv4`}
+                      className="text-xs text-light hover:text-foreground"
+                    >
+                      IPv4 support
+                    </Link>
+                    .
+                  </p>
+                  <p className="text-xs text-foreground-lighter max-w-xs">
+                    You may also use the{' '}
+                    <span className="text-foreground-light">Session Pooler</span> or{' '}
+                    <span className="text-foreground-light">Transaction Pooler</span> if you are on
+                    a IPv4 network.
+                  </p>
+                </div>
+              </CollapsibleContent_Shadcn_>
+            </Collapsible_Shadcn_>
+          )}
         </div>
         {isTransactionDedicatedPooler && <Separator className="w-full" />}
         {children}

--- a/apps/studio/components/interfaces/Connect/ConnectionParameters.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectionParameters.tsx
@@ -28,7 +28,7 @@ export const ConnectionParameters = ({ parameters }: ConnectionParametersProps) 
     <Collapsible_Shadcn_ open={isOpen} onOpenChange={setIsOpen} className="group -space-y-px">
       <CollapsibleTrigger_Shadcn_
         asChild
-        className="w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none border-light px-3"
+        className="w-full justify-start rounded-t-none !last:rounded-b group-data-[state=open]:rounded-b-none data-[state=open]:border-light border-light px-3"
       >
         <Button
           type="default"

--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -1,6 +1,7 @@
-import { ChevronDown, GlobeIcon, InfoIcon } from 'lucide-react'
+import { BookOpen, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
 
 import { useParams } from 'common'
 import { getAddons } from 'components/interfaces/Billing/Subscription/Subscription.utils'
@@ -19,6 +20,7 @@ import { pluckObjectFields } from 'lib/helpers'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import {
   Badge,
+  Button,
   CodeBlock,
   CollapsibleContent_Shadcn_,
   CollapsibleTrigger_Shadcn_,
@@ -30,6 +32,7 @@ import {
   SelectValue_Shadcn_,
   Select_Shadcn_,
   Separator,
+  TextLink,
   cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -275,55 +278,69 @@ export const DatabaseConnectionString = () => {
 
   return (
     <div className="flex flex-col">
-      <div
-        className={cn(
-          'flex flex-col md:flex-row items-stretch md:items-center gap-2 md:gap-3',
-          DIALOG_PADDING_X
-        )}
-      >
-        <div className="flex">
-          <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
-            Type
-          </span>
-          <Select_Shadcn_ value={selectedTab} onValueChange={handleTabChange}>
-            <SelectTrigger_Shadcn_ size="small" className="w-auto rounded-l-none">
-              <SelectValue_Shadcn_ />
-            </SelectTrigger_Shadcn_>
-            <SelectContent_Shadcn_>
-              {DATABASE_CONNECTION_TYPES.map((type) => (
-                <SelectItem_Shadcn_ key={type.id} value={type.id}>
-                  {type.label}
-                </SelectItem_Shadcn_>
-              ))}
-            </SelectContent_Shadcn_>
-          </Select_Shadcn_>
+      <div className={cn('w-full flex flex-col items-start gap-2 lg:gap-3', DIALOG_PADDING_X)}>
+        <div className="flex w-full flex-col md:flex-row items-stretch md:items-center gap-2 md:gap-3">
+          <div className="flex">
+            <span className="w-1/2 md:w-auto flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
+              Type
+            </span>
+            <Select_Shadcn_ value={selectedTab} onValueChange={handleTabChange}>
+              <SelectTrigger_Shadcn_ size="small" className="w-full md:w-auto rounded-l-none">
+                <SelectValue_Shadcn_ />
+              </SelectTrigger_Shadcn_>
+              <SelectContent_Shadcn_>
+                {DATABASE_CONNECTION_TYPES.map((type) => (
+                  <SelectItem_Shadcn_ key={type.id} value={type.id}>
+                    {type.label}
+                  </SelectItem_Shadcn_>
+                ))}
+              </SelectContent_Shadcn_>
+            </Select_Shadcn_>
+          </div>
+          <DatabaseSelector
+            portal={false}
+            buttonProps={{
+              size: 'small',
+              className: 'w-full justify-between pr-2.5 [&_svg]:h-4',
+            }}
+            className="w-full md:w-auto [&>span]:w-1/2 [&>span]:md:w-auto"
+            onSelectId={handleDatabaseChange}
+          />
+          <div className="flex">
+            <span className="w-1/2 md:w-auto flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
+              Method
+            </span>
+            <Select_Shadcn_ value={selectedMethod} onValueChange={handleMethodChange}>
+              <SelectTrigger_Shadcn_ size="small" className="w-full md:w-auto rounded-l-none">
+                <SelectValue_Shadcn_ size="tiny">
+                  {connectionStringMethodOptions[selectedMethod].label}
+                </SelectValue_Shadcn_>
+              </SelectTrigger_Shadcn_>
+              <SelectContent_Shadcn_ className="max-w-sm">
+                {Object.keys(connectionStringMethodOptions).map((method) => (
+                  <ConnectionStringMethodSelectItem
+                    key={method}
+                    method={method as ConnectionStringMethod}
+                    poolerBadge={method === 'transaction' ? poolerBadge : undefined}
+                  />
+                ))}
+              </SelectContent_Shadcn_>
+            </Select_Shadcn_>
+          </div>
         </div>
-        <DatabaseSelector
-          portal={false}
-          buttonProps={{ size: 'small' }}
-          onSelectId={handleDatabaseChange}
-        />
-        <div className="flex">
-          <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
-            Method
-          </span>
-          <Select_Shadcn_ value={selectedMethod} onValueChange={handleMethodChange}>
-            <SelectTrigger_Shadcn_ size="small" className="w-auto rounded-l-none">
-              <SelectValue_Shadcn_ size="tiny">
-                {connectionStringMethodOptions[selectedMethod].label}
-              </SelectValue_Shadcn_>
-            </SelectTrigger_Shadcn_>
-            <SelectContent_Shadcn_ className="max-w-sm">
-              {Object.keys(connectionStringMethodOptions).map((method) => (
-                <ConnectionStringMethodSelectItem
-                  key={method}
-                  method={method as ConnectionStringMethod}
-                  poolerBadge={method === 'transaction' ? poolerBadge : undefined}
-                />
-              ))}
-            </SelectContent_Shadcn_>
-          </Select_Shadcn_>
-        </div>
+        <p className="text-xs inline-flex items-center gap-1 text-foreground-lighter">
+          <BookOpen size={12} strokeWidth={1.5} className="-mb-px" /> Learn how to connect to your
+          Postgres databases.
+          <Link
+            href="https://supabase.com/docs/guides/database/connecting-to-postgres"
+            className="underline transition hover:text-foreground inline-flex items-center gap-1"
+            target="_blank"
+            rel="noreferrer"
+            title="Read docs"
+          >
+            Read docs <ExternalLink size={12} strokeWidth={1.5} />
+          </Link>
+        </p>
       </div>
 
       {isLoading && (
@@ -458,7 +475,49 @@ export const DatabaseConnectionString = () => {
                     { ...CONNECTION_PARAMETERS.pool_mode, value: 'transaction' },
                   ]}
                   onCopyCallback={() => handleCopy(selectedTab, 'transaction_pooler')}
-                />
+                >
+                  {!sharedPoolerPreferred && !ipv4Addon && (
+                    <Collapsible_Shadcn_ className="group">
+                      <CollapsibleTrigger_Shadcn_
+                        asChild
+                        className="w-full justify-start !last:rounded-b group-data-[state=open]:rounded-b-none border-light px-3"
+                      >
+                        <Button
+                          type="default"
+                          size="large"
+                          iconRight={
+                            <ChevronDown className="transition group-data-[state=open]:rotate-180" />
+                          }
+                          className="text-foreground !bg-dash-sidebar justify-between"
+                        >
+                          <div className="text-xs flex items-center py-2 px-1">
+                            <span>Using the Shared Pooler</span>
+                            <Badge variant={'brand'} size={'small'} className="ml-2">
+                              IPv4 compatible
+                            </Badge>
+                          </div>
+                        </Button>
+                      </CollapsibleTrigger_Shadcn_>
+                      <CollapsibleContent_Shadcn_ className="bg-dash-sidebar rounded-b border text-xs">
+                        <CodeBlock
+                          wrapperClassName={cn(
+                            '[&_pre]:border-x-0 [&_pre]:border-t-0 [&_pre]:px-4 [&_pre]:py-3',
+                            '[&_pre]:rounded-t-none'
+                          )}
+                          language={lang}
+                          value={supavisorConnectionStrings['pooler'][selectedTab]}
+                          className="[&_code]:text-[12px] [&_code]:text-foreground"
+                          hideLineNumbers
+                          onCopyCallback={() => handleCopy(selectedTab, 'transaction_pooler')}
+                        />
+                        <p className="px-3 py-2 text-foreground-light">
+                          Only recommended when your network does not support IPv6. Added latency
+                          compared to dedicated pooler.
+                        </p>
+                      </CollapsibleContent_Shadcn_>
+                    </Collapsible_Shadcn_>
+                  )}
+                </ConnectionPanel>
               )}
 
               {selectedMethod === 'session' && IS_PLATFORM && (
@@ -588,20 +647,29 @@ const ConnectionStringMethodSelectItem = ({
 }: {
   method: ConnectionStringMethod
   poolerBadge?: string
-}) => (
-  <SelectItem_Shadcn_ value={method} className="[&>span:first-child]:top-3.5">
-    <div className="flex flex-col w-full py-1">
-      <div className="flex gap-x-2 items-center">
-        {connectionStringMethodOptions[method].label}
-        {method === 'session' ? (
-          <Badge variant="outline">Shared Pooler</Badge>
-        ) : (
-          poolerBadge && <Badge variant="outline">{poolerBadge}</Badge>
-        )}
+}) => {
+  const badges: ReactNode[] = []
+
+  if (method !== 'direct') {
+    badges.push(<Badge className="flex gap-x-1">Shared Pooler</Badge>)
+  }
+  if (poolerBadge === 'Dedicated Pooler') {
+    badges.push(<Badge className="flex gap-x-1">{poolerBadge}</Badge>)
+  }
+
+  return (
+    <SelectItem_Shadcn_ value={method} className="[&>span:first-child]:top-3.5">
+      <div className="flex flex-col w-full py-1">
+        <div className="flex gap-x-2 items-center">
+          {connectionStringMethodOptions[method].label}
+        </div>
+        <div className="text-foreground-lighter text-xs">
+          {connectionStringMethodOptions[method].description}
+        </div>
+        <div className="flex items-center gap-0.5 flex-wrap mt-1.5">
+          {badges.map((badge) => badge)}
+        </div>
       </div>
-      <div className="text-foreground-lighter text-xs">
-        {connectionStringMethodOptions[method].description}
-      </div>
-    </div>
-  </SelectItem_Shadcn_>
-)
+    </SelectItem_Shadcn_>
+  )
+}

--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -318,7 +318,7 @@ export const DatabaseConnectionString = () => {
                 <ConnectionStringMethodSelectItem
                   key={method}
                   method={method as ConnectionStringMethod}
-                  poolerBadge={poolerBadge}
+                  poolerBadge={method === 'transaction' ? poolerBadge : undefined}
                 />
               ))}
             </SelectContent_Shadcn_>
@@ -587,11 +587,18 @@ const ConnectionStringMethodSelectItem = ({
   poolerBadge,
 }: {
   method: ConnectionStringMethod
-  poolerBadge: string
+  poolerBadge?: string
 }) => (
   <SelectItem_Shadcn_ value={method} className="[&>span:first-child]:top-3.5">
     <div className="flex flex-col w-full py-1">
-      <div>{connectionStringMethodOptions[method].label}</div>
+      <div className="flex gap-x-2 items-center">
+        {connectionStringMethodOptions[method].label}
+        {method === 'session' ? (
+          <Badge variant="outline">Shared Pooler</Badge>
+        ) : (
+          poolerBadge && <Badge variant="outline">{poolerBadge}</Badge>
+        )}
+      </div>
       <div className="text-foreground-lighter text-xs">
         {connectionStringMethodOptions[method].description}
       </div>

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -38,6 +38,7 @@ interface DatabaseSelectorProps {
   onSelectId?: (id: string) => void // Optional callback
   onCreateReplicaClick?: () => void
   portal?: boolean
+  className?: string
 }
 
 const DatabaseSelector = ({
@@ -48,6 +49,7 @@ const DatabaseSelector = ({
   buttonProps,
   onCreateReplicaClick = noop,
   portal = true,
+  className,
 }: DatabaseSelectorProps) => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
@@ -79,7 +81,7 @@ const DatabaseSelector = ({
   return (
     <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
       <PopoverTrigger_Shadcn_ asChild>
-        <div className="flex cursor-pointer">
+        <div className={cn('flex cursor-pointer', className)}>
           <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
             Source
           </span>


### PR DESCRIPTION
Add the `Shared Pooler` params again to the transaction pooler in the Connect dialog.

## Before

When in a paid plan, the Transaction pooler layout only shows the "Dedicated pooler" params and the shared pooler params aren't visible.
<img width="1091" height="581" alt="Screenshot 2025-10-29 at 17 03 22" src="https://github.com/user-attachments/assets/09b2ba8e-8dda-43cc-ad45-df4ef4334657" />

## After

Added the Shared pooler params back also making it clear which part refers to the dedicated pooler:
<img width="1086" height="714" alt="Screenshot 2025-10-29 at 16 53 33" src="https://github.com/user-attachments/assets/7d610d48-1020-4794-ac81-f7cb6d6b306f" />

Also added the available pooler options in the method dropdown to improve discoverability:
<img width="488" height="448" alt="Screenshot 2025-10-29 at 16 53 46" src="https://github.com/user-attachments/assets/d6a87045-aad7-463e-ad0e-1abc4347886a" />

---

Bonus:
Also added a link to the [Connect to you database](https://supabase.com/docs/guides/database/connecting-to-postgres) docs to better help the user understand how to connect to the database using the connection strings:
<img width="954" height="388" alt="Screenshot 2025-10-29 at 17 09 34" src="https://github.com/user-attachments/assets/27173b65-923f-49fe-863c-a26e3dfeab81" />