### PR TITLE
chore: Migrate some stray queryKeys to the RQ 5 syntax

### DIFF
--- a/apps/studio/data/database-roles/database-roles-query.ts
+++ b/apps/studio/data/database-roles/database-roles-query.ts
@@ -45,5 +45,5 @@ export const useDatabaseRolesQuery = <TData = DatabaseRolesData>(
   })
 
 export function invalidateRolesQuery(client: QueryClient, projectRef: string | undefined) {
-  return client.invalidateQueries(databaseRoleKeys.databaseRoles(projectRef))
+  return client.invalidateQueries({ queryKey: databaseRoleKeys.databaseRoles(projectRef) })
 }

--- a/apps/studio/data/database/schemas-query.ts
+++ b/apps/studio/data/database/schemas-query.ts
@@ -47,7 +47,7 @@ export const useSchemasQuery = <TData = SchemasData>(
   })
 
 export function invalidateSchemasQuery(client: QueryClient, projectRef: string | undefined) {
-  return client.invalidateQueries(databaseKeys.schemas(projectRef))
+  return client.invalidateQueries({ queryKey: databaseKeys.schemas(projectRef) })
 }
 
 export function prefetchSchemas(

--- a/apps/studio/data/organizations/organization-query.ts
+++ b/apps/studio/data/organizations/organization-query.ts
@@ -50,5 +50,5 @@ export const useOrganizationQuery = <TData = OrganizationsData>(
 }
 
 export function invalidateOrganizationsQuery(client: QueryClient) {
-  return client.invalidateQueries(organizationKeys.list())
+  return client.invalidateQueries({ queryKey: organizationKeys.list() })
 }

--- a/apps/studio/data/privileges/table-privileges-query.ts
+++ b/apps/studio/data/privileges/table-privileges-query.ts
@@ -3,8 +3,8 @@ import { QueryClient, useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
-import { privilegeKeys } from './keys'
 import { UseCustomQueryOptions } from 'types'
+import { privilegeKeys } from './keys'
 
 export type TablePrivilegesVariables = {
   projectRef?: string
@@ -53,5 +53,5 @@ export function invalidateTablePrivilegesQuery(
   client: QueryClient,
   projectRef: string | undefined
 ) {
-  return client.invalidateQueries(privilegeKeys.tablePrivilegesList(projectRef))
+  return client.invalidateQueries({ queryKey: privilegeKeys.tablePrivilegesList(projectRef) })
 }

--- a/apps/studio/data/replication/publication-delete-mutation.ts
+++ b/apps/studio/data/replication/publication-delete-mutation.ts
@@ -50,7 +50,9 @@ export const useDeletePublicationMutation = ({
     mutationFn: (vars) => deletePublication(vars),
     async onSuccess(data, variables, context) {
       const { projectRef, sourceId } = variables
-      await queryClient.invalidateQueries(replicationKeys.publications(projectRef, sourceId))
+      await queryClient.invalidateQueries({
+        queryKey: replicationKeys.publications(projectRef, sourceId),
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/pages/project/[ref]/settings/jwt/index.tsx
+++ b/apps/studio/pages/project/[ref]/settings/jwt/index.tsx
@@ -36,9 +36,9 @@ const JWTKeysLegacyPage: NextPageWithLayout = () => {
     if (previousJwtSecretUpdateStatus.current === Updating) {
       switch (jwtSecretUpdateStatus) {
         case Updated:
-          client.invalidateQueries(configKeys.api(projectRef))
-          client.invalidateQueries(configKeys.settings(projectRef))
-          client.invalidateQueries(configKeys.postgrest(projectRef))
+          client.invalidateQueries({ queryKey: configKeys.api(projectRef) })
+          client.invalidateQueries({ queryKey: configKeys.settings(projectRef) })
+          client.invalidateQueries({ queryKey: configKeys.postgrest(projectRef) })
           toast.success('Successfully updated JWT secret')
           break
         case Failed:

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -299,9 +299,9 @@ async function upsertSnippet(
     if (shouldInvalidate) {
       const queryClient = getQueryClient()
       await Promise.all([
-        queryClient.invalidateQueries(contentKeys.count(projectRef, 'sql')),
-        queryClient.invalidateQueries(contentKeys.sqlSnippets(projectRef)),
-        queryClient.invalidateQueries(contentKeys.folders(projectRef)),
+        queryClient.invalidateQueries({ queryKey: contentKeys.count(projectRef, 'sql') }),
+        queryClient.invalidateQueries({ queryKey: contentKeys.sqlSnippets(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: contentKeys.folders(projectRef) }),
       ])
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces legacy invalidateQueries usages with the v5 object form across data queries, mutations, and JWT settings, plus SQL editor cache invalidations.
> 
> - **React Query v5 migration**
>   - Replace `invalidateQueries(queryKey)` with `invalidateQueries({ queryKey })` in:
>     - `data/database-roles/database-roles-query.ts` (`invalidateRolesQuery`)
>     - `data/database/schemas-query.ts` (`invalidateSchemasQuery`)
>     - `data/organizations/organization-query.ts` (`invalidateOrganizationsQuery`)
>     - `data/privileges/table-privileges-query.ts` (`invalidateTablePrivilegesQuery`)
>     - `data/replication/publication-delete-mutation.ts` (on success of delete)
>     - `pages/project/[ref]/settings/jwt/index.tsx` (post-JWT update refreshes)
>     - `state/sql-editor-v2.ts` (post-upsert cache invalidations)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17e904bfe3f442a0dd1e959ea6b4a4fd550315b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->