### PR TITLE
Consolidate realtime button experiment into single multivariate flag

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -90,12 +90,6 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
     return realtimeButtonVariant
   }, [isTable, isNewProject, realtimeButtonVariant])
 
-  const shouldTrackExposure =
-    isTable &&
-    isNewProject &&
-    realtimeButtonVariant !== false &&
-    realtimeButtonVariant !== undefined
-
   const hasTrackedExposure = useRef(false)
 
   const { mutate: updateTable } = useTableUpdateMutation({
@@ -199,20 +193,21 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const manageTriggersHref = `/project/${ref}/database/triggers?schema=${table.schema}`
 
   useEffect(() => {
-    if (shouldTrackExposure && !hasTrackedExposure.current && project) {
-      hasTrackedExposure.current = true
+    if (!isTable || !isNewProject || !project || hasTrackedExposure.current) return
+    if (realtimeButtonVariant === false || realtimeButtonVariant === undefined) return
 
-      const daysSinceCreation = Math.floor(
-        (Date.now() - new Date(project.inserted_at).getTime()) / (1000 * 60 * 60 * 24)
-      )
+    hasTrackedExposure.current = true
 
-      track('realtime_experiment_exposed', {
-        variant: realtimeButtonVariant as RealtimeButtonVariant,
-        table_has_realtime_enabled: isRealtimeEnabled,
-        days_since_project_creation: daysSinceCreation,
-      })
-    }
-  }, [shouldTrackExposure, realtimeButtonVariant, project, isRealtimeEnabled, track])
+    const daysSinceCreation = Math.floor(
+      (Date.now() - new Date(project.inserted_at).getTime()) / (1000 * 60 * 60 * 24)
+    )
+
+    track('realtime_experiment_exposed', {
+      variant: realtimeButtonVariant,
+      table_has_realtime_enabled: isRealtimeEnabled,
+      days_since_project_creation: daysSinceCreation,
+    })
+  }, [isTable, isNewProject, realtimeButtonVariant, project, isRealtimeEnabled, track])
 
   const toggleRealtime = async () => {
     if (!project) return console.error('Project is required')

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -5,8 +5,10 @@ import Link from 'next/link'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
-import { useFlag, useParams } from 'common'
+import { useParams } from 'common'
 import { usePHFlag } from 'hooks/ui/useFlag'
+import { RealtimeButtonVariant } from 'types'
+import { NEW_PROJECT_THRESHOLD_DAYS } from 'lib/constants'
 import { RefreshButton } from 'components/grid/components/header/RefreshButton'
 import { getEntityLintDetails } from 'components/interfaces/TableGridEditor/TableEntity.utils'
 import { APIDocsButton } from 'components/ui/APIDocsButton'
@@ -26,7 +28,6 @@ import {
 import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { useTrack } from 'lib/telemetry/track'
@@ -53,12 +54,9 @@ export interface GridHeaderActionsProps {
   isRefetching: boolean
 }
 
-const NEW_PROJECT_THRESHOLD_DAYS = 7
-
 export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const { data: org } = useSelectedOrganizationQuery()
   const track = useTrack()
 
   const [showWarning, setShowWarning] = useQueryState(
@@ -74,8 +72,9 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const isView = isTableLikeView(table)
   const isMaterializedView = isTableLikeMaterializedView(table)
 
-  const triggersInsteadOfRealtime = useFlag<boolean>('triggersInsteadOfRealtime')
-  const hideRealtimeButton = usePHFlag<boolean>('hideRealtimeButton')
+  const realtimeButtonVariant = usePHFlag<RealtimeButtonVariant | false | undefined>(
+    'realtimeButtonVariant'
+  )
   const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
   const { isSchemaLocked } = useIsProtectedSchema({ schema: table.schema })
 
@@ -83,6 +82,19 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
     if (!project?.inserted_at) return false
     return dayjs().diff(dayjs(project.inserted_at), 'day') < NEW_PROJECT_THRESHOLD_DAYS
   }, [project?.inserted_at])
+
+  const activeRealtimeVariant = useMemo(() => {
+    if (!isTable || !isNewProject) return null
+    if (!realtimeButtonVariant || realtimeButtonVariant === RealtimeButtonVariant.CONTROL)
+      return null
+    return realtimeButtonVariant
+  }, [isTable, isNewProject, realtimeButtonVariant])
+
+  const shouldTrackExposure =
+    isTable &&
+    isNewProject &&
+    realtimeButtonVariant !== false &&
+    realtimeButtonVariant !== undefined
 
   const hasTrackedExposure = useRef(false)
 
@@ -187,14 +199,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const manageTriggersHref = `/project/${ref}/database/triggers?schema=${table.schema}`
 
   useEffect(() => {
-    if (
-      !hasTrackedExposure.current &&
-      project &&
-      org &&
-      isTable &&
-      isNewProject &&
-      hideRealtimeButton !== undefined
-    ) {
+    if (shouldTrackExposure && !hasTrackedExposure.current && project) {
       hasTrackedExposure.current = true
 
       const daysSinceCreation = Math.floor(
@@ -202,24 +207,24 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
       )
 
       track('realtime_experiment_exposed', {
-        variant: hideRealtimeButton ? 'hide_enable_button' : 'control',
+        variant: realtimeButtonVariant as RealtimeButtonVariant,
         table_has_realtime_enabled: isRealtimeEnabled,
         days_since_project_creation: daysSinceCreation,
       })
     }
-  }, [hideRealtimeButton, project, org, isTable, isNewProject, isRealtimeEnabled, track])
+  }, [shouldTrackExposure, realtimeButtonVariant, project, isRealtimeEnabled, track])
 
   const toggleRealtime = async () => {
     if (!project) return console.error('Project is required')
     if (!realtimePublication) return console.error('Unable to find realtime publication')
 
-    const exists = realtimeEnabledTables.some((x: any) => x.id == table.id)
+    const exists = realtimeEnabledTables.some((x: any) => x.id === table.id)
     const tables = !exists
       ? [`${table.schema}.${table.name}`].concat(
           realtimeEnabledTables.map((t: any) => `${t.schema}.${t.name}`)
         )
       : realtimeEnabledTables
-          .filter((x: any) => x.id != table.id)
+          .filter((x: any) => x.id !== table.id)
           .map((x: any) => `${x.schema}.${x.name}`)
 
     track('realtime_toggle_table_clicked', {
@@ -373,7 +378,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
             )
           ) : null}
 
