### PR TITLE
Refactor/use text confirm modal for delete buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/SimpleConfigurationDetails.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/SimpleConfigurationDetails.tsx
@@ -23,6 +23,8 @@ export const SimpleConfigurationDetails = ({ bucketName }: { bucketName?: string
   const { data: wrapperInstance } = useAnalyticsBucketWrapperInstance({ bucketId: bucketName })
   const wrapperValues = convertKVStringArrayToJson(wrapperInstance?.server_options ?? [])
 
+  if (!wrapperInstance) return null
+
   return (
     <ScaffoldSection isFullWidth>
       <ScaffoldHeader className="flex flex-row justify-between items-end gap-x-8">

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/DeleteAnalyticsBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/DeleteAnalyticsBucketModal.tsx
@@ -1,27 +1,9 @@
-import { zodResolver } from '@hookform/resolvers/zod'
-import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import z from 'zod'
 
 import { useParams } from 'common'
 import { useAnalyticsBucketDeleteMutation } from 'data/storage/analytics-bucket-delete-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogSection,
-  DialogSectionSeparator,
-  DialogTitle,
-  Form_Shadcn_,
-  FormControl_Shadcn_,
-  FormField_Shadcn_,
-  Input_Shadcn_,
-} from 'ui'
-import { Admonition } from 'ui-patterns'
-import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
 import {
   useAnalyticsBucketAssociatedEntities,
   useAnalyticsBucketDeleteCleanUp,
@@ -34,10 +16,6 @@ export interface DeleteAnalyticsBucketModalProps {
   onSuccess?: () => void
 }
 
-const formId = `delete-analytics-bucket-form`
-
-// [Joshen] Can refactor to use TextConfirmModal
-
 export const DeleteAnalyticsBucketModal = ({
   visible,
   bucketId,
@@ -46,16 +24,6 @@ export const DeleteAnalyticsBucketModal = ({
 }: DeleteAnalyticsBucketModalProps) => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
-
-  const schema = z.object({
-    confirm: z.literal(bucketId, {
-      errorMap: () => ({ message: `Please enter "${bucketId}" to confirm` }),
-    }),
-  })
-
-  const form = useForm<z.infer<typeof schema>>({
-    resolver: zodResolver(schema),
-  })
 
   const { icebergWrapper, icebergWrapperMeta, s3AccessKey, publication } =
     useAnalyticsBucketAssociatedEntities({ projectRef, bucketId: bucketId })
@@ -83,7 +51,7 @@ export const DeleteAnalyticsBucketModal = ({
       },
     })
 
-  const onSubmit: SubmitHandler<z.infer<typeof schema>> = async () => {
+  const onConfirmDelete = async () => {
     if (!projectRef) return console.error('Project ref is required')
     if (!bucketId) return console.error('No bucket is selected')
     deleteAnalyticsBucket({ projectRef, id: bucketId })
@@ -92,73 +60,26 @@ export const DeleteAnalyticsBucketModal = ({
   const isDeleting = isDeletingAnalyticsBucket || isCleaningUpAnalyticsBucket
 
   return (
-    <Dialog
-      open={visible}
-      onOpenChange={(open) => {
-        if (!open) onClose()
+    <TextConfirmModal
+      visible={visible}
+      size="medium"
+      variant="destructive"
+      title={`Confirm deletion of ${bucketId}`}
+      loading={isDeleting}
+      confirmPlaceholder="Type bucket name"
+      confirmString={bucketId ?? ''}
+      confirmLabel="Delete bucket"
+      onCancel={onClose}
+      onConfirm={onConfirmDelete}
+      alert={{
+        title: 'You cannot recover this bucket once deleted',
+        description: 'This action cannot be undone',
       }}
     >
-      <DialogContent aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Confirm deletion of {bucketId}</DialogTitle>
-        </DialogHeader>
-
-        <DialogSectionSeparator />
-
-        <Admonition
-          type="destructive"
-          className="rounded-none border-x-0 border-t-0 mb-0"
-          title="You cannot recover this bucket once deleted."
-          description="All bucket data will be lost."
-        />
-
-        <DialogSection>
-          <p className="text-sm">
-            Your bucket <span className="font-bold text-foreground">{bucketId}</span> and all its
-            contents will be permanently deleted.
-          </p>
-        </DialogSection>
-        <DialogSectionSeparator />
-        <DialogSection>
-          <Form_Shadcn_ {...form}>
-            <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-              <FormField_Shadcn_
-                key="confirm"
-                name="confirm"
-                control={form.control}
-                render={({ field }) => (
-                  <FormItemLayout
-                    name="confirm"
-                    label={
-                      <>
-                        Type <span className="font-bold text-foreground">{bucketId}</span> to
-                        confirm.
-                      </>
-                    }
-                  >
-                    <FormControl_Shadcn_>
-                      <Input_Shadcn_
-                        id="confirm"
-                        autoComplete="off"
-                        {...field}
-                        placeholder="Type bucket name"
-                      />
-                    </FormControl_Shadcn_>
-                  </FormItemLayout>
-                )}
-              />
-            </form>
-          </Form_Shadcn_>
-        </DialogSection>
-        <DialogFooter>
-          <Button type="default" disabled={isDeleting} onClick={onClose}>
-            Cancel
-          </Button>
-          <Button form={formId} htmlType="submit" type="danger" loading={isDeleting}>
-            Delete bucket
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <p className="text-sm">
+        Your bucket <span className="font-bold text-foreground">{bucketId}</span> and all of its
+        contents will be permanently deleted.
+      </p>
+    </TextConfirmModal>
   )
 }

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -1,57 +1,26 @@
-import { zodResolver } from '@hookform/resolvers/zod'
 import { get as _get, find } from 'lodash'
 import { useRouter } from 'next/router'
-import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import z from 'zod'
 
 import { useParams } from 'common'
 import { useDatabasePoliciesQuery } from 'data/database-policies/database-policies-query'
 import { useDatabasePolicyDeleteMutation } from 'data/database-policies/database-policy-delete-mutation'
-import { AnalyticsBucket } from 'data/storage/analytics-buckets-query'
 import { useBucketDeleteMutation } from 'data/storage/bucket-delete-mutation'
 import { Bucket, useBucketsQuery } from 'data/storage/buckets-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogSection,
-  DialogSectionSeparator,
-  DialogTitle,
-  Form_Shadcn_,
-  FormControl_Shadcn_,
-  FormField_Shadcn_,
-  Input_Shadcn_,
-} from 'ui'
-import { Admonition } from 'ui-patterns'
-import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { TextConfirmModal } from 'ui-patterns/Dialogs/TextConfirmModal'
 import { formatPoliciesForStorage } from './Storage.utils'
 
 export interface DeleteBucketModalProps {
   visible: boolean
-  bucket: Bucket | AnalyticsBucket
+  bucket: Bucket
   onClose: () => void
 }
-
-const formId = `delete-storage-bucket-form`
 
 export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModalProps) => {
   const router = useRouter()
   const { ref: projectRef, bucketId } = useParams()
   const { data: project } = useSelectedProjectQuery()
-
-  const schema = z.object({
-    confirm: z.literal(bucket.id, {
-      errorMap: () => ({ message: `Please enter "${bucket.id}" to confirm` }),
-    }),
-  })
-
-  const form = useForm<z.infer<typeof schema>>({
-    resolver: zodResolver(schema),
-  })
 
   const { data } = useBucketsQuery({ projectRef })
   const buckets = data ?? []
@@ -62,7 +31,8 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
     schema: 'storage',
   })
 
-  const { mutateAsync: deletePolicy } = useDatabasePolicyDeleteMutation()
+  const { mutateAsync: deletePolicy, isLoading: isDeletingPolicies } =
+    useDatabasePolicyDeleteMutation()
 
   const { mutate: deleteBucket, isLoading: isDeletingBucket } = useBucketDeleteMutation({
     onSuccess: async () => {
@@ -102,80 +72,32 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
     },
   })
 
-  const onSubmit: SubmitHandler<z.infer<typeof schema>> = async () => {
+  const onConfirmDelete = async () => {
     if (!projectRef) return console.error('Project ref is required')
     if (!bucket) return console.error('No bucket is selected')
     deleteBucket({ projectRef, id: bucket.id })
   }
 
   return (
-    <Dialog
-      open={visible}
-      onOpenChange={(open) => {
-        if (!open) onClose()
+    <TextConfirmModal
+      visible={visible}
+      variant="destructive"
+      title={`Confirm deletion of ${bucket.id}`}
+      loading={isDeletingBucket || isDeletingPolicies}
+      confirmPlaceholder="Type bucket name"
+      confirmString={bucket.id}
+      confirmLabel="Delete bucket"
+      onCancel={onClose}
+      onConfirm={onConfirmDelete}
+      alert={{
+        title: 'You cannot recover this bucket once deleted',
+        description: 'This action cannot be undone',
       }}
     >
-      <DialogContent aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Confirm deletion of {bucket.id}</DialogTitle>
-        </DialogHeader>
-
-        <DialogSectionSeparator />
-
-        <Admonition
-          type="destructive"
-          className="rounded-none border-x-0 border-t-0 mb-0"
-          title="You cannot recover this bucket once deleted."
-          description="All bucket data will be lost."
-        />
-
-        <DialogSection>
-          <p className="text-sm">
-            Your bucket <span className="font-bold text-foreground">{bucket.id}</span> and all its
-            contents will be permanently deleted.
-          </p>
-        </DialogSection>
-        <DialogSectionSeparator />
-        <DialogSection>
-          <Form_Shadcn_ {...form}>
-            <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
-              <FormField_Shadcn_
-                key="confirm"
-                name="confirm"
-                control={form.control}
-                render={({ field }) => (
-                  <FormItemLayout
-                    name="confirm"
-                    label={
-                      <>
-                        Type <span className="font-bold text-foreground">{bucket.id}</span> to
-                        confirm.
-                      </>
-                    }
-                  >
-                    <FormControl_Shadcn_>
-                      <Input_Shadcn_
-                        id="confirm"
-                        autoComplete="off"
-                        {...field}
-                        placeholder="Type bucket name"
-                      />
-                    </FormControl_Shadcn_>
-                  </FormItemLayout>
-                )}
-              />
-            </form>
-          </Form_Shadcn_>
-        </DialogSection>
-        <DialogFooter>
-          <Button type="default" disabled={isDeletingBucket} onClick={onClose}>
-            Cancel
-          </Button>
-          <Button form={formId} htmlType="submit" type="danger" loading={isDeletingBucket}>
-            Delete bucket
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <p className="text-sm">
+        Your bucket <span className="font-bold text-foreground">{bucket.id}</span> and all of its
+        contents will be permanently deleted. Are you sure?
+      </p>
+    </TextConfirmModal>
   )
 }

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -81,6 +81,7 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
   return (
     <TextConfirmModal
       visible={visible}
+      size="medium"
       variant="destructive"
       title={`Confirm deletion of ${bucket.id}`}
       loading={isDeletingBucket || isDeletingPolicies}
@@ -96,7 +97,7 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
     >
       <p className="text-sm">
         Your bucket <span className="font-bold text-foreground">{bucket.id}</span> and all of its
-        contents will be permanently deleted. Are you sure?
+        contents will be permanently deleted.
       </p>
     </TextConfirmModal>
   )

--- a/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
@@ -135,7 +135,7 @@ describe(`DeleteBucketModal`, () => {
     fireEvent.click(confirmButton)
 
     await waitFor(() => {
-      expect(screen.getByText(/Please enter/)).toBeInTheDocument()
+      expect(screen.getByText(/Value entered does not match/)).toBeInTheDocument()
     })
   })
 })

--- a/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
@@ -119,23 +119,4 @@ describe(`DeleteBucketModal`, () => {
     await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
     expect(routerMock.asPath).toStrictEqual(`/project/default/storage/files`)
   })
-
-  it(`prevents submission when the input doesn't match the bucket name`, async () => {
-    const onClose = vi.fn()
-    render(<Page onClose={onClose} />)
-
-    const openButton = screen.getByRole(`button`, { name: `Open` })
-    await userEvent.click(openButton)
-    await screen.findByRole(`dialog`)
-
-    const input = screen.getByLabelText(/Type/)
-    await userEvent.type(input, `invalid`)
-
-    const confirmButton = screen.getByRole(`button`, { name: `Delete bucket` })
-    fireEvent.click(confirmButton)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Value entered does not match/)).toBeInTheDocument()
-    })
-  })
 })

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -51,7 +51,7 @@ export interface TextConfirmModalProps {
   errorMessage?: string
 }
 
-const TextConfirmModal = forwardRef<
+export const TextConfirmModal = forwardRef<
   React.ElementRef<typeof DialogContent>,
   React.ComponentPropsWithoutRef<typeof Dialog> & TextConfirmModalProps
 >(
@@ -98,6 +98,8 @@ const TextConfirmModal = forwardRef<
         confirmValue: '',
       },
     })
+
+    const isFormValid = form.formState.isValid
 
     // 2. Define a submit handler.
     function onSubmit(values: z.infer<typeof formSchema>) {
@@ -197,7 +199,7 @@ const TextConfirmModal = forwardRef<
                   }
                   htmlType="submit"
                   loading={loading}
-                  disabled={loading}
+                  disabled={!isFormValid || loading}
                   className="truncate"
                 >
                   {confirmLabel}


### PR DESCRIPTION
Fixes DEPR-204

## Context

Just refactoring all delete bucket modals to use `TextConfirmModal` component instead.

Also updates `TextConfirmModal` to disable the delete CTA until the text string matches for better visual indication that the input value matches the confirmation string