### PR TITLE
studio(feat): nested help and feedback

### DIFF
--- a/apps/studio/components/interfaces/HelpAndFeedbackDropdown.tsx
+++ b/apps/studio/components/interfaces/HelpAndFeedbackDropdown.tsx
@@ -1,0 +1,56 @@
+import { HelpCircle, LifeBuoy, Lightbulb } from 'lucide-react'
+import { useState } from 'react'
+
+import { FeedbackWidget } from 'components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget'
+import { HelpPopover } from 'components/layouts/ProjectLayout/LayoutHeader/HelpPopover'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'ui'
+
+export const HelpAndFeedbackDropdown = () => {
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild className="border flex-shrink-0 px-3">
+        <ButtonTooltip
+          id="help-and-feedback-dropdown-button"
+          type="text"
+          className="rounded-none w-[32px] h-[30px] group"
+          icon={
+            <HelpCircle
+              size={18}
+              strokeWidth={1.5}
+              className="!h-[18px] !w-[18px] text-foreground-light group-hover:text-foreground"
+            />
+          }
+          tooltip={{ content: { side: 'bottom', text: 'Help' } }}
+        />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent side="bottom" align="end">
+        {/* <div className="px-2 py-1 flex flex-col gap-0 text-sm">
+          <span className="w-full text-left text-foreground truncate">Help and feedback</span>
+        </div>
+        <DropdownMenuSeparator /> */}
+        <DropdownMenuGroup>
+          <DropdownMenuItem className="flex gap-2" onClick={() => setHelpOpen(true)}>
+            <LifeBuoy size={14} strokeWidth={1.5} className="text-foreground-lighter" />
+            Get support
+          </DropdownMenuItem>
+          <DropdownMenuItem className="flex gap-2" onClick={() => setFeedbackOpen(true)}>
+            <Lightbulb size={14} strokeWidth={1.5} className="text-foreground-lighter" />
+            Leave feedback
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+      <HelpPopover open={helpOpen} onOpenChange={setHelpOpen} />
+      <FeedbackWidget open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+    </DropdownMenu>
+  )
+}

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -1,8 +1,19 @@
-import { Command, FlaskConical, Loader2, Settings } from 'lucide-react'
+import {
+  FlaskConical,
+  HelpCircle,
+  Lightbulb,
+  Loader2,
+  LogOut,
+  Settings,
+  SwatchBook,
+} from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 
+import { FeedbackWidget } from 'components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget'
+import { HelpPopover } from 'components/layouts/ProjectLayout/LayoutHeader/HelpPopover'
 import { ProfileImage } from 'components/ui/ProfileImage'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSignOut } from 'lib/auth'
@@ -32,6 +43,8 @@ export function UserDropdown() {
   const appStateSnapshot = useAppStateSnapshot()
   const profileShowEmailEnabled = useIsFeatureEnabled('profile:show_email')
   const { username, avatarUrl, primaryEmail, isLoading } = useProfileNameAndPicture()
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
 
   const signOut = useSignOut()
   const setCommandMenuOpen = useSetCommandMenuOpen()
@@ -82,7 +95,7 @@ export function UserDropdown() {
             </div>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem className="flex gap-2" asChild>
+              <DropdownMenuItem className="flex gap-2.5" asChild>
                 <Link
                   href="/account/me"
                   onClick={() => {
@@ -96,23 +109,23 @@ export function UserDropdown() {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem
-                className="flex gap-2"
+                className="flex gap-2.5"
                 onClick={openFeaturePreviewModal}
                 onSelect={openFeaturePreviewModal}
               >
                 <FlaskConical size={14} strokeWidth={1.5} className="text-foreground-lighter" />
                 Feature previews
               </DropdownMenuItem>
-              <DropdownMenuItem className="flex gap-2" onClick={handleCommandMenuOpen}>
-                <Command size={14} strokeWidth={1.5} className="text-foreground-lighter" />
-                Command menu
-              </DropdownMenuItem>
               <DropdownMenuSeparator />
             </DropdownMenuGroup>
           </>
         )}
+
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Theme</DropdownMenuLabel>
+          <DropdownMenuLabel className="flex gap-2.5">
+            <SwatchBook size={14} strokeWidth={1.5} className="text-foreground-lighter" />
+            Theme
+          </DropdownMenuLabel>
           <DropdownMenuRadioGroup
             value={theme}
             onValueChange={(value) => {
@@ -125,22 +138,39 @@ export function UserDropdown() {
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>
+          <DropdownMenuSeparator />
         </DropdownMenuGroup>
+
+        <DropdownMenuGroup>
+          <DropdownMenuItem className="flex gap-2.5" onClick={() => setHelpOpen(true)}>
+            <HelpCircle size={14} strokeWidth={1.5} className="text-foreground-lighter" />
+            Get help
+          </DropdownMenuItem>
+          <DropdownMenuItem className="flex gap-2.5" onClick={() => setFeedbackOpen(true)}>
+            <Lightbulb size={14} strokeWidth={1.5} className="text-foreground-lighter" />
+            Leave feedback
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
         {IS_PLATFORM && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem
+                className="flex gap-2.5"
                 onSelect={async () => {
                   await signOut()
                 }}
               >
+                <LogOut size={14} strokeWidth={1.5} className="text-foreground-lighter" />
                 Log out
               </DropdownMenuItem>
             </DropdownMenuGroup>
           </>
         )}
       </DropdownMenuContent>
+      <HelpPopover open={helpOpen} onOpenChange={setHelpOpen} />
+      <FeedbackWidget open={feedbackOpen} onOpenChange={setFeedbackOpen} />
     </DropdownMenu>
   )
 }

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -25,8 +25,6 @@ import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { Badge, cn } from 'ui'
 import { SIDEBAR_KEYS } from '../LayoutSidebar/LayoutSidebarProvider'
 import { BreadcrumbsView } from './BreadcrumbsView'
-import { FeedbackDropdown } from './FeedbackDropdown/FeedbackDropdown'
-import { HelpPopover } from './HelpPopover'
 import { HomeIcon } from './HomeIcon'
 import { LocalVersionPopover } from './LocalVersionPopover'
 import MergeRequestButton from './MergeRequestButton'
@@ -214,10 +212,8 @@ const LayoutHeader = ({
             {customHeaderComponents && customHeaderComponents}
             {IS_PLATFORM ? (
               <>
-                <FeedbackDropdown />
-
                 <div className="overflow-hidden flex items-center rounded-full border">
-                  <HelpPopover />
+                  {/* <HelpAndFeedbackDropdown /> */}
                   <NotificationsPopoverV2 />
                   <AnimatePresence initial={false}>
                     {!!projectRef && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

- UI feature

## What is the current behavior?

- Help and Feedback are two distinct entry points into a very busy top nav

## What is the new behavior?

- Help and Feedback are nested in the UserDropdown

## To do

Still to come:

- [ ] Restore `IS_PLATFORM` checks in the right places (e.g. not showing feedback, support to platform users)
