### PR TITLE
Fix portal issues happening in PopoverContent when used in FormItemLayout

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -370,7 +370,7 @@ export const CreateHookSheet = ({
                         >
                           <FormControl_Shadcn_>
                             <SchemaSelector
-                              portal={false}
+                              portal
                               size="small"
                               showError={false}
                               selectedSchemaName={field.value}
@@ -392,6 +392,7 @@ export const CreateHookSheet = ({
                         >
                           <FormControl_Shadcn_>
                             <FunctionSelector
+                              portal
                               size="small"
                               schema={values.postgresValues.schema}
                               value={field.value}

--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -305,7 +305,7 @@ export const NewPaymentMethodElement = forwardRef(
                           </Button>
                         </FormControl>
                       </PopoverTrigger>
-                      <PopoverContent sameWidthAsTrigger className="p-0" align="start">
+                      <PopoverContent portal sameWidthAsTrigger className="p-0" align="start">
                         <Command>
                           <CommandInput placeholder="Search tax ID..." />
                           <CommandList>

--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -201,7 +201,7 @@ export const CreateFunction = ({
                     >
                       <FormControl_Shadcn_>
                         <SchemaSelector
-                          portal={false}
+                          portal
                           selectedSchemaName={field.value}
                           excludedSchemas={protectedSchemas?.map((s) => s.name)}
                           size="small"

--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -181,6 +181,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                 </Button>
               </PopoverTrigger_Shadcn_>
               <PopoverContent_Shadcn_
+                portal
                 className="p-0"
                 side="bottom"
                 align="start"
@@ -261,6 +262,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                 </Button>
               </PopoverTrigger_Shadcn_>
               <PopoverContent_Shadcn_
+                portal
                 className="p-0"
                 side="bottom"
                 align="start"

--- a/apps/studio/components/interfaces/Integrations/CronJobs/SqlFunctionSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/SqlFunctionSection.tsx
@@ -21,7 +21,7 @@ export const SqlFunctionSection = ({ form }: SqlFunctionSectionProps) => {
         render={({ field }) => (
           <FormItemLayout label="Schema" className="gap-1">
             <SchemaSelector
-              portal={false}
+              portal
               size="small"
               className="w-56 2xl:w-full"
               selectedSchemaName={field.value}
@@ -41,6 +41,7 @@ export const SqlFunctionSection = ({ form }: SqlFunctionSectionProps) => {
         render={({ field }) => (
           <FormItemLayout label="Function name" className="gap-1">
             <FunctionSelector
+              portal
               size="small"
               className="w-56 2xl:w-full"
               schema={schema}

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -464,7 +464,12 @@ const GitHubIntegrationConnectionForm = ({
                           </Button>
                         </FormControl_Shadcn_>
                       </PopoverTrigger_Shadcn_>
-                      <PopoverContent_Shadcn_ className="p-0 w-80" side="bottom" align="start">
+                      <PopoverContent_Shadcn_
+                        portal
+                        className="p-0 w-80"
+                        side="bottom"
+                        align="start"
+                      >
                         <Command_Shadcn_>
                           <CommandInput_Shadcn_ placeholder="Search repositories..." />
                           <CommandList_Shadcn_ className="!max-h-[200px]">

--- a/apps/studio/components/ui/FunctionSelector.tsx
+++ b/apps/studio/components/ui/FunctionSelector.tsx
@@ -7,6 +7,7 @@ import {
   DatabaseFunctionsData,
   useDatabaseFunctionsQuery,
 } from 'data/database-functions/database-functions-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import {
@@ -26,7 +27,6 @@ import {
   Popover_Shadcn_,
   ScrollArea,
 } from 'ui'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 
 type DatabaseFunction = DatabaseFunctionsData[number]
 
@@ -41,6 +41,7 @@ interface FunctionSelectorProps {
   // used to filter the functions by a criteria
   filterFunction?: (func: DatabaseFunction) => boolean
   noResultsLabel?: React.ReactNode
+  portal?: boolean
 }
 
 const FunctionSelector = ({
@@ -53,6 +54,7 @@ const FunctionSelector = ({
   onChange,
   filterFunction = () => true,
   noResultsLabel = <span>No functions found in this schema.</span>,
+  portal = false,
 }: FunctionSelectorProps) => {
   const router = useRouter()
   const { ref } = useParams()
@@ -117,7 +119,13 @@ const FunctionSelector = ({
               )}
             </Button>
           </PopoverTrigger_Shadcn_>
-          <PopoverContent_Shadcn_ className="p-0" side="bottom" align="start" sameWidthAsTrigger>
+          <PopoverContent_Shadcn_
+            portal={portal}
+            className="p-0"
+            side="bottom"
+            align="start"
+            sameWidthAsTrigger
+          >
             <Command_Shadcn_>
               <CommandInput_Shadcn_ placeholder="Search functions..." />
               <CommandList_Shadcn_>


### PR DESCRIPTION
## Context

There seems to be a series of portal issues happening with `PopoverContent` when being rendered in `FormItemLayout` - related to this previous [PR](https://github.com/supabase/supabase/pull/40029) but I'm unable to revert it, so patching things for now 🙏 

## To test

- [ ] Verify that the popover content for the GH integration repository selector under Project Settings is rendering correctly below the trigger