### PR TITLE
ci: add eslint ratcheting

### DIFF
--- a/.github/workflows/studio-lint-ratchet-decrease.yml
+++ b/.github/workflows/studio-lint-ratchet-decrease.yml
@@ -1,0 +1,80 @@
+name: Decrease studio lint ratchet baselines
+
+on:
+  schedule:
+    - cron: '0 0 * * SUN'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  decrease-baselines:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          sparse-checkout: |
+            .github
+            apps/studio
+            packages
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Decrease ESLint ratchet baselines and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -eo pipefail
+          DEFAULT_BRANCH=${DEFAULT_BRANCH:-master}
+
+          BRANCH="bot/decrease-eslint-ratchet-baselines"
+
+          git fetch origin "$DEFAULT_BRANCH" --depth=1
+          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
+            git fetch origin "$BRANCH":"$BRANCH" --depth=1
+            git switch "$BRANCH"
+            git reset --hard "origin/$DEFAULT_BRANCH"
+          else
+            git switch --create "$BRANCH" "origin/$DEFAULT_BRANCH"
+          fi
+
+          pnpm --filter studio run lint:ratchet --decrease-baselines
+
+          if git diff --quiet; then
+            echo "No baseline updates detected."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git add apps/studio/.github/eslint-rule-baselines.json
+          git commit --message "chore: decrease ESLint ratchet baselines"
+          git push --force origin "$BRANCH"
+
+          pr_url=$(gh pr list --state open --head "$BRANCH" --json url --jq '.[0].url // ""' 2>/dev/null || echo "")
+          if [ -z "$pr_url" ]; then
+            gh pr create \
+              --title "[bot] Decrease ESLint ratchet baselines" \
+              --body "Automated weekly decrease of ESLint ratchet baselines." \
+              --base "$DEFAULT_BRANCH" \
+              --head "$BRANCH"
+          else
+            gh pr comment "$pr_url" --body "Updated ESLint ratchet baselines with the latest weekly decreases."
+          fi

--- a/.github/workflows/studio-lint-ratchet.yml
+++ b/.github/workflows/studio-lint-ratchet.yml
@@ -1,0 +1,45 @@
+name: Ratchet studio lint checks
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'apps/studio/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    # Uses larger hosted runner as it significantly decreases build times
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          sparse-checkout: |
+            .github
+            apps/studio
+            packages
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Run ratchet script 
+        run: pnpm --filter studio run lint:ratchet

--- a/apps/studio/.github/eslint-rule-baselines.json
+++ b/apps/studio/.github/eslint-rule-baselines.json
@@ -1,5 +1,8 @@
 {
   "rules": {
-    "react-hooks/exhaustive-deps": 239
+    "react-hooks/exhaustive-deps": 238,
+    "import/no-anonymous-default-export": 62,
+    "@tanstack/query/exhaustive-deps": 19,
+    "@tanstack/query/no-deprecated-options": 2
   }
 }

--- a/apps/studio/.github/eslint-rule-baselines.json
+++ b/apps/studio/.github/eslint-rule-baselines.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react-hooks/exhaustive-deps": 239
+  }
+}

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -8,7 +8,7 @@
     "build": "next build && ./../../scripts/upload-static-assets.sh",
     "start": "next start",
     "lint": "eslint .",
-    "lint:ratchet": "tsx scripts/ratchet-eslint-rules.ts --rule react-hooks/exhaustive-deps",
+    "lint:ratchet": "tsx scripts/ratchet-eslint-rules.ts --rule react-hooks/exhaustive-deps --rule import/no-anonymous-default-export --rule @tanstack/query/exhaustive-deps --rule @tanstack/query/no-deprecated-options",
     "clean": "rimraf node_modules tsconfig.tsbuildinfo .next .turbo",
     "test": "vitest --run --coverage",
     "test:watch": "vitest watch",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -8,6 +8,7 @@
     "build": "next build && ./../../scripts/upload-static-assets.sh",
     "start": "next start",
     "lint": "eslint .",
