### PR TITLE
fix(studio): add more robust validation check for log drain endpoints

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -93,7 +93,10 @@ const formUnion = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('sentry'),
-    dsn: z.string().min(1, { message: 'Sentry DSN is required' }),
+    dsn: z
+      .string()
+      .min(1, { message: 'Sentry DSN is required' })
+      .refine((dsn) => dsn.startsWith('https://'), 'Sentry DSN must start with https://'),
   }),
 ])
 

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -46,7 +46,13 @@ const FORM_ID = 'log-drain-destination-form'
 const formUnion = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('webhook'),
-    url: z.string().regex(urlRegex(), 'Endpoint URL is required and must be a valid URL'),
+    url: z
+      .string()
+      .regex(urlRegex(), 'Endpoint URL is required and must be a valid URL')
+      .refine(
+        (url) => url.startsWith('http://') || url.startsWith('https://'),
+        'Endpoint URL must start with http:// or https://'
+      ),
     http: z.enum(['http1', 'http2']),
     gzip: z.boolean(),
     headers: z.record(z.string(), z.string()).optional(),

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -64,7 +64,13 @@ const formUnion = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('loki'),
-    url: z.string().min(1, { message: 'Loki URL is required' }),
+    url: z
+      .string()
+      .min(1, { message: 'Loki URL is required' })
+      .refine(
+        (url) => url.startsWith('http://') || url.startsWith('https://'),
+        'Loki URL must start with http:// or https://'
+      ),
     headers: z.record(z.string(), z.string()),
     username: z.string().optional(),
     password: z.string().optional(),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This adds a bit of a "refinement" to the log drains endpoint form validation. Applied to Custom URL, Loki URL and Sentry DSN. Now it always makes sure the endpoint includes `https`, so we don't get rogue url's with no protocol slipping through and folks enabling a log drain add-on that doesn't work. 
