### PR TITLE
fix: handle undefined orgSlug in mobile navsheet on support page

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -377,6 +377,8 @@ const OrganizationLinks = () => {
   const router = useRouter()
   const { slug } = useParams()
 
+  const organizationSlug: string = slug ?? (router.query.orgSlug as string) ?? ''
+
   const { data: org } = useSelectedOrganizationQuery()
   const isUserMFAEnabled = useIsMFAEnabled()
   const disableAccessMfa = org?.organization_requires_mfa && !isUserMFAEnabled
@@ -388,25 +390,25 @@ const OrganizationLinks = () => {
   const navMenuItems = [
     {
       label: 'Projects',
-      href: `/org/${slug}`,
+      href: `/org/${organizationSlug}`,
       key: 'projects',
       icon: <Boxes size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
     },
     {
       label: 'Team',
-      href: `/org/${slug}/team`,
+      href: `/org/${organizationSlug}/team`,
       key: 'team',
       icon: <Users size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
     },
     {
       label: 'Integrations',
-      href: `/org/${slug}/integrations`,
+      href: `/org/${organizationSlug}/integrations`,
       key: 'integrations',
       icon: <Blocks size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
     },
     {
       label: 'Usage',
-      href: `/org/${slug}/usage`,
+      href: `/org/${organizationSlug}/usage`,
       key: 'usage',
       icon: <ChartArea size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
     },
@@ -414,7 +416,7 @@ const OrganizationLinks = () => {
       ? [
           {
             label: 'Billing',
-            href: `/org/${slug}/billing`,
+            href: `/org/${organizationSlug}/billing`,
             key: 'billing',
             icon: <Receipt size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
           },
@@ -422,7 +424,7 @@ const OrganizationLinks = () => {
       : []),
     {
       label: 'Organization settings',
-      href: `/org/${slug}/general`,
+      href: `/org/${organizationSlug}/general`,
       key: 'settings',
       icon: <Settings size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
     },


### PR DESCRIPTION
Fixes the mobile navsheet on the support page so it correctly reads the organization ID from the query string when no path param (slug) exists

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On the support page, on small screens , when a user opens the hamburger menu , all the routes have `undefined `in them . Clicking on them navigates to an undefined organization. This is because the Sidebar content uses params from `useParams().` But on the support page (https://supabase.com/dashboard/support/new?orgSlug=slugid) we do not have the `slug` param. So it's `undefined `

Closes #40269

## What is the new behavior?

The mobile navsheet now correctly populates all routes with the proper organization ID.

- If a `slug `path param exists, it is used.
- If no path param exists, the `orgSlug `query parameter is used instead.

This ensures the sidebar works correctly on both ID-based routes and new-item routes.


## Additional context

To reproduce

1.  Navigate to https://supabase.com/dashboard/support/new?orgSlug={your_org_id}
2. Resize screen to small screen, That's when the hamburger menu shows.
3. Click on any of the routes/links. 
4. You will be navigated here https://supabase.com/dashboard/org/undefined/team


Add any other context or screenshots.
