### PR TITLE
chore(studio): clean up ETL Replication UI

### DIFF
--- a/apps/studio/components/interfaces/Database/ETL/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/ETL/Destinations.tsx
@@ -12,8 +12,9 @@ import { fetchReplicationPipelineVersion } from 'data/etl/pipeline-version-query
 import { useReplicationPipelinesQuery } from 'data/etl/pipelines-query'
 import { useReplicationSourcesQuery } from 'data/etl/sources-query'
 import { DOCS_URL } from 'lib/constants'
-import { Button, cn, Input_Shadcn_ } from 'ui'
+import { Button, cn } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import { DestinationPanel } from './DestinationPanel/DestinationPanel'
 import { DestinationRow } from './DestinationRow'
 import { EnableReplicationModal } from './EnableReplicationModal'
@@ -95,19 +96,16 @@ export const Destinations = () => {
       <div className="mb-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center">
-            <div className="relative">
-              <Search
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-foreground-lighter"
-                size={14}
-              />
-              <Input_Shadcn_
-                className="pl-9 h-7"
-                placeholder={'Filter destinations'}
-                value={filterString}
-                onChange={(e) => setFilterString(e.target.value)}
-              />
-            </div>
+            <Input
+              size="tiny"
+              icon={<Search size={12} />}
+              className="w-48 pl-8"
+              placeholder="Search for a destination"
+              value={filterString}
+              onChange={(e) => setFilterString(e.target.value)}
+            />
           </div>
+
           {!!sourceId && (
             <Button type="default" icon={<Plus />} onClick={() => setShowNewDestinationPanel(true)}>
               Add destination

--- a/apps/studio/pages/project/[ref]/database/etl/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/etl/index.tsx
@@ -3,8 +3,8 @@ import { ReplicationComingSoon } from 'components/interfaces/Database/ETL/Coming
 import { Destinations } from 'components/interfaces/Database/ETL/Destinations'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
-import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { PipelineRequestStatusProvider } from 'state/replication-pipeline-request-status'
@@ -20,35 +20,27 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
   }
 
   return (
-    <>
+    <PageLayout
+      size="large"
+      title="ETL Replication"
+      subtitle={
+        enablePgReplicate
+          ? 'Replicate your database to any analytics destination'
+          : 'Send data to other destinations'
+      }
+    >
       {enablePgReplicate ? (
         <PipelineRequestStatusProvider>
-          <ScaffoldContainer>
-            <ScaffoldSection>
-              <div className="col-span-12">
-                <FormHeader
-                  className="[&>div>p]:max-w-full"
-                  title="ETL Replication"
-                  description="Automatically replicate your database changes to external data warehouses and analytics platforms in real-time"
-                />
-                <Destinations />
-              </div>
+          <ScaffoldContainer size="large">
+            <ScaffoldSection isFullWidth>
+              <Destinations />
             </ScaffoldSection>
           </ScaffoldContainer>
         </PipelineRequestStatusProvider>
       ) : (
-        <>
-          <ScaffoldContainer>
-            <ScaffoldSection>
-              <div className="col-span-12">
-                <FormHeader title="ETL Replication" description="Send data to other destinations" />
-              </div>
-            </ScaffoldSection>
-          </ScaffoldContainer>
-          <ReplicationComingSoon projectRef={ref || '_'} />
-        </>
+        <ReplicationComingSoon projectRef={ref || '_'} />
       )}
-    </>
+    </PageLayout>
   )
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- UI improvements
- Resolves DEPR-245

## What is the current behavior?

The ETL Replication page(s) are a bit out of step with the rest of the studio application. Thsi is especially important as it becomes increasingly intertwined with analytics buckets.

## What is the new behavior?

- The ETL Replication page(s) now use standardised components
- Improved copywriting

| Before | After |
| --- | --- |
|  |  |
|  |  |

## Additional context

This is a draft PR.
