### PR TITLE
docs: remove incorrect timezone note for self-hosted databases

### DIFF
--- a/apps/docs/content/guides/database/postgres/configuration.mdx
+++ b/apps/docs/content/guides/database/postgres/configuration.mdx
@@ -22,12 +22,6 @@ This data can further be used in conjunction with the [`explain`](https://www.po
 
 Every hosted Supabase database is set to UTC timezone by default. We strongly recommend keeping it this way, even if your users are in a different location. This is because it makes it much easier to calculate differences between timezones if you adopt the mental model that everything in your database is in UTC time.
 
-<Admonition type="tip">
-
-On self-hosted databases, the timezone defaults to your local timezone. We recommend [changing this to UTC](/docs/guides/database/postgres/configuration#change-timezone) for the same reasons.
-
-</Admonition>
-
 ### Change timezone
 
 <Tabs


### PR DESCRIPTION
Fixes #40064: Self-hosted databases actually default to UTC, not local timezone.