### PR TITLE
Fix: overflow warnings were being cut off in the editor for edge functions

### DIFF
--- a/apps/studio/components/ui/FileExplorerAndEditor/index.tsx
+++ b/apps/studio/components/ui/FileExplorerAndEditor/index.tsx
@@ -344,6 +344,7 @@ export const FileExplorerAndEditor = ({
               folding: false,
               padding: { top: 20, bottom: 20 },
               lineNumbersMinChars: 3,
+              fixedOverflowWidgets: true,
             }}
           />
         )}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: reported that overflow warnings were being cut off from the Monco editor, noticed a prop and enabled it 

## What is the current behavior?

If you have warnings on the top, you just can't see them because they are cut off

## What is the new behavior?
<img width="727" height="318" alt="Screenshot 2025-10-31 at 3 09 52 PM" src="https://github.com/user-attachments/assets/bdbbeca4-b088-4924-bd3c-0116e89c0c87" />

## Additional context

N/A
