### PR TITLE
fix: import map in example

### DIFF
--- a/examples/user-management/nextjs-user-management/tsconfig.json
+++ b/examples/user-management/nextjs-user-management/tsconfig.json
@@ -19,7 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR updates the import map alias for the "User management with Next.js" tutorial. 

## What is the current behavior?

The alias `@/` is resolved by `@/src` which leads to Next.js not being able to import modules, since this project doesn't use a `src/` folder.

<!-- Please link any relevant issues here. --> 

## What is the new behavior?

The alias `@/` is resolved to the project root.

<!-- 
## Additional context

Add any other context or screenshots.
-->