### PR TITLE
feat: make log table scrollable FE-2060

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
@@ -9,6 +9,7 @@ const columns: Column<LogData>[] = [
   {
     name: 'auth-first-column',
     key: 'auth-first-column',
+    renderHeaderCell: () => null,
     renderCell: (props) => {
       if (!props.row.level) {
         return defaultRenderCell(props)

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
@@ -8,6 +8,7 @@ const columns: Column<LogData>[] = [
   {
     name: 'database-api-first-column',
     key: 'database-api-first-column',
+    renderHeaderCell: () => null,
     renderCell: (props) => {
       if (!props.row.status_code && !props.row.method && !props.row.path) {
         return defaultRenderCell(props)

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
@@ -8,6 +8,7 @@ const columns: Column<LogData>[] = [
   {
     name: 'database-postgres-first-column',
     key: 'database-postgres-first-column',
+    renderHeaderCell: () => null,
     renderCell: (props) => {
       if (!props.row.error_severity) {
         return defaultRenderCell(props)

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
@@ -14,6 +14,7 @@ const columns: Column<LogData>[] = [
   {
     name: 'default-preview-first-column',
     key: 'default-preview-first-column',
+    renderHeaderCell: () => null,
     renderCell: defaultRenderCell,
   },
 ]

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
@@ -8,6 +8,7 @@ const columns: Column<LogData>[] = [
   {
     name: 'functions-edge-first-column',
     key: 'functions-edge-first-column',
+    renderHeaderCell: () => null,
     renderCell: (props) => {
       if (!props.row.status_code && !props.row.method) {
         return defaultRenderCell(props)

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsLogsColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsLogsColumnRender.tsx
@@ -8,6 +8,7 @@ const columns: Column<LogData>[] = [
   {
     name: 'functions-logs-first-column',
     key: 'functions-logs-first-column',
+    renderHeaderCell: () => null,
     renderCell: (props) => {
       if (!props.row.event_type && !props.row.level) {
         return defaultRenderCell(props)

--- a/apps/studio/styles/react-data-grid-logs.scss
+++ b/apps/studio/styles/react-data-grid-logs.scss
@@ -1,9 +1,16 @@
 .data-grid--simple-logs {
+  .rdg {
+    overflow-x: auto;
+    min-width: 0;
+  }
+
   .rdg-cell,
   .rdg-cell span {
     @apply text-foreground-light font-normal;
     border-left: none;
     border-right: none;
+    overflow: visible;
+    text-overflow: clip;
   }
 
   .rdg-cell:first-child {
@@ -27,11 +34,18 @@
 }
 
 .data-grid--logs-explorer {
-  @apply overflow-x-scroll pb-12;
+  @apply pb-12;
+
+  .rdg {
+    overflow-x: auto;
+    min-width: 0;
+  }
 
   .rdg-cell,
   .rdg-cell span {
     @apply text-foreground-light font-normal #{!important};
+    overflow: visible;
+    text-overflow: clip;
   }
 
   .rdg-cell:first-child {


### PR DESCRIPTION
Makes log table scrollable making it easier for users to compare log results in Log Explorer.

![CleanShot 2025-10-31 at 16 14 09](https://github.com/user-attachments/assets/26904577-1459-41c3-9367-5f1b0315bf78)
