### PR TITLE
[Documentation] Fix owner_id type

### DIFF
--- a/apps/docs/content/guides/storage/security/ownership.mdx
+++ b/apps/docs/content/guides/storage/security/ownership.mdx
@@ -32,7 +32,7 @@ on storage.objects
 for delete
 to authenticated
 using (
-    owner_id = (select auth.uid())
+    owner_id = (select auth.uid()::text)
 );
 ```
 


### PR DESCRIPTION
If you don't type cast you'll encounter the following error:
```
Error: ERROR: 42883: operator does not exist: text = uuid HINT: No operator matches the given name and argument types. You might need to add explicit type casts. 
```
This should fix it.
