### PR TITLE
Fix table editor not scrollable when no rows

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -147,7 +147,7 @@ export const Grid = memo(
           {(rows ?? []).length === 0 && (
             <div
               className={cn(
-                'absolute top-9 p-2 w-full z-[1]',
+                'absolute top-9 p-2 w-full z-[1] pointer-events-none',
                 isTableEmpty && isDraggedOver && 'border-2 border-dashed',
                 isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
               )}
@@ -177,7 +177,7 @@ export const Grid = memo(
                     </div>
                   ) : (filters ?? []).length === 0 ? (
                     <div className="flex flex-col items-center justify-center col-span-full h-full">
-                      <p className="text-sm text-light">
+                      <p className="text-sm text-light pointer-events-auto">
                         {isDraggedOver ? (
                           isValidFileDraggedOver ? (
                             'Drop your CSV file here'
@@ -190,7 +190,7 @@ export const Grid = memo(
                       </p>
                       {tableEntityType === ENTITY_TYPE.FOREIGN_TABLE ? (
                         <div className="flex items-center space-x-2 mt-4">
-                          <p className="text-sm text-light">
+                          <p className="text-sm text-light pointer-events-auto">
                             This table is a foreign table. Add data to the connected source to get
                             started.
                           </p>
@@ -215,7 +215,7 @@ export const Grid = memo(
                             >
                               Import data from CSV
                             </Button>
-                            <p className="text-xs text-foreground-light">
+                            <p className="text-xs text-foreground-light pointer-events-auto">
                               or drag and drop a CSV file here
                             </p>
                           </div>
@@ -224,7 +224,7 @@ export const Grid = memo(
                     </div>
                   ) : (
                     <div className="flex flex-col items-center justify-center col-span-full h-full">
-                      <p className="text-sm text-light">
+                      <p className="text-sm text-light pointer-events-auto">
                         The filters applied have returned no results from this table
                       </p>
                       <div className="flex items-center space-x-2 mt-4">


### PR DESCRIPTION
Fixes FE-2105

## Context

Table editor is not horizontally scrollable when there's no rows due to the empty state being rendered outside of the DataGrid. For context the reason why we did it this way (using absolutely positioned divs) is because rendering the empty state in the DataGrid (the library has some param to do so) makes the empty state not stay in place when scrolling horizontally (the empty state will scroll as you scroll the table) and it's anchored to the grid

## Changes involved

- Add pointer events none to the empty state to allow scroll events to pass through
- Add pointer events auto to text renders (just in case for some reason the user wants to select and highlight the texts in the empty state)
- Buttons are already pointer events auto so verified that they're all still clickable

## To test

- Create a table that has sufficient number of columns (or columns with long names) such that it'll be scrollable in the table editor
- Verify that you can still scroll the table columns in the editor while the empty state is shown