### PR TITLE
Fix templateTitle telemetry for production command format

### DIFF
--- a/apps/ui-library/components/command-copy-button.tsx
+++ b/apps/ui-library/components/command-copy-button.tsx
@@ -20,10 +20,11 @@ export function CommandCopyButton({ command }: { command: string }) {
   const parseCommandForTelemetry = (cmd: string) => {
     // Extracts title and framework e.g. "title: password-based-auth, framework: nextjs"
     const match = cmd.match(
-      /(?:\/ui\/r\/|@supabase\/)(.+)-(nextjs|react-router|react|tanstack)(?:@[^@\s]+|\.json)?$/
+      /(?:\/ui\/r\/|@supabase\/)(.+)-(nextjs|react-router|react|tanstack|vue|nuxtjs)(?:@[^@\s]+|\.json)?$/
     )
 
-    const framework = (match?.[2] as 'nextjs' | 'react-router' | 'tanstack' | 'react') ?? 'react'
+    const framework =
+      (match?.[2] as 'nextjs' | 'react-router' | 'tanstack' | 'react' | 'vue' | 'nuxtjs') ?? 'react'
     const title = match?.[1] ?? ''
 
     // Extract package manager from command prefix (npx, pnpm, yarn, bun)

--- a/apps/ui-library/components/command-copy-button.tsx
+++ b/apps/ui-library/components/command-copy-button.tsx
@@ -18,13 +18,13 @@ export function CommandCopyButton({ command }: { command: string }) {
   }, [copied])
 
   const parseCommandForTelemetry = (cmd: string) => {
-    // Extract framework from URL (e.g., 'nextjs' from 'password-based-auth-nextjs.json')
-    const frameworkMatch = cmd.match(/ui\/r\/.*?-(nextjs|react|react-router|tanstack)\.json/)
+    // Extracts title and framework e.g. "title: password-based-auth, framework: nextjs"
+    const match = cmd.match(
+      /(?:\/ui\/r\/|@supabase\/)(.+)-(nextjs|react-router|react|tanstack)(?:@[^@\s]+|\.json)?$/
+    )
 
-    // if the block doesn't have a framework defined (like infinite query), default to react
-    const framework = frameworkMatch
-      ? (frameworkMatch[1] as 'nextjs' | 'react-router' | 'tanstack' | 'react')
-      : 'react'
+    const framework = (match?.[2] as 'nextjs' | 'react-router' | 'tanstack' | 'react') ?? 'react'
+    const title = match?.[1] ?? ''
 
     // Extract package manager from command prefix (npx, pnpm, yarn, bun)
     const packageManager = cmd.startsWith('npx')
@@ -37,15 +37,7 @@ export function CommandCopyButton({ command }: { command: string }) {
             ? ('bun' as const)
             : ('npm' as const)
 
-    // Extract template title from URL (e.g., 'password-based-auth' from 'password-based-auth-nextjs.json')
-    const titleMatch = cmd.match(/\/ui\/r\/(.*?)\.json/)
-    const title = (titleMatch ? titleMatch[1] : '').replaceAll(`-${framework}`, '')
-
-    return {
-      framework,
-      packageManager,
-      title,
-    }
+    return { framework, packageManager, title }
   }
 
   return (

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1219,7 +1219,7 @@ export interface SupabaseUiCommandCopyButtonClickedEvent {
   properties: {
     templateTitle: string
     command: string
-    framework: 'nextjs' | 'react-router' | 'tanstack' | 'react'
+    framework: 'nextjs' | 'react-router' | 'tanstack' | 'react' | 'vue' | 'nuxtjs'
     packageManager: 'npm' | 'pnpm' | 'yarn' | 'bun'
   }
 }


### PR DESCRIPTION
## Problem

The templateTitle property in our command copy button telemetry stopped working in production after we switched to the shadcn registry alias format on Oct 17. Analytics shows templateTitle dropping to zero that week.

## What happened

Back in October we changed the production command format from URL-based to shadcn registry aliases:

**Old format:**
```
npx shadcn@latest add https://supabase.com/ui/r/password-based-auth-nextjs.json
```

**New format:**
```
npx shadcn@latest add @supabase/password-based-auth-nextjs
```

The parsing logic only handled the old `/ui/r/` format, so it couldn't extract template names from the new `@supabase/...` format.

## Changes

Replaced the multi-pass parsing approach with a single consolidated regex that extracts both title and framework atomically:

```typescript
/(?:\/ui\/r\/|@supabase\/)(.+)-(nextjs|react-router|react|tanstack)(?:@[^@\s]+|\.json)?$/
```

This handles both formats in one pass and properly strips the framework suffix from the title through greedy backtracking. Also handles version specifiers like `@latest` correctly.

Went from ~30 lines of conditional logic with multiple regex operations down to ~12 lines.

## Testing

Tested locally with both formats:
- `@supabase/password-based-auth-nextjs` → title: `password-based-auth`, framework: `nextjs`
- `/ui/r/password-based-auth-nextjs.json` → title: `password-based-auth`, framework: `nextjs`
- `@supabase/password-based-auth-nextjs@latest` → title: `password-based-auth`, framework: `nextjs`

**Local testing setup:**
To test telemetry locally, add these to `apps/ui-library/.env`:
```
NEXT_PUBLIC_ENVIRONMENT=local
NEXT_PUBLIC_IS_PLATFORM=true
NEXT_PUBLIC_API_URL="http://localhost:8080/platform"
```
Then restart your dev server. With these set, telemetry consent is auto-accepted and events will be sent to your local backend.

**Note on Vercel preview deployments:**
Telemetry won't work on Vercel preview deployments because they run in production mode and attempt to initialize Usercentrics for consent management. Preview domains are unique per PR and not whitelisted in the Usercentrics account, causing `hasConsented()` to return false and blocking all telemetry. The code works correctly—this is just a deployment configuration limitation. Telemetry will function normally on the production domain once merged.

Fixes GROWTH-538

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates command copy telemetry parsing to handle @supabase registry aliases (and versions) and expands framework support to include vue and nuxtjs.
> 
> - **Supabase UI (command copy button)**:
>   - Replace multi-step parsing with a single regex to extract `title` and `framework` from both `@supabase/...` and `/ui/r/...json` formats, including version suffixes.
>   - Send parsed `framework`, `packageManager`, and `templateTitle` via telemetry.
> - **Telemetry types**:
>   - Extend `SupabaseUiCommandCopyButtonClickedEvent.properties.framework` to include `vue` and `nuxtjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d0b506f944db97c4f5e60fc30ce127676590920. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->