### PR TITLE
Update manifest scope and start_url to /dashboard

### DIFF
--- a/apps/studio/public/favicon/manifest.json
+++ b/apps/studio/public/favicon/manifest.json
@@ -6,8 +6,8 @@
   "display": "standalone",
   "theme_color": "#1C1C1C",
   "background_color": "#1C1C1C",
-  "scope": "/",
-  "start_url": "/",
+  "scope": "/dashboard",
+  "start_url": "/dashboard",
   "icons": [
     {
       "src": "/favicon/android-icon-36x36.png",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

feature

## What is the current behavior?

pwa mode opens the home page instead of the dashboard

## What is the new behavior?

pwa mode opens the dashboard by default

## Additional context

continuation of https://github.com/supabase/supabase/pull/38701#issuecomment-3502407392