### PR TITLE
docs: update React Auth quickstart to use @supabase/auth-js-react (#40388)

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -21,7 +21,6 @@ hideToc: true
      ```sql name=SQL_EDITOR
       select * from auth.users;
       ````
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -38,14 +37,14 @@ hideToc: true
     ```bash name=Terminal
     npm create vite@latest my-app -- --template react
     ```
-
   </StepHikeCompact.Code>
 </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Install the Supabase client library">
 
-    The fastest way to get started is to use Supabase's `auth-ui-react` library which provides a convenient interface for working with Supabase Auth from a React app.
+    The previous `auth-ui-react` library is no longer maintained.  
+    Now, install the Supabase client and the new Auth UI package:
 
     Navigate to the React app and install the Supabase libraries.
 
@@ -54,9 +53,8 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react @supabase/auth-ui-shared
+      cd my-app && npm install @supabase/supabase-js @supabase/auth-js-react
       ```
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -77,8 +75,7 @@ hideToc: true
         import './index.css'
         import { useState, useEffect } from 'react'
         import { createClient } from '@supabase/supabase-js'
-        import { Auth } from '@supabase/auth-ui-react'
-        import { ThemeSupa } from '@supabase/auth-ui-shared'
+        import { Auth, ThemeSupa } from '@supabase/auth-js-react'
 
         const supabase = createClient('https://<project>.supabase.co', '<sb_publishable_... or anon key>')
 
@@ -107,7 +104,6 @@ hideToc: true
           }
         }
       ```
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -124,7 +120,6 @@ hideToc: true
       ```bash name=Terminal
       npm run dev
       ```
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>


### PR DESCRIPTION
Summary

This PR replaces references to the deprecated @supabase/auth-ui-react and @supabase/auth-ui-shared packages with the new @supabase/auth-js-react package in the React Auth quickstart guide.

This aligns the documentation with Supabase’s current recommended Auth UI library.

What was changed - 
Updated installation commands
Updated imports in code samples
Removed outdated auth-ui-react references
Ensured the example compiles correctly with the new package

Why -
Issue #40388 reported outdated library usage in the React Auth guide.
This PR updates the guide to reflect the current, supported Auth UI package.

Linked Issue 
Fixes #40388