### PR TITLE
docs(mcp): improve Claude Code setup/authorization instructions

### DIFF
--- a/apps/docs/features/ui/McpConfigPanel.tsx
+++ b/apps/docs/features/ui/McpConfigPanel.tsx
@@ -294,7 +294,7 @@ export function McpConfigPanel() {
         <Admonition type="note" title="Authentication" className="mt-3">
           <p>
             {
-              "Your MCP client will automatically prompt you to login to Supabase during setup. This will open a browser window where you can login to your Supabase account and grant access to the MCP client. Be sure to choose the organization that contains the project you wish to work with. In the future, we'll offer more fine grain control over these permissions."
+              "Some MCP clients will automatically prompt you to login during setup, while others may require manual authentication steps. Either authentication method will open a browser window where you can login to your Supabase account and grant organization access to the MCP client. In the future, we'll offer more fine grain control over these permissions."
             }
           </p>
           <p>

--- a/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
@@ -54,9 +54,16 @@ export function McpConfigurationDisplay({
         </>
       )}
 
+      {selectedClient.primaryInstructions && selectedClient.primaryInstructions(clientConfig)}
+
       {selectedClient.configFile && (
         <div className="text-xs text-foreground-light">
-          {mcpButtonData ? 'Or add' : 'Add'} this configuration to{' '}
+          {selectedClient.primaryInstructions
+            ? 'Alternatively, add'
+            : mcpButtonData
+              ? 'Or add'
+              : 'Add'}{' '}
+          this configuration to{' '}
           <code className="px-1 py-0.5 bg-surface-200 rounded">{selectedClient.configFile}</code>:
         </div>
       )}

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -142,6 +142,7 @@ export const MCP_CLIENTS: McpClient[] = [
           <CodeBlock
             value={command}
             language="bash"
+            focusable={false}
             // This is a no-op but the CodeBlock component is designed to output
             // inline code if no className is given
             className="block"
@@ -155,7 +156,7 @@ export const MCP_CLIENTS: McpClient[] = [
           After configuring the MCP server, you need to authenticate. In a regular terminal (not the
           IDE extension) run:
         </p>
-        <CodeBlock value="claude /mcp" language="bash" className="block" />
+        <CodeBlock value="claude /mcp" language="bash" focusable={false} className="block" />
         <p className="text-xs text-foreground-light">
           Select the "supabase" server, then "Authenticate" to begin the authentication flow.
         </p>

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -119,7 +119,7 @@ export const MCP_CLIENTS: McpClient[] = [
     key: 'claude-code',
     label: 'Claude Code',
     icon: 'claude',
-    configFile: '~/.claude.json',
+    configFile: '.mcp.json',
     externalDocsUrl: 'https://docs.anthropic.com/en/docs/claude-code/mcp',
     transformConfig: (config): ClaudeCodeMcpConfig => {
       return {
@@ -133,11 +133,11 @@ export const MCP_CLIENTS: McpClient[] = [
     },
     alternateInstructions: (_config) => {
       const config = _config as ClaudeCodeMcpConfig
-      const command = `claude mcp add --transport http supabase "${config.mcpServers.supabase.url}"`
+      const command = `claude mcp add --scope project --transport http supabase "${config.mcpServers.supabase.url}"`
       return (
         <div className="space-y-2">
           <p className="text-xs text-foreground-light">
-            Alternatively, add the MCP server using the command line:
+            Alternatively, add the MCP server to your project config using the command line:
           </p>
           <CodeBlock
             value={command}

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -131,13 +131,13 @@ export const MCP_CLIENTS: McpClient[] = [
         },
       }
     },
-    alternateInstructions: (_config) => {
+    primaryInstructions: (_config) => {
       const config = _config as ClaudeCodeMcpConfig
       const command = `claude mcp add --scope project --transport http supabase "${config.mcpServers.supabase.url}"`
       return (
         <div className="space-y-2">
           <p className="text-xs text-foreground-light">
-            Alternatively, add the MCP server to your project config using the command line:
+            Add the MCP server to your project config using the command line:
           </p>
           <CodeBlock
             value={command}

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -149,6 +149,18 @@ export const MCP_CLIENTS: McpClient[] = [
         </div>
       )
     },
+    alternateInstructions: () => (
+      <div className="space-y-2">
+        <p className="text-xs text-foreground-light">
+          After configuring the MCP server, you need to authenticate. In a regular terminal (not the
+          IDE extension) run:
+        </p>
+        <CodeBlock value="claude /mcp" language="bash" className="block" />
+        <p className="text-xs text-foreground-light">
+          Select the "supabase" server, then "Authenticate" to begin the authentication flow.
+        </p>
+      </div>
+    ),
   },
 ]
 

--- a/packages/ui-patterns/src/McpUrlBuilder/types.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/types.ts
@@ -13,6 +13,7 @@ export interface McpClient {
   configFile?: string
   generateDeepLink?: (config: McpClientConfig) => string | null
   transformConfig?: (config: McpClientBaseConfig) => McpClientConfig
+  primaryInstructions?: (config: McpClientConfig) => React.ReactNode
   alternateInstructions?: (config: McpClientConfig) => React.ReactNode
 }
 


### PR DESCRIPTION
**Changes**

- `claude mcp add` CLI instructions are now prioritized over manual file config
- Added instructions how to trigger server authentication with `claude /mcp`
- Claude Code CLI and config instructions now prefer [project scope](https://docs.claude.com/en/docs/claude-code/mcp#project-scope) config
- Clarified that some clients require manual authentication steps
- Removed the warning about selecting the correct org for your project now that this is handled automatically  https://github.com/supabase/infrastructure/pull/27068

| Before | After |
|--------|--------|
| <img width="1892" height="1524" alt="CleanShot 2025-11-03 at 14 52 48@2x" src="https://github.com/user-attachments/assets/81e032f2-c6e4-42e1-b126-1ae731b6c7b0" /> | <img width="1894" height="1760" alt="CleanShot 2025-11-03 at 14 53 00@2x" src="https://github.com/user-attachments/assets/a1d22b4c-ee23-426f-836f-06011b101f8e" /> | 

Related: https://github.com/orgs/supabase/discussions/39266

Resolves AI-169 and AI-174