### PR TITLE
feat: add us-west-2 region for read replicas

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
@@ -33,6 +33,7 @@ export const AWS_REGIONS_COORDINATES: { [key: string]: [number, number] } = {
   NORTHEAST_ASIA_2: [126.98, 37.56],
   CENTRAL_CANADA: [-73.6, 45.5],
   WEST_US: [-121.96, 37.35],
+  WEST_US_2: [-122.67, 45.51],
   EAST_US: [-78.45, 38.13],
   WEST_EU: [-8, 53],
   WEST_EU_2: [-0.1, 51],

--- a/packages/shared-data/regions.ts
+++ b/packages/shared-data/regions.ts
@@ -7,6 +7,11 @@ export const AWS_REGIONS = {
     displayName: 'West US (North California)',
     location: [37.774929, -122.419418],
   },
+  WEST_US_2: {
+    code: 'us-west-2',
+    displayName: 'West US (Oregon)',
+    location: [45.51, -122.67],
+  },
   EAST_US: {
     code: 'us-east-1',
     displayName: 'East US (North Virginia)',


### PR DESCRIPTION
The region selector for creating a project is powered by the API, read replicas is still controlled by the frontend. This PR simply adds the us-west-2 region info.