### PR TITLE
chore: Disable sending the Lock error to Sentry

### DIFF
--- a/apps/docs/lib/userAuth.ts
+++ b/apps/docs/lib/userAuth.ts
@@ -1,10 +1,5 @@
-import * as Sentry from '@sentry/nextjs'
-import { gotrueClient, setCaptureException } from 'common'
+import { gotrueClient } from 'common'
 import { useEffect } from 'react'
-
-setCaptureException((e: any) => {
-  Sentry.captureException(e)
-})
 
 export const auth = gotrueClient
 

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -1,11 +1,6 @@
-import * as Sentry from '@sentry/nextjs'
 import type { JwtPayload } from '@supabase/supabase-js'
 import { getAccessToken, type User } from 'common/auth'
-import { gotrueClient, setCaptureException } from 'common/gotrue'
-
-setCaptureException((e: any) => {
-  Sentry.captureException(e)
-})
+import { gotrueClient } from 'common/gotrue'
 
 export const auth = gotrueClient
 export { getAccessToken }

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -115,6 +115,9 @@ const logIndexedDB = (message: string, ...args: any[]) => {
   })()
 }
 
+/**
+ * Reference to a function that captures exceptions for debugging purposes to be sent to Sentry.
+ */
 let captureException: ((e: any) => any) | null = null
 
 export function setCaptureException(fn: typeof captureException) {


### PR DESCRIPTION
This PR removes the code which sent the Lock error from Auth to Sentry.