### PR TITLE
Advisor refine

### DIFF
--- a/apps/studio/components/ui/AdvisorPanel/AdvisorDetail.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorDetail.tsx
@@ -1,18 +1,9 @@
-import { lintInfoMap } from 'components/interfaces/Linter/Linter.utils'
 import LintDetail from 'components/interfaces/Linter/LintDetail'
 import { Lint } from 'data/lint/lint-query'
 import { Notification } from 'data/notifications/notifications-v2-query'
 import { noop } from 'lodash'
-import { AdvisorItem } from './AdvisorPanelHeader'
+import type { AdvisorItem } from './AdvisorPanel.types'
 import { NotificationDetail } from './NotificationDetail'
-
-export const getAdvisorItemDisplayTitle = (item: AdvisorItem): string => {
-  if (item.source === 'lint') {
-    const lint = item.original as Lint
-    return lintInfoMap.find((info) => info.name === lint.name)?.title || item.title.replace(/[`\\]/g, '')
-  }
-  return item.title.replace(/[`\\]/g, '')
-}
 
 interface AdvisorDetailProps {
   item: AdvisorItem

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorDetail.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorDetail.tsx
@@ -1,9 +1,18 @@
+import { lintInfoMap } from 'components/interfaces/Linter/Linter.utils'
 import LintDetail from 'components/interfaces/Linter/LintDetail'
 import { Lint } from 'data/lint/lint-query'
 import { Notification } from 'data/notifications/notifications-v2-query'
 import { noop } from 'lodash'
 import { AdvisorItem } from './AdvisorPanelHeader'
 import { NotificationDetail } from './NotificationDetail'
+
+export const getAdvisorItemDisplayTitle = (item: AdvisorItem): string => {
+  if (item.source === 'lint') {
+    const lint = item.original as Lint
+    return lintInfoMap.find((info) => info.name === lint.name)?.title || item.title.replace(/[`\\]/g, '')
+  }
+  return item.title.replace(/[`\\]/g, '')
+}
 
 interface AdvisorDetailProps {
   item: AdvisorItem

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
@@ -16,8 +16,9 @@ import { AdvisorSeverity, AdvisorTab, useAdvisorStateSnapshot } from 'state/advi
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { AdvisorDetail } from './AdvisorDetail'
 import { AdvisorFilters } from './AdvisorFilters'
+import type { AdvisorItem } from './AdvisorPanel.types'
 import { AdvisorPanelBody } from './AdvisorPanelBody'
-import { AdvisorItem, AdvisorPanelHeader } from './AdvisorPanelHeader'
+import { AdvisorPanelHeader } from './AdvisorPanelHeader'
 
 const severityOrder: Record<AdvisorSeverity, number> = {
   critical: 0,

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.types.ts
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.types.ts
@@ -1,0 +1,13 @@
+import { Lint } from 'data/lint/lint-query'
+import { Notification } from 'data/notifications/notifications-v2-query'
+import { AdvisorItemSource, AdvisorSeverity } from 'state/advisor-state'
+
+export type AdvisorItem = {
+  id: string
+  title: string
+  severity: AdvisorSeverity
+  createdAt?: number
+  tab: 'security' | 'performance' | 'messages'
+  source: AdvisorItemSource
+  original: Lint | Notification
+}

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
@@ -1,0 +1,10 @@
+import dayjs from 'dayjs'
+
+export const formatItemDate = (timestamp: number): string => {
+  const insertedAt = timestamp
+  const daysFromNow = dayjs().diff(dayjs(insertedAt), 'day')
+  const formattedTimeFromNow = dayjs(insertedAt).fromNow()
+  const formattedInsertedAt = dayjs(insertedAt).format('MMM DD, YYYY')
+  return daysFromNow > 1 ? formattedInsertedAt : formattedTimeFromNow
+}
+

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
@@ -1,4 +1,10 @@
 import dayjs from 'dayjs'
+import { Gauge, Inbox, Shield } from 'lucide-react'
+
+import { lintInfoMap } from 'components/interfaces/Linter/Linter.utils'
+import { Lint } from 'data/lint/lint-query'
+import { AdvisorSeverity, AdvisorTab } from 'state/advisor-state'
+import type { AdvisorItem } from './AdvisorPanel.types'
 
 export const formatItemDate = (timestamp: number): string => {
   const insertedAt = timestamp
@@ -8,3 +14,37 @@ export const formatItemDate = (timestamp: number): string => {
   return daysFromNow > 1 ? formattedInsertedAt : formattedTimeFromNow
 }
 
+export const getAdvisorItemDisplayTitle = (item: AdvisorItem): string => {
+  if (item.source === 'lint') {
+    const lint = item.original as Lint
+    return (
+      lintInfoMap.find((info) => info.name === lint.name)?.title || item.title.replace(/[`\\]/g, '')
+    )
+  }
+  return item.title.replace(/[`\\]/g, '')
+}
+
+export const tabIconMap: Record<Exclude<AdvisorTab, 'all'>, React.ElementType> = {
+  security: Shield,
+  performance: Gauge,
+  messages: Inbox,
+}
+
+export const severityColorClasses: Record<AdvisorSeverity, string> = {
+  critical: 'text-destructive',
+  warning: 'text-warning',
+  info: 'text-foreground-light',
+}
+
+export const severityBadgeVariants: Record<AdvisorSeverity, 'destructive' | 'warning' | 'default'> =
+  {
+    critical: 'destructive',
+    warning: 'warning',
+    info: 'default',
+  }
+
+export const severityLabels: Record<AdvisorSeverity, string> = {
+  critical: 'Critical',
+  warning: 'Warning',
+  info: 'Info',
+}

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
@@ -7,10 +7,9 @@ import { AdvisorSeverity, AdvisorTab } from 'state/advisor-state'
 import type { AdvisorItem } from './AdvisorPanel.types'
 
 export const formatItemDate = (timestamp: number): string => {
-  const insertedAt = timestamp
-  const daysFromNow = dayjs().diff(dayjs(insertedAt), 'day')
-  const formattedTimeFromNow = dayjs(insertedAt).fromNow()
-  const formattedInsertedAt = dayjs(insertedAt).format('MMM DD, YYYY')
+  const daysFromNow = dayjs().diff(dayjs(timestamp), 'day')
+  const formattedTimeFromNow = dayjs(timestamp).fromNow()
+  const formattedInsertedAt = dayjs(timestamp).format('MMM DD, YYYY')
   return daysFromNow > 1 ? formattedInsertedAt : formattedTimeFromNow
 }
 

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
@@ -48,3 +48,19 @@ export const severityLabels: Record<AdvisorSeverity, string> = {
   warning: 'Warning',
   info: 'Info',
 }
+
+export const getLintEntityString = (lint: Lint | null): string | undefined => {
+  if (!lint?.metadata) {
+    return undefined
+  }
+
+  if (lint.metadata.entity) {
+    return lint.metadata.entity
+  }
+
+  if (lint.metadata.schema && lint.metadata.name) {
+    return `${lint.metadata.schema}.${lint.metadata.name}`
+  }
+
+  return undefined
+}

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
@@ -3,13 +3,15 @@ import { AlertTriangle, ChevronRight, Inbox } from 'lucide-react'
 import { Lint } from 'data/lint/lint-query'
 import { Notification } from 'data/notifications/notifications-v2-query'
 import { AdvisorSeverity, AdvisorTab } from 'state/advisor-state'
-import { Button, cn } from 'ui'
+import { Badge, Button, cn } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
 import type { AdvisorItem } from './AdvisorPanel.types'
 import {
   formatItemDate,
   getAdvisorItemDisplayTitle,
+  severityBadgeVariants,
   severityColorClasses,
+  severityLabels,
   tabIconMap,
 } from './AdvisorPanel.utils'
 import { EmptyAdvisor } from './EmptyAdvisor'
@@ -120,7 +122,7 @@ export const AdvisorPanelBody = ({
                 onClick={() => onItemClick(item)}
               >
                 <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 overflow-hidden">
+                  <div className="flex items-center gap-3 overflow-hidden">
                     <SeverityIcon
                       size={16}
                       strokeWidth={1.5}
@@ -141,11 +143,18 @@ export const AdvisorPanelBody = ({
                       )}
                     </div>
                   </div>
-                  <ChevronRight
-                    size={16}
-                    strokeWidth={1.5}
-                    className="flex-shrink-0 text-foreground-lighter"
-                  />
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {item.severity === 'critical' && (
+                      <Badge variant={severityBadgeVariants[item.severity]}>
+                        {severityLabels[item.severity]}
+                      </Badge>
+                    )}
+                    <ChevronRight
+                      size={16}
+                      strokeWidth={1.5}
+                      className="flex-shrink-0 text-foreground-lighter"
+                    />
+                  </div>
                 </div>
               </Button>
             </div>

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
@@ -9,6 +9,7 @@ import type { AdvisorItem } from './AdvisorPanel.types'
 import {
   formatItemDate,
   getAdvisorItemDisplayTitle,
+  getLintEntityString,
   severityBadgeVariants,
   severityColorClasses,
   severityLabels,
@@ -104,12 +105,7 @@ export const AdvisorPanelBody = ({
 
           // Secondary text: entity for lint items when no date, date for notifications
           const hasDate = !!item.createdAt
-          const entityString =
-            lint?.metadata &&
-            (lint.metadata.entity ||
-              (lint.metadata.schema &&
-                lint.metadata.name &&
-                `${lint.metadata.schema}.${lint.metadata.name}`))
+          const entityString = getLintEntityString(lint)
 
           return (
             <div key={`${item.source}-${item.id}`} className="border-b">

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelBody.tsx
@@ -1,13 +1,17 @@
-import { AlertTriangle, ChevronRight, Gauge, Inbox, Shield } from 'lucide-react'
+import { AlertTriangle, ChevronRight, Inbox } from 'lucide-react'
 
-import { lintInfoMap } from 'components/interfaces/Linter/Linter.utils'
 import { Lint } from 'data/lint/lint-query'
 import { Notification } from 'data/notifications/notifications-v2-query'
 import { AdvisorSeverity, AdvisorTab } from 'state/advisor-state'
 import { Button, cn } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
-import { formatItemDate } from './AdvisorPanel.utils'
-import { AdvisorItem } from './AdvisorPanelHeader'
+import type { AdvisorItem } from './AdvisorPanel.types'
+import {
+  formatItemDate,
+  getAdvisorItemDisplayTitle,
+  severityColorClasses,
+  tabIconMap,
+} from './AdvisorPanel.utils'
 import { EmptyAdvisor } from './EmptyAdvisor'
 
 const NoProjectNotice = () => {
@@ -22,18 +26,6 @@ const NoProjectNotice = () => {
       </div>
     </div>
   )
-}
-
-const tabIconMap: Record<Exclude<AdvisorTab, 'all'>, React.ElementType> = {
-  security: Shield,
-  performance: Gauge,
-  messages: Inbox,
-}
-
-const severityColorClasses: Record<AdvisorSeverity, string> = {
-  critical: 'text-destructive',
-  warning: 'text-warning',
-  info: 'text-foreground-light',
 }
 
 interface AdvisorPanelBodyProps {
@@ -98,18 +90,15 @@ export const AdvisorPanelBody = ({
     <>
       <div className="flex flex-col">
         {filteredItems.map((item) => {
-          const SeverityIcon = tabIconMap[item.tab]
+          const SeverityIcon = tabIconMap[item.tab as Exclude<AdvisorTab, 'all'>]
           const severityClass = severityColorClasses[item.severity]
           const isNotification = item.source === 'notification'
           const notification = isNotification ? (item.original as Notification) : null
           const isUnread = notification?.status === 'new'
           const lint = !isNotification ? (item.original as Lint) : null
 
-          // For lint items, get issue type title from lintInfoMap
-          const issueTypeTitle = lint && lintInfoMap.find((info) => info.name === lint.name)?.title
-
           // Primary text: issue type for lint items, title for notifications
-          const primaryText = issueTypeTitle || item.title.replace(/[`\\]/g, '')
+          const primaryText = getAdvisorItemDisplayTitle(item)
 
           // Secondary text: entity for lint items when no date, date for notifications
           const hasDate = !!item.createdAt

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelHeader.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelHeader.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, X } from 'lucide-react'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { AdvisorItemSource, AdvisorSeverity } from 'state/advisor-state'
 import { Badge } from 'ui'
+import { getAdvisorItemDisplayTitle } from './AdvisorDetail'
 
 export type AdvisorItem = {
   id: string
@@ -12,7 +13,7 @@ export type AdvisorItem = {
   createdAt?: number
   tab: 'security' | 'performance' | 'messages'
   source: AdvisorItemSource
-  original: any
+  original: Lint | Notification
 }
 
 export const severityBadgeVariants: Record<AdvisorSeverity, 'destructive' | 'warning' | 'default'> =
@@ -35,6 +36,8 @@ interface AdvisorPanelHeaderProps {
 }
 
 export const AdvisorPanelHeader = ({ selectedItem, onBack, onClose }: AdvisorPanelHeaderProps) => {
+  const displayTitle = selectedItem ? getAdvisorItemDisplayTitle(selectedItem) : undefined
+
   return (
     <div className="border-b px-4 py-3 flex items-center gap-3">
       <ButtonTooltip
@@ -46,7 +49,7 @@ export const AdvisorPanelHeader = ({ selectedItem, onBack, onClose }: AdvisorPan
       />
       <div className="flex items-center gap-2 overflow-hidden flex-1">
         <div className="flex-1 flex flex-col gap-0.5">
-          <span className="heading-default">{selectedItem?.title?.replace(/[`\\]/g, '')}</span>
+          <span className="heading-default">{displayTitle}</span>
           {selectedItem?.createdAt && (
             <span className="text-xs text-foreground-light capitalize-sentence">
               {(() => {

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelHeader.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelHeader.tsx
@@ -1,33 +1,14 @@
-import dayjs from 'dayjs'
 import { ChevronLeft, X } from 'lucide-react'
 
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { AdvisorItemSource, AdvisorSeverity } from 'state/advisor-state'
 import { Badge } from 'ui'
-import { getAdvisorItemDisplayTitle } from './AdvisorDetail'
-
-export type AdvisorItem = {
-  id: string
-  title: string
-  severity: AdvisorSeverity
-  createdAt?: number
-  tab: 'security' | 'performance' | 'messages'
-  source: AdvisorItemSource
-  original: Lint | Notification
-}
-
-export const severityBadgeVariants: Record<AdvisorSeverity, 'destructive' | 'warning' | 'default'> =
-  {
-    critical: 'destructive',
-    warning: 'warning',
-    info: 'default',
-  }
-
-export const severityLabels: Record<AdvisorSeverity, string> = {
-  critical: 'Critical',
-  warning: 'Warning',
-  info: 'Info',
-}
+import type { AdvisorItem } from './AdvisorPanel.types'
+import {
+  formatItemDate,
+  getAdvisorItemDisplayTitle,
+  severityBadgeVariants,
+  severityLabels,
+} from './AdvisorPanel.utils'
 
 interface AdvisorPanelHeaderProps {
   selectedItem: AdvisorItem | undefined
@@ -52,13 +33,7 @@ export const AdvisorPanelHeader = ({ selectedItem, onBack, onClose }: AdvisorPan
           <span className="heading-default">{displayTitle}</span>
           {selectedItem?.createdAt && (
             <span className="text-xs text-foreground-light capitalize-sentence">
-              {(() => {
-                const insertedAt = selectedItem.createdAt
-                const daysFromNow = dayjs().diff(dayjs(insertedAt), 'day')
-                const formattedTimeFromNow = dayjs(insertedAt).fromNow()
-                const formattedInsertedAt = dayjs(insertedAt).format('MMM DD, YYYY')
-                return daysFromNow > 1 ? formattedInsertedAt : formattedTimeFromNow
-              })()}
+              {formatItemDate(selectedItem.createdAt)}
             </span>
           )}
         </div>


### PR DESCRIPTION

<img width="1044" height="777" alt="image" src="https://github.com/user-attachments/assets/439acde7-09a1-4fc5-890c-48d319d10d87" />


Applies some small visual and content refinements to the Advisor panel. Advisor issue titles can be quite long making it hard to pass. It now displays the type along with entity for Lint issues instead. Also moved a few shared utils and types.

To test:
- Open new advisor panel from toolbar
- View advisor issues
- View messages