### PR TITLE
Smol feex

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
@@ -16,7 +16,6 @@ import {
   FormField_Shadcn_ as FormField,
   FormMessage_Shadcn_ as FormMessage,
   Input_Shadcn_ as Input,
-  Input_Shadcn_,
   Popover_Shadcn_ as Popover,
   PopoverContent_Shadcn_ as PopoverContent,
   PopoverTrigger_Shadcn_ as PopoverTrigger,
@@ -83,7 +82,7 @@ export const BillingCustomerDataForm = ({
       <FormField
         control={form.control}
         name="billing_name"
-        render={({ field }: { field: any }) => (
+        render={({ field }) => (
           <FormItemLayout hideMessage label="Name">
             <FormControl>
               <Input {...field} disabled={disabled} />
@@ -96,7 +95,7 @@ export const BillingCustomerDataForm = ({
       <FormField
         control={form.control}
         name="line1"
-        render={({ field }: { field: any }) => (
+        render={({ field }) => (
           <FormItemLayout hideMessage label="Address line 1">
             <FormControl>
               <Input {...field} placeholder="123 Main Street" disabled={disabled} />
@@ -109,7 +108,7 @@ export const BillingCustomerDataForm = ({
       <FormField
         control={form.control}
         name="line2"
-        render={({ field }: { field: any }) => (
+        render={({ field }) => (
           <FormItemLayout hideMessage label="Address line 2 (optional)">
             <FormControl>
               <Input
@@ -127,7 +126,7 @@ export const BillingCustomerDataForm = ({
         <FormField
           control={form.control}
           name="country"
-          render={({ field }: { field: any }) => (
+          render={({ field }) => (
             <FormItemLayout hideMessage label="Country">
               <Popover open={showCountriesPopover} onOpenChange={setShowCountriesPopover}>
                 <PopoverTrigger asChild>
@@ -195,7 +194,7 @@ export const BillingCustomerDataForm = ({
         <FormField
           control={form.control}
           name="postal_code"
-          render={({ field }: { field: any }) => (
+          render={({ field }) => (
             <FormItemLayout hideMessage label="Postal code">
               <FormControl>
                 <Input {...field} placeholder="12345" disabled={disabled} />
@@ -210,7 +209,7 @@ export const BillingCustomerDataForm = ({
         <FormField
           control={form.control}
           name="city"
-          render={({ field }: { field: any }) => (
+          render={({ field }) => (
             <FormItemLayout hideMessage label="City">
               <FormControl>
                 <Input {...field} disabled={disabled} />
@@ -222,7 +221,7 @@ export const BillingCustomerDataForm = ({
         <FormField
           control={form.control}
           name="state"
-          render={({ field }: { field: any }) => (
+          render={({ field }) => (
             <FormItemLayout hideMessage label="State / Province">
               <FormControl>
                 <Input {...field} disabled={disabled} />
@@ -237,7 +236,7 @@ export const BillingCustomerDataForm = ({
         <FormField
           name="tax_id_name"
           control={form.control}
-          render={({ field }) => (
+          render={() => (
             <FormItemLayout hideMessage layout="vertical" label="Tax ID">
               <Popover open={showTaxIDsPopover} onOpenChange={setShowTaxIDsPopover}>
                 <PopoverTrigger asChild>
@@ -248,14 +247,11 @@ export const BillingCustomerDataForm = ({
                       size="medium"
                       disabled={disabled}
                       className={cn(
-                        'w-full justify-between h-[34px]',
+                        'w-full justify-between h-[34px] pr-2',
                         !selectedTaxId && 'text-muted'
                       )}
                       iconRight={
-                        <ChevronsUpDown
-                          className="ml-2 h-4 w-4 shrink-0 opacity-50"
-                          strokeWidth={1.5}
-                        />
+                        <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" strokeWidth={1.5} />
                       }
                     >
                       {selectedTaxId
@@ -264,7 +260,7 @@ export const BillingCustomerDataForm = ({
                     </Button>
                   </FormControl>
                 </PopoverTrigger>
-                <PopoverContent sameWidthAsTrigger className="p-0" align="start">
+                <PopoverContent portal sameWidthAsTrigger className="p-0" align="start">
                   <Command>
                     <CommandInput placeholder="Search tax ID..." />
                     <CommandList>
@@ -299,17 +295,17 @@ export const BillingCustomerDataForm = ({
         />
 
         {selectedTaxId && (
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center space-x-2 [&>div]:w-full">
             <FormField
               name="tax_id_value"
               control={form.control}
               render={({ field }) => (
-                <FormItemLayout hideMessage className="w-full">
+                <FormItemLayout hideMessage>
                   <FormControl>
-                    <Input_Shadcn_
+                    <Input
                       {...field}
-                      placeholder={selectedTaxId?.placeholder}
                       disabled={disabled}
+                      placeholder={selectedTaxId?.placeholder}
                     />
                   </FormControl>
                 </FormItemLayout>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
@@ -155,7 +155,7 @@ export const BillingCustomerDataForm = ({
                     </Button>
                   </FormControl>
                 </PopoverTrigger>
-                <PopoverContent sameWidthAsTrigger className="p-0" align="start">
+                <PopoverContent portal sameWidthAsTrigger className="p-0" align="start">
                   <Command>
                     <CommandInput placeholder="Search country..." />
                     <CommandList>

--- a/apps/studio/components/layouts/Scaffold.tsx
+++ b/apps/studio/components/layouts/Scaffold.tsx
@@ -34,7 +34,7 @@ export const ScaffoldContainer = forwardRef<
       ref={ref}
       {...props}
       className={cn(
-        'mx-auto w-full',
+        'mx-auto w-full @container',
         maxWidthClass,
         PADDING_CLASSES,
         bottomPadding && 'pb-16',
@@ -93,7 +93,7 @@ export const ScaffoldSection = forwardRef<
       {...props}
       className={cn(
         'flex flex-col first:pt-12 py-6',
-        isFullWidth ? 'w-full' : 'gap-3 @lg:grid @md:grid-cols-12',
+        isFullWidth ? 'w-full' : 'gap-3 @md:grid-cols-12 @lg:grid',
         className
       )}
     />


### PR DESCRIPTION
## Context

There's a portal issue on the country selector for the org billing section

Also fixes layout issues in org billing page,`ScaffoldContainer` was likely missing a `@container` class as `ScaffoldSection` has container classes applied to it

## To test
- [ ] Verify that the country selector popover content shows up correctly
- [ ] Verify that the layout of the org settings integrations + billing pages are back to 2 columns for desktop