### PR TITLE
Fix: update authorization header for database hooks for http requests

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -90,23 +90,23 @@ export const FormContents = ({
     if (values.http_url && isEdgeFunctionSelected) {
       const fnSlug = values.http_url.split('/').at(-1)
       const fn = functions.find((x) => x.slug === fnSlug)
+      const authorizationHeader = httpHeaders.find((x) => x.name === 'Authorization')
+      const edgeFunctionAuthHeaderVal = `Bearer ${legacyServiceRole}`
 
-      if (fn?.verify_jwt) {
-        if (!httpHeaders.some((x) => x.name === 'Authorization')) {
-          const authorizationHeader = {
-            id: uuidv4(),
-            name: 'Authorization',
-            value: `Bearer ${legacyServiceRole}`,
-          }
-          setHttpHeaders([...httpHeaders, authorizationHeader])
+      if (fn?.verify_jwt && authorizationHeader == null) {
+        const authorizationHeader = {
+          id: uuidv4(),
+          name: 'Authorization',
+          value: edgeFunctionAuthHeaderVal,
         }
-      } else {
-        const updatedHttpHeaders = httpHeaders.filter((x) => x.name !== 'Authorization')
+        setHttpHeaders([...httpHeaders, authorizationHeader])
+      } else if (fn?.verify_jwt && authorizationHeader?.value !== edgeFunctionAuthHeaderVal) {
+        const updatedHttpHeaders = httpHeaders.map((x) => {
+          if (x.name === 'Authorization') return { ...x, value: edgeFunctionAuthHeaderVal }
+          else return x
+        })
         setHttpHeaders(updatedHttpHeaders)
       }
-    } else {
-      const updatedHttpHeaders = httpHeaders.filter((x) => x.name !== 'Authorization')
-      setHttpHeaders(updatedHttpHeaders)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values.http_url, isSuccessEdgeFunctions])


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, authorization headers are not showing up for HTTP request endpoints on Database Hooks. The logic for edge functions is erasing the header 

## What is the current behavior?

Add a auth header for a http request database hook

## What is the new behavior?

Auth headers now show up for Database hooks

## Additional context

To test this:
1. Enable database hooks
2. Create a http requests database hook (not edge function)
3. Add a header called "Authorization" 
4. Ensure when you edit the edge function, the header is editable (it was not and disappeared)
