### PR TITLE
Add link to function and table editor

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { includes, sortBy } from 'lodash'
 import { Check, Copy, Edit, Edit2, MoreVertical, Trash, X } from 'lucide-react'
+import Link from 'next/link'
 
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
@@ -61,6 +62,7 @@ const TriggerList = ({
     filteredTriggers.filter((x) => x.schema == schema),
     (trigger) => trigger.name.toLocaleLowerCase()
   )
+  const projectRef = project?.ref
   const { can: canUpdateTriggers } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'triggers'
@@ -111,15 +113,33 @@ const TriggerList = ({
           </TableCell>
 
           <TableCell className="break-all">
-            <p title={x.table} className="truncate">
-              {x.table}
-            </p>
+            {x.table_id ? (
+              <Link
+                href={`/project/${projectRef}/editor/${x.table_id}`}
+                className="truncate text-link"
+                title={x.table}
+              >
+                {x.table}
+              </Link>
+            ) : (
+              <p title={x.table} className="truncate">
+                {x.table}
+              </p>
+            )}
           </TableCell>
 
           <TableCell className="space-x-2">
-            <p title={x.function_name} className="truncate">
-              {x.function_name}
-            </p>
+            {x.function_name ? (
+              <Link
+                href={`/project/${projectRef}/database/functions?search=${x.function_name}`}
+                className="truncate text-link"
+                title={x.function_name}
+              >
+                {x.function_name}
+              </Link>
+            ) : (
+              <p className="truncate text-foreground-light">-</p>
+            )}
           </TableCell>
 
           <TableCell>
@@ -176,7 +196,7 @@ const TriggerList = ({
                           const sql = generateTriggerCreateSQL(x)
                           openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
                           aiSnap.newChat({
-                            name: `Update trigger ${X.name}`,
+                            name: `Update trigger ${x.name}`,
                             initialInput: `Update this trigger which exists on the ${x.schema}.${x.table} table to...`,
                             suggestions: {
                               title:

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
@@ -4,13 +4,11 @@ import { noop } from 'lodash'
 import { DatabaseZap, FunctionSquare, Plus, Search, Shield } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 
-import AlphaPreview from 'components/to-be-cleaned/AlphaPreview'
-import ProductEmptyState from 'components/to-be-cleaned/ProductEmptyState'
+import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import SchemaSelector from 'components/ui/SchemaSelector'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
-import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useDatabaseTriggersQuery } from 'data/database-triggers/database-triggers-query'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -21,10 +19,7 @@ import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import {
   AiIconAnimation,
-  Button,
   Card,
-  CardContent,
-  cn,
   Input,
   Table,
   TableBody,
@@ -33,8 +28,7 @@ import {
   TableRow,
 } from 'ui'
 import { ProtectedSchemaWarning } from '../../ProtectedSchemaWarning'
-import TriggerList from './TriggerList'
-import Link from 'next/link'
+import { TriggerList } from './TriggerList'
 
 interface TriggersListProps {
   createTrigger: () => void
@@ -43,7 +37,7 @@ interface TriggersListProps {
   deleteTrigger: (trigger: PostgresTrigger) => void
 }
 
-const TriggersList = ({
+export const TriggersList = ({
   createTrigger = noop,
   editTrigger = noop,
   duplicateTrigger = noop,
@@ -248,5 +242,3 @@ const TriggersList = ({
     </div>
   )
 }
-
-export default TriggersList

--- a/apps/studio/components/ui/InlineLink.tsx
+++ b/apps/studio/components/ui/InlineLink.tsx
@@ -7,6 +7,7 @@ interface InlineLinkProps {
   className?: string
   target?: string
   rel?: string
+  title?: string
   onClick?: () => void
 }
 
@@ -17,18 +18,26 @@ export const InlineLink = ({
   href,
   className: _className,
   children,
+  title,
   ...props
 }: PropsWithChildren<InlineLinkProps>) => {
   const className = cn(InlineLinkClassName, _className)
   if (href.startsWith('http')) {
     return (
-      <a className={className} href={href} target="_blank" rel="noreferrer noopener" {...props}>
+      <a
+        title={title}
+        className={className}
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        {...props}
+      >
         {children}
       </a>
     )
   }
   return (
-    <Link className={className} href={href} {...props}>
+    <Link className={className} href={href} title={title} {...props}>
       {children}
     </Link>
   )

--- a/apps/studio/pages/project/[ref]/database/triggers.tsx
+++ b/apps/studio/pages/project/[ref]/database/triggers.tsx
@@ -6,7 +6,7 @@ import { useIsInlineEditorEnabled } from 'components/interfaces/App/FeaturePrevi
 import { DeleteTrigger } from 'components/interfaces/Database/Triggers/DeleteTrigger'
 import { TriggerSheet } from 'components/interfaces/Database/Triggers/TriggerSheet'
 import { generateTriggerCreateSQL } from 'components/interfaces/Database/Triggers/TriggersList/TriggerList.utils'
-import TriggersList from 'components/interfaces/Database/Triggers/TriggersList/TriggersList'
+import { TriggersList } from 'components/interfaces/Database/Triggers/TriggersList/TriggersList'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'


### PR DESCRIPTION
Adds a link from trigger list to the corresponding function as well as a link to table via table editor.

To test:
- Create a trigger and function
- Go to triggers list and notice function column now links to function
- Click link and notice takes to function page with search applied

Note that in future we could open the function sidebar or definition on link click but holding off on that for now due to a few moving sidebar parts.