### PR TITLE
fix attack projection and rate limit links in the web3 wallet configs…

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -1524,13 +1524,13 @@ const PROVIDER_WEB3 = {
     EXTERNAL_WEB3_ETHEREUM_ENABLED: {
       title: 'Enable Sign in with Ethereum',
       description:
-        'Allow Ethereum wallets to sign in to your project via the Sign in with Ethereum (EIP-4361). Set up [attack protection](../auth/protection) and adjust [rate limits](../auth/rate-limits) to counter abuse.',
+        'Allow Ethereum wallets to sign in to your project via the Sign in with Ethereum (EIP-4361). Set up [attack protection](/project/${projectRef}/auth/protection) and adjust [rate limits](/project/${projectRef}/auth/rate-limits) to counter abuse.',
       type: 'boolean',
     },
     EXTERNAL_WEB3_SOLANA_ENABLED: {
       title: 'Enable Sign in with Solana',
       description:
-        'Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard. Set up [attack protection](../auth/protection) and adjust [rate limits](../auth/rate-limits) to counter abuse.',
+        'Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard. Set up [attack protection](/project/${projectRef}/auth/protection) and adjust [rate limits](/project/${projectRef}/auth/rate-limits) to counter abuse.',
       type: 'boolean',
     },
   },


### PR DESCRIPTION
… view

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Links update

## What is the current behavior?

Attack protection and rate limits links in the auth/providers?provider=Web3+Wallet config page are leading to [ref] page, which then displays the error "You need additional permissions to access your project's auth provider settings"
<img width="913" height="382" alt="Screenshot 2025-11-13 at 11 17 22" src="https://github.com/user-attachments/assets/c6304420-c054-4ff8-b0d3-163033a4cf48" />


<img width="944" height="399" alt="image" src="https://github.com/user-attachments/assets/686a25dc-6b38-4e73-9d5e-21cdf1124fec" />


## What is the new behavior?

Fixed links

## Additional context

Add any other context or screenshots.
