### PR TITLE
Fix WhatsApp country code extraction bug in SMS hook docs

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/send-sms-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-sms-hook.mdx
@@ -585,10 +585,13 @@ Deno.serve(async (req) => {
             sms
         } = wh.verify(payload, headers);
         const messageBody = `Your OTP is: ${sms.otp}`;
-        const userPhoneNumber = user.phone;
-        const countryCode = userPhoneNumber.substring(1, userPhoneNumber.indexOf(userPhoneNumber.match(/\d/)!));
-
-        const useWhatsApp = latinAmericanCountryCodes.includes(countryCode);
+  const userPhoneNumber = user?.phone ?? '';
+  let useWhatsApp = false;
+  if (userPhoneNumber && userPhoneNumber.startsWith('+')) {
+    // take up to three characters after the '+' to capture 2- or 3-digit country codes
+    const countryCode = userPhoneNumber.substring(1, 4);
+    useWhatsApp = latinAmericanCountryCodes.some(code => countryCode.startsWith(code));
+  }
 
         const response = await sendMessage(
             messageBody,


### PR DESCRIPTION
Fixes the logic in the 'Use WhatsApp with SMS' example where `useWhatsApp` was always false due to faulty substring extraction. Updated with defensive code to properly check Latin American country codes
Changes:
- Replaced broken country code extraction with safe substring and prefix matching.
- Added null checks and defaults for robustness  
Closes [#40062].