### PR TITLE
fix(mssql foreign tables): disallow sort on columns filtered for equality

### DIFF
--- a/apps/studio/components/grid/MsSqlValidation.tsx
+++ b/apps/studio/components/grid/MsSqlValidation.tsx
@@ -1,0 +1,77 @@
+import { isMsSqlForeignTable, type Entity } from 'data/table-editor/table-editor-types'
+import type { ComponentType, ReactNode } from 'react'
+
+import { Admonition } from 'ui-patterns'
+import type { Filter, Sort } from './types'
+
+type ValidateMsSqlSortingParams = {
+  filters: Filter[]
+  sorts: Sort[]
+  table: Entity
+}
+
+type MsSqlWarning = 'ConflictingSort' | 'NoValidSortPossible'
+
+/**
+ * There is an edge case with the Postgres query planner and MS SQL foreign
+ * tables, where the Postgres query planner will drop sort clauses that are
+ * redundant with filters, resulting in invalid MS SQL syntax. We want to
+ * detect any conflicting or impossible sorts on filtered columns when the
+ * table is an MS SQL foreign table, and warn the user.
+ */
+export const validateMsSqlSorting = ({
+  filters,
+  sorts,
+  table,
+}: ValidateMsSqlSortingParams):
+  | { warning: MsSqlWarning; Component: ComponentType }
+  | { warning: null } => {
+  const isMsSql = isMsSqlForeignTable(table)
+  if (!isMsSql) return { warning: null }
+
+  const equalityFilterColumns = new Set(
+    filters
+      .filter((filter) => filter.operator === '=' || filter.operator === 'is')
+      .map((filter) => filter.column)
+  )
+
+  const conflictingSort =
+    sorts.length > 0 && sorts.every((sort) => equalityFilterColumns.has(sort.column))
+  const showMsSqlSortWarning = equalityFilterColumns.size > 0 && !!conflictingSort
+  if (showMsSqlSortWarning)
+    return { warning: 'ConflictingSort', Component: MsSqlSortWarningAdmonition }
+
+  const noSortColumnsRemaining =
+    table.columns.length > 0 &&
+    table.columns.every((col) => col.data_type === 'json' || equalityFilterColumns.has(col.name))
+  const showMsSqlNoValidSortWarning = filters.length > 0 && noSortColumnsRemaining
+  if (showMsSqlNoValidSortWarning)
+    return { warning: 'NoValidSortPossible', Component: MsSqlNoValidSortAdmonition }
+
+  return { warning: null }
+}
+
+type MsSqlAdmonitionProps = {
+  title: string
+  children: string
+}
+
+const MsSqlAdmonition = ({ title, children }: MsSqlAdmonitionProps): ReactNode => (
+  <div className="mt-2 px-3 pb-2">
+    <Admonition type="warning" title={title} description={children} />
+  </div>
+)
+
+const MsSqlSortWarningAdmonition = (): ReactNode => (
+  <MsSqlAdmonition title="Cannot sort by filtered column">
+    Sorting only by columns filtered with "=" or "is" doesn't work on MSSQL tables. Pick a different
+    sorting column, or add a column not in your filter.
+  </MsSqlAdmonition>
+)
+
+const MsSqlNoValidSortAdmonition = (): ReactNode => (
+  <MsSqlAdmonition title="No valid sort column remaining">
+    All columns that can be sorted have been filtered with "=" or "is", which doesn't work on MSSQL
+    tables. Remove a column from your filter to continue.
+  </MsSqlAdmonition>
+)

--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -107,7 +107,7 @@ export const SupabaseGrid = ({
               filters={filters}
               onApplyFilters={onApplyFilters}
             />
-            <Footer disableForeignRowsQuery={!tableQueriesEnabled} />
+      <Footer enableForeignRowsQuery={tableQueriesEnabled} />
             <Shortcuts gridRef={gridRef} rows={rows} />
           </>
         )}

--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -107,7 +107,7 @@ export const SupabaseGrid = ({
               filters={filters}
               onApplyFilters={onApplyFilters}
             />
-      <Footer enableForeignRowsQuery={tableQueriesEnabled} />
+            <Footer enableForeignRowsQuery={tableQueriesEnabled} />
             <Shortcuts gridRef={gridRef} rows={rows} />
           </>
         )}

