### PR TITLE
fix(logout): don't use returnTo on sign-in page if user intentionally logs out

### DIFF
--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -4,9 +4,8 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import { ProfileImage } from 'components/ui/ProfileImage'
-import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useSignOut } from 'lib/auth'
 import { IS_PLATFORM } from 'lib/constants'
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useProfileNameAndPicture } from 'lib/profile'
 import { useAppStateSnapshot } from 'state/app-state'
 import {
@@ -33,7 +32,6 @@ export function UserDropdown() {
   const profileShowEmailEnabled = useIsFeatureEnabled('profile:show_email')
   const { username, avatarUrl, primaryEmail, isLoading } = useProfileNameAndPicture()
 
-  const signOut = useSignOut()
   const setCommandMenuOpen = useSetCommandMenuOpen()
   const sendTelemetry = useCommandMenuOpenedTelemetry()
   const { openFeaturePreviewModal } = useFeaturePreviewModal()
@@ -131,8 +129,8 @@ export function UserDropdown() {
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem
-                onSelect={async () => {
-                  await signOut()
+                onSelect={() => {
+                  router.push('/logout')
                 }}
               >
                 Log out

--- a/apps/studio/hooks/misc/withAuth.tsx
+++ b/apps/studio/hooks/misc/withAuth.tsx
@@ -8,7 +8,7 @@ import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useAuthenticatorAssuranceLevelQuery } from 'data/profile/mfa-authenticator-assurance-level-query'
 import { useSignOut } from 'lib/auth'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-import { type NextPageWithLayout, isNextPageWithLayout } from 'types'
+import { isNextPageWithLayout, type NextPageWithLayout } from 'types'
 
 const MAX_TIMEOUT = 10000 // 10 seconds
 

--- a/apps/studio/lib/auth.tsx
+++ b/apps/studio/lib/auth.tsx
@@ -48,7 +48,7 @@ export function useSignOut() {
     clearLocalStorage()
     // Clear Assistant IndexedDB
     await clearAssistantStorage()
-    await queryClient.clear()
+    queryClient.clear()
 
     return result
   }, [queryClient, clearAssistantStorage])


### PR DESCRIPTION
When user logs out from the user dropdown, they're redirected to the sign-in page via the withAuth redirect, which means that the returnTo param is used -- but if the user _intentionally_ logged out, this might not be the right behavior, i.e., if they want to log in to another account. Instead, if they chose to log out, we shouldn't use the returnTo param.

Since the /logout page already implements this behavior, I changed the "Log out" button to just route to the /logout page.

## Testing

- [x] Log out using the user dropdown button. There should be no `returnTo` on the log in page.
- [x] Log out using another method (e.g., delete the auth token from browser storage). There should be a `returnTo` param on the log in page.

Resolves FE-1842