### PR TITLE
fix(auth): add margin to email templates UI

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -238,7 +238,7 @@ export const EmailTemplates = () => {
               </div>
             </div>
           ) : (
-            <Card>
+            <Card className="mt-12">
               <Tabs_Shadcn_ defaultValue={slugifyTitle(TEMPLATES_SCHEMAS[0].title)}>
                 <TabsList_Shadcn_ className="pt-2 px-6 gap-5 mb-0 overflow-x-scroll no-scrollbar mb-4">
                   {TEMPLATES_SCHEMAS.filter(


### PR DESCRIPTION
Fixes the margins when a custom SMTP provider is configured. Margin sizing matches the new security notifications UI.

Before:

<img width="1245" height="900" alt="Screenshot 2025-11-11 at 09 48 19" src="https://github.com/user-attachments/assets/6d182c8d-3d7f-46d4-aaff-521b4b030328" />

After:

<img width="1237" height="949" alt="Screenshot 2025-11-11 at 09 48 34" src="https://github.com/user-attachments/assets/7d2590a0-13e4-4c0c-a6e0-4b69f8f00c05" />
