### PR TITLE
fix(www): brand asset page tidy up

### DIFF
--- a/apps/www/pages/brand-assets.tsx
+++ b/apps/www/pages/brand-assets.tsx
@@ -11,6 +11,7 @@ import { Download } from 'lucide-react'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 import SectionContainer from '~/components/Layouts/SectionContainer'
+import Link from 'next/link'
 
 const Index = () => {
   // base path for images
@@ -38,18 +39,18 @@ const Index = () => {
       <Layout>
         <Container>
           <SectionContainer className="pb-0 md:pb-0 lg:pb-0">
-            <div className="max-w-xl">
-              <h1 className="text-foreground text-5xl">Brand assets</h1>
-              <p className="text-foreground text-2xl">Download official Supabase logos</p>
-              <p className="text-foreground text-sm">
+            <h1 className="h1">Brand assets</h1>
+            <p className="text-foreground text-xl">Download official Supabase logos</p>
+            <div className="mt-2 sm:max-w-xl max-w-none">
+              <p className="text-foreground-lighter text-sm">
                 All Supabase trademarks, logos, or other brand elements can never be modified or
                 used for any other purpose other than to represent Supabase Inc.
               </p>
             </div>
           </SectionContainer>
-          <SectionContainer>
-            <div className="shadow-small grid grid-cols-12 rounded-lg border border-default">
-              <div className="relative col-span-12 h-60 w-full overflow-auto rounded-lg lg:col-span-5">
+          <SectionContainer className="grid grid-cols-1 md:grid-cols-2 gap-5 lg:pt-12">
+            <div className="shadow-small flex flex-col rounded-lg border border-default bg-surface-75 overflow-hidden">
+              <div className="relative aspect-video w-full overflow-auto border-b">
                 <Image
                   src={supabaseLogoPreview}
                   alt="Supabase logo Preview"
@@ -57,30 +58,28 @@ const Index = () => {
                   objectFit="cover"
                 />
               </div>
-              <div className="col-span-12 flex items-center lg:col-span-7">
-                <div className="p-16">
+              <div className="flex items-center p-5">
+                <div className="gap-y-4 flex flex-col h-full justify-between">
                   <div className="space-y-2">
-                    <h1 className="text-foreground text-4xl">Supabase logos</h1>
-                    <p className="text-foreground-light text-sm">
-                      <p>
-                        Download Supabase official logos, including as SVG's, in both light and dark
-                        theme.
-                      </p>
-                      <p>Do not use any other color for the wordmark.</p>
+                    <h3 className="h3">Supabase logos</h3>
+                    <p className="text-foreground-lighter text-sm">
+                      Download Supabase official logos, including as SVG's, in both light and dark
+                      theme.
                     </p>
-                    <form method="get" action={`/brand-assets.zip`}>
-                      <Button htmlType="submit" type="default" iconRight={<Download />}>
-                        Download logo kit
-                      </Button>
-                    </form>
+                    <p className="text-foreground-lighter text-sm">
+                      Do not use any other color for the wordmark.
+                    </p>
                   </div>
+                  <form method="get" action={`/brand-assets.zip`} className="mt-3">
+                    <Button htmlType="submit" type="default" iconRight={<Download />}>
+                      Download logo kit
+                    </Button>
+                  </form>
                 </div>
               </div>
             </div>
-          </SectionContainer>
-          <SectionContainer className="sm:pt-0 md:pt-0 lg:pt-0 xl:pt-0">
-            <div className="shadow-small grid grid-cols-12 rounded-lg border border-default">
-              <div className="relative col-span-12 h-60 w-full overflow-auto rounded-lg lg:col-span-5 flex items-center justify-center">
+            <div className="shadow-small flex flex-col rounded-lg border border-default bg-surface-75 overflow-hidden">
+              <div className="relative aspect-video w-full overflow-auto flex items-center justify-center border-b">
                 <Image
                   src="https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/supabase-brand-assets/connect-supabase/connect-supabase-dark.svg"
                   alt="Connect Supabase Button"
@@ -88,32 +87,33 @@ const Index = () => {
                   height={31}
                 />
               </div>
-              <div className="col-span-12 flex items-center lg:col-span-7">
-                <div className="p-16">
+              <div className="flex items-center p-5">
+                <div className="gap-y-4 flex flex-col h-full justify-between">
                   <div className="space-y-2">
-                    <h1 className="text-foreground text-4xl">Supabase Integrations</h1>
-                    <p className="text-foreground-light text-sm">
-                      <p>
-                        When building a{' '}
-                        <a
-                          className="underline"
-                          href="/docs/guides/platform/oauth-apps/build-a-supabase-integration"
-                        >
-                          Supabase Integration
-                        </a>
-                        , use this "Connect Supabase" button to initiate the OAuth redirect.
-                      </p>
-                      <p>Do not use any other color for the wordmark.</p>
+                    <h3 className="h3">Supabase Integrations</h3>
+                    <p className="text-foreground-lighter text-sm">
+                      When building a{' '}
+                      <Link
+                        className="text-brand underline"
+                        href="/docs/guides/platform/oauth-apps/build-a-supabase-integration"
+                      >
+                        Supabase Integration
+                      </Link>
+                      , use this "Connect Supabase" button to initiate the OAuth redirect.
                     </p>
-                    <form
-                      method="get"
-                      action={`https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/supabase-brand-assets/connect-supabase/connect-supabase.zip`}
-                    >
-                      <Button htmlType="submit" type="default" iconRight={<Download />}>
-                        Download button kit
-                      </Button>
-                    </form>
+                    <p className="text-foreground-lighter text-sm">
+                      Do not use any other color for the wordmark.
+                    </p>
                   </div>
+                  <form
+                    method="get"
+                    action={`https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/supabase-brand-assets/connect-supabase/connect-supabase.zip`}
+                    className="mt-3"
+                  >
+                    <Button htmlType="submit" type="default" iconRight={<Download />}>
+                      Download button kit
+                    </Button>
+                  </form>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Few alignment/styling issues reported by @craigcannon are now fixed. Took the liberty to tidy the page and simplify it a little. See below:

| Before | After |
|--------|--------|
| <img width="1257" height="765" alt="Screenshot 2025-11-10 at 19 17 10" src="https://github.com/user-attachments/assets/0cf9d403-b197-4bdd-a844-6996ddf7a1d8" /> | <img width="1195" height="897" alt="Screenshot 2025-11-10 at 19 56 45" src="https://github.com/user-attachments/assets/bdc641f3-d34d-4d8e-8103-7f055a37ed2e" /> | 



