### PR TITLE
fix(table editor): request fired per column when updating table

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -70,7 +70,7 @@ export const generateColumnFieldFromPostgresColumn = (
     table: column.table,
     schema: column.schema,
     name: column.name,
-    comment: column?.comment ?? '',
+    comment: column?.comment,
     format: isArray ? column.format.slice(1) : column.format,
     defaultValue: column?.default_value as string | null,
     check: column.check,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.types.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.types.ts
@@ -46,7 +46,7 @@ export interface ColumnField {
   table: string
   schema: string
   check: string | null
-  comment?: string
+  comment?: string | null
   format: string
   defaultValue: string | null
   foreignKey?: ExtendedPostgresRelationship


### PR DESCRIPTION
When updating a table with many columns, a request is fired per column, causing potential rate-limiting.

The biggest contributor is a bug in the `comment` config of each column. If columns have no comment, we coerce the comment to an empty string, but our column payload diff function sees this as a difference, thus tries to set a new comment on every column. Unfortunately this is not a one-time issue, because Postgres considers an empty comment to be null, and coerces it back to null, and on and on we go in a giant circle.

The fix is just to not coerce to empty strings on our end.

There are a few other requests that we might be able to shave, but this is by far the noisiest one.

## Testing

In prod, create a table with many columns (50 will do) and use the side panel to add a new column. Observe how excruciatingly slow it is and how many `query?key=column-update`s fire.

Do the same thing on the preview. Should finish faster and have many fewer column update queries.

Towards FE-2066