### PR TITLE
fix: dont render header in realtime grid

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeMessageColumnRenderer.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeMessageColumnRenderer.tsx
@@ -17,6 +17,7 @@ export const ColumnRenderer: Column<LogData, unknown>[] = [
   {
     name: 'timestamp-with-truncated-text',
     key: 'main-column',
+    renderHeaderCell: () => null,
     renderCell: (data: { row: PreviewLogData }) => {
       const type = data.row.message as keyof typeof ICONS
 


### PR DESCRIPTION
<img width="1504" height="1068" alt="CleanShot 2025-11-03 at 10 44 26@2x" src="https://github.com/user-attachments/assets/f26c8d75-b451-4f2c-9058-7f50197ecf4f" />
