### PR TITLE
switch to default

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/ModelSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/ModelSelector.tsx
@@ -50,7 +50,7 @@ export const ModelSelector = ({ selectedModel, onSelectModel }: ModelSelectorPro
     <Popover_Shadcn_ open={open} onOpenChange={setOpen}>
       <PopoverTrigger_Shadcn_ asChild>
         <Button
-          type="outline"
+          type="default"
           className="text-foreground-light"
           iconRight={<ChevronsUpDown strokeWidth={1} size={12} />}
         >


### PR DESCRIPTION
Fixes an issue where chat form overflow appears under button due to no fill. 

New:

<img width="525" height="285" alt="image" src="https://github.com/user-attachments/assets/1d4aa038-7acf-4ae1-aaec-f18c2f860290" />

Old:

<img width="527" height="288" alt="image" src="https://github.com/user-attachments/assets/735d7265-01a0-47f6-9f96-47a04373114b" />

