### PR TITLE
[FE-2099] chore(docs): top nav homepage link toggleable for nimbus

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/TopNavDropdown.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavDropdown.tsx
@@ -20,18 +20,25 @@ import {
   themes,
 } from 'ui'
 import MenuIconPicker from './MenuIconPicker'
+import { isFeatureEnabled } from 'common'
 
 const menu = [
   [
-    {
-      label: 'Supabase.com',
-      icon: 'home',
-      href: 'https://supabase.com',
-      otherProps: {
-        target: '_blank',
-        rel: 'noreferrer noopener',
-      },
-    },
+    isFeatureEnabled('docs:navigation_dropdown_links_home')
+      ? {
+          label: 'Supabase.com',
+          icon: 'home',
+          href: 'https://supabase.com',
+          otherProps: {
+            target: '_blank',
+            rel: 'noreferrer noopener',
+          },
+        }
+      : {
+          label: 'Dashboard',
+          icon: 'home',
+          href: '../dashboard',
+        },
     {
       label: 'GitHub',
       icon: 'github',

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -52,7 +52,7 @@
   "docs:contribution": true,
   "docs:fdw": true,
   "docs:footer": true,
-  "docs:navigation_dropdown_links_home": false,
+  "docs:navigation_dropdown_links_home": true,
   "docs:self-hosting": true,
   "docs:framework_quickstarts": true,
   "docs:full_getting_started": true,

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -52,6 +52,7 @@
   "docs:contribution": true,
   "docs:fdw": true,
   "docs:footer": true,
+  "docs:navigation_dropdown_links_home": false,
   "docs:self-hosting": true,
   "docs:framework_quickstarts": true,
   "docs:full_getting_started": true,

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -181,6 +181,10 @@
       "type": "boolean",
       "description": "Enable footer on docs site"
     },
+    "docs:navigation_dropdown_links_home": {
+      "type": "boolean",
+      "description": "Should the navigation dropdown homepage link go to Supabase.com or the dashboard"
+    },
     "docs:framework_quickstarts": {
       "type": "boolean",
       "description": "Enable framework quickstarts documentation"


### PR DESCRIPTION
Instead of linking to the Supabase homepage, we can link to dashboard