### PR TITLE
docs(auth): update auth hooks with security definer

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/before-user-created-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/before-user-created-hook.mdx
@@ -246,20 +246,21 @@ insert into public.signup_email_domains (domain, type, reason) values
 create or replace function public.hook_restrict_signup_by_email_domain(event jsonb)
 returns jsonb
 language plpgsql
+security definer
 as $$
 declare
   email text;
-  domain text;
+  email_domain text;
   is_allowed int;
   is_denied int;
 begin
   email := event->'user'->>'email';
-  domain := split_part(email, '@', 2);
+  email_domain := split_part(email, '@', 2);
 
   -- Check for allow match
   select count(*) into is_allowed
   from public.signup_email_domains
-  where type = 'allow' and lower(domain) = lower($1);
+  where type = 'allow' and domain = lower(email_domain);
 
   if is_allowed > 0 then
     return '{}'::jsonb;
@@ -268,7 +269,7 @@ begin
   -- Check for deny match
   select count(*) into is_denied
   from public.signup_email_domains
-  where type = 'deny' and lower(domain) = lower($1);
+  where type = 'deny' and domain = lower(email_domain);
 
   if is_denied > 0 then
     return jsonb_build_object(
@@ -393,6 +394,7 @@ values
 create or replace function public.hook_restrict_signup_by_network(event jsonb)
 returns jsonb
 language plpgsql
+security definer
 as $$
 declare
   ip inet;
@@ -648,6 +650,7 @@ values
 create or replace function public.hook_restrict_signup_by_network(event jsonb)
 returns jsonb
 language plpgsql
+security definer
 as $$
 declare
   ip inet;

--- a/apps/docs/content/guides/auth/auth-hooks/custom-access-token-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/custom-access-token-hook.mdx
@@ -279,6 +279,7 @@ Create a hook:
 create or replace function public.custom_access_token_hook(event jsonb)
 returns jsonb
 language plpgsql
+security definer
 as $$
   declare
     claims jsonb;

--- a/apps/docs/content/guides/auth/auth-hooks/mfa-verification-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/mfa-verification-hook.mdx
@@ -111,6 +111,7 @@ Create a hook to read and write information to this table. For example:
 create function public.hook_mfa_verification_attempt(event jsonb)
   returns jsonb
   language plpgsql
+  security definer
 as $$
   declare
     last_failed_at timestamp;

--- a/apps/docs/content/guides/auth/auth-hooks/password-verification-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/password-verification-hook.mdx
@@ -105,6 +105,7 @@ Create a hook to read and write information to this table. For example:
 create function public.hook_password_verification_attempt(event jsonb)
 returns jsonb
 language plpgsql
+security definer
 as $$
   declare
     last_failed_at timestamp;
@@ -187,6 +188,7 @@ Create the hook:
 create or replace function public.hook_notify_user_on_failed_attempts(event jsonb)
 returns jsonb
 language plpgsql
+security definer
 as $$
   declare
     user_id uuid;

--- a/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
@@ -422,7 +422,7 @@ begin
 
     return '{}'::jsonb;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer;
 
 grant all
   on table public.job_queue
@@ -430,7 +430,7 @@ grant all
 
 revoke all
   on table public.job_queue
-  from authenticated, anon;
+  from authenticated, anon, public;
 ```
 
 Create a function to periodically run and dequeue all jobs
@@ -469,7 +469,7 @@ begin
         end;
     end loop;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer;
 
 grant execute
   on function public.dequeue_and_run_jobs
@@ -477,7 +477,7 @@ grant execute
 
 revoke execute
   on function public.dequeue_and_run_jobs
-  from authenticated, anon;
+  from authenticated, anon, public;
 ```
 
 Configure `pg_cron` to run the job on an interval. You can use a tool like [crontab.guru](https://crontab.guru/) to check that your job is running on an appropriate schedule. Ensure that `pg_cron` is enabled under `Database > Extensions`

--- a/apps/docs/content/guides/auth/auth-hooks/send-sms-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-sms-hook.mdx
@@ -335,7 +335,7 @@ begin
     insert into job_queue (job_data, priority, scheduled_at, max_retries)
     values (job_data, priority, scheduled_time, 2);
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer;
 
 grant all
   on table public.job_queue
@@ -343,7 +343,7 @@ grant all
 
 revoke all
   on table public.job_queue
-  from authenticated, anon;
+  from authenticated, anon, public;
 ```
 
 Create a function to periodically run and dequeue all jobs
@@ -382,7 +382,7 @@ begin
         end;
     end loop;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer;
 
 grant execute
   on function public.dequeue_and_run_jobs
@@ -390,7 +390,7 @@ grant execute
 
 revoke execute
   on function public.dequeue_and_run_jobs
-  from authenticated, anon;
+  from authenticated, anon, public;
 ```
 
 Configure `pg_cron` to run the job on an interval. You can use a tool like [crontab.guru](https://crontab.guru/) to check that your job is running on an appropriate schedule. Ensure that `pg_cron` is enabled under `Database > Extensions`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

- Auth hooks function don't currently work if they reference a table in the `public` schema.
- The `before_user_created` hook example code in the docs don't work as it has a number of issues namely variable name being the same as a column name, adding the `lower` function around the column name and the value was also using the `$1` placeholder instead of the variable name.

## What is the new behavior?

- Auth hooks can now reference tables in the `public` schema as they are now security definer functions.
- The `before_user_created` hook example has been fixed by renaming the `domain` variable to `email_domain` so it doesn't conflict with the `domain` column. Changed the reference to the placeholder `$1` to `email_domain`.

## Additional context

Add any other context or screenshots.