-          {isTable && triggersInsteadOfRealtime ? (
+          {isTable && activeRealtimeVariant === RealtimeButtonVariant.TRIGGERS ? (
             <Button
               asChild
               type={'default'}
@@ -396,7 +401,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
               </Link>
             </Button>
           ) : (
-            !(isNewProject && hideRealtimeButton) &&
+            activeRealtimeVariant !== RealtimeButtonVariant.HIDE_BUTTON &&
             realtimeEnabled && (
               <ButtonTooltip
                 type="default"

--- a/apps/studio/lib/constants/experiments.ts
+++ b/apps/studio/lib/constants/experiments.ts
@@ -1,0 +1,4 @@
+/**
+ * Days after project creation to be considered "new" for experiment targeting
+ */
+export const NEW_PROJECT_THRESHOLD_DAYS = 7

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -1,6 +1,7 @@
 // Ignore barrel file rule here since it's just exporting more constants
 // eslint-disable-next-line barrel-files/avoid-re-export-all
 export * from './infrastructure'
+export * from './experiments'
 
 export const IS_PLATFORM = process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
 

--- a/apps/studio/types/experiments.ts
+++ b/apps/studio/types/experiments.ts
@@ -1,0 +1,5 @@
+export enum RealtimeButtonVariant {
+  CONTROL = 'control',
+  HIDE_BUTTON = 'hide-button',
+  TRIGGERS = 'triggers',
+}

--- a/apps/studio/types/index.ts
+++ b/apps/studio/types/index.ts
@@ -7,6 +7,7 @@ export {
   type Role,
   type SupaResponse,
 } from './base'
+export * from './experiments'
 export type * from './form'
 export type * from './next'
 export { isNextPageWithLayout } from './next'

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1611,7 +1611,7 @@ export interface RealtimeExperimentExposedEvent {
     /**
      * The experiment variant shown to the user
      */
-    variant: 'control' | 'hide_enable_button'
+    variant: 'control' | 'hide-button' | 'triggers'
     /**
      * Whether the table already has realtime enabled
      */


### PR DESCRIPTION
## Summary

Consolidates two separate feature flags into a single multivariate PostHog flag for the realtime button experiment.

**Before:**
- `hideRealtimeButton` PostHog flag (boolean-like)
- `triggersInsteadOfRealtime` ConfigCat flag (separate system)

**After:**
- Single `realtimeButtonVariant` PostHog flag with three variations:
  - `control`: Standard experience with realtime button
  - `hide-button`: Hides the realtime button for new projects
  - `triggers`: Shows triggers link instead of realtime button

## Changes

- Created `types/experiments.ts` for experiment-related type definitions
- Created `lib/constants/experiments.ts` for experiment-related constants
- Updated `GridHeaderActions.tsx` to use consolidated flag
- Updated `TableEditor.tsx` to use consolidated flag
- Removed ConfigCat `triggersInsteadOfRealtime` flag implementation
- Updated telemetry constants to reflect new variant values
- Simplified variant checking logic with early returns and memoization
- Fixed equality operators (== to ===)

## Test Plan

- [ ] Verify control variant shows realtime button as normal
- [ ] Verify hide-button variant hides realtime button for new projects
- [ ] Verify triggers variant shows triggers link instead of button for new projects
- [ ] Verify exposure tracking event fires correctly with proper variant
- [ ] Verify old projects (>7 days) are not affected by experiment