### PR TITLE
docs: replace deprecated auth-ui-react library in React Auth quickstart

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -20,8 +20,7 @@ hideToc: true
 
      ```sql name=SQL_EDITOR
       select * from auth.users;
-      ````
-
+      ```
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -45,7 +44,7 @@ hideToc: true
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Install the Supabase client library">
 
-    The fastest way to get started is to use Supabase's `auth-ui-react` library which provides a convenient interface for working with Supabase Auth from a React app.
+    The fastest way to get started is to use Supabase's UI library, which provides a convenient interface for working with Supabase Auth from a React app.
 
     Navigate to the React app and install the Supabase libraries.
 
@@ -54,7 +53,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react @supabase/auth-ui-shared
+      cd my-app && npm install @supabase/supabase-js @supabase/ui
       ```
 
     </StepHikeCompact.Code>
@@ -68,17 +67,18 @@ hideToc: true
 
     <$Partial path="api_settings_steps.mdx" />
 
-    You can configure the Auth component to display whenever there is no session inside `supabase.auth.getSession()`
+    You can configure the Auth component to display whenever there is no session inside `supabase.auth.getSession()`.
 
     </StepHikeCompact.Details>
+
     <StepHikeCompact.Code>
 
       ```jsx name=src/App.jsx
         import './index.css'
         import { useState, useEffect } from 'react'
         import { createClient } from '@supabase/supabase-js'
-        import { Auth } from '@supabase/auth-ui-react'
-        import { ThemeSupa } from '@supabase/auth-ui-shared'
+        import { Auth } from '@supabase/ui'
+        import { Theme } from '@supabase/ui/themes'
 
         const supabase = createClient('https://<project>.supabase.co', '<sb_publishable_... or anon key>')
 
@@ -90,9 +90,7 @@ hideToc: true
               setSession(session)
             })
 
-            const {
-              data: { subscription },
-            } = supabase.auth.onAuthStateChange((_event, session) => {
+            const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
               setSession(session)
             })
 
@@ -100,9 +98,14 @@ hideToc: true
           }, [])
 
           if (!session) {
-            return (<Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} />)
-          }
-          else {
+            return (
+              <Auth
+                supabaseClient={supabase}
+                providers={['google', 'github']}
+                appearance={{ theme: Theme }}
+              />
+            )
+          } else {
             return (<div>Logged in!</div>)
           }
         }


### PR DESCRIPTION
What this PR does?

This PR updates the React Auth Quickstart guide to replace the deprecated `@supabase/auth-ui-react` and `@supabase/auth-ui-shared` packages with the new `@supabase/ui` library, ensuring compatibility with the latest Supabase Auth components.

Fixes #40388