### PR TITLE
Set up removing tables from namespaces in analytics buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/AnalyticsBucketDetails.utils.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/AnalyticsBucketDetails.utils.ts
@@ -11,3 +11,7 @@ export const getAnalyticsBucketS3KeyName = (bucketId: string) => {
 export const getAnalyticsBucketFDWName = (bucketId: string) => {
   return `${snakeCase(bucketId)}_fdw`
 }
+
+export const getAnalyticsBucketFDWServerName = (bucketId: string) => {
+  return `${snakeCase(bucketId)}_fdw_server`
+}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -29,6 +29,7 @@ import {
   TableRow,
 } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { getAnalyticsBucketFDWServerName } from '../AnalyticsBucketDetails.utils'
 import { useAnalyticsBucketAssociatedEntities } from '../useAnalyticsBucketAssociatedEntities'
 import { useAnalyticsBucketWrapperInstance } from '../useAnalyticsBucketWrapperInstance'
 
@@ -140,12 +141,13 @@ export const TableRowComponent = ({
   }
 
   const onConfirmRemoveTable = async () => {
+    if (!bucketId) return console.error('Bucket ID is required')
     if (!wrapperInstance || !wrapperMeta) return toast.error('Unable to find wrapper')
 
     try {
       setIsRemovingTable(true)
 
-      const serverName = `${snakeCase(bucketId)}_fdw_server`
+      const serverName = getAnalyticsBucketFDWServerName(bucketId)
       const serverOptions = await getDecryptedParameters({
         ref: project?.ref,
         connectionString: project?.connectionString ?? undefined,
@@ -163,6 +165,8 @@ export const TableRowComponent = ({
         (x) => x.table_name !== table.name
       )
 
+      // [Joshen] Once Ivan's PR goes through, swap these out to just use useFDWDropForeignTableMutation
+      // https://github.com/supabase/supabase/pull/40206
       await updateFDW({
         projectRef: project?.ref,
         connectionString: project?.connectionString,

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -187,7 +187,7 @@ export const TableRowComponent = ({
         table: table.name,
       })
 
-      toast.success('Succesfully removed table')
+      toast.success('Successfully removed table!')
       setShowRemoveTableModal(false)
     } catch (error: any) {
       toast.error(`Failed to remove table: ${error.message}`)

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
@@ -238,6 +238,8 @@ export const NamespaceWithTables = ({
               <TableRowComponent
                 key={table.name}
                 table={table}
+                namespace={namespace}
+                token={token}
                 schema={displaySchema}
                 isLoading={isImportingForeignSchema || isLoadingNamespaceTables}
                 index={index}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketWrapperInstance.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketWrapperInstance.tsx
@@ -1,4 +1,3 @@
-import { snakeCase } from 'lodash'
 import { useMemo } from 'react'
 
 import { WRAPPER_HANDLERS } from 'components/interfaces/Integrations/Wrappers/Wrappers.constants'
@@ -8,6 +7,7 @@ import {
 } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
 import { type FDW, useFDWsQuery } from 'data/fdw/fdws-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { getAnalyticsBucketFDWName } from './AnalyticsBucketDetails.utils'
 
 export const useAnalyticsBucketWrapperInstance = (
   { bucketId }: { bucketId?: string },
@@ -36,7 +36,7 @@ export const useAnalyticsBucketWrapperInstance = (
           wrapper
         )
       )
-      .find((w) => w.name === snakeCase(`${bucketId}_fdw`))
+      .find((w) => w.name === getAnalyticsBucketFDWName(bucketId ?? ''))
   }, [data, bucketId])
 
   const icebergWrapperMeta = getWrapperMetaForWrapper(icebergWrapper)

--- a/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { snakeCase, uniq } from 'lodash'
+import { uniq } from 'lodash'
 import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -17,6 +17,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import type { WrapperMeta } from '../Integrations/Wrappers/Wrappers.types'
 import { formatWrapperTables } from '../Integrations/Wrappers/Wrappers.utils'
 import SchemaEditor from '../TableGridEditor/SidePanelEditor/SchemaEditor'
+import { getAnalyticsBucketFDWServerName } from './AnalyticsBuckets/AnalyticsBucketDetails/AnalyticsBucketDetails.utils'
 import { getDecryptedParameters } from './ImportForeignSchemaDialog.utils'
 
 export interface ImportForeignSchemaDialogProps {
@@ -79,7 +80,7 @@ export const ImportForeignSchemaDialog = ({
   })
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
-    const serverName = `${snakeCase(values.bucketName)}_fdw_server`
+    const serverName = getAnalyticsBucketFDWServerName(values.bucketName)
 
     if (!ref) return console.error('Project ref is required')
     setLoading(true)

--- a/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
+++ b/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
@@ -1,0 +1,104 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { constructHeaders, fetchHandler, handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
+import { storageKeys } from './keys'
+
+type DeleteIcebergNamespaceTableVariables = {
+  catalogUri: string
+  warehouse: string
+  token: string
+  namespace: string
+  table: string
+}
+
+// [Joshen] Investigate if we can use the temp API keys here
+async function deleteIcebergNamespaceTable({
+  catalogUri,
+  warehouse,
+  token,
+  namespace,
+  table,
+}: DeleteIcebergNamespaceTableVariables) {
+  let headers = new Headers()
+  // handle both secret key and service role key
+  if (token.startsWith('sb_secret_')) {
+    headers = await constructHeaders({
+      'Content-Type': 'application/json',
+      apikey: `${token}`,
+    })
+    headers.delete('Authorization')
+  } else {
+    headers = await constructHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    })
+  }
+
+  const url = `${catalogUri}/v1/${warehouse}/namespaces/${namespace}/tables/${table}`.replaceAll(
+    /(?<!:)\/\//g,
+    '/'
+  )
+
+  try {
+    const response = await fetchHandler(url, {
+      headers,
+      method: 'DELETE',
+    })
+
+    const result = await response.json()
+    if (result.error) {
+      if (result.error.message) {
+        throw new Error(result.error.message)
+      }
+      throw new Error('Failed to delete Iceberg namespace table')
+    }
+    return result
+  } catch (error) {
+    handleError(error)
+  }
+}
+
+type IcebergNamespaceTableDeleteData = Awaited<ReturnType<typeof deleteIcebergNamespaceTable>>
+
+export const useIcebergNamespaceTableDeleteMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseCustomMutationOptions<
+    IcebergNamespaceTableDeleteData,
+    ResponseError,
+    DeleteIcebergNamespaceTableVariables
+  >,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    IcebergNamespaceTableDeleteData,
+    ResponseError,
+    DeleteIcebergNamespaceTableVariables
+  >({
+    mutationFn: (vars) => deleteIcebergNamespaceTable(vars),
+    async onSuccess(data, variables, context) {
+      await queryClient.invalidateQueries({
+        queryKey: storageKeys.icebergNamespace(
+          variables.catalogUri,
+          variables.warehouse,
+          variables.namespace
+        ),
+      })
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(data, variables, context) {
+      if (onError === undefined) {
+        toast.error(`Failed to delete Iceberg namespace table: ${data.message}`)
+      } else {
+        onError(data, variables, context)
+      }
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
+++ b/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
@@ -36,25 +36,18 @@ async function deleteIcebergNamespaceTable({
     })
   }
 
-  const url = `${catalogUri}/v1/${warehouse}/namespaces/${namespace}/tables/${table}`.replaceAll(
-    /(?<!:)\/\//g,
-    '/'
-  )
+  const url =
+    `${catalogUri}/v1/${warehouse}/namespaces/${namespace}/tables/${table}?purgeRequested=true`.replaceAll(
+      /(?<!:)\/\//g,
+      '/'
+    )
 
   try {
     const response = await fetchHandler(url, {
       headers,
       method: 'DELETE',
     })
-
-    const result = await response.json()
-    if (result.error) {
-      if (result.error.message) {
-        throw new Error(result.error.message)
-      }
-      throw new Error('Failed to delete Iceberg namespace table')
-    }
-    return result
+    return response.status === 204
   } catch (error) {
     handleError(error)
   }


### PR DESCRIPTION
## Context

Add support for removing connected tables from an analytics bucket.

<img width="233" height="165" alt="image" src="https://github.com/user-attachments/assets/f78dad81-27b2-43c7-93cf-41d8bfce30b8" />

Only buckets that aren't replicating can be removed - will need to stop replication first before being allowed to remove

<img width="503" height="178" alt="image" src="https://github.com/user-attachments/assets/ece57822-ec69-408e-a987-ce59f3ae381d" />

Removing a table involves
- Updating the FDW to remove the table
- Deleting the table from the iceberg namespace

Have verified locally the following
- Able to remove a table
- Able to add that table back
