### PR TITLE
Table Editor link to policies page use table name as search instead of ID

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -297,7 +297,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
                   >
                     <Link
                       passHref
-                      href={`/project/${projectRef}/auth/policies?search=${table.id}&schema=${table.schema}`}
+                      href={`/project/${projectRef}/auth/policies?search=${table.name}&schema=${table.schema}`}
                     >
                       RLS {policies.length > 1 ? 'policies' : 'policy'}
                     </Link>

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -267,7 +267,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
                   >
                     <Link
                       passHref
-                      href={`/project/${projectRef}/auth/policies?search=${table.id}&schema=${table.schema}`}
+                      href={`/project/${projectRef}/auth/policies?search=${table.name}&schema=${table.schema}`}
                     >
                       Add RLS policy
                     </Link>

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -1,6 +1,6 @@
 import type { PostgresPolicy, PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Search } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 
@@ -30,6 +30,7 @@ import { DOCS_URL } from 'lib/constants'
 import { useEditorPanelStateSnapshot } from 'state/editor-panel-state'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import type { NextPageWithLayout } from 'types'
+import { Button } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
 /**
@@ -198,7 +199,18 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
   return (
     <ScaffoldContainer size="large">
       <ScaffoldSection isFullWidth>
-        <div className="mb-4 flex flex-row gap-2 justify-between">
+        <div className="mb-4 flex flex-row gap-x-2">
+          <SchemaSelector
+            className="w-full lg:w-[180px]"
+            size="tiny"
+            align="end"
+            showError={false}
+            selectedSchemaName={schema}
+            onSelectSchema={(schemaName) => {
+              setSchema(schemaName)
+              setSearchString('')
+            }}
+          />
           <Input
             size="tiny"
             placeholder="Filter tables and policies"
@@ -210,17 +222,17 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
               setSearchString(str)
             }}
             icon={<Search size={14} />}
-          />
-          <SchemaSelector
-            className="w-full lg:w-[180px]"
-            size="tiny"
-            align="end"
-            showError={false}
-            selectedSchemaName={schema}
-            onSelectSchema={(schemaName) => {
-              setSchema(schemaName)
-              setSearchString('')
-            }}
+            actions={
+              searchString ? (
+                <Button
+                  size="tiny"
+                  type="text"
+                  className="p-0 h-5 w-5"
+                  icon={<X />}
+                  onClick={() => setSearchString('')}
+                />
+              ) : null
+            }
           />
         </div>
 


### PR DESCRIPTION
## Context

Internal feedback that it's a little confusing when navigating to the policies page from the table editor via this button
<img width="324" height="110" alt="image" src="https://github.com/user-attachments/assets/ff2e1143-e958-4a44-81e6-67f0153e7cdf" />

We currently use the table ID as the search param which can be confusing as the number is seemingly random
<img width="476" height="234" alt="image" src="https://github.com/user-attachments/assets/cc515752-383c-4140-88e3-9eaf2068ae80" />

Opting to use the table's name instead
<img width="464" height="249" alt="image" src="https://github.com/user-attachments/assets/7f6a6e93-11c8-4c9c-9df4-0c3b90a2da87" />

Also shifted the schema selector to the left for consistency with other parts of the UI