--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -5,6 +5,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import { createPortal } from 'react-dom'
 
 import { useParams } from 'common'
+import { isMsSqlForeignTable } from 'data/table-editor/table-editor-types'
 import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
 import { RoleImpersonationState } from 'lib/role-impersonation'
 import { EMPTY_ARR } from 'lib/void'
@@ -22,6 +23,7 @@ import { GridProps } from './types'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useTableFilter } from './hooks/useTableFilter'
 import { useTableSort } from './hooks/useTableSort'
+import { validateMsSqlSorting } from './MsSqlValidation'
 
 export const SupabaseGrid = ({
   customHeader,
@@ -47,6 +49,11 @@ export const SupabaseGrid = ({
 
   const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
+  const msSqlWarning = isMsSqlForeignTable(snap.originalTable)
+    ? validateMsSqlSorting({ filters, sorts, table: snap.originalTable })
+    : { warning: null }
+  const tableQueriesEnabled = msSqlWarning.warning === null
+
   const { data, error, isSuccess, isError, isLoading, isRefetching } = useTableRowsQuery(
     {
       projectRef: project?.ref,
@@ -60,6 +67,7 @@ export const SupabaseGrid = ({
     },
     {
       keepPreviousData: true,
+      enabled: tableQueriesEnabled,
       retry: (_, error: any) => {
         const doesNotExistError = error && error.message?.includes('does not exist')
         if (doesNotExistError) onApplySorts([])
@@ -77,7 +85,13 @@ export const SupabaseGrid = ({
   return (
     <DndProvider backend={HTML5Backend} context={window}>
       <div className="sb-grid h-full flex flex-col">
-        <Header customHeader={customHeader} isRefetching={isRefetching} />
+        <Header
+          customHeader={customHeader}
+          isRefetching={isRefetching}
+          tableQueriesEnabled={tableQueriesEnabled}
+        />
+
+        {msSqlWarning.warning !== null && <msSqlWarning.Component />}
 
         {children || (
           <>
@@ -86,13 +100,14 @@ export const SupabaseGrid = ({
               {...gridProps}
               rows={rows}
               error={error}
+              isDisabled={!tableQueriesEnabled}
               isLoading={isLoading}
               isSuccess={isSuccess}
               isError={isError}
               filters={filters}
               onApplyFilters={onApplyFilters}
             />
-            <Footer />
+            <Footer disableForeignRowsQuery={!tableQueriesEnabled} />
             <Shortcuts gridRef={gridRef} rows={rows} />
           </>
         )}

--- a/apps/studio/components/grid/components/footer/Footer.tsx
+++ b/apps/studio/components/grid/components/footer/Footer.tsx
@@ -8,10 +8,12 @@ import { useUrlState } from 'hooks/ui/useUrlState'
 import { Pagination } from './pagination/Pagination'
 
 type FooterProps = {
-  disableForeignRowsQuery?: boolean
+  enableForeignRowsQuery?: boolean
 }
 
-export const Footer: React.FC<FooterProps> = ({ disableForeignRowsQuery = false }: FooterProps) => {
+export const Footer: React.FC<FooterProps> = ({
+  enableForeignRowsQuery = true,
+}: FooterProps) => {
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
   const { data: project } = useSelectedProjectQuery()
@@ -37,7 +39,7 @@ export const Footer: React.FC<FooterProps> = ({ disableForeignRowsQuery = false 
 
   return (
     <GridFooter>
-      {selectedView === 'data' && <Pagination disableForeignRowsQuery={disableForeignRowsQuery} />}
+      {selectedView === 'data' && <Pagination enableForeignRowsQuery={enableForeignRowsQuery} />}
 
       <div className="ml-auto flex items-center gap-x-2">
         {(isViewSelected || isTableSelected) && (

--- a/apps/studio/components/grid/components/footer/Footer.tsx
+++ b/apps/studio/components/grid/components/footer/Footer.tsx
@@ -11,9 +11,7 @@ type FooterProps = {
   enableForeignRowsQuery?: boolean
 }
 
-export const Footer: React.FC<FooterProps> = ({
-  enableForeignRowsQuery = true,
-}: FooterProps) => {
+export const Footer: React.FC<FooterProps> = ({ enableForeignRowsQuery = true }: FooterProps) => {
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
   const { data: project } = useSelectedProjectQuery()

--- a/apps/studio/components/grid/components/footer/Footer.tsx
+++ b/apps/studio/components/grid/components/footer/Footer.tsx
@@ -7,7 +7,11 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { Pagination } from './pagination/Pagination'
 
-export const Footer = () => {
+type FooterProps = {
+  disableForeignRowsQuery?: boolean
+}
+
+export const Footer: React.FC<FooterProps> = ({ disableForeignRowsQuery = false }: FooterProps) => {
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
   const { data: project } = useSelectedProjectQuery()
@@ -33,7 +37,7 @@ export const Footer = () => {
 
   return (
     <GridFooter>
-      {selectedView === 'data' && <Pagination />}
+      {selectedView === 'data' && <Pagination disableForeignRowsQuery={disableForeignRowsQuery} />}
 
       <div className="ml-auto flex items-center gap-x-2">
         {(isViewSelected || isTableSelected) && (

--- a/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -47,7 +47,11 @@ const RowCountSelector = ({
   )
 }
 
-export const Pagination = () => {
+type PaginationProps = {
+  disableForeignRowsQuery?: boolean
+}
+
+export const Pagination = ({ disableForeignRowsQuery = false }: PaginationProps) => {
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
 
@@ -108,7 +112,7 @@ export const Pagination = () => {
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },
     {
-      enabled: isForeignTableSelected,
+      enabled: isForeignTableSelected && !disableForeignRowsQuery,
     }
   )
   const isLastPage = (rowsData?.rows ?? []).length < tableEditorSnap.rowsPerPage
@@ -223,8 +227,8 @@ export const Pagination = () => {
           icon={<ArrowRight />}
           type="outline"
           className="px-1.5"
-          disabled={isLastPage}
-          loading={isLoadingRows}
+          disabled={isLastPage || disableForeignRowsQuery}
+          loading={isLoadingRows && !disableForeignRowsQuery}
           onClick={goToNextPage}
         />
         <RowCountSelector onRowsPerPageChange={onRowsPerPageChange} />

--- a/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -48,10 +48,10 @@ const RowCountSelector = ({
 }
 
 type PaginationProps = {
-  disableForeignRowsQuery?: boolean
+  enableForeignRowsQuery?: boolean
 }
 
-export const Pagination = ({ disableForeignRowsQuery = false }: PaginationProps) => {
+export const Pagination = ({ enableForeignRowsQuery = true }: PaginationProps) => {
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
 
@@ -112,7 +112,7 @@ export const Pagination = ({ disableForeignRowsQuery = false }: PaginationProps)
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },
     {
-      enabled: isForeignTableSelected && !disableForeignRowsQuery,
+      enabled: isForeignTableSelected && enableForeignRowsQuery,
     }
   )
   const isLastPage = (rowsData?.rows ?? []).length < tableEditorSnap.rowsPerPage
@@ -227,8 +227,8 @@ export const Pagination = ({ disableForeignRowsQuery = false }: PaginationProps)
           icon={<ArrowRight />}
           type="outline"
           className="px-1.5"
-          disabled={isLastPage || disableForeignRowsQuery}
-          loading={isLoadingRows && !disableForeignRowsQuery}
+          disabled={isLastPage || !enableForeignRowsQuery}
+          loading={isLoadingRows && enableForeignRowsQuery}
           onClick={goToNextPage}
         />
         <RowCountSelector onRowsPerPageChange={onRowsPerPageChange} />

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -26,6 +26,7 @@ const rowKeyGetter = (row: SupaRow) => {
 interface IGrid extends GridProps {
   rows: any[]
   error: any
+  isDisabled?: boolean
   isLoading: boolean
   isSuccess: boolean
   isError: boolean
@@ -45,6 +46,7 @@ export const Grid = memo(
         rowClass,
         rows,
         error,
+        isDisabled = false,
         isLoading,
         isSuccess,
         isError,
@@ -149,7 +151,7 @@ export const Grid = memo(
               style={{ height: `calc(100% - 35px)` }}
               className="absolute top-9 p-2 w-full z-[1] pointer-events-none"
             >
-              {isLoading && <GenericSkeletonLoader />}
+              {isLoading && !isDisabled && <GenericSkeletonLoader />}
 
               {isError && <GridError error={error} />}
 

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -58,9 +58,10 @@ export const MAX_EXPORT_ROW_COUNT_MESSAGE = (
 export type HeaderProps = {
   customHeader: ReactNode
   isRefetching: boolean
+  tableQueriesEnabled?: boolean
 }
 
-export const Header = ({ customHeader, isRefetching }: HeaderProps) => {
+export const Header = ({ customHeader, isRefetching, tableQueriesEnabled = true }: HeaderProps) => {
   const snap = useTableEditorTableStateSnapshot()
 
   return (
@@ -69,7 +70,7 @@ export const Header = ({ customHeader, isRefetching }: HeaderProps) => {
         {customHeader ? (
           customHeader
         ) : snap.selectedRows.size > 0 ? (
-          <RowHeader />
+          <RowHeader tableQueriesEnabled={tableQueriesEnabled} />
         ) : (
           <DefaultHeader />
         )}
@@ -224,7 +225,12 @@ const DefaultHeader = () => {
   )
 }
 
-const RowHeader = () => {
+type RowHeaderProps = {
+  tableQueriesEnabled?: boolean
+}
+
+const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
+  debugger
   const { data: project } = useSelectedProjectQuery()
   const tableEditorSnap = useTableEditorStateSnapshot()
   const snap = useTableEditorTableStateSnapshot()
@@ -238,16 +244,19 @@ const RowHeader = () => {
   const [isExporting, setIsExporting] = useState(false)
   const [showExportModal, setShowExportModal] = useState(false)
 
-  const { data } = useTableRowsQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-    tableId: snap.table.id,
-    sorts,
-    filters,
-    page: snap.page,
-    limit: tableEditorSnap.rowsPerPage,
-    roleImpersonationState: roleImpersonationState as RoleImpersonationState,
-  })
+  const { data } = useTableRowsQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      tableId: snap.table.id,
+      sorts,
+      filters,
+      page: snap.page,
+      limit: tableEditorSnap.rowsPerPage,
+      roleImpersonationState: roleImpersonationState as RoleImpersonationState,
+    },
+    { enabled: tableQueriesEnabled }
+  )
 
   const { data: countData } = useTableRowsCountQuery(
     {
@@ -258,7 +267,7 @@ const RowHeader = () => {
       enforceExactCount: snap.enforceExactCount,
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },
-    { keepPreviousData: true }
+    { keepPreviousData: true, enabled: tableQueriesEnabled }
   )
 
   const allRows = data?.rows ?? []

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -391,7 +391,7 @@ export const SidePanelEditor = ({
     payload: {
       name: string
       schema: string
-      comment?: string | undefined
+      comment?: string | null
     },
     columns: ColumnField[],
     foreignKeyRelations: ForeignKey[],

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -374,7 +374,7 @@ export const updateColumn = async ({
 export const duplicateTable = async (
   projectRef: string,
   connectionString: string | undefined | null,
-  payload: { name: string; comment?: string },
+  payload: { name: string; comment?: string | null },
   metadata: {
     duplicateTable: RetrieveTableResult
     isRLSEnabled: boolean
@@ -470,7 +470,7 @@ export const createTable = async ({
   payload: {
     name: string
     schema: string
-    comment?: string | undefined
+    comment?: string | null
   }
   columns: ColumnField[]
   foreignKeyRelations: ForeignKey[]

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -56,7 +56,7 @@ export interface TableEditorProps {
     payload: {
       name: string
       schema: string
-      comment?: string | undefined
+      comment?: string | null
     },
     columns: ColumnField[],
     foreignKeyRelations: ForeignKey[],

--- a/apps/studio/data/table-editor/table-editor-query-sql.ts
+++ b/apps/studio/data/table-editor/table-editor-query-sql.ts
@@ -14,9 +14,16 @@ export function getTableEditorSql(id?: number) {
             c.relforcerowsecurity as rls_forced,
             c.relreplident,
             c.relowner,
-            obj_description(c.oid) as comment
+            obj_description(c.oid) as comment,
+            fs.srvname as foreign_server_name,
+            fdw.fdwname as foreign_data_wrapper_name,
+            fdw_handler.proname as foreign_data_wrapper_handler
         from pg_class c
         join pg_namespace nc on nc.oid = c.relnamespace
+        left join pg_foreign_table ft on ft.ftrelid = c.oid
+        left join pg_foreign_server fs on fs.oid = ft.ftserver
+        left join pg_foreign_data_wrapper fdw on fdw.oid = fs.srvfdw
+        left join pg_proc fdw_handler on fdw.fdwhandler = fdw_handler.oid
         where c.oid = ${id}
             and not pg_is_other_temp_schema(nc.oid)
             and (
@@ -252,6 +259,9 @@ export function getTableEditorSql(id?: number) {
                 'schema', b.schema,
                 'name', b.name,
                 'comment', b.comment,
+                'foreign_server_name', b.foreign_server_name,
+                'foreign_data_wrapper_name', b.foreign_data_wrapper_name,
+                'foreign_data_wrapper_handler', b.foreign_data_wrapper_handler,
                 'columns', coalesce(c.columns, '[]'::jsonb)
             )
         end as entity

--- a/apps/studio/data/table-editor/table-editor-types.ts
+++ b/apps/studio/data/table-editor/table-editor-types.ts
@@ -5,6 +5,7 @@ import type {
   PostgresTable,
   PostgresView,
 } from '@supabase/postgres-meta'
+import { WRAPPER_HANDLERS } from 'components/interfaces/Integrations/Wrappers/Wrappers.constants'
 import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 
 interface TableRelationship extends PostgresRelationship {
@@ -40,6 +41,9 @@ export interface ForeignTable {
   schema: string
   name: string
   comment: string | null
+  foreign_server_name: string | null
+  foreign_data_wrapper_name: string | null
+  foreign_data_wrapper_handler: string | null
   columns: PostgresColumn[]
 }
 
@@ -65,6 +69,10 @@ export function isTableLike(entity?: Entity): entity is TableLike {
 
 export function isForeignTable(entity?: Entity): entity is ForeignTable {
   return entity?.entity_type === ENTITY_TYPE.FOREIGN_TABLE
+}
+
+export function isMsSqlForeignTable(entity?: Entity): entity is ForeignTable {
+  return isForeignTable(entity) && entity.foreign_data_wrapper_handler === WRAPPER_HANDLERS.MSSQL
 }
 
 export function isView(entity?: Entity): entity is View {

--- a/apps/studio/data/table-editor/table-editor-types.ts
+++ b/apps/studio/data/table-editor/table-editor-types.ts
@@ -41,9 +41,9 @@ export interface ForeignTable {
   schema: string
   name: string
   comment: string | null
-  foreign_server_name: string | null
-  foreign_data_wrapper_name: string | null
-  foreign_data_wrapper_handler: string | null
+  foreign_server_name: string
+  foreign_data_wrapper_name: string
+  foreign_data_wrapper_handler: string
   columns: PostgresColumn[]
 }
 

--- a/apps/studio/data/tables/table-create-mutation.ts
+++ b/apps/studio/data/tables/table-create-mutation.ts
@@ -9,7 +9,7 @@ import { tableKeys } from './keys'
 export type CreateTableBody = {
   name: string
   schema?: string
-  comment?: string
+  comment?: string | null
 }
 
 export type TableCreateVariables = {

--- a/packages/pg-meta/src/pg-meta-foreign-tables.ts
+++ b/packages/pg-meta/src/pg-meta-foreign-tables.ts
@@ -1,19 +1,19 @@
-import { literal, ident } from './pg-format'
 import { z } from 'zod'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
-import { filterByList, coalesceRowsToArray } from './helpers'
-import { FOREIGN_TABLES_SQL } from './sql/foreign-tables'
-import { COLUMNS_SQL } from './sql/columns'
+import { coalesceRowsToArray, filterByList } from './helpers'
+import { ident, literal } from './pg-format'
 import { pgColumnArrayZod } from './pg-meta-columns'
+import { COLUMNS_SQL } from './sql/columns'
+import { FOREIGN_TABLES_SQL } from './sql/foreign-tables'
 
 export const pgForeignTableZod = z.object({
   id: z.number(),
   schema: z.string(),
   name: z.string(),
   comment: z.string().nullable(),
-  foreign_server_name: z.string().nullable(),
-  foreign_data_wrapper_name: z.string().nullable(),
-  foreign_data_wrapper_handler: z.string().nullable(),
+  foreign_server_name: z.string(),
+  foreign_data_wrapper_name: z.string(),
+  foreign_data_wrapper_handler: z.string(),
   columns: pgColumnArrayZod.optional(),
 })
 

--- a/packages/pg-meta/src/pg-meta-foreign-tables.ts
+++ b/packages/pg-meta/src/pg-meta-foreign-tables.ts
@@ -11,6 +11,9 @@ export const pgForeignTableZod = z.object({
   schema: z.string(),
   name: z.string(),
   comment: z.string().nullable(),
+  foreign_server_name: z.string().nullable(),
+  foreign_data_wrapper_name: z.string().nullable(),
+  foreign_data_wrapper_handler: z.string().nullable(),
   columns: pgColumnArrayZod.optional(),
 })
 

--- a/packages/pg-meta/src/sql/foreign-tables.ts
+++ b/packages/pg-meta/src/sql/foreign-tables.ts
@@ -10,10 +10,10 @@ select
 from
   pg_class c
   join pg_namespace n on n.oid = c.relnamespace
-  left join pg_foreign_table ft on ft.ftrelid = c.oid
-  left join pg_foreign_server fs on fs.oid = ft.ftserver
-  left join pg_foreign_data_wrapper fdw on fdw.oid = fs.srvfdw
-  left join pg_proc handler on handler.oid = fdw.fdwhandler
+  inner join pg_foreign_table ft on ft.ftrelid = c.oid
+  inner join pg_foreign_server fs on fs.oid = ft.ftserver
+  inner join pg_foreign_data_wrapper fdw on fdw.oid = fs.srvfdw
+  inner join pg_proc handler on handler.oid = fdw.fdwhandler
 where
   c.relkind = 'f'
 `

--- a/packages/pg-meta/src/sql/foreign-tables.ts
+++ b/packages/pg-meta/src/sql/foreign-tables.ts
@@ -3,10 +3,17 @@ select
   c.oid::int8 as id,
   n.nspname as schema,
   c.relname as name,
-  obj_description(c.oid) as comment
+  obj_description(c.oid) as comment,
+  fs.srvname as foreign_server_name,
+  fdw.fdwname as foreign_data_wrapper_name,
+  handler.proname as foreign_data_wrapper_handler
 from
   pg_class c
   join pg_namespace n on n.oid = c.relnamespace
+  left join pg_foreign_table ft on ft.ftrelid = c.oid
+  left join pg_foreign_server fs on fs.oid = ft.ftserver
+  left join pg_foreign_data_wrapper fdw on fdw.oid = fs.srvfdw
+  left join pg_proc handler on handler.oid = fdw.fdwhandler
 where
   c.relkind = 'f'
 `

--- a/packages/pg-meta/src/sql/tables.ts
+++ b/packages/pg-meta/src/sql/tables.ts
@@ -43,7 +43,7 @@ FROM
       join pg_class c on i.indrelid = c.oid
       join pg_namespace n on c.relnamespace = n.oid
       join pg_attribute a on a.attrelid = c.oid and a.attnum = any(i.indkey)
-	where
+    where
       i.indisprimary
     group by c.oid
   ) as pk

--- a/packages/pg-meta/test/foreign-tables.test.ts
+++ b/packages/pg-meta/test/foreign-tables.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeAll, afterAll } from 'vitest'
+import { afterAll, beforeAll, expect, test } from 'vitest'
 import pgMeta from '../src/index'
-import { createTestDatabase, cleanupRoot } from './db/utils'
+import { cleanupRoot, createTestDatabase } from './db/utils'
 
 beforeAll(async () => {
   // Any global setup if needed
@@ -98,6 +98,9 @@ withTestDatabase('list foreign tables', async ({ executeQuery }) => {
         },
       ],
       "comment": null,
+      "foreign_data_wrapper_handler": "postgres_fdw_handler",
+      "foreign_data_wrapper_name": "postgres_fdw",
+      "foreign_server_name": "foreign_server",
       "id": Any<Number>,
       "name": "foreign_table",
       "schema": "public",
@@ -115,6 +118,9 @@ withTestDatabase('list foreign tables without columns', async ({ executeQuery })
     `
     {
       "comment": null,
+      "foreign_data_wrapper_handler": "postgres_fdw_handler",
+      "foreign_data_wrapper_name": "postgres_fdw",
+      "foreign_server_name": "foreign_server",
       "id": Any<Number>,
       "name": "foreign_table",
       "schema": "public",
@@ -199,6 +205,9 @@ withTestDatabase('retrieve foreign table by name', async ({ executeQuery }) => {
         },
       ],
       "comment": null,
+      "foreign_data_wrapper_handler": "postgres_fdw_handler",
+      "foreign_data_wrapper_name": "postgres_fdw",
+      "foreign_server_name": "foreign_server",
       "id": Any<Number>,
       "name": "foreign_table",
       "schema": "public",
@@ -282,6 +291,9 @@ withTestDatabase('retrieve foreign table by id', async ({ executeQuery }) => {
         },
       ],
       "comment": null,
+      "foreign_data_wrapper_handler": "postgres_fdw_handler",
+      "foreign_data_wrapper_name": "postgres_fdw",
+      "foreign_server_name": "foreign_server",
       "id": Any<Number>,
       "name": "foreign_table",
       "schema": "public",

--- a/packages/pg-meta/test/query/table-row-query.test.ts
+++ b/packages/pg-meta/test/query/table-row-query.test.ts
@@ -34,6 +34,29 @@ describe('Table Row Query', () => {
       })
       expect(result).toEqual([])
     })
+
+    test('should exclude specified columns when determining default sort', () => {
+      const table = {
+        primary_keys: [{ name: 'id' }],
+        columns: [
+          {
+            name: 'id',
+            data_type: 'integer',
+            format: 'int4',
+            ordinal_position: 1,
+          },
+          {
+            name: 'name',
+            data_type: 'text',
+            format: 'text',
+            ordinal_position: 2,
+          },
+        ],
+      } as any
+
+      const result = getDefaultOrderByColumns(table, { excludedColumns: ['id'] })
+      expect(result).toEqual(['name'])
+    })
   })
 
   describe('getTableRowsSql', () => {

--- a/packages/pg-meta/test/tables.test.ts
+++ b/packages/pg-meta/test/tables.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeAll, afterAll } from 'vitest'
+import { afterAll, beforeAll, expect, test } from 'vitest'
 import pgMeta from '../src/index'
-import { createTestDatabase, cleanupRoot } from './db/utils'
+import { cleanupRoot, createTestDatabase } from './db/utils'
 
 beforeAll(async () => {
   // Any global setup if needed
@@ -1427,7 +1427,6 @@ for (const testCase of tableCreationTests) {
       await testCase.beforeTest(executeQuery)
     }
 
-    //@ts-expect-error
     const { sql } = pgMeta.tables.create(testCase.input)
     await executeQuery(sql)
 


### PR DESCRIPTION
There is an edge case interaction between the Postgres query parser and MSSQL foreign tables, where the query parser may drop sort clauses that are redundant with applied filters. This leads to invalid MSSQL syntax, because the resulting query has a `limit` but no `sort`, and the user sees a confusing error message.

This PR detects this edge case on MSSQL foreign tables. There are three cases:
1. The user filters by a column, but there are still other columns available for sorting. The default search for a sorting column will leave out the filtered column.
2. The user filters by a column/several columns, and there are no more columns that can be used for sorting. We stop the query and show an admonition.
3. The user filters by a column, then tries to sort by the same column. We stop the query and show an admonition.

## Testing

- [ ] Make sure non-MSSQL tables behave as usual

On MSSQL tables:
- [ ] Find the default sorting column. Filter by that column. Make sure that column is not the sorting column in the final query
- [ ] Filter by all sortable columns. Make sure admonition appears and query does not run.
- [ ] Filter by a column and sort by the same column. Make sure admonition appears and query does not run.

Resolves FE-1990