### PR TITLE
docs: Make it clearer that getting your app approved by Google is all you need to make your Google auth consent screen look better

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -39,12 +39,12 @@ It's strongly recommended you set up a custom domain and optionally verify your 
 
 </Admonition>
 
-Google's consent screen is shown to users when they sign in. Optionally configure the following to improve the appearance of the screen, increasing the perception of trust by your users:
+Google's consent screen is shown to users when they sign in. Optionally configure one of the following to improve the appearance of the screen, increasing the perception of trust by your users:
 
+1. Verify your application's brand (logo and name) by configuring it in the [Branding](https://console.cloud.google.com/auth/branding) section of the Google Auth Platform console. Brand verification is not automatic and may take a few business days.
 1. Set up a [custom domain for your project](/docs/guides/platform/custom-domains) to present the user with a clear relationship to the website they clicked Sign in with Google on.
    - A good approach is to use `auth.example.com` or `api.example.com`, if your application is hosted on `example.com`.
    - If you don't set this up, users will see `<project-id>.supabase.co` which does not inspire trust and can make your application more susceptible to successful phishing attempts.
-1. Verify your application's brand (logo and name) by configuring it in the [Branding](https://console.cloud.google.com/auth/branding) section of the Google Auth Platform console. Brand verification is not automatic and may take a few business days.
 
 ## Project setup
 

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -243,7 +243,11 @@ export const PageTelemetry = ({
     if (router !== null) return
 
     // Only track if pathname actually changed (not initial mount)
-    if (appPathname && previousAppPathnameRef.current !== null && previousAppPathnameRef.current !== appPathname) {
+    if (
+      appPathname &&
+      previousAppPathnameRef.current !== null &&
+      previousAppPathnameRef.current !== appPathname
+    ) {
       sendPageTelemetry()
     }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

I often see people complaining that they have to purchase the custom domain add-on in order to prevent their Supabase domain from appearing on the Google sign-in consent screen and display their own domain or app name. Although getting a custom domain is one of the solutions to this problem, there is a free way to do it, and it is to get your app approved by Google, which costs nothing. With the current wording of the docs, it sounds like getting the custom domain is mandatory. This PR fixes the wording to make it clear that getting the app approved is all they need. 