### PR TITLE
feat(etl): Improve destination panel UI

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -12,106 +12,90 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
-// Shared settings that apply to all destination types
-const SharedAdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
-  return (
-    <>
-      <p className="text-xs font-medium text-foreground-light mb-3">Batch settings</p>
-      <FormField_Shadcn_
-        control={form.control}
-        name="maxFillMs"
-        render={({ field }) => (
-          <FormItemLayout
-            className="mb-4"
-            label="Max fill milliseconds"
-            layout="vertical"
-            description="Maximum time to accumulate changes before sending a batch. Leave empty for default."
-          >
-            <FormControl_Shadcn_>
-              <Input_Shadcn_
-                {...field}
-                type="number"
-                value={field.value ?? ''}
-                onChange={(e) => {
-                  const val = e.target.value
-                  field.onChange(val === '' ? undefined : Number(val))
-                }}
-                placeholder="Default value will be used"
-              />
-            </FormControl_Shadcn_>
-          </FormItemLayout>
-        )}
-      />
-    </>
-  )
-}
-
-// BigQuery-specific advanced settings
-const BigQueryAdvancedSettings = ({
-  form,
-}: {
-  form: UseFormReturn<DestinationPanelSchemaType>
-}) => {
-  return (
-    <>
-      <p className="text-xs font-medium text-foreground-light mb-3 mt-6">
-        BigQuery-specific settings
-      </p>
-      <FormField_Shadcn_
-        control={form.control}
-        name="maxStalenessMins"
-        render={({ field }) => (
-          <FormItemLayout
-            className="mb-4"
-            label="Max staleness minutes"
-            layout="vertical"
-            description="Maximum time data can be stale in BigQuery before refresh. Leave empty for default."
-          >
-            <FormControl_Shadcn_>
-              <Input_Shadcn_
-                {...field}
-                type="number"
-                value={field.value ?? ''}
-                onChange={(e) => {
-                  const val = e.target.value
-                  field.onChange(val === '' ? undefined : Number(val))
-                }}
-                placeholder="Default value will be used"
-              />
-            </FormControl_Shadcn_>
-          </FormItemLayout>
-        )}
-      />
-    </>
-  )
-}
-
-// Analytics Bucket-specific advanced settings (placeholder for future settings)
-const AnalyticsBucketAdvancedSettings = ({
-  form,
-}: {
-  form: UseFormReturn<DestinationPanelSchemaType>
-}) => {
-  // Placeholder for future Analytics Bucket-specific settings
-  return null
-}
-
 export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   const { type } = form.watch()
 
   return (
     <Accordion_Shadcn_ type="single" collapsible>
       <AccordionItem_Shadcn_ value="item-1" className="border-none">
-        <AccordionTrigger_Shadcn_ className="font-normal gap-2 justify-between text-sm">
-          Advanced settings
+        <AccordionTrigger_Shadcn_ className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
+          <div className="flex flex-col items-start gap-0.5">
+            <span className="text-sm font-medium">Advanced settings</span>
+            <span className="text-xs text-foreground-lighter font-normal">
+              Optional performance tuning
+            </span>
+          </div>
         </AccordionTrigger_Shadcn_>
-        <AccordionContent_Shadcn_ className="!pb-0 space-y-4">
-          {/* Shared settings for all destinations */}
-          <SharedAdvancedSettings form={form} />
+        <AccordionContent_Shadcn_ className="!pb-0 space-y-6 pt-3">
+          {/* Batch wait time - applies to all destinations */}
+          <FormField_Shadcn_
+            control={form.control}
+            name="maxFillMs"
+            render={({ field }) => (
+              <FormItemLayout
+                label={
+                  <div className="flex items-center gap-2">
+                    <span>Batch wait time (milliseconds)</span>
+                    <span className="text-xs font-normal text-foreground-lighter px-2 py-0.5 rounded-full bg-surface-200">
+                      All destinations
+                    </span>
+                  </div>
+                }
+                layout="vertical"
+                description="How long to wait for more changes before sending. Shorter times mean more real-time updates but higher overhead."
+              >
+                <FormControl_Shadcn_>
+                  <Input_Shadcn_
+                    {...field}
+                    type="number"
+                    value={field.value ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value
+                      field.onChange(val === '' ? undefined : Number(val))
+                    }}
+                    placeholder="e.g., 5000 (5 seconds)"
+                  />
+                </FormControl_Shadcn_>
+              </FormItemLayout>
+            )}
+          />
 
