### PR TITLE
Clean up RQ retries

### DIFF
--- a/apps/studio/data/organizations/organization-billing-subscription-preview.ts
+++ b/apps/studio/data/organizations/organization-billing-subscription-preview.ts
@@ -88,21 +88,4 @@ export const useOrganizationBillingSubscriptionPreview = <
     queryFn: () => previewOrganizationBillingSubscription({ organizationSlug, tier }),
     enabled: enabled && typeof organizationSlug !== 'undefined' && typeof tier !== 'undefined',
     ...options,
-    retry: (failureCount, error) => {
-      // Don't retry on 400s
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        (error as any).code === 400
-      ) {
-        return false
-      }
-
-      if (failureCount < 3) {
-        return true
-      }
-
-      return false
-    },
   })

--- a/apps/studio/data/projects/project-transfer-preview-query.ts
+++ b/apps/studio/data/projects/project-transfer-preview-query.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
-import { projectKeys } from './keys'
 import { UseCustomQueryOptions } from 'types'
+import { projectKeys } from './keys'
 
 export type ProjectTransferPreviewVariables = {
   projectRef?: string
@@ -44,21 +44,4 @@ export const useProjectTransferPreviewQuery = <TData = ProjectTransferPreviewDat
     enabled:
       enabled && typeof projectRef !== 'undefined' && typeof targetOrganizationSlug !== 'undefined',
     ...options,
-    retry: (failureCount, error) => {
-      // Don't retry on 400s
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        (error as any).code === 400
-      ) {
-        return false
-      }
-
-      if (failureCount < 3) {
-        return true
-      }
-
-      return false
-    },
   })

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -4,7 +4,7 @@ import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { ResponseError, type UseCustomQueryOptions } from 'types'
 import { storageKeys } from './keys'
 
 export type BucketsVariables = { projectRef?: string }
@@ -41,11 +41,7 @@ export const useBucketsQuery = <TData = BucketsData>(
     enabled: enabled && typeof projectRef !== 'undefined' && isActive,
     ...options,
     retry: (failureCount, error) => {
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        error.message.includes('Missing tenant config')
-      ) {
+      if (error instanceof ResponseError && error.message.includes('Missing tenant config')) {
         return false
       }
 


### PR DESCRIPTION
## Context

Just realised that the global `query-client` already handles retries logic to stop retrying if error is `>=400` and `< 500`, and if failure count is >= 3. We had some duplicated logic in the individual react queries that this PR cleans up