### PR TITLE
fix: remove invalid supautils.disable_program config

### DIFF
--- a/docker/volumes/db/jwt.sql
+++ b/docker/volumes/db/jwt.sql
@@ -3,3 +3,5 @@
 
 ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
 ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';
+
+ALTER DATABASE postgres RESET "supautils.disable_program";


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #40140

Database connections show a warning:
```
WARNING: invalid configuration parameter name "supautils.disable_program", removing it
DETAIL: "supautils" is now a reserved prefix.
```

This breaks Cloudflare Hyperdrive and causes connection test failures in DataGrip.

## What is the new behavior?

No warning during connection. Reset the invalid parameter in `jwt.sql` initialization script.

## Additional context

Older postgres images set this parameter, but newer PostgreSQL versions reserve the `supautils` prefix. Added `ALTER DATABASE postgres RESET "supautils.disable_program";` to clean it up on init.
