### PR TITLE
chore: Migrate to use custom type for ReactQuery queries and mutations

### DIFF
--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/cloud-marketplace-query.ts
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/cloud-marketplace-query.ts
@@ -1,6 +1,6 @@
+import { useQuery } from '@tanstack/react-query'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { get, handleError } from '../../../../data/fetchers'
-import type { ResponseError } from '../../../../types'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { useProfile } from '../../../../lib/profile'
 import { cloudMarketplaceKeys } from './keys'
 
@@ -35,7 +35,7 @@ export const useCloudMarketplaceOnboardingInfoQuery = <TData = CloudMarketplaceO
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<
+  }: UseCustomQueryOptions<
     CloudMarketplaceOnboardingInfo,
     CloudMarketplaceOnboardingInfoError,
     TData

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/useFetchFileUrlQuery.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/useFetchFileUrlQuery.tsx
@@ -1,9 +1,9 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { getPublicUrlForBucketObject } from 'data/storage/bucket-object-get-public-url-mutation'
 import { signBucketObject } from 'data/storage/bucket-object-sign-mutation'
 import { Bucket } from 'data/storage/buckets-query'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { StorageItem } from '../Storage.types'
 
 const DEFAULT_EXPIRY = 7 * 24 * 60 * 60 // in seconds, default to 1 week
