### PR TITLE
fix: max export row count typo

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -46,7 +46,7 @@ import { SortPopover } from './sort/SortPopover'
 export const MAX_EXPORT_ROW_COUNT = 500000
 export const MAX_EXPORT_ROW_COUNT_MESSAGE = (
   <>
-    Sorry! We're unable to support exporting row counts larger than $
+    Sorry! We're unable to support exporting row counts larger than
     {MAX_EXPORT_ROW_COUNT.toLocaleString()} at the moment. Alternatively, you may consider using
     <Link href={`${DOCS_URL}/reference/cli/supabase-db-dump`} target="_blank">
       pg_dump

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -46,7 +46,7 @@ import { SortPopover } from './sort/SortPopover'
 export const MAX_EXPORT_ROW_COUNT = 500000
 export const MAX_EXPORT_ROW_COUNT_MESSAGE = (
   <>
-    Sorry! We're unable to support exporting row counts larger than
+    Sorry! We're unable to support exporting row counts larger than{' '}
     {MAX_EXPORT_ROW_COUNT.toLocaleString()} at the moment. Alternatively, you may consider using
     <Link href={`${DOCS_URL}/reference/cli/supabase-db-dump`} target="_blank">
       pg_dump


### PR DESCRIPTION
Fixes a typo that introduced a `$` in the max exportable rows.