### PR TITLE
Fix attack protection and rate limit links in the web3 wallet configs

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -196,12 +196,20 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
                       />
 
                       {Object.keys(provider.properties).map((x: string) => {
+                        let description = provider.properties[x].description
+                        if (description && projectRef) {
+                          description = description.replace(
+                            /\(\.\.\/auth\/(.*?)\)/g,
+                            `(/project/${projectRef}/auth/$1)`
+                          )
+                        }
+
                         const properties = {
                           ...provider.properties[x],
                           description:
                             provider.properties[x].isPaid && isFreePlan
-                              ? `${provider.properties[x].description} Only available on [Pro plan](/org/${organization.slug}/billing?panel=subscriptionPlan) and above.`
-                              : provider.properties[x].description,
+                              ? `${description} Only available on [Pro plan](/org/${organization.slug}/billing?panel=subscriptionPlan) and above.`
+                              : description,
                         }
                         const isDisabledDueToPlan = properties.isPaid && isFreePlan
 

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -1524,13 +1524,13 @@ const PROVIDER_WEB3 = {
     EXTERNAL_WEB3_ETHEREUM_ENABLED: {
       title: 'Enable Sign in with Ethereum',
       description:
-        'Allow Ethereum wallets to sign in to your project via the Sign in with Ethereum (EIP-4361). Set up [attack protection](/project/${projectRef}/auth/protection) and adjust [rate limits](/project/${projectRef}/auth/rate-limits) to counter abuse.',
+        'Allow Ethereum wallets to sign in to your project via the Sign in with Ethereum (EIP-4361). Set up [attack protection](../auth/protection) and adjust [rate limits](../auth/rate-limits) to counter abuse.',
       type: 'boolean',
     },
     EXTERNAL_WEB3_SOLANA_ENABLED: {
       title: 'Enable Sign in with Solana',
       description:
-        'Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard. Set up [attack protection](/project/${projectRef}/auth/protection) and adjust [rate limits](/project/${projectRef}/auth/rate-limits) to counter abuse.',
+        'Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard. Set up [attack protection](../auth/protection) and adjust [rate limits](../auth/rate-limits) to counter abuse.',
       type: 'boolean',
     },
   },

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -1524,13 +1524,13 @@ const PROVIDER_WEB3 = {
     EXTERNAL_WEB3_ETHEREUM_ENABLED: {
       title: 'Enable Sign in with Ethereum',
       description:
-        'Allow Ethereum wallets to sign in to your project via the Sign in with Ethereum (EIP-4361). Set up [attack protection](../auth/protection) and adjust [rate limits](../auth/rate-limits) to counter abuse.',
+        'Allow Ethereum wallets to sign in to your project via the Sign in with Ethereum (EIP-4361). Set up [attack protection](/project/${projectRef}/auth/protection) and adjust [rate limits](/project/${projectRef}/auth/rate-limits) to counter abuse.',
       type: 'boolean',
     },
     EXTERNAL_WEB3_SOLANA_ENABLED: {
       title: 'Enable Sign in with Solana',
       description:
-        'Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard. Set up [attack protection](../auth/protection) and adjust [rate limits](../auth/rate-limits) to counter abuse.',
+        'Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard. Set up [attack protection](/project/${projectRef}/auth/protection) and adjust [rate limits](/project/${projectRef}/auth/rate-limits) to counter abuse.',
       type: 'boolean',
     },
   },


### PR DESCRIPTION
… view

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Links update

## What is the current behavior?

Attack protection and rate limits links in the auth/providers?provider=Web3+Wallet config page are leading to [ref] page, which then displays the error "You need additional permissions to access your project's auth provider settings"

<img width="913" height="382" alt="Screenshot 2025-11-13 at 11 17 22" src="https://github.com/user-attachments/assets/4603480b-cfc1-45a2-9ac9-8ed7c6db6d2d" />

<img width="944" height="399" alt="Screenshot 2025-11-13 at 11 19 04" src="https://github.com/user-attachments/assets/c01fe55e-8576-4885-9926-dfc061ce97a5" />


## What is the new behavior?

Fixed links