### PR TITLE
feat(studio): log drains tidy up sheet footer

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -6,7 +6,6 @@ import { toast } from 'sonner'
 import { z } from 'zod'
 
 import { IS_PLATFORM, useFlag, useParams } from 'common'
-import { DocsButton } from 'components/ui/DocsButton'
 import Link from 'next/link'
 import { LogDrainData, useLogDrainsQuery } from 'data/log-drains/log-drains-query'
 import { DOCS_URL } from 'lib/constants'
@@ -577,21 +576,6 @@ export function LogDrainDestinationSheetForm({
               `border-t bg-background-alternative-200 mt-auto py-1.5 ${!IS_PLATFORM ? 'hidden' : ''}`
             )}
           >
-            {/* <FormItemLayout
-              isReactForm={false}
-              layout="vertical"
-              label={
-                <div className="flex flex-col gap-y-2 text-foreground-light">
-                  Additional drain cost
-                  <DocsButton
-                    abbrev={false}
-                    className="w-min"
-                    href={`${DOCS_URL}/guides/platform/log-drains`}
-                  />
-                </div>
-              }
-              className="py-0"
-            > */}
             <ul className="text-right text-foreground-light divide-y divide-dashed text-sm">
               <li className="flex items-center justify-between gap-2 py-2" translate="no">
                 <span className="text-foreground-lighter">Additional drain cost</span>

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod'
 
 import { IS_PLATFORM, useFlag, useParams } from 'common'
 import { DocsButton } from 'components/ui/DocsButton'
+import Link from 'next/link'
 import { LogDrainData, useLogDrainsQuery } from 'data/log-drains/log-drains-query'
 import { DOCS_URL } from 'lib/constants'
 import {
@@ -34,6 +35,7 @@ import {
   SheetSection,
   SheetTitle,
   Switch,
+  cn,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
@@ -571,11 +573,13 @@ export function LogDrainDestinationSheetForm({
 
         <div className="mt-auto">
           <SheetSection
-            className={`border-t bg-background-alternative-200 mt-auto ${!IS_PLATFORM ? 'hidden' : ''}`}
+            className={cn(
+              `border-t bg-background-alternative-200 mt-auto py-1.5 ${!IS_PLATFORM ? 'hidden' : ''}`
+            )}
           >
-            <FormItemLayout
+            {/* <FormItemLayout
               isReactForm={false}
-              layout="horizontal"
+              layout="vertical"
               label={
                 <div className="flex flex-col gap-y-2 text-foreground-light">
                   Additional drain cost
@@ -586,18 +590,34 @@ export function LogDrainDestinationSheetForm({
                   />
                 </div>
               }
-            >
-              <ul className="text-right text-foreground-light">
-                <li className="text-brand-link text-base" translate="no">
-                  $60 per drain per month
-                </li>
-                <li translate="no">+ $0.20 per million events</li>
-                <li translate="no">+ $0.09 per GB egress</li>
-              </ul>
-            </FormItemLayout>
+              className="py-0"
+            > */}
+            <ul className="text-right text-foreground-light divide-y divide-dashed text-sm">
+              <li className="flex items-center justify-between gap-2 py-2" translate="no">
+                <span className="text-foreground-lighter">Additional drain cost</span>
+                <span className="text-foreground">$60 per month</span>
+              </li>
+              <li className="flex items-center justify-between gap-2 py-2" translate="no">
+                <span className="text-foreground-lighter">Per million events</span>
+                <span>+$0.20</span>
+              </li>
+              <li className="flex items-center justify-between gap-2 py-2" translate="no">
+                <span className="text-foreground-lighter">Per GB egress</span>
+                <span>+$0.09</span>
+              </li>
+            </ul>
           </SheetSection>
 
-          <SheetFooter className="p-content !mt-0">
+          <SheetFooter className="p-content !mt-0 !justify-between !flex-row w-full items-center">
+            <span className="text-sm text-foreground-light">
+              <span>See full pricing breakdown</span>{' '}
+              <Link
+                href={`${DOCS_URL}/guides/platform/log-drains`}
+                className="text-foreground underline underline-offset-2 decoration-foreground-muted hover:decoration-foreground transition-all"
+              >
+                here
+              </Link>
+            </span>
             <Button form={FORM_ID} loading={isLoading} htmlType="submit" type="primary">
               Save destination
             </Button>

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -596,7 +596,7 @@ export function LogDrainDestinationSheetForm({
             <span className="text-sm text-foreground-light">
               <span>See full pricing breakdown</span>{' '}
               <Link
-                href={`${DOCS_URL}/guides/platform/log-drains`}
+                href={`${DOCS_URL}/guides/platform/manage-your-usage/log-drains`}
                 className="text-foreground underline underline-offset-2 decoration-foreground-muted hover:decoration-foreground transition-all"
               >
                 here


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A small tidy up for the create log drain sheet footer. Updated the docs link to take the user to pricing breakdown as well.

| Before | After |
|--------|--------|
| <img width="691" height="177" alt="Screenshot 2025-11-03 at 14 10 41" src="https://github.com/user-attachments/assets/ee27e991-7f0c-493a-a0a5-60fcfbd9ee0a" /> | <img width="643" height="212" alt="Screenshot 2025-11-03 at 14 25 14" src="https://github.com/user-attachments/assets/4fef7d6f-d093-4363-aaf4-a06f86348365" /> | 


