### PR TITLE
fix: enable App Router page view tracking on navigation

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -172,6 +172,9 @@ export const PageTelemetry = ({
   // Handle initial page telemetry event
   const hasSentInitialPageTelemetryRef = useRef(false)
 
+  // Track previous pathname for App Router to detect actual changes
+  const previousAppPathnameRef = useRef<string | null>(null)
+
   // Initialize PostHog client when consent is accepted
   useEffect(() => {
     if (hasAcceptedConsent && IS_PLATFORM) {
@@ -239,10 +242,13 @@ export const PageTelemetry = ({
     // For app router
     if (router !== null) return
 
-    // Wait until we've sent the initial page telemetry event
-    if (appPathname && !hasSentInitialPageTelemetryRef.current) {
+    // Only track if pathname actually changed (not initial mount)
+    if (appPathname && previousAppPathnameRef.current !== null && previousAppPathnameRef.current !== appPathname) {
       sendPageTelemetry()
     }
+
+    // Update previous pathname
+    previousAppPathnameRef.current = appPathname
   }, [appPathname, router, sendPageTelemetry])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes bug where App Router pages (docs, www/blog) only tracked the initial page load but not subsequent SPA navigations.

Resolves GROWTH-537

## Root Cause
The issue was introduced in PR #35384 which added consent management. The App Router telemetry used a boolean flag approach that had a fundamental flaw.

**The Problem:**

The original buggy code was:
```typescript
useEffect(() => {
  if (appPathname && !hasSentInitialPageTelemetryRef.current) {
    sendPageTelemetry()
  }
}, [appPathname])
```

This effect fires **both** on initial mount AND on pathname changes. The negated flag check (`!hasSentInitialPageTelemetryRef.current`) meant:
1. Initial mount: Flag is false, `!false` = true, sends telemetry (duplicates the separate initial effect)
2. After initial effect sets flag to true
3. Subsequent navigations: `!true` = false, **never sends telemetry again**

The flag-based approach cannot differentiate between:
- First time effect runs (initial mount) - should NOT send (separate initial effect handles this)
- Effect runs due to pathname change (navigation) - SHOULD send

**Why both approaches fail:**
- `!hasSentInitialPageTelemetryRef.current` - Fires on initial mount (duplicate), then never again
- `hasSentInitialPageTelemetryRef.current` - Fires on initial mount (duplicate) AND on changes (correct but still duplicates initial)

## Fix
Track the previous pathname to detect actual changes, not just "has effect run before":

**New logic:**
```typescript
const previousAppPathnameRef = useRef<string | null>(null)

useEffect(() => {
  // Only fire if pathname actually changed (not initial mount)
  if (appPathname && previousAppPathnameRef.current !== null && previousAppPathnameRef.current !== appPathname) {
    sendPageTelemetry()
  }
  
  previousAppPathnameRef.current = appPathname
}, [appPathname])
```

**How it works:**
- Initial mount: `previousAppPathnameRef.current === null`, skip (separate initial effect handles this)
- Navigation: `previousAppPathnameRef.current !== appPathname`, send telemetry
- Updates ref for next comparison

## Testing
- Code review confirms logic properly differentiates initial mount from navigation
- Pattern matches how Pages Router explicitly handles this with `routeChangeComplete` event

## Impact
- **Before:** Users navigating between docs pages/blog posts generated only 1 page view event (initial load)
- **After:** Each page navigation generates a page view event (expected behavior)

## Affected Apps
- `/supabase/apps/docs` (App Router)
- `/supabase/apps/www` (App Router blog pages only)
- `/supabase/apps/studio` (Pages Router - unaffected, already working)

## Files Changed
- `packages/common/telemetry.tsx`
  - Added `previousAppPathnameRef` to track pathname changes
  - Updated App Router effect to detect actual pathname changes