### PR TITLE
Only show replication action if publication has been created

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -263,22 +263,26 @@ export const TableRowComponent = ({
                     </Link>
                   </DropdownMenuItem>
 
-                  {isReplicating ? (
-                    <DropdownMenuItem
-                      className="flex items-center gap-x-2"
-                      onClick={() => setShowStopReplicationModal(true)}
-                    >
-                      <Pause size={12} className="text-foreground-lighter" />
-                      <p>Stop replication</p>
-                    </DropdownMenuItem>
-                  ) : (
-                    <DropdownMenuItem
-                      className="flex items-center gap-x-2"
-                      onClick={() => setShowStartReplicationModal(true)}
-                    >
-                      <Play size={12} className="text-foreground-lighter" />
-                      <p>Start replication</p>
-                    </DropdownMenuItem>
+                  {!!publication && (
+                    <>
+                      {isReplicating ? (
+                        <DropdownMenuItem
+                          className="flex items-center gap-x-2"
+                          onClick={() => setShowStopReplicationModal(true)}
+                        >
+                          <Pause size={12} className="text-foreground-lighter" />
+                          <p>Stop replication</p>
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          className="flex items-center gap-x-2"
+                          onClick={() => setShowStartReplicationModal(true)}
+                        >
+                          <Play size={12} className="text-foreground-lighter" />
+                          <p>Start replication</p>
+                        </DropdownMenuItem>
+                      )}
+                    </>
                   )}
 
                   <DropdownMenuSeparator />


### PR DESCRIPTION
## Context

Realised that replication actions on a analytics bucket table should only show if there's a corresponding publication created

<img width="237" height="167" alt="image" src="https://github.com/user-attachments/assets/6b6835ce-e7aa-4c21-a394-8baec81142b2" />


We already have that logic in place by hiding the replication status column in the table UI, but left this one out