### PR TITLE
Fix table_quickstart_opened event to track control group

### DIFF
--- a/apps/studio/components/layouts/Tabs/NewTab.tsx
+++ b/apps/studio/components/layouts/Tabs/NewTab.tsx
@@ -81,7 +81,7 @@ export function NewTab() {
 
   /**
    * Returns:
-   * - `QuickstartVariant`: user variation (`ai`, `templates`, `assistant`)
+   * - `QuickstartVariant`: user variation (`control`, `ai`, `templates`, `assistant`)
    * - `false`: user not yet bucketed or not targeted for experiment
    * - `undefined`: PostHog still loading
    */
@@ -102,14 +102,20 @@ export function NewTab() {
       ? tableQuickstartVariant
       : null
 
+  const shouldTrackExposure =
+    editor !== 'sql' &&
+    isNewProject &&
+    tableQuickstartVariant !== false &&
+    tableQuickstartVariant !== undefined
+
   useEffect(() => {
-    if (activeQuickstartVariant && !hasTrackedExposure.current) {
+    if (shouldTrackExposure && tableQuickstartVariant && !hasTrackedExposure.current) {
       hasTrackedExposure.current = true
       track('table_quickstart_opened', {
-        variant: activeQuickstartVariant,
+        variant: tableQuickstartVariant,
       })
     }
-  }, [activeQuickstartVariant, track])
+  }, [shouldTrackExposure, tableQuickstartVariant, track])
 
   const handleOpenAssistant = () => {
     if (isCreatingChat) return

--- a/apps/studio/components/layouts/Tabs/NewTab.tsx
+++ b/apps/studio/components/layouts/Tabs/NewTab.tsx
@@ -109,7 +109,7 @@ export function NewTab() {
     tableQuickstartVariant !== undefined
 
   useEffect(() => {
-    if (shouldTrackExposure && tableQuickstartVariant && !hasTrackedExposure.current) {
+    if (shouldTrackExposure && !hasTrackedExposure.current) {
       hasTrackedExposure.current = true
       track('table_quickstart_opened', {
         variant: tableQuickstartVariant,


### PR DESCRIPTION
## Problem

The `table_quickstart_opened` event wasn't tracking users in the control group, preventing baseline measurement for the A/B test.

**Root cause:** `activeQuickstartVariant` filters out `CONTROL` variants, so the tracking logic never fired for control group users.

## Solution

- Add `shouldTrackExposure` boolean to separate tracking from rendering logic
- Track `tableQuickstartVariant` directly (includes control) instead of `activeQuickstartVariant`

## Test Plan

- [x] Verify control group users send `table_quickstart_opened` event with `variant: 'control'`
- [x] Verify treatment users still send events with correct variant names
- [x] Verify no events sent for projects > 7 days old
- [x] Verify no events sent in SQL editor mode
- [x] Verify event only fires once per session (ref check)