### PR TITLE
fix(troubleshooting sync)

### DIFF
--- a/apps/docs/content/troubleshooting/edge-function-shutdown-reasons-explained.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-shutdown-reasons-explained.mdx
@@ -2,7 +2,6 @@
 title = "Edge Function shutdown reasons explained"
 topics = [ "functions" ]
 keywords = [ "shutdown", "termination", "event loop", "wall clock", "cpu time", "memory", "early drop" ]
-database_id = ""
 
 [[errors]]
 http_status_code = 546

--- a/apps/docs/features/docs/Troubleshooting.script.mjs
+++ b/apps/docs/features/docs/Troubleshooting.script.mjs
@@ -258,37 +258,37 @@ async function updateChecksumIfNeeded(entry) {
 
 /**
  * Converts relative links to absolute URLs for GitHub discussions using MDAST
- * @param {string} content - The markdown content to process
+ * @param {string} content - The markdown content to process (already stripped of JSX)
  */
 function rewriteRelativeLinks(content) {
   const baseUrl = 'https://supabase.com'
-  
+
   // Parse the markdown to AST
   const mdast = fromMarkdown(content, {
-    extensions: [gfm(), mdxjs()],
-    mdastExtensions: [gfmFromMarkdown(), mdxFromMarkdown()],
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()],
   })
-  
+
   // Walk the tree and modify link nodes
-	/** 
-	 * @param {import('mdast').Root|import('mdast').Content} node
-	 */
+  /**
+   * @param {import('mdast').Root|import('mdast').Content} node
+   */
   function visitNode(node) {
     if (node.type === 'link' && node.url && node.url.startsWith('/')) {
       // Convert relative URL to absolute
       node.url = `${baseUrl}${node.url}`
     }
-    
+
     // Recursively visit children
     if ('children' in node) {
       node.children.forEach(visitNode)
     }
   }
-  
+
   visitNode(mdast)
-  
+
   // Convert back to markdown
-  return toMarkdown(mdast, { extensions: [gfmToMarkdown(), mdxToMarkdown()] })
+  return toMarkdown(mdast, { extensions: [gfmToMarkdown()] })
 }
 
 /**


### PR DESCRIPTION
Fix troubleshooting guides that aren't syncing correctly:

- Invalid empty database ID
- MDX parsing being run after JSX is stripped from Markdown content, causes MDX parser to choke