### PR TITLE
feat: Add drag and drop for sql snippets

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -14,6 +14,7 @@ import EditorMenuListSkeleton from 'components/layouts/TableEditorLayout/EditorM
 import { useSqlEditorTabsCleanup } from 'components/layouts/Tabs/Tabs.utils'
 import { useContentCountQuery } from 'data/content/content-count-query'
 import { useContentDeleteMutation } from 'data/content/content-delete-mutation'
+import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
 import { useSQLSnippetFoldersDeleteMutation } from 'data/content/sql-folders-delete-mutation'
 import { Snippet, SnippetFolder, useSQLSnippetFoldersQuery } from 'data/content/sql-folders-query'
 import { useSqlSnippetsQuery } from 'data/content/sql-snippets-query'
@@ -40,6 +41,15 @@ import { formatFolderResponseForTreeView, getLastItemIds, ROOT_NODE } from './SQ
 import { SQLEditorTreeViewItem } from './SQLEditorTreeViewItem'
 import { ShareSnippetModal } from './ShareSnippetModal'
 import { UnshareSnippetModal } from './UnshareSnippetModal'
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 
 interface SQLEditorNavProps {
   sort?: 'inserted_at' | 'name'
@@ -63,6 +73,79 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
     favorite: showFavoriteSnippets,
     private: showPrivateSnippets,
   } = sectionVisibility
+ 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8, // Require 8px movement before drag starts
+      },
+    })
+  )
+
+  // Mutation for updating snippet folder
+  const { mutate: updateSnippet } = useContentUpsertMutation({
+    onSuccess: () => {
+      toast.success('Query moved successfully')
+    },
+    onError: (error) => {
+      toast.error(`Failed to move query: ${error.message}`)
+    },
+  })
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+
+    if (!over || !projectRef) return
+
+    const draggedItem = active.data.current
+    const dropTarget = over.data.current
+
+    // Only handle snippet dragging (not folders)
+    if (draggedItem?.type !== 'snippet') return
+
+    const snippet = draggedItem.element?.metadata as Snippet
+    if (!snippet) return
+
+    // Determine the new folder_id based on drop target
+    let newFolderId: string | null = null
+
+    if (dropTarget?.type === 'folder') {
+      // Dropped on a folder
+      newFolderId = dropTarget.element.id
+    } else if (dropTarget?.type === 'snippet') {
+      // Dropped on another snippet - use that snippet's folder
+      newFolderId = dropTarget.element?.metadata?.folder_id ?? null
+    } else {
+      // Dropped on root/section - remove from folder
+      newFolderId = null
+    }
+
+    // Only update if folder changed
+    if (newFolderId === snippet.folder_id) return
+
+    // Update snippet with new folder_id
+    updateSnippet({
+      projectRef,
+      payload: {
+        id: snippet.id,
+        name: snippet.name,
+        description: snippet.description,
+        type: 'sql',
+        visibility: snippet.visibility,
+        folder_id: newFolderId,
+        content: {}, // Content doesn't need to be changed
+      },
+    })
+
+    // Update local state immediately for responsiveness
+    snapV2.addSnippet({
+      projectRef,
+      snippet: {
+        ...snippet,
+        folder_id: newFolderId,
+      },
+    })
+  }
 
   const [showMoveModal, setShowMoveModal] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
@@ -437,7 +520,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
   }, [allSnippetsInView, isSuccess, sqlEditorTabsCleanup])
 
   return (
-    <>
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
       <InnerSideMenuSeparator />
 
       <InnerSideMenuCollapsible
@@ -790,6 +873,6 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
           Are you sure you want to delete the folder '{selectedFolderToDelete?.name}'?
         </p>
       </ConfirmationModal>
-    </>
+    </DndContext>
   )
 }

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -73,7 +73,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
     favorite: showFavoriteSnippets,
     private: showPrivateSnippets,
   } = sectionVisibility
- 
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -101,14 +101,7 @@ export const SQLEditorTreeViewItem = ({
   const { className, onClick } = getNodeProps()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: element.id,
     data: {
       type: isBranch ? 'folder' : 'snippet',

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -1,4 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import {
   Copy,
   Download,
@@ -98,6 +100,27 @@ export const SQLEditorTreeViewItem = ({
   const { data: project } = useSelectedProjectQuery()
   const { className, onClick } = getNodeProps()
   const snapV2 = useSqlEditorV2StateSnapshot()
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: element.id,
+    data: {
+      type: isBranch ? 'folder' : 'snippet',
+      element,
+    },
+    disabled: isBranch, // Folders can't be dragged (for now)
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
 
   const isOwner = profile?.id === element?.metadata.owner_id
   const isSharedSnippet = element.metadata.visibility === 'project'
@@ -216,11 +239,12 @@ export const SQLEditorTreeViewItem = ({
   }
 
   return (
-    <>
+    <div ref={setNodeRef} style={style} {...attributes}>
       <ContextMenu_Shadcn_ modal={false}>
         <ContextMenuTrigger_Shadcn_ asChild>
           <TreeViewItem
-            className={className}
+            {...listeners}
+            className={cn(className, isDragging && 'opacity-50 cursor-grabbing')}
             level={level}
             isExpanded={isExpanded}
             isBranch={isBranch}
@@ -440,6 +464,6 @@ export const SQLEditorTreeViewItem = ({
           </Button>
         </div>
       )}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
- Hard for me to test manually.
- Manual ordering between each of the snippets are not supported since it uses inserted_at in the db for ordering. Could be fixed by either changing that timestamp or using a different ordering like position. This could also be applied to the storage buckets too since they are super annoying to use too.

https://github.com/orgs/supabase/discussions/40408 