### PR TITLE
Fix: dropdown positioning for OrganizationProjectSelector

### DIFF
--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -145,6 +145,7 @@ export const OrganizationProjectSelector = ({
         )}
       </PopoverTrigger_Shadcn_>
       <PopoverContent_Shadcn_
+        portal={true}
         sameWidthAsTrigger={sameWidthAsTrigger}
         className="p-0"
         side="bottom"

--- a/apps/studio/components/ui/OrganizationProjectSelector.tsx
+++ b/apps/studio/components/ui/OrganizationProjectSelector.tsx
@@ -145,7 +145,7 @@ export const OrganizationProjectSelector = ({
         )}
       </PopoverTrigger_Shadcn_>
       <PopoverContent_Shadcn_
-        portal={true}
+        portal
         sameWidthAsTrigger={sameWidthAsTrigger}
         className="p-0"
         side="bottom"


### PR DESCRIPTION
Fixes FE-2114

The 'All Projects' dropdown was appearing at the top of the page instead of below the trigger button. This was caused by the dropdown being rendered without a portal while inside a sticky positioned container.

Solution: Added portal={true} to PopoverContent_Shadcn_ to render the dropdown in a portal at the document root, ensuring correct positioning regardless of parent container CSS.