### PR TITLE
Fix connection details analytics buckets, remove go to vault CTA for fields that aren't in vault

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
@@ -49,21 +49,23 @@ export const DecryptedReadOnlyInput = ({
         label={
           <div className="flex items-center gap-x-2">
             <span>{label}</span>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  href={`/project/${ref}/integrations/vault/secrets?search=${value}`}
-                >
-                  <ExternalLink
-                    size={14}
-                    className="text-foreground-muted hover:text-foreground-lighter transition"
-                  />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open in Vault</TooltipContent>
-            </Tooltip>
+            {secureEntry && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <a
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    href={`/project/${ref}/integrations/vault/secrets?search=${value}`}
+                  >
+                    <ExternalLink
+                      size={14}
+                      className="text-foreground-muted hover:text-foreground-lighter transition"
+                    />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Open in Vault</TooltipContent>
+              </Tooltip>
+            )}
           </div>
         }
         description={descriptionText}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/index.tsx
@@ -36,9 +36,6 @@ import { Admonition } from 'ui-patterns/admonition'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { DeleteAnalyticsBucketModal } from '../DeleteAnalyticsBucketModal'
 import { ConnectTablesDialog } from './ConnectTablesDialog'
-import { DESCRIPTIONS, LABELS, OPTION_ORDER } from './constants'
-import { CopyEnvButton } from './CopyEnvButton'
-import { DecryptedReadOnlyInput } from './DecryptedReadOnlyInput'
 import { NamespaceWithTables } from './NamespaceWithTables'
 import { SimpleConfigurationDetails } from './SimpleConfigurationDetails'
 import { useAnalyticsBucketWrapperInstance } from './useAnalyticsBucketWrapperInstance'
@@ -199,44 +196,7 @@ export const AnalyticBucketDetails = () => {
                 )}
               </ScaffoldSection>
 
-              <ScaffoldSection isFullWidth>
-                <ScaffoldHeader className="flex flex-row justify-between items-end gap-x-8">
-                  <div>
-                    <ScaffoldSectionTitle>Connection details</ScaffoldSectionTitle>
-                    <ScaffoldSectionDescription>
-                      Connect an Iceberg client to this bucket.{' '}
-                      <InlineLink
-                        href={`${DOCS_URL}/guides/storage/analytics/connecting-to-analytics-bucket`}
-                      >
-                        Learn more
-                      </InlineLink>
-                    </ScaffoldSectionDescription>
-                  </div>
-                  <CopyEnvButton
-                    serverOptions={wrapperMeta.server.options.filter(
-                      (option) => !option.hidden && wrapperValues[option.name]
-                    )}
-                    values={wrapperValues}
-                  />
-                </ScaffoldHeader>
-
-                <Card>
-                  {wrapperMeta.server.options
-                    .filter((option) => !option.hidden && wrapperValues[option.name])
-                    .sort((a, b) => OPTION_ORDER.indexOf(a.name) - OPTION_ORDER.indexOf(b.name))
-                    .map((option) => {
-                      return (
-                        <DecryptedReadOnlyInput
-                          key={option.name}
-                          label={LABELS[option.name]}
-                          value={wrapperValues[option.name]}
-                          secureEntry={option.secureEntry}
-                          descriptionText={DESCRIPTIONS[option.name]}
-                        />
-                      )
-                    })}
-                </Card>
-              </ScaffoldSection>
+              <SimpleConfigurationDetails bucketName={bucket?.id} />
             </>
           )}
           {state === 'missing' && <WrapperMissing bucketName={bucket?.id} />}


### PR DESCRIPTION
## Context

In Analytics Buckets -> Connection details, we're incorrectly showing the "Open in Vault" CTA for fields that aren't stored in vault (e.g Catalog URI here isn't, but Catalog token is)

<img width="326" height="218" alt="image" src="https://github.com/user-attachments/assets/313d9675-17e4-4eb3-bdeb-d5d4c21d6631" />

## Changes involved
- Only show "Open in vault" tooltip for fields that are stored in vault (catalog token, s3 access key, s3 secret key)
- (Unrelated) Realised that `AnalyticBucketDetails` isn't using the `SimpleConfigurationDetails` component, and there's some discrepancy as well
  - The configuration details in `AnalyticBucketDetails` has more info than that in `SimpleConfigurationDetails`
  - Updated `SimpleConfigurationDetails` to show all fields required, and have `AnalyticBucketDetails` use that component as well

## To Test

- [ ] Verify that there's no "Open in vault" CTA for analytics buckets connection details for non encrypted values