@@ -41,7 +41,7 @@ type UseFileUrlQueryVariables = {
 
 export const useFetchFileUrlQuery = (
   { file, projectRef, bucket }: UseFileUrlQueryVariables,
-  { ...options }: UseQueryOptions<string, ResponseError> = {}
+  { ...options }: UseCustomQueryOptions<string, ResponseError> = {}
 ) => {
   const { getPathAlongOpenedFolders } = useStorageExplorerStateSnapshot()
   const pathToFile = getPathAlongOpenedFolders(false)

--- a/apps/studio/data/__templates/resource-query.ts
+++ b/apps/studio/data/__templates/resource-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { resourceKeys } from './keys'
 
 export type ResourceVariables = {
@@ -31,7 +31,7 @@ export type ResourceError = ResponseError
 
 export const useResourceQuery = <TData = ResourceData>(
   { projectRef, id }: ResourceVariables,
-  { enabled = true, ...options }: UseQueryOptions<ResourceData, ResourceError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ResourceData, ResourceError, TData> = {}
 ) =>
   useQuery<ResourceData, ResourceError, TData>({
     queryKey: resourceKeys.resource(projectRef, id),

--- a/apps/studio/data/__templates/resource-update-mutation.ts
+++ b/apps/studio/data/__templates/resource-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { resourceKeys } from './keys'
 
 export type ResourceUpdateVariables = {
@@ -29,7 +29,7 @@ export const useResourceUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ResourceUpdateData, ResponseError, ResourceUpdateVariables>,
+  UseCustomMutationOptions<ResourceUpdateData, ResponseError, ResourceUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/__templates/resources-query.ts
+++ b/apps/studio/data/__templates/resources-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { resourceKeys } from './keys'
 
 export type ResourcesVariables = {
@@ -26,7 +26,7 @@ export type ResourcesError = ResponseError
 
 export const useResourcesQuery = <TData = ResourcesData>(
   { projectRef }: ResourcesVariables,
-  { enabled = true, ...options }: UseQueryOptions<ResourcesData, ResourcesError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ResourcesData, ResourcesError, TData> = {}
 ) =>
   useQuery<ResourcesData, ResourcesError, TData>({
     queryKey: resourceKeys.list(projectRef),

--- a/apps/studio/data/access-tokens/access-tokens-create-mutation.ts
+++ b/apps/studio/data/access-tokens/access-tokens-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { accessTokenKeys } from './keys'
 
 export type AccessTokenCreateVariables = components['schemas']['CreateAccessTokenBody']
@@ -27,7 +27,7 @@ export const useAccessTokenCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AccessTokenCreateData, ResponseError, AccessTokenCreateVariables>,
+  UseCustomMutationOptions<AccessTokenCreateData, ResponseError, AccessTokenCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/access-tokens/access-tokens-delete-mutation.ts
+++ b/apps/studio/data/access-tokens/access-tokens-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { accessTokenKeys } from './keys'
 
 export type AccessTokenDeleteVariables = {
@@ -25,7 +25,7 @@ export const useAccessTokenDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AccessTokenDeleteData, ResponseError, AccessTokenDeleteVariables>,
+  UseCustomMutationOptions<AccessTokenDeleteData, ResponseError, AccessTokenDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/access-tokens/access-tokens-query.ts
+++ b/apps/studio/data/access-tokens/access-tokens-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { accessTokenKeys } from './keys'
 
 export async function getAccessTokens(signal?: AbortSignal) {
@@ -20,7 +20,7 @@ export type AccessToken = AccessTokensData[number]
 export const useAccessTokensQuery = <TData = AccessTokensData>({
   enabled = true,
   ...options
-}: UseQueryOptions<AccessTokensData, AccessTokensError, TData> = {}) =>
+}: UseCustomQueryOptions<AccessTokensData, AccessTokensError, TData> = {}) =>
   useQuery<AccessTokensData, AccessTokensError, TData>({
     queryKey: accessTokenKeys.list(),
     queryFn: ({ signal }) => getAccessTokens(signal),

--- a/apps/studio/data/actions/action-detail-query.ts
+++ b/apps/studio/data/actions/action-detail-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { operations } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { actionKeys } from './keys'
 
 export type ActionRunVariables = operations['v1-get-action-run']['parameters']['path']
@@ -21,7 +21,7 @@ export type ActionRunError = ResponseError
 
 export const useActionRunQuery = <TData = ActionRunData>(
   { ref, run_id }: ActionRunVariables,
-  { enabled = true, ...options }: UseQueryOptions<ActionRunData, ActionRunError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ActionRunData, ActionRunError, TData> = {}
 ) =>
   useQuery<ActionRunData, ActionRunError, TData>({
     queryKey: actionKeys.detail(ref, run_id),

--- a/apps/studio/data/actions/action-logs-query.ts
+++ b/apps/studio/data/actions/action-logs-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { operations } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { actionKeys } from './keys'
 
 export type ActionLogsVariables = operations['v1-get-action-run-logs']['parameters']['path']
@@ -27,7 +27,10 @@ export type WorkflowRunLogsError = ResponseError
 
 export const useActionRunLogsQuery = <TData = ActionLogsData>(
   { ref, run_id }: ActionLogsVariables,
-  { enabled = true, ...options }: UseQueryOptions<ActionLogsData, WorkflowRunLogsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ActionLogsData, WorkflowRunLogsError, TData> = {}
 ) =>
   useQuery<ActionLogsData, WorkflowRunLogsError, TData>({
     queryKey: actionKeys.detail(ref, run_id),

--- a/apps/studio/data/actions/action-runs-query.ts
+++ b/apps/studio/data/actions/action-runs-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { operations } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { actionKeys } from './keys'
 
 export type ActionsVariables = operations['v1-list-action-runs']['parameters']['path']
@@ -25,7 +25,7 @@ export type ActionStatus = ActionRunStep['status']
 
 export const useActionsQuery = <TData = ActionsData>(
   { ref }: ActionsVariables,
-  { enabled = true, ...options }: UseQueryOptions<ActionsData, ActionsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ActionsData, ActionsError, TData> = {}
 ) =>
   useQuery<ActionsData, ActionsError, TData>({
     queryKey: actionKeys.list(ref),

--- a/apps/studio/data/ai/check-api-key-query.ts
+++ b/apps/studio/data/ai/check-api-key-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { constructHeaders, fetchHandler } from 'data/fetchers'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-import { ResponseError } from 'types'
+import { ResponseError, UseCustomQueryOptions } from 'types'
 import { aiKeys } from './keys'
 
 // check to see if the OPENAI_API_KEY env var is set in self-hosted
@@ -33,7 +33,7 @@ export type ResourceError = { errorEventId: string; message: string }
 export const useCheckOpenAIKeyQuery = <TData = ResourceData>({
   enabled = true,
   ...options
-}: UseQueryOptions<ResourceData, ResourceError, TData> = {}) =>
+}: UseCustomQueryOptions<ResourceData, ResourceError, TData> = {}) =>
   useQuery<ResourceData, ResourceError, TData>({
     queryKey: aiKeys.apiKey(),
     queryFn: ({ signal }) => checkOpenAIKey(signal),

--- a/apps/studio/data/ai/rate-message-mutation.ts
+++ b/apps/studio/data/ai/rate-message-mutation.ts
@@ -1,10 +1,10 @@
 import { UIMessage } from '@ai-sdk/react'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import type { RateMessageResponse } from 'components/ui/AIAssistantPanel/Message.utils'
 import { constructHeaders, fetchHandler } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
-import { ResponseError } from 'types'
+import { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type RateMessageVariables = {
   rating: 'positive' | 'negative'
@@ -52,7 +52,7 @@ export const useRateMessageMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<RateMessageData, ResponseError, RateMessageVariables>,
+  UseCustomMutationOptions<RateMessageData, ResponseError, RateMessageVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<RateMessageData, ResponseError, RateMessageVariables>({

--- a/apps/studio/data/ai/sql-cron-mutation.ts
+++ b/apps/studio/data/ai/sql-cron-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { constructHeaders, fetchHandler } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
-import { ResponseError } from 'types'
+import { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type SqlCronGenerateResponse = string
 
@@ -41,7 +41,7 @@ export const useSqlCronGenerateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SqlCronGenerateData, ResponseError, SqlCronGenerateVariables>,
+  UseCustomMutationOptions<SqlCronGenerateData, ResponseError, SqlCronGenerateVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<SqlCronGenerateData, ResponseError, SqlCronGenerateVariables>({

--- a/apps/studio/data/ai/sql-title-mutation.ts
+++ b/apps/studio/data/ai/sql-title-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { constructHeaders, fetchHandler } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
-import { ResponseError } from 'types'
+import { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type SqlTitleGenerateResponse = {
   title: string
@@ -45,7 +45,7 @@ export const useSqlTitleGenerateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SqlTitleGenerateData, ResponseError, SqlTitleGenerateVariables>,
+  UseCustomMutationOptions<SqlTitleGenerateData, ResponseError, SqlTitleGenerateVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<SqlTitleGenerateData, ResponseError, SqlTitleGenerateVariables>({

--- a/apps/studio/data/analytics/functions-combined-stats-query.ts
+++ b/apps/studio/data/analytics/functions-combined-stats-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { analyticsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type FunctionsCombinedStatsVariables = {
   projectRef?: string
@@ -54,7 +55,7 @@ export const useFunctionsCombinedStatsQuery = <TData = FunctionsCombinedStatsDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<FunctionsCombinedStatsData, FunctionsCombinedStatsError, TData> = {}
+  }: UseCustomQueryOptions<FunctionsCombinedStatsData, FunctionsCombinedStatsError, TData> = {}
 ) =>
   useQuery<FunctionsCombinedStatsData, FunctionsCombinedStatsError, TData>({
     queryKey: analyticsKeys.functionsCombinedStats(projectRef, { functionId, interval }),

--- a/apps/studio/data/analytics/functions-req-stats-query.ts
+++ b/apps/studio/data/analytics/functions-req-stats-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { analyticsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type FunctionsReqStatsVariables = {
   projectRef?: string
@@ -54,7 +55,7 @@ export const useFunctionsReqStatsQuery = <TData = FunctionsReqStatsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<FunctionsReqStatsData, FunctionsReqStatsError, TData> = {}
+  }: UseCustomQueryOptions<FunctionsReqStatsData, FunctionsReqStatsError, TData> = {}
 ) =>
   useQuery<FunctionsReqStatsData, FunctionsReqStatsError, TData>({
     queryKey: analyticsKeys.functionsReqStats(projectRef, { functionId, interval }),

--- a/apps/studio/data/analytics/functions-resource-usage-query.ts
+++ b/apps/studio/data/analytics/functions-resource-usage-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { analyticsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type FunctionsResourceUsageVariables = {
   projectRef?: string
@@ -54,7 +55,7 @@ export const useFunctionsResourceUsageQuery = <TData = FunctionsResourceUsageDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<FunctionsResourceUsageData, FunctionsResourceUsageError, TData> = {}
+  }: UseCustomQueryOptions<FunctionsResourceUsageData, FunctionsResourceUsageError, TData> = {}
 ) =>
   useQuery<FunctionsResourceUsageData, FunctionsResourceUsageError, TData>({
     queryKey: analyticsKeys.functionsResourceUsage(projectRef, { functionId, interval }),

--- a/apps/studio/data/analytics/infra-monitoring-query.ts
+++ b/apps/studio/data/analytics/infra-monitoring-query.ts
@@ -1,9 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 
 import { get, handleError } from 'data/fetchers'
 import type { AnalyticsData, AnalyticsInterval } from './constants'
 import { analyticsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type InfraMonitoringAttribute =
   | 'max_cpu_usage'
@@ -76,7 +77,7 @@ export const useInfraMonitoringQuery = <TData = InfraMonitoringData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<InfraMonitoringData, InfraMonitoringError, TData> = {}
+  }: UseCustomQueryOptions<InfraMonitoringData, InfraMonitoringError, TData> = {}
 ) =>
   useQuery<InfraMonitoringData, InfraMonitoringError, TData>({
     queryKey: analyticsKeys.infraMonitoring(projectRef, {

--- a/apps/studio/data/analytics/org-daily-stats-query.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { analyticsKeys } from './keys'
 
 export enum EgressType {
@@ -149,7 +149,10 @@ export type OrgDailyStatsError = ResponseError
 
 export const useOrgDailyStatsQuery = <TData = OrgDailyStatsData>(
   { orgSlug, startDate, endDate, projectRef }: OrgDailyStatsVariables,
-  { enabled = true, ...options }: UseQueryOptions<OrgDailyStatsData, OrgDailyStatsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<OrgDailyStatsData, OrgDailyStatsError, TData> = {}
 ) =>
   useQuery<OrgDailyStatsData, OrgDailyStatsError, TData>({
     queryKey: analyticsKeys.orgDailyStats(orgSlug, { startDate, endDate, projectRef }),

--- a/apps/studio/data/analytics/project-daily-stats-query.ts
+++ b/apps/studio/data/analytics/project-daily-stats-query.ts
@@ -1,9 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import type { AnalyticsData } from './constants'
 import { analyticsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type ProjectDailyStatsAttribute =
   operations['DailyStatsController_getDailyStats']['parameters']['query']['attribute']
@@ -48,7 +49,7 @@ export const useProjectDailyStatsQuery = <TData = ProjectDailyStatsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectDailyStatsData, ProjectDailyStatsError, TData> = {}
+  }: UseCustomQueryOptions<ProjectDailyStatsData, ProjectDailyStatsError, TData> = {}
 ) =>
   useQuery<ProjectDailyStatsData, ProjectDailyStatsError, TData>({
     queryKey: analyticsKeys.infraMonitoring(projectRef, {

--- a/apps/studio/data/analytics/project-log-requests-count-query.ts
+++ b/apps/studio/data/analytics/project-log-requests-count-query.ts
@@ -1,7 +1,7 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { analyticsKeys } from './keys'
 
 export type ProjectLogRequestsCountVariables = {
@@ -38,7 +38,7 @@ export const useProjectLogRequestsCountQuery = <TData = ProjectLogRequestsCountD
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectLogRequestsCountData, ProjectLogRequestsCountError, TData> = {}
+  }: UseCustomQueryOptions<ProjectLogRequestsCountData, ProjectLogRequestsCountError, TData> = {}
 ) =>
   useQuery<ProjectLogRequestsCountData, ProjectLogRequestsCountError, TData>({
     queryKey: analyticsKeys.usageApiRequestsCount(projectRef),

--- a/apps/studio/data/analytics/project-log-stats-query.ts
+++ b/apps/studio/data/analytics/project-log-stats-query.ts
@@ -1,7 +1,8 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { analyticsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type ProjectLogStatsVariables = {
   projectRef?: string
@@ -58,7 +59,7 @@ export const useProjectLogStatsQuery = <TData = ProjectLogStatsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectLogStatsData, ProjectLogStatsError, TData> = {}
+  }: UseCustomQueryOptions<ProjectLogStatsData, ProjectLogStatsError, TData> = {}
 ) =>
   useQuery<ProjectLogStatsData, ProjectLogStatsError, TData>({
     queryKey: analyticsKeys.usageApiCounts(projectRef, interval),

--- a/apps/studio/data/api-authorization/api-authorization-approve-mutation.ts
+++ b/apps/studio/data/api-authorization/api-authorization-approve-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ApiAuthorizationApproveVariables = {
   id: string
@@ -33,7 +33,11 @@ export const useApiAuthorizationApproveMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ApiAuthorizationApproveData, ResponseError, ApiAuthorizationApproveVariables>,
+  UseCustomMutationOptions<
+    ApiAuthorizationApproveData,
+    ResponseError,
+    ApiAuthorizationApproveVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<ApiAuthorizationApproveData, ResponseError, ApiAuthorizationApproveVariables>({

--- a/apps/studio/data/api-authorization/api-authorization-decline-mutation.ts
+++ b/apps/studio/data/api-authorization/api-authorization-decline-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ApiAuthorizationDeclineVariables = {
   id: string
@@ -32,7 +32,11 @@ export const useApiAuthorizationDeclineMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ApiAuthorizationDeclineData, ResponseError, ApiAuthorizationDeclineVariables>,
+  UseCustomMutationOptions<
+    ApiAuthorizationDeclineData,
+    ResponseError,
+    ApiAuthorizationDeclineVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<ApiAuthorizationDeclineData, ResponseError, ApiAuthorizationDeclineVariables>({

--- a/apps/studio/data/api-authorization/api-authorization-query.ts
+++ b/apps/studio/data/api-authorization/api-authorization-query.ts
@@ -1,8 +1,9 @@
 import type { OAuthScope } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { resourceKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type ApiAuthorizationVariables = {
   id?: string
@@ -40,7 +41,7 @@ export type ResourceError = { errorEventId: string; message: string }
 
 export const useApiAuthorizationQuery = <TData = ResourceData>(
   { id }: ApiAuthorizationVariables,
-  { enabled = true, ...options }: UseQueryOptions<ResourceData, ResourceError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ResourceData, ResourceError, TData> = {}
 ) =>
   useQuery<ResourceData, ResourceError, TData>({
     queryKey: resourceKeys.resource(id),

--- a/apps/studio/data/api-keys/[id]/api-key-id-query.ts
+++ b/apps/studio/data/api-keys/[id]/api-key-id-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { apiKeysKeys } from './../keys'
 
 export interface APIKeyVariables {
@@ -35,7 +35,7 @@ export type APIKeyIdData = Awaited<ReturnType<typeof getAPIKeysById>>
 
 export const useAPIKeyIdQuery = <TData = APIKeyIdData>(
   { projectRef, id, reveal }: APIKeyVariables,
-  { enabled = true, ...options }: UseQueryOptions<APIKeyIdData, ResponseError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<APIKeyIdData, ResponseError, TData> = {}
 ) =>
   useQuery<APIKeyIdData, ResponseError, TData>({
     queryKey: apiKeysKeys.single(projectRef, id),

--- a/apps/studio/data/api-keys/[id]/api-key-id-update-mutation.ts
+++ b/apps/studio/data/api-keys/[id]/api-key-id-update-mutation.ts
@@ -1,8 +1,8 @@
 import { toast } from 'sonner'
 
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { apiKeysKeys } from '../keys'
 
 export interface UpdateAPIKeybyIdVariables {
@@ -43,7 +43,7 @@ export const useResourceUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ResourceUpdateData, ResponseError, UpdateAPIKeybyIdVariables>,
+  UseCustomMutationOptions<ResourceUpdateData, ResponseError, UpdateAPIKeybyIdVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/api-keys/api-key-create-mutation.ts
+++ b/apps/studio/data/api-keys/api-key-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { apiKeysKeys } from './keys'
 
 export type APIKeyCreateVariables = {
@@ -58,7 +58,7 @@ export const useAPIKeyCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<APIKeyCreateData, ResponseError, APIKeyCreateVariables>,
+  UseCustomMutationOptions<APIKeyCreateData, ResponseError, APIKeyCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/api-keys/api-key-delete-mutation.ts
+++ b/apps/studio/data/api-keys/api-key-delete-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { del, handleError } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { apiKeysKeys } from './keys'
 
 export type APIKeyDeleteVariables = {
@@ -30,7 +30,7 @@ export const useAPIKeyDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<APIKeyDeleteData, ResponseError, APIKeyDeleteVariables>,
+  UseCustomMutationOptions<APIKeyDeleteData, ResponseError, APIKeyDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/api-keys/api-keys-query.ts
+++ b/apps/studio/data/api-keys/api-keys-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { apiKeysKeys } from './keys'
 
 type LegacyKeys = {
@@ -68,7 +68,7 @@ export type APIKeysData = Awaited<ReturnType<typeof getAPIKeys>>
 
 export const useAPIKeysQuery = <TData = APIKeysData>(
   { projectRef, reveal = false }: APIKeysVariables,
-  { enabled = true, ...options }: UseQueryOptions<APIKeysData, ResponseError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<APIKeysData, ResponseError, TData> = {}
 ) => {
   return useQuery<APIKeysData, ResponseError, TData>({
     queryKey: apiKeysKeys.list(projectRef, reveal),

--- a/apps/studio/data/api-keys/legacy-api-key-toggle-mutation.ts
+++ b/apps/studio/data/api-keys/legacy-api-key-toggle-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { handleError, put } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { apiKeysKeys } from './keys'
 
 export type ToggleLegacyAPIKeysVariables = {
@@ -30,7 +30,7 @@ export const useToggleLegacyAPIKeysMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ToggleLegacyAPIKeysData, ResponseError, ToggleLegacyAPIKeysVariables>,
+  UseCustomMutationOptions<ToggleLegacyAPIKeysData, ResponseError, ToggleLegacyAPIKeysVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/api-keys/legacy-api-keys-status-query.ts
+++ b/apps/studio/data/api-keys/legacy-api-keys-status-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { apiKeysKeys } from './keys'
 
 interface LegacyAPIKeysStatusVariables {
@@ -31,7 +31,7 @@ export const useLegacyAPIKeysStatusQuery = <TData = LegacyAPIKeysStatusData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<LegacyAPIKeysStatusData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<LegacyAPIKeysStatusData, ResponseError, TData> = {}
 ) =>
   useQuery<LegacyAPIKeysStatusData, ResponseError, TData>({
     queryKey: apiKeysKeys.status(projectRef),

--- a/apps/studio/data/api-keys/temp-api-keys-query.ts
+++ b/apps/studio/data/api-keys/temp-api-keys-query.ts
@@ -1,7 +1,7 @@
-import { type UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { apiKeysKeys } from './keys'
 
 interface getTemporaryAPIKeyVariables {
@@ -36,7 +36,10 @@ export type TemporaryAPIKeyData = Awaited<ReturnType<typeof getTemporaryAPIKey>>
 
 export const useTemporaryAPIKeyQuery = <TData = TemporaryAPIKeyData>(
   { projectRef, expiry = 300 }: getTemporaryAPIKeyVariables,
-  { enabled = true, ...options }: UseQueryOptions<TemporaryAPIKeyData, ResponseError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<TemporaryAPIKeyData, ResponseError, TData> = {}
 ) => {
   return useQuery<TemporaryAPIKeyData, ResponseError, TData>({
     queryKey: apiKeysKeys.temporary(projectRef),

--- a/apps/studio/data/api-settings/create-and-expose-api-schema-mutation.ts
+++ b/apps/studio/data/api-settings/create-and-expose-api-schema-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { configKeys } from 'data/config/keys'
 import { databaseKeys } from 'data/database/keys'
 import { handleError, patch } from 'data/fetchers'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type CreateAndExposeAPISchemaVariables = {
   projectRef: string
@@ -52,7 +52,7 @@ export const useCreateAndExposeAPISchemaMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     CreateAndExposeAPISchemaData,
     ResponseError,
     CreateAndExposeAPISchemaVariables

--- a/apps/studio/data/auth/auth-config-query.ts
+++ b/apps/studio/data/auth/auth-config-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
 import { useCallback } from 'react'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { authKeys } from './keys'
 
 export type AuthConfigVariables = {
@@ -35,7 +35,7 @@ export const useAuthConfigQuery = <TData = ProjectAuthConfigData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectAuthConfigData, ProjectAuthConfigError, TData> = {}
+  }: UseCustomQueryOptions<ProjectAuthConfigData, ProjectAuthConfigError, TData> = {}
 ) =>
   useQuery<ProjectAuthConfigData, ProjectAuthConfigError, TData>({
     queryKey: authKeys.authConfig(projectRef),

--- a/apps/studio/data/auth/auth-config-update-mutation.ts
+++ b/apps/studio/data/auth/auth-config-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
 export type AuthConfigUpdateVariables = {
@@ -32,7 +32,7 @@ export const useAuthConfigUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AuthConfigUpdateData, ResponseError, AuthConfigUpdateVariables>,
+  UseCustomMutationOptions<AuthConfigUpdateData, ResponseError, AuthConfigUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/auth/auth-hooks-update-mutation.ts
+++ b/apps/studio/data/auth/auth-hooks-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
 export type AuthHooksUpdateVariables = {
@@ -28,7 +28,7 @@ export const useAuthHooksUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AuthHooksUpdateData, ResponseError, AuthHooksUpdateVariables>,
+  UseCustomMutationOptions<AuthHooksUpdateData, ResponseError, AuthHooksUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/auth/session-access-token-query.ts
+++ b/apps/studio/data/auth/session-access-token-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getAccessToken } from 'common'
 import { authKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export async function getSessionAccessToken() {
   // ignore if server-side
@@ -21,7 +22,7 @@ export type SessionAccessTokenError = unknown
 export const useSessionAccessTokenQuery = <TData = SessionAccessTokenData>({
   enabled = true,
   ...options
-}: UseQueryOptions<SessionAccessTokenData, SessionAccessTokenError, TData> = {}) =>
+}: UseCustomQueryOptions<SessionAccessTokenData, SessionAccessTokenError, TData> = {}) =>
   useQuery<SessionAccessTokenData, SessionAccessTokenError, TData>({
     queryKey: authKeys.accessToken(),
     queryFn: () => getSessionAccessToken(),

--- a/apps/studio/data/auth/user-create-mutation.ts
+++ b/apps/studio/data/auth/user-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
 export type UserCreateVariables = {
@@ -34,7 +34,7 @@ export const useUserCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserCreateData, ResponseError, UserCreateVariables>,
+  UseCustomMutationOptions<UserCreateData, ResponseError, UserCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/auth/user-delete-mfa-factors-mutation.ts
+++ b/apps/studio/data/auth/user-delete-mfa-factors-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type UserDeleteMFAFactorsVariables = {
   projectRef: string
@@ -26,7 +26,7 @@ export const useUserDeleteMFAFactorsMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserDeleteMFAFactorsData, ResponseError, UserDeleteMFAFactorsVariables>,
+  UseCustomMutationOptions<UserDeleteMFAFactorsData, ResponseError, UserDeleteMFAFactorsVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<UserDeleteMFAFactorsData, ResponseError, UserDeleteMFAFactorsVariables>({

--- a/apps/studio/data/auth/user-delete-mutation.ts
+++ b/apps/studio/data/auth/user-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
 export type UserDeleteVariables = {
@@ -26,7 +26,7 @@ export const useUserDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserDeleteData, ResponseError, UserDeleteVariables>,
+  UseCustomMutationOptions<UserDeleteData, ResponseError, UserDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/auth/user-invite-mutation.ts
+++ b/apps/studio/data/auth/user-invite-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
 export type UserInviteVariables = {
@@ -26,7 +26,7 @@ export const useUserInviteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserInviteData, ResponseError, UserInviteVariables>,
+  UseCustomMutationOptions<UserInviteData, ResponseError, UserInviteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/auth/user-reset-password-mutation.ts
+++ b/apps/studio/data/auth/user-reset-password-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { User } from './users-infinite-query'
 
 export type UserResetPasswordVariables = {
@@ -28,7 +28,7 @@ export const useUserResetPasswordMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserResetPasswordData, ResponseError, UserResetPasswordVariables>,
+  UseCustomMutationOptions<UserResetPasswordData, ResponseError, UserResetPasswordVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<UserResetPasswordData, ResponseError, UserResetPasswordVariables>({

--- a/apps/studio/data/auth/user-send-magic-link-mutation.ts
+++ b/apps/studio/data/auth/user-send-magic-link-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { User } from './users-infinite-query'
 
 export type UserSendMagicLinkVariables = {
@@ -28,7 +28,7 @@ export const useUserSendMagicLinkMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserSendMagicLinkData, ResponseError, UserSendMagicLinkVariables>,
+  UseCustomMutationOptions<UserSendMagicLinkData, ResponseError, UserSendMagicLinkVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<UserSendMagicLinkData, ResponseError, UserSendMagicLinkVariables>({

--- a/apps/studio/data/auth/user-send-otp-mutation.ts
+++ b/apps/studio/data/auth/user-send-otp-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { User } from './users-infinite-query'
 
 export type UserSendOTPVariables = {
@@ -28,7 +28,7 @@ export const useUserSendOTPMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserSendOTPData, ResponseError, UserSendOTPVariables>,
+  UseCustomMutationOptions<UserSendOTPData, ResponseError, UserSendOTPVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<UserSendOTPData, ResponseError, UserSendOTPVariables>({

--- a/apps/studio/data/auth/user-update-mutation.ts
+++ b/apps/studio/data/auth/user-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
 export type UserUpdateVariables = {
@@ -29,7 +29,7 @@ export const useUserUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UserUpdateData, ResponseError, UserUpdateVariables>,
+  UseCustomMutationOptions<UserUpdateData, ResponseError, UserUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/auth/users-count-query.ts
+++ b/apps/studio/data/auth/users-count-query.ts
@@ -1,7 +1,8 @@
 import { getUsersCountSQL } from '@supabase/pg-meta/src/sql/studio/get-users-count'
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql, type ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { UseCustomQueryOptions } from 'types'
 import { authKeys } from './keys'
 import { type Filter } from './users-infinite-query'
 
@@ -63,7 +64,7 @@ export const useUsersCountQuery = <TData = UsersCountData>(
     providers,
     forceExactCount,
   }: UsersCountVariables,
-  { enabled = true, ...options }: UseQueryOptions<UsersCountData, UsersCountError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<UsersCountData, UsersCountError, TData> = {}
 ) =>
   useQuery<UsersCountData, UsersCountError, TData>({
     queryKey: authKeys.usersCount(projectRef, {

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -1,10 +1,11 @@
 import { getPaginatedUsersSQL } from '@supabase/pg-meta/src/sql/studio/get-users-paginated'
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
+import { UseCustomInfiniteQueryOptions } from 'types'
 import { authKeys } from './keys'
 
 const USERS_PAGE_LIMIT = 50
@@ -38,7 +39,7 @@ export const useUsersInfiniteQuery = <TData = UsersData>(
     order,
     column,
   }: UsersVariables,
-  { enabled = true, ...options }: UseInfiniteQueryOptions<UsersData, UsersError, TData> = {}
+  { enabled = true, ...options }: UseCustomInfiniteQueryOptions<UsersData, UsersError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/auth/validate-spam-mutation.ts
+++ b/apps/studio/data/auth/validate-spam-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ValidateSpamVariables = {
   projectRef: string
@@ -29,7 +29,7 @@ export const useValidateSpamMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ValidateSpamData, ResponseError, ValidateSpamVariables>,
+  UseCustomMutationOptions<ValidateSpamData, ResponseError, ValidateSpamVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<ValidateSpamData, ResponseError, ValidateSpamVariables>({

--- a/apps/studio/data/banned-ips/banned-ips-delete-mutations.ts
+++ b/apps/studio/data/banned-ips/banned-ips-delete-mutations.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { BannedIPKeys } from './keys'
 
 export type IPDeleteVariables = {
@@ -29,7 +29,10 @@ export const useBannedIPsDeleteMutation = ({
   onSuccess,
   onError,
   ...options
-}: Omit<UseMutationOptions<IPDeleteData, ResponseError, IPDeleteVariables>, 'mutationFn'> = {}) => {
+}: Omit<
+  UseCustomMutationOptions<IPDeleteData, ResponseError, IPDeleteVariables>,
+  'mutationFn'
+> = {}) => {
   const queryClient = useQueryClient()
   return useMutation<IPDeleteData, ResponseError, IPDeleteVariables>({
     mutationFn: (vars) => deleteBannedIPs(vars),

--- a/apps/studio/data/banned-ips/banned-ips-query.ts
+++ b/apps/studio/data/banned-ips/banned-ips-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { BannedIPKeys } from './keys'
 
 export type BannedIPVariables = {
@@ -28,7 +28,7 @@ export type IPError = ResponseError
 
 export const useBannedIPsQuery = <TData = IPData>(
   { projectRef }: BannedIPVariables,
-  { enabled = true, ...options }: UseQueryOptions<IPData, IPError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<IPData, IPError, TData> = {}
 ) =>
   useQuery<IPData, IPError, TData>({
     queryKey: BannedIPKeys.list(projectRef),

--- a/apps/studio/data/branches/branch-create-mutation.ts
+++ b/apps/studio/data/branches/branch-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchCreateVariables = {
@@ -48,7 +48,7 @@ export const useBranchCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BranchCreateData, ResponseError, BranchCreateVariables>,
+  UseCustomMutationOptions<BranchCreateData, ResponseError, BranchCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/branches/branch-delete-mutation.ts
+++ b/apps/studio/data/branches/branch-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { BranchesData } from './branches-query'
 import { branchKeys } from './keys'
 
@@ -27,7 +27,7 @@ export const useBranchDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BranchDeleteData, ResponseError, BranchDeleteVariables>,
+  UseCustomMutationOptions<BranchDeleteData, ResponseError, BranchDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/branches/branch-diff-query.ts
+++ b/apps/studio/data/branches/branch-diff-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchDiffVariables = {
@@ -45,7 +45,7 @@ export const useBranchDiffQuery = (
   {
     enabled = true,
     ...options
-  }: Omit<UseQueryOptions<BranchDiffData, ResponseError>, 'queryKey' | 'queryFn'> = {}
+  }: Omit<UseCustomQueryOptions<BranchDiffData, ResponseError>, 'queryKey' | 'queryFn'> = {}
 ) =>
   useQuery<BranchDiffData, ResponseError>({
     queryKey: branchKeys.diff(projectRef, branchRef),

--- a/apps/studio/data/branches/branch-merge-mutation.ts
+++ b/apps/studio/data/branches/branch-merge-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { upsertMigration } from '../database/migration-upsert-mutation'
 import { getBranchDiff } from './branch-diff-query'
 import { branchKeys } from './keys'
@@ -59,7 +59,7 @@ export const useBranchMergeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BranchMergeData, ResponseError, BranchMergeVariables>,
+  UseCustomMutationOptions<BranchMergeData, ResponseError, BranchMergeVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/branches/branch-push-mutation.ts
+++ b/apps/studio/data/branches/branch-push-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchPushVariables = {
@@ -27,7 +27,7 @@ export const useBranchPushMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BranchPushData, ResponseError, BranchPushVariables>,
+  UseCustomMutationOptions<BranchPushData, ResponseError, BranchPushVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/branches/branch-query.ts
+++ b/apps/studio/data/branches/branch-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchVariables = {
@@ -27,7 +27,7 @@ export type BranchError = ResponseError
 
 export const useBranchQuery = <TData = BranchData>(
   { projectRef, branchRef }: BranchVariables,
-  { enabled = true, ...options }: UseQueryOptions<BranchData, BranchError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<BranchData, BranchError, TData> = {}
 ) =>
   useQuery<BranchData, BranchError, TData>({
     queryKey: branchKeys.detail(projectRef, branchRef),

--- a/apps/studio/data/branches/branch-reset-mutation.ts
+++ b/apps/studio/data/branches/branch-reset-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchResetVariables = {
@@ -27,7 +27,7 @@ export const useBranchResetMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BranchResetData, ResponseError, BranchResetVariables>,
+  UseCustomMutationOptions<BranchResetData, ResponseError, BranchResetVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/branches/branch-update-mutation.ts
+++ b/apps/studio/data/branches/branch-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchUpdateVariables = {
@@ -44,7 +44,7 @@ export const useBranchUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BranchUpdateData, ResponseError, BranchUpdateVariables>,
+  UseCustomMutationOptions<BranchUpdateData, ResponseError, BranchUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/branches/branches-query.ts
+++ b/apps/studio/data/branches/branches-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { branchKeys } from './keys'
 
 export type BranchesVariables = {
@@ -36,7 +36,7 @@ export type BranchesError = ResponseError
 
 export const useBranchesQuery = <TData = BranchesData>(
   { projectRef }: BranchesVariables,
-  { enabled = true, ...options }: UseQueryOptions<BranchesData, BranchesError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<BranchesData, BranchesError, TData> = {}
 ) =>
   useQuery<BranchesData, BranchesError, TData>({
     queryKey: branchKeys.list(projectRef),

--- a/apps/studio/data/config/disk-attributes-query.ts
+++ b/apps/studio/data/config/disk-attributes-query.ts
@@ -1,10 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { useMemo } from 'react'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { COOLDOWN_DURATION } from './disk-attributes-update-mutation'
 import { configKeys } from './keys'
 
@@ -37,7 +37,7 @@ export const useDiskAttributesQuery = <TData = DiskAttributesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DiskAttributesData, DiskAttributesError, TData> = {}
+  }: UseCustomQueryOptions<DiskAttributesData, DiskAttributesError, TData> = {}
 ) =>
   useQuery<DiskAttributesData, DiskAttributesError, TData>({
     queryKey: configKeys.diskAttributes(projectRef),

--- a/apps/studio/data/config/disk-attributes-update-mutation.ts
+++ b/apps/studio/data/config/disk-attributes-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { configKeys } from './keys'
 
 export const COOLDOWN_DURATION = 60 * 60 * 6
@@ -50,7 +50,7 @@ export const useUpdateDiskAttributesMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UpdateDiskAttributesData, ResponseError, UpdateDiskAttributesVariables>,
+  UseCustomMutationOptions<UpdateDiskAttributesData, ResponseError, UpdateDiskAttributesVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/config/disk-autoscale-config-query.ts
+++ b/apps/studio/data/config/disk-autoscale-config-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type DiskAutoscaleCustomConfigVariables = {
@@ -33,7 +33,11 @@ export const useDiskAutoscaleCustomConfigQuery = <TData = DiskAutoscaleCustomCon
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DiskAutoscaleCustomConfigData, DiskAutoscaleCustomConfigError, TData> = {}
+  }: UseCustomQueryOptions<
+    DiskAutoscaleCustomConfigData,
+    DiskAutoscaleCustomConfigError,
+    TData
+  > = {}
 ) =>
   useQuery<DiskAutoscaleCustomConfigData, DiskAutoscaleCustomConfigError, TData>({
     queryKey: configKeys.diskAutoscaleConfig(projectRef),

--- a/apps/studio/data/config/disk-autoscale-config-update-mutation.ts
+++ b/apps/studio/data/config/disk-autoscale-config-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { configKeys } from './keys'
 
 export type UpdateDiskAutoscaleConfigVariables = {
@@ -41,7 +41,7 @@ export const useUpdateDiskAutoscaleConfigMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     UpdateDiskAutoscaleConfigData,
     ResponseError,
     UpdateDiskAutoscaleConfigVariables

--- a/apps/studio/data/config/disk-breakdown-query.ts
+++ b/apps/studio/data/config/disk-breakdown-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
-import type { ResponseError } from 'types'
-import { configKeys } from './keys'
 import { executeSql } from 'data/sql/execute-sql-query'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { configKeys } from './keys'
 
 export type DiskBreakdownVariables = {
   projectRef?: string
@@ -50,7 +50,10 @@ export type DiskBreakdownError = ResponseError
 
 export const useDiskBreakdownQuery = <TData = DiskBreakdownData>(
   { projectRef, connectionString }: DiskBreakdownVariables,
-  { enabled = true, ...options }: UseQueryOptions<DiskBreakdownData, DiskBreakdownError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DiskBreakdownData, DiskBreakdownError, TData> = {}
 ) =>
   useQuery<DiskBreakdownData, DiskBreakdownError, TData>({
     queryKey: configKeys.diskBreakdown(projectRef),

--- a/apps/studio/data/config/disk-utilization-query.ts
+++ b/apps/studio/data/config/disk-utilization-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type DiskUtilizationVariables = {
@@ -31,7 +31,7 @@ export const useDiskUtilizationQuery = <TData = DiskUtilizationData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DiskUtilizationData, DiskUtilizationError, TData> = {}
+  }: UseCustomQueryOptions<DiskUtilizationData, DiskUtilizationError, TData> = {}
 ) =>
   useQuery<DiskUtilizationData, DiskUtilizationError, TData>({
     queryKey: configKeys.diskUtilization(projectRef),

--- a/apps/studio/data/config/jwt-secret-update-mutation.ts
+++ b/apps/studio/data/config/jwt-secret-update-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { configKeys } from './keys'
 
 export type JwtSecretUpdateVariables = {
@@ -37,7 +37,7 @@ export const useJwtSecretUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<JwtSecretUpdateData, ResponseError, JwtSecretUpdateVariables>,
+  UseCustomMutationOptions<JwtSecretUpdateData, ResponseError, JwtSecretUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/config/jwt-secret-updating-status-query.ts
+++ b/apps/studio/data/config/jwt-secret-updating-status-query.ts
@@ -1,6 +1,7 @@
 import { JwtSecretUpdateStatus } from '@supabase/shared-types/out/events'
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
+import { UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type JwtSecretUpdatingStatusVariables = {
@@ -49,7 +50,7 @@ export const useJwtSecretUpdatingStatusQuery = <TData = JwtSecretUpdatingStatusD
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<JwtSecretUpdatingStatusData, JwtSecretUpdatingStatusError, TData> = {}
+  }: UseCustomQueryOptions<JwtSecretUpdatingStatusData, JwtSecretUpdatingStatusError, TData> = {}
 ) => {
   const client = useQueryClient()
 

--- a/apps/studio/data/config/project-compliance-config-mutation.ts
+++ b/apps/studio/data/config/project-compliance-config-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ComplianceConfigUpdateVariables = {
@@ -32,7 +32,11 @@ export const useComplianceConfigUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ComplianceConfigUpdateData, ResponseError, ComplianceConfigUpdateVariables>,
+  UseCustomMutationOptions<
+    ComplianceConfigUpdateData,
+    ResponseError,
+    ComplianceConfigUpdateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/config/project-creation-postgres-versions-query.ts
+++ b/apps/studio/data/config/project-creation-postgres-versions-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
 import { CloudProvider } from 'shared-data'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectCreationPostgresVersionsVariables = {
@@ -37,7 +37,7 @@ export const useProjectCreationPostgresVersionsQuery = <TData = ProjectCreationP
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<
+  }: UseCustomQueryOptions<
     ProjectCreationPostgresVersionData,
     ProjectCreationPostgresVersionError,
     TData

--- a/apps/studio/data/config/project-disk-resize-mutation.ts
+++ b/apps/studio/data/config/project-disk-resize-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { usageKeys } from '../usage/keys'
 
 export type ProjectDiskResizeVariables = {
@@ -35,7 +35,7 @@ export const useProjectDiskResizeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectDiskResizeData, ResponseError, ProjectDiskResizeVariables>,
+  UseCustomMutationOptions<ProjectDiskResizeData, ResponseError, ProjectDiskResizeVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/config/project-postgrest-config-query.ts
+++ b/apps/studio/data/config/project-postgrest-config-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectPostgrestConfigVariables = {
@@ -37,7 +37,7 @@ export const useProjectPostgrestConfigQuery = <TData = ProjectPostgrestConfigDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectPostgrestConfigData, ProjectPostgrestConfigError, TData> = {}
+  }: UseCustomQueryOptions<ProjectPostgrestConfigData, ProjectPostgrestConfigError, TData> = {}
 ) =>
   useQuery<ProjectPostgrestConfigData, ProjectPostgrestConfigError, TData>({
     queryKey: configKeys.postgrest(projectRef),

--- a/apps/studio/data/config/project-postgrest-config-update-mutation.ts
+++ b/apps/studio/data/config/project-postgrest-config-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectPostgrestConfigUpdateVariables = {
@@ -46,7 +46,7 @@ export const useProjectPostgrestConfigUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     ProjectPostgrestConfigUpdateData,
     ResponseError,
     ProjectPostgrestConfigUpdateVariables

--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -1,10 +1,10 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectSettingsVariables = { projectRef?: string }
@@ -40,7 +40,7 @@ export const useProjectSettingsV2Query = <TData = ProjectSettingsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectSettingsData, ProjectSettingsError, TData> = {}
+  }: UseCustomQueryOptions<ProjectSettingsData, ProjectSettingsError, TData> = {}
 ) => {
   // [Joshen] Sync with API perms checking here - shouldReturnApiKeys
   // https://github.com/supabase/infrastructure/blob/develop/api/src/routes/platform/projects/ref/settings.controller.ts#L92

--- a/apps/studio/data/config/project-storage-config-query.ts
+++ b/apps/studio/data/config/project-storage-config-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectStorageConfigVariables = {
@@ -43,7 +43,7 @@ export const useProjectStorageConfigQuery = <TData = ProjectStorageConfigData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectStorageConfigData, ProjectStorageConfigError, TData> = {}
+  }: UseCustomQueryOptions<ProjectStorageConfigData, ProjectStorageConfigError, TData> = {}
 ) =>
   useQuery<ProjectStorageConfigData, ProjectStorageConfigError, TData>({
     queryKey: configKeys.storage(projectRef),

--- a/apps/studio/data/config/project-storage-config-update-mutation.ts
+++ b/apps/studio/data/config/project-storage-config-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { configKeys } from './keys'
 
 type StorageConfigUpdatePayload = components['schemas']['UpdateStorageConfigBody']
@@ -34,7 +34,7 @@ export const useProjectStorageConfigUpdateUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     ProjectStorageConfigUpdateUpdateData,
     ResponseError,
     ProjectStorageConfigUpdateUpdateVariables

--- a/apps/studio/data/config/project-temp-disable-read-only-mutation.ts
+++ b/apps/studio/data/config/project-temp-disable-read-only-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
 import { usageKeys } from 'data/usage/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type TempDisableReadOnlyModeVariables = {
   projectRef: string
@@ -25,7 +25,11 @@ export const useDisableReadOnlyModeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DisableReadOnlyModeData, ResponseError, TempDisableReadOnlyModeVariables>,
+  UseCustomMutationOptions<
+    DisableReadOnlyModeData,
+    ResponseError,
+    TempDisableReadOnlyModeVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/config/project-unpause-postgres-versions-query.ts
+++ b/apps/studio/data/config/project-unpause-postgres-versions-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectUnpausePostgresVersionsVariables = {
@@ -33,7 +33,7 @@ export const useProjectUnpausePostgresVersionsQuery = <TData = ProjectUnpausePos
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<
+  }: UseCustomQueryOptions<
     ProjectUnpausePostgresVersionData,
     ProjectUnpausePostgresVersionError,
     TData

--- a/apps/studio/data/config/project-upgrade-eligibility-query.ts
+++ b/apps/studio/data/config/project-upgrade-eligibility-query.ts
@@ -1,11 +1,11 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { IS_PLATFORM } from 'common'
 import { get, handleError } from 'data/fetchers'
 import { useProjectDetailQuery } from 'data/projects/project-detail-query'
 import { PROJECT_STATUS } from 'lib/constants/infrastructure'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectUpgradeTargetVersion = { postgres_version: string; release_channel: string }
@@ -36,7 +36,11 @@ export const useProjectUpgradeEligibilityQuery = <TData = ProjectUpgradeEligibil
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectUpgradeEligibilityData, ProjectUpgradeEligibilityError, TData> = {}
+  }: UseCustomQueryOptions<
+    ProjectUpgradeEligibilityData,
+    ProjectUpgradeEligibilityError,
+    TData
+  > = {}
 ) => {
   const { data: project } = useProjectDetailQuery({ ref: projectRef })
   return useQuery<ProjectUpgradeEligibilityData, ProjectUpgradeEligibilityError, TData>({

--- a/apps/studio/data/config/project-upgrade-status-query.ts
+++ b/apps/studio/data/config/project-upgrade-status-query.ts
@@ -1,8 +1,9 @@
 import { DatabaseUpgradeStatus } from '@supabase/shared-types/out/events'
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { PROJECT_STATUS } from 'lib/constants'
 import { configKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type ProjectUpgradingStatusVariables = {
   projectRef?: string
@@ -38,7 +39,7 @@ export const useProjectUpgradingStatusQuery = <TData = ProjectUpgradingStatusDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectUpgradingStatusData, ProjectUpgradingStatusError, TData> = {}
+  }: UseCustomQueryOptions<ProjectUpgradingStatusData, ProjectUpgradingStatusError, TData> = {}
 ) => {
   const client = useQueryClient()
 

--- a/apps/studio/data/content-api/docs-error-codes-query.ts
+++ b/apps/studio/data/content-api/docs-error-codes-query.ts
@@ -1,8 +1,9 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeGraphQL } from 'data/graphql/execute'
 import { graphql } from 'data/graphql/gql'
 import { Service } from 'data/graphql/graphql'
 import { contentApiKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 const ErrorCodeQuery = graphql(`
   query ErrorCodeQuery($code: String!, $service: Service) {
@@ -33,7 +34,7 @@ export const useErrorCodesQuery = <TData = ErrorCodeDescriptionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ErrorCodeDescriptionsData, ErrorCodeDescriptionsError, TData> = {}
+  }: UseCustomQueryOptions<ErrorCodeDescriptionsData, ErrorCodeDescriptionsError, TData> = {}
 ) => {
   return useQuery<ErrorCodeDescriptionsData, ErrorCodeDescriptionsError, TData>({
     queryKey: contentApiKeys.errorCodes(variables),

--- a/apps/studio/data/content/content-count-query.ts
+++ b/apps/studio/data/content/content-count-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { contentKeys } from './keys'
 
 type GetContentCountVariables =
@@ -37,7 +37,7 @@ export type ContentIdError = ResponseError
 
 export const useContentCountQuery = <TData = ContentIdData>(
   { projectRef, type, name }: GetContentCountVariables,
-  { enabled = true, ...options }: UseQueryOptions<ContentIdData, ContentIdError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ContentIdData, ContentIdError, TData> = {}
 ) =>
   useQuery<ContentIdData, ContentIdError, TData>({
     queryKey: contentKeys.count(projectRef, type, {

--- a/apps/studio/data/content/content-delete-mutation.ts
+++ b/apps/studio/data/content/content-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { contentKeys } from './keys'
 
 type DeleteContentVariables = { projectRef: string; ids: string[] }
@@ -31,7 +31,7 @@ export const useContentDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DeleteContentData, ResponseError, DeleteContentVariables>,
+  UseCustomMutationOptions<DeleteContentData, ResponseError, DeleteContentVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/content/content-id-query.ts
+++ b/apps/studio/data/content/content-id-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import type { Content } from './content-query'
 import { contentKeys } from './keys'
 
@@ -35,7 +35,7 @@ export type ContentIdError = ResponseError
 
 export const useContentIdQuery = <TData = ContentIdData>(
   { projectRef, id }: { projectRef?: string; id?: string },
-  { enabled = true, ...options }: UseQueryOptions<ContentIdData, ContentIdError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ContentIdData, ContentIdError, TData> = {}
 ) =>
   useQuery<ContentIdData, ContentIdError, TData>({
     queryKey: contentKeys.resource(projectRef, id),

--- a/apps/studio/data/content/content-infinite-query.ts
+++ b/apps/studio/data/content/content-infinite-query.ts
@@ -1,6 +1,7 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
+import { UseCustomInfiniteQueryOptions } from 'types'
 import { Content, ContentType } from './content-query'
 import { contentKeys } from './keys'
 
@@ -48,7 +49,10 @@ export type ContentError = unknown
 
 export const useContentInfiniteQuery = <TData = ContentData>(
   { projectRef, type, name, limit, sort }: GetContentVariables,
-  { enabled = true, ...options }: UseInfiniteQueryOptions<ContentData, ContentError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomInfiniteQueryOptions<ContentData, ContentError, TData> = {}
 ) => {
   return useInfiniteQuery<ContentData, ContentError, TData>({
     queryKey: contentKeys.infiniteList(projectRef, { type, name, limit, sort }),

--- a/apps/studio/data/content/content-insert-mutation.ts
+++ b/apps/studio/data/content/content-insert-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { Content } from './content-query'
 import { contentKeys } from './keys'
 
@@ -47,7 +47,7 @@ export const useContentInsertMutation = ({
   onSuccess,
   ...options
 }: Omit<
-  UseMutationOptions<InsertContentData, ResponseError, InsertContentVariables>,
+  UseCustomMutationOptions<InsertContentData, ResponseError, InsertContentVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/content/content-query.ts
+++ b/apps/studio/data/content/content-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { Dashboards, LogSqlSnippets, SqlSnippets } from 'types'
+import type { Dashboards, LogSqlSnippets, SqlSnippets, UseCustomQueryOptions } from 'types'
 import { contentKeys } from './keys'
 
 export type ContentBase = components['schemas']['GetUserContentResponse']['data'][number]
@@ -59,7 +59,7 @@ export type ContentError = unknown
 /** @deprecated Use useContentInfiniteQuery from content-infinite-query instead */
 export const useContentQuery = <TData = ContentData>(
   { projectRef, type, name, limit }: GetContentVariables,
-  { enabled = true, ...options }: UseQueryOptions<ContentData, ContentError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ContentData, ContentError, TData> = {}
 ) =>
   useQuery<ContentData, ContentError, TData>({
     queryKey: contentKeys.list(projectRef, { type, name, limit }),

--- a/apps/studio/data/content/content-upsert-mutation.ts
+++ b/apps/studio/data/content/content-upsert-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { Content } from './content-query'
 import { contentKeys } from './keys'
 
@@ -39,7 +39,7 @@ export const useContentUpsertMutation = ({
   invalidateQueriesOnSuccess = true,
   ...options
 }: Omit<
-  UseMutationOptions<UpsertContentData, ResponseError, UpsertContentVariables>,
+  UseCustomMutationOptions<UpsertContentData, ResponseError, UpsertContentVariables>,
   'mutationFn'
 > & {
   invalidateQueriesOnSuccess?: boolean

--- a/apps/studio/data/content/sql-folder-contents-query.ts
+++ b/apps/studio/data/content/sql-folder-contents-query.ts
@@ -1,7 +1,7 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { contentKeys } from './keys'
 import { SNIPPET_PAGE_LIMIT } from './sql-folders-query'
 
@@ -51,7 +51,7 @@ export const useSQLSnippetFolderContentsQuery = <TData = SQLSnippetFolderContent
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<
+  }: UseCustomInfiniteQueryOptions<
     SQLSnippetFolderContentsData,
     SQLSnippetFolderContentsError,
     TData

--- a/apps/studio/data/content/sql-folder-create-mutation.ts
+++ b/apps/studio/data/content/sql-folder-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { contentKeys } from './keys'
 
 export type CreateSQLSnippetFolderVariables = {
@@ -36,7 +36,11 @@ export const useSQLSnippetFolderCreateMutation = ({
   invalidateQueriesOnSuccess = true,
   ...options
 }: Omit<
-  UseMutationOptions<CreateSQLSnippetFolderData, ResponseError, CreateSQLSnippetFolderVariables>,
+  UseCustomMutationOptions<
+    CreateSQLSnippetFolderData,
+    ResponseError,
+    CreateSQLSnippetFolderVariables
+  >,
   'mutationFn'
 > & {
   invalidateQueriesOnSuccess?: boolean

--- a/apps/studio/data/content/sql-folder-update-mutation.ts
+++ b/apps/studio/data/content/sql-folder-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { contentKeys } from './keys'
 
 export type UpdateSQLSnippetFolderVariables = {
@@ -37,7 +37,11 @@ export const useSQLSnippetFolderCreateMutation = ({
   invalidateQueriesOnSuccess = true,
   ...options
 }: Omit<
-  UseMutationOptions<UpdateSQLSnippetFolderData, ResponseError, UpdateSQLSnippetFolderVariables>,
+  UseCustomMutationOptions<
+    UpdateSQLSnippetFolderData,
+    ResponseError,
+    UpdateSQLSnippetFolderVariables
+  >,
   'mutationFn'
 > & {
   invalidateQueriesOnSuccess?: boolean

--- a/apps/studio/data/content/sql-folders-delete-mutation.ts
+++ b/apps/studio/data/content/sql-folders-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { contentKeys } from './keys'
 
 export type DeleteSQLSnippetFoldersVariables = {
@@ -32,7 +32,11 @@ export const useSQLSnippetFoldersDeleteMutation = ({
   invalidateQueriesOnSuccess = true,
   ...options
 }: Omit<
-  UseMutationOptions<DeleteSQLSnippetFoldersData, ResponseError, DeleteSQLSnippetFoldersVariables>,
+  UseCustomMutationOptions<
+    DeleteSQLSnippetFoldersData,
+    ResponseError,
+    DeleteSQLSnippetFoldersVariables
+  >,
   'mutationFn'
 > & {
   invalidateQueriesOnSuccess?: boolean

--- a/apps/studio/data/content/sql-folders-query.ts
+++ b/apps/studio/data/content/sql-folders-query.ts
@@ -1,8 +1,8 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { contentKeys } from './keys'
 
 export type SnippetFolderResponse = components['schemas']['GetUserContentFolderResponse']['data']
@@ -60,7 +60,7 @@ export const useSQLSnippetFoldersQuery = <TData = SQLSnippetFoldersData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<SQLSnippetFoldersData, SQLSnippetFoldersError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<SQLSnippetFoldersData, SQLSnippetFoldersError, TData> = {}
 ) =>
   useInfiniteQuery<SQLSnippetFoldersData, SQLSnippetFoldersError, TData>({
     queryKey: contentKeys.folders(projectRef, { name, sort }),

--- a/apps/studio/data/content/sql-snippets-query.ts
+++ b/apps/studio/data/content/sql-snippets-query.ts
@@ -1,6 +1,7 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { get } from 'data/fetchers'
+import { UseCustomInfiniteQueryOptions } from 'types'
 import { Content } from './content-query'
 import { contentKeys } from './keys'
 import { SNIPPET_PAGE_LIMIT } from './sql-folders-query'
@@ -61,7 +62,7 @@ export const useSqlSnippetsQuery = <TData = SqlSnippetsData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<SqlSnippetsData, SqlSnippetsError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<SqlSnippetsData, SqlSnippetsError, TData> = {}
 ) =>
   useInfiniteQuery<SqlSnippetsData, SqlSnippetsError, TData>({
     queryKey: contentKeys.sqlSnippets(projectRef, { sort, name, visibility, favorite }),

--- a/apps/studio/data/custom-domains/check-cname-mutation.ts
+++ b/apps/studio/data/custom-domains/check-cname-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { fetchHandler, handleError } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
 import { toast } from 'sonner'
 
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type CheckCNAMERecordVariables = {
   domain: string
@@ -47,7 +47,7 @@ export const useCheckCNAMERecordMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CheckCNAMERecordData, ResponseError, CheckCNAMERecordVariables>,
+  UseCustomMutationOptions<CheckCNAMERecordData, ResponseError, CheckCNAMERecordVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<CheckCNAMERecordData, ResponseError, CheckCNAMERecordVariables>({

--- a/apps/studio/data/custom-domains/custom-domains-activate-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-activate-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { customDomainKeys } from './keys'
 
 export type CustomDomainActivateVariables = {
@@ -25,7 +25,7 @@ export const useCustomDomainActivateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomDomainActivateData, ResponseError, CustomDomainActivateVariables>,
+  UseCustomMutationOptions<CustomDomainActivateData, ResponseError, CustomDomainActivateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/custom-domains/custom-domains-create-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { customDomainKeys } from './keys'
 
 export type CustomDomainCreateVariables = {
@@ -30,7 +30,7 @@ export const useCustomDomainCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomDomainCreateData, ResponseError, CustomDomainCreateVariables>,
+  UseCustomMutationOptions<CustomDomainCreateData, ResponseError, CustomDomainCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
 import { subscriptionKeys } from 'data/subscriptions/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { customDomainKeys } from './keys'
 
 export type CustomDomainDeleteVariables = {
@@ -28,7 +28,7 @@ export const useCustomDomainDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomDomainDeleteData, ResponseError, CustomDomainDeleteVariables>,
+  UseCustomMutationOptions<CustomDomainDeleteData, ResponseError, CustomDomainDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/custom-domains/custom-domains-query.ts
+++ b/apps/studio/data/custom-domains/custom-domains-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { customDomainKeys } from './keys'
 
 export type CustomDomainsVariables = {
@@ -105,7 +105,10 @@ export type CustomDomainsError = ResponseError
 
 export const useCustomDomainsQuery = <TData = CustomDomainsData>(
   { projectRef }: CustomDomainsVariables,
-  { enabled = true, ...options }: UseQueryOptions<CustomDomainsData, CustomDomainsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<CustomDomainsData, CustomDomainsError, TData> = {}
 ) => {
   const { data } = useProjectAddonsQuery({ projectRef })
   const hasCustomDomainsAddon = !!data?.selected_addons.find((x) => x.type === 'custom_domain')

--- a/apps/studio/data/custom-domains/custom-domains-reverify-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-reverify-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { customDomainKeys } from './keys'
 
 export type CustomDomainReverifyVariables = {
@@ -25,7 +25,7 @@ export const useCustomDomainReverifyMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomDomainReverifyData, ResponseError, CustomDomainReverifyVariables>,
+  UseCustomMutationOptions<CustomDomainReverifyData, ResponseError, CustomDomainReverifyVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-columns/database-column-create-mutation.ts
+++ b/apps/studio/data/database-columns/database-column-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type CreateColumnBody = {
   schema: string
@@ -65,7 +65,7 @@ export const useDatabaseColumnCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseColumnCreateData, ResponseError, DatabaseColumnCreateVariables>,
+  UseCustomMutationOptions<DatabaseColumnCreateData, ResponseError, DatabaseColumnCreateVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<DatabaseColumnCreateData, ResponseError, DatabaseColumnCreateVariables>({

--- a/apps/studio/data/database-columns/database-column-delete-mutation.ts
+++ b/apps/studio/data/database-columns/database-column-delete-mutation.ts
@@ -1,6 +1,6 @@
 import pgMeta from '@supabase/pg-meta'
 import { PGColumn } from '@supabase/pg-meta/src/pg-meta-columns'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { databaseKeys } from 'data/database/keys'
@@ -9,7 +9,7 @@ import { executeSql } from 'data/sql/execute-sql-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
 import { tableRowKeys } from 'data/table-rows/keys'
 import { viewKeys } from 'data/views/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type DatabaseColumnDeleteVariables = {
   projectRef: string
@@ -43,7 +43,7 @@ export const useDatabaseColumnDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseColumnDeleteData, ResponseError, DatabaseColumnDeleteVariables>,
+  UseCustomMutationOptions<DatabaseColumnDeleteData, ResponseError, DatabaseColumnDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-columns/database-column-update-mutation.ts
+++ b/apps/studio/data/database-columns/database-column-update-mutation.ts
@@ -1,10 +1,10 @@
 import pgMeta from '@supabase/pg-meta'
 import { PGColumn } from '@supabase/pg-meta/src/pg-meta-columns'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { CreateColumnBody } from './database-column-create-mutation'
 
 export type UpdateColumnBody = Partial<
@@ -67,7 +67,7 @@ export const useDatabaseColumnUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseColumnUpdateData, ResponseError, DatabaseColumnUpdateVariables>,
+  UseCustomMutationOptions<DatabaseColumnUpdateData, ResponseError, DatabaseColumnUpdateVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<DatabaseColumnUpdateData, ResponseError, DatabaseColumnUpdateVariables>({

--- a/apps/studio/data/database-cron-jobs/database-cron-job-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-job-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { CronJob } from './database-cron-jobs-infinite-query'
 import { databaseCronJobsKeys } from './keys'
 
@@ -40,7 +40,7 @@ export const useCronJobQuery = <TData = DatabaseCronJobData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseCronJobData, DatabaseCronJobError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseCronJobData, DatabaseCronJobError, TData> = {}
 ) =>
   useQuery<DatabaseCronJobData, DatabaseCronJobError, TData>({
     queryKey: databaseCronJobsKeys.job(projectRef, id ?? name),

--- a/apps/studio/data/database-cron-jobs/database-cron-job-run-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-job-run-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 export type DatabaseCronJobRunVariables = {
@@ -44,7 +44,7 @@ export const useDatabaseCronJobRunCommandMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseCronJobRunData, ResponseError, DatabaseCronJobRunVariables>,
+  UseCustomMutationOptions<DatabaseCronJobRunData, ResponseError, DatabaseCronJobRunVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<DatabaseCronJobRunData, ResponseError, DatabaseCronJobRunVariables>({

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-count-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-count-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 type DatabaseCronJobsCountVariables = {
@@ -33,7 +33,7 @@ export const useCronJobsCountQuery = <TData = DatabaseCronJobData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseCronJobData, DatabaseCronJobError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseCronJobData, DatabaseCronJobError, TData> = {}
 ) =>
   useQuery<DatabaseCronJobData, DatabaseCronJobError, TData>({
     queryKey: databaseCronJobsKeys.count(projectRef),

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-create-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 export type DatabaseCronJobCreateVariables = {
@@ -35,7 +35,11 @@ export const useDatabaseCronJobCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseCronJobCreateData, ResponseError, DatabaseCronJobCreateVariables>,
+  UseCustomMutationOptions<
+    DatabaseCronJobCreateData,
+    ResponseError,
+    DatabaseCronJobCreateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-delete-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 export type DatabaseCronJobDeleteVariables = {
@@ -34,7 +34,11 @@ export const useDatabaseCronJobDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseCronJobDeleteData, ResponseError, DatabaseCronJobDeleteVariables>,
+  UseCustomMutationOptions<
+    DatabaseCronJobDeleteData,
+    ResponseError,
+    DatabaseCronJobDeleteVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-infinite-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-infinite-query.ts
@@ -1,7 +1,7 @@
-import { UseInfiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 const CRON_JOBS_PAGE_LIMIT = 20
@@ -87,7 +87,7 @@ export const useCronJobsInfiniteQuery = <TData = DatabaseCronJobsInfiniteData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<
+  }: UseCustomInfiniteQueryOptions<
     DatabaseCronJobsInfiniteData,
     DatabaseCronJobsInfiniteError,
     TData

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-runs-infinite-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-runs-infinite-query.ts
@@ -1,8 +1,8 @@
-import { UseInfiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { last } from 'lodash'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 export type DatabaseCronJobRunsVariables = {
@@ -59,7 +59,7 @@ export const useCronJobRunsInfiniteQuery = <TData = DatabaseCronJobRunData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<DatabaseCronJobRunData, DatabaseCronJobError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<DatabaseCronJobRunData, DatabaseCronJobError, TData> = {}
 ) =>
   useInfiniteQuery<DatabaseCronJobRunData, DatabaseCronJobError, TData>({
     queryKey: databaseCronJobsKeys.runsInfinite(projectRef, jobId, { status }),

--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-toggle-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 export type DatabaseCronJobToggleVariables = {
@@ -36,7 +36,11 @@ export const useDatabaseCronJobToggleMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseCronJobToggleData, ResponseError, DatabaseCronJobToggleVariables>,
+  UseCustomMutationOptions<
+    DatabaseCronJobToggleData,
+    ResponseError,
+    DatabaseCronJobToggleVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-cron-jobs/database-cron-timezone-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-timezone-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseCronJobsKeys } from './keys'
 
 export type DatabaseCronJobsVariables = {
@@ -26,7 +26,7 @@ export type DatabaseCronJobError = ResponseError
 
 export const useCronTimezoneQuery = <TData = string>(
   { projectRef, connectionString }: DatabaseCronJobsVariables,
-  { enabled = true, ...options }: UseQueryOptions<string, DatabaseCronJobError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<string, DatabaseCronJobError, TData> = {}
 ) =>
   useQuery<string, DatabaseCronJobError, TData>({
     queryKey: databaseCronJobsKeys.timezone(projectRef),

--- a/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-disable-mutation.ts
@@ -1,10 +1,10 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { configKeys } from 'data/config/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseExtensionsKeys } from './keys'
 
 export type DatabaseExtensionDisableVariables = {
@@ -41,7 +41,7 @@ export const useDatabaseExtensionDisableMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabaseExtensionDisableData,
     ResponseError,
     DatabaseExtensionDisableVariables

--- a/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
+++ b/apps/studio/data/database-extensions/database-extension-enable-mutation.ts
@@ -1,11 +1,11 @@
 import pgMeta from '@supabase/pg-meta'
 import { ident } from '@supabase/pg-meta/src/pg-format'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { configKeys } from 'data/config/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseExtensionsKeys } from './keys'
 
 export type DatabaseExtensionEnableVariables = {
@@ -48,7 +48,11 @@ export const useDatabaseExtensionEnableMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseExtensionEnableData, ResponseError, DatabaseExtensionEnableVariables>,
+  UseCustomMutationOptions<
+    DatabaseExtensionEnableData,
+    ResponseError,
+    DatabaseExtensionEnableVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-extensions/database-extensions-query.ts
+++ b/apps/studio/data/database-extensions/database-extensions-query.ts
@@ -1,10 +1,10 @@
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseExtensionsKeys } from './keys'
 
 export type DatabaseExtension = components['schemas']['PostgresExtension']
@@ -50,7 +50,7 @@ export const useDatabaseExtensionsQuery = <TData = DatabaseExtensionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseExtensionsData, DatabaseExtensionsError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseExtensionsData, DatabaseExtensionsError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/database-functions/database-functions-create-mutation.ts
+++ b/apps/studio/data/database-functions/database-functions-create-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
 import pgMeta from '@supabase/pg-meta'
 import { databaseKeys } from 'data/database/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type DatabaseFunctionCreateVariables = {
   projectRef: string
@@ -37,7 +37,11 @@ export const useDatabaseFunctionCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseFunctionCreateData, ResponseError, DatabaseFunctionCreateVariables>,
+  UseCustomMutationOptions<
+    DatabaseFunctionCreateData,
+    ResponseError,
+    DatabaseFunctionCreateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-functions/database-functions-delete-mutation.ts
+++ b/apps/studio/data/database-functions/database-functions-delete-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
 import pgMeta from '@supabase/pg-meta'
 import { databaseKeys } from 'data/database/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { DatabaseFunction } from './database-functions-query'
 
 export type DatabaseFunctionDeleteVariables = {
@@ -38,7 +38,11 @@ export const useDatabaseFunctionDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseFunctionDeleteData, ResponseError, DatabaseFunctionDeleteVariables>,
+  UseCustomMutationOptions<
+    DatabaseFunctionDeleteData,
+    ResponseError,
+    DatabaseFunctionDeleteVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-functions/database-functions-query.ts
+++ b/apps/studio/data/database-functions/database-functions-query.ts
@@ -1,8 +1,8 @@
 import pgMeta from '@supabase/pg-meta'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { databaseKeys } from 'data/database/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { z } from 'zod'
 
 export type DatabaseFunctionsVariables = {
@@ -43,7 +43,7 @@ export const useDatabaseFunctionsQuery = <TData = DatabaseFunctionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseFunctionsData, DatabaseFunctionsError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseFunctionsData, DatabaseFunctionsError, TData> = {}
 ) =>
   useQuery<DatabaseFunctionsData, DatabaseFunctionsError, TData>({
     queryKey: databaseKeys.databaseFunctions(projectRef),

--- a/apps/studio/data/database-functions/database-functions-update-mutation.ts
+++ b/apps/studio/data/database-functions/database-functions-update-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
 import pgMeta from '@supabase/pg-meta'
 import { databaseKeys } from 'data/database/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { DatabaseFunction } from './database-functions-query'
 
 export type DatabaseFunctionUpdateVariables = {
@@ -40,7 +40,11 @@ export const useDatabaseFunctionUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseFunctionUpdateData, ResponseError, DatabaseFunctionUpdateVariables>,
+  UseCustomMutationOptions<
+    DatabaseFunctionUpdateData,
+    ResponseError,
+    DatabaseFunctionUpdateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseIndexesKeys } from './keys'
 
 export type DatabaseIndexCreateVariables = {
@@ -46,7 +46,7 @@ export const useDatabaseIndexCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseIndexCreateData, ResponseError, DatabaseIndexCreateVariables>,
+  UseCustomMutationOptions<DatabaseIndexCreateData, ResponseError, DatabaseIndexCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseIndexesKeys } from './keys'
 
 export type DatabaseIndexDeleteVariables = {
@@ -37,7 +37,7 @@ export const useDatabaseIndexDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseIndexDeleteData, ResponseError, DatabaseIndexDeleteVariables>,
+  UseCustomMutationOptions<DatabaseIndexDeleteData, ResponseError, DatabaseIndexDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-indexes/indexes-query.ts
+++ b/apps/studio/data/database-indexes/indexes-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseIndexesKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 type GetIndexesArgs = {
   schema?: string
@@ -55,7 +56,7 @@ export type IndexesError = ExecuteSqlError
 
 export const useIndexesQuery = <TData = IndexesData>(
   { projectRef, connectionString, schema }: IndexesVariables,
-  { enabled = true, ...options }: UseQueryOptions<IndexesData, IndexesError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<IndexesData, IndexesError, TData> = {}
 ) =>
   useQuery<IndexesData, IndexesError, TData>({
     queryKey: databaseIndexesKeys.list(projectRef, schema),

--- a/apps/studio/data/database-policies/database-policies-query.ts
+++ b/apps/studio/data/database-policies/database-policies-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { get, handleError } from 'data/fetchers'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databasePoliciesKeys } from './keys'
 
 export type DatabasePoliciesVariables = {
@@ -51,7 +51,7 @@ export const useDatabasePoliciesQuery = <TData = DatabasePoliciesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabasePoliciesData, DatabasePoliciesError, TData> = {}
+  }: UseCustomQueryOptions<DatabasePoliciesData, DatabasePoliciesError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/database-policies/database-policy-create-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databasePoliciesKeys } from './keys'
 
 type CreatePolicyBody = {
@@ -49,7 +49,7 @@ export const useDatabasePolicyCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabasePolicyCreateData, ResponseError, DatabasePolicyCreateVariables>,
+  UseCustomMutationOptions<DatabasePolicyCreateData, ResponseError, DatabasePolicyCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-policies/database-policy-delete-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-delete-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databasePoliciesKeys } from './keys'
 
 export type DatabasePolicyDeleteVariables = {
@@ -43,7 +43,7 @@ export const useDatabasePolicyDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabasePolicyDeleteData, ResponseError, DatabasePolicyDeleteVariables>,
+  UseCustomMutationOptions<DatabasePolicyDeleteData, ResponseError, DatabasePolicyDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-policies/database-policy-update-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-update-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databasePoliciesKeys } from './keys'
 
 export type DatabasePolicyUpdateVariables = {
@@ -50,7 +50,7 @@ export const useDatabasePolicyUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabasePolicyUpdateData, ResponseError, DatabasePolicyUpdateVariables>,
+  UseCustomMutationOptions<DatabasePolicyUpdateData, ResponseError, DatabasePolicyUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-publications/database-publications-create-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databasePublicationsKeys } from './keys'
 
 export type DatabasePublicationCreateVariables = {
@@ -53,7 +53,7 @@ export const useDatabasePublicationCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabasePublicationCreateData,
     ResponseError,
     DatabasePublicationCreateVariables

--- a/apps/studio/data/database-publications/database-publications-query.ts
+++ b/apps/studio/data/database-publications/database-publications-query.ts
@@ -1,8 +1,8 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
-import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
-import { databasePublicationsKeys } from './keys'
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import { useQuery } from '@tanstack/react-query'
+import { get, handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { databasePublicationsKeys } from './keys'
 
 export type DatabasePublicationsVariables = {
   projectRef?: string
@@ -44,7 +44,7 @@ export const useDatabasePublicationsQuery = <TData = DatabasePublicationsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabasePublicationsData, DatabasePublicationsError, TData> = {}
+  }: UseCustomQueryOptions<DatabasePublicationsData, DatabasePublicationsError, TData> = {}
 ) =>
   useQuery<DatabasePublicationsData, DatabasePublicationsError, TData>({
     queryKey: databasePublicationsKeys.list(projectRef),

--- a/apps/studio/data/database-publications/database-publications-update-mutation.ts
+++ b/apps/studio/data/database-publications/database-publications-update-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databasePublicationsKeys } from './keys'
 
 export type DatabasePublicationUpdateVariables = {
@@ -52,7 +52,7 @@ export const useDatabasePublicationUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabasePublicationUpdateData,
     ResponseError,
     DatabasePublicationUpdateVariables

--- a/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageArchiveVariables = {
@@ -35,7 +35,7 @@ export const useDatabaseQueueMessageArchiveMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabaseQueueMessageArchiveData,
     ResponseError,
     DatabaseQueueMessageArchiveVariables

--- a/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageDeleteVariables = {
@@ -35,7 +35,7 @@ export const useDatabaseQueueMessageDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabaseQueueMessageDeleteData,
     ResponseError,
     DatabaseQueueMessageDeleteVariables

--- a/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
@@ -1,11 +1,11 @@
-import { UseInfiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { last } from 'lodash'
 
 import { QUEUE_MESSAGE_TYPE } from 'components/interfaces/Integrations/Queues/SingleQueue/Queue.utils'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { DATE_FORMAT } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueVariables = {
@@ -80,7 +80,7 @@ export const useQueueMessagesInfiniteQuery = <TData = DatabaseQueueData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
 ) =>
   useInfiniteQuery<DatabaseQueueData, DatabaseQueueError, TData>({
     queryKey: databaseQueuesKeys.getMessagesInfinite(projectRef, queueName, { status }),

--- a/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageReadVariables = {
@@ -37,7 +37,7 @@ export const useDatabaseQueueMessageReadMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabaseQueueMessageReadData,
     ResponseError,
     DatabaseQueueMessageReadVariables

--- a/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageSendVariables = {
@@ -37,7 +37,7 @@ export const useDatabaseQueueMessageSendMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabaseQueueMessageSendData,
     ResponseError,
     DatabaseQueueMessageSendVariables

--- a/apps/studio/data/database-queues/database-queues-create-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import { tableKeys } from 'data/tables/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueCreateVariables = {
@@ -52,7 +52,7 @@ export const useDatabaseQueueCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseQueueCreateData, ResponseError, DatabaseQueueCreateVariables>,
+  UseCustomMutationOptions<DatabaseQueueCreateData, ResponseError, DatabaseQueueCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-queues/database-queues-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueDeleteVariables = {
@@ -33,7 +33,7 @@ export const useDatabaseQueueDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseQueueDeleteData, ResponseError, DatabaseQueueDeleteVariables>,
+  UseCustomMutationOptions<DatabaseQueueDeleteData, ResponseError, DatabaseQueueDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-queues/database-queues-expose-postgrest-status-query.ts
+++ b/apps/studio/data/database-queues/database-queues-expose-postgrest-status-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import minify from 'pg-minify'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { QUEUES_SCHEMA } from './database-queues-toggle-postgrest-mutation'
 import { databaseQueuesKeys } from './keys'
 
@@ -35,7 +35,10 @@ export type DatabaseQueueError = ResponseError
 
 export const useQueuesExposePostgrestStatusQuery = <TData = DatabaseQueueData>(
   { projectRef, connectionString }: DatabaseQueuesVariables,
-  { enabled = true, ...options }: UseQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
 ) =>
   useQuery<DatabaseQueueData, DatabaseQueueError, TData>({
     queryKey: databaseQueuesKeys.exposePostgrestStatus(projectRef),

--- a/apps/studio/data/database-queues/database-queues-metrics-query.ts
+++ b/apps/studio/data/database-queues/database-queues-metrics-query.ts
@@ -1,6 +1,6 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueuesMetricsVariables = {
@@ -77,7 +77,7 @@ export const useQueuesMetricsQuery = <TData = DatabaseQueuesMetricsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseQueuesMetricsData, DatabaseQueuesMetricsError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseQueuesMetricsData, DatabaseQueuesMetricsError, TData> = {}
 ) =>
   useQuery<DatabaseQueuesMetricsData, DatabaseQueuesMetricsError, TData>({
     queryKey: databaseQueuesKeys.metrics(projectRef, queueName),

--- a/apps/studio/data/database-queues/database-queues-purge-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-purge-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueuePurgeVariables = {
@@ -33,7 +33,7 @@ export const useDatabaseQueuePurgeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseQueuePurgeData, ResponseError, DatabaseQueuePurgeVariables>,
+  UseCustomMutationOptions<DatabaseQueuePurgeData, ResponseError, DatabaseQueuePurgeVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-queues/database-queues-query.ts
+++ b/apps/studio/data/database-queues/database-queues-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueuesVariables = {
@@ -33,7 +33,10 @@ export type DatabaseQueueError = ResponseError
 
 export const useQueuesQuery = <TData = DatabaseQueueData>(
   { projectRef, connectionString }: DatabaseQueuesVariables,
-  { enabled = true, ...options }: UseQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DatabaseQueueData, DatabaseQueueError, TData> = {}
 ) =>
   useQuery<DatabaseQueueData, DatabaseQueueError, TData>({
     queryKey: databaseQueuesKeys.list(projectRef),

--- a/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import minify from 'pg-minify'
 import { toast } from 'sonner'
 
 import { databaseKeys } from 'data/database/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { isGreaterThanOrEqual } from 'lib/semver'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueExposePostgrestVariables = {
@@ -258,7 +258,7 @@ export const useDatabaseQueueToggleExposeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DatabaseQueueExposePostgrestData,
     ResponseError,
     DatabaseQueueExposePostgrestVariables

--- a/apps/studio/data/database-roles/database-role-create-mutation.ts
+++ b/apps/studio/data/database-roles/database-role-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { invalidateRolesQuery } from './database-roles-query'
 
 type CreateRoleBody = Parameters<typeof pgMeta.roles.create>[0]
@@ -36,7 +36,7 @@ export const useDatabaseRoleCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseRoleCreateData, ResponseError, DatabaseRoleCreateVariables>,
+  UseCustomMutationOptions<DatabaseRoleCreateData, ResponseError, DatabaseRoleCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-roles/database-role-delete-mutation.ts
+++ b/apps/studio/data/database-roles/database-role-delete-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { invalidateRolesQuery } from './database-roles-query'
 
 type DropRoleBody = Parameters<typeof pgMeta.roles.remove>[1]
@@ -38,7 +38,7 @@ export const useDatabaseRoleDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseRoleDeleteData, ResponseError, DatabaseRoleDeleteVariables>,
+  UseCustomMutationOptions<DatabaseRoleDeleteData, ResponseError, DatabaseRoleDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-roles/database-role-update-mutation.ts
+++ b/apps/studio/data/database-roles/database-role-update-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { invalidateRolesQuery } from './database-roles-query'
 
 type UpdateRoleBody = Parameters<typeof pgMeta.roles.update>[1]
@@ -38,7 +38,7 @@ export const useDatabaseRoleUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseRoleUpdateData, ResponseError, DatabaseRoleUpdateVariables>,
+  UseCustomMutationOptions<DatabaseRoleUpdateData, ResponseError, DatabaseRoleUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-roles/database-roles-query.ts
+++ b/apps/studio/data/database-roles/database-roles-query.ts
@@ -1,8 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { UseCustomQueryOptions } from 'types'
 import { databaseRoleKeys } from './keys'
 
 export type DatabaseRolesVariables = {
@@ -31,7 +32,10 @@ export type DatabaseRolesError = ExecuteSqlError
 
 export const useDatabaseRolesQuery = <TData = DatabaseRolesData>(
   { projectRef, connectionString }: DatabaseRolesVariables,
-  { enabled = true, ...options }: UseQueryOptions<DatabaseRolesData, DatabaseRolesError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DatabaseRolesData, DatabaseRolesError, TData> = {}
 ) =>
   useQuery<DatabaseRolesData, DatabaseRolesError, TData>({
     queryKey: databaseRoleKeys.databaseRoles(projectRef),

--- a/apps/studio/data/database-triggers/database-trigger-create-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
 import { PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseTriggerKeys } from './keys'
 
 export type DatabaseTriggerCreateVariables = {
@@ -36,7 +36,11 @@ export const useDatabaseTriggerCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseTriggerCreateData, ResponseError, DatabaseTriggerCreateVariables>,
+  UseCustomMutationOptions<
+    DatabaseTriggerCreateData,
+    ResponseError,
+    DatabaseTriggerCreateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-delete-mutation.ts
@@ -1,8 +1,8 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseTriggerKeys } from './keys'
 
 export type DatabaseTriggerDeleteVariables = {
@@ -40,7 +40,11 @@ export const useDatabaseTriggerDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseTriggerDeleteData, ResponseError, DatabaseTriggerDeleteVariables>,
+  UseCustomMutationOptions<
+    DatabaseTriggerDeleteData,
+    ResponseError,
+    DatabaseTriggerDeleteVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
 import { PGTriggerUpdate } from '@supabase/pg-meta/src/pg-meta-triggers'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseTriggerKeys } from './keys'
 
 export type DatabaseTriggerUpdateVariables = {
@@ -43,7 +43,11 @@ export const useDatabaseTriggerUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseTriggerUpdateData, ResponseError, DatabaseTriggerUpdateVariables>,
+  UseCustomMutationOptions<
+    DatabaseTriggerUpdateData,
+    ResponseError,
+    DatabaseTriggerUpdateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
+++ b/apps/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { PGTrigger, PGTriggerCreate } from '@supabase/pg-meta/src/pg-meta-triggers'
 import { PostgresTrigger } from '@supabase/postgres-meta'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { quoteLiteral } from 'lib/pg-format'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseTriggerKeys } from './keys'
 
 // [Joshen] Writing this query within FE as the PATCH endpoint from pg-meta only supports updating
@@ -58,7 +58,11 @@ export const useDatabaseTriggerUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabaseTriggerUpdateTxnData, ResponseError, DatabaseTriggerUpdateVariables>,
+  UseCustomMutationOptions<
+    DatabaseTriggerUpdateTxnData,
+    ResponseError,
+    DatabaseTriggerUpdateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database-triggers/database-triggers-query.ts
+++ b/apps/studio/data/database-triggers/database-triggers-query.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseTriggerKeys } from './keys'
 
 export type DatabaseTriggersVariables = {
@@ -43,7 +43,7 @@ export const useDatabaseHooksQuery = <TData = DatabaseTriggersData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseTriggersData, DatabaseTriggersError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseTriggersData, DatabaseTriggersError, TData> = {}
 ) =>
   useQuery<DatabaseTriggersData, DatabaseTriggersError, TData>({
     queryKey: databaseTriggerKeys.list(projectRef),
@@ -65,7 +65,7 @@ export const useDatabaseTriggersQuery = <TData = DatabaseTriggersData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DatabaseTriggersData, DatabaseTriggersError, TData> = {}
+  }: UseCustomQueryOptions<DatabaseTriggersData, DatabaseTriggersError, TData> = {}
 ) =>
   useQuery<DatabaseTriggersData, DatabaseTriggersError, TData>({
     queryKey: databaseTriggerKeys.list(projectRef),

--- a/apps/studio/data/database/backup-download-mutation.ts
+++ b/apps/studio/data/database/backup-download-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
 import { components } from 'api-types'
+import { handleError, post } from 'data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type BackupDownloadVariables = {
   ref: string
@@ -28,7 +28,7 @@ export const useBackupDownloadMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BackupDownloadData, ResponseError, BackupDownloadVariables>,
+  UseCustomMutationOptions<BackupDownloadData, ResponseError, BackupDownloadVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<BackupDownloadData, ResponseError, BackupDownloadVariables>({

--- a/apps/studio/data/database/backup-query.ts
+++ b/apps/studio/data/database/backup-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type DownloadableBackupVariables = {
@@ -31,7 +31,7 @@ export const useDownloadableBackupQuery = <TData = DownloadableBackupData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<DownloadableBackupData, DownloadableBackupError, TData> = {}
+  }: UseCustomQueryOptions<DownloadableBackupData, DownloadableBackupError, TData> = {}
 ) =>
   useQuery<DownloadableBackupData, DownloadableBackupError, TData>({
     queryKey: databaseKeys.backups(projectRef),

--- a/apps/studio/data/database/backup-restore-mutation.ts
+++ b/apps/studio/data/database/backup-restore-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type BackupRestoreVariables = {
   ref: string
@@ -38,7 +38,7 @@ export const useBackupRestoreMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BackupRestoreData, ResponseError, BackupRestoreVariables>,
+  UseCustomMutationOptions<BackupRestoreData, ResponseError, BackupRestoreVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<BackupRestoreData, ResponseError, BackupRestoreVariables>({

--- a/apps/studio/data/database/backups-query.ts
+++ b/apps/studio/data/database/backups-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { useIsOrioleDbInAws } from 'hooks/misc/useSelectedProject'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type BackupsVariables = {
@@ -29,7 +29,7 @@ export type BackupsError = ResponseError
 
 export const useBackupsQuery = <TData = BackupsData>(
   { projectRef }: BackupsVariables,
-  { enabled = true, ...options }: UseQueryOptions<BackupsData, BackupsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<BackupsData, BackupsError, TData> = {}
 ) => {
   // [Joshen] Check for specifically false to account for project not loaded yet
   const isOrioleDbInAws = useIsOrioleDbInAws()

--- a/apps/studio/data/database/constraints-query.ts
+++ b/apps/studio/data/database/constraints-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 type GetTableConstraintsVariables = {
   id?: number
@@ -75,7 +76,7 @@ export const useTableConstraintsQuery = <TData = TableConstraintsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<TableConstraintsData, TableConstraintsError, TData> = {}
+  }: UseCustomQueryOptions<TableConstraintsData, TableConstraintsError, TData> = {}
 ) =>
   useQuery<TableConstraintsData, TableConstraintsError, TData>({
     queryKey: databaseKeys.tableConstraints(projectRef, id),

--- a/apps/studio/data/database/database-password-reset-mutation.ts
+++ b/apps/studio/data/database/database-password-reset-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
 import { projectKeys } from 'data/projects/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type DatabasePasswordResetVariables = {
   ref: string
@@ -29,7 +29,11 @@ export const useDatabasePasswordResetMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DatabasePasswordResetData, ResponseError, DatabasePasswordResetVariables>,
+  UseCustomMutationOptions<
+    DatabasePasswordResetData,
+    ResponseError,
+    DatabasePasswordResetVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database/database-size-query.ts
+++ b/apps/studio/data/database/database-size-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export const getDatabaseSizeSql = () => {
   const sql = /* SQL */ `
@@ -44,7 +45,10 @@ export type DatabaseSizeError = ExecuteSqlError
 
 export const useDatabaseSizeQuery = <TData = DatabaseSizeData>(
   { projectRef, connectionString }: DatabaseSizeVariables,
-  { enabled = true, ...options }: UseQueryOptions<DatabaseSizeData, DatabaseSizeError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DatabaseSizeData, DatabaseSizeError, TData> = {}
 ) =>
   useQuery<DatabaseSizeData, DatabaseSizeError, TData>({
     queryKey: databaseKeys.databaseSize(projectRef),

--- a/apps/studio/data/database/enable-physical-backups-mutation.ts
+++ b/apps/studio/data/database/enable-physical-backups-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type EnablePhysicalBackupsVariables = {
   ref: string
@@ -23,7 +23,7 @@ export const useEnablePhysicalBackupsMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BackupRestoreData, ResponseError, EnablePhysicalBackupsVariables>,
+  UseCustomMutationOptions<BackupRestoreData, ResponseError, EnablePhysicalBackupsVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<BackupRestoreData, ResponseError, EnablePhysicalBackupsVariables>({

--- a/apps/studio/data/database/entity-definitions-query.ts
+++ b/apps/studio/data/database/entity-definitions-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { CREATE_PG_GET_TABLEDEF_SQL } from './database-table-definition'
 import { databaseKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export const getEntityDefinitionsSql = ({
   schemas,
@@ -109,7 +110,7 @@ export const useEntityDefinitionsQuery = <TData = EntityDefinitionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<EntityDefinitionsData, EntityDefinitionsError, TData> = {}
+  }: UseCustomQueryOptions<EntityDefinitionsData, EntityDefinitionsError, TData> = {}
 ) =>
   useQuery<EntityDefinitionsData, EntityDefinitionsError, TData>({
     queryKey: databaseKeys.entityDefinitions(projectRef, schemas),

--- a/apps/studio/data/database/foreign-key-constraints-query.ts
+++ b/apps/studio/data/database/foreign-key-constraints-query.ts
@@ -1,7 +1,8 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 type GetForeignKeyConstraintsVariables = {
   schema?: string
@@ -132,7 +133,7 @@ export const useForeignKeyConstraintsQuery = <TData = ForeignKeyConstraintsData>
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ForeignKeyConstraintsData, ForeignKeyConstraintsError, TData> = {}
+  }: UseCustomQueryOptions<ForeignKeyConstraintsData, ForeignKeyConstraintsError, TData> = {}
 ) =>
   useQuery<ForeignKeyConstraintsData, ForeignKeyConstraintsError, TData>({
     queryKey: databaseKeys.foreignKeyConstraints(projectRef, schema),

--- a/apps/studio/data/database/hooks-enable-mutation.ts
+++ b/apps/studio/data/database/hooks-enable-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { invalidateSchemasQuery } from './schemas-query'
 
 export type HooksEnableVariables = {
@@ -24,7 +24,7 @@ export const useHooksEnableMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<HooksEnableData, ResponseError, HooksEnableVariables>,
+  UseCustomMutationOptions<HooksEnableData, ResponseError, HooksEnableVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database/keywords-query.ts
+++ b/apps/studio/data/database/keywords-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export const getKeywordsSql = () => {
   const sql = /* SQL */ `
@@ -34,7 +35,7 @@ export type KeywordsError = ExecuteSqlError
 
 export const useKeywordsQuery = <TData = KeywordsData>(
   { projectRef, connectionString }: KeywordsVariables,
-  { enabled = true, ...options }: UseQueryOptions<KeywordsData, KeywordsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<KeywordsData, KeywordsError, TData> = {}
 ) =>
   useQuery<KeywordsData, KeywordsError, TData>({
     queryKey: databaseKeys.keywords(projectRef),

--- a/apps/studio/data/database/max-connections-query.ts
+++ b/apps/studio/data/database/max-connections-query.ts
@@ -1,4 +1,5 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { UseCustomQueryOptions } from 'types'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
 
@@ -39,7 +40,7 @@ export const useMaxConnectionsQuery = <TData = MaxConnectionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<MaxConnectionsData, MaxConnectionsError, TData> = {}
+  }: UseCustomQueryOptions<MaxConnectionsData, MaxConnectionsError, TData> = {}
 ) =>
   useQuery<MaxConnectionsData, MaxConnectionsError, TData>({
     queryKey: databaseKeys.maxConnections(projectRef),

--- a/apps/studio/data/database/migration-upsert-mutation.ts
+++ b/apps/studio/data/database/migration-upsert-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type MigrationUpsertVariables = {
@@ -45,7 +45,7 @@ export const useMigrationUpsertMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<MigrationUpsertData, ResponseError, MigrationUpsertVariables>,
+  UseCustomMutationOptions<MigrationUpsertData, ResponseError, MigrationUpsertVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database/migrations-query.ts
+++ b/apps/studio/data/database/migrations-query.ts
@@ -1,4 +1,5 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { UseCustomQueryOptions } from 'types'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
 
@@ -55,7 +56,7 @@ export type MigrationsError = ExecuteSqlError
 
 export const useMigrationsQuery = <TData = MigrationsData>(
   { projectRef, connectionString }: MigrationsVariables,
-  { enabled = true, ...options }: UseQueryOptions<MigrationsData, MigrationsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<MigrationsData, MigrationsError, TData> = {}
 ) =>
   useQuery<MigrationsData, MigrationsError, TData>({
     queryKey: databaseKeys.migrations(projectRef),

--- a/apps/studio/data/database/pgbouncer-config-query.ts
+++ b/apps/studio/data/database/pgbouncer-config-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type PgbouncerConfigVariables = {
@@ -31,7 +31,7 @@ export const usePgbouncerConfigQuery = <TData = PgbouncerConfigData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<PgbouncerConfigData, PgbouncerConfigError, TData> = {}
+  }: UseCustomQueryOptions<PgbouncerConfigData, PgbouncerConfigError, TData> = {}
 ) =>
   useQuery<PgbouncerConfigData, PgbouncerConfigError, TData>({
     queryKey: databaseKeys.pgbouncerConfig(projectRef),

--- a/apps/studio/data/database/pgbouncer-config-update-mutation.ts
+++ b/apps/studio/data/database/pgbouncer-config-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type PgbouncerConfigurationUpdateVariables = {
@@ -41,7 +41,7 @@ export const usePgbouncerConfigurationUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     PgbouncerConfigurationUpdateData,
     ResponseError,
     PgbouncerConfigurationUpdateVariables

--- a/apps/studio/data/database/pgbouncer-status-query.ts
+++ b/apps/studio/data/database/pgbouncer-status-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type PgbouncerStatusVariables = {
@@ -30,7 +30,7 @@ export const usePgbouncerStatusQuery = <TData = PgbouncerStatusData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<PgbouncerStatusData, PgbouncerStatusError, TData> = {}
+  }: UseCustomQueryOptions<PgbouncerStatusData, PgbouncerStatusError, TData> = {}
 ) =>
   useQuery<PgbouncerStatusData, PgbouncerStatusError, TData>({
     queryKey: databaseKeys.pgbouncerStatus(projectRef),

--- a/apps/studio/data/database/pitr-restore-mutation.ts
+++ b/apps/studio/data/database/pitr-restore-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type PitrRestoreVariables = {
   ref: string
@@ -25,7 +25,7 @@ export const usePitrRestoreMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<PitrRestoreData, ResponseError, PitrRestoreVariables>,
+  UseCustomMutationOptions<PitrRestoreData, ResponseError, PitrRestoreVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<PitrRestoreData, ResponseError, PitrRestoreVariables>({

--- a/apps/studio/data/database/primary-keys-exists-query.ts
+++ b/apps/studio/data/database/primary-keys-exists-query.ts
@@ -1,8 +1,8 @@
 import { getCheckPrimaryKeysExistsSQL } from '@supabase/pg-meta/src/sql/studio/check-primary-keys-exists'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 type CheckPrimaryKeysExistsVariables = {
@@ -44,7 +44,7 @@ export const useCheckPrimaryKeysExists = <TData = CheckPrimaryKeysExistsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<CheckPrimaryKeysExistsData, CheckPrimaryKeysExistsError, TData> = {}
+  }: UseCustomQueryOptions<CheckPrimaryKeysExistsData, CheckPrimaryKeysExistsError, TData> = {}
 ) =>
   useQuery<CheckPrimaryKeysExistsData, CheckPrimaryKeysExistsError, TData>({
     queryKey: databaseKeys.checkPrimaryKeysExists(projectRef, tables),

--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type GetIndexAdvisorResultVariables = {
@@ -45,7 +45,7 @@ export const useGetIndexAdvisorResult = <TData = GetIndexAdvisorResultData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<GetIndexAdvisorResultData, GetIndexAdvisorResultError, TData> = {}
+  }: UseCustomQueryOptions<GetIndexAdvisorResultData, GetIndexAdvisorResultError, TData> = {}
 ) =>
   useQuery<GetIndexAdvisorResultData, GetIndexAdvisorResultError, TData>({
     queryKey: databaseKeys.indexAdvisorFromQuery(projectRef, query),

--- a/apps/studio/data/database/retrieve-index-from-select-query.ts
+++ b/apps/studio/data/database/retrieve-index-from-select-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type GetInvolvedIndexesFromSelectQueryVariables = {
@@ -132,7 +132,7 @@ export const useGetIndexesFromSelectQuery = <TData = GetInvolvedIndexesFromSelec
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<
+  }: UseCustomQueryOptions<
     GetInvolvedIndexesFromSelectQueryData,
     GetInvolvedIndexesFromSelectQueryError,
     TData

--- a/apps/studio/data/database/schema-create-mutation.ts
+++ b/apps/studio/data/database/schema-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { invalidateSchemasQuery } from './schemas-query'
 
 export type SchemaCreateVariables = {
@@ -30,7 +30,7 @@ export const useSchemaCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SchemaCreateData, ResponseError, SchemaCreateVariables>,
+  UseCustomMutationOptions<SchemaCreateData, ResponseError, SchemaCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/database/schemas-query.ts
+++ b/apps/studio/data/database/schemas-query.ts
@@ -1,8 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 export type SchemasVariables = {
@@ -36,7 +37,7 @@ export async function getSchemas(
 
 export const useSchemasQuery = <TData = SchemasData>(
   { projectRef, connectionString }: SchemasVariables,
-  { enabled = true, ...options }: UseQueryOptions<SchemasData, SchemasError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<SchemasData, SchemasError, TData> = {}
 ) =>
   useQuery<SchemasData, SchemasError, TData>({
     queryKey: databaseKeys.schemas(projectRef),

--- a/apps/studio/data/database/supavisor-configuration-query.ts
+++ b/apps/studio/data/database/supavisor-configuration-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { databaseKeys } from './keys'
 
 type SupavisorConfigurationVariables = {
@@ -31,7 +31,7 @@ export const useSupavisorConfigurationQuery = <TData = SupavisorConfigurationDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<SupavisorConfigurationData, SupavisorConfigurationError, TData> = {}
+  }: UseCustomQueryOptions<SupavisorConfigurationData, SupavisorConfigurationError, TData> = {}
 ) =>
   useQuery<SupavisorConfigurationData, SupavisorConfigurationError, TData>({
     queryKey: databaseKeys.poolingConfiguration(projectRef),

--- a/apps/studio/data/database/supavisor-configuration-update-mutation.ts
+++ b/apps/studio/data/database/supavisor-configuration-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { databaseKeys } from './keys'
 
 type SupavisorConfigurationUpdateVariables = {
@@ -32,7 +32,7 @@ export const useSupavisorConfigurationUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     SupavisorConfigurationUpdateData,
     ResponseError,
     SupavisorConfigurationUpdateVariables

--- a/apps/studio/data/database/table-columns-query.ts
+++ b/apps/studio/data/database/table-columns-query.ts
@@ -1,4 +1,5 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { UseCustomQueryOptions } from 'types'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
 
@@ -111,7 +112,10 @@ export type TableColumnsError = ExecuteSqlError
 
 export const useTableColumnsQuery = <TData = TableColumnsData>(
   { projectRef, connectionString, schema, table }: TableColumnsVariables,
-  { enabled = true, ...options }: UseQueryOptions<TableColumnsData, TableColumnsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<TableColumnsData, TableColumnsError, TData> = {}
 ) =>
   useQuery<TableColumnsData, TableColumnsError, TData>({
     queryKey: databaseKeys.tableColumns(projectRef, schema, table),

--- a/apps/studio/data/database/table-definition-query.ts
+++ b/apps/studio/data/database/table-definition-query.ts
@@ -1,4 +1,5 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { UseCustomQueryOptions } from 'types'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { CREATE_PG_GET_TABLEDEF_SQL } from './database-table-definition'
 import { databaseKeys } from './keys'
@@ -68,7 +69,7 @@ export const useTableDefinitionQuery = <TData = TableDefinitionData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<TableDefinitionData, TableDefinitionError, TData> = {}
+  }: UseCustomQueryOptions<TableDefinitionData, TableDefinitionError, TData> = {}
 ) =>
   useQuery<TableDefinitionData, TableDefinitionError, TData>({
     queryKey: databaseKeys.tableDefinition(projectRef, id),

--- a/apps/studio/data/database/view-definition-query.ts
+++ b/apps/studio/data/database/view-definition-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { databaseKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 type GetViewDefinitionArgs = {
   id?: number
@@ -60,7 +61,7 @@ export const useViewDefinitionQuery = <TData = ViewDefinitionData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ViewDefinitionData, ViewDefinitionError, TData> = {}
+  }: UseCustomQueryOptions<ViewDefinitionData, ViewDefinitionError, TData> = {}
 ) =>
   useQuery<ViewDefinitionData, ViewDefinitionError, TData>({
     queryKey: databaseKeys.viewDefinition(projectRef, id),

--- a/apps/studio/data/docs/project-json-schema-query.ts
+++ b/apps/studio/data/docs/project-json-schema-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { docsKeys } from './keys'
 
 export type ProjectJsonSchemaVariables = {
@@ -93,7 +93,7 @@ export const useProjectJsonSchemaQuery = <TData = ProjectJsonSchemaData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectJsonSchemaData, ProjectJsonSchemaError, TData> = {}
+  }: UseCustomQueryOptions<ProjectJsonSchemaData, ProjectJsonSchemaError, TData> = {}
 ) =>
   useQuery<ProjectJsonSchemaData, ProjectJsonSchemaError, TData>({
     queryKey: docsKeys.jsonSchema(projectRef),

--- a/apps/studio/data/documents/document-query.ts
+++ b/apps/studio/data/documents/document-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { documentKeys } from './keys'
 
 export type DocType = 'standard-security-questionnaire' | 'soc2-type-2-report'
@@ -45,7 +45,7 @@ export type DocumentError = ResponseError
 
 export const useDocumentQuery = <TData = DocumentData>(
   { orgSlug, docType }: DocumentVariables,
-  { enabled = true, ...options }: UseQueryOptions<DocumentData, DocumentError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<DocumentData, DocumentError, TData> = {}
 ) =>
   useQuery<DocumentData, DocumentError, TData>({
     queryKey: documentKeys.resource(orgSlug, docType),

--- a/apps/studio/data/documents/dpa-request-mutation.ts
+++ b/apps/studio/data/documents/dpa-request-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { post, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import { handleError, post } from 'data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type DpaRequestVariables = {
   recipient_email: string
@@ -25,7 +25,7 @@ export const useDpaRequestMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DpaRequestData, ResponseError, DpaRequestVariables>,
+  UseCustomMutationOptions<DpaRequestData, ResponseError, DpaRequestVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<DpaRequestData, ResponseError, DpaRequestVariables>({

--- a/apps/studio/data/edge-functions/edge-function-body-query.ts
+++ b/apps/studio/data/edge-functions/edge-function-body-query.ts
@@ -1,8 +1,8 @@
 import { getMultipartBoundary, parseMultipartStream } from '@mjackson/multipart-parser'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { edgeFunctionsKeys } from './keys'
 
 export type EdgeFunctionBodyVariables = {
@@ -81,7 +81,7 @@ export const useEdgeFunctionBodyQuery = <TData = EdgeFunctionBodyData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<EdgeFunctionBodyData, EdgeFunctionBodyError, TData> = {}
+  }: UseCustomQueryOptions<EdgeFunctionBodyData, EdgeFunctionBodyError, TData> = {}
 ) =>
   useQuery<EdgeFunctionBodyData, EdgeFunctionBodyError, TData>({
     queryKey: edgeFunctionsKeys.body(projectRef, slug),

--- a/apps/studio/data/edge-functions/edge-function-query.ts
+++ b/apps/studio/data/edge-functions/edge-function-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { edgeFunctionsKeys } from './keys'
 
 export type EdgeFunctionVariables = {
@@ -33,7 +33,10 @@ export type EdgeFunctionError = ResponseError
 
 export const useEdgeFunctionQuery = <TData = EdgeFunctionData>(
   { projectRef, slug }: EdgeFunctionVariables,
-  { enabled = true, ...options }: UseQueryOptions<EdgeFunctionData, EdgeFunctionError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<EdgeFunctionData, EdgeFunctionError, TData> = {}
 ) =>
   useQuery<EdgeFunctionData, EdgeFunctionError, TData>({
     queryKey: edgeFunctionsKeys.detail(projectRef, slug),

--- a/apps/studio/data/edge-functions/edge-function-test-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-function-test-mutation.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { ResponseData } from 'components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.types'
 import { constructHeaders, fetchHandler } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type EdgeFunctionTestResponse = {
   title: string
@@ -49,7 +49,7 @@ export const useEdgeFunctionTestMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EdgeFunctionTestData, ResponseError, EdgeFunctionTestVariables>,
+  UseCustomMutationOptions<EdgeFunctionTestData, ResponseError, EdgeFunctionTestVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<EdgeFunctionTestData, ResponseError, EdgeFunctionTestVariables>({

--- a/apps/studio/data/edge-functions/edge-functions-delete-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-functions-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { edgeFunctionsKeys } from './keys'
 
 export type EdgeFunctionsDeleteVariables = {
@@ -30,7 +30,7 @@ export const useEdgeFunctionDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EdgeFunctionsDeleteData, ResponseError, EdgeFunctionsDeleteVariables>,
+  UseCustomMutationOptions<EdgeFunctionsDeleteData, ResponseError, EdgeFunctionsDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/edge-functions/edge-functions-deploy-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-functions-deploy-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { edgeFunctionsKeys } from './keys'
 
 export type EdgeFunctionsDeployVariables = {
@@ -53,7 +53,7 @@ export const useEdgeFunctionDeployMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EdgeFunctionsDeployData, ResponseError, EdgeFunctionsDeployVariables>,
+  UseCustomMutationOptions<EdgeFunctionsDeployData, ResponseError, EdgeFunctionsDeployVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/edge-functions/edge-functions-query.ts
+++ b/apps/studio/data/edge-functions/edge-functions-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { edgeFunctionsKeys } from './keys'
 
 export type EdgeFunctionsVariables = { projectRef?: string }
@@ -29,7 +29,10 @@ export type EdgeFunctionsError = ResponseError
 
 export const useEdgeFunctionsQuery = <TData = EdgeFunctionsData>(
   { projectRef }: EdgeFunctionsVariables,
-  { enabled = true, ...options }: UseQueryOptions<EdgeFunctionsData, EdgeFunctionsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<EdgeFunctionsData, EdgeFunctionsError, TData> = {}
 ) =>
   useQuery<EdgeFunctionsData, EdgeFunctionsError, TData>({
     queryKey: edgeFunctionsKeys.list(projectRef),

--- a/apps/studio/data/edge-functions/edge-functions-update-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-functions-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { edgeFunctionsKeys } from './keys'
 export type EdgeFunctionsUpdateVariables = {
   projectRef: string
@@ -39,7 +39,7 @@ export const useEdgeFunctionUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EdgeFunctionsUpdateData, ResponseError, EdgeFunctionsUpdateVariables>,
+  UseCustomMutationOptions<EdgeFunctionsUpdateData, ResponseError, EdgeFunctionsUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/entitlements/entitlements-query.ts
+++ b/apps/studio/data/entitlements/entitlements-query.ts
@@ -1,8 +1,9 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { get, handleError } from 'data/fetchers'
-import { ResponseError } from 'types/base'
+import { useQuery } from '@tanstack/react-query'
 import type { components } from 'api-types'
+import { get, handleError } from 'data/fetchers'
 import { organizationKeys } from 'data/organizations/keys'
+import { UseCustomQueryOptions } from 'types'
+import { ResponseError } from 'types/base'
 
 export type EntitlementsVariables = {
   slug: string
@@ -30,7 +31,10 @@ export type EntitlementsError = ResponseError
 
 export const useEntitlementsQuery = <TData = EntitlementsData>(
   { slug }: EntitlementsVariables,
-  { enabled = true, ...options }: UseQueryOptions<EntitlementsData, EntitlementsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<EntitlementsData, EntitlementsError, TData> = {}
 ) => {
   return useQuery<EntitlementsData, EntitlementsError, TData>({
     queryKey: [organizationKeys.entitlements(slug)],

--- a/apps/studio/data/entity-types/entity-types-infinite-query.ts
+++ b/apps/studio/data/entity-types/entity-types-infinite-query.ts
@@ -1,6 +1,6 @@
-import { QueryClient, useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useInfiniteQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlVariables } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { ENTITY_TYPE } from './entity-type-constants'
 import { entityTypeKeys } from './keys'
 
@@ -130,7 +130,7 @@ export const useEntityTypesQuery = <TData = EntityTypesData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<EntityTypesData, EntityTypesError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<EntityTypesData, EntityTypesError, TData> = {}
 ) => {
   return useInfiniteQuery<EntityTypesData, EntityTypesError, TData>({
     queryKey: entityTypeKeys.list(projectRef, { schemas, search, sort, limit, filterTypes }),

--- a/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { enumeratedTypesKeys } from './keys'
 
 export type EnumeratedTypeCreateVariables = {
@@ -40,7 +40,7 @@ export const useEnumeratedTypeCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EnumeratedTypeCreateData, ResponseError, EnumeratedTypeCreateVariables>,
+  UseCustomMutationOptions<EnumeratedTypeCreateData, ResponseError, EnumeratedTypeCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { enumeratedTypesKeys } from './keys'
 
 export type EnumeratedTypeDeleteVariables = {
@@ -30,7 +30,7 @@ export const useEnumeratedTypeDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EnumeratedTypeDeleteData, ResponseError, EnumeratedTypeDeleteVariables>,
+  UseCustomMutationOptions<EnumeratedTypeDeleteData, ResponseError, EnumeratedTypeDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { enumeratedTypesKeys } from './keys'
 
 export type EnumeratedTypeUpdateVariables = {
@@ -66,7 +66,7 @@ export const useEnumeratedTypeUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EnumeratedTypeUpdateData, ResponseError, EnumeratedTypeUpdateVariables>,
+  UseCustomMutationOptions<EnumeratedTypeUpdateData, ResponseError, EnumeratedTypeUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/enumerated-types/enumerated-types-query.ts
+++ b/apps/studio/data/enumerated-types/enumerated-types-query.ts
@@ -1,10 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { enumeratedTypesKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type EnumeratedTypesVariables = {
   projectRef?: string
@@ -46,7 +46,7 @@ export const useEnumeratedTypesQuery = <TData = EnumeratedTypesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<EnumeratedTypesData, EnumeratedTypesError, TData> = {}
+  }: UseCustomQueryOptions<EnumeratedTypesData, EnumeratedTypesError, TData> = {}
 ) =>
   useQuery<EnumeratedTypesData, EnumeratedTypesError, TData>({
     queryKey: enumeratedTypesKeys.list(projectRef),

--- a/apps/studio/data/fdw/fdw-create-mutation.ts
+++ b/apps/studio/data/fdw/fdw-create-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import {
@@ -10,7 +10,7 @@ import { foreignTableKeys } from 'data/foreign-tables/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
 import { vaultSecretsKeys } from 'data/vault/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { fdwKeys } from './keys'
 
 export type FDWCreateVariables = {
@@ -242,7 +242,7 @@ export const useFDWCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<FDWCreateData, ResponseError, FDWCreateVariables>,
+  UseCustomMutationOptions<FDWCreateData, ResponseError, FDWCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/fdw/fdw-delete-mutation.ts
+++ b/apps/studio/data/fdw/fdw-delete-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { WrapperMeta } from 'components/interfaces/Integrations/Wrappers/Wrappers.types'
@@ -7,7 +7,7 @@ import { foreignTableKeys } from 'data/foreign-tables/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
 import { vaultSecretsKeys } from 'data/vault/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { FDW } from './fdws-query'
 import { fdwKeys } from './keys'
 
@@ -99,7 +99,7 @@ export const useFDWDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<FDWDeleteData, ResponseError, FDWDeleteVariables>,
+  UseCustomMutationOptions<FDWDeleteData, ResponseError, FDWDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/fdw/fdw-import-foreign-schema-mutation.ts
+++ b/apps/studio/data/fdw/fdw-import-foreign-schema-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { entityTypeKeys } from 'data/entity-types/keys'
@@ -6,7 +6,7 @@ import { foreignTableKeys } from 'data/foreign-tables/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
 import { vaultSecretsKeys } from 'data/vault/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { fdwKeys } from './keys'
 
 export type FDWImportForeignSchemaVariables = {
@@ -45,7 +45,7 @@ export const useFDWImportForeignSchemaMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ImportForeignSchemaData, ResponseError, FDWImportForeignSchemaVariables>,
+  UseCustomMutationOptions<ImportForeignSchemaData, ResponseError, FDWImportForeignSchemaVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/fdw/fdw-update-mutation.ts
+++ b/apps/studio/data/fdw/fdw-update-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { WrapperMeta } from 'components/interfaces/Integrations/Wrappers/Wrappers.types'
@@ -7,7 +7,7 @@ import { foreignTableKeys } from 'data/foreign-tables/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
 import { vaultSecretsKeys } from 'data/vault/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { getCreateFDWSql } from './fdw-create-mutation'
 import { getDeleteFDWSql } from './fdw-delete-mutation'
 import { FDW } from './fdws-query'
@@ -69,7 +69,7 @@ export const useFDWUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<FDWUpdateData, ResponseError, FDWUpdateVariables>,
+  UseCustomMutationOptions<FDWUpdateData, ResponseError, FDWUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/fdw/fdws-query.ts
+++ b/apps/studio/data/fdw/fdws-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { fdwKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export const getFDWsSql = () => {
   const sql = /* SQL */ `
@@ -87,7 +88,7 @@ export type FDWsError = ExecuteSqlError
 
 export const useFDWsQuery = <TData = FDWsData>(
   { projectRef, connectionString }: FDWsVariables,
-  { enabled = true, ...options }: UseQueryOptions<FDWsData, FDWsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<FDWsData, FDWsError, TData> = {}
 ) =>
   useQuery<FDWsData, FDWsError, TData>({
     queryKey: fdwKeys.list(projectRef),

--- a/apps/studio/data/feedback/exit-survey-send.ts
+++ b/apps/studio/data/feedback/exit-survey-send.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type SendDowngradeFeedbackVariables = {
   projectRef?: string
@@ -38,7 +38,11 @@ export const useSendDowngradeFeedbackMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SendDowngradeFeedbackData, ResponseError, SendDowngradeFeedbackVariables>,
+  UseCustomMutationOptions<
+    SendDowngradeFeedbackData,
+    ResponseError,
+    SendDowngradeFeedbackVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<SendDowngradeFeedbackData, ResponseError, SendDowngradeFeedbackVariables>({

--- a/apps/studio/data/feedback/feedback-category.ts
+++ b/apps/studio/data/feedback/feedback-category.ts
@@ -1,6 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
+import { UseCustomQueryOptions } from 'types'
 
 export type FeedbackCategoryVariables = {
   prompt: string
@@ -47,7 +48,7 @@ export const useFeedbackCategoryQuery = <TData = FeedbackCategory>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<FeedbackCategory, FeedbackCategoryError, TData> = {}
+  }: UseCustomQueryOptions<FeedbackCategory, FeedbackCategoryError, TData> = {}
 ) =>
   useQuery<FeedbackCategory, FeedbackCategoryError, TData>({
     queryKey: ['feedback-category', prompt],

--- a/apps/studio/data/feedback/feedback-send.ts
+++ b/apps/studio/data/feedback/feedback-send.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type SendFeedbackVariables = {
   message: string
@@ -37,7 +37,7 @@ export const useSendFeedbackMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SendFeedbackData, ResponseError, SendFeedbackVariables>,
+  UseCustomMutationOptions<SendFeedbackData, ResponseError, SendFeedbackVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<SendFeedbackData, ResponseError, SendFeedbackVariables>({

--- a/apps/studio/data/feedback/support-ticket-send.ts
+++ b/apps/studio/data/feedback/support-ticket-send.ts
@@ -1,10 +1,10 @@
-import { type UseMutationOptions, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 // End of third-party imports
 
 import type { ExtendedSupportCategories } from 'components/interfaces/Support/Support.constants'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type sendSupportTicketVariables = {
   subject: string
@@ -77,7 +77,7 @@ export const useSendSupportTicketMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<sendSupportTicketData, ResponseError, sendSupportTicketVariables>,
+  UseCustomMutationOptions<sendSupportTicketData, ResponseError, sendSupportTicketVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<sendSupportTicketData, ResponseError, sendSupportTicketVariables>({

--- a/apps/studio/data/feedback/upgrade-survey-send.ts
+++ b/apps/studio/data/feedback/upgrade-survey-send.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type SendUpgradeFeedbackVariables = {
   orgSlug?: string
@@ -38,7 +38,7 @@ export const useSendUpgradeFeedbackMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SendUpgradeFeedbackData, ResponseError, SendUpgradeFeedbackVariables>,
+  UseCustomMutationOptions<SendUpgradeFeedbackData, ResponseError, SendUpgradeFeedbackVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<SendUpgradeFeedbackData, ResponseError, SendUpgradeFeedbackVariables>({

--- a/apps/studio/data/foreign-tables/foreign-tables-query.ts
+++ b/apps/studio/data/foreign-tables/foreign-tables-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { PostgresView } from '@supabase/postgres-meta'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { foreignTableKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type ForeignTablesVariables = {
   projectRef?: string
@@ -46,7 +46,10 @@ export type ForeignTablesError = ResponseError
 
 export const useForeignTablesQuery = <TData = ForeignTablesData>(
   { projectRef, connectionString, schema }: ForeignTablesVariables,
-  { enabled = true, ...options }: UseQueryOptions<ForeignTablesData, ForeignTablesError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ForeignTablesData, ForeignTablesError, TData> = {}
 ) =>
   useQuery<ForeignTablesData, ForeignTablesError, TData>({
     queryKey: schema

--- a/apps/studio/data/integrations/aws-redirect-query.ts
+++ b/apps/studio/data/integrations/aws-redirect-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import type { ResponseError } from 'types'
-import { integrationKeys } from './keys'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { integrationKeys } from './keys'
 
 export type AwsRedirectVariables = {
   organizationSlug?: string
@@ -26,7 +26,10 @@ export type AwsRedirectError = ResponseError
 
 export const useAwsRedirectQuery = <TData = AwsRedirectData>(
   { organizationSlug }: AwsRedirectVariables,
-  { enabled = true, ...options }: UseQueryOptions<AwsRedirectData, AwsRedirectError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<AwsRedirectData, AwsRedirectError, TData> = {}
 ) =>
   useQuery<AwsRedirectData, AwsRedirectError, TData>({
     queryKey: integrationKeys.awsRedirect(organizationSlug),

--- a/apps/studio/data/integrations/github-authorization-create-mutation.ts
+++ b/apps/studio/data/integrations/github-authorization-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
 import { LOCAL_STORAGE_KEYS } from 'common'
+import { handleError, post } from 'data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type GitHubAuthorizationCreateVariables = {
   code: string
@@ -37,7 +37,7 @@ export const useGitHubAuthorizationCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     GitHubAuthorizationCreateData,
     ResponseError,
     GitHubAuthorizationCreateVariables

--- a/apps/studio/data/integrations/github-authorization-query.ts
+++ b/apps/studio/data/integrations/github-authorization-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
 // FIXME(kamil): Do not retry, a single check is fine.
@@ -21,7 +21,7 @@ export type GitHubAuthorizationError = ResponseError
 export const useGitHubAuthorizationQuery = <TData = GitHubAuthorizationData>({
   enabled = true,
   ...options
-}: UseQueryOptions<GitHubAuthorizationData, GitHubAuthorizationError, TData> = {}) => {
+}: UseCustomQueryOptions<GitHubAuthorizationData, GitHubAuthorizationError, TData> = {}) => {
   return useQuery<GitHubAuthorizationData, GitHubAuthorizationError, TData>({
     queryKey: integrationKeys.githubAuthorization(),
     queryFn: ({ signal }) => getGitHubAuthorization(signal),

--- a/apps/studio/data/integrations/github-branch-check-query.ts
+++ b/apps/studio/data/integrations/github-branch-check-query.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type GithubBranchVariables = {
   repositoryId: number
@@ -37,7 +37,7 @@ export const useCheckGithubBranchValidity = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<GitHubIntegrationCreateData, ResponseError, GithubBranchVariables>,
+  UseCustomMutationOptions<GitHubIntegrationCreateData, ResponseError, GithubBranchVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<GitHubIntegrationCreateData, ResponseError, GithubBranchVariables>({

--- a/apps/studio/data/integrations/github-branches-query.ts
+++ b/apps/studio/data/integrations/github-branches-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
 export type GitHubBranchesVariables = {
@@ -30,7 +30,7 @@ export const useGitHubBranchesQuery = <TData = GitHubBranchesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<GitHubBranchesData, GitHubBranchesError, TData> = {}
+  }: UseCustomQueryOptions<GitHubBranchesData, GitHubBranchesError, TData> = {}
 ) =>
   useQuery<GitHubBranchesData, GitHubBranchesError, TData>({
     queryKey: integrationKeys.githubBranchesList(connectionId),

--- a/apps/studio/data/integrations/github-connection-create-mutation.ts
+++ b/apps/studio/data/integrations/github-connection-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { integrationKeys } from './keys'
 
 type GitHubConnectionCreateVariables = {
@@ -27,7 +27,11 @@ export const useGitHubConnectionCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<GitHubConnectionCreateData, ResponseError, GitHubConnectionCreateVariables>,
+  UseCustomMutationOptions<
+    GitHubConnectionCreateData,
+    ResponseError,
+    GitHubConnectionCreateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/integrations/github-connection-delete-mutation.ts
+++ b/apps/studio/data/integrations/github-connection-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { integrationKeys } from './keys'
 
 type DeleteVariables = {
@@ -27,7 +27,7 @@ export const useGitHubConnectionDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DeleteContentData, ResponseError, DeleteVariables>,
+  UseCustomMutationOptions<DeleteContentData, ResponseError, DeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/integrations/github-connection-update-mutation.ts
+++ b/apps/studio/data/integrations/github-connection-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { integrationKeys } from './keys'
 
 type GitHubConnectionUpdateVariables = {
@@ -33,7 +33,7 @@ export const useGitHubConnectionUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UpdateContentData, ResponseError, GitHubConnectionUpdateVariables>,
+  UseCustomMutationOptions<UpdateContentData, ResponseError, GitHubConnectionUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/integrations/github-connections-query.ts
+++ b/apps/studio/data/integrations/github-connections-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
 export type GitHubConnectionsVariables = {
@@ -37,7 +37,7 @@ export const useGitHubConnectionsQuery = <TData = GitHubConnectionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<GitHubConnectionsData, GitHubConnectionsError, TData> = {}
+  }: UseCustomQueryOptions<GitHubConnectionsData, GitHubConnectionsError, TData> = {}
 ) => {
   return useQuery<GitHubConnectionsData, GitHubConnectionsError, TData>({
     queryKey: integrationKeys.githubConnectionsList(organizationId),

--- a/apps/studio/data/integrations/github-repositories-query.ts
+++ b/apps/studio/data/integrations/github-repositories-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
 export async function getGitHubRepositories(signal?: AbortSignal) {
@@ -22,7 +22,7 @@ export type GitHubRepositoriesError = ResponseError
 export const useGitHubRepositoriesQuery = <TData = GitHubRepositoriesData>({
   enabled = true,
   ...options
-}: UseQueryOptions<GitHubRepositoriesData, GitHubRepositoriesError, TData> = {}) => {
+}: UseCustomQueryOptions<GitHubRepositoriesData, GitHubRepositoriesError, TData> = {}) => {
   return useQuery<GitHubRepositoriesData, GitHubRepositoriesError, TData>({
     queryKey: integrationKeys.githubRepositoriesList(),
     queryFn: ({ signal }) => getGitHubRepositories(signal),

--- a/apps/studio/data/integrations/integrations-query-org-only.ts
+++ b/apps/studio/data/integrations/integrations-query-org-only.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { Integration } from './integrations.types'
 import { integrationKeys } from './keys'
 
@@ -25,7 +25,10 @@ export type IntegrationsError = ResponseError
 
 export const useOrgIntegrationsQuery = <TData = IntegrationsData>(
   { orgSlug }: IntegrationsVariables,
-  { enabled = true, ...options }: UseQueryOptions<IntegrationsData, IntegrationsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<IntegrationsData, IntegrationsError, TData> = {}
 ) =>
   useQuery<IntegrationsData, IntegrationsError, TData>({
     queryKey: integrationKeys.integrationsListWithOrg(orgSlug),

--- a/apps/studio/data/integrations/integrations-query.ts
+++ b/apps/studio/data/integrations/integrations-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
 export async function getIntegrations(signal?: AbortSignal) {
@@ -20,7 +20,7 @@ export type IntegrationsError = ResponseError
 export const useIntegrationsQuery = <TData = IntegrationsData>({
   enabled = true,
   ...options
-}: UseQueryOptions<IntegrationsData, IntegrationsError, TData> = {}) =>
+}: UseCustomQueryOptions<IntegrationsData, IntegrationsError, TData> = {}) =>
   useQuery<IntegrationsData, IntegrationsError, TData>({
     queryKey: integrationKeys.integrationsList(),
     queryFn: ({ signal }) => getIntegrations(signal),

--- a/apps/studio/data/integrations/integrations-vercel-connection-sync-envs-mutation.ts
+++ b/apps/studio/data/integrations/integrations-vercel-connection-sync-envs-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type IntegrationsVercelConnectionSyncEnvsVariables = {
   connectionId: string
@@ -33,7 +33,7 @@ export const useIntegrationsVercelConnectionSyncEnvsMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     IntegrationsVercelConnectionSyncEnvsData,
     ResponseError,
     IntegrationsVercelConnectionSyncEnvsVariables

--- a/apps/studio/data/integrations/integrations-vercel-connections-create-mutation.ts
+++ b/apps/studio/data/integrations/integrations-vercel-connections-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
 import { useIntegrationInstallationSnapshot } from 'state/integration-installation'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { IntegrationConnectionsCreateVariables } from './integrations.types'
 import { integrationKeys } from './keys'
 
@@ -35,7 +35,7 @@ export const useIntegrationVercelConnectionsCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     IntegrationVercelConnectionsCreateData,
     ResponseError,
     IntegrationConnectionsCreateVariables

--- a/apps/studio/data/integrations/integrations-vercel-installed-connection-delete-mutation.ts
+++ b/apps/studio/data/integrations/integrations-vercel-installed-connection-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { integrationKeys } from './keys'
 
 type DeleteVariables = {
@@ -33,7 +33,7 @@ export const useIntegrationsVercelInstalledConnectionDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DeleteContentData, ResponseError, DeleteVariables>,
+  UseCustomMutationOptions<DeleteContentData, ResponseError, DeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/integrations/integrations-vercel-projects-query.ts
+++ b/apps/studio/data/integrations/integrations-vercel-projects-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { integrationKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type VercelProjectsVariables = {
   organization_integration_id: string | undefined
@@ -42,7 +43,7 @@ export const useVercelProjectsQuery = <TData = VercelProjectsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<VercelProjectsData, VercelProjectsError, TData> = {}
+  }: UseCustomQueryOptions<VercelProjectsData, VercelProjectsError, TData> = {}
 ) =>
   useQuery<VercelProjectsData, VercelProjectsError, TData>({
     queryKey: integrationKeys.vercelProjectList(organization_integration_id),

--- a/apps/studio/data/integrations/vercel-connection-update-mutate.ts
+++ b/apps/studio/data/integrations/vercel-connection-update-mutate.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { EnvironmentTargets } from './integrations.types'
 import { integrationKeys } from './keys'
 
@@ -40,7 +40,7 @@ export const useVercelConnectionUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UpdateVercelConnectionData, ResponseError, UpdateConnectionPayload>,
+  UseCustomMutationOptions<UpdateVercelConnectionData, ResponseError, UpdateConnectionPayload>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/integrations/vercel-integration-create-mutation.ts
+++ b/apps/studio/data/integrations/vercel-integration-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { integrationKeys } from './keys'
 
 export type VercelIntegrationCreateVariables = {
@@ -48,7 +48,11 @@ export const useVercelIntegrationCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<VercelIntegrationCreateData, ResponseError, VercelIntegrationCreateVariables>,
+  UseCustomMutationOptions<
+    VercelIntegrationCreateData,
+    ResponseError,
+    VercelIntegrationCreateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/integrations/vercel-redirect-query.ts
+++ b/apps/studio/data/integrations/vercel-redirect-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
 export type VercelRedirectVariables = {
@@ -30,7 +30,7 @@ export const useVercelRedirectQuery = <TData = VercelRedirectData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<VercelRedirectData, VercelRedirectError, TData> = {}
+  }: UseCustomQueryOptions<VercelRedirectData, VercelRedirectError, TData> = {}
 ) =>
   useQuery<VercelRedirectData, VercelRedirectError, TData>({
     queryKey: integrationKeys.vercelRedirect(installationId),

--- a/apps/studio/data/invoices/invoice-payment-link-mutation.ts
+++ b/apps/studio/data/invoices/invoice-payment-link-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { invoicesKeys } from './keys'
 
 export type InvoicePaymentLinkGetVariables = {
@@ -39,7 +39,11 @@ export const useInvoicePaymentLinkGetMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<InvoicePaymentLinkGetData, ResponseError, InvoicePaymentLinkGetVariables>,
+  UseCustomMutationOptions<
+    InvoicePaymentLinkGetData,
+    ResponseError,
+    InvoicePaymentLinkGetVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/invoices/invoice-query.ts
+++ b/apps/studio/data/invoices/invoice-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { invoicesKeys } from './keys'
 
 export type InvoiceVariables = {
@@ -29,7 +29,7 @@ export type InvoiceError = ResponseError
 
 export const useInvoiceQuery = <TData = InvoiceData>(
   { invoiceId: id }: InvoiceVariables,
-  { enabled = true, ...options }: UseQueryOptions<InvoiceData, InvoiceError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<InvoiceData, InvoiceError, TData> = {}
 ) =>
   useQuery<InvoiceData, InvoiceError, TData>({
     queryKey: invoicesKeys.invoice(id),

--- a/apps/studio/data/invoices/invoices-count-query.ts
+++ b/apps/studio/data/invoices/invoices-count-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { head } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { invoicesKeys } from './keys'
 
 export type InvoicesCountVariables = {
@@ -25,7 +25,10 @@ export type InvoicesCountError = ResponseError
 
 export const useInvoicesCountQuery = <TData = InvoicesCountData>(
   { slug }: InvoicesCountVariables,
-  { enabled = true, ...options }: UseQueryOptions<InvoicesCountData, InvoicesCountError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<InvoicesCountData, InvoicesCountError, TData> = {}
 ) =>
   useQuery<InvoicesCountData, InvoicesCountError, TData>({
     queryKey: invoicesKeys.count(slug),

--- a/apps/studio/data/invoices/invoices-overdue-query.ts
+++ b/apps/studio/data/invoices/invoices-overdue-query.ts
@@ -1,9 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { useIsLoggedIn } from 'common'
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import { invoicesKeys } from './keys'
 import { IS_PLATFORM } from 'lib/constants'
-import { useIsLoggedIn } from 'common'
+import { invoicesKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type OverdueInvoicesResponse = components['schemas']['OverdueInvoiceCount']
 
@@ -22,7 +23,7 @@ export type OverdueInvoicesError = unknown
 export const useOverdueInvoicesQuery = <TData = OverdueInvoicesData>({
   enabled = true,
   ...options
-}: UseQueryOptions<OverdueInvoicesData, OverdueInvoicesError, TData> = {}) => {
+}: UseCustomQueryOptions<OverdueInvoicesData, OverdueInvoicesError, TData> = {}) => {
   const isLoggedIn = useIsLoggedIn()
   return useQuery<OverdueInvoicesData, OverdueInvoicesError, TData>({
     queryKey: invoicesKeys.overdueInvoices(),

--- a/apps/studio/data/invoices/invoices-query.ts
+++ b/apps/studio/data/invoices/invoices-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { invoicesKeys } from './keys'
 
 export type InvoicesVariables = {
@@ -32,7 +32,7 @@ export type InvoicesError = ResponseError
 
 export const useInvoicesQuery = <TData = InvoicesData>(
   { slug, offset, limit }: InvoicesVariables,
-  { enabled = true, ...options }: UseQueryOptions<InvoicesData, InvoicesError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<InvoicesData, InvoicesError, TData> = {}
 ) =>
   // [Joshen] Switch to useInfiniteQuery
   useQuery<InvoicesData, InvoicesError, TData>({

--- a/apps/studio/data/invoices/org-invoice-upcoming-query.ts
+++ b/apps/studio/data/invoices/org-invoice-upcoming-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { PricingMetric } from 'data/analytics/org-daily-stats-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { invoicesKeys } from './keys'
 
 export type UpcomingInvoiceVariables = {
@@ -68,7 +68,7 @@ export const useOrgUpcomingInvoiceQuery = <TData = UpcomingInvoiceData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<UpcomingInvoiceData, UpcomingInvoiceError, TData> = {}
+  }: UseCustomQueryOptions<UpcomingInvoiceData, UpcomingInvoiceError, TData> = {}
 ) =>
   useQuery<UpcomingInvoiceData, UpcomingInvoiceError, TData>({
     queryKey: invoicesKeys.orgUpcomingPreview(orgSlug),

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-key-create-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-key-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { JWTAlgorithm } from './jwt-signing-keys-query'
 import { jwtSigningKeysKeys } from './keys'
 
@@ -38,7 +38,7 @@ export const useJWTSigningKeyCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<JWTSigningKeyCreateData, ResponseError, JWTSigningKeyCreateVariables>,
+  UseCustomMutationOptions<JWTSigningKeyCreateData, ResponseError, JWTSigningKeyCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-key-delete-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-key-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { jwtSigningKeysKeys } from './keys'
 
 interface JWTSigningKeyDeleteVariables {
@@ -30,7 +30,7 @@ export const useJWTSigningKeyDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<JWTSigningKeyDeleteData, ResponseError, JWTSigningKeyDeleteVariables>,
+  UseCustomMutationOptions<JWTSigningKeyDeleteData, ResponseError, JWTSigningKeyDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-key-update-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-key-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { jwtSigningKeysKeys } from './keys'
 
 interface JWTSigningKeyUpdateVariables {
@@ -34,7 +34,7 @@ export const useJWTSigningKeyUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<JWTSigningKeyUpdateData, ResponseError, JWTSigningKeyUpdateVariables>,
+  UseCustomMutationOptions<JWTSigningKeyUpdateData, ResponseError, JWTSigningKeyUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/jwt-signing-keys/jwt-signing-keys-query.ts
+++ b/apps/studio/data/jwt-signing-keys/jwt-signing-keys-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { jwtSigningKeysKeys } from './keys'
 
 export type JWTSigningKey = components['schemas']['SigningKeyResponse']
@@ -31,7 +31,7 @@ export type JWTSigningKeysData = Awaited<ReturnType<typeof getJWTSigningKeys>>
 
 export const useJWTSigningKeysQuery = <TData = JWTSigningKeysData>(
   { projectRef }: JWTSigningKeysVariables,
-  { enabled, ...options }: UseQueryOptions<JWTSigningKeysData, ResponseError, TData> = {}
+  { enabled, ...options }: UseCustomQueryOptions<JWTSigningKeysData, ResponseError, TData> = {}
 ) =>
   useQuery<JWTSigningKeysData, ResponseError, TData>({
     queryKey: jwtSigningKeysKeys.list(projectRef),

--- a/apps/studio/data/jwt-signing-keys/legacy-jwt-signing-key-create-mutation.ts
+++ b/apps/studio/data/jwt-signing-keys/legacy-jwt-signing-key-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { jwtSigningKeysKeys } from './keys'
 
 interface LegacyJWTSigningKeyCreateVariables {
@@ -29,7 +29,7 @@ export const useLegacyJWTSigningKeyCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     LegacyJWTSigningKeyCreateData,
     ResponseError,
     LegacyJWTSigningKeyCreateVariables

--- a/apps/studio/data/jwt-signing-keys/legacy-jwt-signing-key-query.ts
+++ b/apps/studio/data/jwt-signing-keys/legacy-jwt-signing-key-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 
 import { jwtSigningKeysKeys } from './keys'
 
@@ -30,7 +30,7 @@ export type LegacyJWTSigningKeyData = Awaited<ReturnType<typeof getLegacyJWTSign
 
 export const useLegacyJWTSigningKeyQuery = <TData = LegacyJWTSigningKeyData>(
   { projectRef }: LegacyJWTSigningKeyVariables,
-  { enabled, ...options }: UseQueryOptions<LegacyJWTSigningKeyData, ResponseError, TData> = {}
+  { enabled, ...options }: UseCustomQueryOptions<LegacyJWTSigningKeyData, ResponseError, TData> = {}
 ) =>
   useQuery<LegacyJWTSigningKeyData, ResponseError, TData>({
     queryKey: jwtSigningKeysKeys.legacy(projectRef),

--- a/apps/studio/data/lint/create-lint-rule-mutation.ts
+++ b/apps/studio/data/lint/create-lint-rule-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { lintKeys } from './keys'
 
 type ExceptionPayload = components['schemas']['CreateNotificationExceptionsBody']['exceptions'][0]
@@ -32,7 +32,7 @@ export const useLintRuleCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LintRuleCreateData, ResponseError, LintRuleCreateVariables>,
+  UseCustomMutationOptions<LintRuleCreateData, ResponseError, LintRuleCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/lint/delete-lint-rule-mutation.ts
+++ b/apps/studio/data/lint/delete-lint-rule-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { lintKeys } from './keys'
 
 export type LintRuleDeleteVariables = {
@@ -26,7 +26,7 @@ export const useLintRuleDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LintRuleDeleteData, ResponseError, LintRuleDeleteVariables>,
+  UseCustomMutationOptions<LintRuleDeleteData, ResponseError, LintRuleDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/lint/lint-query.ts
+++ b/apps/studio/data/lint/lint-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { lintKeys } from './keys'
 
 type ProjectLintsVariables = {
@@ -32,7 +32,10 @@ export type ProjectLintsError = ResponseError
 
 export const useProjectLintsQuery = <TData = ProjectLintsData>(
   { projectRef }: ProjectLintsVariables,
-  { enabled = true, ...options }: UseQueryOptions<ProjectLintsData, ProjectLintsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ProjectLintsData, ProjectLintsError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/lint/lint-rules-query.ts
+++ b/apps/studio/data/lint/lint-rules-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { lintKeys } from './keys'
 
 type ProjectLintRulesVariables = {
@@ -37,7 +37,7 @@ export const useProjectLintRulesQuery = <TData = ProjectLintRulesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectLintRulesData, ProjectLintRulesError, TData> = {}
+  }: UseCustomQueryOptions<ProjectLintRulesData, ProjectLintRulesError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/log-drains/create-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/create-log-drain-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { LogDrainType } from 'components/interfaces/LogDrains/LogDrains.constants'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { logDrainsKeys } from './keys'
 
 export type LogDrainCreateVariables = {
@@ -36,7 +36,7 @@ export const useCreateLogDrainMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LogDrainCreateData, ResponseError, LogDrainCreateVariables>,
+  UseCustomMutationOptions<LogDrainCreateData, ResponseError, LogDrainCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/log-drains/delete-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/delete-log-drain-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { logDrainsKeys } from './keys'
 
 export type LogDrainDeleteVariables = {
@@ -27,7 +27,7 @@ export const useDeleteLogDrainMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LogDrainDeleteData, ResponseError, LogDrainDeleteVariables>,
+  UseCustomMutationOptions<LogDrainDeleteData, ResponseError, LogDrainDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/log-drains/log-drains-query.ts
+++ b/apps/studio/data/log-drains/log-drains-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { logDrainsKeys } from './keys'
 
 export type LogDrainsVariables = {
@@ -30,7 +30,7 @@ export type LogDrainsyError = ResponseError
 
 export const useLogDrainsQuery = <TData = LogDrainsData>(
   { ref }: LogDrainsVariables,
-  { enabled = true, ...options }: UseQueryOptions<LogDrainsData, LogDrainsyError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<LogDrainsData, LogDrainsyError, TData> = {}
 ) =>
   useQuery<LogDrainsData, LogDrainsyError, TData>({
     queryKey: logDrainsKeys.list(ref),

--- a/apps/studio/data/log-drains/update-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/update-log-drain-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { LogDrainType } from 'components/interfaces/LogDrains/LogDrains.constants'
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { logDrainsKeys } from './keys'
 
 export type LogDrainUpdateVariables = {
@@ -41,7 +41,7 @@ export const useUpdateLogDrainMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LogDrainUpdateData, ResponseError, LogDrainUpdateVariables>,
+  UseCustomMutationOptions<LogDrainUpdateData, ResponseError, LogDrainUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/logs/get-unified-logs.ts
+++ b/apps/studio/data/logs/get-unified-logs.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { getUnifiedLogsQuery } from 'components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { QuerySearchParamsType } from 'components/interfaces/UnifiedLogs/UnifiedLogs.types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { getUnifiedLogsISOStartEnd } from './unified-logs-infinite-query'
 
 export type getUnifiedLogsVariables = {
@@ -69,7 +69,7 @@ export const useGetUnifiedLogsMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LogDrainCreateData, ResponseError, getUnifiedLogsVariables>,
+  UseCustomMutationOptions<LogDrainCreateData, ResponseError, getUnifiedLogsVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<LogDrainCreateData, ResponseError, getUnifiedLogsVariables>({

--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import {
   getAuthServiceFlowQuery,
@@ -9,7 +9,7 @@ import {
 } from 'components/interfaces/UnifiedLogs/Queries/ServiceFlowQueries/ServiceFlow.sql'
 import { QuerySearchParamsType } from 'components/interfaces/UnifiedLogs/UnifiedLogs.types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { logsKeys } from './keys'
 import {
   getUnifiedLogsISOStartEnd,
@@ -178,7 +178,7 @@ export const useUnifiedLogInspectionQuery = <TData = UnifiedLogInspectionData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<UnifiedLogInspectionData, UnifiedLogInspectionError, TData> = {}
+  }: UseCustomQueryOptions<UnifiedLogInspectionData, UnifiedLogInspectionError, TData> = {}
 ) =>
   useQuery<UnifiedLogInspectionData, UnifiedLogInspectionError, TData>({
     queryKey: logsKeys.serviceFlow(projectRef, search, logId),

--- a/apps/studio/data/logs/unified-logs-chart-query.ts
+++ b/apps/studio/data/logs/unified-logs-chart-query.ts
@@ -1,10 +1,11 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getLogsChartQuery } from 'components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { handleError, post } from 'data/fetchers'
 import { ExecuteSqlError } from 'data/sql/execute-sql-query'
 import { logsKeys } from './keys'
 import { UNIFIED_LOGS_QUERY_OPTIONS, UnifiedLogsVariables } from './unified-logs-infinite-query'
+import { UseCustomQueryOptions } from 'types'
 
 export async function getUnifiedLogsChart(
   { projectRef, search }: UnifiedLogsVariables,
@@ -148,7 +149,7 @@ export const useUnifiedLogsChartQuery = <TData = UnifiedLogsChartData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<UnifiedLogsChartData, UnifiedLogsChartError, TData> = {}
+  }: UseCustomQueryOptions<UnifiedLogsChartData, UnifiedLogsChartError, TData> = {}
 ) =>
   useQuery<UnifiedLogsChartData, UnifiedLogsChartError, TData>({
     queryKey: logsKeys.unifiedLogsChart(projectRef, search),

--- a/apps/studio/data/logs/unified-logs-count-query.ts
+++ b/apps/studio/data/logs/unified-logs-count-query.ts
@@ -1,9 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getLogsCountQuery } from 'components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { FacetMetadataSchema } from 'components/interfaces/UnifiedLogs/UnifiedLogs.schema'
 import { handleError, post } from 'data/fetchers'
 import { ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { UseCustomQueryOptions } from 'types'
 import { logsKeys } from './keys'
 import {
   getUnifiedLogsISOStartEnd,
@@ -81,7 +82,7 @@ export const useUnifiedLogsCountQuery = <TData = UnifiedLogsCountData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<UnifiedLogsCountData, UnifiedLogsCountError, TData> = {}
+  }: UseCustomQueryOptions<UnifiedLogsCountData, UnifiedLogsCountError, TData> = {}
 ) =>
   useQuery<UnifiedLogsCountData, UnifiedLogsCountError, TData>({
     queryKey: logsKeys.unifiedLogsCount(projectRef, search),

--- a/apps/studio/data/logs/unified-logs-facet-count-query.ts
+++ b/apps/studio/data/logs/unified-logs-facet-count-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import {
   getFacetCountCTE,
@@ -7,6 +7,7 @@ import {
 import { Option } from 'components/ui/DataTable/DataTable.types'
 import { handleError, post } from 'data/fetchers'
 import { ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { UseCustomQueryOptions } from 'types'
 import { logsKeys } from './keys'
 import {
   getUnifiedLogsISOStartEnd,
@@ -51,7 +52,7 @@ export const useUnifiedLogsFacetCountQuery = <TData = UnifiedLogsFacetCountData>
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<UnifiedLogsFacetCountData, UnifiedLogsFacetCountError, TData> = {}
+  }: UseCustomQueryOptions<UnifiedLogsFacetCountData, UnifiedLogsFacetCountError, TData> = {}
 ) =>
   useQuery<UnifiedLogsFacetCountData, UnifiedLogsFacetCountError, TData>({
     queryKey: logsKeys.unifiedLogsFacetCount(projectRef, facet, facetSearch, search),

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { getUnifiedLogsQuery } from 'components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import {
@@ -6,7 +6,7 @@ import {
   QuerySearchParamsType,
 } from 'components/interfaces/UnifiedLogs/UnifiedLogs.types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { logsKeys } from './keys'
 
 const LOGS_PAGE_LIMIT = 50
@@ -159,7 +159,7 @@ export const useUnifiedLogsInfiniteQuery = <TData = UnifiedLogsData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<UnifiedLogsData, UnifiedLogsError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<UnifiedLogsData, UnifiedLogsError, TData> = {}
 ) => {
   return useInfiniteQuery<UnifiedLogsData, UnifiedLogsError, TData>({
     queryKey: logsKeys.unifiedLogsInfinite(projectRef, search),

--- a/apps/studio/data/materialized-views/materialized-views-query.ts
+++ b/apps/studio/data/materialized-views/materialized-views-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { PostgresMaterializedView } from '@supabase/postgres-meta'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { materializedViewKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type MaterializedViewsVariables = {
   projectRef?: string
@@ -49,7 +49,7 @@ export const useMaterializedViewsQuery = <TData = MaterializedViewsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<MaterializedViewsData, MaterializedViewsError, TData> = {}
+  }: UseCustomQueryOptions<MaterializedViewsData, MaterializedViewsError, TData> = {}
 ) =>
   useQuery<MaterializedViewsData, MaterializedViewsError, TData>({
     queryKey: schema

--- a/apps/studio/data/misc/audit-login-mutation.ts
+++ b/apps/studio/data/misc/audit-login-mutation.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/nextjs'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export async function addLoginEvent() {
   const { error } = await post('/platform/profile/audit-login')
@@ -18,7 +18,7 @@ export const useAddLoginEvent = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AddLoginEventData, ResponseError, AddLoginEventVariables>,
+  UseCustomMutationOptions<AddLoginEventData, ResponseError, AddLoginEventVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<AddLoginEventData, ResponseError, AddLoginEventVariables>({

--- a/apps/studio/data/misc/cli-release-version-query.ts
+++ b/apps/studio/data/misc/cli-release-version-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { fetchHandler } from 'data/fetchers'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { miscKeys } from './keys'
 
 export async function getCLIReleaseVersion() {
@@ -22,7 +22,7 @@ export type CLIReleaseVersionError = ResponseError
 export const useCLIReleaseVersionQuery = <TData = CLIReleaseVersionData>({
   enabled = true,
   ...options
-}: UseQueryOptions<CLIReleaseVersionData, CLIReleaseVersionError, TData> = {}) =>
+}: UseCustomQueryOptions<CLIReleaseVersionData, CLIReleaseVersionError, TData> = {}) =>
   useQuery<CLIReleaseVersionData, CLIReleaseVersionError, TData>({
     queryKey: miscKeys.cliReleaseVersion(),
     queryFn: () => getCLIReleaseVersion(),

--- a/apps/studio/data/misc/get-default-region-query.ts
+++ b/apps/studio/data/misc/get-default-region-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { useFlag } from 'common'
 import { COUNTRY_LAT_LON } from 'components/interfaces/ProjectCreation/ProjectCreation.constants'
@@ -10,7 +10,7 @@ import { fetchHandler } from 'data/fetchers'
 import { getDistanceLatLonKM, tryParseJson } from 'lib/helpers'
 import type { CloudProvider } from 'shared-data'
 import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { miscKeys } from './keys'
 
 export type DefaultRegionVariables = {
@@ -70,7 +70,10 @@ export type DefaultRegionError = ResponseError
 
 export const useDefaultRegionQuery = <TData = DefaultRegionData>(
   { cloudProvider, useRestrictedPool }: DefaultRegionVariables,
-  { enabled = true, ...options }: UseQueryOptions<DefaultRegionData, DefaultRegionError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DefaultRegionData, DefaultRegionError, TData> = {}
 ) => {
   // [Joshen] Flag allows us to specify restricted regions for users based on percentage
   const restrictedPoolFlag = useFlag('defaultRegionRestrictedPool')

--- a/apps/studio/data/misc/reset-password-mutation.ts
+++ b/apps/studio/data/misc/reset-password-mutation.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/nextjs'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 const WHITELIST_ERRORS = ['email must be an email']
 
@@ -30,7 +30,7 @@ export const useResetPasswordMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ResetPasswordData, ResponseError, ResetPasswordVariables>,
+  UseCustomMutationOptions<ResetPasswordData, ResponseError, ResetPasswordVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<ResetPasswordData, ResponseError, ResetPasswordVariables>({

--- a/apps/studio/data/misc/signup-mutation.ts
+++ b/apps/studio/data/misc/signup-mutation.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/nextjs'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 const WHITELIST_ERRORS = [
   'A user with this email already exists',
@@ -36,7 +36,10 @@ export const useSignUpMutation = ({
   onSuccess,
   onError,
   ...options
-}: Omit<UseMutationOptions<SignUpData, ResponseError, SignUpVariables>, 'mutationFn'> = {}) => {
+}: Omit<
+  UseCustomMutationOptions<SignUpData, ResponseError, SignUpVariables>,
+  'mutationFn'
+> = {}) => {
   return useMutation<SignUpData, ResponseError, SignUpVariables>({
     mutationFn: (vars) => signup(vars),
     async onSuccess(data, variables, context) {

--- a/apps/studio/data/misc/user-ip-address-query.ts
+++ b/apps/studio/data/misc/user-ip-address-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { fetchHandler } from 'data/fetchers'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { miscKeys } from './keys'
 
 export async function getUserIPAddress() {
@@ -20,7 +20,7 @@ export type UserIPAddressError = ResponseError
 export const useUserIPAddressQuery = <TData = UserIPAddressData>({
   enabled = true,
   ...options
-}: UseQueryOptions<UserIPAddressData, UserIPAddressError, TData> = {}) =>
+}: UseCustomQueryOptions<UserIPAddressData, UserIPAddressError, TData> = {}) =>
   useQuery<UserIPAddressData, UserIPAddressError, TData>({
     queryKey: miscKeys.ipAddress(),
     queryFn: () => getUserIPAddress(),

--- a/apps/studio/data/network-restrictions/network-restrictions-query.ts
+++ b/apps/studio/data/network-restrictions/network-restrictions-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { networkRestrictionKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type NetworkRestrictionsVariables = { projectRef?: string }
 
@@ -53,7 +54,7 @@ export const useNetworkRestrictionsQuery = <TData = NetworkRestrictionsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<NetworkRestrictionsData, NetworkRestrictionsError, TData> = {}
+  }: UseCustomQueryOptions<NetworkRestrictionsData, NetworkRestrictionsError, TData> = {}
 ) =>
   useQuery<NetworkRestrictionsData, NetworkRestrictionsError, TData>({
     queryKey: networkRestrictionKeys.list(projectRef),

--- a/apps/studio/data/network-restrictions/network-retrictions-apply-mutation.ts
+++ b/apps/studio/data/network-restrictions/network-retrictions-apply-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { networkRestrictionKeys } from './keys'
 
 export type NetworkRestrictionsApplyVariables = {
@@ -34,7 +34,7 @@ export const useNetworkRestrictionsApplyMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     NetworkRestrictionsApplyData,
     ResponseError,
     NetworkRestrictionsApplyVariables

--- a/apps/studio/data/notifications/notifications-v2-archive-all-mutation.ts
+++ b/apps/studio/data/notifications/notifications-v2-archive-all-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { notificationKeys } from './keys'
 
 export async function archiveAllNotifications() {
@@ -20,7 +20,10 @@ export const useNotificationsArchiveAllMutation = ({
   onSuccess,
   onError,
   ...options
-}: Omit<UseMutationOptions<NotificationsArchiveAllData, ResponseError>, 'mutationFn'> = {}) => {
+}: Omit<
+  UseCustomMutationOptions<NotificationsArchiveAllData, ResponseError>,
+  'mutationFn'
+> = {}) => {
   const queryClient = useQueryClient()
   return useMutation<NotificationsArchiveAllData, ResponseError>({
     mutationFn: () => archiveAllNotifications(),

--- a/apps/studio/data/notifications/notifications-v2-query.ts
+++ b/apps/studio/data/notifications/notifications-v2-query.ts
@@ -1,8 +1,8 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 
 import type { components } from 'data/api'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { notificationKeys } from './keys'
 
 const NOTIFICATIONS_PAGE_LIMIT = 10
@@ -66,7 +66,7 @@ export const useNotificationsV2Query = <TData = NotificationsData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<NotificationsData, NotificationsError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<NotificationsData, NotificationsError, TData> = {}
 ) => {
   return useInfiniteQuery<NotificationsData, NotificationsError, TData>({
     queryKey: notificationKeys.listV2({ status, filters, limit }),

--- a/apps/studio/data/notifications/notifications-v2-summary-query.ts
+++ b/apps/studio/data/notifications/notifications-v2-summary-query.ts
@@ -1,8 +1,8 @@
 import type { Notification } from '@supabase/shared-types/out/notifications'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { notificationKeys } from './keys'
 
 export type NotificationsResponse = Notification[]
@@ -19,7 +19,7 @@ export type NotificationsData = Awaited<ReturnType<typeof getNotificationsSummar
 export type NotificationsError = ResponseError
 
 export const useNotificationsSummaryQuery = <TData = NotificationsData>(
-  options: UseQueryOptions<NotificationsData, NotificationsError, TData> = {}
+  options: UseCustomQueryOptions<NotificationsData, NotificationsError, TData> = {}
 ) =>
   useQuery<NotificationsData, NotificationsError, TData>({
     queryKey: notificationKeys.summary(),

--- a/apps/studio/data/notifications/notifications-v2-update-mutation.ts
+++ b/apps/studio/data/notifications/notifications-v2-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type NotificationsUpdateVariables = {
   ids: string[]
@@ -27,7 +27,7 @@ export const useNotificationsV2UpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<NotificationsUpdateData, ResponseError, NotificationsUpdateVariables>,
+  UseCustomMutationOptions<NotificationsUpdateData, ResponseError, NotificationsUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth-secrets/client-secret-create-mutation.ts
+++ b/apps/studio/data/oauth-secrets/client-secret-create-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { handleError, post } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { clientSecretKeys } from './keys'
 
 export type ClientSecretCreateVariables = {
@@ -23,7 +23,7 @@ export const useClientSecretCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<any, ResponseError, ClientSecretCreateVariables>,
+  UseCustomMutationOptions<any, ResponseError, ClientSecretCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth-secrets/client-secret-delete-mutation.ts
+++ b/apps/studio/data/oauth-secrets/client-secret-delete-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { del, handleError } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { clientSecretKeys } from './keys'
 
 export type ClientSecretDeleteVariables = {
@@ -24,7 +24,7 @@ export const useClientSecretDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<boolean, ResponseError, ClientSecretDeleteVariables>,
+  UseCustomMutationOptions<boolean, ResponseError, ClientSecretDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth-secrets/client-secrets-query.ts
+++ b/apps/studio/data/oauth-secrets/client-secrets-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { clientSecretKeys } from './keys'
 
 import { components } from 'api-types'
@@ -49,7 +49,10 @@ export type ClientSecretsError = ResponseError
 
 export const useClientSecretsQuery = <TData = ClientSecretsData>(
   { slug, appId }: ClientSecretsVariables,
-  { enabled = true, ...options }: UseQueryOptions<ClientSecretsData, ClientSecretsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ClientSecretsData, ClientSecretsError, TData> = {}
 ) =>
   useQuery<ClientSecretsData, ClientSecretsError, TData>({
     queryKey: clientSecretKeys.list(slug, appId),

--- a/apps/studio/data/oauth-server-apps/oauth-server-app-create-mutation.ts
+++ b/apps/studio/data/oauth-server-apps/oauth-server-app-create-mutation.ts
@@ -1,9 +1,9 @@
 import { CreateOAuthClientParams, SupabaseClient } from '@supabase/supabase-js'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthServerAppKeys } from './keys'
 
 export type OAuthServerAppCreateVariables = CreateOAuthClientParams & {
@@ -32,7 +32,7 @@ export const useOAuthServerAppCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OAuthAppCreateData, ResponseError, OAuthServerAppCreateVariables>,
+  UseCustomMutationOptions<OAuthAppCreateData, ResponseError, OAuthServerAppCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth-server-apps/oauth-server-app-delete-mutation.ts
+++ b/apps/studio/data/oauth-server-apps/oauth-server-app-delete-mutation.ts
@@ -1,9 +1,9 @@
 import { SupabaseClient } from '@supabase/supabase-js'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthServerAppKeys } from './keys'
 
 export type OAuthServerAppDeleteVariables = {
@@ -34,7 +34,7 @@ export const useOAuthServerAppDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OAuthAppDeleteData, ResponseError, OAuthServerAppDeleteVariables>,
+  UseCustomMutationOptions<OAuthAppDeleteData, ResponseError, OAuthServerAppDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth-server-apps/oauth-server-app-regenerate-secret-mutation.ts
+++ b/apps/studio/data/oauth-server-apps/oauth-server-app-regenerate-secret-mutation.ts
@@ -1,9 +1,9 @@
 import { SupabaseClient } from '@supabase/supabase-js'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthServerAppKeys } from './keys'
 
 export type OAuthServerAppRegenerateSecretVariables = {
@@ -34,7 +34,7 @@ export const useOAuthServerAppRegenerateSecretMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OAuthAppRegenerateSecretData,
     ResponseError,
     OAuthServerAppRegenerateSecretVariables

--- a/apps/studio/data/oauth-server-apps/oauth-server-apps-query.ts
+++ b/apps/studio/data/oauth-server-apps/oauth-server-apps-query.ts
@@ -1,9 +1,9 @@
 import { SupabaseClient } from '@supabase/supabase-js'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { oauthServerAppKeys } from './keys'
 
 export type OAuthServerAppsVariables = {
@@ -41,7 +41,7 @@ export const useOAuthServerAppsQuery = <TData = OAuthServerAppsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OAuthServerAppsData, OAuthServerAppsError, TData> = {}
+  }: UseCustomQueryOptions<OAuthServerAppsData, OAuthServerAppsError, TData> = {}
 ) => {
   return useQuery({
     queryKey: oauthServerAppKeys.list(projectRef),

--- a/apps/studio/data/oauth/authorized-app-revoke-mutation.ts
+++ b/apps/studio/data/oauth/authorized-app-revoke-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthAppKeys } from './keys'
 
 export type AuthorizedAppRevokeVariables = {
@@ -29,7 +29,7 @@ export const useAuthorizedAppRevokeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AuthorizedAppRevokeData, ResponseError, AuthorizedAppRevokeVariables>,
+  UseCustomMutationOptions<AuthorizedAppRevokeData, ResponseError, AuthorizedAppRevokeVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth/authorized-apps-query.ts
+++ b/apps/studio/data/oauth/authorized-apps-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { oauthAppKeys } from './keys'
 
 export type AuthorizedAppsVariables = {
@@ -37,7 +37,7 @@ export const useAuthorizedAppsQuery = <TData = AuthorizedAppsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<AuthorizedAppsData, AuthorizedAppsError, TData> = {}
+  }: UseCustomQueryOptions<AuthorizedAppsData, AuthorizedAppsError, TData> = {}
 ) =>
   useQuery<AuthorizedAppsData, AuthorizedAppsError, TData>({
     queryKey: oauthAppKeys.authorizedApps(slug),

--- a/apps/studio/data/oauth/oauth-app-create-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-create-mutation.ts
@@ -1,10 +1,10 @@
 import type { OAuthScope } from '@supabase/shared-types/out/constants'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthAppKeys } from './keys'
 
 export type OAuthAppCreateVariables = {
@@ -48,7 +48,7 @@ export const useOAuthAppCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OAuthAppCreateData, ResponseError, OAuthAppCreateVariables>,
+  UseCustomMutationOptions<OAuthAppCreateData, ResponseError, OAuthAppCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth/oauth-app-delete-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthAppKeys } from './keys'
 
 export type OAuthAppDeleteVariables = {
@@ -29,7 +29,7 @@ export const useOAuthAppDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OAuthAppDeleteData, ResponseError, OAuthAppDeleteVariables>,
+  UseCustomMutationOptions<OAuthAppDeleteData, ResponseError, OAuthAppDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth/oauth-app-update-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-update-mutation.ts
@@ -1,9 +1,9 @@
 import type { OAuthScope } from '@supabase/shared-types/out/constants'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { oauthAppKeys } from './keys'
 
 export type OAuthAppUpdateVariables = {
@@ -52,7 +52,7 @@ export const useOAuthAppUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OAuthAppUpdateData, ResponseError, OAuthAppUpdateVariables>,
+  UseCustomMutationOptions<OAuthAppUpdateData, ResponseError, OAuthAppUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/oauth/oauth-apps-query.ts
+++ b/apps/studio/data/oauth/oauth-apps-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { oauthAppKeys } from './keys'
 
 export type OAuthAppsVariables = {
@@ -27,7 +27,7 @@ export type OAuthAppsError = ResponseError
 
 export const useOAuthAppsQuery = <TData = OAuthAppsData>(
   { slug }: OAuthAppsVariables,
-  { enabled = true, ...options }: UseQueryOptions<OAuthAppsData, OAuthAppsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<OAuthAppsData, OAuthAppsError, TData> = {}
 ) =>
   useQuery<OAuthAppsData, OAuthAppsError, TData>({
     queryKey: oauthAppKeys.oauthApps(slug),

--- a/apps/studio/data/open-api/api-spec-query.ts
+++ b/apps/studio/data/open-api/api-spec-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { openApiKeys } from './keys'
 
 export type OpenAPISpecVariables = {
@@ -56,7 +56,10 @@ export type OpenAPISpecError = ResponseError
 
 export const useOpenAPISpecQuery = <TData = OpenAPISpecData>(
   { projectRef }: OpenAPISpecVariables,
-  { enabled = true, ...options }: UseQueryOptions<OpenAPISpecData, OpenAPISpecError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<OpenAPISpecData, OpenAPISpecError, TData> = {}
 ) =>
   useQuery<OpenAPISpecData, OpenAPISpecError, TData>({
     queryKey: openApiKeys.apiSpec(projectRef),

--- a/apps/studio/data/organization-members/organization-invitation-accept-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-accept-mutation.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
 import { invalidateOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useInvalidateProjectsInfiniteQuery } from 'data/projects/org-projects-infinite-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type OrganizationAcceptInvitationVariables = {
   slug: string
@@ -30,7 +30,7 @@ export const useOrganizationAcceptInvitationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationMemberUpdateData,
     ResponseError,
     OrganizationAcceptInvitationVariables

--- a/apps/studio/data/organization-members/organization-invitation-create-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-create-mutation.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
 import { organizationKeys as organizationKeysV1 } from 'data/organizations/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationCreateInvitationVariables = {
@@ -39,7 +39,7 @@ export const useOrganizationCreateInvitationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationMemberUpdateData,
     ResponseError,
     OrganizationCreateInvitationVariables

--- a/apps/studio/data/organization-members/organization-invitation-delete-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys as organizationKeysV1 } from '../organizations/keys'
 import { organizationKeys } from './keys'
 
@@ -31,7 +31,7 @@ export const useOrganizationDeleteInvitationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationDeleteInvitationData,
     ResponseError,
     OrganizationDeleteInvitationVariables

--- a/apps/studio/data/organization-members/organization-invitation-token-query.ts
+++ b/apps/studio/data/organization-members/organization-invitation-token-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
-import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
-import { organizationKeys } from './keys'
 import { components } from 'api-types'
+import { get, handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { organizationKeys } from './keys'
 
 export type OrganizationInviteTokenVariables = { slug?: string; token?: string }
 
@@ -33,7 +33,7 @@ export const useOrganizationInvitationTokenQuery = <TData = OrganizationInviteTo
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationInviteTokenData, OrganizationInviteTokenError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationInviteTokenData, OrganizationInviteTokenError, TData> = {}
 ) => {
   return useQuery<OrganizationInviteTokenData, OrganizationInviteTokenError, TData>({
     queryKey: organizationKeys.token(slug, token),

--- a/apps/studio/data/organization-members/organization-member-role-assign-mutation.ts
+++ b/apps/studio/data/organization-members/organization-member-role-assign-mutation.ts
@@ -1,10 +1,10 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, patch } from 'data/fetchers'
 import { organizationKeys as organizationKeysV1 } from 'data/organizations/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMemberAssignRoleVariables = {
@@ -41,7 +41,7 @@ export const useOrganizationMemberAssignRoleMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationMemberAssignData,
     ResponseError,
     OrganizationMemberAssignRoleVariables

--- a/apps/studio/data/organization-members/organization-member-role-unassign-mutation.ts
+++ b/apps/studio/data/organization-members/organization-member-role-unassign-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
 import { organizationKeys as organizationKeysV1 } from 'data/organizations/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMemberUnassignRoleVariables = {
@@ -42,7 +42,7 @@ export const useOrganizationMemberUnassignRoleMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationMemberUnassignRoleData,
     ResponseError,
     OrganizationMemberUnassignRoleVariables

--- a/apps/studio/data/organization-members/organization-member-role-update-mutation.ts
+++ b/apps/studio/data/organization-members/organization-member-role-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, put } from 'data/fetchers'
 import { organizationKeys as organizationKeysV1 } from 'data/organizations/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMemberUpdateRoleVariables = {
@@ -41,7 +41,7 @@ export const useOrganizationMemberUpdateRoleMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationMemberAssignData,
     ResponseError,
     OrganizationMemberUpdateRoleVariables

--- a/apps/studio/data/organization-members/organization-roles-query.ts
+++ b/apps/studio/data/organization-members/organization-roles-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export const FIXED_ROLE_ORDER = ['Owner', 'Administrator', 'Developer', 'Read-only']
@@ -34,7 +34,7 @@ export const useOrganizationRolesV2Query = <TData = OrganizationRolesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationRolesData, OrganizationRolesError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationRolesData, OrganizationRolesError, TData> = {}
 ) =>
   useQuery<OrganizationRolesData, OrganizationRolesError, TData>({
     queryKey: organizationKeys.rolesV2(slug),

--- a/apps/studio/data/organizations/free-project-limit-check-query.ts
+++ b/apps/studio/data/organizations/free-project-limit-check-query.ts
@@ -1,8 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { organizationKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type MemberWithFreeProjectLimit = components['schemas']['MemberWithFreeProjectLimit']
 
@@ -36,7 +37,7 @@ export const useFreeProjectLimitCheckQuery = <TData = FreeProjectLimitCheckData>
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<FreeProjectLimitCheckData, FreeProjectLimitCheckError, TData> = {}
+  }: UseCustomQueryOptions<FreeProjectLimitCheckData, FreeProjectLimitCheckError, TData> = {}
 ) =>
   useQuery<FreeProjectLimitCheckData, FreeProjectLimitCheckError, TData>({
     queryKey: organizationKeys.freeProjectLimitCheck(slug),

--- a/apps/studio/data/organizations/organization-audit-logs-query.ts
+++ b/apps/studio/data/organizations/organization-audit-logs-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type AuditLog = {
@@ -64,7 +64,7 @@ export const useOrganizationAuditLogsQuery = <TData = OrganizationAuditLogsData>
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationAuditLogsData, OrganizationAuditLogsError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationAuditLogsData, OrganizationAuditLogsError, TData> = {}
 ) => {
   const { slug, iso_timestamp_start, iso_timestamp_end } = vars
 

--- a/apps/studio/data/organizations/organization-available-regions-query.ts
+++ b/apps/studio/data/organizations/organization-available-regions-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type DesiredInstanceSizeForAvailableRegions =
@@ -44,7 +44,7 @@ export const useOrganizationAvailableRegionsQuery = <TData = OrganizationAvailab
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<
+  }: UseCustomQueryOptions<
     OrganizationAvailableRegionsData,
     OrganizationAvailableRegionsError,
     TData

--- a/apps/studio/data/organizations/organization-billing-subscription-preview.ts
+++ b/apps/studio/data/organizations/organization-billing-subscription-preview.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { handleError, post } from 'data/fetchers'
 import type { SubscriptionTier } from 'data/subscriptions/types'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationBillingSubscriptionPreviewVariables = {
@@ -81,7 +81,7 @@ export const useOrganizationBillingSubscriptionPreview = <
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationBillingSubscriptionPreviewData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationBillingSubscriptionPreviewData, ResponseError, TData> = {}
 ) =>
   useQuery<OrganizationBillingSubscriptionPreviewData, ResponseError, TData>({
     queryKey: organizationKeys.subscriptionPreview(organizationSlug, tier),

--- a/apps/studio/data/organizations/organization-by-fly-organization-id-mutation.ts
+++ b/apps/studio/data/organizations/organization-by-fly-organization-id-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type OrganizationByFlyOrgIdVariables = {
   flyOrganizationId: string
@@ -28,7 +28,11 @@ export const useOrganizationByFlyOrgIdMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationByFlyOrgIdData, ResponseError, OrganizationByFlyOrgIdVariables>,
+  UseCustomMutationOptions<
+    OrganizationByFlyOrgIdData,
+    ResponseError,
+    OrganizationByFlyOrgIdVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<OrganizationByFlyOrgIdData, ResponseError, OrganizationByFlyOrgIdVariables>({

--- a/apps/studio/data/organizations/organization-create-mutation.ts
+++ b/apps/studio/data/organizations/organization-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
 import { permissionKeys } from 'data/permissions/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 import { castOrganizationResponseToOrganization } from './organizations-query'
 import type { CustomerAddress, CustomerTaxId } from './types'
@@ -53,7 +53,7 @@ export const useOrganizationCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationCreateData, ResponseError, OrganizationCreateVariables>,
+  UseCustomMutationOptions<OrganizationCreateData, ResponseError, OrganizationCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()
@@ -125,7 +125,7 @@ export const useAwsManagedOrganizationCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     AwsManagedOrganizationCreateData,
     ResponseError,
     AwsManagedOrganizationCreateVariables

--- a/apps/studio/data/organizations/organization-credit-top-up-mutation.ts
+++ b/apps/studio/data/organizations/organization-credit-top-up-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import type { CustomerAddress, CustomerTaxId } from './types'
 
 export type OrganizationCreditTopUpVariables = {
@@ -64,7 +64,11 @@ export const useOrganizationCreditTopUpMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationTaxIdUpdateData, ResponseError, OrganizationCreditTopUpVariables>,
+  UseCustomMutationOptions<
+    OrganizationTaxIdUpdateData,
+    ResponseError,
+    OrganizationCreditTopUpVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<OrganizationTaxIdUpdateData, ResponseError, OrganizationCreditTopUpVariables>({

--- a/apps/studio/data/organizations/organization-customer-profile-query.ts
+++ b/apps/studio/data/organizations/organization-customer-profile-query.ts
@@ -1,11 +1,11 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
+import { IS_PLATFORM } from 'common'
 import { get, handleError } from 'data/fetchers'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
-import { IS_PLATFORM } from 'common'
 
 export type OrganizationCustomerProfileVariables = {
   slug?: string
@@ -40,7 +40,11 @@ export const useOrganizationCustomerProfileQuery = <TData = OrganizationCustomer
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationCustomerProfileData, OrganizationCustomerProfileError, TData> = {}
+  }: UseCustomQueryOptions<
+    OrganizationCustomerProfileData,
+    OrganizationCustomerProfileError,
+    TData
+  > = {}
 ) => {
   // [Joshen] Thinking it makes sense to add this check at the RQ level - prevent
   // unnecessary requests, although this behaviour still needs handling on the UI

--- a/apps/studio/data/organizations/organization-customer-profile-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-customer-profile-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 import type { CustomerAddress } from './types'
 
@@ -43,7 +43,7 @@ export const useOrganizationCustomerProfileUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationCustomerProfileUpdateData,
     ResponseError,
     OrganizationCustomerProfileUpdateVariables

--- a/apps/studio/data/organizations/organization-delete-mutation.ts
+++ b/apps/studio/data/organizations/organization-delete-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
 import { permissionKeys } from 'data/permissions/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationDeleteVariables = {
@@ -25,7 +25,7 @@ export const useOrganizationDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationDeleteData, ResponseError, OrganizationDeleteVariables>,
+  UseCustomMutationOptions<OrganizationDeleteData, ResponseError, OrganizationDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/organizations/organization-link-aws-marketplace-mutation.ts
+++ b/apps/studio/data/organizations/organization-link-aws-marketplace-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import type { ResponseError, UseCustomMutationOptions } from '../../types'
 import { handleError, put } from '../fetchers'
-import type { ResponseError } from '../../types'
 
 export type OrganizationLinkAwsMarketplaceVariables = {
   buyerId: string
@@ -29,7 +29,11 @@ export const useOrganizationLinkAwsMarketplaceMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<LinkOrganizationData, ResponseError, OrganizationLinkAwsMarketplaceVariables>,
+  UseCustomMutationOptions<
+    LinkOrganizationData,
+    ResponseError,
+    OrganizationLinkAwsMarketplaceVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<LinkOrganizationData, ResponseError, OrganizationLinkAwsMarketplaceVariables>({

--- a/apps/studio/data/organizations/organization-member-delete-mutation.ts
+++ b/apps/studio/data/organizations/organization-member-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMemberDeleteVariables = {
@@ -28,7 +28,7 @@ export const useOrganizationMemberDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationMemberDeleteData,
     ResponseError,
     OrganizationMemberDeleteVariables

--- a/apps/studio/data/organizations/organization-members-query.ts
+++ b/apps/studio/data/organizations/organization-members-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMembersVariables = {
@@ -58,7 +58,7 @@ export const useOrganizationMembersQuery = <TData = OrganizationMembersData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationMembersData, OrganizationMembersError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationMembersData, OrganizationMembersError, TData> = {}
 ) =>
   useQuery<OrganizationMembersData, OrganizationMembersError, TData>({
     queryKey: organizationKeys.members(slug),

--- a/apps/studio/data/organizations/organization-mfa-mutation.ts
+++ b/apps/studio/data/organizations/organization-mfa-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { patch, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import { handleError, patch } from 'data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMfaToggleVariables = {
@@ -29,7 +29,11 @@ export const useOrganizationMfaToggleMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationMfaToggleData, ResponseError, OrganizationMfaToggleVariables>,
+  UseCustomMutationOptions<
+    OrganizationMfaToggleData,
+    ResponseError,
+    OrganizationMfaToggleVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/organizations/organization-mfa-query.ts
+++ b/apps/studio/data/organizations/organization-mfa-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationMfaVariables = {
@@ -29,7 +29,7 @@ export type OrganizationMfaError = ResponseError
 
 export const useOrganizationMfaQuery = <TData = boolean>(
   { slug }: OrganizationMfaVariables,
-  { enabled = true, ...options }: UseQueryOptions<boolean, OrganizationMfaError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<boolean, OrganizationMfaError, TData> = {}
 ) =>
   useQuery<boolean, OrganizationMfaError, TData>({
     queryKey: organizationKeys.mfa(slug),

--- a/apps/studio/data/organizations/organization-payment-method-default-mutation.ts
+++ b/apps/studio/data/organizations/organization-payment-method-default-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { handleError, put } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationPaymentMethodDefaultVariables = {
@@ -34,7 +34,7 @@ export const useOrganizationPaymentMethodMarkAsDefaultMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationPaymentMethodDefaultData,
     ResponseError,
     OrganizationPaymentMethodDefaultVariables

--- a/apps/studio/data/organizations/organization-payment-method-delete-mutation.ts
+++ b/apps/studio/data/organizations/organization-payment-method-delete-mutation.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { del, handleError } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationPaymentMethodDeleteVariables = {
@@ -35,7 +35,7 @@ export const useOrganizationPaymentMethodDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationPaymentMethodDeleteData,
     ResponseError,
     OrganizationPaymentMethodDeleteVariables

--- a/apps/studio/data/organizations/organization-payment-method-setup-intent-mutation.ts
+++ b/apps/studio/data/organizations/organization-payment-method-setup-intent-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type OrganizationPaymentMethodSetupIntentVariables = {
   slug: string
@@ -30,7 +30,7 @@ export const useOrganizationPaymentMethodSetupIntent = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     OrganizationPaymentMethodSetupIntentData,
     ResponseError,
     OrganizationPaymentMethodSetupIntentVariables

--- a/apps/studio/data/organizations/organization-payment-methods-query.ts
+++ b/apps/studio/data/organizations/organization-payment-methods-query.ts
@@ -1,10 +1,10 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationPaymentMethodsVariables = { slug?: string }
@@ -42,7 +42,11 @@ export const useOrganizationPaymentMethodsQuery = <TData = OrganizationPaymentMe
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationPaymentMethodsData, OrganizationPaymentMethodsError, TData> = {}
+  }: UseCustomQueryOptions<
+    OrganizationPaymentMethodsData,
+    OrganizationPaymentMethodsError,
+    TData
+  > = {}
 ) => {
   const { can: canReadSubscriptions } = useAsyncCheckPermissions(
     PermissionAction.BILLING_READ,

--- a/apps/studio/data/organizations/organization-project-claim-mutation.ts
+++ b/apps/studio/data/organizations/organization-project-claim-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type OrganizationProjectClaimVariables = {
   slug: string
@@ -24,7 +24,7 @@ export const useOrganizationProjectClaimMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     ClaimOrganizationProjectData,
     ResponseError,
     OrganizationProjectClaimVariables

--- a/apps/studio/data/organizations/organization-project-claim-query.ts
+++ b/apps/studio/data/organizations/organization-project-claim-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { organizationKeys } from './keys'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { organizationKeys } from './keys'
 
 type OrganizationProjectClaimVariables = {
   slug: string
@@ -67,7 +67,7 @@ export const useOrganizationProjectClaimQuery = <TData = OrganizationProjectClai
   { slug, token }: OrganizationProjectClaimVariables,
   {
     ...options
-  }: UseQueryOptions<OrganizationProjectClaimData, OrganizationProjectClaimError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationProjectClaimData, OrganizationProjectClaimError, TData> = {}
 ) =>
   useQuery<OrganizationProjectClaimData, OrganizationProjectClaimError, TData>({
     queryKey: organizationKeys.projectClaim(slug, token),

--- a/apps/studio/data/organizations/organization-query.ts
+++ b/apps/studio/data/organizations/organization-query.ts
@@ -1,8 +1,8 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationVariables = { slug?: string }
@@ -35,7 +35,10 @@ export type OrganizationsError = ResponseError
 
 export const useOrganizationQuery = <TData = OrganizationsData>(
   { slug }: OrganizationVariables,
-  { enabled = true, ...options }: UseQueryOptions<OrganizationsData, OrganizationsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<OrganizationsData, OrganizationsError, TData> = {}
 ) => {
   return useQuery<OrganizationsData, OrganizationsError, TData>({
     queryKey: organizationKeys.detail(slug),

--- a/apps/studio/data/organizations/organization-tax-id-query.ts
+++ b/apps/studio/data/organizations/organization-tax-id-query.ts
@@ -1,10 +1,10 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationTaxIdVariables = {
@@ -34,7 +34,7 @@ export const useOrganizationTaxIdQuery = <TData = OrganizationTaxIdData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrganizationTaxIdData, OrganizationTaxIdError, TData> = {}
+  }: UseCustomQueryOptions<OrganizationTaxIdData, OrganizationTaxIdError, TData> = {}
 ) => {
   const { can: canReadSubscriptions } = useAsyncCheckPermissions(
     PermissionAction.BILLING_READ,

--- a/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationTaxIdUpdateVariables = {
@@ -54,7 +54,11 @@ export const useOrganizationTaxIdUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationTaxIdUpdateData, ResponseError, OrganizationTaxIdUpdateVariables>,
+  UseCustomMutationOptions<
+    OrganizationTaxIdUpdateData,
+    ResponseError,
+    OrganizationTaxIdUpdateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/organizations/organization-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
 
 export type OrganizationUpdateVariables = {
@@ -44,7 +44,7 @@ export const useOrganizationUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrganizationUpdateData, ResponseError, OrganizationUpdateVariables>,
+  UseCustomMutationOptions<OrganizationUpdateData, ResponseError, OrganizationUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/organizations/organizations-query.ts
+++ b/apps/studio/data/organizations/organizations-query.ts
@@ -1,11 +1,11 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import { useProfile } from 'lib/profile'
-import type { Organization, ResponseError } from 'types'
-import { organizationKeys } from './keys'
 import { MANAGED_BY, ManagedBy } from 'lib/constants/infrastructure'
+import { useProfile } from 'lib/profile'
+import type { Organization, ResponseError, UseCustomQueryOptions } from 'types'
+import { organizationKeys } from './keys'
 
 export type OrganizationBase = components['schemas']['OrganizationResponse']
 
@@ -52,7 +52,7 @@ export type OrganizationsError = ResponseError
 export const useOrganizationsQuery = <TData = OrganizationsData>({
   enabled = true,
   ...options
-}: UseQueryOptions<OrganizationsData, OrganizationsError, TData> = {}) => {
+}: UseCustomQueryOptions<OrganizationsData, OrganizationsError, TData> = {}) => {
   const { profile } = useProfile()
   return useQuery<OrganizationsData, OrganizationsError, TData>({
     queryKey: organizationKeys.list(),

--- a/apps/studio/data/permissions/permissions-query.ts
+++ b/apps/studio/data/permissions/permissions-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { useIsLoggedIn } from 'common'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { Permission, ResponseError } from 'types'
+import type { Permission, ResponseError, UseCustomQueryOptions } from 'types'
 import { permissionKeys } from './keys'
 
 export type PermissionsResponse = Permission[]
@@ -33,7 +33,7 @@ export type PermissionsError = ResponseError
 export const usePermissionsQuery = <TData = PermissionsData>({
   enabled = true,
   ...options
-}: UseQueryOptions<PermissionsData, PermissionsError, TData> = {}) => {
+}: UseCustomQueryOptions<PermissionsData, PermissionsError, TData> = {}) => {
   const isLoggedIn = useIsLoggedIn()
 
   return useQuery<PermissionsData, PermissionsError, TData>({

--- a/apps/studio/data/platform/platform-status-query.ts
+++ b/apps/studio/data/platform/platform-status-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { platformKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type PlatformStatusResponse = {
   isHealthy: boolean
@@ -17,7 +18,7 @@ export type PlatformStatusData = Awaited<ReturnType<typeof getPlatformStatus>>
 export type PlatformStatusError = unknown
 
 export const usePlatformStatusQuery = <TData = PlatformStatusData>(
-  options: UseQueryOptions<PlatformStatusData, PlatformStatusError, TData> = {}
+  options: UseCustomQueryOptions<PlatformStatusData, PlatformStatusError, TData> = {}
 ) =>
   useQuery<PlatformStatusData, PlatformStatusError, TData>({
     queryKey: platformKeys.status(),

--- a/apps/studio/data/privileges/column-privileges-grant-mutation.ts
+++ b/apps/studio/data/privileges/column-privileges-grant-mutation.ts
@@ -1,8 +1,8 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { privilegeKeys } from './keys'
 
 export type ColumnPrivilegesGrant = {
@@ -49,7 +49,11 @@ export const useColumnPrivilegesGrantMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ColumnPrivilegesGrantData, ResponseError, ColumnPrivilegesGrantVariables>,
+  UseCustomMutationOptions<
+    ColumnPrivilegesGrantData,
+    ResponseError,
+    ColumnPrivilegesGrantVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/privileges/column-privileges-query.ts
+++ b/apps/studio/data/privileges/column-privileges-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { privilegeKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type ColumnPrivilegesVariables = {
   projectRef?: string
@@ -47,7 +47,7 @@ export const useColumnPrivilegesQuery = <TData = ColumnPrivilegesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ColumnPrivilegesData, ColumnPrivilegesError, TData> = {}
+  }: UseCustomQueryOptions<ColumnPrivilegesData, ColumnPrivilegesError, TData> = {}
 ) =>
   useQuery<ColumnPrivilegesData, ColumnPrivilegesError, TData>({
     queryKey: privilegeKeys.columnPrivilegesList(projectRef),

--- a/apps/studio/data/privileges/column-privileges-revoke-mutation.ts
+++ b/apps/studio/data/privileges/column-privileges-revoke-mutation.ts
@@ -1,8 +1,8 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { privilegeKeys } from './keys'
 
 export type ColumnPrivilegesRevoke = {
@@ -47,7 +47,11 @@ export const useColumnPrivilegesRevokeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ColumnPrivilegesRevokeData, ResponseError, ColumnPrivilegesRevokeVariables>,
+  UseCustomMutationOptions<
+    ColumnPrivilegesRevokeData,
+    ResponseError,
+    ColumnPrivilegesRevokeVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/privileges/table-privileges-grant-mutation.ts
+++ b/apps/studio/data/privileges/table-privileges-grant-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { privilegeKeys } from './keys'
 import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 
@@ -41,7 +41,7 @@ export const useTablePrivilegesGrantMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TablePrivilegesGrantData, ResponseError, TablePrivilegesGrantVariables>,
+  UseCustomMutationOptions<TablePrivilegesGrantData, ResponseError, TablePrivilegesGrantVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/privileges/table-privileges-query.ts
+++ b/apps/studio/data/privileges/table-privileges-query.ts
@@ -1,9 +1,10 @@
 import pgMeta from '@supabase/pg-meta'
-import { QueryClient, UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
 import { privilegeKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type TablePrivilegesVariables = {
   projectRef?: string
@@ -39,7 +40,7 @@ export const useTablePrivilegesQuery = <TData = TablePrivilegesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<TablePrivilegesData, TablePrivilegesError, TData> = {}
+  }: UseCustomQueryOptions<TablePrivilegesData, TablePrivilegesError, TData> = {}
 ) =>
   useQuery<TablePrivilegesData, TablePrivilegesError, TData>({
     queryKey: privilegeKeys.tablePrivilegesList(projectRef),

--- a/apps/studio/data/privileges/table-privileges-revoke-mutation.ts
+++ b/apps/studio/data/privileges/table-privileges-revoke-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { privilegeKeys } from './keys'
 import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 
@@ -41,7 +41,11 @@ export const useTablePrivilegesRevokeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TablePrivilegesRevokeData, ResponseError, TablePrivilegesRevokeVariables>,
+  UseCustomMutationOptions<
+    TablePrivilegesRevokeData,
+    ResponseError,
+    TablePrivilegesRevokeVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/profile/mfa-authenticator-assurance-level-query.ts
+++ b/apps/studio/data/profile/mfa-authenticator-assurance-level-query.ts
@@ -1,8 +1,9 @@
 import type { AuthMFAGetAuthenticatorAssuranceLevelResponse } from '@supabase/supabase-js'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { auth } from 'lib/gotrue'
 import { profileKeys } from './keys'
 import type { Profile } from './types'
+import { UseCustomQueryOptions } from 'types'
 
 export type ProfileResponse = Profile
 
@@ -25,7 +26,7 @@ export const useAuthenticatorAssuranceLevelQuery = <
 >({
   enabled = true,
   ...options
-}: UseQueryOptions<
+}: UseCustomQueryOptions<
   CustomAuthMFAGetAuthenticatorAssuranceLevelData,
   CustomAuthMFAGetAuthenticatorAssuranceLevelError,
   TData

--- a/apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts
+++ b/apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts
@@ -1,10 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
 import type { AuthMFAVerifyResponse, MFAChallengeAndVerifyParams } from '@supabase/supabase-js'
-import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { auth } from 'lib/gotrue'
 import { profileKeys } from './keys'
+import { UseCustomMutationOptions } from 'types'
 
 const WHITELIST_ERRORS = ['Invalid TOTP code entered']
 
@@ -26,7 +27,11 @@ export const useMfaChallengeAndVerifyMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomMFAVerifyResponse, CustomMFAVerifyError, MFAChallengeAndVerifyVariables>,
+  UseCustomMutationOptions<
+    CustomMFAVerifyResponse,
+    CustomMFAVerifyError,
+    MFAChallengeAndVerifyVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/profile/mfa-enroll-mutation.ts
+++ b/apps/studio/data/profile/mfa-enroll-mutation.ts
@@ -1,7 +1,8 @@
 import type { AuthMFAEnrollResponse, MFAEnrollParams } from '@supabase/supabase-js'
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { auth } from 'lib/gotrue'
 import { toast } from 'sonner'
+import { UseCustomMutationOptions } from 'types'
 
 const mfaEnroll = async (params: MFAEnrollParams) => {
   const { error, data } = await auth.mfa.enroll(params)
@@ -18,7 +19,7 @@ export const useMfaEnrollMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomMFAEnrollResponse, CustomMFAEnrollError, MFAEnrollParams>,
+  UseCustomMutationOptions<CustomMFAEnrollResponse, CustomMFAEnrollError, MFAEnrollParams>,
   'mutationFn'
 > = {}) => {
   return useMutation({

--- a/apps/studio/data/profile/mfa-list-factors-query.ts
+++ b/apps/studio/data/profile/mfa-list-factors-query.ts
@@ -1,7 +1,8 @@
 import type { AuthMFAListFactorsResponse, Factor } from '@supabase/supabase-js'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { auth } from 'lib/gotrue'
 import { profileKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export async function getMfaListFactors() {
   const { error, data } = await auth.mfa.listFactors()
@@ -17,7 +18,7 @@ type CustomMFAListFactorsError = NonNullable<AuthMFAListFactorsResponse['error']
 export const useMfaListFactorsQuery = <TData = CustomMFAListFactorsData>({
   enabled = true,
   ...options
-}: UseQueryOptions<CustomMFAListFactorsData, CustomMFAListFactorsError, TData> = {}) => {
+}: UseCustomQueryOptions<CustomMFAListFactorsData, CustomMFAListFactorsError, TData> = {}) => {
   return useQuery<CustomMFAListFactorsData, CustomMFAListFactorsError, TData>({
     queryKey: profileKeys.mfaFactors(),
     queryFn: () => getMfaListFactors(),

--- a/apps/studio/data/profile/mfa-unenroll-mutation.ts
+++ b/apps/studio/data/profile/mfa-unenroll-mutation.ts
@@ -1,8 +1,9 @@
 import type { AuthMFAUnenrollResponse, MFAUnenrollParams } from '@supabase/supabase-js'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { auth } from 'lib/gotrue'
 import { toast } from 'sonner'
 import { profileKeys } from './keys'
+import { UseCustomMutationOptions } from 'types'
 
 const mfaUnenroll = async (params: MFAUnenrollParams) => {
   const { error, data } = await auth.mfa.unenroll(params)
@@ -19,7 +20,7 @@ export const useMfaUnenrollMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CustomMFAUnenrollResponse, CustomMFAUnenrollError, MFAUnenrollParams>,
+  UseCustomMutationOptions<CustomMFAUnenrollResponse, CustomMFAUnenrollError, MFAUnenrollParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/profile/profile-audit-logs-query.ts
+++ b/apps/studio/data/profile/profile-audit-logs-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import type { AuditLog } from 'data/organizations/organization-audit-logs-query'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { profileKeys } from './keys'
 
 export type ProfileAuditLogsVariables = {
@@ -37,7 +37,7 @@ export type ProfileAuditLogsData = {
 
 export const useProfileAuditLogsQuery = <TData = ProfileAuditLogsData>(
   vars: ProfileAuditLogsVariables,
-  options: UseQueryOptions<ProfileAuditLogsData, ProfileAuditLogsError, TData> = {}
+  options: UseCustomQueryOptions<ProfileAuditLogsData, ProfileAuditLogsError, TData> = {}
 ) => {
   const { iso_timestamp_start, iso_timestamp_end } = vars
   return useQuery<ProfileAuditLogsData, ProfileAuditLogsError, TData>({

--- a/apps/studio/data/profile/profile-create-mutation.ts
+++ b/apps/studio/data/profile/profile-create-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
 import { organizationKeys } from 'data/organizations/keys'
 import { permissionKeys } from 'data/permissions/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { profileKeys } from './keys'
 
 export type ProfileResponse = components['schemas']['ProfileResponse']
@@ -23,7 +23,7 @@ export const useProfileCreateMutation = ({
   onSuccess,
   onError,
   ...options
-}: Omit<UseMutationOptions<ProfileCreateData, ResponseError, void>, 'mutationFn'> = {}) => {
+}: Omit<UseCustomMutationOptions<ProfileCreateData, ResponseError, void>, 'mutationFn'> = {}) => {
   const queryClient = useQueryClient()
 
   return useMutation<ProfileCreateData, ResponseError, void>({

--- a/apps/studio/data/profile/profile-identities-query.ts
+++ b/apps/studio/data/profile/profile-identities-query.ts
@@ -1,8 +1,9 @@
 import type { UserIdentity } from '@supabase/supabase-js'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { auth } from 'lib/gotrue'
 import { profileKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export async function getProfileIdentities() {
   // getSession() uses a cached user object, which is almost never stale as the
@@ -28,7 +29,7 @@ type ProfileIdentitiesError = any
 export const useProfileIdentitiesQuery = <TData = ProfileIdentitiesData>({
   enabled = true,
   ...options
-}: UseQueryOptions<ProfileIdentitiesData, ProfileIdentitiesError, TData> = {}) => {
+}: UseCustomQueryOptions<ProfileIdentitiesData, ProfileIdentitiesError, TData> = {}) => {
   return useQuery<ProfileIdentitiesData, ProfileIdentitiesError, TData>({
     queryKey: profileKeys.identities(),
     queryFn: () => getProfileIdentities(),

--- a/apps/studio/data/profile/profile-query.ts
+++ b/apps/studio/data/profile/profile-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { profileKeys } from './keys'
 import type { Profile } from './types'
 
@@ -30,7 +30,7 @@ export type ProfileError = ResponseError
 export const useProfileQuery = <TData = ProfileData>({
   enabled = true,
   ...options
-}: UseQueryOptions<ProfileData, ProfileError, TData> = {}) => {
+}: UseCustomQueryOptions<ProfileData, ProfileError, TData> = {}) => {
   return useQuery<ProfileData, ProfileError, TData>({
     queryKey: profileKeys.profile(),
     queryFn: ({ signal }) => getProfile(signal),

--- a/apps/studio/data/profile/profile-unlink-identity-mutation.ts
+++ b/apps/studio/data/profile/profile-unlink-identity-mutation.ts
@@ -1,8 +1,9 @@
 import type { UserIdentity } from '@supabase/supabase-js'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { auth } from 'lib/gotrue'
+import { UseCustomMutationOptions } from 'types'
 import { profileKeys } from './keys'
 
 const unlinkIdentity = async (identity: UserIdentity) => {
@@ -20,7 +21,7 @@ export const useUnlinkIdentityMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UnlinkIdentityResponse, UnlinkIdentityError, UserIdentity>,
+  UseCustomMutationOptions<UnlinkIdentityResponse, UnlinkIdentityError, UserIdentity>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/profile/profile-update-email-mutation.ts
+++ b/apps/studio/data/profile/profile-update-email-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, put } from 'data/fetchers'
 import { auth } from 'lib/gotrue'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { profileKeys } from './keys'
 
 export type EmailUpdateVariables = {
@@ -27,7 +27,7 @@ export const useEmailUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<EmailUpdateData, ResponseError, EmailUpdateVariables>,
+  UseCustomMutationOptions<EmailUpdateData, ResponseError, EmailUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/profile/profile-update-mutation.ts
+++ b/apps/studio/data/profile/profile-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { profileKeys } from './keys'
 
 export type ProfileUpdateVariables = {
@@ -38,7 +38,7 @@ export const useProfileUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProfileUpdateData, ResponseError, ProfileUpdateVariables>,
+  UseCustomMutationOptions<ProfileUpdateData, ResponseError, ProfileUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/projects/clone-mutation.ts
+++ b/apps/studio/data/projects/clone-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectCloneVariables = {
@@ -42,7 +42,7 @@ export const useProjectCloneMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectCloneData, ResponseError, ProjectCloneVariables>,
+  UseCustomMutationOptions<ProjectCloneData, ResponseError, ProjectCloneVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/projects/clone-query.ts
+++ b/apps/studio/data/projects/clone-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { InfraInstanceSize } from 'components/interfaces/DiskManagement/DiskManagement.types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 export async function getCloneBackups(projectRef?: string) {
@@ -25,7 +25,7 @@ export const useCloneBackupsQuery = <
   },
 >(
   { projectRef }: { projectRef?: string },
-  options: UseQueryOptions<CloneBackupsData, CloneBackupsError, TData> = {}
+  options: UseCustomQueryOptions<CloneBackupsData, CloneBackupsError, TData> = {}
 ) => {
   return useQuery<CloneBackupsData, CloneBackupsError, TData>({
     queryKey: projectKeys.listCloneBackups(projectRef),

--- a/apps/studio/data/projects/clone-status-query.ts
+++ b/apps/studio/data/projects/clone-status-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type CloneStatus = components['schemas']['ProjectClonedStatusResponse']
@@ -22,7 +22,7 @@ export type CloneStatusError = ResponseError
 
 export const useCloneStatusQuery = <TData = CloneStatusData>(
   { projectRef }: { projectRef?: string },
-  options: UseQueryOptions<CloneStatusData, CloneStatusError, TData> = {}
+  options: UseCustomQueryOptions<CloneStatusData, CloneStatusError, TData> = {}
 ) => {
   return useQuery<CloneStatusData, CloneStatusError, TData>({
     queryKey: projectKeys.listCloneStatus(projectRef),

--- a/apps/studio/data/projects/org-projects-infinite-query.ts
+++ b/apps/studio/data/projects/org-projects-infinite-query.ts
@@ -1,9 +1,9 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions, useQueryClient } from '@tanstack/react-query'
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useProfile } from 'lib/profile'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { INFINITE_PROJECTS_KEY_PREFIX, projectKeys } from './keys'
 
 // [Joshen] Try to keep this value a multiple of 6 (common denominator of 2 and 3) to fit the cards view
@@ -65,7 +65,7 @@ export const useOrgProjectsInfiniteQuery = <TData = OrgProjectsInfiniteData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<OrgProjectsInfiniteData, OrgProjectsInfiniteError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<OrgProjectsInfiniteData, OrgProjectsInfiniteError, TData> = {}
 ) => {
   const { profile } = useProfile()
   return useInfiniteQuery<OrgProjectsInfiniteData, OrgProjectsInfiniteError, TData>({

--- a/apps/studio/data/projects/project-by-fly-extension-id-mutation.ts
+++ b/apps/studio/data/projects/project-by-fly-extension-id-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ProjectByFlyExtensionIdVariables = {
   flyExtensionId: string
@@ -28,7 +28,11 @@ export const useProjectByFlyExtensionIdMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectByFlyExtensionIdData, ResponseError, ProjectByFlyExtensionIdVariables>,
+  UseCustomMutationOptions<
+    ProjectByFlyExtensionIdData,
+    ResponseError,
+    ProjectByFlyExtensionIdVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<ProjectByFlyExtensionIdData, ResponseError, ProjectByFlyExtensionIdVariables>({

--- a/apps/studio/data/projects/project-create-mutation.ts
+++ b/apps/studio/data/projects/project-create-mutation.ts
@@ -1,11 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
 import { PROVIDERS } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { projectKeys } from './keys'
 import { DesiredInstanceSize, PostgresEngine, ReleaseChannel } from './new-project.constants'
 
@@ -90,7 +90,7 @@ export const useProjectCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectCreateData, ResponseError, ProjectCreateVariables>,
+  UseCustomMutationOptions<ProjectCreateData, ResponseError, ProjectCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/projects/project-delete-mutation.ts
+++ b/apps/studio/data/projects/project-delete-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
 import { organizationKeys } from 'data/organizations/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectDeleteVariables = {
@@ -27,7 +27,7 @@ export const useProjectDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectDeleteData, ResponseError, ProjectDeleteVariables>,
+  UseCustomMutationOptions<ProjectDeleteData, ResponseError, ProjectDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -1,8 +1,8 @@
-import { QueryClient, useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError, isValidConnString } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 import { OrgProjectsResponse } from './org-projects-infinite-query'
 
@@ -42,7 +42,10 @@ export type ProjectDetailError = ResponseError
 
 export const useProjectDetailQuery = <TData = ProjectDetailData>(
   { ref }: ProjectDetailVariables,
-  { enabled = true, ...options }: UseQueryOptions<ProjectDetailData, ProjectDetailError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ProjectDetailData, ProjectDetailError, TData> = {}
 ) =>
   useQuery<ProjectDetailData, ProjectDetailError, TData>({
     queryKey: projectKeys.detail(ref),

--- a/apps/studio/data/projects/project-pause-mutation.ts
+++ b/apps/studio/data/projects/project-pause-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ProjectPauseVariables = {
   ref: string
@@ -23,7 +23,7 @@ export const useProjectPauseMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectPauseData, ResponseError, ProjectPauseVariables>,
+  UseCustomMutationOptions<ProjectPauseData, ResponseError, ProjectPauseVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<ProjectPauseData, ResponseError, ProjectPauseVariables>({

--- a/apps/studio/data/projects/project-pause-status-query.ts
+++ b/apps/studio/data/projects/project-pause-status-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectPauseStatusVariables = { ref?: string }
@@ -29,7 +29,7 @@ export const useProjectPauseStatusQuery = <TData = ProjectPauseStatusData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectPauseStatusData, ProjectPauseStatusError, TData> = {}
+  }: UseCustomQueryOptions<ProjectPauseStatusData, ProjectPauseStatusError, TData> = {}
 ) =>
   useQuery<ProjectPauseStatusData, ProjectPauseStatusError, TData>({
     queryKey: projectKeys.pauseStatus(ref),

--- a/apps/studio/data/projects/project-restart-mutation.ts
+++ b/apps/studio/data/projects/project-restart-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ProjectRestartVariables = {
   ref: string
@@ -31,7 +31,7 @@ export const useProjectRestartMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectRestartData, ResponseError, ProjectRestartVariables>,
+  UseCustomMutationOptions<ProjectRestartData, ResponseError, ProjectRestartVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<ProjectRestartData, ResponseError, ProjectRestartVariables>({

--- a/apps/studio/data/projects/project-restart-services-mutation.ts
+++ b/apps/studio/data/projects/project-restart-services-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ProjectRestartServicesVariables = {
   ref: string
@@ -52,7 +52,11 @@ export const useProjectRestartServicesMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectRestartServicesData, ResponseError, ProjectRestartServicesVariables>,
+  UseCustomMutationOptions<
+    ProjectRestartServicesData,
+    ResponseError,
+    ProjectRestartServicesVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<ProjectRestartServicesData, ResponseError, ProjectRestartServicesVariables>({

--- a/apps/studio/data/projects/project-restore-mutation.ts
+++ b/apps/studio/data/projects/project-restore-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { PostgresEngine, ReleaseChannel } from './new-project.constants'
 
 export type ProjectRestoreVariables = {
@@ -34,7 +34,7 @@ export const useProjectRestoreMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectRestoreData, ResponseError, ProjectRestoreVariables>,
+  UseCustomMutationOptions<ProjectRestoreData, ResponseError, ProjectRestoreVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<ProjectRestoreData, ResponseError, ProjectRestoreVariables>({

--- a/apps/studio/data/projects/project-service-versions.ts
+++ b/apps/studio/data/projects/project-service-versions.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectServiceVersionsVariables = {
@@ -30,7 +30,7 @@ export const useProjectServiceVersionsQuery = <TData = ProjectServiceVersionsDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectServiceVersionsData, ProjectServiceVersionsError, TData> = {}
+  }: UseCustomQueryOptions<ProjectServiceVersionsData, ProjectServiceVersionsError, TData> = {}
 ) =>
   useQuery<ProjectServiceVersionsData, ProjectServiceVersionsError, TData>({
     queryKey: projectKeys.serviceVersions(projectRef),

--- a/apps/studio/data/projects/project-status-query.ts
+++ b/apps/studio/data/projects/project-status-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectStatusVariables = {
@@ -28,7 +28,10 @@ export type ProjectStatusError = ResponseError
 
 export const useProjectStatusQuery = <TData = ProjectStatusData>(
   { projectRef }: ProjectStatusVariables,
-  { enabled = true, ...options }: UseQueryOptions<ProjectStatusData, ProjectStatusError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ProjectStatusData, ProjectStatusError, TData> = {}
 ) =>
   useQuery<ProjectStatusData, ProjectStatusError, TData>({
     queryKey: projectKeys.status(projectRef),

--- a/apps/studio/data/projects/project-transfer-mutation.ts
+++ b/apps/studio/data/projects/project-transfer-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectTransferVariables = {
@@ -36,7 +36,7 @@ export const useProjectTransferMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectTransferData, ResponseError, ProjectTransferVariables>,
+  UseCustomMutationOptions<ProjectTransferData, ResponseError, ProjectTransferVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/projects/project-transfer-preview-query.ts
+++ b/apps/studio/data/projects/project-transfer-preview-query.ts
@@ -1,7 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
 import { projectKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type ProjectTransferPreviewVariables = {
   projectRef?: string
@@ -35,7 +36,7 @@ export const useProjectTransferPreviewQuery = <TData = ProjectTransferPreviewDat
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectTransferPreviewData, ProjectTransferPreviewError, TData> = {}
+  }: UseCustomQueryOptions<ProjectTransferPreviewData, ProjectTransferPreviewError, TData> = {}
 ) =>
   useQuery<ProjectTransferPreviewData, ProjectTransferPreviewError, TData>({
     queryKey: projectKeys.projectTransferPreview(projectRef, targetOrganizationSlug),

--- a/apps/studio/data/projects/project-type-generation-query.ts
+++ b/apps/studio/data/projects/project-type-generation-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type GenerateTypesVariables = { ref?: string; included_schemas?: string }
@@ -26,7 +26,10 @@ export type GenerateTypesError = ResponseError
 
 export const useGenerateTypesQuery = <TData = GenerateTypesData>(
   { ref, included_schemas }: GenerateTypesVariables,
-  { enabled = true, ...options }: UseQueryOptions<GenerateTypesData, GenerateTypesError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<GenerateTypesData, GenerateTypesError, TData> = {}
 ) =>
   useQuery<GenerateTypesData, GenerateTypesError, TData>({
     queryKey: projectKeys.types(ref),

--- a/apps/studio/data/projects/project-update-mutation.ts
+++ b/apps/studio/data/projects/project-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { projectKeys } from './keys'
 
 export type ProjectUpdateVariables = {
@@ -32,7 +32,7 @@ export const useProjectUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectUpdateData, ResponseError, ProjectUpdateVariables>,
+  UseCustomMutationOptions<ProjectUpdateData, ResponseError, ProjectUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/projects/project-upgrade-mutation.ts
+++ b/apps/studio/data/projects/project-upgrade-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type ProjectUpgradeVariables = components['schemas']['UpgradeDatabaseBody'] & {
   ref: string
@@ -29,7 +29,7 @@ export const useProjectUpgradeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectUpgradeData, ResponseError, ProjectUpgradeVariables>,
+  UseCustomMutationOptions<ProjectUpgradeData, ResponseError, ProjectUpgradeVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<ProjectUpgradeData, ResponseError, ProjectUpgradeVariables>({

--- a/apps/studio/data/projects/projects-infinite-query.ts
+++ b/apps/studio/data/projects/projects-infinite-query.ts
@@ -1,9 +1,9 @@
-import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useProfile } from 'lib/profile'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 const DEFAULT_LIMIT = 100
@@ -50,7 +50,7 @@ export const useProjectsInfiniteQuery = <TData = ProjectsInfiniteData>(
   {
     enabled = true,
     ...options
-  }: UseInfiniteQueryOptions<ProjectsInfiniteData, ProjectsInfiniteError, TData> = {}
+  }: UseCustomInfiniteQueryOptions<ProjectsInfiniteData, ProjectsInfiniteError, TData> = {}
 ) => {
   const { profile } = useProfile()
   return useInfiniteQuery<ProjectsInfiniteData, ProjectsInfiniteError, TData>({

--- a/apps/studio/data/projects/projects-query.ts
+++ b/apps/studio/data/projects/projects-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { useProfile } from 'lib/profile'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { projectKeys } from './keys'
 
 type PaginatedProjectsResponse = components['schemas']['ListProjectsPaginatedResponse']
@@ -32,7 +32,7 @@ export type ProjectsError = ResponseError
 export const useProjectsQuery = <TData = ProjectsData>({
   enabled = true,
   ...options
-}: UseQueryOptions<ProjectsData, ProjectsError, TData> = {}) => {
+}: UseCustomQueryOptions<ProjectsData, ProjectsError, TData> = {}) => {
   const { profile } = useProfile()
   return useQuery<ProjectsData, ProjectsError, TData>({
     queryKey: projectKeys.list(),

--- a/apps/studio/data/read-replicas/load-balancers-query.ts
+++ b/apps/studio/data/read-replicas/load-balancers-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicaKeys } from './keys'
 
 export type LoadBalancersVariables = {
@@ -32,7 +32,10 @@ export type LoadBalancersError = ResponseError
 
 export const useLoadBalancersQuery = <TData = LoadBalancersData>(
   { projectRef }: LoadBalancersVariables,
-  { enabled = true, ...options }: UseQueryOptions<LoadBalancersData, LoadBalancersError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<LoadBalancersData, LoadBalancersError, TData> = {}
 ) => {
   return useQuery<LoadBalancersData, LoadBalancersError, TData>({
     queryKey: replicaKeys.loadBalancers(projectRef),

--- a/apps/studio/data/read-replicas/replica-lag-query.ts
+++ b/apps/studio/data/read-replicas/replica-lag-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { replicaKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export const replicationLagSql = () => {
   const sql = /* SQL */ `
@@ -43,7 +44,7 @@ export const useReplicationLagQuery = <TData = ReplicationLagData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationLagData, ReplicationLagError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationLagData, ReplicationLagError, TData> = {}
 ) =>
   useQuery<ReplicationLagData, ReplicationLagError, TData>({
     queryKey: replicaKeys.replicaLag(projectRef, id),

--- a/apps/studio/data/read-replicas/replica-remove-mutation.ts
+++ b/apps/studio/data/read-replicas/replica-remove-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicaKeys } from './keys'
 
 export type ReadReplicaRemoveVariables = {
@@ -31,7 +31,7 @@ export const useReadReplicaRemoveMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ReadReplicaRemoveData, ResponseError, ReadReplicaRemoveVariables>,
+  UseCustomMutationOptions<ReadReplicaRemoveData, ResponseError, ReadReplicaRemoveVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/read-replicas/replica-setup-mutation.ts
+++ b/apps/studio/data/read-replicas/replica-setup-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicaKeys } from './keys'
 
 export type Region =
@@ -47,7 +47,7 @@ export const useReadReplicaSetUpMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ReadReplicaSetUpData, ResponseError, ReadReplicaSetUpVariables>,
+  UseCustomMutationOptions<ReadReplicaSetUpData, ResponseError, ReadReplicaSetUpVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/read-replicas/replicas-query.ts
+++ b/apps/studio/data/read-replicas/replicas-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicaKeys } from './keys'
 
 export const MAX_REPLICAS_BELOW_XL = 2
@@ -31,7 +31,10 @@ export type ReadReplicasError = ResponseError
 
 export const useReadReplicasQuery = <TData = ReadReplicasData>(
   { projectRef }: ReadReplicasVariables,
-  { enabled = true, ...options }: UseQueryOptions<ReadReplicasData, ReadReplicasError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ReadReplicasData, ReadReplicasError, TData> = {}
 ) => {
   return useQuery<ReadReplicasData, ReadReplicasError, TData>({
     queryKey: replicaKeys.list(projectRef),

--- a/apps/studio/data/read-replicas/replicas-status-query.ts
+++ b/apps/studio/data/read-replicas/replicas-status-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicaKeys } from './keys'
 
 // [Joshen] Is it possible to import this from the code gen?
@@ -46,7 +46,7 @@ export const useReadReplicasStatusesQuery = <TData = ReadReplicasStatusesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReadReplicasStatusesData, ReadReplicasStatusesError, TData> = {}
+  }: UseCustomQueryOptions<ReadReplicasStatusesData, ReadReplicasStatusesError, TData> = {}
 ) => {
   return useQuery<ReadReplicasStatusesData, ReadReplicasStatusesError, TData>({
     queryKey: replicaKeys.statuses(projectRef),

--- a/apps/studio/data/realtime/realtime-config-mutation.ts
+++ b/apps/studio/data/realtime/realtime-config-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { realtimeKeys } from './keys'
 
 export type RealtimeConfigurationUpdateVariables = {
@@ -52,7 +52,7 @@ export const useRealtimeConfigurationUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     RealtimeConfigurationUpdateData,
     ResponseError,
     RealtimeConfigurationUpdateVariables

--- a/apps/studio/data/realtime/realtime-config-query.ts
+++ b/apps/studio/data/realtime/realtime-config-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { realtimeKeys } from './keys'
 
 export type RealtimeConfigurationVariables = {
@@ -50,7 +50,7 @@ export const useRealtimeConfigurationQuery = <TData = RealtimeConfigurationData>
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<RealtimeConfigurationData, RealtimeConfigurationError, TData> = {}
+  }: UseCustomQueryOptions<RealtimeConfigurationData, RealtimeConfigurationError, TData> = {}
 ) =>
   useQuery<RealtimeConfigurationData, RealtimeConfigurationError, TData>({
     queryKey: realtimeKeys.configuration(projectRef),

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type BigQueryDestinationConfig = {
@@ -121,7 +121,11 @@ export const useCreateDestinationPipelineMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CreateDestinationPipelineData, ResponseError, CreateDestinationPipelineParams>,
+  UseCustomMutationOptions<
+    CreateDestinationPipelineData,
+    ResponseError,
+    CreateDestinationPipelineParams
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/create-publication-mutation.ts
+++ b/apps/studio/data/replication/create-publication-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type CreatePublicationParams = {
@@ -40,7 +40,7 @@ export const useCreatePublicationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CreatePublicationData, ResponseError, CreatePublicationParams>,
+  UseCustomMutationOptions<CreatePublicationData, ResponseError, CreatePublicationParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/create-tenant-source-mutation.ts
+++ b/apps/studio/data/replication/create-tenant-source-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type CreateTenantSourceParams = {
@@ -30,7 +30,7 @@ export const useCreateTenantSourceMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<CreateTenantSourceData, ResponseError, CreateTenantSourceParams>,
+  UseCustomMutationOptions<CreateTenantSourceData, ResponseError, CreateTenantSourceParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/delete-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/delete-destination-pipeline-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type DeleteDestinationPipelineParams = {
@@ -38,7 +38,11 @@ export const useDeleteDestinationPipelineMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DeleteDestinationPipelineData, ResponseError, DeleteDestinationPipelineParams>,
+  UseCustomMutationOptions<
+    DeleteDestinationPipelineData,
+    ResponseError,
+    DeleteDestinationPipelineParams
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/destination-by-id-query.ts
+++ b/apps/studio/data/replication/destination-by-id-query.ts
@@ -1,8 +1,8 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationDestinationByIdParams = { projectRef?: string; destinationId?: number }
@@ -31,7 +31,7 @@ export const useReplicationDestinationByIdQuery = <TData = ReplicationDestinatio
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationDestinationByIdData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationDestinationByIdData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationDestinationByIdData, ResponseError, TData>({
     queryKey: replicationKeys.destinationById(projectRef, destinationId),

--- a/apps/studio/data/replication/destinations-query.ts
+++ b/apps/studio/data/replication/destinations-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationDestinationsParams = { projectRef?: string }
@@ -30,7 +30,7 @@ export const useReplicationDestinationsQuery = <TData = ReplicationDestinationsD
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationDestinationsData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationDestinationsData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationDestinationsData, ResponseError, TData>({
     queryKey: replicationKeys.destinations(projectRef),

--- a/apps/studio/data/replication/pipeline-by-id-query.ts
+++ b/apps/studio/data/replication/pipeline-by-id-query.ts
@@ -1,8 +1,8 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationPipelineByIdParams = { projectRef?: string; pipelineId?: number }
@@ -31,7 +31,7 @@ export const useReplicationPipelineByIdQuery = <TData = ReplicationPipelineByIdD
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationPipelineByIdData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationPipelineByIdData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationPipelineByIdData, ResponseError, TData>({
     queryKey: replicationKeys.pipelineById(projectRef, pipelineId),

--- a/apps/studio/data/replication/pipeline-replication-status-query.ts
+++ b/apps/studio/data/replication/pipeline-replication-status-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationPipelineReplicationStatusParams = { projectRef?: string; pipelineId?: number }
@@ -38,7 +38,7 @@ export const useReplicationPipelineReplicationStatusQuery = <
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationPipelineReplicationStatusData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationPipelineReplicationStatusData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationPipelineReplicationStatusData, ResponseError, TData>({
     queryKey: replicationKeys.pipelinesReplicationStatus(projectRef, pipelineId),

--- a/apps/studio/data/replication/pipeline-status-query.ts
+++ b/apps/studio/data/replication/pipeline-status-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationPipelinesStatusParams = { projectRef?: string; pipelineId?: number }
@@ -33,7 +33,7 @@ export const useReplicationPipelineStatusQuery = <TData = ReplicationPipelineSta
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationPipelineStatusData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationPipelineStatusData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationPipelineStatusData, ResponseError, TData>({
     queryKey: replicationKeys.pipelinesStatus(projectRef, pipelineId),

--- a/apps/studio/data/replication/pipeline-version-query.ts
+++ b/apps/studio/data/replication/pipeline-version-query.ts
@@ -1,8 +1,8 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationPipelineVersionParams = { projectRef?: string; pipelineId?: number }
@@ -35,7 +35,7 @@ export const useReplicationPipelineVersionQuery = <TData = ReplicationPipelineVe
     refetchOnMount = false,
     refetchOnWindowFocus = false,
     ...options
-  }: UseQueryOptions<ReplicationPipelineVersionData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationPipelineVersionData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationPipelineVersionData, ResponseError, TData>({
     queryKey: replicationKeys.pipelinesVersion(projectRef, pipelineId),

--- a/apps/studio/data/replication/pipelines-query.ts
+++ b/apps/studio/data/replication/pipelines-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationPipelinesParams = { projectRef?: string }
@@ -31,7 +31,7 @@ export const useReplicationPipelinesQuery = <TData = ReplicationPipelinesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationPipelinesData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationPipelinesData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationPipelinesData, ResponseError, TData>({
     queryKey: replicationKeys.pipelines(projectRef),

--- a/apps/studio/data/replication/publication-delete-mutation.ts
+++ b/apps/studio/data/replication/publication-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type DeletePublicationParams = {
@@ -41,7 +41,7 @@ export const useDeletePublicationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<DeletePublicationData, ResponseError, DeletePublicationParams>,
+  UseCustomMutationOptions<DeletePublicationData, ResponseError, DeletePublicationParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/publications-query.ts
+++ b/apps/studio/data/replication/publications-query.ts
@@ -1,8 +1,8 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationPublicationsParams = { projectRef?: string; sourceId?: number }
@@ -39,7 +39,7 @@ export const useReplicationPublicationsQuery = <TData = ReplicationPublicationsD
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ReplicationPublicationsData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ReplicationPublicationsData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationPublicationsData, ResponseError, TData>({
     queryKey: replicationKeys.publications(projectRef, sourceId),

--- a/apps/studio/data/replication/rollback-table-mutation.ts
+++ b/apps/studio/data/replication/rollback-table-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type RollbackType = 'individual' | 'full'
@@ -52,7 +52,7 @@ export const useRollbackTableMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<RollbackTableData, ResponseError, RollbackTableParams>,
+  UseCustomMutationOptions<RollbackTableData, ResponseError, RollbackTableParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/sources-query.ts
+++ b/apps/studio/data/replication/sources-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationSourcesParams = { projectRef?: string }
@@ -27,7 +27,10 @@ export type ReplicationSourcesData = Awaited<ReturnType<typeof fetchReplicationS
 
 export const useReplicationSourcesQuery = <TData = ReplicationSourcesData>(
   { projectRef }: ReplicationSourcesParams,
-  { enabled = true, ...options }: UseQueryOptions<ReplicationSourcesData, ResponseError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ReplicationSourcesData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationSourcesData, ResponseError, TData>({
     queryKey: replicationKeys.sources(projectRef),

--- a/apps/studio/data/replication/start-pipeline-mutation.ts
+++ b/apps/studio/data/replication/start-pipeline-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type StartPipelineParams = {
@@ -34,7 +34,7 @@ export const useStartPipelineMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<StartPipelineData, ResponseError, StartPipelineParams>,
+  UseCustomMutationOptions<StartPipelineData, ResponseError, StartPipelineParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/stop-pipeline-mutation.ts
+++ b/apps/studio/data/replication/stop-pipeline-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type StopPipelineParams = {
@@ -31,7 +31,7 @@ export const useStopPipelineMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<StartPipelineData, ResponseError, StopPipelineParams>,
+  UseCustomMutationOptions<StartPipelineData, ResponseError, StopPipelineParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/tables-query.ts
+++ b/apps/studio/data/replication/tables-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type ReplicationTablesParams = { projectRef?: string; sourceId?: number }
@@ -28,7 +28,10 @@ export type ReplicationTablesData = Awaited<ReturnType<typeof fetchReplicationTa
 
 export const useReplicationTablesQuery = <TData = ReplicationTablesData>(
   { projectRef, sourceId }: ReplicationTablesParams,
-  { enabled = true, ...options }: UseQueryOptions<ReplicationTablesData, ResponseError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ReplicationTablesData, ResponseError, TData> = {}
 ) =>
   useQuery<ReplicationTablesData, ResponseError, TData>({
     queryKey: replicationKeys.tables(projectRef, sourceId),

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 export type BigQueryDestinationConfig = {
@@ -125,7 +125,11 @@ export const useUpdateDestinationPipelineMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UpdateDestinationPipelineData, ResponseError, UpdateDestinationPipelineParams>,
+  UseCustomMutationOptions<
+    UpdateDestinationPipelineData,
+    ResponseError,
+    UpdateDestinationPipelineParams
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/replication/update-pipeline-version-mutation.ts
+++ b/apps/studio/data/replication/update-pipeline-version-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { replicationKeys } from './keys'
 
 type UpdatePipelineVersionParams = {
@@ -39,7 +39,7 @@ export const useUpdatePipelineVersionMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<UpdatePipelineVersionData, ResponseError, UpdatePipelineVersionParams>,
+  UseCustomMutationOptions<UpdatePipelineVersionData, ResponseError, UpdatePipelineVersionParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/secrets/secrets-create-mutation.ts
+++ b/apps/studio/data/secrets/secrets-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { secretsKeys } from './keys'
 
 export type SecretsCreateVariables = {
@@ -29,7 +29,7 @@ export const useSecretsCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SecretsCreateData, ResponseError, SecretsCreateVariables>,
+  UseCustomMutationOptions<SecretsCreateData, ResponseError, SecretsCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/secrets/secrets-delete-mutation.ts
+++ b/apps/studio/data/secrets/secrets-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { secretsKeys } from './keys'
 
 export type SecretsDeleteVariables = {
@@ -29,7 +29,7 @@ export const useSecretsDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SecretsDeleteData, ResponseError, SecretsDeleteVariables>,
+  UseCustomMutationOptions<SecretsDeleteData, ResponseError, SecretsDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/secrets/secrets-query.ts
+++ b/apps/studio/data/secrets/secrets-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { secretsKeys } from './keys'
 
 export type SecretsVariables = {
@@ -28,7 +28,7 @@ export type SecretsError = ResponseError
 
 export const useSecretsQuery = <TData = SecretsData>(
   { projectRef }: SecretsVariables,
-  { enabled = true, ...options }: UseQueryOptions<SecretsData, SecretsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<SecretsData, SecretsError, TData> = {}
 ) =>
   useQuery<SecretsData, SecretsError, TData>({
     queryKey: secretsKeys.list(projectRef),

--- a/apps/studio/data/service-status/edge-functions-status-query.ts
+++ b/apps/studio/data/service-status/edge-functions-status-query.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { serviceStatusKeys } from './keys'
 
 export type EdgeFunctionServiceStatusVariables = {
@@ -28,7 +28,11 @@ export const useEdgeFunctionServiceStatusQuery = <TData = EdgeFunctionServiceSta
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<EdgeFunctionServiceStatusData, EdgeFunctionServiceStatusError, TData> = {}
+  }: UseCustomQueryOptions<
+    EdgeFunctionServiceStatusData,
+    EdgeFunctionServiceStatusError,
+    TData
+  > = {}
 ) =>
   useQuery<EdgeFunctionServiceStatusData, EdgeFunctionServiceStatusError, TData>({
     queryKey: serviceStatusKeys.edgeFunctions(projectRef),

--- a/apps/studio/data/service-status/service-status-query.ts
+++ b/apps/studio/data/service-status/service-status-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { serviceStatusKeys } from './keys'
 
 export type ProjectServiceStatusVariables = {
@@ -37,7 +37,7 @@ export const useProjectServiceStatusQuery = <TData = ProjectServiceStatusData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ProjectServiceStatusData, ProjectServiceStatusError, TData> = {}
+  }: UseCustomQueryOptions<ProjectServiceStatusData, ProjectServiceStatusError, TData> = {}
 ) =>
   useQuery<ProjectServiceStatusData, ProjectServiceStatusError, TData>({
     queryKey: serviceStatusKeys.serviceStatus(projectRef),

--- a/apps/studio/data/sql/abort-query-mutation.ts
+++ b/apps/studio/data/sql/abort-query-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { sqlKeys } from './keys'
 
 export type QueryAbortVariables = {
@@ -24,7 +24,7 @@ export const useQueryAbortMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<QueryAbortData, ResponseError, QueryAbortVariables>,
+  UseCustomMutationOptions<QueryAbortData, ResponseError, QueryAbortVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -1,10 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { sqlEventParser } from 'lib/sql-event-parser'
 import { executeSql, ExecuteSqlData, ExecuteSqlVariables } from './execute-sql-query'
+import { UseCustomMutationOptions } from 'types'
 
 // [Joshen] Intention is that we invalidate all database related keys whenever running a mutation related query
 // So we attempt to ignore all the non-related query keys. We could probably look into grouping our query keys better
@@ -30,7 +31,7 @@ export const useExecuteSqlMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ExecuteSqlData, QueryResponseError, ExecuteSqlVariables>,
+  UseCustomMutationOptions<ExecuteSqlData, QueryResponseError, ExecuteSqlVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -1,4 +1,4 @@
-import { QueryKey, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryKey, useQuery } from '@tanstack/react-query'
 
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { handleError as handleErrorFetchers, post } from 'data/fetchers'
@@ -8,7 +8,7 @@ import {
   ROLE_IMPERSONATION_NO_RESULTS,
   ROLE_IMPERSONATION_SQL_LINE_COUNT,
 } from 'lib/role-impersonation'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { sqlKeys } from './keys'
 
 export type ExecuteSqlVariables = {
@@ -157,7 +157,7 @@ export const useExecuteSqlQuery = <TData = ExecuteSqlData>(
     handleError,
     isRoleImpersonationEnabled,
   }: ExecuteSqlVariables,
-  { enabled = true, ...options }: UseQueryOptions<ExecuteSqlData, ExecuteSqlError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ExecuteSqlData, ExecuteSqlError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/sql/ongoing-queries-query.ts
+++ b/apps/studio/data/sql/ongoing-queries-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { sqlKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 type OngoingQuery = {
   pid: number
@@ -43,7 +44,7 @@ export const useOngoingQueriesQuery = <TData = OngoingQueriesData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OngoingQueriesData, OngoingQueriesError, TData> = {}
+  }: UseCustomQueryOptions<OngoingQueriesData, OngoingQueriesError, TData> = {}
 ) =>
   useQuery<OngoingQueriesData, OngoingQueriesError, TData>({
     queryKey: sqlKeys.ongoingQueries(projectRef),

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-query.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { sslEnforcementKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 export type SSLEnforcementVariables = { projectRef?: string }
 
@@ -44,7 +45,7 @@ export const useSSLEnforcementQuery = <TData = SSLEnforcementData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<SSLEnforcementData, SSLEnforcementError, TData> = {}
+  }: UseCustomQueryOptions<SSLEnforcementData, SSLEnforcementError, TData> = {}
 ) =>
   useQuery<SSLEnforcementData, SSLEnforcementError, TData>({
     queryKey: sslEnforcementKeys.list(projectRef),

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { sslEnforcementKeys } from './keys'
 
 export type SSLEnforcementUpdateVariables = {
@@ -38,7 +38,7 @@ export const useSSLEnforcementUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SSLEnforcementUpdateData, ResponseError, SSLEnforcementUpdateVariables>,
+  UseCustomMutationOptions<SSLEnforcementUpdateData, ResponseError, SSLEnforcementUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/sso/sso-config-create-mutation.ts
+++ b/apps/studio/data/sso/sso-config-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { orgSSOKeys } from './keys'
 
 export type SSOConfigCreateVariables = {
@@ -28,7 +28,7 @@ export const useSSOConfigCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SSOConfigCreateData, ResponseError, SSOConfigCreateVariables>,
+  UseCustomMutationOptions<SSOConfigCreateData, ResponseError, SSOConfigCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/sso/sso-config-query.ts
+++ b/apps/studio/data/sso/sso-config-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { orgSSOKeys } from './keys'
 
 export type OrgSSOConfigVariables = {
@@ -37,7 +37,10 @@ export type OrgSSOConfigError = ResponseError
 
 export const useOrgSSOConfigQuery = <TData = OrgSSOConfigData>(
   { orgSlug }: OrgSSOConfigVariables,
-  { enabled = true, ...options }: UseQueryOptions<OrgSSOConfigData, OrgSSOConfigError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<OrgSSOConfigData, OrgSSOConfigError, TData> = {}
 ) => {
   const { data: organization } = useSelectedOrganizationQuery()
   const plan = organization?.plan.id

--- a/apps/studio/data/sso/sso-config-update-mutation.ts
+++ b/apps/studio/data/sso/sso-config-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, put } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { orgSSOKeys } from './keys'
 
 export type SSOConfigUpdateVariables = {
@@ -28,7 +28,7 @@ export const useSSOConfigUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SSOConfigUpdateData, ResponseError, SSOConfigUpdateVariables>,
+  UseCustomMutationOptions<SSOConfigUpdateData, ResponseError, SSOConfigUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/analytics-bucket-create-mutation.ts
+++ b/apps/studio/data/storage/analytics-bucket-create-mutation.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // [Joshen] To remove after infra changes for analytics bucket is in
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
@@ -34,7 +34,11 @@ export const useAnalyticsBucketCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AnalyticsBucketCreateData, ResponseError, AnalyticsBucketCreateVariables>,
+  UseCustomMutationOptions<
+    AnalyticsBucketCreateData,
+    ResponseError,
+    AnalyticsBucketCreateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/analytics-bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/analytics-bucket-delete-mutation.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // [Joshen] To remove after infra changes for analytics bucket is in
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { useIsNewStorageUIEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
@@ -32,7 +32,11 @@ export const useAnalyticsBucketDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<AnalyticsBucketDeleteData, ResponseError, AnalyticsBucketDeleteVariables>,
+  UseCustomMutationOptions<
+    AnalyticsBucketDeleteData,
+    ResponseError,
+    AnalyticsBucketDeleteVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/analytics-buckets-query.ts
+++ b/apps/studio/data/storage/analytics-buckets-query.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // [Joshen] To remove after infra changes for analytics bucket is in
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
@@ -36,7 +36,7 @@ export const useAnalyticsBucketsQuery = <TData = AnalyticsBucketsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<AnalyticsBucketsData, AnalyticsBucketsError, TData> = {}
+  }: UseCustomQueryOptions<AnalyticsBucketsData, AnalyticsBucketsError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/storage/bucket-create-mutation.ts
+++ b/apps/studio/data/storage/bucket-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
 
 type BucketCreateVariables = Omit<CreateStorageBucketBody, 'public'> & {
@@ -46,7 +46,7 @@ export const useBucketCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketCreateData, ResponseError, BucketCreateVariables>,
+  UseCustomMutationOptions<BucketCreateData, ResponseError, BucketCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
 
 type BucketDeleteVariables = {
@@ -34,7 +34,7 @@ export const useBucketDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketDeleteData, ResponseError, BucketDeleteVariables>,
+  UseCustomMutationOptions<BucketDeleteData, ResponseError, BucketDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/bucket-empty-mutation.ts
+++ b/apps/studio/data/storage/bucket-empty-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
 
 export type BucketEmptyVariables = {
@@ -29,7 +29,7 @@ export const useBucketEmptyMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketEmptyData, ResponseError, BucketEmptyVariables>,
+  UseCustomMutationOptions<BucketEmptyData, ResponseError, BucketEmptyVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/bucket-object-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-object-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { del, handleError } from 'data/fetchers'
 import { toast } from 'sonner'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type DeleteBucketObjectParams = {
   projectRef: string
@@ -39,7 +39,7 @@ export const useBucketObjectDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketObjectDeleteData, ResponseError, DeleteBucketObjectParams>,
+  UseCustomMutationOptions<BucketObjectDeleteData, ResponseError, DeleteBucketObjectParams>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/bucket-object-download-mutation.ts
+++ b/apps/studio/data/storage/bucket-object-download-mutation.ts
@@ -1,10 +1,10 @@
-import { UseMutationOptions, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'data/api'
 import { fetchPost } from 'data/fetchers'
 import { API_URL, IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type DownloadBucketObjectParams = {
   projectRef: string
@@ -34,7 +34,7 @@ export const useBucketObjectDownloadMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketObjectDeleteData, ResponseError, DownloadBucketObjectParams>,
+  UseCustomMutationOptions<BucketObjectDeleteData, ResponseError, DownloadBucketObjectParams>,
   'mutationFn'
 > = {}) => {
   return useMutation<BucketObjectDeleteData, ResponseError, DownloadBucketObjectParams>({

--- a/apps/studio/data/storage/bucket-object-get-public-url-mutation.ts
+++ b/apps/studio/data/storage/bucket-object-get-public-url-mutation.ts
@@ -1,9 +1,9 @@
-import { UseMutationOptions, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type BucketObjectPublicUrlParams = {
   projectRef: string
@@ -39,7 +39,7 @@ export const useGetBucketObjectPublicUrlMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketObjectPublicUrlData, ResponseError, BucketObjectPublicUrlParams>,
+  UseCustomMutationOptions<BucketObjectPublicUrlData, ResponseError, BucketObjectPublicUrlParams>,
   'mutationFn'
 > = {}) => {
   return useMutation<BucketObjectPublicUrlData, ResponseError, BucketObjectPublicUrlParams>({

--- a/apps/studio/data/storage/bucket-object-sign-mutation.ts
+++ b/apps/studio/data/storage/bucket-object-sign-mutation.ts
@@ -1,9 +1,9 @@
-import { UseMutationOptions, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type SignBucketObjectParams = {
   projectRef: string
@@ -40,7 +40,7 @@ export const useGetSignBucketObjectMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SignBucketObjectData, ResponseError, SignBucketObjectParams>,
+  UseCustomMutationOptions<SignBucketObjectData, ResponseError, SignBucketObjectParams>,
   'mutationFn'
 > = {}) => {
   return useMutation<SignBucketObjectData, ResponseError, SignBucketObjectParams>({

--- a/apps/studio/data/storage/bucket-objects-list-mutation.ts
+++ b/apps/studio/data/storage/bucket-objects-list-mutation.ts
@@ -1,9 +1,9 @@
-import { UseMutationOptions, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'data/api'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type ListBucketObjectsParams = {
   projectRef: string
@@ -46,7 +46,7 @@ export const useGetSignBucketObjectMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ListBucketObjectsData, ResponseError, ListBucketObjectsParams>,
+  UseCustomMutationOptions<ListBucketObjectsData, ResponseError, ListBucketObjectsParams>,
   'mutationFn'
 > = {}) => {
   return useMutation<ListBucketObjectsData, ResponseError, ListBucketObjectsParams>({

--- a/apps/studio/data/storage/bucket-update-mutation.ts
+++ b/apps/studio/data/storage/bucket-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { patch } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
 
 type BucketUpdateVariables = {
@@ -58,7 +58,7 @@ export const useBucketUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<BucketUpdateData, ResponseError, BucketUpdateVariables>,
+  UseCustomMutationOptions<BucketUpdateData, ResponseError, BucketUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -1,10 +1,10 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { storageKeys } from './keys'
 
 export type BucketsVariables = { projectRef?: string }
@@ -30,7 +30,7 @@ export type BucketsError = ResponseError
 
 export const useBucketsQuery = <TData = BucketsData>(
   { projectRef }: BucketsVariables,
-  { enabled = true, ...options }: UseQueryOptions<BucketsData, BucketsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<BucketsData, BucketsError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY

--- a/apps/studio/data/storage/iceberg-namespace-create-mutation.ts
+++ b/apps/studio/data/storage/iceberg-namespace-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
 
 type CreateIcebergNamespaceVariables = {
@@ -65,7 +65,11 @@ export const useIcebergNamespaceCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<IcebergNamespaceCreateData, ResponseError, CreateIcebergNamespaceVariables>,
+  UseCustomMutationOptions<
+    IcebergNamespaceCreateData,
+    ResponseError,
+    CreateIcebergNamespaceVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/iceberg-namespace-exists-query.ts
+++ b/apps/studio/data/storage/iceberg-namespace-exists-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { storageKeys } from './keys'
 
 type ExistsNamespaceVariables = {
@@ -54,7 +54,7 @@ export const useIcebergNamespaceExistsQuery = <TData = IcebergNamespaceExistsDat
   params: ExistsNamespaceVariables,
   {
     ...options
-  }: UseQueryOptions<IcebergNamespaceExistsData, IcebergNamespaceExistsError, TData> = {}
+  }: UseCustomQueryOptions<IcebergNamespaceExistsData, IcebergNamespaceExistsError, TData> = {}
 ) => {
   return useQuery<IcebergNamespaceExistsData, IcebergNamespaceExistsError, TData>({
     queryKey: storageKeys.icebergNamespace(params.catalogUri, params.warehouse, params.namespace),

--- a/apps/studio/data/storage/iceberg-namespace-tables-query.ts
+++ b/apps/studio/data/storage/iceberg-namespace-tables-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { storageKeys } from './keys'
 
 type GetNamespaceTablesVariables = {
@@ -65,7 +65,7 @@ export const useIcebergNamespaceTablesQuery = <TData = IcebergNamespaceTablesDat
   params: GetNamespaceTablesVariables,
   {
     ...options
-  }: UseQueryOptions<IcebergNamespaceTablesData, IcebergNamespaceTablesError, TData> = {}
+  }: UseCustomQueryOptions<IcebergNamespaceTablesData, IcebergNamespaceTablesError, TData> = {}
 ) => {
   return useQuery<IcebergNamespaceTablesData, IcebergNamespaceTablesError, TData>({
     queryKey: storageKeys.icebergNamespaceTables(

--- a/apps/studio/data/storage/iceberg-namespaces-query.ts
+++ b/apps/studio/data/storage/iceberg-namespaces-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { storageKeys } from './keys'
 
 type GetNamespacesVariables = {
@@ -55,7 +55,7 @@ export type IcebergNamespacesError = ResponseError
 
 export const useIcebergNamespacesQuery = <TData = IcebergNamespacesData>(
   params: GetNamespacesVariables,
-  { ...options }: UseQueryOptions<IcebergNamespacesData, IcebergNamespacesError, TData> = {}
+  { ...options }: UseCustomQueryOptions<IcebergNamespacesData, IcebergNamespacesError, TData> = {}
 ) => {
   return useQuery<IcebergNamespacesData, IcebergNamespacesError, TData>({
     queryKey: storageKeys.icebergNamespaces(params.catalogUri, params.warehouse),

--- a/apps/studio/data/storage/object-move-mutation.ts
+++ b/apps/studio/data/storage/object-move-mutation.ts
@@ -1,8 +1,8 @@
-import { UseMutationOptions, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 type MoveStorageObjectParams = {
   projectRef: string
@@ -42,7 +42,7 @@ export const useGetSignBucketObjectMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<MoveBucketObjectData, ResponseError, MoveStorageObjectParams>,
+  UseCustomMutationOptions<MoveBucketObjectData, ResponseError, MoveStorageObjectParams>,
   'mutationFn'
 > = {}) => {
   return useMutation<MoveBucketObjectData, ResponseError, MoveStorageObjectParams>({

--- a/apps/studio/data/storage/s3-access-key-create-mutation.ts
+++ b/apps/studio/data/storage/s3-access-key-create-mutation.ts
@@ -1,8 +1,8 @@
-import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageCredentialsKeys } from './s3-access-key-keys'
 
 type CreateS3AccessKeyCredentialVariables = {
@@ -32,7 +32,11 @@ export function useS3AccessKeyCreateMutation({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<S3AccessKeyCreateData, ResponseError, CreateS3AccessKeyCredentialVariables>,
+  UseCustomMutationOptions<
+    S3AccessKeyCreateData,
+    ResponseError,
+    CreateS3AccessKeyCredentialVariables
+  >,
   'mutationFn'
 > = {}) {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/s3-access-key-delete-mutation.ts
+++ b/apps/studio/data/storage/s3-access-key-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageCredentialsKeys } from './s3-access-key-keys'
 
 type S3AccessKeyDeleteVariables = {
@@ -35,7 +35,7 @@ export function useS3AccessKeyDeleteMutation({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<S3AccessKeyDeleteData, ResponseError, S3AccessKeyDeleteVariables>,
+  UseCustomMutationOptions<S3AccessKeyDeleteData, ResponseError, S3AccessKeyDeleteVariables>,
   'mutationFn'
 > = {}) {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/s3-access-key-query.ts
+++ b/apps/studio/data/storage/s3-access-key-query.ts
@@ -1,9 +1,9 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { storageCredentialsKeys } from './s3-access-key-keys'
 
 type StorageCredentialsVariables = { projectRef?: string }
@@ -31,7 +31,10 @@ export type StorageCredentialsData = Awaited<ReturnType<typeof fetchStorageCrede
 
 export const useStorageCredentialsQuery = <TData = StorageCredentialsData>(
   { projectRef }: StorageCredentialsVariables,
-  { enabled = true, ...options }: UseQueryOptions<StorageCredentialsData, ResponseError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<StorageCredentialsData, ResponseError, TData> = {}
 ) =>
   useQuery<StorageCredentialsData, ResponseError, TData>({
     queryKey: storageCredentialsKeys.credentials(projectRef),

--- a/apps/studio/data/storage/storage-archive-create-mutation.ts
+++ b/apps/studio/data/storage/storage-archive-create-mutation.ts
@@ -1,8 +1,8 @@
-import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
 
 type StorageArchiveCreateVariables = {
@@ -27,7 +27,7 @@ export function useStorageArchiveCreateMutation({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<StorageArchiveCreateData, ResponseError, StorageArchiveCreateVariables>,
+  UseCustomMutationOptions<StorageArchiveCreateData, ResponseError, StorageArchiveCreateVariables>,
   'mutationFn'
 > = {}) {
   const queryClient = useQueryClient()

--- a/apps/studio/data/storage/storage-archive-query.ts
+++ b/apps/studio/data/storage/storage-archive-query.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { storageKeys } from './keys'
 
 type StorageArchiveVariables = { projectRef?: string }
@@ -27,7 +27,10 @@ export type StorageArchiveData = Awaited<ReturnType<typeof fetchStorageArchive>>
 
 export const useStorageArchiveQuery = <TData = StorageArchiveData>(
   { projectRef }: StorageArchiveVariables,
-  { enabled = true, ...options }: UseQueryOptions<StorageArchiveData, ResponseError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<StorageArchiveData, ResponseError, TData> = {}
 ) =>
   useQuery<StorageArchiveData, ResponseError, TData>({
     queryKey: storageKeys.archive(projectRef),

--- a/apps/studio/data/stripe/setup-intent-mutation.ts
+++ b/apps/studio/data/stripe/setup-intent-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type SetupIntentVariables = {
   hcaptchaToken: string
@@ -26,7 +26,7 @@ export const useSetupIntent = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<SetupIntentData, ResponseError, SetupIntentVariables>,
+  UseCustomMutationOptions<SetupIntentData, ResponseError, SetupIntentVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<SetupIntentData, ResponseError, SetupIntentVariables>({

--- a/apps/studio/data/subscriptions/org-plans-query.ts
+++ b/apps/studio/data/subscriptions/org-plans-query.ts
@@ -1,8 +1,9 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { UseCustomQueryOptions } from 'types'
 import { subscriptionKeys } from './keys'
 
 export type OrgPlansVariables = {
@@ -25,7 +26,7 @@ export type OrgPlansError = unknown
 
 export const useOrgPlansQuery = <TData = OrgPlansData>(
   { orgSlug }: OrgPlansVariables,
-  { enabled = true, ...options }: UseQueryOptions<OrgPlansData, OrgPlansError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<OrgPlansData, OrgPlansError, TData> = {}
 ) => {
   const { can: canReadSubscriptions } = useAsyncCheckPermissions(
     PermissionAction.BILLING_READ,

--- a/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
+++ b/apps/studio/data/subscriptions/org-subscription-confirm-pending-change.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'api-types'
@@ -6,7 +6,7 @@ import { handleError, post } from 'data/fetchers'
 import { invoicesKeys } from 'data/invoices/keys'
 import { organizationKeys } from 'data/organizations/keys'
 import { usageKeys } from 'data/usage/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { subscriptionKeys } from './keys'
 
 export type PendingSubscriptionChangeVariables = {
@@ -47,7 +47,7 @@ export const useConfirmPendingSubscriptionChangeMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     PendingSubscriptionChangeData,
     ResponseError,
     PendingSubscriptionChangeVariables

--- a/apps/studio/data/subscriptions/org-subscription-confirm-pending-create.ts
+++ b/apps/studio/data/subscriptions/org-subscription-confirm-pending-create.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { components } from 'api-types'
@@ -6,7 +6,7 @@ import { handleError, post } from 'data/fetchers'
 import { organizationKeys } from 'data/organizations/keys'
 import { castOrganizationResponseToOrganization } from 'data/organizations/organizations-query'
 import { permissionKeys } from 'data/permissions/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type PendingSubscriptionCreateVariables = {
   payment_intent_id: string
@@ -41,7 +41,7 @@ export const useConfirmPendingSubscriptionCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     PendingSubscriptionCreateData,
     ResponseError,
     PendingSubscriptionCreateVariables

--- a/apps/studio/data/subscriptions/org-subscription-query.ts
+++ b/apps/studio/data/subscriptions/org-subscription-query.ts
@@ -1,9 +1,9 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { subscriptionKeys } from './keys'
 
 export type OrgSubscriptionVariables = {
@@ -33,7 +33,7 @@ export const useOrgSubscriptionQuery = <TData = OrgSubscriptionData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<OrgSubscriptionData, OrgSubscriptionError, TData> = {}
+  }: UseCustomQueryOptions<OrgSubscriptionData, OrgSubscriptionError, TData> = {}
 ) => {
   // [Joshen] Thinking it makes sense to add this check at the RQ level - prevent
   // unnecessary requests, although this behaviour still needs handling on the UI

--- a/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
+++ b/apps/studio/data/subscriptions/org-subscription-update-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { handleError, put } from 'data/fetchers'
 import { invoicesKeys } from 'data/invoices/keys'
 import { organizationKeys } from 'data/organizations/keys'
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 import type { ResponseError } from 'types/base'
 import { subscriptionKeys } from './keys'
 import type { SubscriptionTier } from './types'
+import { UseCustomMutationOptions } from 'types'
 
 export type OrgSubscriptionUpdateVariables = {
   slug: string
@@ -54,7 +55,11 @@ export const useOrgSubscriptionUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<OrgSubscriptionUpdateData, ResponseError, OrgSubscriptionUpdateVariables>,
+  UseCustomMutationOptions<
+    OrgSubscriptionUpdateData,
+    ResponseError,
+    OrgSubscriptionUpdateVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/subscriptions/project-addon-remove-mutation.ts
+++ b/apps/studio/data/subscriptions/project-addon-remove-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { subscriptionKeys } from './keys'
 import type { AddonVariantId } from './types'
 
@@ -38,7 +38,7 @@ export const useProjectAddonRemoveMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectAddonRemoveData, ResponseError, ProjectAddonRemoveVariables>,
+  UseCustomMutationOptions<ProjectAddonRemoveData, ResponseError, ProjectAddonRemoveVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/subscriptions/project-addon-update-mutation.ts
+++ b/apps/studio/data/subscriptions/project-addon-update-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { subscriptionKeys } from './keys'
 import type { AddonVariantId, ProjectAddonType } from './types'
 
@@ -45,7 +45,7 @@ export const useProjectAddonUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ProjectAddonUpdateData, ResponseError, ProjectAddonUpdateVariables>,
+  UseCustomMutationOptions<ProjectAddonUpdateData, ResponseError, ProjectAddonUpdateVariables>,
   'mutationFn'
 > & { suppressToast?: boolean } = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/subscriptions/project-addons-query.ts
+++ b/apps/studio/data/subscriptions/project-addons-query.ts
@@ -1,8 +1,8 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { subscriptionKeys } from './keys'
 
 export type ProjectAddonsVariables = {
@@ -32,7 +32,10 @@ export type ProjectAddonsError = ResponseError
 
 export const useProjectAddonsQuery = <TData = ProjectAddonsData>(
   { projectRef }: ProjectAddonsVariables,
-  { enabled = true, ...options }: UseQueryOptions<ProjectAddonsData, ProjectAddonsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ProjectAddonsData, ProjectAddonsError, TData> = {}
 ) =>
   useQuery<ProjectAddonsData, ProjectAddonsError, TData>({
     queryKey: subscriptionKeys.addons(projectRef),

--- a/apps/studio/data/support/generate-attachment-urls-mutation.ts
+++ b/apps/studio/data/support/generate-attachment-urls-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { constructHeaders } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type GenerateAttachmentURLsResponse = {
   title: string
@@ -52,7 +52,11 @@ export const useGenerateAttachmentURLsMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<GenerateAttachmentURLsData, ResponseError, GenerateAttachmentURLsVariables>,
+  UseCustomMutationOptions<
+    GenerateAttachmentURLsData,
+    ResponseError,
+    GenerateAttachmentURLsVariables
+  >,
   'mutationFn'
 > = {}) => {
   return useMutation<GenerateAttachmentURLsData, ResponseError, GenerateAttachmentURLsVariables>({

--- a/apps/studio/data/table-editor/table-editor-query.ts
+++ b/apps/studio/data/table-editor/table-editor-query.ts
@@ -1,9 +1,10 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { tableEditorKeys } from './keys'
 import { getTableEditorSql } from './table-editor-query-sql'
 import { Entity } from './table-editor-types'
+import { UseCustomQueryOptions } from 'types'
 
 type TableEditorArgs = {
   id?: number
@@ -41,7 +42,10 @@ export type TableEditorError = ExecuteSqlError
 
 export const useTableEditorQuery = <TData = TableEditorData>(
   { projectRef, connectionString, id }: TableEditorVariables,
-  { enabled = true, ...options }: UseQueryOptions<TableEditorData, TableEditorError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<TableEditorData, TableEditorError, TData> = {}
 ) =>
   useQuery<TableEditorData, TableEditorError, TData>({
     queryKey: tableEditorKeys.tableEditor(projectRef, id),

--- a/apps/studio/data/table-rows/get-cell-value-mutation.ts
+++ b/apps/studio/data/table-rows/get-cell-value-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export type GetCellValueVariables = {
   projectRef: string
@@ -44,7 +44,7 @@ export const useGetCellValueMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableRowCreateData, ResponseError, GetCellValueVariables>,
+  UseCustomMutationOptions<TableRowCreateData, ResponseError, GetCellValueVariables>,
   'mutationFn'
 > = {}) => {
   return useMutation<TableRowCreateData, ResponseError, GetCellValueVariables>({

--- a/apps/studio/data/table-rows/table-row-create-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-create-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
@@ -7,7 +7,7 @@ import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
 import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableRowKeys } from './keys'
 
 export type TableRowCreateVariables = {
@@ -63,7 +63,7 @@ export const useTableRowCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableRowCreateData, ResponseError, TableRowCreateVariables>,
+  UseCustomMutationOptions<TableRowCreateData, ResponseError, TableRowCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/table-rows/table-row-delete-all-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-delete-all-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
@@ -7,7 +7,7 @@ import { executeSql } from 'data/sql/execute-sql-query'
 import { Entity } from 'data/table-editor/table-editor-types'
 import { RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
 import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableRowKeys } from './keys'
 import { formatFilterValue } from './utils'
 
@@ -67,7 +67,7 @@ export const useTableRowDeleteAllMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableRowDeleteAllData, ResponseError, TableRowDeleteAllVariables>,
+  UseCustomMutationOptions<TableRowDeleteAllData, ResponseError, TableRowDeleteAllVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/table-rows/table-row-delete-mutation.tsx
+++ b/apps/studio/data/table-rows/table-row-delete-mutation.tsx
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
@@ -10,7 +10,7 @@ import { Entity } from 'data/table-editor/table-editor-types'
 import { DOCS_URL } from 'lib/constants'
 import { RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
 import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableRowKeys } from './keys'
 import { getPrimaryKeys } from './utils'
 
@@ -67,7 +67,7 @@ export const useTableRowDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableRowDeleteData, ResponseError, TableRowDeleteVariables>,
+  UseCustomMutationOptions<TableRowDeleteData, ResponseError, TableRowDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/table-rows/table-row-truncate-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-truncate-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableRowKeys } from './keys'
 
 export type TableRowTruncateVariables = {
@@ -41,7 +41,7 @@ export const useTableRowTruncateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableRowTruncateData, ResponseError, TableRowTruncateVariables>,
+  UseCustomMutationOptions<TableRowTruncateData, ResponseError, TableRowTruncateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/table-rows/table-row-update-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-update-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
 import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableRowKeys } from './keys'
 
 export type TableRowUpdateVariables = {
@@ -69,7 +69,7 @@ export const useTableRowUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableRowUpdateData, ResponseError, TableRowUpdateVariables>,
+  UseCustomMutationOptions<TableRowUpdateData, ResponseError, TableRowUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/table-rows/table-rows-count-query.ts
+++ b/apps/studio/data/table-rows/table-rows-count-query.ts
@@ -3,7 +3,7 @@ import {
   COUNT_ESTIMATE_SQL,
   THRESHOLD_COUNT,
 } from '@supabase/pg-meta/src/sql/studio/get-count-estimate'
-import { QueryClient, useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import type { Filter, SupaTable } from 'components/grid/types'
@@ -13,6 +13,7 @@ import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { tableRowKeys } from './keys'
 import { formatFilterValue } from './utils'
+import { UseCustomQueryOptions } from 'types'
 
 type GetTableRowsCountArgs = {
   table?: SupaTable
@@ -145,7 +146,7 @@ export const useTableRowsCountQuery = <TData = TableRowsCountData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<TableRowsCountData, TableRowsCountError, TData> = {}
+  }: UseCustomQueryOptions<TableRowsCountData, TableRowsCountError, TData> = {}
 ) => {
   const queryClient = useQueryClient()
   return useQuery<TableRowsCountData, TableRowsCountError, TData>({

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -1,11 +1,6 @@
 import { Query } from '@supabase/pg-meta/src/query'
 import { getTableRowsSql } from '@supabase/pg-meta/src/query/table-row-query'
-import {
-  useQuery,
-  useQueryClient,
-  type QueryClient,
-  type UseQueryOptions,
-} from '@tanstack/react-query'
+import { useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query'
 
 import { IS_PLATFORM } from 'common'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
@@ -17,10 +12,10 @@ import {
   wrapWithRoleImpersonation,
 } from 'lib/role-impersonation'
 import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
+import { ResponseError, UseCustomQueryOptions } from 'types'
 import { ExecuteSqlError, executeSql } from '../sql/execute-sql-query'
 import { tableRowKeys } from './keys'
 import { formatFilterValue } from './utils'
-import { ResponseError } from 'types'
 
 export interface GetTableRowsArgs {
   table?: SupaTable
@@ -282,7 +277,7 @@ export async function getTableRows(
 
 export const useTableRowsQuery = <TData = TableRowsData>(
   { projectRef, connectionString, tableId, ...args }: Omit<TableRowsVariables, 'queryClient'>,
-  { enabled = true, ...options }: UseQueryOptions<TableRowsData, TableRowsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<TableRowsData, TableRowsError, TData> = {}
 ) => {
   const queryClient = useQueryClient()
   return useQuery<TableRowsData, TableRowsError, TData>({

--- a/apps/studio/data/tables/table-create-mutation.ts
+++ b/apps/studio/data/tables/table-create-mutation.ts
@@ -1,9 +1,9 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableKeys } from './keys'
 
 export type CreateTableBody = {
@@ -39,7 +39,7 @@ export const useTableCreateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableCreateData, ResponseError, TableCreateVariables>,
+  UseCustomMutationOptions<TableCreateData, ResponseError, TableCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/tables/table-delete-mutation.ts
+++ b/apps/studio/data/tables/table-delete-mutation.ts
@@ -1,12 +1,12 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { entityTypeKeys } from 'data/entity-types/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
 import { viewKeys } from 'data/views/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableKeys } from './keys'
 
 export type TableDeleteVariables = {
@@ -45,7 +45,7 @@ export const useTableDeleteMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableDeleteData, ResponseError, TableDeleteVariables>,
+  UseCustomMutationOptions<TableDeleteData, ResponseError, TableDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/tables/table-retrieve-query.ts
+++ b/apps/studio/data/tables/table-retrieve-query.ts
@@ -1,8 +1,8 @@
 import pgMeta from '@supabase/pg-meta'
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { tableKeys } from './keys'
 
 export type TablesVariables = {
@@ -39,7 +39,7 @@ export const useTablesQuery = <TData = RetrieveTableResult>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<RetrieveTableResult, RetrieveTableError, TData> = {}
+  }: UseCustomQueryOptions<RetrieveTableResult, RetrieveTableError, TData> = {}
 ) => {
   return useQuery<RetrieveTableResult, RetrieveTableError, TData>({
     queryKey: tableKeys.retrieve(projectRef, name, schema),

--- a/apps/studio/data/tables/table-update-mutation.ts
+++ b/apps/studio/data/tables/table-update-mutation.ts
@@ -1,11 +1,11 @@
 import pgMeta from '@supabase/pg-meta'
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { lintKeys } from 'data/lint/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { tableKeys } from './keys'
 import { CreateTableBody } from './table-create-mutation'
 
@@ -53,7 +53,7 @@ export const useTableUpdateMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<TableUpdateData, ResponseError, TableUpdateVariables>,
+  UseCustomMutationOptions<TableUpdateData, ResponseError, TableUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/tables/tables-query.ts
+++ b/apps/studio/data/tables/tables-query.ts
@@ -1,11 +1,11 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
-import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { sortBy } from 'lodash'
 import { useCallback } from 'react'
 
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { tableKeys } from './keys'
 
 export type TablesVariables = {
@@ -72,7 +72,7 @@ export type TablesError = ResponseError
 
 export const useTablesQuery = <TData = TablesData>(
   { projectRef, connectionString, schema, includeColumns }: TablesVariables,
-  { enabled = true, ...options }: UseQueryOptions<TablesData, TablesError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<TablesData, TablesError, TData> = {}
 ) => {
   return useQuery<TablesData, TablesError, TData>({
     queryKey: tableKeys.list(projectRef, schema, includeColumns),

--- a/apps/studio/data/tables/tables-roles-access-query.ts
+++ b/apps/studio/data/tables/tables-roles-access-query.ts
@@ -1,8 +1,9 @@
 import { getTablesWithAnonAuthenticatedAccessSQL } from '@supabase/pg-meta/src/sql/studio/check-tables-anon-authenticated-access'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { tableKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 type TablesRolesAccessArgs = {
   schema: string
@@ -37,7 +38,7 @@ export const useTablesRolesAccessQuery = <TData = TablesRolesAccessData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<TablesRolesAccessData, TablesRolesAccessError, TData> = {}
+  }: UseCustomQueryOptions<TablesRolesAccessData, TablesRolesAccessError, TData> = {}
 ) =>
   useQuery<TablesRolesAccessData, TablesRolesAccessError, TData>({
     queryKey: tableKeys.rolesAccess(projectRef, schema),

--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -1,11 +1,11 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import { sendTelemetryEvent } from 'common'
 import { TelemetryEvent } from 'common/telemetry-constants'
 import { handleError } from 'data/fetchers'
 import { API_URL } from 'lib/constants'
 import { useRouter } from 'next/router'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 interface SendEventVariables {
   event: TelemetryEvent
@@ -26,7 +26,10 @@ export const useSendEventMutation = ({
   onSuccess,
   onError,
   ...options
-}: Omit<UseMutationOptions<SendEventData, ResponseError, TelemetryEvent>, 'mutationFn'> = {}) => {
+}: Omit<
+  UseCustomMutationOptions<SendEventData, ResponseError, TelemetryEvent>,
+  'mutationFn'
+> = {}) => {
   const router = useRouter()
 
   return useMutation<SendEventData, ResponseError, TelemetryEvent>({

--- a/apps/studio/data/telemetry/send-reset-mutation.ts
+++ b/apps/studio/data/telemetry/send-reset-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 
 export async function sendReset() {
   if (!IS_PLATFORM) return undefined
@@ -18,7 +18,7 @@ export const useSendResetMutation = ({
   onSuccess,
   onError,
   ...options
-}: Omit<UseMutationOptions<SendResetData, ResponseError>, 'mutationFn'> = {}) => {
+}: Omit<UseCustomMutationOptions<SendResetData, ResponseError>, 'mutationFn'> = {}) => {
   return useMutation<SendResetData, ResponseError>({
     mutationFn: () => sendReset(),
     async onSuccess(data, variables, context) {

--- a/apps/studio/data/third-party-auth/integration-create-mutation.ts
+++ b/apps/studio/data/third-party-auth/integration-create-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { handleError, post } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { keys } from './keys'
 
 export type CreateThirdPartyAuthVariables = {
@@ -42,7 +42,11 @@ export const useCreateThirdPartyAuthIntegrationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<ThirdPartyIntegrationCreateData, ResponseError, CreateThirdPartyAuthVariables>,
+  UseCustomMutationOptions<
+    ThirdPartyIntegrationCreateData,
+    ResponseError,
+    CreateThirdPartyAuthVariables
+  >,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/third-party-auth/integration-delete-mutation.ts
+++ b/apps/studio/data/third-party-auth/integration-delete-mutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { del, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { keys } from './keys'
 
 export type DeleteThirdPartyAuthIntegrationVariables = {
@@ -33,7 +33,7 @@ export const useDeleteThirdPartyAuthIntegrationMutation = ({
   onError,
   ...options
 }: Omit<
-  UseMutationOptions<
+  UseCustomMutationOptions<
     DeleteThirdPartyAuthIntegrationData,
     ResponseError,
     DeleteThirdPartyAuthIntegrationVariables

--- a/apps/studio/data/third-party-auth/integrations-query.ts
+++ b/apps/studio/data/third-party-auth/integrations-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { keys } from './keys'
 
 export type GetThirdPartyAuthIntegrationsVariables = {
@@ -34,7 +34,7 @@ export const useThirdPartyAuthIntegrationsQuery = <TData = ThirdPartyAuthIntegra
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ThirdPartyAuthIntegrationsData, ResponseError, TData> = {}
+  }: UseCustomQueryOptions<ThirdPartyAuthIntegrationsData, ResponseError, TData> = {}
 ) =>
   useQuery<ThirdPartyAuthIntegrationsData, ResponseError, TData>({
     queryKey: keys.integrations(projectRef),

--- a/apps/studio/data/usage/org-usage-query.ts
+++ b/apps/studio/data/usage/org-usage-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { IS_PLATFORM } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { usageKeys } from './keys'
 
 export type OrgUsageVariables = {
@@ -41,7 +41,7 @@ export type OrgUsageError = ResponseError
 
 export const useOrgUsageQuery = <TData = OrgUsageData>(
   { orgSlug, projectRef, start, end }: OrgUsageVariables,
-  { enabled = true, ...options }: UseQueryOptions<OrgUsageData, OrgUsageError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<OrgUsageData, OrgUsageError, TData> = {}
 ) =>
   useQuery<OrgUsageData, OrgUsageError, TData>({
     queryKey: usageKeys.orgUsage(

--- a/apps/studio/data/usage/resource-warnings-query.ts
+++ b/apps/studio/data/usage/resource-warnings-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { IS_PLATFORM } from 'common'
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { usageKeys } from './keys'
 
 export type ResourceWarningsVariables = {
@@ -38,7 +38,7 @@ export const useResourceWarningsQuery = <TData = ResourceWarningsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<ResourceWarningsData, ResourceWarningsError, TData> = {}
+  }: UseCustomQueryOptions<ResourceWarningsData, ResourceWarningsError, TData> = {}
 ) =>
   useQuery<ResourceWarningsData, ResourceWarningsError, TData>({
     queryKey: usageKeys.resourceWarnings(variables.slug, variables.ref),

--- a/apps/studio/data/utils/deployment-commit-query.ts
+++ b/apps/studio/data/utils/deployment-commit-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { fetchHandler } from 'data/fetchers'
 import { BASE_PATH } from 'lib/constants'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 
 export async function getDeploymentCommit(signal?: AbortSignal) {
   const response = await fetchHandler(`${BASE_PATH}/api/get-deployment-commit`)
@@ -13,7 +13,7 @@ export type DeploymentCommitData = Awaited<ReturnType<typeof getDeploymentCommit
 export const useDeploymentCommitQuery = <TData = DeploymentCommitData>({
   enabled = true,
   ...options
-}: UseQueryOptions<DeploymentCommitData, ResponseError, TData> = {}) =>
+}: UseCustomQueryOptions<DeploymentCommitData, ResponseError, TData> = {}) =>
   useQuery<DeploymentCommitData, ResponseError, TData>({
     queryKey: ['deployment-commit'],
     queryFn: ({ signal }) => getDeploymentCommit(signal),

--- a/apps/studio/data/vault/vault-secret-create-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-create-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import { quoteLiteral } from 'lib/pg-format'
-import type { ResponseError, VaultSecret } from 'types'
+import type { ResponseError, UseCustomMutationOptions, VaultSecret } from 'types'
 import { vaultSecretsKeys } from './keys'
 
 export type VaultSecretCreateVariables = {
@@ -36,7 +36,7 @@ export const useVaultSecretCreateMutation = ({
   onSuccess,
   ...options
 }: Omit<
-  UseMutationOptions<VaultSecretCreateData, ResponseError, VaultSecretCreateVariables>,
+  UseCustomMutationOptions<VaultSecretCreateData, ResponseError, VaultSecretCreateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
+++ b/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
@@ -1,7 +1,8 @@
 import { Query } from '@supabase/pg-meta/src/query'
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { executeSql } from '../sql/execute-sql-query'
 import { vaultSecretsKeys } from './keys'
+import { UseCustomQueryOptions } from 'types'
 
 const vaultSecretDecryptedValueQuery = (id: string) => {
   const sql = new Query()
@@ -55,7 +56,7 @@ export const useVaultSecretDecryptedValueQuery = <TData = string>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<getDecryptedValueResult, VaultSecretsDecryptedValueError, TData> = {}
+  }: UseCustomQueryOptions<getDecryptedValueResult, VaultSecretsDecryptedValueError, TData> = {}
 ) =>
   useQuery<getDecryptedValueResult, VaultSecretsDecryptedValueError, TData>({
     queryKey: vaultSecretsKeys.getDecryptedValue(projectRef, id),

--- a/apps/studio/data/vault/vault-secret-delete-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-delete-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Query } from '@supabase/pg-meta/src/query'
 import { executeSql } from 'data/sql/execute-sql-query'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { vaultSecretsKeys } from './keys'
 
 export type VaultSecretDeleteVariables = {
@@ -29,7 +29,7 @@ export const useVaultSecretDeleteMutation = ({
   onSuccess,
   ...options
 }: Omit<
-  UseMutationOptions<VaultSecretDeleteData, ResponseError, VaultSecretDeleteVariables>,
+  UseCustomMutationOptions<VaultSecretDeleteData, ResponseError, VaultSecretDeleteVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/vault/vault-secret-update-mutation.ts
+++ b/apps/studio/data/vault/vault-secret-update-mutation.ts
@@ -1,9 +1,9 @@
-import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { executeSql } from 'data/sql/execute-sql-query'
 import { quoteLiteral } from 'lib/pg-format'
-import type { ResponseError, VaultSecret } from 'types'
+import type { ResponseError, UseCustomMutationOptions, VaultSecret } from 'types'
 import { vaultSecretsKeys } from './keys'
 
 export type VaultSecretUpdateVariables = {
@@ -39,7 +39,7 @@ export const useVaultSecretUpdateMutation = ({
   onSuccess,
   ...options
 }: Omit<
-  UseMutationOptions<VaultSecretUpdateData, ResponseError, VaultSecretUpdateVariables>,
+  UseCustomMutationOptions<VaultSecretUpdateData, ResponseError, VaultSecretUpdateVariables>,
   'mutationFn'
 > = {}) => {
   const queryClient = useQueryClient()

--- a/apps/studio/data/vault/vault-secrets-query.ts
+++ b/apps/studio/data/vault/vault-secrets-query.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { Query } from '@supabase/pg-meta/src/query'
-import type { VaultSecret } from 'types'
+import { useQuery } from '@tanstack/react-query'
+
+import type { UseCustomQueryOptions, VaultSecret } from 'types'
 import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { vaultSecretsKeys } from './keys'
 
@@ -37,7 +38,10 @@ export type VaultSecretsError = ExecuteSqlError
 
 export const useVaultSecretsQuery = <TData = VaultSecretsData>(
   { projectRef, connectionString }: VaultSecretsVariables,
-  { enabled = true, ...options }: UseQueryOptions<VaultSecretsData, VaultSecretsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<VaultSecretsData, VaultSecretsError, TData> = {}
 ) =>
   useQuery<VaultSecretsData, VaultSecretsError, TData>({
     queryKey: vaultSecretsKeys.list(projectRef),

--- a/apps/studio/data/views/views-query.ts
+++ b/apps/studio/data/views/views-query.ts
@@ -1,10 +1,10 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
+import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { PostgresView } from '@supabase/postgres-meta'
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { viewKeys } from './keys'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 
 export type ViewsVariables = {
   projectRef?: string
@@ -45,7 +45,7 @@ export type ViewsError = ResponseError
 
 export const useViewsQuery = <TData = ViewsData>(
   { projectRef, connectionString, schema }: ViewsVariables,
-  { enabled = true, ...options }: UseQueryOptions<ViewsData, ViewsError, TData> = {}
+  { enabled = true, ...options }: UseCustomQueryOptions<ViewsData, ViewsError, TData> = {}
 ) =>
   useQuery<ViewsData, ViewsError, TData>({
     queryKey: schema ? viewKeys.listBySchema(projectRef, schema) : viewKeys.list(projectRef),

--- a/apps/studio/data/workflow-runs/workflow-run-logs-query.ts
+++ b/apps/studio/data/workflow-runs/workflow-run-logs-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { workflowRunKeys } from './keys'
 
 export type WorkflowRunLogsVariables = {
@@ -42,7 +42,7 @@ export const useWorkflowRunLogsQuery = <TData = WorkflowRunLogsData>(
   {
     enabled = true,
     ...options
-  }: UseQueryOptions<WorkflowRunLogsData, WorkflowRunLogsError, TData> = {}
+  }: UseCustomQueryOptions<WorkflowRunLogsData, WorkflowRunLogsError, TData> = {}
 ) =>
   useQuery<WorkflowRunLogsData, WorkflowRunLogsError, TData>({
     queryKey: workflowRunKeys.list(workflowRunId),

--- a/apps/studio/data/workflow-runs/workflow-run-query.ts
+++ b/apps/studio/data/workflow-runs/workflow-run-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { workflowRunKeys } from './keys'
 
 export type WorkflowRunVariables = {
@@ -39,7 +39,10 @@ export type WorkflowRunError = ResponseError
 
 export const useWorkflowRunQuery = <TData = WorkflowRunData>(
   { projectRef, workflowRunId }: WorkflowRunVariables,
-  { enabled = true, ...options }: UseQueryOptions<WorkflowRunData, WorkflowRunError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<WorkflowRunData, WorkflowRunError, TData> = {}
 ) =>
   useQuery<WorkflowRunData, WorkflowRunError, TData>({
     queryKey: workflowRunKeys.detail(projectRef, workflowRunId),

--- a/apps/studio/data/workflow-runs/workflow-runs-query.ts
+++ b/apps/studio/data/workflow-runs/workflow-runs-query.ts
@@ -1,7 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
-import type { ResponseError } from 'types'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { workflowRunKeys } from './keys'
 
 export type WorkflowRunsVariables = {
@@ -28,7 +28,10 @@ export type WorkflowRunsError = ResponseError
 
 export const useWorkflowRunsQuery = <TData = WorkflowRunsData>(
   { projectRef }: WorkflowRunsVariables,
-  { enabled = true, ...options }: UseQueryOptions<WorkflowRunsData, WorkflowRunsError, TData> = {}
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<WorkflowRunsData, WorkflowRunsError, TData> = {}
 ) =>
   useQuery<WorkflowRunsData, WorkflowRunsError, TData>({
     queryKey: workflowRunKeys.list(projectRef),

--- a/apps/studio/types/base.ts
+++ b/apps/studio/types/base.ts
@@ -1,8 +1,8 @@
-import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { OrganizationBase } from 'data/organizations/organizations-query'
-import { PlanId } from 'data/subscriptions/types'
-import jsonLogic from 'json-logic-js'
-import { ManagedBy } from 'lib/constants/infrastructure'
+import type { PermissionAction } from '@supabase/shared-types/out/constants'
+import type { OrganizationBase } from 'data/organizations/organizations-query'
+import type { PlanId } from 'data/subscriptions/types'
+import type jsonLogic from 'json-logic-js'
+import type { ManagedBy } from 'lib/constants/infrastructure'
 
 export interface Organization extends OrganizationBase {
   managed_by: ManagedBy

--- a/apps/studio/types/index.ts
+++ b/apps/studio/types/index.ts
@@ -10,5 +10,6 @@ export {
 export type * from './form'
 export type * from './next'
 export { isNextPageWithLayout } from './next'
+export type * from './react-query'
 export type * from './ui'
 export type * from './userContent'

--- a/apps/studio/types/react-query.ts
+++ b/apps/studio/types/react-query.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   QueryKey,
   UseInfiniteQueryOptions,
   UseMutationOptions,

--- a/apps/studio/types/react-query.ts
+++ b/apps/studio/types/react-query.ts
@@ -1,0 +1,28 @@
+import {
+  QueryKey,
+  UseInfiniteQueryOptions,
+  UseMutationOptions,
+  UseQueryOptions,
+} from '@tanstack/react-query'
+
+export type UseCustomQueryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+
+export type UseCustomMutationOptions<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown,
+> = UseMutationOptions<TData, TError, TVariables, TContext>
+
+export type UseCustomInfiniteQueryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>


### PR DESCRIPTION
Introduce custom React Query option types and replace all UseQueryOptions/UseMutationOptions/UseInfiniteQueryOptions usages across the codebase.
 
 - **Types**:
   - Add `types/react-query.ts` with `UseCustomQueryOptions`, `UseCustomMutationOptions`, and `UseCustomInfiniteQueryOptions`; export via `types/index.ts`.
 - **Refactor (wide)**:
   - Replace React Query's `UseQueryOptions`/`UseMutationOptions`/`UseInfiniteQueryOptions` with custom types in all hooks (`useQuery`/`useMutation`/`useInfiniteQuery`).
   - Update imports to source custom types from `types`; remove unused base types/imports where applicable.
   - No functional logic changes; signature/typing-only migration to ease future React Query v5 upgrade.
 
