### PR TITLE
docs: Clarify email prefetch options

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -79,7 +79,7 @@ To guard against this there are the options below:
 ```html
 <a href="{{ .SiteURL }}/confirm-signup">Confirm your signup</a>
 ```
-- Log them in by verifying the OTP token value with their email e.g. with [`supabase.auth.verifyOtp`](https://supabase.com/docs/reference/javascript/auth-verifyotp) show below
+- Log them in by verifying the OTP token value with their email e.g. with [`supabase.auth.verifyOtp`](/docs/reference/javascript/auth-verifyotp) show below
 ```ts
 const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email'})
 ```

--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -74,20 +74,30 @@ In this scenario, the `{{ .ConfirmationURL }}` sent will be consumed instantly w
 To guard against this there are the options below:
 
 **Option 1**
+
 - Use an email OTP instead by including `{{ .Token }}` in the email template
 - Create your own custom email link to redirect the user to a page where they can enter with their email and token to login
+
 ```html
 <a href="{{ .SiteURL }}/confirm-signup">Confirm your signup</a>
 ```
+
 - Log them in by verifying the OTP token value with their email e.g. with [`supabase.auth.verifyOtp`](/docs/reference/javascript/auth-verifyotp) show below
+
 ```ts
-const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email'})
+const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email' })
 ```
+
 **Option 2**
+
 - Create your own custom email link to redirect the user to a page where they can click on a button to confirm the action
+
 ```html
-<a href="{{ .SiteURL }}/confirm-signup?confirmation_url={{ .ConfirmationURL }}">Confirm your signup</a>
+<a href="{{ .SiteURL }}/confirm-signup?confirmation_url={{ .ConfirmationURL }}"
+  >Confirm your signup</a
+>
 ```
+
 - The button should contain the actual confirmation link which can be obtained from parsing the `confirmation_url={{ .ConfirmationURL }}` query parameter in the URL.
 
 ### Email tracking

--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -71,20 +71,24 @@ For mobile applications, you might need to link or redirect to a specific page w
 
 Certain email providers may have spam detection or other security features that prefetch URL links from incoming emails (e.g. [Safe Links in Microsoft Defender for Office 365](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-links-about?view=o365-worldwide)).
 In this scenario, the `{{ .ConfirmationURL }}` sent will be consumed instantly which leads to a "Token has expired or is invalid" error.
-To guard against this:
+To guard against this there are the options below:
 
-- Use an email OTP instead by including `{{ .Token }}` in the email template.
-- Create your own custom email link to redirect the user to a page where they can click on a button to confirm the action.
-  For example, you can include the following in your email template:
-
-  ```html
-  <a href="{{ .SiteURL }}/confirm-signup?confirmation_url={{ .ConfirmationURL }}"
-    >Confirm your signup
-  </a>
-  ```
-
-  The user should be brought to a page on your site where they can confirm the action by clicking a button.
-  The button should contain the actual confirmation link which can be obtained from parsing the `confirmation_url={{ .ConfirmationURL }}` query parameter in the URL.
+**Option 1**
+- Use an email OTP instead by including `{{ .Token }}` in the email template
+- Create your own custom email link to redirect the user to a page where they can enter with their email and token to login
+```html
+<a href="{{ .SiteURL }}/confirm-signup">Confirm your signup</a>
+```
+- Log them in by verifying the OTP token value with their email e.g. with [`supabase.auth.verifyOtp`](https://supabase.com/docs/reference/javascript/auth-verifyotp) show below
+```ts
+const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email'})
+```
+**Option 2**
+- Create your own custom email link to redirect the user to a page where they can click on a button to confirm the action
+```html
+<a href="{{ .SiteURL }}/confirm-signup?confirmation_url={{ .ConfirmationURL }}">Confirm your signup</a>
+```
+- The button should contain the actual confirmation link which can be obtained from parsing the `confirmation_url={{ .ConfirmationURL }}` query parameter in the URL.
 
 ### Email tracking
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Clarify the email prefetch options 
- Current text is a bit confusing
   - it could be understood that you need to do both 
   - and it says to use `{{ .Token }}` but does not give the full details of what to do with it after