### PR TITLE
chore(studio): default opt-in security notifications

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -34,7 +34,7 @@ export const FeaturePreviewContextProvider = ({ children }: PropsWithChildren<{}
   const isDefaultOptIn = (feature: (typeof FEATURE_PREVIEWS)[number]) => {
     switch (feature.key) {
       case LOCAL_STORAGE_KEYS.UI_PREVIEW_SECURITY_NOTIFICATIONS:
-        return securityNotificationsFlag === true
+        return securityNotificationsFlag
       default:
         return false
     }
@@ -119,12 +119,11 @@ export const useFeaturePreviewModal = () => {
   const gitlessBranchingEnabled = useFlag('gitlessBranching')
   const advisorRulesEnabled = useFlag('advisorRules')
   const isUnifiedLogsPreviewAvailable = useFlag('unifiedLogs')
-  const isSecurityNotificationsAvailable = useFlag('securityNotifications')
 
   const selectedFeatureKeyFromQuery = featurePreviewModal?.trim() ?? null
   const showFeaturePreviewModal = selectedFeatureKeyFromQuery !== null
 
-  // [Joshen] Use this if we want to make publicly available feature flag previews
+  // [Joshen] Use this if we want to feature flag previews
   const isFeaturePreviewReleasedToPublic = useCallback(
     (feature: (typeof FEATURE_PREVIEWS)[number]) => {
       switch (feature.key) {
@@ -134,7 +133,6 @@ export const useFeaturePreviewModal = () => {
           return advisorRulesEnabled
         case 'supabase-ui-preview-unified-logs':
           return isUnifiedLogsPreviewAvailable
-
         default:
           return true
       }

--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -28,10 +28,13 @@ export const useFeaturePreviewContext = () => useContext(FeaturePreviewContext)
 
 export const FeaturePreviewContextProvider = ({ children }: PropsWithChildren<{}>) => {
   const { hasLoaded } = useContext(FeatureFlagContext)
+  const securityNotificationsFlag = useFlag('securityNotifications')
 
   // [Joshen] Similar logic to feature flagging previews, we can use flags to default opt in previews
   const isDefaultOptIn = (feature: (typeof FEATURE_PREVIEWS)[number]) => {
     switch (feature.key) {
+      case LOCAL_STORAGE_KEYS.UI_PREVIEW_SECURITY_NOTIFICATIONS:
+        return securityNotificationsFlag === true
       default:
         return false
     }
@@ -121,7 +124,7 @@ export const useFeaturePreviewModal = () => {
   const selectedFeatureKeyFromQuery = featurePreviewModal?.trim() ?? null
   const showFeaturePreviewModal = selectedFeatureKeyFromQuery !== null
 
-  // [Joshen] Use this if we want to feature flag previews
+  // [Joshen] Use this if we want to make publicly available feature flag previews
   const isFeaturePreviewReleasedToPublic = useCallback(
     (feature: (typeof FEATURE_PREVIEWS)[number]) => {
       switch (feature.key) {
@@ -131,18 +134,12 @@ export const useFeaturePreviewModal = () => {
           return advisorRulesEnabled
         case 'supabase-ui-preview-unified-logs':
           return isUnifiedLogsPreviewAvailable
-        case 'security-notifications':
-          return isSecurityNotificationsAvailable
+
         default:
           return true
       }
     },
-    [
-      gitlessBranchingEnabled,
-      advisorRulesEnabled,
-      isUnifiedLogsPreviewAvailable,
-      isSecurityNotificationsAvailable,
-    ]
+    [gitlessBranchingEnabled, advisorRulesEnabled, isUnifiedLogsPreviewAvailable]
   )
 
   const selectedFeatureKey = (


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Feature flag tweaks
- Resolves DEPR-134

## What is the current behavior?

- The `securityNotifications` flag’s related feature preview is opt-in
	- Meaning all users must explicitly opt-in to see the feature

## What is the new behavior?

- The `securityNotifications` flag’s related feature preview is  opt-out
	- Meaning all users have this feature preview enabled, and must explicitly opt-out to go back to the previous UI
- 

> [!NOTE]
> We need to set the corresponding ConfigCat flag to 20% (or similar) to avoid rolling this out to everyone all at once.

## Additional context

I decided not to update the notice Admonition (with a link back to this feature preview in case folks want to later opt-out) because:

- I don’t think it’s a controversial enough change
- The Admonition is already quite lengthy