-          {/* Destination-specific settings */}
-          {type === 'BigQuery' && <BigQueryAdvancedSettings form={form} />}
-          {type === 'Analytics Bucket' && <AnalyticsBucketAdvancedSettings form={form} />}
+          {/* BigQuery-specific: Max staleness */}
+          {type === 'BigQuery' && (
+            <div className="pt-2">
+              <FormField_Shadcn_
+                control={form.control}
+                name="maxStalenessMins"
+                render={({ field }) => (
+                <FormItemLayout
+                  label={
+                    <div className="flex items-center gap-2">
+                      <span>Maximum staleness (minutes)</span>
+                      <span className="text-xs font-normal text-brand-600 px-2 py-0.5 rounded-full bg-brand-200">
+                        BigQuery only
+                      </span>
+                    </div>
+                  }
+                  layout="vertical"
+                  description="How long data can remain outdated in BigQuery before a refresh is triggered. Lower values keep data fresher but may increase costs."
+                >
+                  <FormControl_Shadcn_>
+                    <Input_Shadcn_
+                      {...field}
+                      type="number"
+                      value={field.value ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value
+                        field.onChange(val === '' ? undefined : Number(val))
+                      }}
+                      placeholder="e.g., 60 (1 hour)"
+                    />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+              />
+            </div>
+          )}
         </AccordionContent_Shadcn_>
       </AccordionItem_Shadcn_>
     </Accordion_Shadcn_>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -12,7 +12,7 @@ import {
   Input_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+import type { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   const { type } = form.watch()

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -42,11 +42,7 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
               name="maxFillMs"
               render={({ field }) => (
                 <FormItemLayout
-                  label={
-                    <div className="flex items-center gap-2">
-                      <span>Batch wait time (milliseconds)</span>
-                    </div>
-                  }
+                  label="Batch wait time (milliseconds)"
                   layout="vertical"
                   description="How long to wait for more changes before sending. Shorter times mean more real-time updates but higher overhead."
                 >

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ReactNode } from 'react'
+import type { ChangeEvent } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 
 import {
@@ -6,30 +6,13 @@ import {
   AccordionContent_Shadcn_,
   AccordionItem_Shadcn_,
   AccordionTrigger_Shadcn_,
-  cn,
+  Badge,
   FormControl_Shadcn_,
   FormField_Shadcn_,
   Input_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { DestinationPanelSchemaType } from './DestinationPanel.schema'
-
-const Badge = ({
-  children,
-  variant = 'default',
-}: {
-  children: ReactNode
-  variant?: 'default' | 'brand'
-}) => (
-  <span
-    className={cn(
-      'text-xs font-normal px-2 py-0.5 rounded-full',
-      variant === 'brand' ? 'text-brand-600 bg-brand-200' : 'text-foreground-lighter bg-surface-200'
-    )}
-  >
-    {children}
-  </span>
-)
 
 export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   const { type } = form.watch()
@@ -91,7 +74,7 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
                       label={
                         <div className="flex items-center gap-2">
                           <span>Maximum staleness (minutes)</span>
-                          <Badge variant="brand">BigQuery only</Badge>
+                          <Badge>BigQuery only</Badge>
                         </div>
                       }
                       layout="vertical"

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -58,7 +58,6 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
                 label={
                   <div className="flex items-center gap-2">
                     <span>Batch wait time (milliseconds)</span>
-                    <Badge>All destinations</Badge>
                   </div>
                 }
                 layout="vertical"
@@ -92,7 +91,7 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
                       </div>
                     }
                     layout="vertical"
-                    description="How long data can remain outdated in BigQuery before a refresh is triggered. Lower values keep data fresher but may increase costs."
+                    description="Maximum age of cached data before BigQuery reads from base tables at query time. Lower values ensure fresher results but may increase query costs."
                   >
                     <FormControl_Shadcn_>
                       <Input_Shadcn_

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -1,11 +1,12 @@
-import React from 'react'
-import { UseFormReturn } from 'react-hook-form'
+import type { ChangeEvent, ReactNode } from 'react'
+import type { UseFormReturn } from 'react-hook-form'
 
 import {
   Accordion_Shadcn_,
   AccordionContent_Shadcn_,
   AccordionItem_Shadcn_,
   AccordionTrigger_Shadcn_,
+  cn,
   FormControl_Shadcn_,
   FormField_Shadcn_,
   Input_Shadcn_,
@@ -17,13 +18,14 @@ const Badge = ({
   children,
   variant = 'default',
 }: {
-  children: React.ReactNode
+  children: ReactNode
   variant?: 'default' | 'brand'
 }) => (
   <span
-    className={`text-xs font-normal px-2 py-0.5 rounded-full ${
+    className={cn(
+      'text-xs font-normal px-2 py-0.5 rounded-full',
       variant === 'brand' ? 'text-brand-600 bg-brand-200' : 'text-foreground-lighter bg-surface-200'
-    }`}
+    )}
   >
     {children}
   </span>
@@ -32,83 +34,86 @@ const Badge = ({
 export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   const { type } = form.watch()
 
-  const handleNumberChange = (field: any) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value
-    field.onChange(val === '' ? undefined : Number(val))
-  }
+  const handleNumberChange =
+    (field: { onChange: (value?: number) => void }) => (e: ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value
+      field.onChange(val === '' ? undefined : Number(val))
+    }
 
   return (
-    <Accordion_Shadcn_ type="single" collapsible>
-      <AccordionItem_Shadcn_ value="item-1" className="border-none">
-        <AccordionTrigger_Shadcn_ className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
-          <div className="flex flex-col items-start gap-0.5">
-            <span className="text-sm font-medium">Advanced settings</span>
-            <span className="text-xs text-foreground-lighter font-normal">
-              Optional performance tuning
-            </span>
-          </div>
-        </AccordionTrigger_Shadcn_>
-        <AccordionContent_Shadcn_ className="!pb-0 space-y-6 pt-3">
-          {/* Batch wait time - applies to all destinations */}
-          <FormField_Shadcn_
-            control={form.control}
-            name="maxFillMs"
-            render={({ field }) => (
-              <FormItemLayout
-                label={
-                  <div className="flex items-center gap-2">
-                    <span>Batch wait time (milliseconds)</span>
-                  </div>
-                }
-                layout="vertical"
-                description="How long to wait for more changes before sending. Shorter times mean more real-time updates but higher overhead."
-              >
-                <FormControl_Shadcn_>
-                  <Input_Shadcn_
-                    {...field}
-                    type="number"
-                    value={field.value ?? ''}
-                    onChange={handleNumberChange(field)}
-                    placeholder="e.g., 5000 (5 seconds)"
-                  />
-                </FormControl_Shadcn_>
-              </FormItemLayout>
-            )}
-          />
-
-          {/* BigQuery-specific: Max staleness */}
-          {type === 'BigQuery' && (
-            <div className="pt-2">
-              <FormField_Shadcn_
-                control={form.control}
-                name="maxStalenessMins"
-                render={({ field }) => (
-                  <FormItemLayout
-                    label={
-                      <div className="flex items-center gap-2">
-                        <span>Maximum staleness (minutes)</span>
-                        <Badge variant="brand">BigQuery only</Badge>
-                      </div>
-                    }
-                    layout="vertical"
-                    description="Maximum age of cached data before BigQuery reads from base tables at query time. Lower values ensure fresher results but may increase query costs."
-                  >
-                    <FormControl_Shadcn_>
-                      <Input_Shadcn_
-                        {...field}
-                        type="number"
-                        value={field.value ?? ''}
-                        onChange={handleNumberChange(field)}
-                        placeholder="e.g., 60 (1 hour)"
-                      />
-                    </FormControl_Shadcn_>
-                  </FormItemLayout>
-                )}
-              />
+    <div className="px-5">
+      <Accordion_Shadcn_ type="single" collapsible>
+        <AccordionItem_Shadcn_ value="item-1" className="border-none">
+          <AccordionTrigger_Shadcn_ className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
+            <div className="flex flex-col items-start gap-0.5">
+              <span className="text-sm font-medium">Advanced settings</span>
+              <span className="text-sm text-foreground-lighter font-normal">
+                Optional performance tuning
+              </span>
             </div>
-          )}
-        </AccordionContent_Shadcn_>
-      </AccordionItem_Shadcn_>
-    </Accordion_Shadcn_>
+          </AccordionTrigger_Shadcn_>
+          <AccordionContent_Shadcn_ className="!pb-0 space-y-6 pt-3">
+            {/* Batch wait time - applies to all destinations */}
+            <FormField_Shadcn_
+              control={form.control}
+              name="maxFillMs"
+              render={({ field }) => (
+                <FormItemLayout
+                  label={
+                    <div className="flex items-center gap-2">
+                      <span>Batch wait time (milliseconds)</span>
+                    </div>
+                  }
+                  layout="vertical"
+                  description="How long to wait for more changes before sending. Shorter times mean more real-time updates but higher overhead."
+                >
+                  <FormControl_Shadcn_>
+                    <Input_Shadcn_
+                      {...field}
+                      type="number"
+                      value={field.value ?? ''}
+                      onChange={handleNumberChange(field)}
+                      placeholder="e.g., 5000 (5 seconds)"
+                    />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+
+            {/* BigQuery-specific: Max staleness */}
+            {type === 'BigQuery' && (
+              <div className="pt-2">
+                <FormField_Shadcn_
+                  control={form.control}
+                  name="maxStalenessMins"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      label={
+                        <div className="flex items-center gap-2">
+                          <span>Maximum staleness (minutes)</span>
+                          <Badge variant="brand">BigQuery only</Badge>
+                        </div>
+                      }
+                      layout="vertical"
+                      description="Maximum age of cached data before BigQuery reads from base tables at query time. Lower values ensure fresher results but may increase query costs."
+                    >
+                      <FormControl_Shadcn_>
+                        <Input_Shadcn_
+                          {...field}
+                          type="number"
+                          value={field.value ?? ''}
+                          onChange={handleNumberChange(field)}
+                          placeholder="e.g. 60 (1 hour)"
+                        />
+                      </FormControl_Shadcn_>
+                    </FormItemLayout>
+                  )}
+                />
+              </div>
+            )}
+          </AccordionContent_Shadcn_>
+        </AccordionItem_Shadcn_>
+      </Accordion_Shadcn_>
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -12,6 +12,90 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
+// Shared settings that apply to all destination types
+const SharedAdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
+  return (
+    <>
+      <p className="text-xs font-medium text-foreground-light mb-3">Batch settings</p>
+      <FormField_Shadcn_
+        control={form.control}
+        name="maxFillMs"
+        render={({ field }) => (
+          <FormItemLayout
+            className="mb-4"
+            label="Max fill milliseconds"
+            layout="vertical"
+            description="Maximum time to accumulate changes before sending a batch. Leave empty for default."
+          >
+            <FormControl_Shadcn_>
+              <Input_Shadcn_
+                {...field}
+                type="number"
+                value={field.value ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value
+                  field.onChange(val === '' ? undefined : Number(val))
+                }}
+                placeholder="Default value will be used"
+              />
+            </FormControl_Shadcn_>
+          </FormItemLayout>
+        )}
+      />
+    </>
+  )
+}
+
+// BigQuery-specific advanced settings
+const BigQueryAdvancedSettings = ({
+  form,
+}: {
+  form: UseFormReturn<DestinationPanelSchemaType>
+}) => {
+  return (
+    <>
+      <p className="text-xs font-medium text-foreground-light mb-3 mt-6">
+        BigQuery-specific settings
+      </p>
+      <FormField_Shadcn_
+        control={form.control}
+        name="maxStalenessMins"
+        render={({ field }) => (
+          <FormItemLayout
+            className="mb-4"
+            label="Max staleness minutes"
+            layout="vertical"
+            description="Maximum time data can be stale in BigQuery before refresh. Leave empty for default."
+          >
+            <FormControl_Shadcn_>
+              <Input_Shadcn_
+                {...field}
+                type="number"
+                value={field.value ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value
+                  field.onChange(val === '' ? undefined : Number(val))
+                }}
+                placeholder="Default value will be used"
+              />
+            </FormControl_Shadcn_>
+          </FormItemLayout>
+        )}
+      />
+    </>
+  )
+}
+
+// Analytics Bucket-specific advanced settings (placeholder for future settings)
+const AnalyticsBucketAdvancedSettings = ({
+  form,
+}: {
+  form: UseFormReturn<DestinationPanelSchemaType>
+}) => {
+  // Placeholder for future Analytics Bucket-specific settings
+  return null
+}
+
 export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   const { type } = form.watch()
 
@@ -19,61 +103,15 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
     <Accordion_Shadcn_ type="single" collapsible>
       <AccordionItem_Shadcn_ value="item-1" className="border-none">
         <AccordionTrigger_Shadcn_ className="font-normal gap-2 justify-between text-sm">
-          Advanced Settings
+          Advanced settings
         </AccordionTrigger_Shadcn_>
-        <AccordionContent_Shadcn_ asChild className="!pb-0">
-          <FormField_Shadcn_
-            control={form.control}
-            name="maxFillMs"
-            render={({ field }) => (
-              <FormItemLayout
-                className="mb-4"
-                label="Max fill milliseconds"
-                layout="vertical"
-                description="The maximum amount of time to fill the data in milliseconds. Leave empty to use default value."
-              >
-                <FormControl_Shadcn_>
-                  <Input_Shadcn_
-                    {...field}
-                    type="number"
-                    value={field.value ?? ''}
-                    onChange={(e) => {
-                      const val = e.target.value
-                      field.onChange(val === '' ? undefined : Number(val))
-                    }}
-                    placeholder="Leave empty for default"
-                  />
-                </FormControl_Shadcn_>
-              </FormItemLayout>
-            )}
-          />
-          {type === 'BigQuery' && (
-            <FormField_Shadcn_
-              control={form.control}
-              name="maxStalenessMins"
-              render={({ field }) => (
-                <FormItemLayout
-                  className="mb-4"
-                  label="Max staleness minutes"
-                  layout="vertical"
-                  description="Maximum staleness time allowed in minutes. Leave empty to use default value."
-                >
-                  <FormControl_Shadcn_>
-                    <Input_Shadcn_
-                      {...field}
-                      type="number"
-                      value={field.value ?? ''}
-                      onChange={(e) => {
-                        const val = e.target.value
-                        field.onChange(val === '' ? undefined : Number(val))
-                      }}
-                      placeholder="Leave empty for default"
-                    />
-                  </FormControl_Shadcn_>
-                </FormItemLayout>
-              )}
-            />
-          )}
+        <AccordionContent_Shadcn_ className="!pb-0 space-y-4">
+          {/* Shared settings for all destinations */}
+          <SharedAdvancedSettings form={form} />
+
+          {/* Destination-specific settings */}
+          {type === 'BigQuery' && <BigQueryAdvancedSettings form={form} />}
+          {type === 'Analytics Bucket' && <AnalyticsBucketAdvancedSettings form={form} />}
         </AccordionContent_Shadcn_>
       </AccordionItem_Shadcn_>
     </Accordion_Shadcn_>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/AdvancedSettings.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { UseFormReturn } from 'react-hook-form'
 
 import {
@@ -12,8 +13,29 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
+const Badge = ({
+  children,
+  variant = 'default',
+}: {
+  children: React.ReactNode
+  variant?: 'default' | 'brand'
+}) => (
+  <span
+    className={`text-xs font-normal px-2 py-0.5 rounded-full ${
+      variant === 'brand' ? 'text-brand-600 bg-brand-200' : 'text-foreground-lighter bg-surface-200'
+    }`}
+  >
+    {children}
+  </span>
+)
+
 export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   const { type } = form.watch()
+
+  const handleNumberChange = (field: any) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    field.onChange(val === '' ? undefined : Number(val))
+  }
 
   return (
     <Accordion_Shadcn_ type="single" collapsible>
@@ -36,9 +58,7 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
                 label={
                   <div className="flex items-center gap-2">
                     <span>Batch wait time (milliseconds)</span>
-                    <span className="text-xs font-normal text-foreground-lighter px-2 py-0.5 rounded-full bg-surface-200">
-                      All destinations
-                    </span>
+                    <Badge>All destinations</Badge>
                   </div>
                 }
                 layout="vertical"
@@ -49,10 +69,7 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
                     {...field}
                     type="number"
                     value={field.value ?? ''}
-                    onChange={(e) => {
-                      const val = e.target.value
-                      field.onChange(val === '' ? undefined : Number(val))
-                    }}
+                    onChange={handleNumberChange(field)}
                     placeholder="e.g., 5000 (5 seconds)"
                   />
                 </FormControl_Shadcn_>
@@ -67,32 +84,27 @@ export const AdvancedSettings = ({ form }: { form: UseFormReturn<DestinationPane
                 control={form.control}
                 name="maxStalenessMins"
                 render={({ field }) => (
-                <FormItemLayout
-                  label={
-                    <div className="flex items-center gap-2">
-                      <span>Maximum staleness (minutes)</span>
-                      <span className="text-xs font-normal text-brand-600 px-2 py-0.5 rounded-full bg-brand-200">
-                        BigQuery only
-                      </span>
-                    </div>
-                  }
-                  layout="vertical"
-                  description="How long data can remain outdated in BigQuery before a refresh is triggered. Lower values keep data fresher but may increase costs."
-                >
-                  <FormControl_Shadcn_>
-                    <Input_Shadcn_
-                      {...field}
-                      type="number"
-                      value={field.value ?? ''}
-                      onChange={(e) => {
-                        const val = e.target.value
-                        field.onChange(val === '' ? undefined : Number(val))
-                      }}
-                      placeholder="e.g., 60 (1 hour)"
-                    />
-                  </FormControl_Shadcn_>
-                </FormItemLayout>
-              )}
+                  <FormItemLayout
+                    label={
+                      <div className="flex items-center gap-2">
+                        <span>Maximum staleness (minutes)</span>
+                        <Badge variant="brand">BigQuery only</Badge>
+                      </div>
+                    }
+                    layout="vertical"
+                    description="How long data can remain outdated in BigQuery before a refresh is triggered. Lower values keep data fresher but may increase costs."
+                  >
+                    <FormControl_Shadcn_>
+                      <Input_Shadcn_
+                        {...field}
+                        type="number"
+                        value={field.value ?? ''}
+                        onChange={handleNumberChange(field)}
+                        placeholder="e.g., 60 (1 hour)"
+                      />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                )}
               />
             </div>
           )}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationNameInput.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationNameInput.tsx
@@ -1,7 +1,8 @@
-import { UseFormReturn } from 'react-hook-form'
+import type { UseFormReturn } from 'react-hook-form'
+
 import { FormControl_Shadcn_, FormField_Shadcn_, Input_Shadcn_ } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+import type { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 type DestinationNameInputProps = {
   form: UseFormReturn<DestinationPanelSchemaType>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationNameInput.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationNameInput.tsx
@@ -1,0 +1,28 @@
+import { UseFormReturn } from 'react-hook-form'
+import { FormControl_Shadcn_, FormField_Shadcn_, Input_Shadcn_ } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+
+type DestinationNameInputProps = {
+  form: UseFormReturn<DestinationPanelSchemaType>
+}
+
+export const DestinationNameInput = ({ form }: DestinationNameInputProps) => {
+  return (
+    <FormField_Shadcn_
+      control={form.control}
+      name="name"
+      render={({ field }) => (
+        <FormItemLayout
+          label="Name"
+          layout="vertical"
+          description="A descriptive name to identify this destination"
+        >
+          <FormControl_Shadcn_>
+            <Input_Shadcn_ {...field} placeholder="My destination" />
+          </FormControl_Shadcn_>
+        </FormItemLayout>
+      )}
+    />
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.schema.ts
@@ -57,6 +57,9 @@ export const DestinationPanelFormSchema = z
 
       if (!data.s3Region?.length) addRequiredFieldError('s3Region', 'S3 Region is required')
 
+      if (!data.s3AccessKeyId?.length)
+        addRequiredFieldError('s3AccessKeyId', 'S3 Access Key ID is required')
+
       if (data.s3AccessKeyId !== 'create-new' && !data.s3SecretAccessKey?.length) {
         addRequiredFieldError('s3SecretAccessKey', 'S3 Secret Access Key is required')
       }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.schema.ts
@@ -59,7 +59,9 @@ export const DestinationPanelFormSchema = z
       }
 
       const hasValidNamespace =
-        (data.namespace && data.namespace.length > 0 && data.namespace !== 'create-new-namespace') ||
+        (data.namespace &&
+          data.namespace.length > 0 &&
+          data.namespace !== 'create-new-namespace') ||
         (data.namespace === 'create-new-namespace' &&
           data.newNamespaceName &&
           data.newNamespaceName.length > 0)
@@ -89,7 +91,10 @@ export const DestinationPanelFormSchema = z
       }
 
       // Validate S3 keys when not creating new
-      if (data.s3AccessKeyId !== 'create-new' && (!data.s3SecretAccessKey || data.s3SecretAccessKey.length === 0)) {
+      if (
+        data.s3AccessKeyId !== 'create-new' &&
+        (!data.s3SecretAccessKey || data.s3SecretAccessKey.length === 0)
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'S3 Secret Access Key is required',

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -145,32 +145,15 @@ export const DestinationPanel = ({
   const { data: projectSettings } = useProjectSettingsV2Query({ projectRef })
 
   const defaultValues = useMemo(() => {
-    // Type guards to safely access union properties
     const config = destinationData?.config
     const isBigQueryConfig = config && 'big_query' in config
     const isIcebergConfig = config && 'iceberg' in config
 
-    // In edit mode, use existing destination type
-    // In create mode, select the first available destination type
-    let defaultType: z.infer<typeof TypeEnum>
-    if (editMode) {
-      defaultType = (
-        isBigQueryConfig
-          ? TypeEnum.enum.BigQuery
-          : isIcebergConfig
-            ? TypeEnum.enum['Analytics Bucket']
-            : TypeEnum.enum.BigQuery
-      ) as z.infer<typeof TypeEnum>
-    } else {
-      // Select first available destination type in create mode
-      defaultType = (
-        etlEnableBigQuery
-          ? TypeEnum.enum.BigQuery
-          : etlEnableIceberg
-            ? TypeEnum.enum['Analytics Bucket']
-            : TypeEnum.enum.BigQuery
-      ) as z.infer<typeof TypeEnum>
-    }
+    const defaultType = editMode
+      ? isBigQueryConfig
+        ? TypeEnum.enum.BigQuery
+        : TypeEnum.enum['Analytics Bucket']
+      : availableDestinations[0]?.value || TypeEnum.enum.BigQuery
 
     return {
       // Common fields
@@ -199,8 +182,7 @@ export const DestinationPanel = ({
     catalogToken,
     projectSettings,
     editMode,
-    etlEnableBigQuery,
-    etlEnableIceberg,
+    availableDestinations,
   ])
 
   const form = useForm<z.infer<typeof FormSchema>>({

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -477,228 +477,233 @@ export const DestinationPanel = ({
               ) : (
                 <Form_Shadcn_ {...form}>
                   <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-                    <FormField_Shadcn_
-                      control={form.control}
-                      name="name"
-                      render={({ field }) => (
-                        <FormItemLayout
-                          className="p-5"
-                          label={
-                            <span>
-                              Name <span className="text-destructive-600">*</span>
-                            </span>
-                          }
-                          layout="vertical"
-                          description="A descriptive name to identify this destination"
-                        >
-                          <FormControl_Shadcn_>
-                            <Input_Shadcn_ {...field} placeholder="My destination" />
-                          </FormControl_Shadcn_>
-                        </FormItemLayout>
-                      )}
-                    />
+                    <div className="p-5">
+                      <p className="text-sm font-medium text-foreground mb-1">
+                        Destination details
+                      </p>
+                      <p className="text-xs text-foreground-light mb-4">
+                        Name your destination and choose which data to replicate
+                      </p>
+
+                      <div className="space-y-4">
+                        <FormField_Shadcn_
+                          control={form.control}
+                          name="name"
+                          render={({ field }) => (
+                            <FormItemLayout
+                              label={
+                                <span>
+                                  Name <span className="text-destructive-600">*</span>
+                                </span>
+                              }
+                              layout="vertical"
+                              description="A descriptive name to identify this destination"
+                            >
+                              <FormControl_Shadcn_>
+                                <Input_Shadcn_ {...field} placeholder="My destination" />
+                              </FormControl_Shadcn_>
+                            </FormItemLayout>
+                          )}
+                        />
+
+                        <FormField_Shadcn_
+                          control={form.control}
+                          name="publicationName"
+                          render={({ field }) => (
+                            <FormItemLayout
+                              label={
+                                <span>
+                                  Publication <span className="text-destructive-600">*</span>
+                                </span>
+                              }
+                              layout="vertical"
+                              description="Choose which tables to replicate to this destination"
+                            >
+                              <FormControl_Shadcn_>
+                                <PublicationsComboBox
+                                  publications={publicationNames}
+                                  isLoadingPublications={isLoadingPublications}
+                                  isLoadingCheck={!!selectedPublication && isLoadingCheck}
+                                  field={field}
+                                  onNewPublicationClick={() => setPublicationPanelVisible(true)}
+                                />
+                              </FormControl_Shadcn_>
+                              {isSelectedPublicationMissing ? (
+                                <Admonition type="warning" className="mt-2 mb-0">
+                                  <p className="!leading-normal">
+                                    The publication{' '}
+                                    <strong className="text-foreground">{publicationName}</strong>{' '}
+                                    was not found, it may have been renamed or deleted, please
+                                    select another one.
+                                  </p>
+                                </Admonition>
+                              ) : hasTablesWithNoPrimaryKeys ? (
+                                <Admonition type="warning" className="mt-2 mb-0">
+                                  <p className="!leading-normal">
+                                    Replication requires every table in the publication to have a
+                                    primary key to work, which these tables are missing:
+                                  </p>
+                                  <ul className="list-disc pl-6 mb-2">
+                                    {(checkPrimaryKeysExistsData?.offendingTables ?? []).map(
+                                      (x) => {
+                                        const value = `${x.schema}.${x.name}`
+                                        return (
+                                          <li key={value} className="!leading-normal">
+                                            <InlineLink
+                                              href={`/project/${projectRef}/editor/${x.id}`}
+                                            >
+                                              {value}
+                                            </InlineLink>
+                                          </li>
+                                        )
+                                      }
+                                    )}
+                                  </ul>
+                                  <p className="!leading-normal">
+                                    Ensure that these tables have primary keys first.
+                                  </p>
+                                </Admonition>
+                              ) : null}
+                            </FormItemLayout>
+                          )}
+                        />
+                      </div>
+                    </div>
 
                     <DialogSectionSeparator />
 
-                    <div className="p-5">
-                      <p className="text-sm text-foreground-light mb-4">
-                        Select which data to replicate
-                      </p>
+                    <div className="px-5 py-5">
+                      <p className="text-sm font-medium text-foreground mb-1">Destination type</p>
+                      {editMode ? (
+                        <p className="text-xs text-foreground-light mb-4">
+                          The destination type cannot be changed after creation
+                        </p>
+                      ) : (
+                        <p className="text-xs text-foreground-light mb-4">
+                          Choose which platform to send your database changes to
+                        </p>
+                      )}
                       <FormField_Shadcn_
+                        name="type"
                         control={form.control}
-                        name="publicationName"
                         render={({ field }) => (
-                          <FormItemLayout
-                            label={
-                              <span>
-                                Publication <span className="text-destructive-600">*</span>
-                              </span>
-                            }
-                            layout="vertical"
-                            description="Choose which tables to replicate to this destination"
-                          >
-                            <FormControl_Shadcn_>
-                              <PublicationsComboBox
-                                publications={publicationNames}
-                                isLoadingPublications={isLoadingPublications}
-                                isLoadingCheck={!!selectedPublication && isLoadingCheck}
-                                field={field}
-                                onNewPublicationClick={() => setPublicationPanelVisible(true)}
-                              />
-                            </FormControl_Shadcn_>
-                            {isSelectedPublicationMissing ? (
-                              <Admonition type="warning" className="mt-2 mb-0">
-                                <p className="!leading-normal">
-                                  The publication{' '}
-                                  <strong className="text-foreground">{publicationName}</strong> was
-                                  not found, it may have been renamed or deleted, please select
-                                  another one.
-                                </p>
-                              </Admonition>
-                            ) : hasTablesWithNoPrimaryKeys ? (
-                              <Admonition type="warning" className="mt-2 mb-0">
-                                <p className="!leading-normal">
-                                  Replication requires every table in the publication to have a
-                                  primary key to work, which these tables are missing:
-                                </p>
-                                <ul className="list-disc pl-6 mb-2">
-                                  {(checkPrimaryKeysExistsData?.offendingTables ?? []).map((x) => {
-                                    const value = `${x.schema}.${x.name}`
-                                    return (
-                                      <li key={value} className="!leading-normal">
-                                        <InlineLink href={`/project/${projectRef}/editor/${x.id}`}>
-                                          {value}
-                                        </InlineLink>
-                                      </li>
-                                    )
-                                  })}
-                                </ul>
-                                <p className="!leading-normal">
-                                  Ensure that these tables have primary keys first.
-                                </p>
-                              </Admonition>
-                            ) : null}
-                          </FormItemLayout>
+                          <FormControl_Shadcn_>
+                            {editMode ? (
+                              <div className="relative">
+                                <div className="flex items-start gap-3 p-4 rounded-lg border-2 border-default bg-surface-100 opacity-75">
+                                  <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 mb-1">
+                                      <p className="text-sm font-medium text-foreground">
+                                        {field.value}
+                                      </p>
+                                      <Lock className="w-3 h-3 text-foreground-lighter" />
+                                    </div>
+                                    <p className="text-xs text-foreground-light leading-relaxed">
+                                      {field.value === 'BigQuery'
+                                        ? "Send data to Google Cloud's data warehouse for analytics and business intelligence"
+                                        : 'Send data to Apache Iceberg tables in your Supabase Storage for flexible analytics workflows'}
+                                    </p>
+                                  </div>
+                                </div>
+                                <div className="absolute inset-0 cursor-not-allowed" />
+                              </div>
+                            ) : (
+                              <div className="grid gap-3">
+                                {etlEnableBigQuery && (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setIsFormInteracting(true)
+                                      field.onChange('BigQuery')
+                                    }}
+                                    className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
+                                      field.value === 'BigQuery'
+                                        ? 'border-brand-600 bg-surface-200'
+                                        : 'border-default bg-surface-100 hover:border-stronger'
+                                    }`}
+                                  >
+                                    <div className="flex-1 min-w-0">
+                                      <div className="flex items-center gap-2 mb-1">
+                                        <p className="text-sm font-medium text-foreground">
+                                          BigQuery
+                                        </p>
+                                        {field.value === 'BigQuery' && (
+                                          <div className="w-2 h-2 rounded-full bg-brand-600" />
+                                        )}
+                                      </div>
+                                      <p className="text-xs text-foreground-light leading-relaxed">
+                                        Send data to Google Cloud's data warehouse for analytics and
+                                        business intelligence
+                                      </p>
+                                    </div>
+                                  </button>
+                                )}
+                                {etlEnableIceberg && (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setIsFormInteracting(true)
+                                      field.onChange('Analytics Bucket')
+                                    }}
+                                    className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
+                                      field.value === 'Analytics Bucket'
+                                        ? 'border-brand-600 bg-surface-200'
+                                        : 'border-default bg-surface-100 hover:border-stronger'
+                                    }`}
+                                  >
+                                    <div className="flex-1 min-w-0">
+                                      <div className="flex items-center gap-2 mb-1">
+                                        <p className="text-sm font-medium text-foreground">
+                                          Analytics Bucket
+                                        </p>
+                                        {field.value === 'Analytics Bucket' && (
+                                          <div className="w-2 h-2 rounded-full bg-brand-600" />
+                                        )}
+                                      </div>
+                                      <p className="text-xs text-foreground-light leading-relaxed">
+                                        Send data to Apache Iceberg tables in your Supabase Storage
+                                        for flexible analytics workflows
+                                      </p>
+                                    </div>
+                                  </button>
+                                )}
+                              </div>
+                            )}
+                          </FormControl_Shadcn_>
                         )}
                       />
                     </div>
 
-                    <DialogSectionSeparator />
-
-                    <div className="py-5 flex flex-col gap-y-4">
-                      <div className="px-5">
-                        <p className="text-sm font-medium text-foreground mb-1">Destination type</p>
-                        {editMode ? (
-                          <p className="text-xs text-foreground-light mb-4">
-                            The destination type cannot be changed after creation
+                    {selectedType === 'BigQuery' && etlEnableBigQuery ? (
+                      <>
+                        <DialogSectionSeparator />
+                        <div className="px-5 pt-5">
+                          <p className="text-sm font-medium text-foreground mb-1">
+                            BigQuery settings
                           </p>
-                        ) : (
                           <p className="text-xs text-foreground-light mb-4">
-                            Choose which platform to send your database changes to
+                            Configure how data is sent to your BigQuery destination
                           </p>
-                        )}
-                        <FormField_Shadcn_
-                          name="type"
-                          control={form.control}
-                          render={({ field }) => (
-                            <FormControl_Shadcn_>
-                              {editMode ? (
-                                <div className="relative">
-                                  <div className="flex items-start gap-3 p-4 rounded-lg border-2 border-default bg-surface-100 opacity-75">
-                                    <div className="flex-1 min-w-0">
-                                      <div className="flex items-center gap-2 mb-1">
-                                        <p className="text-sm font-medium text-foreground">
-                                          {field.value}
-                                        </p>
-                                        <Lock className="w-3 h-3 text-foreground-lighter" />
-                                      </div>
-                                      <p className="text-xs text-foreground-light leading-relaxed">
-                                        {field.value === 'BigQuery'
-                                          ? "Send data to Google Cloud's data warehouse for analytics and business intelligence"
-                                          : 'Send data to Apache Iceberg tables in your Supabase Storage for flexible analytics workflows'}
-                                      </p>
-                                    </div>
-                                  </div>
-                                  <div className="absolute inset-0 cursor-not-allowed" />
-                                </div>
-                              ) : (
-                                <div className="grid gap-3">
-                                  {etlEnableBigQuery && (
-                                    <button
-                                      type="button"
-                                      onClick={() => {
-                                        setIsFormInteracting(true)
-                                        field.onChange('BigQuery')
-                                      }}
-                                      className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
-                                        field.value === 'BigQuery'
-                                          ? 'border-brand-600 bg-surface-200'
-                                          : 'border-default bg-surface-100 hover:border-stronger'
-                                      }`}
-                                    >
-                                      <div className="flex-1 min-w-0">
-                                        <div className="flex items-center gap-2 mb-1">
-                                          <p className="text-sm font-medium text-foreground">
-                                            BigQuery
-                                          </p>
-                                          {field.value === 'BigQuery' && (
-                                            <div className="w-2 h-2 rounded-full bg-brand-600" />
-                                          )}
-                                        </div>
-                                        <p className="text-xs text-foreground-light leading-relaxed">
-                                          Send data to Google Cloud's data warehouse for analytics
-                                          and business intelligence
-                                        </p>
-                                      </div>
-                                    </button>
-                                  )}
-                                  {etlEnableIceberg && (
-                                    <button
-                                      type="button"
-                                      onClick={() => {
-                                        setIsFormInteracting(true)
-                                        field.onChange('Analytics Bucket')
-                                      }}
-                                      className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
-                                        field.value === 'Analytics Bucket'
-                                          ? 'border-brand-600 bg-surface-200'
-                                          : 'border-default bg-surface-100 hover:border-stronger'
-                                      }`}
-                                    >
-                                      <div className="flex-1 min-w-0">
-                                        <div className="flex items-center gap-2 mb-1">
-                                          <p className="text-sm font-medium text-foreground">
-                                            Analytics Bucket
-                                          </p>
-                                          {field.value === 'Analytics Bucket' && (
-                                            <div className="w-2 h-2 rounded-full bg-brand-600" />
-                                          )}
-                                        </div>
-                                        <p className="text-xs text-foreground-light leading-relaxed">
-                                          Send data to Apache Iceberg tables in your Supabase
-                                          Storage for flexible analytics workflows
-                                        </p>
-                                      </div>
-                                    </button>
-                                  )}
-                                </div>
-                              )}
-                            </FormControl_Shadcn_>
-                          )}
+                        </div>
+                        <BigQueryFields form={form} />
+                      </>
+                    ) : selectedType === 'Analytics Bucket' && etlEnableIceberg ? (
+                      <>
+                        <DialogSectionSeparator />
+                        <div className="px-5 pt-5">
+                          <p className="text-sm font-medium text-foreground mb-1">
+                            Analytics Bucket settings
+                          </p>
+                          <p className="text-xs text-foreground-light mb-4">
+                            Configure how data is sent to your Analytics Bucket destination
+                          </p>
+                        </div>
+                        <AnalyticsBucketFields
+                          form={form}
+                          setIsFormInteracting={setIsFormInteracting}
                         />
-                      </div>
-
-                      {selectedType === 'BigQuery' && etlEnableBigQuery ? (
-                        <>
-                          <DialogSectionSeparator />
-                          <div className="px-5">
-                            <p className="text-sm font-medium text-foreground mb-1">
-                              BigQuery settings
-                            </p>
-                            <p className="text-xs text-foreground-light mb-4">
-                              Configure how data is sent to your BigQuery destination
-                            </p>
-                          </div>
-                          <BigQueryFields form={form} />
-                        </>
-                      ) : selectedType === 'Analytics Bucket' && etlEnableIceberg ? (
-                        <>
-                          <DialogSectionSeparator />
-                          <div className="px-5">
-                            <p className="text-sm font-medium text-foreground mb-1">
-                              Analytics Bucket settings
-                            </p>
-                            <p className="text-xs text-foreground-light mb-4">
-                              Configure how data is sent to your Analytics Bucket destination
-                            </p>
-                          </div>
-                          <AnalyticsBucketFields
-                            form={form}
-                            setIsFormInteracting={setIsFormInteracting}
-                          />
-                        </>
-                      ) : null}
-                    </div>
+                      </>
+                    ) : null}
 
                     <DialogSectionSeparator />
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -88,7 +88,8 @@ export const DestinationPanel = ({
   const availableDestinations = useMemo(() => {
     const destinations = []
     if (etlEnableBigQuery) destinations.push({ value: 'BigQuery', label: 'BigQuery' })
-    if (etlEnableIceberg) destinations.push({ value: 'Analytics Bucket', label: 'Analytics Bucket' })
+    if (etlEnableIceberg)
+      destinations.push({ value: 'Analytics Bucket', label: 'Analytics Bucket' })
     return destinations
   }, [etlEnableBigQuery, etlEnableIceberg])
 
@@ -153,18 +154,22 @@ export const DestinationPanel = ({
     // In create mode, select the first available destination type
     let defaultType: z.infer<typeof TypeEnum>
     if (editMode) {
-      defaultType = (isBigQueryConfig
-        ? TypeEnum.enum.BigQuery
-        : isIcebergConfig
-          ? TypeEnum.enum['Analytics Bucket']
-          : TypeEnum.enum.BigQuery) as z.infer<typeof TypeEnum>
+      defaultType = (
+        isBigQueryConfig
+          ? TypeEnum.enum.BigQuery
+          : isIcebergConfig
+            ? TypeEnum.enum['Analytics Bucket']
+            : TypeEnum.enum.BigQuery
+      ) as z.infer<typeof TypeEnum>
     } else {
       // Select first available destination type in create mode
-      defaultType = (etlEnableBigQuery
-        ? TypeEnum.enum.BigQuery
-        : etlEnableIceberg
-          ? TypeEnum.enum['Analytics Bucket']
-          : TypeEnum.enum.BigQuery) as z.infer<typeof TypeEnum>
+      defaultType = (
+        etlEnableBigQuery
+          ? TypeEnum.enum.BigQuery
+          : etlEnableIceberg
+            ? TypeEnum.enum['Analytics Bucket']
+            : TypeEnum.enum.BigQuery
+      ) as z.infer<typeof TypeEnum>
     }
 
     return {
@@ -188,7 +193,15 @@ export const DestinationPanel = ({
       s3Region:
         projectSettings?.region ?? (isIcebergConfig ? config.iceberg.supabase.s3_region : ''),
     }
-  }, [destinationData, pipelineData, catalogToken, projectSettings, editMode, etlEnableBigQuery, etlEnableIceberg])
+  }, [
+    destinationData,
+    pipelineData,
+    catalogToken,
+    projectSettings,
+    editMode,
+    etlEnableBigQuery,
+    etlEnableIceberg,
+  ])
 
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onChange',
@@ -505,209 +518,207 @@ export const DestinationPanel = ({
 
                     <DialogSectionSeparator />
 
-                  <div className="p-5">
-                    <p className="text-sm text-foreground-light mb-4">
-                      Select which data to replicate
-                    </p>
-                    <FormField_Shadcn_
-                      control={form.control}
-                      name="publicationName"
-                      render={({ field }) => (
-                        <FormItemLayout
-                          label={
-                            <span>
-                              Publication <span className="text-destructive-600">*</span>
-                            </span>
-                          }
-                          layout="vertical"
-                          description="Choose which tables to replicate to this destination"
-                        >
-                          <FormControl_Shadcn_>
-                            <PublicationsComboBox
-                              publications={publicationNames}
-                              isLoadingPublications={isLoadingPublications}
-                              isLoadingCheck={!!selectedPublication && isLoadingCheck}
-                              field={field}
-                              onNewPublicationClick={() => setPublicationPanelVisible(true)}
-                            />
-                          </FormControl_Shadcn_>
-                          {isSelectedPublicationMissing ? (
-                            <Admonition type="warning" className="mt-2 mb-0">
-                              <p className="!leading-normal">
-                                The publication{' '}
-                                <strong className="text-foreground">{publicationName}</strong> was
-                                not found, it may have been renamed or deleted, please select
-                                another one.
-                              </p>
-                            </Admonition>
-                          ) : hasTablesWithNoPrimaryKeys ? (
-                            <Admonition type="warning" className="mt-2 mb-0">
-                              <p className="!leading-normal">
-                                Replication requires every table in the publication to have a
-                                primary key to work, which these tables are missing:
-                              </p>
-                              <ul className="list-disc pl-6 mb-2">
-                                {(checkPrimaryKeysExistsData?.offendingTables ?? []).map((x) => {
-                                  const value = `${x.schema}.${x.name}`
-                                  return (
-                                    <li key={value} className="!leading-normal">
-                                      <InlineLink href={`/project/${projectRef}/editor/${x.id}`}>
-                                        {value}
-                                      </InlineLink>
-                                    </li>
-                                  )
-                                })}
-                              </ul>
-                              <p className="!leading-normal">
-                                Ensure that these tables have primary keys first.
-                              </p>
-                            </Admonition>
-                          ) : null}
-                        </FormItemLayout>
-                      )}
-                    />
-                  </div>
-
-                  <DialogSectionSeparator />
-
-                  <div className="py-5 flex flex-col gap-y-4">
-                    <div className="px-5">
-                      <p className="text-sm font-medium text-foreground mb-1">
-                        Destination type
+                    <div className="p-5">
+                      <p className="text-sm text-foreground-light mb-4">
+                        Select which data to replicate
                       </p>
-                      {editMode ? (
-                        <p className="text-xs text-foreground-light mb-4">
-                          The destination type cannot be changed after creation
-                        </p>
-                      ) : (
-                        <p className="text-xs text-foreground-light mb-4">
-                          Choose which platform to send your database changes to
-                        </p>
-                      )}
                       <FormField_Shadcn_
-                        name="type"
                         control={form.control}
+                        name="publicationName"
                         render={({ field }) => (
-                          <FormControl_Shadcn_>
-                            {editMode ? (
-                              <div className="relative">
-                                <div className="flex items-start gap-3 p-4 rounded-lg border-2 border-default bg-surface-100 opacity-75">
-                                  <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 mb-1">
-                                      <p className="text-sm font-medium text-foreground">
-                                        {field.value}
-                                      </p>
-                                      <Lock className="w-3 h-3 text-foreground-lighter" />
-                                    </div>
-                                    <p className="text-xs text-foreground-light leading-relaxed">
-                                      {field.value === 'BigQuery'
-                                        ? 'Send data to Google Cloud\'s data warehouse for analytics and business intelligence'
-                                        : 'Send data to Apache Iceberg tables in your Supabase Storage for flexible analytics workflows'}
-                                    </p>
-                                  </div>
-                                </div>
-                                <div className="absolute inset-0 cursor-not-allowed" />
-                              </div>
-                            ) : (
-                              <div className="grid gap-3">
-                                {etlEnableBigQuery && (
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      setIsFormInteracting(true)
-                                      field.onChange('BigQuery')
-                                    }}
-                                    className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
-                                      field.value === 'BigQuery'
-                                        ? 'border-brand-600 bg-surface-200'
-                                        : 'border-default bg-surface-100 hover:border-stronger'
-                                    }`}
-                                  >
-                                    <div className="flex-1 min-w-0">
-                                      <div className="flex items-center gap-2 mb-1">
-                                        <p className="text-sm font-medium text-foreground">
-                                          BigQuery
-                                        </p>
-                                        {field.value === 'BigQuery' && (
-                                          <div className="w-2 h-2 rounded-full bg-brand-600" />
-                                        )}
-                                      </div>
-                                      <p className="text-xs text-foreground-light leading-relaxed">
-                                        Send data to Google Cloud's data warehouse for analytics and
-                                        business intelligence
-                                      </p>
-                                    </div>
-                                  </button>
-                                )}
-                                {etlEnableIceberg && (
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      setIsFormInteracting(true)
-                                      field.onChange('Analytics Bucket')
-                                    }}
-                                    className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
-                                      field.value === 'Analytics Bucket'
-                                        ? 'border-brand-600 bg-surface-200'
-                                        : 'border-default bg-surface-100 hover:border-stronger'
-                                    }`}
-                                  >
-                                    <div className="flex-1 min-w-0">
-                                      <div className="flex items-center gap-2 mb-1">
-                                        <p className="text-sm font-medium text-foreground">
-                                          Analytics Bucket
-                                        </p>
-                                        {field.value === 'Analytics Bucket' && (
-                                          <div className="w-2 h-2 rounded-full bg-brand-600" />
-                                        )}
-                                      </div>
-                                      <p className="text-xs text-foreground-light leading-relaxed">
-                                        Send data to Apache Iceberg tables in your Supabase Storage for
-                                        flexible analytics workflows
-                                      </p>
-                                    </div>
-                                  </button>
-                                )}
-                              </div>
-                            )}
-                          </FormControl_Shadcn_>
+                          <FormItemLayout
+                            label={
+                              <span>
+                                Publication <span className="text-destructive-600">*</span>
+                              </span>
+                            }
+                            layout="vertical"
+                            description="Choose which tables to replicate to this destination"
+                          >
+                            <FormControl_Shadcn_>
+                              <PublicationsComboBox
+                                publications={publicationNames}
+                                isLoadingPublications={isLoadingPublications}
+                                isLoadingCheck={!!selectedPublication && isLoadingCheck}
+                                field={field}
+                                onNewPublicationClick={() => setPublicationPanelVisible(true)}
+                              />
+                            </FormControl_Shadcn_>
+                            {isSelectedPublicationMissing ? (
+                              <Admonition type="warning" className="mt-2 mb-0">
+                                <p className="!leading-normal">
+                                  The publication{' '}
+                                  <strong className="text-foreground">{publicationName}</strong> was
+                                  not found, it may have been renamed or deleted, please select
+                                  another one.
+                                </p>
+                              </Admonition>
+                            ) : hasTablesWithNoPrimaryKeys ? (
+                              <Admonition type="warning" className="mt-2 mb-0">
+                                <p className="!leading-normal">
+                                  Replication requires every table in the publication to have a
+                                  primary key to work, which these tables are missing:
+                                </p>
+                                <ul className="list-disc pl-6 mb-2">
+                                  {(checkPrimaryKeysExistsData?.offendingTables ?? []).map((x) => {
+                                    const value = `${x.schema}.${x.name}`
+                                    return (
+                                      <li key={value} className="!leading-normal">
+                                        <InlineLink href={`/project/${projectRef}/editor/${x.id}`}>
+                                          {value}
+                                        </InlineLink>
+                                      </li>
+                                    )
+                                  })}
+                                </ul>
+                                <p className="!leading-normal">
+                                  Ensure that these tables have primary keys first.
+                                </p>
+                              </Admonition>
+                            ) : null}
+                          </FormItemLayout>
                         )}
                       />
                     </div>
 
-                    {selectedType === 'BigQuery' && etlEnableBigQuery ? (
-                      <>
-                        <DialogSectionSeparator />
-                        <div className="px-5">
-                          <p className="text-sm font-medium text-foreground mb-1">
-                            BigQuery settings
-                          </p>
-                          <p className="text-xs text-foreground-light mb-4">
-                            Configure how data is sent to your BigQuery destination
-                          </p>
-                        </div>
-                        <BigQueryFields form={form} />
-                      </>
-                    ) : selectedType === 'Analytics Bucket' && etlEnableIceberg ? (
-                      <>
-                        <DialogSectionSeparator />
-                        <div className="px-5">
-                          <p className="text-sm font-medium text-foreground mb-1">
-                            Analytics Bucket settings
-                          </p>
-                          <p className="text-xs text-foreground-light mb-4">
-                            Configure how data is sent to your Analytics Bucket destination
-                          </p>
-                        </div>
-                        <AnalyticsBucketFields
-                          form={form}
-                          setIsFormInteracting={setIsFormInteracting}
-                        />
-                      </>
-                    ) : null}
-                  </div>
+                    <DialogSectionSeparator />
 
-                  <DialogSectionSeparator />
+                    <div className="py-5 flex flex-col gap-y-4">
+                      <div className="px-5">
+                        <p className="text-sm font-medium text-foreground mb-1">Destination type</p>
+                        {editMode ? (
+                          <p className="text-xs text-foreground-light mb-4">
+                            The destination type cannot be changed after creation
+                          </p>
+                        ) : (
+                          <p className="text-xs text-foreground-light mb-4">
+                            Choose which platform to send your database changes to
+                          </p>
+                        )}
+                        <FormField_Shadcn_
+                          name="type"
+                          control={form.control}
+                          render={({ field }) => (
+                            <FormControl_Shadcn_>
+                              {editMode ? (
+                                <div className="relative">
+                                  <div className="flex items-start gap-3 p-4 rounded-lg border-2 border-default bg-surface-100 opacity-75">
+                                    <div className="flex-1 min-w-0">
+                                      <div className="flex items-center gap-2 mb-1">
+                                        <p className="text-sm font-medium text-foreground">
+                                          {field.value}
+                                        </p>
+                                        <Lock className="w-3 h-3 text-foreground-lighter" />
+                                      </div>
+                                      <p className="text-xs text-foreground-light leading-relaxed">
+                                        {field.value === 'BigQuery'
+                                          ? "Send data to Google Cloud's data warehouse for analytics and business intelligence"
+                                          : 'Send data to Apache Iceberg tables in your Supabase Storage for flexible analytics workflows'}
+                                      </p>
+                                    </div>
+                                  </div>
+                                  <div className="absolute inset-0 cursor-not-allowed" />
+                                </div>
+                              ) : (
+                                <div className="grid gap-3">
+                                  {etlEnableBigQuery && (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        setIsFormInteracting(true)
+                                        field.onChange('BigQuery')
+                                      }}
+                                      className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
+                                        field.value === 'BigQuery'
+                                          ? 'border-brand-600 bg-surface-200'
+                                          : 'border-default bg-surface-100 hover:border-stronger'
+                                      }`}
+                                    >
+                                      <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-1">
+                                          <p className="text-sm font-medium text-foreground">
+                                            BigQuery
+                                          </p>
+                                          {field.value === 'BigQuery' && (
+                                            <div className="w-2 h-2 rounded-full bg-brand-600" />
+                                          )}
+                                        </div>
+                                        <p className="text-xs text-foreground-light leading-relaxed">
+                                          Send data to Google Cloud's data warehouse for analytics
+                                          and business intelligence
+                                        </p>
+                                      </div>
+                                    </button>
+                                  )}
+                                  {etlEnableIceberg && (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        setIsFormInteracting(true)
+                                        field.onChange('Analytics Bucket')
+                                      }}
+                                      className={`relative flex items-start gap-3 p-4 rounded-lg border-2 transition-all text-left ${
+                                        field.value === 'Analytics Bucket'
+                                          ? 'border-brand-600 bg-surface-200'
+                                          : 'border-default bg-surface-100 hover:border-stronger'
+                                      }`}
+                                    >
+                                      <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-1">
+                                          <p className="text-sm font-medium text-foreground">
+                                            Analytics Bucket
+                                          </p>
+                                          {field.value === 'Analytics Bucket' && (
+                                            <div className="w-2 h-2 rounded-full bg-brand-600" />
+                                          )}
+                                        </div>
+                                        <p className="text-xs text-foreground-light leading-relaxed">
+                                          Send data to Apache Iceberg tables in your Supabase
+                                          Storage for flexible analytics workflows
+                                        </p>
+                                      </div>
+                                    </button>
+                                  )}
+                                </div>
+                              )}
+                            </FormControl_Shadcn_>
+                          )}
+                        />
+                      </div>
+
+                      {selectedType === 'BigQuery' && etlEnableBigQuery ? (
+                        <>
+                          <DialogSectionSeparator />
+                          <div className="px-5">
+                            <p className="text-sm font-medium text-foreground mb-1">
+                              BigQuery settings
+                            </p>
+                            <p className="text-xs text-foreground-light mb-4">
+                              Configure how data is sent to your BigQuery destination
+                            </p>
+                          </div>
+                          <BigQueryFields form={form} />
+                        </>
+                      ) : selectedType === 'Analytics Bucket' && etlEnableIceberg ? (
+                        <>
+                          <DialogSectionSeparator />
+                          <div className="px-5">
+                            <p className="text-sm font-medium text-foreground mb-1">
+                              Analytics Bucket settings
+                            </p>
+                            <p className="text-xs text-foreground-light mb-4">
+                              Configure how data is sent to your Analytics Bucket destination
+                            </p>
+                          </div>
+                          <AnalyticsBucketFields
+                            form={form}
+                            setIsFormInteracting={setIsFormInteracting}
+                          />
+                        </>
+                      ) : null}
+                    </div>
+
+                    <DialogSectionSeparator />
 
                     <div className="px-5">
                       <AdvancedSettings form={form} />

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -445,7 +445,9 @@ export const DestinationPanel = ({
             <SheetHeader>
               <SheetTitle>{editMode ? 'Edit destination' : 'Create a new destination'}</SheetTitle>
               <SheetDescription>
-                {editMode ? null : 'Send data to a new destination'}
+                {editMode
+                  ? 'Update the configuration for this destination'
+                  : 'A destination is an external platform where your database changes are automatically sent in real-time'}
               </SheetDescription>
             </SheetHeader>
 
@@ -459,8 +461,8 @@ export const DestinationPanel = ({
                     No destinations available
                   </h3>
                   <p className="text-sm text-foreground-light max-w-md leading-relaxed">
-                    Database replication destinations are not currently available for this project.
-                    Please contact support if you need to enable data replication to external warehouses.
+                    Replication destinations are not currently enabled for this project. Contact
+                    support to enable real-time data replication to external platforms.
                   </p>
                 </div>
               ) : (
@@ -478,7 +480,7 @@ export const DestinationPanel = ({
                             </span>
                           }
                           layout="vertical"
-                          description="A name you will use to identify this destination"
+                          description="A descriptive name to identify this destination"
                         >
                           <FormControl_Shadcn_>
                             <Input_Shadcn_ {...field} placeholder="My destination" />
@@ -490,7 +492,9 @@ export const DestinationPanel = ({
                     <DialogSectionSeparator />
 
                   <div className="p-5">
-                    <p className="text-sm text-foreground-light mb-4">What data to send</p>
+                    <p className="text-sm text-foreground-light mb-4">
+                      Select which data to replicate
+                    </p>
                     <FormField_Shadcn_
                       control={form.control}
                       name="publicationName"
@@ -502,7 +506,7 @@ export const DestinationPanel = ({
                             </span>
                           }
                           layout="vertical"
-                          description="A publication is a collection of tables that you want to replicate "
+                          description="Choose which tables to replicate to this destination"
                         >
                           <FormControl_Shadcn_>
                             <PublicationsComboBox
@@ -559,11 +563,11 @@ export const DestinationPanel = ({
                       </p>
                       {editMode ? (
                         <p className="text-xs text-foreground-light mb-4">
-                          Destination type cannot be changed after creation
+                          The destination type cannot be changed after creation
                         </p>
                       ) : (
                         <p className="text-xs text-foreground-light mb-4">
-                          Select where you want to send your data
+                          Choose which platform to send your database changes to
                         </p>
                       )}
                       <FormField_Shadcn_
@@ -590,8 +594,8 @@ export const DestinationPanel = ({
                                     </div>
                                     <p className="text-xs text-foreground-light leading-relaxed">
                                       {field.value === 'BigQuery'
-                                        ? "Google Cloud's serverless data warehouse for analytics and business intelligence"
-                                        : 'Apache Iceberg tables in your Supabase Storage for flexible analytics workflows'}
+                                        ? 'Send data to Google Cloud\'s data warehouse for analytics and business intelligence'
+                                        : 'Send data to Apache Iceberg tables in your Supabase Storage for flexible analytics workflows'}
                                     </p>
                                   </div>
                                 </div>
@@ -631,7 +635,7 @@ export const DestinationPanel = ({
                                         )}
                                       </div>
                                       <p className="text-xs text-foreground-light leading-relaxed">
-                                        Google Cloud's serverless data warehouse for analytics and
+                                        Send data to Google Cloud's data warehouse for analytics and
                                         business intelligence
                                       </p>
                                     </div>
@@ -669,8 +673,8 @@ export const DestinationPanel = ({
                                         )}
                                       </div>
                                       <p className="text-xs text-foreground-light leading-relaxed">
-                                        Apache Iceberg tables in your Supabase Storage for flexible
-                                        analytics workflows
+                                        Send data to Apache Iceberg tables in your Supabase Storage for
+                                        flexible analytics workflows
                                       </p>
                                     </div>
                                   </button>
@@ -687,10 +691,10 @@ export const DestinationPanel = ({
                         <DialogSectionSeparator />
                         <div className="px-5">
                           <p className="text-sm font-medium text-foreground mb-1">
-                            BigQuery configuration
+                            BigQuery settings
                           </p>
                           <p className="text-xs text-foreground-light mb-4">
-                            Configure your Google Cloud BigQuery destination
+                            Configure how data is sent to your BigQuery destination
                           </p>
                         </div>
                         <BigQueryFields form={form} />
@@ -700,10 +704,10 @@ export const DestinationPanel = ({
                         <DialogSectionSeparator />
                         <div className="px-5">
                           <p className="text-sm font-medium text-foreground mb-1">
-                            Analytics Bucket configuration
+                            Analytics Bucket settings
                           </p>
                           <p className="text-xs text-foreground-light mb-4">
-                            Configure your Supabase Storage Analytics Bucket
+                            Configure how data is sent to your Analytics Bucket destination
                           </p>
                         </div>
                         <AnalyticsBucketFields
@@ -724,29 +728,22 @@ export const DestinationPanel = ({
               )}
             </SheetSection>
 
-            <SheetFooter className="flex-col items-stretch gap-2">
-              {!editMode && !form.formState.isValid && form.formState.isDirty && (
-                <p className="text-xs text-foreground-lighter text-center">
-                  Please fill in all required fields to continue
-                </p>
-              )}
-              <div className="flex gap-2 justify-end">
-                <Button disabled={isSaving} type="default" onClick={onClose}>
-                  Cancel
-                </Button>
-                <Button
-                  disabled={isSubmitDisabled}
-                  loading={isSaving}
-                  form={formId}
-                  htmlType="submit"
-                >
-                  {editMode
-                    ? existingDestination?.enabled
-                      ? 'Apply and restart'
-                      : 'Apply and start'
-                    : 'Create and start'}
-                </Button>
-              </div>
+            <SheetFooter>
+              <Button disabled={isSaving} type="default" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                disabled={isSubmitDisabled}
+                loading={isSaving}
+                form={formId}
+                htmlType="submit"
+              >
+                {editMode
+                  ? existingDestination?.enabled
+                    ? 'Apply and restart'
+                    : 'Apply and start'
+                  : 'Create and start'}
+              </Button>
             </SheetFooter>
           </div>
         </SheetContent>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -153,7 +153,7 @@ export const DestinationPanel = ({
       ? isBigQueryConfig
         ? TypeEnum.enum.BigQuery
         : TypeEnum.enum['Analytics Bucket']
-      : availableDestinations[0]?.value || TypeEnum.enum.BigQuery
+      : (availableDestinations[0]?.value as z.infer<typeof TypeEnum>) || TypeEnum.enum.BigQuery
 
     return {
       // Common fields

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
@@ -14,7 +14,6 @@ import { useStorageCredentialsQuery } from 'data/storage/s3-access-key-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import {
   Button,
-  DialogSectionSeparator,
   FormControl_Shadcn_,
   FormField_Shadcn_,
   Input_Shadcn_,
@@ -35,76 +34,72 @@ import { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   return (
-    <div className="space-y-4 pb-5">
-      <FormField_Shadcn_
-        control={form.control}
-        name="projectId"
-        render={({ field }) => (
-          <FormItemLayout
-            layout="vertical"
-            className="px-5"
-            label={
-              <span>
-                Project ID <span className="text-destructive-600">*</span>
-              </span>
-            }
-            description="The Google Cloud project ID where data will be sent"
-          >
-            <FormControl_Shadcn_>
-              <Input_Shadcn_ {...field} placeholder="my-gcp-project" />
-            </FormControl_Shadcn_>
-          </FormItemLayout>
-        )}
-      />
+    <>
+      <div className="px-5 pt-5">
+        <p className="text-sm font-medium text-foreground mb-1">BigQuery settings</p>
+        <p className="text-sm text-foreground-light mb-4">
+          Configure how data is sent to your BigQuery destination
+        </p>
+      </div>
+      <div className="space-y-4 pb-5">
+        <FormField_Shadcn_
+          control={form.control}
+          name="projectId"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="vertical"
+              className="px-5"
+              label="Project ID"
+              description="The Google Cloud project ID where data will be sent"
+            >
+              <FormControl_Shadcn_>
+                <Input_Shadcn_ {...field} placeholder="my-gcp-project" />
+              </FormControl_Shadcn_>
+            </FormItemLayout>
+          )}
+        />
 
-      <FormField_Shadcn_
-        control={form.control}
-        name="datasetId"
-        render={({ field }) => (
-          <FormItemLayout
-            label={
-              <span>
-                Dataset ID <span className="text-destructive-600">*</span>
-              </span>
-            }
-            layout="vertical"
-            className="px-5"
-            description="The BigQuery dataset where replicated tables will be created"
-          >
-            <FormControl_Shadcn_>
-              <Input_Shadcn_ {...field} placeholder="my_dataset" />
-            </FormControl_Shadcn_>
-          </FormItemLayout>
-        )}
-      />
+        <FormField_Shadcn_
+          control={form.control}
+          name="datasetId"
+          render={({ field }) => (
+            <FormItemLayout
+              label="Dataset ID"
+              layout="vertical"
+              className="px-5"
+              description="The BigQuery dataset where replicated tables will be created"
+            >
+              <FormControl_Shadcn_>
+                <Input_Shadcn_ {...field} placeholder="my_dataset" />
+              </FormControl_Shadcn_>
+            </FormItemLayout>
+          )}
+        />
 
-      <FormField_Shadcn_
-        control={form.control}
-        name="serviceAccountKey"
-        render={({ field }) => (
-          <FormItemLayout
-            layout="vertical"
-            className="px-5"
-            label={
-              <span>
-                Service Account Key <span className="text-destructive-600">*</span>
-              </span>
-            }
-            description="Service account credentials JSON for authenticating with BigQuery"
-          >
-            <FormControl_Shadcn_>
-              <TextArea_Shadcn_
-                {...field}
-                rows={5}
-                maxLength={5000}
-                placeholder='{"type": "service_account", "project_id": "...", ...}'
-                className="font-mono text-xs"
-              />
-            </FormControl_Shadcn_>
-          </FormItemLayout>
-        )}
-      />
-    </div>
+        <FormField_Shadcn_
+          control={form.control}
+          name="serviceAccountKey"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="vertical"
+              className="px-5"
+              label="Service Account Key"
+              description="Service account credentials JSON for authenticating with BigQuery"
+            >
+              <FormControl_Shadcn_>
+                <TextArea_Shadcn_
+                  {...field}
+                  rows={5}
+                  maxLength={5000}
+                  placeholder='{"type": "service_account", "project_id": "...", ...}'
+                  className="font-mono text-xs"
+                />
+              </FormControl_Shadcn_>
+            </FormItemLayout>
+          )}
+        />
+      </div>
+    </>
   )
 }
 
@@ -185,347 +180,334 @@ export const AnalyticsBucketFields = ({
   )
 
   return (
-    <div className="space-y-4 pb-5">
-      <div className="px-5">
-        <p className="text-xs font-medium text-foreground-light mb-3">Storage</p>
+    <>
+      <div className="px-5 pt-5">
+        <p className="text-sm font-medium text-foreground mb-1">Analytics Bucket settings</p>
+        <p className="text-sm text-foreground-light mb-4">
+          Configure how data is sent to your Analytics Bucket destination
+        </p>
       </div>
-      <FormField_Shadcn_
-        control={form.control}
-        name="warehouseName"
-        render={({ field }) => (
-          <FormItemLayout
-            label={
-              <span>
-                Bucket <span className="text-destructive-600">*</span>
-              </span>
-            }
-            layout="vertical"
-            className="px-5"
-            description="The Analytics Bucket where data will be stored"
-          >
-            {isLoadingBuckets ? (
-              <Button
-                disabled
-                type="default"
-                className="w-full justify-between"
-                size="small"
-                iconRight={<Loader2 className="animate-spin" />}
-              >
-                Retrieving buckets
-              </Button>
-            ) : isErrorBuckets ? (
-              <Button
-                disabled
-                type="default"
-                className="w-full justify-start"
-                size="small"
-                icon={<WarningIcon />}
-              >
-                Failed to retrieve buckets
-              </Button>
-            ) : (
-              <FormControl_Shadcn_>
-                <Select_Shadcn_
-                  value={field.value}
-                  onValueChange={(value) => {
-                    setIsFormInteracting(true)
-                    field.onChange(value)
-                    // [Joshen] Ideally should select the first namespace of the selected bucket
-                    form.setValue('namespace', '')
-                  }}
-                >
-                  <SelectTrigger_Shadcn_>{field.value || 'Select a bucket'}</SelectTrigger_Shadcn_>
-                  <SelectContent_Shadcn_>
-                    <SelectGroup_Shadcn_>
-                      {analyticsBuckets.length === 0 ? (
-                        <SelectItem_Shadcn_ value="__no_buckets__" disabled>
-                          No buckets available
-                        </SelectItem_Shadcn_>
-                      ) : (
-                        analyticsBuckets.map((bucket) => (
-                          <SelectItem_Shadcn_ key={bucket.id} value={bucket.name}>
-                            {bucket.name}
-                          </SelectItem_Shadcn_>
-                        ))
-                      )}
-                    </SelectGroup_Shadcn_>
-                  </SelectContent_Shadcn_>
-                </Select_Shadcn_>
-              </FormControl_Shadcn_>
-            )}
-          </FormItemLayout>
-        )}
-      />
-
-      <FormField_Shadcn_
-        control={form.control}
-        name="namespace"
-        render={({ field }) => (
-          <FormItemLayout
-            label={
-              <span>
-                Namespace <span className="text-destructive-600">*</span>
-              </span>
-            }
-            layout="vertical"
-            className="px-5"
-            description="The namespace within the bucket where tables will be organized"
-          >
-            {isLoadingNamespaces && canSelectNamespace ? (
-              <Button
-                disabled
-                type="default"
-                className="w-full justify-between"
-                size="small"
-                iconRight={<Loader2 className="animate-spin" />}
-              >
-                Retrieving namespaces
-              </Button>
-            ) : isErrorNamespaces ? (
-              <Button
-                disabled
-                type="default"
-                className="w-full justify-start"
-                size="small"
-                icon={<WarningIcon />}
-              >
-                Failed to retrieve namespaces
-              </Button>
-            ) : (
-              <FormControl_Shadcn_>
-                <Select_Shadcn_
-                  value={field.value}
-                  onValueChange={(value) => {
-                    setIsFormInteracting(true)
-                    field.onChange(value)
-                  }}
-                  disabled={!canSelectNamespace}
-                >
-                  <SelectTrigger_Shadcn_>
-                    {!canSelectNamespace
-                      ? 'Select a warehouse first'
-                      : field.value === CREATE_NEW_NAMESPACE
-                        ? 'Create a new namespace'
-                        : field.value || 'Select a namespace'}
-                  </SelectTrigger_Shadcn_>
-                  <SelectContent_Shadcn_>
-                    <SelectGroup_Shadcn_>
-                      {namespaces.length === 0 ? (
-                        <SelectItem_Shadcn_ value="__no_namespaces__" disabled>
-                          No namespaces available
-                        </SelectItem_Shadcn_>
-                      ) : (
-                        namespaces.map((namespace) => (
-                          <SelectItem_Shadcn_ key={namespace} value={namespace}>
-                            {namespace}
-                          </SelectItem_Shadcn_>
-                        ))
-                      )}
-                      {namespaces.length > 0 && <SelectSeparator_Shadcn_ />}
-                      <SelectItem_Shadcn_ key={CREATE_NEW_NAMESPACE} value={CREATE_NEW_NAMESPACE}>
-                        Create a new namespace
-                      </SelectItem_Shadcn_>
-                    </SelectGroup_Shadcn_>
-                  </SelectContent_Shadcn_>
-                </Select_Shadcn_>
-              </FormControl_Shadcn_>
-            )}
-          </FormItemLayout>
-        )}
-      />
-
-      {namespace === CREATE_NEW_NAMESPACE && (
+      <div className="space-y-4 pb-5">
         <FormField_Shadcn_
           control={form.control}
-          name="newNamespaceName"
+          name="warehouseName"
           render={({ field }) => (
             <FormItemLayout
-              label={
-                <span>
-                  New Namespace Name <span className="text-destructive-600">*</span>
-                </span>
-              }
+              label="Bucket"
               layout="vertical"
               className="px-5"
-              description="A unique name for the new namespace"
+              description="The Analytics Bucket where data will be stored"
             >
-              <FormControl_Shadcn_>
-                <Input_Shadcn_ {...field} placeholder="new_namespace" value={field.value || ''} />
-              </FormControl_Shadcn_>
+              {isLoadingBuckets ? (
+                <Button
+                  disabled
+                  type="default"
+                  className="w-full justify-between"
+                  size="small"
+                  iconRight={<Loader2 className="animate-spin" />}
+                >
+                  Retrieving buckets
+                </Button>
+              ) : isErrorBuckets ? (
+                <Button
+                  disabled
+                  type="default"
+                  className="w-full justify-start"
+                  size="small"
+                  icon={<WarningIcon />}
+                >
+                  Failed to retrieve buckets
+                </Button>
+              ) : (
+                <FormControl_Shadcn_>
+                  <Select_Shadcn_
+                    value={field.value}
+                    onValueChange={(value) => {
+                      setIsFormInteracting(true)
+                      field.onChange(value)
+                      // [Joshen] Ideally should select the first namespace of the selected bucket
+                      form.setValue('namespace', '')
+                    }}
+                  >
+                    <SelectTrigger_Shadcn_>
+                      {field.value || 'Select a bucket'}
+                    </SelectTrigger_Shadcn_>
+                    <SelectContent_Shadcn_>
+                      <SelectGroup_Shadcn_>
+                        {analyticsBuckets.length === 0 ? (
+                          <SelectItem_Shadcn_ value="__no_buckets__" disabled>
+                            No buckets available
+                          </SelectItem_Shadcn_>
+                        ) : (
+                          analyticsBuckets.map((bucket) => (
+                            <SelectItem_Shadcn_ key={bucket.id} value={bucket.name}>
+                              {bucket.name}
+                            </SelectItem_Shadcn_>
+                          ))
+                        )}
+                      </SelectGroup_Shadcn_>
+                    </SelectContent_Shadcn_>
+                  </Select_Shadcn_>
+                </FormControl_Shadcn_>
+              )}
             </FormItemLayout>
           )}
         />
-      )}
 
-      <div className="px-5 pt-4">
-        <p className="text-xs font-medium text-foreground-light mb-3">Credentials</p>
-      </div>
-
-      <FormField_Shadcn_
-        control={form.control}
-        name="catalogToken"
-        render={({ field }) => (
-          <FormItemLayout
-            layout="vertical"
-            label="Catalog Token"
-            className="px-5"
-            description={
-              <>
-                Automatically retrieved from your project's{' '}
-                <InlineLink href={`/project/${projectRef}/settings/api-keys`}>
-                  service role key
-                </InlineLink>
-              </>
-            }
-          >
-            <Input
-              disabled
-              value={field.value}
-              type={showCatalogToken ? 'text' : 'password'}
-              placeholder="Auto-populated"
-              actions={
-                serviceApiKey ? (
-                  <div className="flex items-center justify-center">
-                    <Button
-                      type="default"
-                      className="w-7"
-                      icon={showCatalogToken ? <Eye /> : <EyeOff />}
-                      onClick={() => setShowCatalogToken(!showCatalogToken)}
-                    />
-                  </div>
-                ) : null
-              }
-            />
-          </FormItemLayout>
-        )}
-      />
-
-      <FormField_Shadcn_
-        control={form.control}
-        name="s3AccessKeyId"
-        render={({ field }) => (
-          <FormItemLayout layout="vertical" label="S3 Access Key ID" className="px-5">
-            {isLoadingKeys ? (
-              <Button
-                disabled
-                type="default"
-                className="w-full justify-between"
-                size="small"
-                iconRight={<Loader2 className="animate-spin" />}
-              >
-                Retrieving keys
-              </Button>
-            ) : isErrorKeys ? (
-              <Button
-                disabled
-                type="default"
-                className="w-full justify-start"
-                size="small"
-                icon={<WarningIcon />}
-              >
-                Failed to retrieve keys
-              </Button>
-            ) : (
-              <FormControl_Shadcn_>
-                <Select_Shadcn_ value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger_Shadcn_>
-                    {field.value === CREATE_NEW_KEY
-                      ? 'Create a new key'
-                      : (field.value ?? '').length === 0
-                        ? 'Select an access key ID'
-                        : field.value}
-                  </SelectTrigger_Shadcn_>
-                  <SelectContent_Shadcn_>
-                    <SelectGroup_Shadcn_>
-                      {s3Keys.map((key) => (
-                        <SelectItem_Shadcn_ key={key.id} value={key.access_key}>
-                          {key.access_key}
-                          <p className="text-foreground-lighter">{key.description}</p>
-                        </SelectItem_Shadcn_>
-                      ))}
-                      <SelectSeparator_Shadcn_ />
-                      <SelectItem_Shadcn_ key={CREATE_NEW_KEY} value={CREATE_NEW_KEY}>
-                        Create a new key
-                      </SelectItem_Shadcn_>
-                    </SelectGroup_Shadcn_>
-                  </SelectContent_Shadcn_>
-                </Select_Shadcn_>
-              </FormControl_Shadcn_>
-            )}
-          </FormItemLayout>
-        )}
-      />
-
-      {isSuccessKeys && keyNoLongerExists && (
-        <div className="px-5">
-          <Admonition type="warning" title="Unable to find access key ID in project">
-            <p className="!leading-normal">
-              Please select another key or create a new set, as this destination will not work
-              otherwise. S3 access keys can be managed in your{' '}
-              <InlineLink
-                href={
-                  isStorageV2
-                    ? `/project/${projectRef}/storage/files/settings`
-                    : `/project/${projectRef}/storage/settings`
-                }
-              >
-                storage settings
-              </InlineLink>
-            </p>
-          </Admonition>
-        </div>
-      )}
-
-      {s3AccessKeyId === CREATE_NEW_KEY ? (
-        <div className="px-5">
-          <Admonition type="default" title="A new set of S3 access keys will be created">
-            <p className="!leading-normal">
-              S3 access keys can be managed in your{' '}
-              <InlineLink
-                href={
-                  isStorageV2
-                    ? `/project/${projectRef}/storage/files/settings`
-                    : `/project/${projectRef}/storage/settings`
-                }
-              >
-                storage settings
-              </InlineLink>
-              .
-            </p>
-          </Admonition>
-        </div>
-      ) : (
         <FormField_Shadcn_
           control={form.control}
-          name="s3SecretAccessKey"
+          name="namespace"
+          render={({ field }) => (
+            <FormItemLayout
+              label="Namespace"
+              layout="vertical"
+              className="px-5"
+              description="The namespace within the bucket where tables will be organized"
+            >
+              {isLoadingNamespaces && canSelectNamespace ? (
+                <Button
+                  disabled
+                  type="default"
+                  className="w-full justify-between"
+                  size="small"
+                  iconRight={<Loader2 className="animate-spin" />}
+                >
+                  Retrieving namespaces
+                </Button>
+              ) : isErrorNamespaces ? (
+                <Button
+                  disabled
+                  type="default"
+                  className="w-full justify-start"
+                  size="small"
+                  icon={<WarningIcon />}
+                >
+                  Failed to retrieve namespaces
+                </Button>
+              ) : (
+                <FormControl_Shadcn_>
+                  <Select_Shadcn_
+                    value={field.value}
+                    onValueChange={(value) => {
+                      setIsFormInteracting(true)
+                      field.onChange(value)
+                    }}
+                    disabled={!canSelectNamespace}
+                  >
+                    <SelectTrigger_Shadcn_>
+                      {!canSelectNamespace
+                        ? 'Select a warehouse first'
+                        : field.value === CREATE_NEW_NAMESPACE
+                          ? 'Create a new namespace'
+                          : field.value || 'Select a namespace'}
+                    </SelectTrigger_Shadcn_>
+                    <SelectContent_Shadcn_>
+                      <SelectGroup_Shadcn_>
+                        {namespaces.length === 0 ? (
+                          <SelectItem_Shadcn_ value="__no_namespaces__" disabled>
+                            No namespaces available
+                          </SelectItem_Shadcn_>
+                        ) : (
+                          namespaces.map((namespace) => (
+                            <SelectItem_Shadcn_ key={namespace} value={namespace}>
+                              {namespace}
+                            </SelectItem_Shadcn_>
+                          ))
+                        )}
+                        {namespaces.length > 0 && <SelectSeparator_Shadcn_ />}
+                        <SelectItem_Shadcn_ key={CREATE_NEW_NAMESPACE} value={CREATE_NEW_NAMESPACE}>
+                          Create a new namespace
+                        </SelectItem_Shadcn_>
+                      </SelectGroup_Shadcn_>
+                    </SelectContent_Shadcn_>
+                  </Select_Shadcn_>
+                </FormControl_Shadcn_>
+              )}
+            </FormItemLayout>
+          )}
+        />
+
+        {namespace === CREATE_NEW_NAMESPACE && (
+          <FormField_Shadcn_
+            control={form.control}
+            name="newNamespaceName"
+            render={({ field }) => (
+              <FormItemLayout
+                label="New Namespace Name"
+                layout="vertical"
+                className="px-5"
+                description="A unique name for the new namespace"
+              >
+                <FormControl_Shadcn_>
+                  <Input_Shadcn_ {...field} placeholder="new_namespace" value={field.value || ''} />
+                </FormControl_Shadcn_>
+              </FormItemLayout>
+            )}
+          />
+        )}
+
+        <FormField_Shadcn_
+          control={form.control}
+          name="catalogToken"
           render={({ field }) => (
             <FormItemLayout
               layout="vertical"
-              label={
-                <span>
-                  S3 Secret Access Key <span className="text-destructive-600">*</span>
-                </span>
+              label="Catalog Token"
+              className="px-5"
+              description={
+                <>
+                  Automatically retrieved from your project's{' '}
+                  <InlineLink href={`/project/${projectRef}/settings/api-keys`}>
+                    service role key
+                  </InlineLink>
+                </>
               }
-              className="relative px-5"
-              description="The secret key corresponding to your selected access key ID"
             >
-              <FormControl_Shadcn_>
-                <Input_Shadcn_
-                  {...field}
-                  type={showSecretAccessKey ? 'text' : 'password'}
-                  value={field.value ?? ''}
-                />
-              </FormControl_Shadcn_>
-              <Button
-                type="default"
-                icon={showSecretAccessKey ? <Eye /> : <EyeOff />}
-                className="w-7 absolute right-6 top-[33px]"
-                onClick={() => setShowSecretAccessKey(!showSecretAccessKey)}
+              <Input
+                disabled
+                value={field.value}
+                type={showCatalogToken ? 'text' : 'password'}
+                placeholder="Auto-populated"
+                actions={
+                  serviceApiKey ? (
+                    <div className="flex items-center justify-center">
+                      <Button
+                        type="default"
+                        className="w-7"
+                        icon={showCatalogToken ? <Eye /> : <EyeOff />}
+                        onClick={() => setShowCatalogToken(!showCatalogToken)}
+                      />
+                    </div>
+                  ) : null
+                }
               />
             </FormItemLayout>
           )}
         />
-      )}
-    </div>
+
+        <FormField_Shadcn_
+          control={form.control}
+          name="s3AccessKeyId"
+          render={({ field }) => (
+            <FormItemLayout layout="vertical" label="S3 Access Key ID" className="px-5">
+              {isLoadingKeys ? (
+                <Button
+                  disabled
+                  type="default"
+                  className="w-full justify-between"
+                  size="small"
+                  iconRight={<Loader2 className="animate-spin" />}
+                >
+                  Retrieving keys
+                </Button>
+              ) : isErrorKeys ? (
+                <Button
+                  disabled
+                  type="default"
+                  className="w-full justify-start"
+                  size="small"
+                  icon={<WarningIcon />}
+                >
+                  Failed to retrieve keys
+                </Button>
+              ) : (
+                <FormControl_Shadcn_>
+                  <Select_Shadcn_ value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger_Shadcn_>
+                      {field.value === CREATE_NEW_KEY
+                        ? 'Create a new key'
+                        : (field.value ?? '').length === 0
+                          ? 'Select an access key ID'
+                          : field.value}
+                    </SelectTrigger_Shadcn_>
+                    <SelectContent_Shadcn_>
+                      <SelectGroup_Shadcn_>
+                        {s3Keys.map((key) => (
+                          <SelectItem_Shadcn_ key={key.id} value={key.access_key}>
+                            {key.access_key}
+                            <p className="text-foreground-lighter">{key.description}</p>
+                          </SelectItem_Shadcn_>
+                        ))}
+                        <SelectSeparator_Shadcn_ />
+                        <SelectItem_Shadcn_ key={CREATE_NEW_KEY} value={CREATE_NEW_KEY}>
+                          Create a new key
+                        </SelectItem_Shadcn_>
+                      </SelectGroup_Shadcn_>
+                    </SelectContent_Shadcn_>
+                  </Select_Shadcn_>
+                </FormControl_Shadcn_>
+              )}
+            </FormItemLayout>
+          )}
+        />
+
+        {isSuccessKeys && keyNoLongerExists && (
+          <div className="px-5">
+            <Admonition type="warning" title="Unable to find access key ID in project">
+              <p className="!leading-normal">
+                Please select another key or create a new set, as this destination will not work
+                otherwise. S3 access keys can be managed in your{' '}
+                <InlineLink
+                  href={
+                    isStorageV2
+                      ? `/project/${projectRef}/storage/files/settings`
+                      : `/project/${projectRef}/storage/settings`
+                  }
+                >
+                  storage settings
+                </InlineLink>
+              </p>
+            </Admonition>
+          </div>
+        )}
+
+        {s3AccessKeyId === CREATE_NEW_KEY ? (
+          <div className="px-5">
+            <Admonition type="default" title="A new set of S3 access keys will be created">
+              <p className="!leading-normal">
+                S3 access keys can be managed in your{' '}
+                <InlineLink
+                  href={
+                    isStorageV2
+                      ? `/project/${projectRef}/storage/files/settings`
+                      : `/project/${projectRef}/storage/settings`
+                  }
+                >
+                  storage settings
+                </InlineLink>
+                .
+              </p>
+            </Admonition>
+          </div>
+        ) : (
+          <FormField_Shadcn_
+            control={form.control}
+            name="s3SecretAccessKey"
+            render={({ field }) => (
+              <FormItemLayout
+                layout="vertical"
+                label="S3 Secret Access Key"
+                className="relative px-5"
+                description="The secret key corresponding to your selected access key ID"
+              >
+                <FormControl_Shadcn_>
+                  <Input_Shadcn_
+                    {...field}
+                    type={showSecretAccessKey ? 'text' : 'password'}
+                    value={field.value ?? ''}
+                  />
+                </FormControl_Shadcn_>
+                <Button
+                  type="default"
+                  icon={showSecretAccessKey ? <Eye /> : <EyeOff />}
+                  className="w-7 absolute right-6 top-[33px]"
+                  onClick={() => setShowSecretAccessKey(!showSecretAccessKey)}
+                />
+              </FormItemLayout>
+            )}
+          />
+        )}
+      </div>
+    </>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
@@ -1,6 +1,6 @@
 import { Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { UseFormReturn } from 'react-hook-form'
+import type { UseFormReturn } from 'react-hook-form'
 
 import { useParams } from 'common'
 import { useIsNewStorageUIEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
@@ -30,7 +30,7 @@ import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { CREATE_NEW_KEY, CREATE_NEW_NAMESPACE } from './DestinationPanel.constants'
-import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+import type { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   return (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
@@ -35,7 +35,7 @@ import { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pb-5">
       <FormField_Shadcn_
         control={form.control}
         name="projectId"
@@ -185,7 +185,7 @@ export const AnalyticsBucketFields = ({
   )
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pb-5">
       <div className="px-5">
         <p className="text-xs font-medium text-foreground-light mb-3">Storage</p>
       </div>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
@@ -35,7 +35,7 @@ import { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
   return (
-    <>
+    <div className="space-y-4">
       <FormField_Shadcn_
         control={form.control}
         name="projectId"
@@ -44,10 +44,10 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
             layout="vertical"
             className="px-5"
             label="Project ID"
-            description="Which BigQuery project to send data to"
+            description="Your Google Cloud project identifier"
           >
             <FormControl_Shadcn_>
-              <Input_Shadcn_ {...field} placeholder="Project ID" />
+              <Input_Shadcn_ {...field} placeholder="my-gcp-project" />
             </FormControl_Shadcn_>
           </FormItemLayout>
         )}
@@ -57,9 +57,14 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
         control={form.control}
         name="datasetId"
         render={({ field }) => (
-          <FormItemLayout label="Project's Dataset ID" layout="vertical" className="px-5">
+          <FormItemLayout
+            label="Dataset ID"
+            layout="vertical"
+            className="px-5"
+            description="The dataset where tables will be created"
+          >
             <FormControl_Shadcn_>
-              <Input_Shadcn_ {...field} placeholder="Dataset ID" />
+              <Input_Shadcn_ {...field} placeholder="my_dataset" />
             </FormControl_Shadcn_>
           </FormItemLayout>
         )}
@@ -73,20 +78,21 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
             layout="vertical"
             className="px-5"
             label="Service Account Key"
-            description="The service account key for BigQuery"
+            description="JSON key file for authentication with BigQuery"
           >
             <FormControl_Shadcn_>
               <TextArea_Shadcn_
                 {...field}
-                rows={4}
+                rows={5}
                 maxLength={5000}
-                placeholder="Service account key"
+                placeholder='{"type": "service_account", "project_id": "...", ...}'
+                className="font-mono text-xs"
               />
             </FormControl_Shadcn_>
           </FormItemLayout>
         )}
       />
-    </>
+    </div>
   )
 }
 
@@ -167,7 +173,10 @@ export const AnalyticsBucketFields = ({
   )
 
   return (
-    <>
+    <div className="space-y-4">
+      <div className="px-5">
+        <p className="text-xs font-medium text-foreground-light mb-3">Storage</p>
+      </div>
       <FormField_Shadcn_
         control={form.control}
         name="warehouseName"
@@ -324,9 +333,9 @@ export const AnalyticsBucketFields = ({
         />
       )}
 
-      <DialogSectionSeparator />
-
-      <p className="px-5 text-sm text-foreground-light">Credentials</p>
+      <div className="px-5 pt-4">
+        <p className="text-xs font-medium text-foreground-light mb-3">Credentials</p>
+      </div>
 
       <FormField_Shadcn_
         control={form.control}
@@ -489,6 +498,6 @@ export const AnalyticsBucketFields = ({
           )}
         />
       )}
-    </>
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
@@ -48,7 +48,7 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
                 Project ID <span className="text-destructive-600">*</span>
               </span>
             }
-            description="Your Google Cloud project identifier"
+            description="The Google Cloud project ID where data will be sent"
           >
             <FormControl_Shadcn_>
               <Input_Shadcn_ {...field} placeholder="my-gcp-project" />
@@ -69,7 +69,7 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
             }
             layout="vertical"
             className="px-5"
-            description="The dataset where tables will be created"
+            description="The BigQuery dataset where replicated tables will be created"
           >
             <FormControl_Shadcn_>
               <Input_Shadcn_ {...field} placeholder="my_dataset" />
@@ -90,7 +90,7 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
                 Service Account Key <span className="text-destructive-600">*</span>
               </span>
             }
-            description="JSON key file for authentication with BigQuery"
+            description="Service account credentials JSON for authenticating with BigQuery"
           >
             <FormControl_Shadcn_>
               <TextArea_Shadcn_
@@ -201,7 +201,7 @@ export const AnalyticsBucketFields = ({
             }
             layout="vertical"
             className="px-5"
-            description="Select a storage Analytics Bucket to use as your warehouse"
+            description="The Analytics Bucket where data will be stored"
           >
             {isLoadingBuckets ? (
               <Button
@@ -269,7 +269,7 @@ export const AnalyticsBucketFields = ({
             }
             layout="vertical"
             className="px-5"
-            description="Select a namespace from your Analytics Bucket"
+            description="The namespace within the bucket where tables will be organized"
           >
             {isLoadingNamespaces && canSelectNamespace ? (
               <Button
@@ -347,7 +347,7 @@ export const AnalyticsBucketFields = ({
               }
               layout="vertical"
               className="px-5"
-              description="Enter a name for the new namespace"
+              description="A unique name for the new namespace"
             >
               <FormControl_Shadcn_>
                 <Input_Shadcn_ {...field} placeholder="new_namespace" value={field.value || ''} />
@@ -507,7 +507,7 @@ export const AnalyticsBucketFields = ({
                 </span>
               }
               className="relative px-5"
-              description="The corresponding secret access key for the selected key ID"
+              description="The secret key corresponding to your selected access key ID"
             >
               <FormControl_Shadcn_>
                 <Input_Shadcn_

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanelFields.tsx
@@ -43,7 +43,11 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
           <FormItemLayout
             layout="vertical"
             className="px-5"
-            label="Project ID"
+            label={
+              <span>
+                Project ID <span className="text-destructive-600">*</span>
+              </span>
+            }
             description="Your Google Cloud project identifier"
           >
             <FormControl_Shadcn_>
@@ -58,7 +62,11 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
         name="datasetId"
         render={({ field }) => (
           <FormItemLayout
-            label="Dataset ID"
+            label={
+              <span>
+                Dataset ID <span className="text-destructive-600">*</span>
+              </span>
+            }
             layout="vertical"
             className="px-5"
             description="The dataset where tables will be created"
@@ -77,7 +85,11 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
           <FormItemLayout
             layout="vertical"
             className="px-5"
-            label="Service Account Key"
+            label={
+              <span>
+                Service Account Key <span className="text-destructive-600">*</span>
+              </span>
+            }
             description="JSON key file for authentication with BigQuery"
           >
             <FormControl_Shadcn_>
@@ -182,7 +194,11 @@ export const AnalyticsBucketFields = ({
         name="warehouseName"
         render={({ field }) => (
           <FormItemLayout
-            label="Bucket"
+            label={
+              <span>
+                Bucket <span className="text-destructive-600">*</span>
+              </span>
+            }
             layout="vertical"
             className="px-5"
             description="Select a storage Analytics Bucket to use as your warehouse"
@@ -246,7 +262,11 @@ export const AnalyticsBucketFields = ({
         name="namespace"
         render={({ field }) => (
           <FormItemLayout
-            label="Namespace"
+            label={
+              <span>
+                Namespace <span className="text-destructive-600">*</span>
+              </span>
+            }
             layout="vertical"
             className="px-5"
             description="Select a namespace from your Analytics Bucket"
@@ -320,7 +340,11 @@ export const AnalyticsBucketFields = ({
           name="newNamespaceName"
           render={({ field }) => (
             <FormItemLayout
-              label="New Namespace Name"
+              label={
+                <span>
+                  New Namespace Name <span className="text-destructive-600">*</span>
+                </span>
+              }
               layout="vertical"
               className="px-5"
               description="Enter a name for the new namespace"
@@ -477,7 +501,11 @@ export const AnalyticsBucketFields = ({
           render={({ field }) => (
             <FormItemLayout
               layout="vertical"
-              label="S3 Secret Access Key"
+              label={
+                <span>
+                  S3 Secret Access Key <span className="text-destructive-600">*</span>
+                </span>
+              }
               className="relative px-5"
               description="The corresponding secret access key for the selected key ID"
             >

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -1,0 +1,68 @@
+import { UseFormReturn } from 'react-hook-form'
+
+import { useFlag } from 'common'
+import {
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  RadioGroupStacked,
+  RadioGroupStackedItem,
+} from 'ui'
+import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+
+type DestinationTypeSelectionProps = {
+  form: UseFormReturn<DestinationPanelSchemaType>
+  editMode: boolean
+}
+
+export const DestinationTypeSelection = ({ form, editMode }: DestinationTypeSelectionProps) => {
+  const etlEnableBigQuery = useFlag('etlEnableBigQuery')
+  const etlEnableIceberg = useFlag('etlEnableIceberg')
+
+  return (
+    <div className="px-5 py-5">
+      <p className="text-sm font-medium text-foreground mb-1">Destination type</p>
+      {editMode ? (
+        <p className="text-sm text-foreground-light mb-4">
+          The destination type cannot be changed after creation
+        </p>
+      ) : (
+        <p className="text-sm text-foreground-light mb-4">
+          Choose which platform to send your database changes to
+        </p>
+      )}
+      <FormField_Shadcn_
+        name="type"
+        control={form.control}
+        render={({ field }) => (
+          <FormControl_Shadcn_>
+            <RadioGroupStacked
+              disabled={editMode}
+              value={field.value}
+              onValueChange={(value) => field.onChange(value)}
+            >
+              {((!editMode && etlEnableBigQuery) || (editMode && field.value === 'BigQuery')) && (
+                <RadioGroupStackedItem
+                  id="BigQuery"
+                  value="BigQuery"
+                  label="BigQuery"
+                  className="[&>div>div>p]:text-left"
+                  description="Send data to Google Cloud's data warehouse for analytics and business intelligence"
+                />
+              )}
+              {((!editMode && etlEnableIceberg) ||
+                (editMode && field.value === 'Analytics Bucket')) && (
+                <RadioGroupStackedItem
+                  value="Analytics Bucket"
+                  id="Analytics Bucket"
+                  label="Analytics Bucket"
+                  className="[&>div>div>p]:text-left"
+                  description="Send data to Apache Iceberg tables in your Supabase Storage for flexible analytics workflows"
+                />
+              )}
+            </RadioGroupStacked>
+          </FormControl_Shadcn_>
+        )}
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form'
+import type { UseFormReturn } from 'react-hook-form'
 
 import { useFlag } from 'common'
 import {
@@ -7,7 +7,7 @@ import {
   RadioGroupStacked,
   RadioGroupStackedItem,
 } from 'ui'
-import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+import type { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 type DestinationTypeSelectionProps = {
   form: UseFormReturn<DestinationPanelSchemaType>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/NoDestinationsAvailable.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/NoDestinationsAvailable.tsx
@@ -1,0 +1,16 @@
+import { DatabaseZap } from 'lucide-react'
+
+export const NoDestinationsAvailable = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full px-8 py-16 text-center">
+      <div className="flex items-center justify-center w-20 h-20 rounded-full bg-surface-300 mb-6">
+        <DatabaseZap className="w-10 h-10 text-foreground-light" strokeWidth={1.5} />
+      </div>
+      <h3 className="text-xl font-medium text-foreground mb-3">No destinations available</h3>
+      <p className="text-sm text-foreground-light max-w-md leading-relaxed">
+        Replication destinations are not currently enabled for this project. Contact support to
+        enable real-time data replication to external platforms.
+      </p>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/NoDestinationsAvailable.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/NoDestinationsAvailable.tsx
@@ -3,11 +3,11 @@ import { DatabaseZap } from 'lucide-react'
 export const NoDestinationsAvailable = () => {
   return (
     <div className="flex flex-col items-center justify-center h-full px-8 py-16 text-center">
-      <div className="flex items-center justify-center w-20 h-20 rounded-full bg-surface-300 mb-6">
-        <DatabaseZap className="w-10 h-10 text-foreground-light" strokeWidth={1.5} />
+      <div className="flex items-center justify-center w-14 h-14 rounded-full bg-surface-300 mb-5">
+        <DatabaseZap size={26} className="text-foreground-light" strokeWidth={1.5} />
       </div>
-      <h3 className="text-xl font-medium text-foreground mb-3">No destinations available</h3>
-      <p className="text-sm text-foreground-light max-w-md leading-relaxed">
+      <h3 className="text-lg font-medium text-foreground mb-2">No destinations available</h3>
+      <p className="text-sm text-foreground-light max-w-lg">
         Replication destinations are not currently enabled for this project. Contact support to
         enable real-time data replication to external platforms.
       </p>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/PublicationSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/PublicationSelection.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from 'react'
+import { UseFormReturn } from 'react-hook-form'
+
+import { useParams } from 'common'
+import { InlineLink } from 'components/ui/InlineLink'
+import { useCheckPrimaryKeysExists } from 'data/database/primary-keys-exists-query'
+import { useReplicationPublicationsQuery } from 'data/replication/publications-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { FormControl_Shadcn_, FormField_Shadcn_ } from 'ui'
+import { Admonition } from 'ui-patterns'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { NewPublicationPanel } from '../NewPublicationPanel'
+import { PublicationsComboBox } from '../PublicationsComboBox'
+import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+
+type PublicationSelectionProps = {
+  form: UseFormReturn<DestinationPanelSchemaType>
+  sourceId?: number
+  visible: boolean
+}
+
+export const PublicationSelection = ({ form, sourceId, visible }: PublicationSelectionProps) => {
+  const { ref: projectRef } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+  const { publicationName } = form.watch()
+
+  const [publicationPanelVisible, setPublicationPanelVisible] = useState(false)
+
+  const {
+    data: publications = [],
+    isLoading: isLoadingPublications,
+    isSuccess: isSuccessPublications,
+  } = useReplicationPublicationsQuery({ projectRef, sourceId })
+
+  const publicationNames = useMemo(() => publications?.map((pub) => pub.name) ?? [], [publications])
+  const selectedPublication = publications.find((pub) => pub.name === publicationName)
+  const isSelectedPublicationMissing =
+    isSuccessPublications && !!publicationName && !publicationNames.includes(publicationName)
+
+  const { data: checkPrimaryKeysExistsData, isLoading: isLoadingCheck } = useCheckPrimaryKeysExists(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      tables: selectedPublication?.tables ?? [],
+    },
+    { enabled: visible && !!selectedPublication }
+  )
+  const hasTablesWithNoPrimaryKeys = (checkPrimaryKeysExistsData?.offendingTables ?? []).length > 0
+
+  return (
+    <>
+      <FormField_Shadcn_
+        control={form.control}
+        name="publicationName"
+        render={({ field }) => (
+          <FormItemLayout
+            label="Publication"
+            layout="vertical"
+            description="Choose which tables to replicate to this destination"
+          >
+            <FormControl_Shadcn_>
+              <PublicationsComboBox
+                publications={publicationNames}
+                isLoadingPublications={isLoadingPublications}
+                isLoadingCheck={!!selectedPublication && isLoadingCheck}
+                field={field}
+                onNewPublicationClick={() => setPublicationPanelVisible(true)}
+              />
+            </FormControl_Shadcn_>
+            {isSelectedPublicationMissing ? (
+              <Admonition type="warning" className="mt-2 mb-0">
+                <p className="!leading-normal">
+                  The publication <strong className="text-foreground">{publicationName}</strong> was
+                  not found, it may have been renamed or deleted, please select another one.
+                </p>
+              </Admonition>
+            ) : hasTablesWithNoPrimaryKeys ? (
+              <Admonition type="warning" className="mt-2 mb-0">
+                <p className="!leading-normal">
+                  Replication requires every table in the publication to have a primary key to work,
+                  which these tables are missing:
+                </p>
+                <ul className="list-disc pl-6 mb-2">
+                  {(checkPrimaryKeysExistsData?.offendingTables ?? []).map((x) => {
+                    const value = `${x.schema}.${x.name}`
+                    return (
+                      <li key={value} className="!leading-normal">
+                        <InlineLink href={`/project/${projectRef}/editor/${x.id}`}>
+                          {value}
+                        </InlineLink>
+                      </li>
+                    )
+                  })}
+                </ul>
+                <p className="!leading-normal">Ensure that these tables have primary keys first.</p>
+              </Admonition>
+            ) : null}
+          </FormItemLayout>
+        )}
+      />
+
+      <NewPublicationPanel
+        sourceId={sourceId}
+        visible={publicationPanelVisible}
+        onClose={() => setPublicationPanelVisible(false)}
+      />
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/PublicationSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/PublicationSelection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { UseFormReturn } from 'react-hook-form'
+import type { UseFormReturn } from 'react-hook-form'
 
 import { useParams } from 'common'
 import { InlineLink } from 'components/ui/InlineLink'
@@ -11,7 +11,7 @@ import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { NewPublicationPanel } from '../NewPublicationPanel'
 import { PublicationsComboBox } from '../PublicationsComboBox'
-import { DestinationPanelSchemaType } from './DestinationPanel.schema'
+import type { DestinationPanelSchemaType } from './DestinationPanel.schema'
 
 type PublicationSelectionProps = {
   form: UseFormReturn<DestinationPanelSchemaType>

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -129,9 +129,10 @@ export const Destinations = () => {
         {replicationNotEnabled ? (
           <div className="border rounded-md p-4 md:p-12 flex flex-col gap-y-4">
             <div className="flex flex-col gap-y-1">
-              <h3>Run analysis on your data via integrations with Replication</h3>
+              <h3>Stream data to external destinations in real-time</h3>
               <p className="text-sm text-foreground-light">
-                Enable replication on your project to send data to your first destination
+                Enable replication to start sending your database changes to data warehouses and
+                analytics platforms
               </p>
             </div>
             <div className="flex gap-x-2">
@@ -189,10 +190,11 @@ export const Destinations = () => {
                 'flex flex-col px-10 rounded-lg justify-center items-center py-8 mt-4'
               )}
             >
-              <h4>Send data to your first destination</h4>
+              <h4>Create your first destination</h4>
               <p className="prose text-sm text-center mt-1 max-w-full">
-                Use destinations to improve performance or run analysis on your data via
-                integrations like BigQuery
+                Destinations are external platforms where your database changes are automatically
+                sent. Connect to data warehouses like BigQuery or analytics buckets to enable
+                real-time data pipelines.
               </p>
               <Button
                 icon={<Plus />}

--- a/apps/studio/components/interfaces/Database/Replication/NewPublicationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/NewPublicationPanel.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useParams } from 'common'
-import { useCreatePublicationMutation } from 'data/replication/create-publication-mutation'
-import { useReplicationTablesQuery } from 'data/replication/tables-query'
 import { X } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { useParams } from 'common'
+import { useCreatePublicationMutation } from 'data/replication/create-publication-mutation'
+import { useReplicationTablesQuery } from 'data/replication/tables-query'
 import {
   Button,
   cn,
@@ -23,7 +25,6 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { MultiSelector } from 'ui-patterns/multi-select'
-import { z } from 'zod'
 
 interface NewPublicationPanelProps {
   visible: boolean

--- a/apps/studio/components/interfaces/Database/Replication/PublicationsComboBox.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/PublicationsComboBox.tsx
@@ -36,19 +36,15 @@ export const PublicationsComboBox = ({
   const [selectedPublication, setSelectedPublication] = useState<string>(field?.value || '')
   const [searchTerm, setSearchTerm] = useState('')
 
-  useEffect(() => {
-    setSelectedPublication(field?.value || '')
-  }, [field?.value])
-
-  function handleSearchChange(value: string) {
-    setSearchTerm(value)
-  }
-
   function handlePublicationSelect(pub: string) {
     setSelectedPublication(pub)
     setDropdownOpen(false)
     field.onChange(pub)
   }
+
+  useEffect(() => {
+    setSelectedPublication(field?.value || '')
+  }, [field?.value])
 
   return (
     <Popover_Shadcn_
@@ -87,7 +83,7 @@ export const PublicationsComboBox = ({
           <CommandInput_Shadcn_
             placeholder="Find publication..."
             value={searchTerm}
-            onValueChange={handleSearchChange}
+            onValueChange={setSearchTerm}
           />
           <CommandList_Shadcn_>
             <CommandEmpty_Shadcn_>
@@ -100,7 +96,13 @@ export const PublicationsComboBox = ({
                 'No publications found'
               )}
             </CommandEmpty_Shadcn_>
+
             <CommandGroup_Shadcn_>
+              {publications.length === 0 && (
+                <p className="text-foreground-lighter text-xs py-3 px-2">
+                  No publications available
+                </p>
+              )}
               <ScrollArea className={publications.length > 7 ? 'h-[210px]' : ''}>
                 {publications.map((pub) => (
                   <CommandItem_Shadcn_
@@ -121,7 +123,9 @@ export const PublicationsComboBox = ({
                 ))}
               </ScrollArea>
             </CommandGroup_Shadcn_>
+
             <CommandSeparator_Shadcn_ />
+
             <CommandGroup_Shadcn_>
               <CommandItem_Shadcn_
                 className="cursor-pointer w-full"

--- a/apps/studio/components/interfaces/Database/Replication/RowMenu.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/RowMenu.tsx
@@ -63,29 +63,21 @@ export const RowMenu = ({
     ? getRequestStatus(pipeline.id)
     : PipelineStatusRequestStatus.None
 
-  const hasPipelineAction =
+  // Show actions when not in a transitional state
+  const canPerformActions =
     requestStatus === PipelineStatusRequestStatus.None &&
+    statusName !== PipelineStatusName.STARTING &&
     [PipelineStatusName.STOPPED, PipelineStatusName.STARTED, PipelineStatusName.FAILED].includes(
       statusName as PipelineStatusName
     )
 
-  const pipelineActionIcon =
-    statusName === PipelineStatusName.STOPPED ? (
-      <Play size={14} />
-    ) : statusName === PipelineStatusName.STARTED ? (
-      <Pause size={14} />
-    ) : statusName === PipelineStatusName.FAILED ? (
-      <RotateCcw size={14} />
-    ) : null
+  // Show both stop and restart for started/failed states
+  const showStopAndRestart =
+    canPerformActions &&
+    (statusName === PipelineStatusName.STARTED || statusName === PipelineStatusName.FAILED)
 
-  const pipelineActionLabel =
-    statusName === PipelineStatusName.STOPPED
-      ? 'Start pipeline'
-      : statusName === PipelineStatusName.STARTED
-        ? 'Stop pipeline'
-        : statusName === PipelineStatusName.FAILED
-          ? 'Restart pipeline'
-          : null
+  // Show only start for stopped state
+  const showStart = canPerformActions && statusName === PipelineStatusName.STOPPED
 
   const onEnablePipeline = async () => {
     if (!projectRef) return console.error('Project ref is required')
@@ -160,23 +152,24 @@ export const RowMenu = ({
               <DropdownMenuSeparator />
             </>
           )}
-          {hasPipelineAction && (
+          {showStart && (
             <>
-              <DropdownMenuItem
-                className="space-x-2"
-                disabled={!PIPELINE_ACTIONABLE_STATES.includes((statusName ?? '') as any)}
-                onClick={() => {
-                  if (statusName === PipelineStatusName.STOPPED) {
-                    onEnablePipeline()
-                  } else if (statusName === PipelineStatusName.STARTED) {
-                    onDisablePipeline()
-                  } else if (statusName === PipelineStatusName.FAILED) {
-                    onRestartPipeline()
-                  }
-                }}
-              >
-                {pipelineActionIcon}
-                <p>{pipelineActionLabel}</p>
+              <DropdownMenuItem className="space-x-2" onClick={onEnablePipeline}>
+                <Play size={14} />
+                <p>Start pipeline</p>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {showStopAndRestart && (
+            <>
+              <DropdownMenuItem className="space-x-2" onClick={onRestartPipeline}>
+                <RotateCcw size={14} />
+                <p>Restart pipeline</p>
+              </DropdownMenuItem>
+              <DropdownMenuItem className="space-x-2" onClick={onDisablePipeline}>
+                <Pause size={14} />
+                <p>Stop pipeline</p>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
             </>

--- a/apps/studio/components/interfaces/HomeNew/Home.tsx
+++ b/apps/studio/components/interfaces/HomeNew/Home.tsx
@@ -1,6 +1,6 @@
-import dayjs from 'dayjs'
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import dayjs from 'dayjs'
 import { useEffect, useRef } from 'react'
 
 import { IS_PLATFORM, useParams } from 'common'

--- a/apps/studio/components/ui/Forms/FormHeader.tsx
+++ b/apps/studio/components/ui/Forms/FormHeader.tsx
@@ -23,7 +23,7 @@ const FormHeader = ({
     >
       <div className="space-y-1">
         <h3 className="text-foreground text-xl prose">{title}</h3>
-        {description && <div className="prose text-sm max-w-2xl">{description}</div>}
+        {description && <p className="prose text-sm max-w-2xl">{description}</p>}
       </div>
       <div className="flex flex-col sm:flex-row md:items-center gap-x-2">
         {docsUrl !== undefined && <DocsButton href={docsUrl} />}

--- a/apps/studio/pages/project/[ref]/database/replication/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/index.tsx
@@ -26,7 +26,10 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
           <ScaffoldContainer>
             <ScaffoldSection>
               <div className="col-span-12">
-                <FormHeader title="Replication" />
+                <FormHeader
+                  title="Replication"
+                  description="Automatically replicate your database changes to external data warehouses and analytics platforms in real-time"
+                />
                 <Destinations />
               </div>
             </ScaffoldSection>

--- a/apps/studio/pages/project/[ref]/database/replication/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/index.tsx
@@ -27,6 +27,7 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
             <ScaffoldSection>
               <div className="col-span-12">
                 <FormHeader
+                  className="[&>div>p]:max-w-full"
                   title="Replication"
                   description="Automatically replicate your database changes to external data warehouses and analytics platforms in real-time"
                 />


### PR DESCRIPTION
This PR improves the ETL UI with the following improvements:
- Each destination is gated behind a feature flag, enabling us to control which destinations are available to our users.
- The copy of the entire ETL UI has been improved and aligned.
- A new UI for changing destinations has been added which also makes it clear that changing a destination after pipeline creation is not possible.
- Better handling of required fields has been added, with a clear UI showing which fields are mandatory and properly disabling buttons when not all required fields are filled in.
- Now there is a `Restart` and `Stop` button for all active states of a pipeline, to give our users more control.
- A subtitle has been added under the replication title to clearly specify what replication is.
- A better division of sections of the panel has been implemented, to clearly define the hierarchy of information.

### Screenshots

UI when no destinations are available
<img width="588" height="1056" alt="image" src="https://github.com/user-attachments/assets/0b2f4e97-f79c-42d6-84e0-908567054822" />

Subtitle
<img width="880" height="109" alt="image" src="https://github.com/user-attachments/assets/f7e70956-5fe1-47c8-b037-097c34c773d3" />

New destination selection
<img width="511" height="1055" alt="image" src="https://github.com/user-attachments/assets/12846476-c710-4c0d-a973-07b6deb40977" />

Updating a destination
<img width="534" height="1077" alt="image" src="https://github.com/user-attachments/assets/b1e3ed8e-f658-4c1a-b458-c645c519394b" />

New stop and restart buttons
<img width="287" height="205" alt="image" src="https://github.com/user-attachments/assets/47d74732-e6c1-43aa-9a8f-552586c6684f" />

Improved advanced settings
<img width="501" height="475" alt="image" src="https://github.com/user-attachments/assets/c19fb616-da05-459f-8a09-46b0ee855b8d" />