### PR TITLE
fix(studio): local studio broken pages for platform hosted

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
@@ -22,9 +22,7 @@ export default function StudioCommandMenu() {
   useApiUrlCommand()
   useProjectLevelTableEditorCommands()
   useProjectSwitchCommand()
-
-  IS_PLATFORM && useConfigureOrganizationCommand()
-
+  useConfigureOrganizationCommand()
   useQueryTableCommands()
   useBranchCommands()
   useSnippetCommands()

--- a/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
@@ -22,7 +22,9 @@ export default function StudioCommandMenu() {
   useApiUrlCommand()
   useProjectLevelTableEditorCommands()
   useProjectSwitchCommand()
-  useConfigureOrganizationCommand()
+
+  IS_PLATFORM && useConfigureOrganizationCommand()
+
   useQueryTableCommands()
   useBranchCommands()
   useSnippetCommands()

--- a/apps/studio/components/interfaces/App/CommandMenu/OrgProjectSwitcher.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/OrgProjectSwitcher.tsx
@@ -79,7 +79,10 @@ export function useConfigureOrganizationCommand() {
         },
       ],
     },
-    { deps: [organizations], enabled: !!organizations && organizations.length > 0 }
+    {
+      deps: [organizations],
+      enabled: IS_PLATFORM && !!organizations && organizations.length > 0,
+    }
   )
 
   useRegisterCommands(
@@ -93,6 +96,6 @@ export function useConfigureOrganizationCommand() {
         icon: () => <Building />,
       },
     ],
