### PR TITLE
Fix: updated monaco editor to not eat up CMD + i

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -57,10 +57,14 @@ const MonacoEditor = ({
   const snapV2 = useSqlEditorV2StateSnapshot()
   const tabsSnap = useTabsStateSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
-  const { openSidebar } = useSidebarManagerSnapshot()
+  const { openSidebar, toggleSidebar } = useSidebarManagerSnapshot()
 
   const [intellisenseEnabled] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.SQL_EDITOR_INTELLISENSE,
+    true
+  )
+  const [isAIAssistantHotkeyEnabled] = useLocalStorageQuery<boolean>(
+    LOCAL_STORAGE_KEYS.HOTKEY_SIDEBAR(SIDEBAR_KEYS.AI_ASSISTANT),
     true
   )
 
@@ -121,6 +125,17 @@ const MonacoEditor = ({
           sqlSnippets: [selectedValue],
           initialInput: 'Can you explain this section to me in more detail?',
         })
+      },
+    })
+
+    editor.addAction({
+      id: 'toggle-ai-assistant',
+      label: 'Toggle AI Assistant',
+      keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.KeyI],
+      run: () => {
+        if (isAIAssistantHotkeyEnabled) {
+          toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+        }
       },
     })
 

--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -5,8 +5,10 @@ import { editor as monacoEditor } from 'monaco-editor'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { constructHeaders } from 'data/fetchers'
 import { detectOS } from 'lib/helpers'
+import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import ResizableAIWidget from './ResizableAIWidget'
 
 interface AIEditorProps {
@@ -28,6 +30,7 @@ interface AIEditorProps {
   onChange?: (value: string) => void
   onClose?: () => void
   closeShortcutEnabled?: boolean
+  openAIAssistantShortcutEnabled?: boolean
   executeQuery?: () => void
 }
 
@@ -49,9 +52,11 @@ const AIEditor = ({
   onChange,
   onClose,
   closeShortcutEnabled = true,
+  openAIAssistantShortcutEnabled = true,
   executeQuery,
 }: AIEditorProps) => {
   const os = detectOS()
+  const { toggleSidebar } = useSidebarManagerSnapshot()
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
   const diffEditorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
@@ -220,6 +225,18 @@ const AIEditor = ({
     }
 
     refreshCloseAction()
+
+    // Add AI Assistant toggle keybinding (Cmd+I)
+    if (openAIAssistantShortcutEnabled) {
+      editor.addAction({
+        id: 'toggle-ai-assistant',
+        label: 'Toggle AI Assistant',
+        keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.KeyI],
+        run: () => {
+          toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+        },
+      })
+    }
 
     editor.addAction({
       id: 'generate-ai',

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -67,6 +67,10 @@ export const EditorPanel = () => {
     LOCAL_STORAGE_KEYS.HOTKEY_SIDEBAR(SIDEBAR_KEYS.EDITOR_PANEL),
     true
   )
+  const [isAIAssistantHotkeyEnabled] = useLocalStorageQuery<boolean>(
+    LOCAL_STORAGE_KEYS.HOTKEY_SIDEBAR(SIDEBAR_KEYS.AI_ASSISTANT),
+    true
+  )
 
   const currentValue = value || ''
 
@@ -294,6 +298,7 @@ export const EditorPanel = () => {
             executeQuery={onExecuteSql}
             onClose={handleClosePanel}
             closeShortcutEnabled={isInlineEditorHotkeyEnabled}
+            openAIAssistantShortcutEnabled={isAIAssistantHotkeyEnabled}
           />
         </div>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, editor is not toggle-able in SQL editor using the shortcut (cmd + i)

## What is the current behavior?

Can't open the AI editor when using the SQL editor

## What is the new behavior?

You can toggle between the AI editor 

## Additional context

Add any other context or screenshots.

resolves: FE-1371
