### PR TITLE
[FE-2111] chore: adjust custom domains refetch interval

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -42,7 +42,7 @@ export const CustomDomainConfig = () => {
       refetchInterval(data) {
         // while setting up the ssl certificate, we want to poll every 5 seconds
         if (data?.customDomain?.ssl.status) {
-          return 5000
+          return 10000 // 10 seconds
         }
 
         return false


### PR DESCRIPTION
Doubles the custom domains refetch interval (to 10 seconds) to respect the new API rate limiter settings.