### PR TITLE
fix(docs): SvelteKit Auth hooks.server.ts inconsistent

### DIFF
--- a/examples/user-management/sveltekit-user-management/src/hooks.server.ts
+++ b/examples/user-management/sveltekit-user-management/src/hooks.server.ts
@@ -27,6 +27,12 @@ export const handle: Handle = async ({ event, resolve }) => {
    * `getUser` and aborts early if the JWT signature is invalid.
    */
   event.locals.safeGetSession = async () => {
+     const {
+      data: { session },
+    } = await event.locals.supabase.auth.getSession()
+    return { session, user }
+  }
+  
     const {
       data: { user },
       error,
@@ -35,12 +41,7 @@ export const handle: Handle = async ({ event, resolve }) => {
       return { session: null, user: null }
     }
 
-    const {
-      data: { session },
-    } = await event.locals.supabase.auth.getSession()
-    return { session, user }
-  }
-
+   
   return resolve(event, {
     filterSerializedResponseHeaders(name: string) {
       return name === 'content-range' || name === 'x-supabase-api-version'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Fix getSession() call before getUser(), which helps to resolve to resolve unnecessary auth server calls.


## What is the current behavior?

getSession() is now called before getUser(), which helps to resolve to resolve unnecessary auth server calls.


Please link any relevant issues here. #39987


## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
<img width="762" height="396" alt="Screenshot 2025-11-09 182325" src="https://github.com/user-attachments/assets/34b61c82-6777-445f-9be9-c9d0c6624141" />

