### PR TITLE
Smol fix files bucket

### DIFF
--- a/apps/studio/pages/project/[ref]/storage/files/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/files/buckets/[bucketId].tsx
@@ -35,7 +35,7 @@ const BucketPage: NextPageWithLayout = () => {
   }
 
   // If the bucket is not found or the bucket type is ANALYTICS or VECTOR, show an error message
-  if (!bucket || bucket.type !== 'STANDARD') {
+  if (!bucket || ('type' in bucket && bucket.type !== 'STANDARD')) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <p className="text-sm text-foreground-light">Bucket "{bucketId}" cannot be found</p>


### PR DESCRIPTION
## Context

There's a small subset of projects which storage hasn't been updated just yet, such that the buckets that get returned from `GET /storage/buckets` do not have the `type` property - whereas FE currently expects the `type` property to be there. This causes a bug in the UI to show "Bucket cannot be found" when opening a file bucket, so this PR resolves this by checking if the `type` property is present as part of the check

For context we're checking `type` property also because GET /storage/buckets returns analytics buckets as well, but not for projects on older storage versions though. So this property check is alright as it's safe to presume that the project doesn't have analytics buckets with that storage version