### PR TITLE
docs: Clarify connection string host/domain variability in migration …

### DIFF
--- a/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
@@ -71,6 +71,17 @@ Here are some things that are not stored directly in your database and will requ
         Use the [Session pooler](/dashboard/project/_?showConnect=true&method=session) connection string by default. If your ISP supports IPv6 or you have the IPv4 add-on enabled, use the direct connection string.
 
       </Admonition>
+      <Admonition type="warning">
+        
+        **Important: Connection String Variation**
+
+        The host name and domain in the examples below (`aws-0-us-east-1` and `.com`) are specific to the default US East 1 region.
+
+        If your project is hosted in a **different region** (e.g., Europe, Asia-Pacific), your actual connection string will have a **different host and domain structure**           (e.g., `.co` or a different regional prefix).
+
+        **Always copy the exact connection string from your active project's dashboard** instead of manually editing the template below.
+
+      </Admonition>
 
       Session pooler connection string:
       ```bash


### PR DESCRIPTION
…guide

The existing connection string examples in Step 1 of the "Restore Dashboard backup" guide are region-specific (e.g., aws-0-us-east-1 and .com). This specificity can mislead users who have projects in different regions (e.g., EU-Central-1, Asia-Pacific), as their actual host domain and structure may differ (e.g., using .co or a different regional prefix).

This commit addresses the issue by:

1.  **Adding a prominent warning/admonition** above the connection string code blocks.
2.  The warning explicitly advises users to **copy the exact connection string from their project dashboard** rather than relying on the template's host/domain structure, preventing potential connection errors due to manual modification.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The existing connection string examples are region-specific, causing confusion for users in different regions who might mistakenly think their dashboard string is incorrect due to domain variations (e.g., .co vs .com).

## What is the new behavior?

A warning admonition is added above the connection string code blocks, explicitly instructing users to copy the exact string from their dashboard rather than relying on the template's host/domain structure.

## Additional context

Add any other context or screenshots.
