### PR TITLE
fix(cron): optimize queries for cron tables

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.tsx
@@ -167,7 +167,7 @@ export const PreviousRunsTab = () => {
       connectionString: project?.connectionString,
       jobId: jobId,
     },
-    { enabled: !!jobId, staleTime: 30000 }
+    { enabled: !!jobId, staleTime: 30_000 }
   )
 
   const cronJobRuns = useMemo(() => data?.pages.flatMap((p) => p) || [], [data?.pages])


### PR DESCRIPTION
The `cron.job_run_details` table can get very long (millions of rows).
It's only indexed on the `runid` column, and adding a new index is a
non-trivial matter.

On the job run details table, we automatically sort and paginate by the
`start_time` column, so this creates a problem for very large tables.
This PR changes to use the `runid` column instead. Since `runid`s are
sequential, this should correlate pretty closely with `start_time`
anyway, while letting Postgres use the index.

Similarly, on the cron overviews table, the search for the latest run
required a sequential scan on the `job_run_details` table. Changed this
to also use the `runid` index instead.

Resolves FE-2115