### PR TITLE
feat: added @forwardemail to recommended SMTP providers (per #28290)

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
@@ -758,7 +758,7 @@ Deno.serve(async (req) => {
 
 </TabPanel>
 {/* <TabPanel id="http-backup-email-provider" label="Add Backup Email Provider">
-Your company is rapidly growing and depends heavily on email signups. You'd like to configure a backup email provider in case the email provider runs out of credits during your new product launch. Postmark and Sengrid are used as examples but in practice you can use any email provider.
+Your company is rapidly growing and depends heavily on email signups. You'd like to configure a backup email provider in case the email provider runs out of credits during your new product launch. Postmark and Sengrid are used as examples but in practice you can use any email provider such as Forward Email.
 Ensure that you have configured `POSTMARK_SERVER_TOKEN`, `SENDGRID_API_KEY` and `SEND_EMAIL_HOOK_SECRET` in your `.env` file.
 
 ```javascript

--- a/apps/docs/content/guides/auth/auth-smtp.mdx
+++ b/apps/docs/content/guides/auth/auth-smtp.mdx
@@ -41,6 +41,7 @@ Supabase Auth works with any email sending service that supports the SMTP protoc
 
 A non-exhaustive list of services that work with Supabase Auth is:
 
+- [Forward Email](https://forwardemail.net/en/guides/send-email-with-custom-domain-smtp)
 - [Resend](https://resend.com/docs/send-with-supabase-smtp)
 - [AWS SES](https://docs.aws.amazon.com/ses/latest/dg/send-email-smtp.html)
 - [Postmark](https://postmarkapp.com/developer/user-guide/send-email-with-smtp)

--- a/apps/docs/content/guides/deployment/going-into-prod.mdx
+++ b/apps/docs/content/guides/deployment/going-into-prod.mdx
@@ -29,7 +29,7 @@ After developing your project and deciding it's Production Ready, you should run
 - Ensure that you've [set the expiry](/dashboard/project/_/auth/providers) for one-time passwords (OTPs) to a reasonable value that you are comfortable with. We recommend setting this to 3600 seconds (1 hour) or lower.
 - Increase the length of the OTP if you need a higher level of entropy.
 - If your application requires a higher level of security, consider setting up [multi-factor authentication](/docs/guides/auth/auth-mfa) (MFA) for your users.
-- Use a custom SMTP server for auth emails so that your users can see that the mails are coming from a trusted domain (preferably the same domain that your app is hosted on). Grab SMTP credentials from any major email provider such as SendGrid, AWS SES, etc.
+- Use a custom SMTP server for auth emails so that your users can see that the mails are coming from a trusted domain (preferably the same domain that your app is hosted on). Grab SMTP credentials from any major email provider such as Forward Email, SendGrid, AWS SES, etc.
 - Think hard about how _you_ would abuse your service as an attacker, and mitigate.
 - Review these [common cybersecurity threats](https://auth0.com/docs/security/prevent-threats).
 - Check and review issues in your database using [Security Advisor](/dashboard/project/_/database/security-advisor).
@@ -49,7 +49,7 @@ After developing your project and deciding it's Production Ready, you should run
 ## Availability
 
 - Use your own SMTP credentials so that you have full control over the deliverability of your transactional auth emails (see Settings > Auth)
-  - you can grab SMTP credentials from any major email provider such as SendGrid, AWS SES, etc. You can refer to our [SMTP guide](/docs/guides/auth/auth-smtp) for more details.
+  - you can grab SMTP credentials from any major email provider such as Forward Email, SendGrid, AWS SES, etc. You can refer to our [SMTP guide](/docs/guides/auth/auth-smtp) for more details.
   - The default rate limit for auth emails when using a custom SMTP provider is 30 new users per hour, if doing a major public announcement you will likely require more than this.
 - Applications on the Free Plan that exhibit extremely low activity in a 7 day period may be paused by Supabase to save on server resources.
   - You can restore paused projects from the Supabase dashboard.

--- a/apps/docs/content/guides/functions/examples/auth-send-email-hook-react-email-resend.mdx
+++ b/apps/docs/content/guides/functions/examples/auth-send-email-hook-react-email-resend.mdx
@@ -4,7 +4,7 @@ description: 'Use the send email hook to send custom auth emails with React Emai
 tocVideo: 'tlA7BomSCgU'
 ---
 
-Use the [send email hook](/docs/guides/auth/auth-hooks/send-email-hook?queryGroups=language&language=http) to send custom auth emails with [React Email](https://react.email/) and [Resend](https://resend.com/) in Supabase Edge Functions.
+Use the [send email hook](/docs/guides/auth/auth-hooks/send-email-hook?queryGroups=language&language=http) to send custom auth emails with [React Email](https://react.email/) and [Resend](https://resend.com/) in Supabase Edge Functions. This example uses Resend, but you can adapt it to work with other email providers like [Forward Email](https://forwardemail.net/).
 
 <Admonition type="note">
 

--- a/apps/docs/content/guides/functions/examples/send-emails.mdx
+++ b/apps/docs/content/guides/functions/examples/send-emails.mdx
@@ -4,7 +4,7 @@ description: 'Sending emails from Edge Functions using the Resend API.'
 tocVideo: 'Qf7XvL1fjvo'
 ---
 
-Sending emails from Edge Functions using the [Resend API](https://resend.com/).
+Sending emails from Edge Functions using the [Resend API](https://resend.com/). You can also use other email providers like [Forward Email](https://forwardemail.net/).
 
 ### Prerequisites
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -378,7 +378,7 @@ SMTP_PASS=
 SMTP_SENDER_NAME=
 ```
 
-We recommend using [AWS SES](https://aws.amazon.com/ses/). It's extremely cheap and reliable. Restart all services to pick up the new configuration.
+We recommend using [Forward Email](https://forwardemail.net/) or [AWS SES](https://aws.amazon.com/ses/). Both are reliable options for SMTP services. Restart all services to pick up the new configuration.
 
 #### Configuring S3 Storage
 

--- a/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
+++ b/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
@@ -27,6 +27,7 @@ Hey everyone, i've been hearing feedback about how challenging it can be to get 
 A lot of this was figured out through trial and error.
 This is unlikely to be a Supabase Auth bug because Supabase Auth uses the [native Golang SMTP library ](https://pkg.go.dev/net/smtp). If you still have issues setting up Google SMTP, you can try switching to one of these SMTP providers:
 
+- [Forward Email](https://forwardemail.net/en/guides/send-email-with-custom-domain-smtp)
 - [Resend](https://resend.com/blog/how-to-configure-supabase-to-send-emails-from-your-domain)
 - [SendGrid](https://sendgrid.com/en-us)
 - [Mailgun](https://www.mailgun.com/)

--- a/examples/edge-functions/supabase/functions/auth-hook-react-email-resend/README.md
+++ b/examples/edge-functions/supabase/functions/auth-hook-react-email-resend/README.md
@@ -1,5 +1,7 @@
 # Supabase Auth Send Email Hook with React Email and Resend
 
+This example uses Resend, but you can adapt it to work with other email providers like [Forward Email](https://forwardemail.net/).
+
 - [Supabase docs](https://supabase.com/docs/guides/auth/auth-hooks/send-email-hook?queryGroups=language&language=http)
 - [React Email Docs](https://react.email/docs/introduction)
 - [Create a Resend account](https://resend.com/)

--- a/examples/edge-functions/supabase/functions/send-email-resend/README.md
+++ b/examples/edge-functions/supabase/functions/send-email-resend/README.md
@@ -1,6 +1,6 @@
 # Resend with Supabase Edge Functions
 
-This example shows how to use Resend with [Supabase Edge Functions](https://supabase.com/docs/guides/functions).
+This example shows how to use Resend with [Supabase Edge Functions](https://supabase.com/docs/guides/functions). You can adapt this example to work with other email providers like [Forward Email](https://forwardemail.net/).
 
 ## Prerequisites
 

--- a/examples/edge-functions/supabase/functions/send-email-smtp/README.md
+++ b/examples/edge-functions/supabase/functions/send-email-smtp/README.md
@@ -8,7 +8,7 @@ supabase secrets set SMTP_HOSTNAME="your.hostname.com" SMTP_PORT="2587" SMTP_USE
 supabase functions deploy send-email-smtp
 ```
 
-Note: `SMTP_PORT` must be a port other than `25` and `587` as Deno Deploy does not support outgoing connections to ports. AWS SES (port 2587) is recommended.
+Note: `SMTP_PORT` must be a port other than `25` and `587` as Deno Deploy does not support outgoing connections to ports. Forward Email or AWS SES (port 2587) are recommended.
 
 ## Test locally
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs and examples update (this supersedes the closed PR at <https://github.com/supabase/supabase/pull/28290> under the advice of @Hallidayo to reopen a new one).

## What is the current behavior?

Does not include @forwardemail

## What is the new behavior?

Includes @forwardemail as a suggested provider

## Additional context

Forward Email is self-hostable and is 100% open source.  See https://github.com/forwardemail

**Technical whitepaper at https://forwardemail.net/technical-whitepaper.pdf**
