### PR TITLE
fix: project selector dropdown positioning in usage page

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -158,6 +158,7 @@ export const Usage = () => {
                     open={openProjectSelector}
                     setOpen={setOpenProjectSelector}
                     selectedRef={selectedProjectRef}
+                    portal={true}
                     onSelect={(project) => {
                       setSelectedProjectRef(project.ref)
                     }}

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -28,6 +28,7 @@ interface OrganizationProjectSelectorSelectorProps {
   selectedRef?: string | null
   searchPlaceholder?: string
   sameWidthAsTrigger?: boolean
+  portal?: boolean
   checkPosition?: 'right' | 'left'
   setOpen?: (value: boolean) => void
   renderRow?: (project: OrgProject) => ReactNode
@@ -51,6 +52,7 @@ export const OrganizationProjectSelector = ({
   selectedRef,
   searchPlaceholder = 'Find project...',
   sameWidthAsTrigger = false,
+  portal = false,
   checkPosition = 'right',
   renderRow,
   renderTrigger,
@@ -149,6 +151,7 @@ export const OrganizationProjectSelector = ({
         className="p-0"
         side="bottom"
         align="start"
+        portal={portal}
       >
         <Command_Shadcn_ shouldFilter={false}>
           <CommandInput_Shadcn_


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Add optional portal prop to OrganizationProjectSelector (default false) to fix dropdown positioning in sticky container on usage page. 
Usage page opts into portal={true} while preserving existing behavior in all other locations (dialogs, forms, navigation).

P.S Follows established portal pattern used in DatabaseSelector, SchemaSelector, and FilterPopover components for consistent selector dropdown behavior.

Fixes #40256

<details>
  <summary><strong>Screenshots</strong></summary>

  ### Before
  <img width="600" height="254" alt="Before" src="https://github.com/user-attachments/assets/865c8f46-3d15-4df3-945d-e38519a7374c" />

  ### After
  <img width="576" height="254" alt="After" src="https://github.com/user-attachments/assets/839414cb-4a1c-4dfc-ac5a-0ed4ae78044c" />
</details>

