### PR TITLE
Document region runtime information for functions

### DIFF
--- a/apps/docs/content/guides/functions/regional-invocation.mdx
+++ b/apps/docs/content/guides/functions/regional-invocation.mdx
@@ -85,7 +85,7 @@ Functions have access to the following environment variables:
 
 SB_REGION: The AWS region function was invoked
 
-This is usefull if you have read replicate and want to postgres connect to a different replicate according of the Region.
+This is useful if you have read replicate and want to Postgres connect to a different replicate according of the Region.
 
 ---
 

--- a/apps/docs/content/guides/functions/regional-invocation.mdx
+++ b/apps/docs/content/guides/functions/regional-invocation.mdx
@@ -79,6 +79,16 @@ You can verify the execution region by looking at the `x-sb-edge-region` HTTP he
 
 ---
 
+## Region runtime information
+
+Functions have access to the following environment variables:
+
+SB_REGION: The AWS region function was invoked
+
+This is usefull if you have read replicate and want to postgres connect to a different replicate according of the Region.
+
+---
+
 ## Region outages
 
 When you explicitly specify a region via the `x-region` header, requests will NOT be automatically


### PR DESCRIPTION
This pull request adds documentation about region runtime information for functions, specifically detailing available environment variables. This helps developers understand how to access region-specific details during function execution.

Documentation updates:

* Added a new section describing the `SB_REGION` environment variable, which indicates the AWS region where the function was invoked. This is useful for connecting to different database replicas based on region.Added section on region runtime information and environment variables.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
