### PR TITLE
Fix PostHog user identification persisting after signout

### DIFF
--- a/apps/studio/lib/auth.tsx
+++ b/apps/studio/lib/auth.tsx
@@ -6,6 +6,7 @@ import {
   AuthProvider as AuthProviderInternal,
   clearLocalStorage,
   gotrueClient,
+  posthogClient,
   useAuthError,
 } from 'common'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
@@ -45,6 +46,7 @@ export function useSignOut() {
 
   return useCallback(async () => {
     const result = await gotrueClient.signOut()
+    posthogClient.reset()
     clearLocalStorage()
     // Clear Assistant IndexedDB
     await clearAssistantStorage()

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -142,6 +142,20 @@ class PostHogClient {
       console.error('PostHog identify failed:', error)
     }
   }
+
+  reset() {
+    this.pendingIdentification = null
+    this.pendingGroups = {}
+    this.pendingEvents = []
+
+    if (!this.initialized) return
+
+    try {
+      posthog.reset()
+    } catch (error) {
+      console.error('PostHog reset failed:', error)
+    }
+  }
 }
 
 export const posthogClient = new PostHogClient()

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -17,6 +17,8 @@ import { TelemetryEvent } from './telemetry-constants'
 import { getSharedTelemetryData } from './telemetry-utils'
 import { posthogClient } from './posthog-client'
 
+export { posthogClient }
+
 const { TELEMETRY_DATA } = LOCAL_STORAGE_KEYS
 
 // Reexports GoogleTagManager with the right API key set


### PR DESCRIPTION
## Problem

PostHog user identification data was persisting after signout, potentially causing analytics contamination in certain situations. This was happening because there were no calls to [PostHog's `reset()` method](https://posthog.com/docs/libraries/js/usage) in the logout flow. This PR fixes that.

## Solution

- Added `reset()` method to PostHogClient class that:
  - Clears all pending state (identification, groups, events)
  - Calls PostHog SDK's `reset()` method to clear user identification
  - Includes proper null safety checks
  - Prevents memory leaks by clearing pending event queue
- Integrated `posthogClient.reset()` into the signout flow in `useSignOut` hook
- Called `reset()` before `clearLocalStorage()` to prevent race conditions

## Testing

Tested locally by:
1. Running `mise fullstack` from infrastructure repo
2. Logging into the dashboard at http://localhost:8082
3. Opening browser console and inspecting PostHog localStorage before signout:
   ```javascript
   JSON.parse(localStorage.getItem(Object.keys(localStorage).find(k => k.startsWith('ph_phc_'))))
   ```
4. Signing out
5. Inspecting PostHog localStorage after signout using the same command

Expected behavior:

Before signout, the PostHog localStorage key should contain user identification:
```javascript
{
  $user_id: "<uuid>",
  $user_state: "identified",
  $groups: {
    organization: "<org-slug>",
    project: "<project-ref>"
  },
  // ... other properties
}
```

After signout, the PostHog localStorage key should contain only anonymous session data:
```javascript
{
  $user_state: "anonymous",
  // No $user_id property
  // No $groups property
  // ... other anonymous session properties
}
```

Tested locally and confirmed working as expected. PostHog correctly clears user identification while maintaining anonymous analytics capability.

Resolves GROWTH-535