### PR TITLE
fix(blog): ensure share links have slug

### DIFF
--- a/apps/www/app/blog/[slug]/page.tsx
+++ b/apps/www/app/blog/[slug]/page.tsx
@@ -201,6 +201,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
     const { generateReadingTime } = await import('lib/helpers')
     const blogPost = {
       ...parsedContent.data,
+      slug,
       readingTime: generateReadingTime(content),
     }
 
@@ -228,6 +229,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
       relatedPosts,
       blog: {
         ...(blogPost as any),
+        slug,
         content: mdxSource,
         toc: {
           ...tocResult,
@@ -268,6 +270,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
         relatedPosts: [],
         blog: {
           ...publishedPost,
+          slug: publishedPost.slug ?? slug,
           tags: publishedPost.tags || [],
           authors: publishedPost.authors || [],
           isCMS: true,
@@ -312,6 +315,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
     relatedPosts: [],
     blog: {
       ...cmsPost,
+      slug: cmsPost.slug ?? slug,
       tags: cmsPost.tags || [],
       authors: cmsPost.authors || [],
       isCMS: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix – blog share buttons now build URLs with the correct slug.

## What is the current behavior?

Share links for every blog post point to `/blog/undefined`, because `ShareArticleActions` receives `slug = undefined` from the blog page. This is tracked in https://github.com/supabase/supabase/issues/40370.

## What is the new behavior?

- Static MDX posts and CMS-backed posts both set the slug on the blog data before rendering, so `ShareArticleActions` always receives the correct permalink.
- Twitter/X, LinkedIn, and Hacker News share buttons now encode the real article URL.

## Additional context

No UI changes, but lint ran with `corepack pnpm --filter www lint -- app/blog/[slug]/page.tsx` (existing repo warnings around default exports remain). This PR closes #40370.
