### PR TITLE
fix: add image version tracking and changelog for self-hosted supabase

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -12,7 +12,6 @@ for complete image version history and rollback information.
 
 ### Auth
 - Updated to `v2.182.1` - [Changelog](https://github.com/supabase/auth/blob/master/CHANGELOG.md#21821-2025-11-05) | [Release](https://github.com/supabase/auth/releases/tag/v2.182.1)
-- Note: Introduces OAuth 2.1 server capabilities (authorization list/revoke endpoints) and v2 refresh token algorithm
 
 ### Realtime
 - Updated to `v2.63.0` - [Release](https://github.com/supabase/realtime/releases/tag/v2.63.0)

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to the Supabase self-hosted Docker configuration.
+
+Changes are grouped by service rather than by change type. See [versions.md](./versions.md) 
+for complete image version history and rollback information.
+
+## [2025-11-12]
+
+### Studio
+- Updated to `2025.11.10-sha-5291fe3` - [Dashboard updates](https://github.com/orgs/supabase/discussions/40083)
+
+### Auth
+- Updated to `v2.182.1` - [Changelog](https://github.com/supabase/auth/blob/master/CHANGELOG.md#21821-2025-11-05) | [Release](https://github.com/supabase/auth/releases/tag/v2.182.1)
+- Note: Introduces OAuth 2.1 server capabilities (authorization list/revoke endpoints) and v2 refresh token algorithm
+
+### Realtime
+- Updated to `v2.63.0` - [Release](https://github.com/supabase/realtime/releases/tag/v2.63.0)
+
+### Storage
+- Updated to `v1.29.0` - [Release](https://github.com/supabase/storage/releases/tag/v1.29.0)
+
+### Edge Runtime
+- Updated to `v1.69.23` - [Release](https://github.com/supabase/edge-runtime/releases/tag/v1.69.23)
+
+### Supavisor
+- Updated to `2.7.4` - [Release](https://github.com/supabase/supavisor/releases/tag/v2.7.4)
+
+---

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -15,7 +15,7 @@
 - supabase/postgres-meta:v0.93.1 (prev v0.93.0)
 - supabase/edge-runtime:v1.69.15 (prev v1.69.14)
 
-# 2025-10-21
+## 2025-10-21
 - supabase/studio:2025.10.20-sha-5005fc6 (prev 2025.10.01-sha-8460121)
 - supabase/realtime:v2.56.0 (prev v2.51.11)
 - supabase/storage-api:v1.28.1 (prev v1.28.0)
@@ -23,10 +23,10 @@
 - supabase/edge-runtime:v1.69.14 (prev v1.69.6)
 - supabase/supavisor:2.7.3 (prev 2.7.0)
 
-# 2025-10-13
+## 2025-10-13
 - supabase/logflare:1.22.6 (prev 1.22.4)
 
-# 2025-10-08
+## 2025-10-08
 - supabase/studio:2025.10.01-sha-8460121 (prev 2025.06.30-sha-6f5982d)
 - supabase/gotrue:v2.180.0 (prev v2.177.0)
 - postgrest/postgrest:v13.0.7 (prev v12.2.12)
@@ -37,19 +37,19 @@
 - supabase/postgres:15.8.1.085 (prev 15.8.1.060)
 - supabase/supavisor:2.7.0 (prev 2.5.7)
 
-# 2025-07-15
+## 2025-07-15
 - supabase/gotrue:v2.177.0 (prev v2.176.1)
 - supabase/storage-api:v1.25.7 (prev v1.24.7)
 - supabase/postgres-meta:v0.91.0 (prev v0.89.3)
 - supabase/supavisor:2.5.7 (prev 2.5.6)
 
-# 2025-07-02
+## 2025-07-02
 - supabase/studio:2025.06.30-sha-6f5982d (prev 2025.06.02-sha-8f2993d)
 - supabase/gotrue:v2.176.1 (prev v2.174.0)
 - supabase/storage-api:v1.24.7 (prev v1.23.0)
 - supabase/supavisor:2.5.6 (prev 2.5.1)
 
-# 2025-06-03
+## 2025-06-03
 - supabase/studio:2025.06.02-sha-8f2993d (prev 2025.05.19-sha-3487831)
 - supabase/gotrue:v2.174.0 (prev v2.172.1)
 - supabase/storage-api:v1.23.0 (prev v1.22.17)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,0 +1,56 @@
+# Docker Image Versions
+
+## 2025-11-12
+- supabase/studio:2025.11.10-sha-5291fe3 (prev 2025.10.27-sha-85b84e0)
+- supabase/gotrue:v2.182.1 (prev v2.180.0)
+- supabase/realtime:v2.63.0 (prev v2.57.2)
+- supabase/storage-api:v1.29.0 (prev v1.28.2)
+- supabase/edge-runtime:v1.69.23 (prev v1.69.15)
+- supabase/supavisor:2.7.4 (prev 2.7.3)
+
+## 2025-10-28
+- supabase/studio:2025.10.27-sha-85b84e0 (prev 2025.10.20-sha-5005fc6)
+- supabase/realtime:v2.57.2 (prev v2.56.0)
+- supabase/storage-api:v1.28.2 (prev v1.28.1)
+- supabase/postgres-meta:v0.93.1 (prev v0.93.0)
+- supabase/edge-runtime:v1.69.15 (prev v1.69.14)
+
+# 2025-10-21
+- supabase/studio:2025.10.20-sha-5005fc6 (prev 2025.10.01-sha-8460121)
+- supabase/realtime:v2.56.0 (prev v2.51.11)
+- supabase/storage-api:v1.28.1 (prev v1.28.0)
+- supabase/postgres-meta:v0.93.0 (prev v0.91.6)
+- supabase/edge-runtime:v1.69.14 (prev v1.69.6)
+- supabase/supavisor:2.7.3 (prev 2.7.0)
+
+# 2025-10-13
+- supabase/logflare:1.22.6 (prev 1.22.4)
+
+# 2025-10-08
+- supabase/studio:2025.10.01-sha-8460121 (prev 2025.06.30-sha-6f5982d)
+- supabase/gotrue:v2.180.0 (prev v2.177.0)
+- postgrest/postgrest:v13.0.7 (prev v12.2.12)
+- supabase/realtime:v2.51.11 (prev v2.34.47)
+- supabase/storage-api:v1.28.0 (prev v1.25.7)
+- supabase/postgres-meta:v0.91.6 (prev v0.91.0)
+- supabase/logflare:1.22.4 (prev 1.14.2)
+- supabase/postgres:15.8.1.085 (prev 15.8.1.060)
+- supabase/supavisor:2.7.0 (prev 2.5.7)
+
+# 2025-07-15
+- supabase/gotrue:v2.177.0 (prev v2.176.1)
+- supabase/storage-api:v1.25.7 (prev v1.24.7)
+- supabase/postgres-meta:v0.91.0 (prev v0.89.3)
+- supabase/supavisor:2.5.7 (prev 2.5.6)
+
+# 2025-07-02
+- supabase/studio:2025.06.30-sha-6f5982d (prev 2025.06.02-sha-8f2993d)
+- supabase/gotrue:v2.176.1 (prev v2.174.0)
+- supabase/storage-api:v1.24.7 (prev v1.23.0)
+- supabase/supavisor:2.5.6 (prev 2.5.1)
+
+# 2025-06-03
+- supabase/studio:2025.06.02-sha-8f2993d (prev 2025.05.19-sha-3487831)
+- supabase/gotrue:v2.174.0 (prev v2.172.1)
+- supabase/storage-api:v1.23.0 (prev v1.22.17)
+- supabase/postgres-meta:v0.89.3 (prev v0.89.0)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This adds changelog and version updates information so that it's easier for the users to track changes.
 
## What is the new behavior?

CHANGELOG.md - to quickly see what's been updated and optionally read more in the components own changelogs/release notes. The versions.md file could be automatically updated to track the history of image updates. It'll also help with image versions rollbacks if things go wrong.