+	"lint:ratchet": "node scripts/ratchet-eslint-rules.js --rule react-hooks/exhaustive-deps",
     "clean": "rimraf node_modules tsconfig.tsbuildinfo .next .turbo",
     "test": "vitest --run --coverage",
     "test:watch": "vitest watch",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -8,7 +8,7 @@
     "build": "next build && ./../../scripts/upload-static-assets.sh",
     "start": "next start",
     "lint": "eslint .",
-	"lint:ratchet": "node scripts/ratchet-eslint-rules.js --rule react-hooks/exhaustive-deps",
+    "lint:ratchet": "tsx scripts/ratchet-eslint-rules.ts --rule react-hooks/exhaustive-deps",
     "clean": "rimraf node_modules tsconfig.tsbuildinfo .next .turbo",
     "test": "vitest --run --coverage",
     "test:watch": "vitest watch",

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -313,20 +313,6 @@ const MergePage: NextPageWithLayout = () => {
     })
   }
 
-  const handleReadyForReview = () => {
-    if (!ref || !parentProjectRef) return
-    updateBranch(
-      {
-        branchRef: ref,
-        projectRef: parentProjectRef,
-        requestReview: true,
-      },
-      {
-        onSuccess: () => toast.success('Successfully marked as ready for review'),
-      }
-    )
-  }
-
   const breadcrumbs = useMemo(
     () => [
       {
@@ -334,7 +320,7 @@ const MergePage: NextPageWithLayout = () => {
         href: `/project/${project?.ref}/branches/merge-requests`,
       },
     ],
-    [parentProjectRef]
+    [project?.ref]
   )
 
   const currentTab = (router.query.tab as string) || 'database'

--- a/apps/studio/scripts/ratchet-eslint-rules.js
+++ b/apps/studio/scripts/ratchet-eslint-rules.js
@@ -1,0 +1,238 @@
+/**
+ * Ratchet ESLint violations for selected rules.
+ *
+ * Examples:
+ *   # Initialize baselines for two rules
+ *   node scripts/ratchet-eslint-rules.js --init \
+ *     --rule exhaustive-deps --rule no-console
+ *
+ *   # Compare current counts vs baselines
+ *   node scripts/ratchet-eslint-rules.js \
+ *     --rule exhaustive-deps --rule no-console
+ *
+ * Flags:
+ *   --metadata <path>     Path to baseline file (default .github/eslint-rule-baselines.json)
+ *   --init                Write current counts for the provided --rule(s) into metadata and exit 0
+ *   --eslint "<cmd>"      ESLint command to run (default "npx eslint")
+ *   --eslint-args "<...>" Extra args/paths for ESLint (e.g., ".")
+ *   --rule <id>[,<id>...] Rule id(s). Repeat flag or comma-separate. REQUIRED.
+ *
+ * Notes:
+ * - Counts occurrences regardless of severity (warn/error).
+ * - Fails if any selected rule has currentCount > baselineCount.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+function parseArgs(argv) {
+  const args = {
+    metadata: '.github/eslint-rule-baselines.json',
+    init: false,
+    eslint: 'npx eslint',
+    eslintArgs: '',
+    rules: [],
+  }
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--init') {
+      args.init = true
+    } else if (a === '--metadata') {
+      args.metadata = argv[++i]
+    } else if (a === '--eslint') {
+      args.eslint = argv[++i]
+    } else if (a === '--eslint-args') {
+      args.eslintArgs = argv[++i]
+    } else if (a === '--rule') {
+      const val = (argv[++i] || '').trim()
+      if (val)
+        args.rules.push(
+          ...val
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        )
+    } else {
+      console.warn(`Unknown argument: ${a}`)
+    }
+  }
+
+  // Fail if no rules are provided
+  if (args.rules.length === 0) {
+    console.error('Error: You must provide at least one --rule <rule-id>.')
+    console.error('Example: --rule exhaustive-deps --rule no-console')
+    process.exit(2)
+  }
+
+  // De-duplicate and preserve order
+  args.rules = [...new Set(args.rules)]
+
+  return args
+}
+
+function runESLint(eslintCmd, eslintArgs) {
+  const fullCmd = `${eslintCmd} ${eslintArgs || ''} --format json`.trim()
+  const proc = spawnSync(fullCmd, {
+    shell: true,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024, // allow large ESLint JSON payloads
+  })
+
+  const stdout = proc.stdout || ''
+  const stderr = proc.stderr || ''
+
+  if (!stdout.trim()) {
+    console.error('ESLint did not produce JSON output. stderr:\n', stderr)
+    process.exit(2)
+  }
+
+  let results
+  try {
+    results = JSON.parse(stdout)
+  } catch (e) {
+    console.error('Failed to parse ESLint JSON output:', e)
+    console.error('Raw output (truncated to 4k):\n', stdout.slice(0, 4096))
+    process.exit(2)
+  }
+
+  return { results, stderr }
+}
+
+function countRules(results, ruleIds) {
+  const expanded = new Set(ruleIds)
+
+  const counts = Object.fromEntries(ruleIds.map((id) => [id, 0]))
+
+  for (const file of results) {
+    if (!file || !Array.isArray(file.messages)) continue
+    for (const msg of file.messages) {
+      const id = msg?.ruleId || ''
+      if (expanded.has(id)) {
+        if (counts[id] != null) counts[id] += 1
+      }
+    }
+  }
+  return counts
+}
+
+function readBaselines(fp) {
+  if (!fs.existsSync(fp)) return { rules: {} }
+  try {
+    const data = JSON.parse(fs.readFileSync(fp, 'utf8'))
+    if (data && typeof data === 'object' && data.rules && typeof data.rules === 'object') {
+      return { rules: data.rules }
+    }
+  } catch {}
+  return { rules: {} }
+}
+
+function writeBaselines(fp, updates, merge = true) {
+  const dir = path.dirname(fp)
+  fs.mkdirSync(dir, { recursive: true })
+
+  let current = { rules: {} }
+  if (merge && fs.existsSync(fp)) {
+    current = readBaselines(fp)
+  }
+
+  const next = { rules: { ...current.rules, ...updates } }
+  fs.writeFileSync(fp, JSON.stringify(next, null, 2) + '\n', 'utf8')
+}
+
+function writeSummary(markdown) {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY
+  if (summaryFile) {
+    try {
+      fs.appendFileSync(summaryFile, markdown + '\n', 'utf8')
+    } catch {}
+  }
+}
+
+;(function main() {
+  const args = parseArgs(process.argv)
+
+  const { results, stderr } = runESLint(args.eslint, args.eslintArgs)
+  const currentCounts = countRules(results, args.rules)
+
+  if (args.init) {
+    writeBaselines(args.metadata, currentCounts, /*merge*/ true)
+
+    const rows = Object.entries(currentCounts)
+      .map(([rule, count]) => `| \`${rule}\` | **${count}** |`)
+      .join('\n')
+
+    writeSummary(
+      [
+        `### ESLint rule baselines initialized`,
+        `Metadata: \`${args.metadata}\``,
+        ``,
+        `| Rule | Baseline |`,
+        `| --- | ---: |`,
+        rows,
+        ``,
+      ].join('\n')
+    )
+
+    console.log(
+      `Initialized/updated baselines for: ${args.rules.join(', ')} (saved to ${args.metadata}).`
+    )
+    process.exit(0)
+  }
+
+  const baselines = readBaselines(args.metadata).rules || {}
+
+  const missing = args.rules.filter((r) => typeof baselines[r] !== 'number')
+  if (missing.length) {
+    const msg = `Missing baselines for: ${missing.join(', ')} in ${args.metadata}. Run with --init to set them.`
+    console.error(msg)
+    writeSummary(`### ESLint rule ratchet\n${msg}`)
+    console.log(`::error title=Missing baselines::${msg}`)
+    process.exit(2)
+  }
+
+  let failed = false
+  const tableRows = []
+  for (const rule of args.rules) {
+    const baseline = baselines[rule] ?? 0
+    const current = currentCounts[rule] ?? 0
+    const delta = current - baseline
+
+    tableRows.push(
+      `| \`${rule}\` | **${baseline}** | **${current}** | ${delta >= 0 ? '+' : ''}${delta} |`
+    )
+
+    if (current > baseline) {
+      failed = true
+      const msg = `ESLint violations regressed for ${rule}: baseline=${baseline}, current=${current}`
+      console.error(msg)
+      console.log(`::error title=Rule regressed::${msg}`)
+    }
+  }
+
+  writeSummary(
+    [
+      `### ESLint rule ratchet`,
+      `Metadata: \`${args.metadata}\``,
+      ``,
+      `| Rule | Baseline | Current | Δ |`,
+      `| --- | ---: | ---: | ---: |`,
+      ...tableRows,
+      ``,
+    ].join('\n')
+  )
+
+  if (failed) {
+    if (stderr && stderr.trim()) console.error('\nESLint stderr:\n', stderr)
+    process.exit(1)
+  } else {
+    const improved = args.rules.some((r) => (currentCounts[r] ?? 0) < (baselines[r] ?? 0))
+    console.log(
+      improved ? 'Nice! Some rules improved.' : 'Stable: No regressions for selected rules.'
+    )
+    process.exit(0)
+  }
+})()

