### PR TITLE
Fix branch merge request link

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -6,7 +6,7 @@ import { PropsWithChildren, ReactNode } from 'react'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import type { Branch } from 'data/branches/branches-query'
-import { BASE_PATH } from 'lib/constants'
+import Link from 'next/link'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { WorkflowLogs } from './WorkflowLogs'
 
@@ -25,9 +25,7 @@ export const BranchManagementSection = ({
       <div className="bg-surface-100 shadow-sm flex justify-between items-center px-4 py-3 rounded-t-lg text-xs font-mono uppercase">
         {typeof header === 'string' ? <span>{header}</span> : header}
       </div>
-      <div className="bg-surface border-t shadow-sm rounded-b-lg text-sm divide-y px-4">
-        {children}
-      </div>
+      <div className="bg-surface border-t shadow-sm rounded-b-lg text-sm divide-y">{children}</div>
       {footer !== undefined && <div className="bg-surface-100 px-6 py-1 border-t">{footer}</div>}
     </div>
   )
@@ -86,14 +84,6 @@ export const BranchRow = ({
 
   const navigateUrl = rowLink ?? `/project/${branch.project_ref}`
 
-  const handleRowClick = () => {
-    if (external) {
-      window.open(`${BASE_PATH}/${navigateUrl}`, '_blank', 'noopener noreferrer')
-    } else {
-      router.push(navigateUrl)
-    }
-  }
-
   return (
     <div className="w-full flex items-center justify-between px-4 py-2.5 hover:bg-surface-100">
       <div className="flex items-center gap-x-3">
@@ -114,10 +104,15 @@ export const BranchRow = ({
           </ButtonTooltip>
         )}
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center cursor-pointer" onClick={handleRowClick}>
+          <TooltipTrigger>
+            <Link
+              target={external ? '_blank' : '_self'}
+              rel={external ? 'noopener noreferrer' : undefined}
+              href={navigateUrl}
+              className="flex items-center"
+            >
               {label || branch.name}
-            </div>
+            </Link>
           </TooltipTrigger>
           {((page === 'branches' && !branch.is_default) || page === 'merge-requests') && (
             <TooltipContent side="bottom">

--- a/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
+++ b/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
@@ -68,6 +68,7 @@ const MergeRequestsPage: NextPageWithLayout = () => {
     error: branchesError,
     isLoading: isLoadingBranches,
     isError: isErrorBranches,
+    isSuccess: isSuccessBranches,
   } = useBranchesQuery({ projectRef })
   const [[mainBranch], previewBranchesUnsorted] = partition(branches, (branch) => branch.is_default)
   const previewBranches = previewBranchesUnsorted.sort((a, b) =>
@@ -215,12 +216,11 @@ const MergeRequestsPage: NextPageWithLayout = () => {
                     <BranchManagementSection
                       header={`${mergeRequestBranches.length} merge requests`}
                     >
-                      {isLoadingBranches && (
+                      {isLoadingBranches ? (
                         <div className="p-4">
                           <GenericSkeletonLoader />
                         </div>
-                      )}
-                      {mergeRequestBranches.length > 0 ? (
+                      ) : mergeRequestBranches.length > 0 ? (
                         mergeRequestBranches.map((branch) => {
                           const isPR = branch.pr_number !== undefined
                           const rowLink = isPR


### PR DESCRIPTION
## Context

Bug report that the links do not tally in the branches merge request page if the merge request corresponds to one in GH
<img width="2296" height="1656" alt="image" src="https://github.com/user-attachments/assets/b34c6cd2-bd6c-45b2-bb4e-f23b3e96b75c" />

Realised that this was due to `BranchRow` component using `BASE_PATH` to open an external URL which isn't required

## Changes involved

- Update `BranchRow` to use `Link` component instead to open links rather than manually calling `window.open` or `router.push`
- (Unrelated) Remove odd padding in `BranchManagementSection`
  <img width="169" height="128" alt="image" src="https://github.com/user-attachments/assets/7613b94d-2f62-4448-9726-f73a714508de" />
- (Unrelated) Fix premature empty state for merge requests before branches are loaded

## To test

- [ ] Verify that merge requests from GH in the dashboard open the correct links when clicking on the branch name
