### PR TITLE
fix: correct default timezone info for self-hosted database (closes #…

### DIFF
--- a/apps/docs/content/guides/database/postgres/configuration.mdx
+++ b/apps/docs/content/guides/database/postgres/configuration.mdx
@@ -24,7 +24,7 @@ Every hosted Supabase database is set to UTC timezone by default. We strongly re
 
 <Admonition type="tip">
 
-On self-hosted databases, the timezone defaults to your local timezone. We recommend [changing this to UTC](/docs/guides/database/postgres/configuration#change-timezone) for the same reasons.
+On self-hosted databases, the timezone defaults to UTC. We recommend [changing this to UTC](/docs/guides/database/postgres/configuration#change-timezone) for the same reasons.
 
 </Admonition>
 


### PR DESCRIPTION
…40064)

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
