### PR TITLE
docs: Add John Schaeffer to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -81,6 +81,7 @@ Jenny Kibiri
 Jess Shears
 Jim Chanco Jr
 John Pena
+John Schaeffer
 Jon M
 Jonny Summers-Muir
 Jordi Enric


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR adds John Schaeffer to the Supabase humans.txt file.
