### PR TITLE
fix(studio): type ManagedBy more strongly

### DIFF
--- a/apps/studio/lib/constants/infrastructure.ts
+++ b/apps/studio/lib/constants/infrastructure.ts
@@ -16,7 +16,7 @@ export const MANAGED_BY = {
   VERCEL_MARKETPLACE: 'vercel-marketplace',
   AWS_MARKETPLACE: 'aws-marketplace',
   SUPABASE: 'supabase',
-}
+} as const
 
 export type ManagedBy = (typeof MANAGED_BY)[keyof typeof MANAGED_BY]
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`type ManagedBy` is actually `string`, not just `"vercel-marketplace" | "aws-marketplace" | "supabase"` as was intended by defining `ManagedBy` as `(typeof MANAGED_BY)[keyof typeof MANAGED_BY]`.

## What is the new behavior?

`ManagedBy` is more specific now.