### PR TITLE
fix(table editor): prevent unnecessary update requests

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -474,7 +474,7 @@ export const SidePanelEditor = ({
         toast.success(`Table ${table.name} is good to go!`, { id: toastId })
         onTableCreated(table)
       } else if (selectedTable) {
-        toastId = toast.loading(`Updating table: ${selectedTable?.name}...`)
+        toastId = toast.loading(`Updating table: ${selectedTable.name}...`)
 
         const { table, hasError } = await updateTable({
           projectRef: project?.ref!,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -724,7 +724,6 @@ export const updateTable = async ({
   const primaryKeyColumns = columns
     .filter((column) => column.isPrimaryKey)
     .map((column) => column.name)
-
   const existingPrimaryKeyColumns = table.primary_keys.map((pk: PostgresPrimaryKey) => pk.name)
   const isPrimaryKeyUpdated = !isEqual(primaryKeyColumns, existingPrimaryKeyColumns)
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -394,7 +394,7 @@ export const duplicateTable = async (
     connectionString,
     sql: [
       `CREATE TABLE "${sourceTableSchema}"."${duplicatedTableName}" (LIKE "${sourceTableSchema}"."${sourceTableName}" INCLUDING ALL);`,
-      payload.comment !== undefined
+      payload.comment != undefined
         ? `comment on table "${sourceTableSchema}"."${duplicatedTableName}" is '${payload.comment}';`
         : '',
     ].join('\n'),
@@ -737,15 +737,16 @@ export const updateTable = async ({
     }
   }
 
-  // Update the table
-  await updateTableMutation({
-    projectRef,
-    connectionString,
-    id: table.id,
-    name: table.name,
-    schema: table.schema,
-    payload,
-  })
+  if (Object.keys(payload).length > 0) {
+    await updateTableMutation({
+      projectRef,
+      connectionString,
+      id: table.id,
+      name: table.name,
+      schema: table.schema,
+      payload,
+    })
+  }
 
   // Track RLS enablement if it's being turned on
   if (payload.rls_enabled === true) {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
@@ -4,7 +4,7 @@ import type { ColumnField } from '../SidePanelEditor.types'
 export interface TableField {
   id: number
   name: string
-  comment?: string
+  comment?: string | null
   columns: ColumnField[]
   isRLSEnabled: boolean
   isRealtimeEnabled: boolean

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -10,8 +10,13 @@ import type { ColumnField } from '../SidePanelEditor.types'
 import { DEFAULT_COLUMNS } from './TableEditor.constants'
 import type { ImportContent, TableField } from './TableEditor.types'
 
-export const validateFields = (field: TableField) => {
-  const errors = {} as any
+type ValidateFieldsReturn = {
+  name?: string
+  columns?: string
+}
+
+export const validateFields = (field: TableField): ValidateFieldsReturn => {
+  const errors: ValidateFieldsReturn = {}
   if (field.name.length === 0) {
     errors['name'] = 'Please assign a name for your table'
   }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -44,7 +44,7 @@ export const generateTableFieldFromPostgresTable = (
   return {
     id: table.id,
     name: isDuplicating ? `${table.name}_duplicate` : table.name,
-    comment: isDuplicating ? `This is a duplicate of ${table.name}` : table?.comment ?? '',
+    comment: isDuplicating ? `This is a duplicate of ${table.name}` : table?.comment,
     columns: (table.columns ?? []).map((column) => {
       return generateColumnFieldFromPostgresColumn(column, table, foreignKeys)
     }),

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -1,7 +1,8 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
-import { PropsWithChildren, createContext, useContext, useRef } from 'react'
+import { PropsWithChildren, createContext, useContext } from 'react'
 import { proxy, useSnapshot } from 'valtio'
 
+import { useConstant } from 'common'
 import type { SupaRow } from 'components/grid/types'
 import { ForeignKey } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
 import type { EditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
@@ -210,7 +211,7 @@ export type TableEditorState = ReturnType<typeof createTableEditorState>
 export const TableEditorStateContext = createContext<TableEditorState>(createTableEditorState())
 
 export const TableEditorStateContextProvider = ({ children }: PropsWithChildren<{}>) => {
-  const state = useRef(createTableEditorState()).current
+  const state = useConstant(createTableEditorState)
 
   return (
     <TableEditorStateContext.Provider value={state}>{children}</TableEditorStateContext.Provider>

--- a/packages/pg-meta/src/pg-meta-tables.ts
+++ b/packages/pg-meta/src/pg-meta-tables.ts
@@ -144,9 +144,10 @@ type TableCreateParams = {
 
 function create({ name, schema = 'public', comment }: TableCreateParams): { sql: string } {
   const tableSql = `CREATE TABLE ${ident(schema)}.${ident(name)} ();`
-  const commentSql = comment
-    ? `COMMENT ON TABLE ${ident(schema)}.${ident(name)} IS ${literal(comment)};`
-    : ''
+  const commentSql =
+    comment != undefined
+      ? `COMMENT ON TABLE ${ident(schema)}.${ident(name)} IS ${literal(comment)};`
+      : ''
   const sql = `BEGIN; ${tableSql} ${commentSql} COMMIT;`
   return { sql }
 }
@@ -230,9 +231,11 @@ $$;
         .join(',')});`
     }
   }
-  const commentSql = !!comment
-    ? `COMMENT ON TABLE ${ident(old.schema)}.${ident(old.name)} IS ${literal(comment)};`
-    : ''
+  const commentSql =
+    comment == undefined
+      ? ''
+      : `COMMENT ON TABLE ${ident(old.schema)}.${ident(old.name)} IS ${literal(comment)};`
+
   // nameSql must be last, right below schemaSql
   const sql = `
 BEGIN;

--- a/packages/ui/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ui/src/components/SidePanel/SidePanel.tsx
@@ -72,7 +72,7 @@ const SidePanel = ({
           {cancelText}
         </Button>
       </div>
-      {onConfirm !== undefined && (
+      {!!onConfirm && (
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-block">
@@ -80,7 +80,7 @@ const SidePanel = ({
                 htmlType="submit"
                 disabled={disabled || loading}
                 loading={loading}
-                onClick={() => (onConfirm ? onConfirm() : null)}
+                onClick={onConfirm}
               >
                 {confirmText}
               </Button>


### PR DESCRIPTION
Continues on from https://github.com/supabase/supabase/pull/40160, reducing the number of unnecessary requests made when table changes are saved.

Currently, when you open the "Edit table" side panel, make _zero changes_, and click "Save", an unnecessary request runs to:
- Alter the table's comment to its existing comment
- Alter the table's schema to its existing schema
- Alter the table's RLS enable status to its existing RLS enable status

This PR changes the payload so we only alter what has actually changed. It also adds some refactoring to define clearer types and add type safety for the three possible kinds of table save actions (create new, duplicate, update existing).

After this, there are still a few unnecessary column update actions happening on array columns; those will be fixed in a final PR.

## Testing

- [ ] Creating a table works as before
- [ ] Duplicating a table works as before
- [ ] Updating a table with a real update works as before
- [ ] Updating a table with no actual changes does not send a `table-update` request

Towards FE-2066