### PR TITLE
default filters and state fix

### DIFF
--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
@@ -1,12 +1,12 @@
+import dayjs from 'dayjs'
 import { AlertTriangle, ChevronRight, Gauge, Inbox, Shield } from 'lucide-react'
 
-import { Button } from 'ui'
-import { GenericSkeletonLoader } from 'ui-patterns'
-import { EmptyAdvisor } from './EmptyAdvisor'
-import { AdvisorItem } from './AdvisorPanelHeader'
 import { Notification } from 'data/notifications/notifications-v2-query'
 import { AdvisorSeverity, AdvisorTab } from 'state/advisor-state'
-import { cn } from 'ui'
+import { Button, cn } from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns'
+import { AdvisorItem } from './AdvisorPanelHeader'
+import { EmptyAdvisor } from './EmptyAdvisor'
 
 const NoProjectNotice = () => {
   return (
@@ -119,7 +119,20 @@ export const AdvisorPanelBody = ({
                       strokeWidth={1.5}
                       className={cn('flex-shrink-0', severityClass)}
                     />
-                    <span className="truncate">{item.title.replace(/[`\\]/g, '')}</span>
+                    <div className="text-left flex flex-col gap-0.5 truncate flex-1 min-w-0">
+                      <div className="truncate">{item.title.replace(/[`\\]/g, '')}</div>
+                      {item.createdAt && (
+                        <span className="text-xs text-foreground-light capitalize-sentence">
+                          {(() => {
+                            const insertedAt = item.createdAt
+                            const daysFromNow = dayjs().diff(dayjs(insertedAt), 'day')
+                            const formattedTimeFromNow = dayjs(insertedAt).fromNow()
+                            const formattedInsertedAt = dayjs(insertedAt).format('MMM DD, YYYY')
+                            return daysFromNow > 1 ? formattedInsertedAt : formattedTimeFromNow
+                          })()}
+                        </span>
+                      )}
+                    </div>
                   </div>
                   <ChevronRight
                     size={16}

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
@@ -107,7 +107,7 @@ export const AdvisorPanelBody = ({
               <Button
                 type="text"
                 className={cn(
-                  'justify-start w-full block rounded-none h-auto py-3 px-4 text-foreground-light hover:text-foreground',
+                  'justify-start w-full block rounded-none h-auto py-3 px-4 hover:text-foreground',
                   isUnread && 'bg-surface-100/50'
                 )}
                 onClick={() => onItemClick(item)}

--- a/apps/studio/components/ui/AdvisorPanel/EmptyAdvisor.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/EmptyAdvisor.tsx
@@ -33,9 +33,9 @@ export const EmptyAdvisor = ({ activeTab, hasFilters, onClearFilters }: EmptyAdv
       case 'performance':
         return 'Congrats! There are no performance issues detected for this project'
       case 'messages':
-        return 'There are no messages for this project'
+        return 'Messages alert you of upcoming changes or potential issues with your project'
       default:
-        return 'Congrats! There are no issues detected for this project'
+        return 'Congrats! There are no issues detected'
     }
   }
 

--- a/apps/studio/state/advisor-state.ts
+++ b/apps/studio/state/advisor-state.ts
@@ -6,7 +6,7 @@ export type AdvisorItemSource = 'lint' | 'notification'
 
 const initialState = {
   activeTab: 'all' as AdvisorTab,
-  severityFilters: ['critical'] as AdvisorSeverity[],
+  severityFilters: ['critical', 'warning'] as AdvisorSeverity[],
   selectedItemId: undefined as string | undefined,
   selectedItemSource: undefined as AdvisorItemSource | undefined,
   // Notification filters

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -156,11 +156,9 @@ export const useRegisterSidebar = (
   const handlersRef = useLatest(handlers)
 
   useEffect(() => {
-    if (enabled === false) {
-      return
+    if (enabled) {
+      sidebarManagerState.registerSidebar(id, () => componentRef.current(), handlersRef.current)
     }
-
-    sidebarManagerState.registerSidebar(id, () => componentRef.current(), handlersRef.current)
 
     return () => {
       sidebarManagerState.unregisterSidebar(id)

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -1,4 +1,5 @@
 import { LOCAL_STORAGE_KEYS } from 'common/constants'
+import useLatest from 'hooks/misc/useLatest'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { ReactNode, useEffect, useRef } from 'react'
 import { proxy, snapshot, useSnapshot } from 'valtio'
@@ -151,11 +152,8 @@ export const useRegisterSidebar = (
     true
   )
 
-  const componentRef = useRef(component)
-  const handlersRef = useRef(handlers)
-
-  componentRef.current = component
-  handlersRef.current = handlers
+  const componentRef = useLatest(component)
+  const handlersRef = useLatest(handlers)
 
   useEffect(() => {
     if (enabled === false) {

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -1,6 +1,6 @@
 import { LOCAL_STORAGE_KEYS } from 'common/constants'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useRef } from 'react'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 
 type SidebarHandlers = {
@@ -151,20 +151,21 @@ export const useRegisterSidebar = (
     true
   )
 
-  const { sidebars, registerSidebar, unregisterSidebar } = useSidebarManagerSnapshot()
+  const componentRef = useRef(component)
+  const handlersRef = useRef(handlers)
+
+  componentRef.current = component
+  handlersRef.current = handlers
 
   useEffect(() => {
-    const isEnabled = enabled !== false
-    if (!sidebars[id] && isEnabled) {
-      registerSidebar(id, component, handlers)
-    } else if (sidebars[id] && !isEnabled) {
-      unregisterSidebar(id)
+    if (enabled === false) {
+      return
     }
 
+    sidebarManagerState.registerSidebar(id, () => componentRef.current(), handlersRef.current)
+
     return () => {
-      if (sidebars[id]) {
-        unregisterSidebar(id)
-      }
+      sidebarManagerState.unregisterSidebar(id)
     }
   }, [id, enabled])
 


### PR DESCRIPTION
Adjusts default filters in advisor to show critical and warnings for now until can come up with a better pattern for revealing warnings particularly for "messages".

This also fixes an issue where if you traversed up to a level like account/me, then back down to project, it would run into an issue where sidebar was not being registered correctly / state was outdated. This meant you could not open up the sidebar.