### PR TITLE
feat: add min calls filter to Query Performance FE-2071

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -72,7 +72,7 @@ export const QueryPerformanceGrid = ({
 }: QueryPerformanceGridProps) => {
   const { sort, setSortConfig } = useQueryPerformanceSort()
   const gridRef = useRef<DataGridHandle>(null)
-  const { sort: urlSort, order, roles, search } = useParams()
+  const { sort: urlSort, order, roles, search, minCalls } = useParams()
   const dataGridContainerRef = useRef<HTMLDivElement>(null)
 
   const [view, setView] = useState<'details' | 'suggestion'>('details')
@@ -341,6 +341,11 @@ export const QueryPerformanceGrid = ({
       data = data.filter((row) => row.rolname && roles.includes(row.rolname))
     }
 
+    const minCallsNum = Number(minCalls)
+    if (!Number.isNaN(minCallsNum) && minCallsNum > 0) {
+      data = data.filter((row) => (row.calls || 0) >= minCallsNum)
+    }
+
     if (sort?.column === 'prop_total_time') {
       data.sort((a, b) => {
         const aValue = a.prop_total_time || 0
@@ -360,7 +365,7 @@ export const QueryPerformanceGrid = ({
     }
 
     return data
-  }, [aggregatedData, sort, search, roles])
+  }, [aggregatedData, sort, search, roles, minCalls])
 
   const selectedQuery = selectedRow !== undefined ? reportData[selectedRow]?.query : undefined
   const query = (selectedQuery ?? '').trim().toLowerCase()
@@ -372,7 +377,7 @@ export const QueryPerformanceGrid = ({
 
   useEffect(() => {
     setSelectedRow(undefined)
-  }, [search, roles, urlSort, order])
+  }, [search, roles, urlSort, order, minCalls])
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {

--- a/apps/studio/components/interfaces/Reports/Reports.queries.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.queries.ts
@@ -29,6 +29,7 @@ export type QueryPerformanceQueryOpts = {
   orderBy?: QueryPerformanceSort
   roles?: string[]
   runIndexAdvisor?: boolean
+  minCalls?: number
 }
 
 export const useQueryPerformanceQuery = ({
@@ -37,6 +38,7 @@ export const useQueryPerformanceQuery = ({
   searchQuery = '',
   roles,
   runIndexAdvisor = false,
+  minCalls,
 }: QueryPerformanceQueryOpts) => {
   const queryPerfQueries = PRESET_CONFIG[Presets.QUERY_PERFORMANCE]
   const baseSQL = queryPerfQueries.queries[preset]
@@ -46,6 +48,7 @@ export const useQueryPerformanceQuery = ({
       ? `auth.rolname in (${roles.map((r) => `'${r}'`).join(', ')})`
       : '',
     searchQuery.length > 0 ? `statements.query ~* '${searchQuery}'` : '',
+    typeof minCalls === 'number' && minCalls > 0 ? `statements.calls >= ${minCalls}` : '',
   ]
     .filter((x) => x.length > 0)
     .join(' AND ')

--- a/apps/studio/pages/project/[ref]/reports/query-performance.tsx
+++ b/apps/studio/pages/project/[ref]/reports/query-performance.tsx
@@ -1,4 +1,4 @@
-import { parseAsArrayOf, parseAsString, useQueryStates } from 'nuqs'
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from 'nuqs'
 
 import { useParams } from 'common'
 import { useIndexAdvisorStatus } from 'components/interfaces/QueryPerformance/hooks/useIsIndexAdvisorStatus'
@@ -37,11 +37,12 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
     handleDatePickerChange,
   } = useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
 
-  const [{ search: searchQuery, roles }] = useQueryStates({
+  const [{ search: searchQuery, roles, minCalls }] = useQueryStates({
     sort: parseAsString,
     order: parseAsString,
     search: parseAsString.withDefault(''),
     roles: parseAsArrayOf(parseAsString).withDefault([]),
+    minCalls: parseAsInteger,
   })
 
   const config = PRESET_CONFIG[Presets.QUERY_PERFORMANCE]
@@ -55,6 +56,7 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
     preset: 'unified',
     roles,
     runIndexAdvisor: isIndexAdvisorEnabled,
+    minCalls: minCalls ?? undefined,
   })
 
   const isPgStatMonitorEnabled = project?.dbVersion === '17.4.1.076-psml-1'


### PR DESCRIPTION
https://linear.app/supabase/issue/FE-2071/add-min-calls-filter-to-query-performance

## To Test
- go to query performance
- try to filter by min calls (e.g. 1000) 
- table should update and show correct results
- sorts and query filter should still work as expected 