### PR TITLE
Fix jsonb_set usage for claims and roles

### DIFF
--- a/apps/docs/content/guides/database/postgres/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/database/postgres/custom-claims-and-role-based-access-control-rbac.mdx
@@ -100,13 +100,13 @@ as $$
 
     if user_role is not null then
       -- Set the claim
-      claims := jsonb_set(claims, '{user_role}', to_jsonb(user_role));
+      claims := jsonb_set(claims, '{user_role}'::text[], to_jsonb(user_role));
     else
-      claims := jsonb_set(claims, '{user_role}', 'null');
+      claims := jsonb_set(claims, '{user_role}'::text[], 'null');
     end if;
 
     -- Update the 'claims' object in the original event
-    event := jsonb_set(event, '{claims}', claims);
+    event := jsonb_set(event, '{claims}'::text[], claims);
 
     -- Return the modified or original event
     return event;
@@ -134,7 +134,7 @@ revoke all
 create policy "Allow auth admin to read user roles" ON public.user_roles
 as permissive for select
 to supabase_auth_admin
-using (true)
+using (true);
 ```
 
 </TabPanel>


### PR DESCRIPTION
These calls need a explicit casting otherwise they cause errors when login. I also took the opportunity to add a missing semicolon in the same snippet.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?
Login fails with this response: 
{
  "code":"unexpected_failure",
  "message":"Error running hook URI: pg-functions://postgres/public/custom_access_token_hook"
}

The errors in the logs like this: 
ERROR: function json_set(jsonb, unknown, jsonb) does not exist (SQLSTATE 42883)

## What is the new behavior?
No errors from the hook. Login or not but not because of this.

## Additional context

The missing semicolon was mentioned in #39911 so its a good chance to fix that too. 
Everyday I found an instance where PL/pgSQL linter would reduce so much debugging, looking forward to its release.