--- a/apps/studio/scripts/ratchet-eslint-rules.ts
+++ b/apps/studio/scripts/ratchet-eslint-rules.ts
@@ -11,6 +11,11 @@
  *   tsx scripts/ratchet-eslint-rules.ts \
  *     --rule react-hooks/exhaustive-deps --rule no-console
  *
+	 # Decrease baselines when improvements occur
+ *   tsx scripts/ratchet-eslint-rules.ts \
+	 *   --rule react-hooks/exhaustive-deps --rule no-console \
+	 *   --decrease-baselines
+ *
  * Flags:
  *   --metadata <path>     Path to baseline file (default .github/eslint-rule-baselines.json)
  *   --init                Write current counts for the provided --rule(s) into metadata and exit 0
@@ -105,8 +110,8 @@ function parseArgs(argv: string[]): Args {
 
 /**
  * SECURITY:
- * Directly spawns a command from its arguments. Should **never** be
- * called with untrusted input.
+ * Directly spawns a command from its arguments. Should not be called with
+ * untrusted input.
  */
 function dangerouslyRunEsLint(eslintCmd: string, eslintArgs: string): ESLintExecutionResult {
   const fullCmd = `${eslintCmd} ${eslintArgs || ''} --format json`.trim()
@@ -139,7 +144,7 @@ function dangerouslyRunEsLint(eslintCmd: string, eslintArgs: string): ESLintExec
 }
 
 function countRules(results: ESLintResult[], ruleIds: string[]): Record<string, number> {
-  const expanded = new Set(ruleIds)
+  const checkedIds = new Set(ruleIds)
   const counts: Record<string, number> = {}
 
   for (const id of ruleIds) {
@@ -150,7 +155,7 @@ function countRules(results: ESLintResult[], ruleIds: string[]): Record<string, 
     if (!file || !Array.isArray(file.messages)) continue
     for (const msg of file.messages) {
       const id = msg?.ruleId ?? ''
-      if (id && expanded.has(id)) {
+      if (id && checkedIds.has(id)) {
         counts[id] += 1
       }
     }


### PR DESCRIPTION
Add an ESLint ratchet script and actions.

- Ratchet script runs ESLint and reads a metadata file containing some baselines. For any tracked lint rule, if the number of violations exceeds the baseline, it fails. New rules can be added locally with the `--init --rule <rule-id>` option and pushed to the repo to be tracked.
- Ratchet action runs on each PR to make sure no additional ESLint violations are introduced.
- Ratchet update action runs weekly to decrease the baseline to the new lowest number if possible.

Tracking some of our most common rule warnings. The only one missing is `no-restricted-exports`, because there are legitimate reasons to add default exports (mandatory Next.js convention). We need to figure out if it's possible to configure this rule to ignore specific directories/files before we can start tracking it.