### PR TITLE
Fix: Updated roles to managed by Supabase

### DIFF
--- a/apps/studio/components/interfaces/Database/Roles/Roles.constants.ts
+++ b/apps/studio/components/interfaces/Database/Roles/Roles.constants.ts
@@ -16,6 +16,8 @@ export const SUPABASE_ROLES = [
   'pgsodium_keyiduser',
   'pgsodium_keymaker',
   'pgtle_admin',
+  'cli_login_postgres',
+  'supabase_etl_admin',
 ] as const
 
 // [Joshen] This was originally in the Roles mobx store


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES 

## What kind of change does this PR introduce?

Small fix: Moved cli_login_postgres and supabase_etl_admin

## What is the current behavior?

Roles are showing up in "Other" users can delete and face an error :(

## What is the new behavior?

Roles are managed by supabase and should appear in othe

## Additional context

N/A
