### PR TITLE
chore: bump @supabase/mcp-server-supabase to 0.5.8

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -57,7 +57,7 @@
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.5.0",
     "@supabase/auth-js": "catalog:",
-    "@supabase/mcp-server-supabase": "^0.5.6",
+    "@supabase/mcp-server-supabase": "^0.5.8",
     "@supabase/mcp-utils": "^0.2.0",
     "@supabase/pg-meta": "workspace:*",
     "@supabase/realtime-js": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,8 +826,8 @@ importers:
         specifier: 'catalog:'
         version: 2.78.0
       '@supabase/mcp-server-supabase':
-        specifier: ^0.5.6
-        version: 0.5.6(supports-color@8.1.1)
+        specifier: ^0.5.8
+        version: 0.5.8(supports-color@8.1.1)
       '@supabase/mcp-utils':
         specifier: ^0.2.0
         version: 0.2.1(supports-color@8.1.1)
@@ -8811,15 +8811,15 @@ packages:
   '@supabase/functions-js@2.78.0':
     resolution: {integrity: sha512-t1jOvArBsOINyqaRee1xJ3gryXLvkBzqnKfi6q3YRzzhJbGS6eXz0pXR5fqmJeB01fLC+1njpf3YhMszdPEF7g==}
 
-  '@supabase/mcp-server-supabase@0.5.6':
-    resolution: {integrity: sha512-pLVukhxx0oxwAcvAEaJEwNngcPIEieFyd4bWK4phpXpbxqs4xp3i3f7nwrnflkSmG5PnRhLCKcurw3fwQHnCKQ==}
+  '@supabase/mcp-server-supabase@0.5.8':
+    resolution: {integrity: sha512-+kpHomRCKyK1D1nEM2s89qGAfN4zN8JrDpcyAvZd19Z/KexNvaByRKpwBWnE3GEtcEx9H+XUFM72Z5O7rC802Q==}
     hasBin: true
 
   '@supabase/mcp-utils@0.2.1':
     resolution: {integrity: sha512-T3LEAEKXOxHGVzhPvxqbAYbxluUKNxQpFnYVyRIazQJOQzZ03tCg+pp3LUYQi0HkWPIo+u+AgtULJVEvgeNr/Q==}
 
-  '@supabase/mcp-utils@0.2.2':
-    resolution: {integrity: sha512-hg4IR1iw2k3zdCiB5abvROSsVK/rOdUoyai3N97uG7c3NSQjWp0M6xPJEoH4TJE63pwY0oTc4eQAjXSmTlNK4Q==}
+  '@supabase/mcp-utils@0.2.3':
+    resolution: {integrity: sha512-tw+DENThCaf5PrD5VrD9Gej8K0mi76mmrILdxpCnmJSaga1jFMpOpEaIjkQBXG5YKlhUqlyKfcaqx9bTuz8Bxg==}
 
   '@supabase/node-fetch@2.6.15':
     resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
@@ -28415,11 +28415,11 @@ snapshots:
       '@supabase/node-fetch': 2.6.15
       tslib: 2.8.1
 
-  '@supabase/mcp-server-supabase@0.5.6(supports-color@8.1.1)':
+  '@supabase/mcp-server-supabase@0.5.8(supports-color@8.1.1)':
     dependencies:
       '@mjackson/multipart-parser': 0.10.1
       '@modelcontextprotocol/sdk': 1.18.0(supports-color@8.1.1)
-      '@supabase/mcp-utils': 0.2.2(supports-color@8.1.1)
+      '@supabase/mcp-utils': 0.2.3(supports-color@8.1.1)
       common-tags: 1.8.2
       graphql: 16.11.0
       openapi-fetch: 0.13.8
@@ -28435,7 +28435,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@supabase/mcp-utils@0.2.2(supports-color@8.1.1)':
+  '@supabase/mcp-utils@0.2.3(supports-color@8.1.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.18.0(supports-color@8.1.1)
       zod: 3.25.76


### PR DESCRIPTION
Updates `@supabase/mcp-server-supabase` from `0.5.6` to `0.5.8` in Studio.

Closes [AI-183](https://linear.app/supabase/issue/AI-183/update-supabase-studio-with-new-release)

### Changes
- Bumped `@supabase/mcp-server-supabase` dependency in `apps/studio/package.json`
- Updated `pnpm-lock.yaml`