### PR TITLE
Improve granularity of replication status

### DIFF
--- a/apps/studio/components/interfaces/Database/ETL/EnableReplicationModal.tsx
+++ b/apps/studio/components/interfaces/Database/ETL/EnableReplicationModal.tsx
@@ -20,7 +20,7 @@ export const EnableReplicationModal = () => {
   const { ref: projectRef } = useParams()
   const [open, setOpen] = useState(false)
 
-  const { mutateAsync: createTenantSource, isLoading: creatingTenantSource } =
+  const { mutate: createTenantSource, isLoading: creatingTenantSource } =
     useCreateTenantSourceMutation({
       onSuccess: () => {
         toast.success('Replication has been successfully enabled!')
@@ -33,7 +33,7 @@ export const EnableReplicationModal = () => {
 
   const onEnableReplication = async () => {
     if (!projectRef) return console.error('Project ref is required')
-    await createTenantSource({ projectRef })
+    createTenantSource({ projectRef })
   }
 
   return (

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/NamespaceWithTables.utils.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/NamespaceWithTables.utils.ts
@@ -1,0 +1,13 @@
+import { snakeCase } from 'lodash'
+
+import { ReplicationPublication } from 'data/etl/publications-query'
+
+export const inferPostgresTableFromNamespaceTable = ({
+  publication,
+  tableName,
+}: {
+  publication?: ReplicationPublication
+  tableName: string
+}) => {
+  return publication?.tables.find((x) => tableName === snakeCase(`${x.schema}.${x.name}_changelog`))
+}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -124,9 +124,9 @@ export const TableRowComponent = ({
       })
       await startPipeline({ projectRef, pipelineId: pipeline.id })
       setShowStopReplicationModal(false)
-      toast.success('Successfully stopped replication for table! Pipeline is being restarted.')
+      toast.success('Successfully disabled replication for table! Pipeline is being restarted.')
     } catch (error: any) {
-      toast.error(`Failed to stop replication for table: ${error.message}`)
+      toast.error(`Failed to disable replication for table: ${error.message}`)
     } finally {
       setIsUpdatingReplication(false)
     }
@@ -156,9 +156,9 @@ export const TableRowComponent = ({
       })
       await startPipeline({ projectRef, pipelineId: pipeline.id })
       setShowStartReplicationModal(false)
-      toast.success('Successfully stopped replication for table! Pipeline is being restarted.')
+      toast.success('Successfully enabled replication for table! Pipeline is being restarted.')
     } catch (error: any) {
-      toast.error(`Failed to stop replication for table: ${error.message}`)
+      toast.error(`Failed to enable replication for table: ${error.message}`)
     } finally {
       setIsUpdatingReplication(false)
     }

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -12,7 +12,6 @@ import {
 import { getDecryptedParameters } from 'components/interfaces/Storage/ImportForeignSchemaDialog.utils'
 import { DotPing } from 'components/ui/DotPing'
 import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
-import { InlineLink } from 'components/ui/InlineLink'
 import { useReplicationPipelineStatusQuery } from 'data/etl/pipeline-status-query'
 import { useUpdatePublicationMutation } from 'data/etl/publication-update-mutation'
 import { useStartPipelineMutation } from 'data/etl/start-pipeline-mutation'
@@ -94,12 +93,12 @@ export const TableRowComponent = ({
     if (isLoading) return 'Checking'
     if (hasReplication && isTableUnderReplicationPublication) {
       if (isPipelineRunning) {
-        return 'Replicating'
+        return 'Running'
       } else {
-        return `Replication ${pipelineStatus ?? 'unknown'}`
+        return pipelineStatus ?? 'unknown'
       }
     } else {
-      return 'Not replicating'
+      return 'Stopped'
     }
   }
 
@@ -243,22 +242,15 @@ export const TableRowComponent = ({
                         variant={isReplicating ? 'primary' : 'default'}
                       />
                     )}
-                    <span className="text-foreground-lighter">{getStatusLabel()}</span>
+                    <span className="text-foreground-lighter capitalize">{getStatusLabel()}</span>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  {isReplicating ? (
-                    `Table data is currently replicating${!!inferredPostgresTable ? ` from ${inferredPostgresTable.schema}.${inferredPostgresTable.name}` : ''}`
-                  ) : !isTableUnderReplicationPublication ? (
-                    'Replication is stopped for this table'
-                  ) : (
-                    <>
-                      View replication for more details{' '}
-                      <InlineLink href={`/project/${projectRef}/database/etl/${pipeline?.id}`}>
-                        here
-                      </InlineLink>
-                    </>
-                  )}
+                  {isReplicating
+                    ? `Table data is currently replicating${!!inferredPostgresTable ? ` from ${inferredPostgresTable.schema}.${inferredPostgresTable.name}` : ''}`
+                    : !isTableUnderReplicationPublication
+                      ? 'Replication is disabled for this table'
+                      : `Replication on the bucket is ${pipelineStatus}`}
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -296,7 +288,7 @@ export const TableRowComponent = ({
                           onClick={() => setShowStopReplicationModal(true)}
                         >
                           <Pause size={12} className="text-foreground-lighter" />
-                          <p>Stop replication</p>
+                          <p>Disable replication</p>
                         </DropdownMenuItem>
                       ) : (
                         <DropdownMenuItem
@@ -304,7 +296,7 @@ export const TableRowComponent = ({
                           onClick={() => setShowStartReplicationModal(true)}
                         >
                           <Play size={12} className="text-foreground-lighter" />
-                          <p>Start replication</p>
+                          <p>Enable replication</p>
                         </DropdownMenuItem>
                       )}
                     </>
@@ -337,14 +329,14 @@ export const TableRowComponent = ({
         variant="warning"
         visible={showStopReplicationModal}
         loading={isUpdatingReplication}
-        title="Confirm to stop replication for table"
-        confirmLabel="Stop replication"
+        title="Confirm to disable replication for table"
+        confirmLabel="Disable replication"
         onCancel={() => setShowStopReplicationModal(false)}
         onConfirm={() => onConfirmStopReplication()}
       >
         <p className="text-sm text-foreground-light">
           Data within the "{table.name}" table will stop replicating. However do note that,
-          restarting replication on the table will clear and re-sync all data in it. Are you sure?
+          re-enabling replication on this table will clear and re-sync all data in it. Are you sure?
         </p>
       </ConfirmationModal>
 
@@ -353,13 +345,13 @@ export const TableRowComponent = ({
         variant="warning"
         visible={showStartReplicationModal}
         loading={isUpdatingReplication}
-        title="Confirm to start replication for table"
-        confirmLabel="Start replication"
+        title="Confirm to enable replication for table"
+        confirmLabel="Enable replication"
         onCancel={() => setShowStartReplicationModal(false)}
         onConfirm={() => onConfirmStartReplication()}
       >
         <p className="text-sm text-foreground-light">
-          Restarting replication on the "{table.name}" table will clear and re-sync all data in it.
+          Re-enabling replication on the "{table.name}" table will clear and re-sync all data in it.
           Are you sure?
         </p>
       </ConfirmationModal>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
@@ -234,7 +234,7 @@ export const NamespaceWithTables = ({
               </TableCell>
             </TableRow>
           ) : (
-            allTables.map((table, index) => (
+            allTables.map((table) => (
               <TableRowComponent
                 key={table.name}
                 table={table}
@@ -242,7 +242,6 @@ export const NamespaceWithTables = ({
                 token={token}
                 schema={displaySchema}
                 isLoading={isImportingForeignSchema || isLoadingNamespaceTables}
-                index={index}
               />
             ))
           )}

--- a/apps/studio/components/ui/DotPing.tsx
+++ b/apps/studio/components/ui/DotPing.tsx
@@ -1,0 +1,34 @@
+import { cn } from 'ui'
+
+interface DotPingProps {
+  animate?: boolean
+  variant?: 'primary' | 'default' | 'warning'
+}
+
+export const DotPing = ({ animate = true, variant = 'primary' }: DotPingProps) => {
+  return (
+    <div className="relative align-middle w-2.5 h-2.5">
+      <span
+        className={cn(
+          'absolute inset-0 rounded-full',
+          animate && 'animate-ping',
+          variant === 'primary' && 'bg-brand/20',
+          variant === 'default' && 'bg-selection/20',
+          variant === 'warning' && 'bg-warning/20'
+        )}
+        style={{
+          animationDelay: '1s',
+          animationDuration: '1.5s',
+        }}
+      />
+      <span
+        className={cn(
+          'absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 inline-block w-2 h-2 rounded-full',
+          variant === 'primary' && 'bg-brand',
+          variant === 'default' && 'bg-selection',
+          variant === 'warning' && 'bg-warning'
+        )}
+      />
+    </div>
+  )
+}

--- a/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
@@ -34,7 +34,7 @@ export interface ConfirmationModalProps {
   }
 }
 
-const ConfirmationModal = forwardRef<
+export const ConfirmationModal = forwardRef<
   React.ElementRef<typeof DialogContent>,
   React.ComponentPropsWithoutRef<typeof Dialog> & ConfirmationModalProps
 >(

--- a/packages/ui-patterns/src/admonition.tsx
+++ b/packages/ui-patterns/src/admonition.tsx
@@ -1,5 +1,5 @@
 import { cva } from 'class-variance-authority'
-import { forwardRef, ReactNode } from 'react'
+import { ComponentProps, forwardRef, ReactNode } from 'react'
 import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, cn } from 'ui'
 
 export interface AdmonitionProps {
@@ -14,11 +14,11 @@ export interface AdmonitionProps {
     | 'warning'
   label?: string
   title?: string
-  description?: string | React.ReactNode
+  description?: string | ReactNode
   showIcon?: boolean
   childProps?: {
-    title?: React.ComponentProps<typeof AlertTitle_Shadcn_>
-    description?: React.ComponentProps<typeof AlertDescription_Shadcn_>
+    title?: ComponentProps<typeof AlertTitle_Shadcn_>
+    description?: ComponentProps<typeof AlertDescription_Shadcn_>
   }
   layout?: 'horizontal' | 'vertical'
   actions?: ReactNode


### PR DESCRIPTION
## Context

For analytics buckets, currently the replication status column is a little too broad where it's only checking if the corresponding postgres table of the namespace table exists in the replication publication. However we should also be considering the replication pipeline as well for a more accurate representation and so this PR handles a couple of these scenarios

## Changes involved

- Replication status column will only show if the analytics bucket has a corresponding publication + replication pipeline
  - Previously was only checking for corresponding publication 
- More granular status reflection + tooltips
  - If the table is under the replication publication, and the pipeline is running
    <img width="347" height="96" alt="image" src="https://github.com/user-attachments/assets/95bcedaf-8d88-462f-a36e-99c9cb89c22d" />
  - If there's issues with the replication pipeline itself
    <img width="281" height="99" alt="image" src="https://github.com/user-attachments/assets/f8b338e5-cbb5-4b98-8b03-873e390e8810" />
  - If the table is not under the replication publication
    <img width="261" height="103" alt="image" src="https://github.com/user-attachments/assets/76557f5c-8a37-46b4-8f00-beb96285eb8b" />

## To test

- [ ] Minimally sanity check the analytics buckets UI on staging preview - e.g start/stop replication on a table

