### PR TITLE
docs(realtime): use the new httpSend for REST broadcast

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -7375,12 +7375,7 @@ functions:
           ```js
           supabase
             .channel('room1')
-            .send({
-              type: 'broadcast',
-              event: 'cursor-pos',
-              payload: { x: Math.random(), y: Math.random()
-              },
-            })
+            .httpSend('cursor-pos', { x: Math.random(), y: Math.random() })
           ```
   - id: get-channels
     title: getChannels()


### PR DESCRIPTION
channel.send has been soft deprecated for REST broadcast usage

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update realtime broadcast REST docs to use `httpSend` 

Related to https://github.com/supabase/supabase-js/pull/1751

## Additional context

Add any other context or screenshots.
