### PR TITLE
Fix: updated RLS to use messages instead of formatted error

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/QueryError.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/QueryError.tsx
@@ -23,7 +23,7 @@ export const QueryError = ({
   setOpen: Dispatch<SetStateAction<boolean>>
 }) => {
   const formattedError =
-    (error?.formattedError?.split('\n') ?? [])?.filter((x: string) => x.length > 0) ?? []
+    (error?.message?.split('\n') ?? [])?.filter((x: string) => x.length > 0) ?? []
 
   return (
     <div className="flex flex-col gap-y-3 px-5">

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -16,7 +16,6 @@ export type QueryResponseError = {
   code: string
   message: string
   error: string
-  formattedError: string
   file: string
   length: number
   line: string


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

RLS error messages were not showing up, this fixes it to use the message string

## What is the current behavior?

No error messages

## What is the new behavior?

Error messages when modify RLS through editor

## Additional context

- closes #40282 