-    { enabled: !!organizations && organizations.length > 0 }
+    { enabled: IS_PLATFORM && !!organizations && organizations.length > 0 }
   )
 }

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings-local-state.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings-local-state.tsx
@@ -1,0 +1,99 @@
+import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
+import Panel from 'components/ui/Panel'
+import { useAuthConfigQuery } from 'data/auth/auth-config-query'
+import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
+import { DOCS_URL, IS_LOCAL_CLI } from 'lib/constants'
+import { AlertCircle } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle, Input, InputNumber } from 'ui'
+
+const JWTSettingsLocalState = () => {
+  const { ref: projectRef } = useParams()
+
+  const { data: config, isError } = useProjectPostgrestConfigQuery({ projectRef })
+  const { data: authConfig } = useAuthConfigQuery({ projectRef })
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Managing JWT Keys {IS_LOCAL_CLI ? 'locally' : 'for self-hosted'}</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+          <div className="p-8">
+            <div className="flex items-center gap-2">
+              <h4 className="text-base text-foreground">Managing settings</h4>
+            </div>
+
+            <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+              <p className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+                Local JWT config can be loaded through{' '}
+                {IS_LOCAL_CLI ? (
+                  <span>
+                    <code>config.toml</code> file placed at <code>supabase/config.toml</code>, which
+                    is automatically loaded on <code>supabase start</code>
+                  </span>
+                ) : (
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/supabase/supabase/blob/master/docker/.env.example"
+                  >
+                    .env file
+                  </a>
+                )}
+              </p>
+            </div>
+
+            {IS_LOCAL_CLI ? (
+              <DocsButton
+                href={`${DOCS_URL}/guides/local-development/cli/config#auth.jwt_expiry`}
+              />
+            ) : (
+              <DocsButton href={`${DOCS_URL}/guides/self-hosting/docker#update-secrets`} />
+            )}
+          </div>
+        </CardContent>
+      </Card>
+      <Panel>
+        <Panel.Content className="space-y-6 border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+          {isError ? (
+            <div className="flex items-center justify-center py-8 space-x-2">
+              <AlertCircle size={16} strokeWidth={1.5} />
+              <p className="text-sm text-foreground-light">Failed to retrieve JWT settings</p>
+            </div>
+          ) : (
+            <>
+              <Input
+                label={'Legacy JWT secret'}
+                readOnly
+                copy
+                reveal
+                disabled
+                value={config?.jwt_secret || ''}
+                className="input-mono"
+                descriptionText="Used to sign and verify JWTs issued by Supabase Auth"
+                layout="horizontal"
+              />
+
+              <InputNumber
+                id="JWT_EXP"
+                name="JWT_EXP"
+                size="small"
+                label="Access token expiry time"
+                value={authConfig?.JWT_EXP ?? 3600}
+                descriptionText="How long access tokens are valid for before a refresh token has to be used. Recommendation: 3600 (1 hour)."
+                layout="horizontal"
+                actions={<span className="mr-3 text-foreground-lighter">seconds</span>}
+                disabled
+                readOnly
+              />
+            </>
+          )}
+        </Panel.Content>
+      </Panel>
+    </>
+  )
+}
+
+export default JWTSettingsLocalState

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfigLocalState.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfigLocalState.tsx
@@ -1,0 +1,142 @@
+import Link from 'next/link'
+
+import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
+import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
+import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
+import { useSchemasQuery } from 'data/database/schemas-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { DOCS_URL } from 'lib/constants'
+import { Badge, Button, Card, CardContent, CardHeader, Input_Shadcn_, Skeleton, cn } from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns'
+import { Admonition } from 'ui-patterns/admonition'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
+
+export const PostgrestConfigLocalState = () => {
+  const { ref: projectRef } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const {
+    data: config,
+    isError,
+    isLoading: isLoadingConfig,
+  } = useProjectPostgrestConfigQuery({ projectRef })
+  const { data: extensions } = useDatabaseExtensionsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+  const { data: allSchemas = [], isLoading: isLoadingSchemas } = useSchemasQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  const isLoading = isLoadingConfig || isLoadingSchemas
+
+  const isGraphqlExtensionEnabled =
+    (extensions ?? []).find((ext) => ext.name === 'pg_graphql')?.installed_version !== null
+
+  const dbSchema = config?.db_schema ? config?.db_schema.replace(/ /g, '').split(',') : []
+  const defaultValues = {
+    dbSchema,
+    maxRows: config?.max_rows,
+    dbExtraSearchPath: (config?.db_extra_search_path ?? '')
+      .split(',')
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0 && allSchemas.find((y) => y.name === x)),
+    dbPool: config?.db_pool,
+  }
+
+  return (
+    <Card id="postgrest-config">
+      <CardHeader className="flex-row items-center justify-between">
+        Data API
+        <div className="flex items-center gap-x-2">
+          <DocsButton href={`${DOCS_URL}/guides/database/connecting-to-postgres#data-apis`} />
+        </div>
+      </CardHeader>
+      <CardContent className={cn(!isLoading ? 'p-0' : '')}>
+        {isLoading ? (
+          <GenericSkeletonLoader />
+        ) : isError ? (
+          <Admonition type="destructive" title="Failed to retrieve API settings" />
+        ) : (
+          <>
+            <FormLayout
+              label="Exposed schemas"
+              description="The schemas to expose in your API. Tables, views and stored procedures in
+                          these schemas will get API endpoints."
+              layout="horizontal"
+              className="px-8 py-8"
+            >
+              {isLoadingSchemas ? (
+                <div className="col-span-12 flex flex-col gap-2 lg:col-span-7">
+                  <Skeleton className="w-full h-[38px]" />
+                </div>
+              ) : (
+                <div
+                  className={cn(
+                    'flex w-full min-w-[200px] min-h-[40px] items-center justify-between rounded-md border',
+                    'border-alternative bg-foreground/[.026] px-3 py-2 text-sm'
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'flex gap-1 -ml-1 overflow-hidden flex-1',
+                      'flex-wrap',
+                      'overflow-x-auto scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg'
+                    )}
+                  >
+                    {defaultValues.dbSchema.map((value) => (
+                      <Badge key={value} className="rounded shrink-0 px-1.5">
+                        {value}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {!defaultValues.dbSchema.includes('public') && defaultValues.dbSchema.length > 0 && (
+                <Admonition
+                  type="default"
+                  title="The public schema for this project is not exposed"
+                  className="mt-2"
+                  description={
+                    <>
+                      <p className="prose text-sm">
+                        You will not be able to query tables and views in the{' '}
+                        <code className="text-xs">public</code> schema via supabase-js or HTTP
+                        clients.
+                      </p>
+                      {isGraphqlExtensionEnabled && (
+                        <>
+                          <p className="prose text-sm mt-2">
+                            Tables in the <code className="text-xs">public</code> schema are still
+                            exposed over our GraphQL endpoints.
+                          </p>
+                          <Button asChild type="default" className="mt-2">
+                            <Link href={`/project/${projectRef}/database/extensions`}>
+                              Disable the pg_graphql extension
+                            </Link>
+                          </Button>
+                        </>
+                      )}
+                    </>
+                  }
+                />
+              )}
+            </FormLayout>
+
+            <FormLayout
+              className="w-full px-8 py-8"
+              layout="horizontal"
+              label="Max rows"
+              description="The maximum number of rows returned from a view, table, or stored procedure. Limits payload size for accidental or malicious requests."
+            >
+              <Input_Shadcn_ readOnly className="font-mono" value={defaultValues.maxRows} />
+            </FormLayout>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/API/ServiceListLocalState.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ServiceListLocalState.tsx
@@ -1,0 +1,109 @@
+import { AlertCircle } from 'lucide-react'
+
+import { useParams } from 'common'
+import { ScaffoldSection } from 'components/layouts/Scaffold'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { IS_SELF_HOST, PROJECT_STATUS } from 'lib/constants'
+import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
+import { Alert_Shadcn_, AlertTitle_Shadcn_, Card, CardContent, CardHeader, CardTitle } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
+import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
+import { PostgrestConfigLocalState } from './PostgrestConfigLocalState'
+import { DocsButton } from 'components/ui/DocsButton'
+
+export const ServiceListLocalState = () => {
+  const { data: project, isLoading } = useSelectedProjectQuery()
+  const { ref: projectRef } = useParams()
+  const state = useDatabaseSelectorStateSnapshot()
+  const {
+    data: databases,
+    isError,
+    isLoading: isLoadingDatabases,
+  } = useReadReplicasQuery({ projectRef })
+
+  // Get the API service
+  const selectedDatabase = databases?.find((db) => db.identifier === state.selectedDatabaseId)
+
+  const endpoint = selectedDatabase?.restUrl
+
+  return (
+    <ScaffoldSection isFullWidth id="api-settings" className="gap-6">
+      {!isLoading && project?.status !== PROJECT_STATUS.ACTIVE_HEALTHY ? (
+        <Alert_Shadcn_ variant="destructive">
+          <AlertCircle size={16} />
+          <AlertTitle_Shadcn_>
+            API settings are unavailable as the project is not active
+          </AlertTitle_Shadcn_>
+        </Alert_Shadcn_>
+      ) : (
+        <>
+          {IS_SELF_HOST && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Managing API settings for self-hosted</CardTitle>
+              </CardHeader>
+              <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+                <div className="p-8">
+                  <div className="flex items-center gap-2">
+                    <h4 className="text-base text-foreground">Managing settings</h4>
+                  </div>
+
+                  <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+                    <p className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+                      <span>API config can be loaded through </span>
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://github.com/supabase/supabase/blob/master/docker/.env.example"
+                      >
+                        .env file
+                      </a>
+
+                      <span>
+                        and added inside the <code>rest</code> service in{' '}
+                        <code>docker-compose.yml</code>
+                      </span>
+                    </p>
+                  </div>
+
+                  <DocsButton href="https://postgrest.org/en/stable/references/configuration.html" />
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              Project URL
+            </CardHeader>
+            <CardContent>
+              {isLoading || isLoadingDatabases ? (
+                <div className="space-y-2">
+                  <ShimmeringLoader className="py-3.5" />
+                  <ShimmeringLoader className="py-3.5 w-3/4" delayIndex={1} />
+                </div>
+              ) : isError ? (
+                <Alert_Shadcn_ variant="destructive">
+                  <AlertCircle size={16} />
+                  <AlertTitle_Shadcn_>Failed to retrieve project URL</AlertTitle_Shadcn_>
+                </Alert_Shadcn_>
+              ) : (
+                <FormLayout
+                  layout="horizontal"
+                  label={'URL'}
+                  description={'RESTful endpoint for querying and managing your database'}
+                >
+                  <Input copy readOnly className="font-mono" value={endpoint} />
+                </FormLayout>
+              )}
+            </CardContent>
+          </Card>
+
+          <PostgrestConfigLocalState />
+        </>
+      )}
+    </ScaffoldSection>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Database/SettingsDatabase.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SettingsDatabase.tsx
@@ -1,0 +1,45 @@
+import { DiskManagementPanelForm } from 'components/interfaces/DiskManagement/DiskManagementPanelForm'
+import { ConnectionPooling } from 'components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling'
+import { DatabaseReadOnlyAlert } from 'components/interfaces/Settings/Database/DatabaseReadOnlyAlert'
+import { PoolingModesModal } from 'components/interfaces/Settings/Database/PoolingModesModal'
+import { NetworkRestrictions } from 'components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions'
+import BannedIPs from 'components/interfaces/Settings/Database/BannedIPs'
+import ResetDbPassword from 'components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword'
+import DiskSizeConfiguration from 'components/interfaces/Settings/Database/DiskSizeConfiguration'
+import SSLConfiguration from 'components/interfaces/Settings/Database/SSLConfiguration'
+
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { useIsAwsCloudProvider, useIsAwsK8sCloudProvider } from 'hooks/misc/useSelectedProject'
+
+export function SettingsDatabase() {
+  const isAws = useIsAwsCloudProvider()
+  const isAwsK8s = useIsAwsK8sCloudProvider()
+
+  const showNewDiskManagementUI = isAws || isAwsK8s
+
+  const { databaseNetworkRestrictions } = useIsFeatureEnabled(['database:network_restrictions'])
+
+  return (
+    <>
+      <div className="space-y-10">
+        <div className="flex flex-col gap-y-10">
+          <DatabaseReadOnlyAlert />
+          <ResetDbPassword />
+          <ConnectionPooling />
+        </div>
+
+        <SSLConfiguration />
+        {showNewDiskManagementUI ? (
+          // This form is hidden if Disk and Compute form is enabled, new form is on ./settings/compute-and-disk
+          <DiskManagementPanelForm />
+        ) : (
+          <DiskSizeConfiguration />
+        )}
+        {databaseNetworkRestrictions && <NetworkRestrictions />}
+        <BannedIPs />
+      </div>
+
+      <PoolingModesModal />
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Database/SettingsDatabaseEmptyStateLocal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SettingsDatabaseEmptyStateLocal.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardHeader, CardTitle } from 'ui'
+import { DOCS_URL } from 'lib/constants'
+import { DocsButton } from 'components/ui/DocsButton'
+
+export function SettingsDatabaseEmptyStateLocal() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Managing database settings locally</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+        <div className="p-8">
+          <div className="flex items-center gap-2">
+            <h4 className="text-base text-foreground">Managing settings</h4>
+          </div>
+          <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+            <p>Local database config can be loaded in either of the following two ways</p>
+            <ul className="list-disc pl-6">
+              <li className="prose [&>code]:text-xs text-sm max-w-full">
+                Through <code>config.toml</code> file placed at <code>supabase/config.toml</code>,
+                which is automatically loaded on <code>supabase start</code>
+              </li>
+              <li className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+                <span>Through</span>
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://github.com/supabase/supabase/blob/master/docker/.env.example"
+                >
+                  .env file
+                </a>
+                <span>option when self-hosting</span>
+              </li>
+            </ul>
+          </div>
+
+          <DocsButton href={`${DOCS_URL}/guides/local-development/cli/config#database-config`} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/studio/components/interfaces/Settings/Database/SettingsDatabaseEmptyStateLocal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SettingsDatabaseEmptyStateLocal.tsx
@@ -1,27 +1,30 @@
 import { Card, CardContent, CardHeader, CardTitle } from 'ui'
-import { DOCS_URL } from 'lib/constants'
+import { DOCS_URL, IS_LOCAL_CLI } from 'lib/constants'
 import { DocsButton } from 'components/ui/DocsButton'
 
 export function SettingsDatabaseEmptyStateLocal() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Managing database settings locally</CardTitle>
+        <CardTitle>
+          Managing database settings {IS_LOCAL_CLI ? 'locally' : 'for self-hosted'}
+        </CardTitle>
       </CardHeader>
       <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
         <div className="p-8">
           <div className="flex items-center gap-2">
             <h4 className="text-base text-foreground">Managing settings</h4>
           </div>
+
           <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
-            <p>Local database config can be loaded in either of the following two ways</p>
-            <ul className="list-disc pl-6">
-              <li className="prose [&>code]:text-xs text-sm max-w-full">
-                Through <code>config.toml</code> file placed at <code>supabase/config.toml</code>,
-                which is automatically loaded on <code>supabase start</code>
-              </li>
-              <li className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
-                <span>Through</span>
+            <p className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+              Local database config can be loaded through{' '}
+              {IS_LOCAL_CLI ? (
+                <span>
+                  <code>config.toml</code> file placed at <code>supabase/config.toml</code>, which
+                  is automatically loaded on <code>supabase start</code>
+                </span>
+              ) : (
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
@@ -29,12 +32,15 @@ export function SettingsDatabaseEmptyStateLocal() {
                 >
                   .env file
                 </a>
-                <span>option when self-hosting</span>
-              </li>
-            </ul>
+              )}
+            </p>
           </div>
 
-          <DocsButton href={`${DOCS_URL}/guides/local-development/cli/config#database-config`} />
+          {IS_LOCAL_CLI ? (
+            <DocsButton href={`${DOCS_URL}/guides/local-development/cli/config#database-config`} />
+          ) : (
+            <DocsButton href={`${DOCS_URL}/guides/self-hosting`} />
+          )}
         </div>
       </CardContent>
     </Card>

--- a/apps/studio/components/interfaces/Settings/General/GeneralEmptyLocalState.tsx
+++ b/apps/studio/components/interfaces/Settings/General/GeneralEmptyLocalState.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent, CardHeader, CardTitle } from 'ui'
+import { DOCS_URL, IS_LOCAL_CLI } from 'lib/constants'
+import { DocsButton } from 'components/ui/DocsButton'
+
+export function GeneralEmptyStateLocal() {
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            Managing project settings {IS_LOCAL_CLI ? 'locally' : 'for self-hosted'}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+          <div className="p-8">
+            <div className="flex items-center gap-2">
+              <h4 className="text-base text-foreground">Managing settings</h4>
+            </div>
+
+            <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+              <p className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+                Local project config can be loaded through{' '}
+                {IS_LOCAL_CLI ? (
+                  <span>
+                    <code>config.toml</code> file placed at <code>supabase/config.toml</code>, which
+                    is automatically loaded on <code>supabase start</code>
+                  </span>
+                ) : (
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/supabase/supabase/blob/master/docker/.env.example"
+                  >
+                    .env file
+                  </a>
+                )}
+              </p>
+            </div>
+
+            {IS_LOCAL_CLI ? (
+              <DocsButton href={`${DOCS_URL}/guides/local-development/cli/config#general-config`} />
+            ) : (
+              <DocsButton href={`${DOCS_URL}/guides/self-hosting`} />
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+          <div className="p-8">
+            <div className="flex items-center gap-2">
+              <h4 className="text-base text-foreground">Managing project execution</h4>
+            </div>
+
+            <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+              <p className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+                Local project can be restarted/stopped through{' '}
+                {IS_LOCAL_CLI ? (
+                  <span>
+                    <code>supabase</code> cli
+                  </span>
+                ) : (
+                  <span>Docker</span>
+                )}
+              </p>
+            </div>
+
+            {IS_LOCAL_CLI ? (
+              <DocsButton href={`${DOCS_URL}/guides/local-development/cli/config#general-config`} />
+            ) : (
+              <DocsButton href={`${DOCS_URL}/guides/self-hosting/docker#restarting-all-services`} />
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/studio/components/layouts/APIKeys/APIKeysLayout.tsx
+++ b/apps/studio/components/layouts/APIKeys/APIKeysLayout.tsx
@@ -2,7 +2,7 @@ import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer } from 'components/layouts/Scaffold'
 import { PropsWithChildren } from 'react'
 
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 
 const ApiKeysLayout = ({ children }: PropsWithChildren) => {
   const { ref: projectRef } = useParams()
@@ -13,11 +13,15 @@ const ApiKeysLayout = ({ children }: PropsWithChildren) => {
       href: `/project/${projectRef}/settings/api-keys`,
       id: 'legacy-keys',
     },
-    {
-      label: 'API Keys',
-      href: `/project/${projectRef}/settings/api-keys/new`,
-      id: 'new-keys',
-    },
+    ...(IS_PLATFORM
+      ? [
+          {
+            label: 'API Keys',
+            href: `/project/${projectRef}/settings/api-keys/new`,
+            id: 'new-keys',
+          },
+        ]
+      : []),
   ]
 
   return (

--- a/apps/studio/components/layouts/APIKeys/APIKeysLayout.tsx
+++ b/apps/studio/components/layouts/APIKeys/APIKeysLayout.tsx
@@ -8,13 +8,13 @@ const ApiKeysLayout = ({ children }: PropsWithChildren) => {
   const { ref: projectRef } = useParams()
 
   const navigationItems = [
-    {
-      label: 'Legacy API Keys',
-      href: `/project/${projectRef}/settings/api-keys`,
-      id: 'legacy-keys',
-    },
     ...(IS_PLATFORM
       ? [
+          {
+            label: 'Legacy API Keys',
+            href: `/project/${projectRef}/settings/api-keys`,
+            id: 'legacy-keys',
+          },
           {
             label: 'API Keys',
             href: `/project/${projectRef}/settings/api-keys/new`,

--- a/apps/studio/components/layouts/AuthLayout/Auth.Commands.tsx
+++ b/apps/studio/components/layouts/AuthLayout/Auth.Commands.tsx
@@ -1,6 +1,6 @@
 import { Lock } from 'lucide-react'
 
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { COMMAND_MENU_SECTIONS } from 'components/interfaces/App/CommandMenu/CommandMenu.utils'
 import { orderCommandSectionsByPriority } from 'components/interfaces/App/CommandMenu/ordering'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
@@ -67,7 +67,32 @@ export function useAuthGotoCommands(options?: CommandOptions) {
         route: `/project/${ref}/auth/policies`,
         defaultHidden: true,
       },
-      ...(authenticationSignInProviders
+      ...(IS_PLATFORM
+        ? ([
+            {
+              id: 'nav-auth-sessions',
+              name: 'Sessions',
+              value: 'Auth: Sessions (User Sessions)',
+              route: `/project/${ref}/auth/sessions`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-auth-url-configuration',
+              name: 'URL Configuration',
+              value: 'Auth: URL Configuration (Site URL, Redirect URLs)',
+              route: `/project/${ref}/auth/url-configuration`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-auth-auth-hooks',
+              name: 'Auth Hooks',
+              value: 'Auth: Auth Hooks',
+              route: `/project/${ref}/auth/hooks`,
+              defaultHidden: true,
+            },
+          ] as IRouteCommand[])
+        : []),
+      ...(IS_PLATFORM && authenticationSignInProviders
         ? [
             {
               id: 'nav-auth-providers',
@@ -78,7 +103,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      ...(authenticationThirdPartyAuth
+      ...(IS_PLATFORM && authenticationThirdPartyAuth
         ? [
             {
               id: 'nav-auth-providers',
@@ -89,14 +114,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      {
-        id: 'nav-auth-sessions',
-        name: 'Sessions',
-        value: 'Auth: Sessions (User Sessions)',
-        route: `/project/${ref}/auth/sessions`,
-        defaultHidden: true,
-      },
-      ...(authenticationRateLimits
+      ...(IS_PLATFORM && authenticationRateLimits
         ? [
             {
               id: 'nav-auth-rate-limits',
@@ -107,7 +125,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      ...(authenticationEmails
+      ...(IS_PLATFORM && authenticationEmails
         ? [
             {
               id: 'nav-auth-templates',
@@ -118,7 +136,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      ...(authenticationMultiFactor
+      ...(IS_PLATFORM && authenticationMultiFactor
         ? [
             {
               id: 'nav-auth-mfa',
@@ -129,14 +147,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      {
-        id: 'nav-auth-url-configuration',
-        name: 'URL Configuration',
-        value: 'Auth: URL Configuration (Site URL, Redirect URLs)',
-        route: `/project/${ref}/auth/url-configuration`,
-        defaultHidden: true,
-      },
-      ...(authenticationAttackProtection
+      ...(IS_PLATFORM && authenticationAttackProtection
         ? [
             {
               id: 'nav-auth-attack-protection',
@@ -147,14 +158,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      {
-        id: 'nav-auth-auth-hooks',
-        name: 'Auth Hooks',
-        value: 'Auth: Auth Hooks',
-        route: `/project/${ref}/auth/hooks`,
-        defaultHidden: true,
-      },
-      ...(authenticationAdvanced
+      ...(IS_PLATFORM && authenticationAdvanced
         ? [
             {
               id: 'nav-auth-advanced-settings',

--- a/apps/studio/components/layouts/JWTKeys/JWTKeysLayout.tsx
+++ b/apps/studio/components/layouts/JWTKeys/JWTKeysLayout.tsx
@@ -2,29 +2,31 @@ import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer } from 'components/layouts/Scaffold'
 import { PropsWithChildren } from 'react'
 
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 
 const JWTKeysLayout = ({ children }: PropsWithChildren) => {
   const { ref: projectRef } = useParams()
   const { projectSettingsLegacyJwtKeys } = useIsFeatureEnabled(['project_settings:legacy_jwt_keys'])
 
-  const navigationItems = [
-    ...(projectSettingsLegacyJwtKeys
-      ? [
-          {
-            label: 'Legacy JWT Secret',
-            href: `/project/${projectRef}/settings/jwt`,
-            id: 'legacy-jwt-keys',
-          },
-        ]
-      : []),
-    {
-      label: 'JWT Signing Keys',
-      href: `/project/${projectRef}/settings/jwt/signing-keys`,
-      id: 'signing-keys',
-    },
-  ]
+  const navigationItems = IS_PLATFORM
+    ? [
+        ...(projectSettingsLegacyJwtKeys
+          ? [
+              {
+                label: 'Legacy JWT Secret',
+                href: `/project/${projectRef}/settings/jwt`,
+                id: 'legacy-jwt-keys',
+              },
+            ]
+          : []),
+        {
+          label: 'JWT Signing Keys',
+          href: `/project/${projectRef}/settings/jwt/signing-keys`,
+          id: 'signing-keys',
+        },
+      ]
+    : []
 
   return (
     <PageLayout

--- a/apps/studio/components/layouts/ProjectSettingsLayout/ProjectSettings.Commands.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/ProjectSettings.Commands.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'common'
+import { IS_PLATFORM } from 'lib/constants'
 import { COMMAND_MENU_SECTIONS } from 'components/interfaces/App/CommandMenu/CommandMenu.utils'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { CommandOptions } from 'ui-patterns/CommandMenu'
@@ -20,38 +21,102 @@ export function useProjectSettingsGotoCommands(options?: CommandOptions) {
     COMMAND_MENU_SECTIONS.NAVIGATE,
     [
       {
-        id: 'nav-project-settings-general',
-        name: 'General Settings',
-        route: `/project/${ref}/settings/general`,
-        defaultHidden: true,
-      },
-      {
         id: 'nav-project-settings-database',
         name: 'Database Settings',
         route: `/project/${ref}/database/settings`,
         defaultHidden: true,
       },
-      {
-        id: 'nav-project-settings-auth',
-        name: 'Auth Settings',
-        route: authenticationSignInProviders
-          ? `/project/${ref}/auth/providers`
-          : `/project/${ref}/auth/policies`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-api',
-        name: 'API Settings',
-        route: `/project/${ref}/settings/api`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-storage',
-        name: 'Storage Settings',
-        route: `/project/${ref}/storage/settings`,
-        defaultHidden: true,
-      },
-      ...(projectSettingsCustomDomains
+      ...(IS_PLATFORM
+        ? ([
+            {
+              id: 'nav-project-settings-general',
+              name: 'General Settings',
+              route: `/project/${ref}/settings/general`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-auth',
+              name: 'Auth Settings',
+              route: authenticationSignInProviders
+                ? `/project/${ref}/auth/providers`
+                : `/project/${ref}/auth/policies`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-api',
+              name: 'API Settings',
+              route: `/project/${ref}/settings/api`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-storage',
+              name: 'Storage Settings',
+              route: `/project/${ref}/storage/settings`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-restart-project',
+              name: 'Restart project',
+              route: `/project/${ref}/settings/general#restart-project`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-pause-project',
+              name: 'Pause project',
+              route: `/project/${ref}/settings/general#pause-project`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-transfer-project',
+              name: 'Transfer project',
+              route: `/project/${ref}/settings/general#transfer-project`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-delete-project',
+              name: 'Delete project',
+              route: `/project/${ref}/settings/general#delete-project`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-database-password',
+              name: 'Database password',
+              route: `/project/${ref}/settings/general#database-password`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-connection-string',
+              name: 'Connection string',
+              route: `/project/${ref}/settings/general#connection-string`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-connection-pooling',
+              name: 'Connection pooling',
+              route: `/project/${ref}/settings/general#connection-pooling`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-ssl-configuration',
+              name: 'SSL configuration',
+              route: `/project/${ref}/settings/general#ssl-configuration`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-network-restrictions',
+              name: 'Network restrictions',
+              route: `/project/${ref}/database/settings#network-restrictions`,
+              defaultHidden: true,
+            },
+            {
+              id: 'nav-project-settings-banned-ips',
+              name: 'Banned IPs',
+              route: `/project/${ref}/database/settings#banned-ips`,
+              defaultHidden: true,
+            },
+          ] as IRouteCommand[])
+        : []),
+      ...(IS_PLATFORM && projectSettingsCustomDomains
         ? [
             {
               id: 'nav-project-settings-custom-domains',
@@ -61,66 +126,6 @@ export function useProjectSettingsGotoCommands(options?: CommandOptions) {
             } as IRouteCommand,
           ]
         : []),
-      {
-        id: 'nav-project-settings-restart-project',
-        name: 'Restart project',
-        route: `/project/${ref}/settings/general#restart-project`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-pause-project',
-        name: 'Pause project',
-        route: `/project/${ref}/settings/general#pause-project`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-transfer-project',
-        name: 'Transfer project',
-        route: `/project/${ref}/settings/general#transfer-project`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-delete-project',
-        name: 'Delete project',
-        route: `/project/${ref}/settings/general#delete-project`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-database-password',
-        name: 'Database password',
-        route: `/project/${ref}/settings/general#database-password`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-connection-string',
-        name: 'Connection string',
-        route: `/project/${ref}/settings/general#connection-string`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-connection-pooling',
-        name: 'Connection pooling',
-        route: `/project/${ref}/settings/general#connection-pooling`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-ssl-configuration',
-        name: 'SSL configuration',
-        route: `/project/${ref}/settings/general#ssl-configuration`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-network-restrictions',
-        name: 'Network restrictions',
-        route: `/project/${ref}/database/settings#network-restrictions`,
-        defaultHidden: true,
-      },
-      {
-        id: 'nav-project-settings-banned-ips',
-        name: 'Banned IPs',
-        route: `/project/${ref}/database/settings#banned-ips`,
-        defaultHidden: true,
-      },
       ...(projectSettingsLogDrains
         ? [
             {

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -26,6 +26,12 @@ export const generateSettingsMenu = (
         title: 'Project Settings',
         items: [
           {
+            name: 'General',
+            key: 'general',
+            url: `/project/${ref}/settings/general`,
+            items: [],
+          },
+          {
             name: `Log Drains`,
             key: `log-drains`,
             url: `/project/${ref}/settings/log-drains`,

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -44,6 +44,12 @@ export const generateSettingsMenu = (
             items: [],
           },
           {
+            name: 'JWT Keys',
+            key: 'jwt',
+            url: `/project/${ref}/settings/jwt`,
+            items: [],
+          },
+          {
             name: `Log Drains`,
             key: `log-drains`,
             url: `/project/${ref}/settings/log-drains`,

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -32,6 +32,12 @@ export const generateSettingsMenu = (
             items: [],
           },
           {
+            name: 'Data API',
+            key: 'api',
+            url: `/project/${ref}/settings/api`,
+            items: [],
+          },
+          {
             name: `Log Drains`,
             key: `log-drains`,
             url: `/project/${ref}/settings/log-drains`,
@@ -73,14 +79,12 @@ export const generateSettingsMenu = (
           url: isProjectBuilding ? buildingUrl : `/project/${ref}/settings/infrastructure`,
           items: [],
         },
-
         {
           name: 'Integrations',
           key: 'integrations',
           url: `/project/${ref}/settings/integrations`,
           items: [],
         },
-
         {
           name: 'Data API',
           key: 'api',

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -38,6 +38,12 @@ export const generateSettingsMenu = (
             items: [],
           },
           {
+            name: 'API Keys',
+            key: 'api-keys',
+            url: `/project/${ref}/settings/api-keys`,
+            items: [],
+          },
+          {
             name: `Log Drains`,
             key: `log-drains`,
             url: `/project/${ref}/settings/log-drains`,

--- a/apps/studio/components/layouts/ReportsLayout/Reports.Commands.tsx
+++ b/apps/studio/components/layouts/ReportsLayout/Reports.Commands.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { useParams } from 'common'
+import { IS_PLATFORM } from 'lib/constants'
 import { COMMAND_MENU_SECTIONS } from 'components/interfaces/App/CommandMenu/CommandMenu.utils'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { CommandOptions, ICommand } from 'ui-patterns/CommandMenu'
@@ -67,6 +68,7 @@ export function useReportsGotoCommands(options?: CommandOptions) {
       ...options,
       orderSection: orderNavigateSection,
       deps: [ref, orderNavigateSection, ...(options?.deps ?? [])],
+      enabled: IS_PLATFORM,
     }
   )
 
@@ -87,6 +89,7 @@ export function useReportsGotoCommands(options?: CommandOptions) {
       orderCommands: orderQueryPerformanceCommand ?? options?.orderCommands,
       orderSection: orderNavigateSection,
       deps: [ref, orderQueryPerformanceCommand, orderNavigateSection, ...(options?.deps ?? [])],
+      enabled: IS_PLATFORM,
     }
   )
 }

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettingsLocalState.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettingsLocalState.tsx
@@ -3,7 +3,10 @@ import { useParams } from 'common'
 import Panel from 'components/ui/Panel'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
-import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
+import { useAPIKeysQuery } from 'data/api-keys/api-keys-query'
+import { DOCS_URL, IS_SELF_HOST } from 'lib/constants'
+import { DocsButton } from '../DocsButton'
+import { Card, CardContent, CardHeader, CardTitle } from 'ui'
 
 export const DisplayApiSettingsLocalState = ({
   showTitle = true,
@@ -19,103 +22,134 @@ export const DisplayApiSettingsLocalState = ({
   const isApiKeysEmpty = apiKeys === undefined || apiKeys.length === 0
 
   return (
-    <Panel
-      noMargin
-      title={
-        showTitle && (
-          <div className="space-y-3">
-            <h5 className="text-base">Project API Keys</h5>
-            <p className="text-sm text-foreground-light">
-              Your API is secured behind an API gateway which requires an API Key for every request.
-              <br />
-              You can use the keys below in the Supabase client libraries.
-              <br />
-            </p>
+    <div className="flex flex-col gap-6">
+      {IS_SELF_HOST && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Managing API Keys for self-hosted</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
+            <div className="p-8">
+              <div className="flex items-center gap-2">
+                <h4 className="text-base text-foreground">Managing API Keys</h4>
+              </div>
+
+              <div className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
+                <p className="prose [&>code]:text-xs space-x-1 text-sm max-w-full">
+                  Local API Keys can be loaded through{' '}
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/supabase/supabase/blob/master/docker/.env.example"
+                  >
+                    .env file
+                  </a>
+                </p>
+              </div>
+              <DocsButton href={`${DOCS_URL}/guides/self-hosting/docker#update-api-keys`} />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+      <Panel
+        noMargin
+        title={
+          showTitle && (
+            <div className="space-y-3">
+              <h5 className="text-base">Project API Keys</h5>
+              <p className="text-sm text-foreground-light">
+                Your API is secured behind an API gateway which requires an API Key for every
+                request.
+                <br />
+                You can use the keys below in the Supabase client libraries.
+                <br />
+              </p>
+            </div>
+          )
+        }
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8 space-x-2">
+            <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
+            <p className="text-sm text-foreground-light">Retrieving API keys</p>
           </div>
-        )
-      }
-    >
-      {isLoading ? (
-        <div className="flex items-center justify-center py-8 space-x-2">
-          <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
-          <p className="text-sm text-foreground-light">Retrieving API keys</p>
-        </div>
-      ) : isError ? (
-        <div className="flex items-center justify-center py-8 space-x-2">
-          <AlertCircle size={16} strokeWidth={1.5} />
-          <p className="text-sm text-foreground-light">Failed to retrieve API keys</p>
-        </div>
-      ) : isApiKeysEmpty ? (
-        <div className="flex items-center justify-center py-8 space-x-2">
-          <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
-          <p className="text-sm text-foreground-light">Retrieving API keys</p>
-        </div>
-      ) : (
-        apiKeys.map((x, i: number) => (
-          <Panel.Content
-            key={x.api_key}
-            className={
-              i >= 1 &&
-              'border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark'
-            }
-          >
-            <FormLayout
-              layout="horizontal"
-              label={
-                <>
-                  {x.name?.split(',').map((x, i: number) => (
-                    <code key={`${x}${i}`} className="text-xs text-code">
-                      {x}
-                    </code>
-                  ))}
-                  {x.name === 'service_role' && (
-                    <>
-                      <code className="text-xs text-code !bg-destructive !text-white !border-destructive">
-                        secret
-                      </code>
-                    </>
-                  )}
-                  {x.name === 'anon' && <code className="text-xs text-code">public</code>}
-                </>
-              }
-              description={
-                x.name === 'service_role' ? (
-                  <>
-                    This key has the ability to bypass Row Level Security. Never share it publicly.
-                    If leaked, generate a new JWT secret immediately.{' '}
-                  </>
-                ) : (
-                  <>
-                    This key is safe to use in a browser if you have enabled Row Level Security for
-                    your tables and configured policies.{' '}
-                  </>
-                )
+        ) : isError ? (
+          <div className="flex items-center justify-center py-8 space-x-2">
+            <AlertCircle size={16} strokeWidth={1.5} />
+            <p className="text-sm text-foreground-light">Failed to retrieve API keys</p>
+          </div>
+        ) : isApiKeysEmpty ? (
+          <div className="flex items-center justify-center py-8 space-x-2">
+            <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
+            <p className="text-sm text-foreground-light">Retrieving API keys</p>
+          </div>
+        ) : (
+          apiKeys.map((x, i: number) => (
+            <Panel.Content
+              key={x.api_key}
+              className={
+                i >= 1 &&
+                'border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark'
               }
             >
-              <Input
-                readOnly
-                className="font-mono"
-                copy
-                reveal={x.name !== 'anon'}
-                value={x?.api_key}
-                onChange={() => {}}
-              />
-            </FormLayout>
-          </Panel.Content>
-        ))
-      )}
-      {showNotice ? (
-        <Panel.Notice
-          className="border-t"
-          title="API keys have moved"
-          badgeLabel="Changelog"
-          description={`
+              <FormLayout
+                layout="horizontal"
+                label={
+                  <>
+                    {x.name?.split(',').map((x, i: number) => (
+                      <code key={`${x}${i}`} className="text-xs text-code">
+                        {x}
+                      </code>
+                    ))}
+                    {x.name === 'service_role' && (
+                      <>
+                        <code className="text-xs text-code !bg-destructive !text-white !border-destructive">
+                          secret
+                        </code>
+                      </>
+                    )}
+                    {x.name === 'anon' && <code className="text-xs text-code">public</code>}
+                  </>
+                }
+                description={
+                  x.name === 'service_role' ? (
+                    <>
+                      This key has the ability to bypass Row Level Security. Never share it
+                      publicly. If leaked, generate a new JWT secret immediately.{' '}
+                    </>
+                  ) : (
+                    <>
+                      This key is safe to use in a browser if you have enabled Row Level Security
+                      for your tables and configured policies.{' '}
+                    </>
+                  )
+                }
+              >
+                <Input
+                  readOnly
+                  className="font-mono"
+                  copy
+                  reveal={x.name !== 'anon'}
+                  value={x?.api_key}
+                  onChange={() => {}}
+                />
+              </FormLayout>
+            </Panel.Content>
+          ))
+        )}
+        {showNotice ? (
+          <Panel.Notice
+            className="border-t"
+            title="API keys have moved"
+            badgeLabel="Changelog"
+            description={`
   \`anon\` and \`service_role\` API keys can now be replaced with \`publishable\` and \`secret\` API keys.
   `}
-          href="https://github.com/orgs/supabase/discussions/29260"
-          buttonText="Read the announcement"
-        />
-      ) : null}
-    </Panel>
+            href="https://github.com/orgs/supabase/discussions/29260"
+            buttonText="Read the announcement"
+          />
+        ) : null}
+      </Panel>
+    </div>
   )
 }

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettingsLocalState.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettingsLocalState.tsx
@@ -1,0 +1,121 @@
+import { AlertCircle, Loader2 } from 'lucide-react'
+import { useParams } from 'common'
+import Panel from 'components/ui/Panel'
+import { Input } from 'ui-patterns/DataInputs/Input'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
+import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
+
+export const DisplayApiSettingsLocalState = ({
+  showTitle = true,
+  showNotice = true,
+}: {
+  showTitle?: boolean
+  showNotice?: boolean
+}) => {
+  const { ref: projectRef } = useParams()
+
+  const { data: apiKeys, isLoading, isError } = useAPIKeysQuery({ projectRef })
+  // api keys should not be empty. However it can be populated with a delay on project creation
+  const isApiKeysEmpty = apiKeys === undefined || apiKeys.length === 0
+
+  return (
+    <Panel
+      noMargin
+      title={
+        showTitle && (
+          <div className="space-y-3">
+            <h5 className="text-base">Project API Keys</h5>
+            <p className="text-sm text-foreground-light">
+              Your API is secured behind an API gateway which requires an API Key for every request.
+              <br />
+              You can use the keys below in the Supabase client libraries.
+              <br />
+            </p>
+          </div>
+        )
+      }
+    >
+      {isLoading ? (
+        <div className="flex items-center justify-center py-8 space-x-2">
+          <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
+          <p className="text-sm text-foreground-light">Retrieving API keys</p>
+        </div>
+      ) : isError ? (
+        <div className="flex items-center justify-center py-8 space-x-2">
+          <AlertCircle size={16} strokeWidth={1.5} />
+          <p className="text-sm text-foreground-light">Failed to retrieve API keys</p>
+        </div>
+      ) : isApiKeysEmpty ? (
+        <div className="flex items-center justify-center py-8 space-x-2">
+          <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
+          <p className="text-sm text-foreground-light">Retrieving API keys</p>
+        </div>
+      ) : (
+        apiKeys.map((x, i: number) => (
+          <Panel.Content
+            key={x.api_key}
+            className={
+              i >= 1 &&
+              'border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark'
+            }
+          >
+            <FormLayout
+              layout="horizontal"
+              label={
+                <>
+                  {x.name?.split(',').map((x, i: number) => (
+                    <code key={`${x}${i}`} className="text-xs text-code">
+                      {x}
+                    </code>
+                  ))}
+                  {x.name === 'service_role' && (
+                    <>
+                      <code className="text-xs text-code !bg-destructive !text-white !border-destructive">
+                        secret
+                      </code>
+                    </>
+                  )}
+                  {x.name === 'anon' && <code className="text-xs text-code">public</code>}
+                </>
+              }
+              description={
+                x.name === 'service_role' ? (
+                  <>
+                    This key has the ability to bypass Row Level Security. Never share it publicly.
+                    If leaked, generate a new JWT secret immediately.{' '}
+                  </>
+                ) : (
+                  <>
+                    This key is safe to use in a browser if you have enabled Row Level Security for
+                    your tables and configured policies.{' '}
+                  </>
+                )
+              }
+            >
+              <Input
+                readOnly
+                className="font-mono"
+                copy
+                reveal={x.name !== 'anon'}
+                value={x?.api_key}
+                onChange={() => {}}
+              />
+            </FormLayout>
+          </Panel.Content>
+        ))
+      )}
+      {showNotice ? (
+        <Panel.Notice
+          className="border-t"
+          title="API keys have moved"
+          badgeLabel="Changelog"
+          description={`
+  \`anon\` and \`service_role\` API keys can now be replaced with \`publishable\` and \`secret\` API keys.
+  `}
+          href="https://github.com/orgs/supabase/discussions/29260"
+          buttonText="Read the announcement"
+        />
+      ) : null}
+    </Panel>
+  )
+}

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -3,6 +3,9 @@
 export * from './infrastructure'
 
 export const IS_PLATFORM = process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
+export const IS_LOCAL_CLI =
+  !IS_PLATFORM && !!(process.env.CURRENT_CLI_VERSION ?? process.env.NEXT_PUBLIC_CURRENT_CLI_VERSION)
+export const IS_SELF_HOST = !IS_PLATFORM && !IS_LOCAL_CLI
 
 export const API_URL = (() => {
   if (process.env.NODE_ENV === 'test') return 'http://localhost:3000/api'

--- a/apps/studio/middleware.ts
+++ b/apps/studio/middleware.ts
@@ -1,5 +1,5 @@
 import { IS_PLATFORM } from 'lib/constants'
-import type { NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 
 export const config = {
   matcher: ['/api/:function*', '/org/:path*'],
@@ -40,6 +40,6 @@ export function middleware(request: NextRequest) {
 
   // Handle page blocking for local/self-hosted
   if (!IS_PLATFORM && pathname.startsWith('/org/')) {
-    return Response.redirect(new URL('/404', request.url))
+    return NextResponse.rewrite(new URL('/404', request.url))
   }
 }

--- a/apps/studio/pages/404.tsx
+++ b/apps/studio/pages/404.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { Button } from 'ui'
 import { useTheme } from 'next-themes'
 import { BASE_PATH } from 'lib/constants'
+import { IS_PLATFORM } from 'common'
 
 const Error404: NextPage = ({}) => {
   const { resolvedTheme } = useTheme()
@@ -22,7 +23,7 @@ const Error404: NextPage = ({}) => {
         <nav className="relative flex items-center justify-between sm:h-10">
           <div className="flex flex-shrink-0 flex-grow items-center lg:flex-grow-0">
             <div className="flex w-full items-center justify-between md:w-auto">
-              <Link href="/projects">
+              <Link href={IS_PLATFORM ? '/projects' : '/'}>
                 <Image
                   src={
                     resolvedTheme?.includes('dark')
@@ -58,7 +59,7 @@ const Error404: NextPage = ({}) => {
         </div>
         <div className="flex items-center space-x-4">
           <Button asChild size="small">
-            <Link href="/projects">Head back</Link>
+            <Link href={IS_PLATFORM ? '/projects' : '/'}>Head back</Link>
           </Button>
         </div>
       </div>

--- a/apps/studio/pages/project/[ref]/database/settings.tsx
+++ b/apps/studio/pages/project/[ref]/database/settings.tsx
@@ -1,27 +1,12 @@
-import { DiskManagementPanelForm } from 'components/interfaces/DiskManagement/DiskManagementPanelForm'
-import BannedIPs from 'components/interfaces/Settings/Database/BannedIPs'
-import { ConnectionPooling } from 'components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling'
-import { DatabaseReadOnlyAlert } from 'components/interfaces/Settings/Database/DatabaseReadOnlyAlert'
-import ResetDbPassword from 'components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword'
-import DiskSizeConfiguration from 'components/interfaces/Settings/Database/DiskSizeConfiguration'
-import { NetworkRestrictions } from 'components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions'
-import { PoolingModesModal } from 'components/interfaces/Settings/Database/PoolingModesModal'
-import SSLConfiguration from 'components/interfaces/Settings/Database/SSLConfiguration'
+import { IS_PLATFORM } from 'lib/constants'
+import type { NextPageWithLayout } from 'types'
+import { SettingsDatabase } from 'components/interfaces/Settings/Database/SettingsDatabase'
+import { SettingsDatabaseEmptyStateLocal } from 'components/interfaces/Settings/Database/SettingsDatabaseEmptyStateLocal'
+import { ScaffoldContainer, ScaffoldHeader, ScaffoldTitle } from 'components/layouts/Scaffold'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
-import { ScaffoldContainer, ScaffoldHeader, ScaffoldTitle } from 'components/layouts/Scaffold'
-import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useIsAwsCloudProvider, useIsAwsK8sCloudProvider } from 'hooks/misc/useSelectedProject'
-import type { NextPageWithLayout } from 'types'
 
 const ProjectSettings: NextPageWithLayout = () => {
-  const isAws = useIsAwsCloudProvider()
-  const isAwsK8s = useIsAwsK8sCloudProvider()
-
-  const showNewDiskManagementUI = isAws || isAwsK8s
-
-  const { databaseNetworkRestrictions } = useIsFeatureEnabled(['database:network_restrictions'])
-
   return (
     <>
       <ScaffoldContainer>
@@ -30,25 +15,8 @@ const ProjectSettings: NextPageWithLayout = () => {
         </ScaffoldHeader>
       </ScaffoldContainer>
       <ScaffoldContainer bottomPadding>
-        <div className="space-y-10">
-          <div className="flex flex-col gap-y-10">
-            <DatabaseReadOnlyAlert />
-            <ResetDbPassword />
-            <ConnectionPooling />
-          </div>
-
-          <SSLConfiguration />
-          {showNewDiskManagementUI ? (
-            // This form is hidden if Disk and Compute form is enabled, new form is on ./settings/compute-and-disk
-            <DiskManagementPanelForm />
-          ) : (
-            <DiskSizeConfiguration />
-          )}
-          {databaseNetworkRestrictions && <NetworkRestrictions />}
-          <BannedIPs />
-        </div>
+        {IS_PLATFORM ? <SettingsDatabase /> : <SettingsDatabaseEmptyStateLocal />}
       </ScaffoldContainer>
-      <PoolingModesModal />
     </>
   )
 }

--- a/apps/studio/pages/project/[ref]/settings/api-keys/index.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api-keys/index.tsx
@@ -1,7 +1,9 @@
+import { IS_PLATFORM } from 'common'
 import ApiKeysLayout from 'components/layouts/APIKeys/APIKeysLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
 import { DisplayApiSettings } from 'components/ui/ProjectSettings/DisplayApiSettings'
+import { DisplayApiSettingsLocalState } from 'components/ui/ProjectSettings/DisplayApiSettingsLocalState'
 import { ToggleLegacyApiKeysPanel } from 'components/ui/ProjectSettings/ToggleLegacyApiKeys'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
@@ -13,8 +15,14 @@ const ApiKeysLegacyPage: NextPageWithLayout = () => {
 
   return (
     <>
-      <DisplayApiSettings showTitle={false} showNotice={false} />
-      {projectSettingsShowDisableLegacyApiKeys && <ToggleLegacyApiKeysPanel />}
+      {IS_PLATFORM ? (
+        <>
+          <DisplayApiSettings showTitle={false} showNotice={false} />
+          {projectSettingsShowDisableLegacyApiKeys && <ToggleLegacyApiKeysPanel />}
+        </>
+      ) : (
+        <DisplayApiSettingsLocalState showTitle={false} showNotice={false} />
+      )}
     </>
   )
 }

--- a/apps/studio/pages/project/[ref]/settings/api.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api.tsx
@@ -1,4 +1,6 @@
+import { IS_PLATFORM } from 'common'
 import { ServiceList } from 'components/interfaces/Settings/API/ServiceList'
+import { ServiceListLocalState } from 'components/interfaces/Settings/API/ServiceListLocalState'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
@@ -8,7 +10,7 @@ import type { NextPageWithLayout } from 'types'
 const ApiSettings: NextPageWithLayout = () => {
   return (
     <ScaffoldContainer bottomPadding>
-      <ServiceList />
+      {IS_PLATFORM ? <ServiceList /> : <ServiceListLocalState />}
     </ScaffoldContainer>
   )
 }

--- a/apps/studio/pages/project/[ref]/settings/general.tsx
+++ b/apps/studio/pages/project/[ref]/settings/general.tsx
@@ -4,6 +4,7 @@ import { ComplianceConfig } from 'components/interfaces/Settings/General/Complia
 import { CustomDomainConfig } from 'components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig'
 import { DeleteProjectPanel } from 'components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectPanel'
 import { General } from 'components/interfaces/Settings/General/General'
+import { GeneralEmptyStateLocal } from 'components/interfaces/Settings/General/GeneralEmptyLocalState'
 import { TransferProjectPanel } from 'components/interfaces/Settings/General/TransferProjectPanel/TransferProjectPanel'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
@@ -12,8 +13,6 @@ import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-que
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
 
 const ProjectSettings: NextPageWithLayout = () => {
@@ -23,13 +22,6 @@ const ProjectSettings: NextPageWithLayout = () => {
   const isBranch = !!project?.parent_project_ref
   const { projectsTransfer: projectTransferEnabled, projectSettingsCustomDomains } =
     useIsFeatureEnabled(['projects:transfer', 'project_settings:custom_domains'])
-  const router = useRouter()
-
-  useEffect(() => {
-    if (!IS_PLATFORM) {
-      router.push(`/project/default/settings/log-drains`)
-    }
-  }, [router])
 
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: selectedOrganization?.slug })
   const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
@@ -42,13 +34,18 @@ const ProjectSettings: NextPageWithLayout = () => {
         </ScaffoldHeader>
       </ScaffoldContainer>
       <ScaffoldContainer className="flex flex-col gap-10" bottomPadding>
-        <General />
-
-        {/* this is only settable on compliance orgs, currently that means HIPAA orgs */}
-        {!isBranch && hasHipaaAddon && <ComplianceConfig />}
-        {projectSettingsCustomDomains && <CustomDomainConfig />}
-        {!isBranch && projectTransferEnabled && <TransferProjectPanel />}
-        {!isBranch && <DeleteProjectPanel />}
+        {IS_PLATFORM ? (
+          <>
+            <General />
+            {/* this is only settable on compliance orgs, currently that means HIPAA orgs */}
+            {!isBranch && hasHipaaAddon && <ComplianceConfig />}
+            {projectSettingsCustomDomains && <CustomDomainConfig />}
+            {!isBranch && projectTransferEnabled && <TransferProjectPanel />}
+            {!isBranch && <DeleteProjectPanel />}
+          </>
+        ) : (
+          <GeneralEmptyStateLocal />
+        )}
       </ScaffoldContainer>
     </>
   )

--- a/apps/studio/pages/project/[ref]/settings/jwt/index.tsx
+++ b/apps/studio/pages/project/[ref]/settings/jwt/index.tsx
@@ -1,4 +1,5 @@
 import JWTSettings from 'components/interfaces/JwtSecrets/jwt-settings'
+import JWTSettingsLocalState from 'components/interfaces/JwtSecrets/jwt-settings-local-state'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import JWTKeysLayout from 'components/layouts/JWTKeys/JWTKeysLayout'
 import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
@@ -6,7 +7,7 @@ import type { NextPageWithLayout } from 'types'
 
 import { JwtSecretUpdateError, JwtSecretUpdateStatus } from '@supabase/shared-types/out/events'
 import { useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { JWT_SECRET_UPDATE_ERROR_MESSAGES } from 'components/interfaces/JwtSecrets/jwt.constants'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating-status-query'
@@ -54,11 +55,7 @@ const JWTKeysLegacyPage: NextPageWithLayout = () => {
     return <UnknownInterface urlBack={`/project/${projectRef}/settings/jwt/signing-keys`} />
   }
 
-  return (
-    <JWTKeysLayout>
-      <JWTSettings />
-    </JWTKeysLayout>
-  )
+  return <JWTKeysLayout>{IS_PLATFORM ? <JWTSettings /> : <JWTSettingsLocalState />}</JWTKeysLayout>
 }
 
 JWTKeysLegacyPage.getLayout = (page) => (

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "e2e": "pnpm --prefix e2e/studio run e2e",
     "perf:kong": "ab -t 5 -c 20 -T application/json http://localhost:8000/",
     "perf:meta": "ab -t 5 -c 20 -T application/json http://localhost:5555/tables",
-    "setup:cli": "supabase start -x studio && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
+    "setup:cli": "supabase start -x studio && supabase status --output json > keys.json && CURRENT_CLI_VERSION=$(supabase -v) node scripts/generateLocalEnv.js",
     "generate:types": "supabase gen types typescript --local > ./supabase/functions/common/database-types.ts",
     "api:codegen": "cd packages/api-types && pnpm run codegen",
     "knip": "pnpx knip@~5.50.0"
@@ -59,6 +59,13 @@
     "pnpm": "10.18",
     "node": ">=22"
   },
-  "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
+  "keywords": [
+    "postgres",
+    "firebase",
+    "storage",
+    "functions",
+    "database",
+    "auth"
+  ],
   "packageManager": "pnpm@10.18.0"
 }

--- a/scripts/generateLocalEnv.js
+++ b/scripts/generateLocalEnv.js
@@ -30,6 +30,8 @@ const defaultEnv = {
   NEXT_PUBLIC_GOTRUE_URL: '$SUPABASE_PUBLIC_URL/auth/v1',
   NEXT_PUBLIC_HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',
   NEXT_PUBLIC_NODE_ENV: 'test',
+  CURRENT_CLI_VERSION: process.env.CURRENT_CLI_VERSION,
+  NEXT_PUBLIC_CURRENT_CLI_VERSION: '$CURRENT_CLI_VERSION',
 }
 
 const environment = { ...generatedEnv, ...defaultEnv }


### PR DESCRIPTION
Part 1

## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Some pages and commands are broken for local studio version.

## What is the new behaviour?

- closes #40106 
- closes #40109
- closes #40198 
- fixes  #16903 

---

- related #40543 
- related #39329 
- related #40677

## Additional context

- [x] `Database > Settings` page not loading
- [x] Organization commands not being hidden for non-platform version
- [x] `"Project Settings"` button quick loads `Settings > General` and then redirects to `Settings > Log Drain`

~AI editor referencing broken pages~
~Disable edge-functions editor and sub-pages~
