### PR TITLE
docs: Fix SvelteKit quickstart code example formatting (#40442)

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -167,15 +167,15 @@ hideToc: true
 
 
       ```svelte name=src/routes/+page.svelte
-        <script>
-          let { data } = $props();
-        </script>
+      <script>
+        let { data } = $props();
+      </script>
 
-        <ul>
-          {#each data.instruments as instrument}
-            <li>{instrument.name}</li>
-          {/each}
-        </ul>
+      <ul>
+        {#each data.instruments as instrument}
+          <li>{instrument.name}</li>
+        {/each}
+      </ul>
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

#40442 
SvelteKit quickstart docs code example for +page.svelte has whitespace formatting issue

## What is the new behavior?

Whitespace formatting issue is fixed

## Additional context

Minor issue
