### PR TITLE
Fix discord link in GA page

### DIFF
--- a/apps/www/data/ga.tsx
+++ b/apps/www/data/ga.tsx
@@ -88,7 +88,7 @@ We're committed to our Free Plan - we know the importance of this for testing ho
       {
         number: '25,000',
         text: 'Discord members',
-        url: 'https://discord.com/invite/R7bSpeBSJE',
+        url: 'https://discord.supabase.com',
         icon: <IconDiscord />,
       },
       {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

It updates the discord reference to use our subdomain: discord.supabase.com

## What is the current behavior?

It points out to a custom invite link, which could be disabled or change (we recently change).

## What is the new behavior?

Now users will clic and go to discord.supabase.com, which will do a proper redirect to our Discord Server.
