### PR TITLE
fix(table editor): unnecessary column updates

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -142,7 +142,11 @@ export const generateUpdateColumnPayload = (
     payload.check = check
   }
 
-  if (!isEqual(originalColumn.format, type)) {
+  const originalFormat =
+    originalColumn.data_type === 'ARRAY'
+      ? `${originalColumn.format.replace(/^_/, '')}[]`
+      : originalColumn.format
+  if (!isEqual(originalFormat, type)) {
     payload.type = type
   }
   if (!isEqual(originalColumn.default_value, field.defaultValue)) {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -1,5 +1,5 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
-import { isEqual, isNull } from 'lodash'
+import { isNull } from 'lodash'
 import type { Dictionary } from 'types'
 
 import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
@@ -132,13 +132,13 @@ export const generateUpdateColumnPayload = (
   const payload: Partial<UpdateColumnPayload> = {}
   // [Joshen] Trimming on the original name as well so we don't rename columns that already
   // contain whitespaces (and accidentally bringing user apps down)
-  if (!isEqual(originalColumn.name.trim(), name)) {
+  if (originalColumn.name.trim() !== name) {
     payload.name = name
   }
-  if (!isEqual(originalColumn.comment?.trim(), comment)) {
+  if (originalColumn.comment?.trim() !== comment) {
     payload.comment = comment
   }
-  if (!isEqual(originalColumn.check?.trim(), check)) {
+  if (originalColumn.check?.trim() !== check) {
     payload.check = check
   }
 
@@ -146,25 +146,26 @@ export const generateUpdateColumnPayload = (
     originalColumn.data_type === 'ARRAY'
       ? `${originalColumn.format.replace(/^_/, '')}[]`
       : originalColumn.format
-  if (!isEqual(originalFormat, type)) {
+  if (originalFormat !== type) {
     payload.type = type
   }
-  if (!isEqual(originalColumn.default_value, field.defaultValue)) {
+
+  if (originalColumn.default_value !== field.defaultValue) {
     const defaultValue = field.defaultValue
     payload.defaultValue = defaultValue as unknown as Record<string, never> | undefined
     payload.defaultValueFormat =
       isNull(defaultValue) || isSQLExpression(defaultValue) ? 'expression' : 'literal'
   }
-  if (!isEqual(originalColumn.is_identity, field.isIdentity)) {
+  if (originalColumn.is_identity !== field.isIdentity) {
     payload.isIdentity = field.isIdentity
   }
-  if (!isEqual(originalColumn.is_nullable, field.isNullable)) {
+  if (originalColumn.is_nullable !== field.isNullable) {
     payload.isNullable = field.isNullable
   }
-  if (!isEqual(originalColumn.is_unique, field.isUnique)) {
+  if (originalColumn.is_unique !== field.isUnique) {
     payload.isUnique = field.isUnique
   }
-  if (!isEqual(isOriginallyPrimaryKey, field.isPrimaryKey)) {
+  if (isOriginallyPrimaryKey !== field.isPrimaryKey) {
     payload.isPrimaryKey = field.isPrimaryKey
   }
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -823,7 +823,7 @@ export const updateTable = async ({
       })
       if (!!error) hasError = true
     } else {
-      const originalColumn = find(originalColumns, { id: column.id })
+      const originalColumn = find(table.columns, { id: column.id })
       if (originalColumn) {
         const columnPayload = generateUpdateColumnPayload(originalColumn, updatedTable, column)
         if (!isEmpty(columnPayload)) {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -10,6 +10,7 @@ import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constra
 import { useEnumeratedTypesQuery } from 'data/enumerated-types/enumerated-types-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCustomContent } from 'hooks/custom-content/useCustomContent'
+import { useChanged } from 'hooks/misc/useChanged'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -258,8 +259,9 @@ export const TableEditor = ({
     }
   }
 
+  const visibleChanged = useChanged(visible)
   useEffect(() => {
-    if (visible) {
+    if (visibleChanged && visible) {
       setErrors({})
       setImportContent(undefined)
       setIsDuplicateRows(false)
@@ -281,7 +283,28 @@ export const TableEditor = ({
         setTableFields(tableFields)
       }
     }
-  }, [visible, templateData])
+  }, [
+    visible,
+    templateData,
+    foreignKeyMeta,
+    isRealtimeEnabled,
+    isNewRecord,
+    isDuplicating,
+    table,
+    visibleChanged,
+  ])
+
+  useEffect(() => {
+    if (!isNewRecord) {
+      const tableFields = generateTableFieldFromPostgresTable(
+        table,
+        foreignKeyMeta ?? [],
+        isDuplicating,
+        isRealtimeEnabled
+      )
+      setTableFields(tableFields)
+    }
+  }, [isNewRecord, table, foreignKeyMeta, isDuplicating, isRealtimeEnabled])
 
   useEffect(() => {
     if (isSuccessForeignKeyMeta) setFkRelations(formatForeignKeys(foreignKeys))


### PR DESCRIPTION
When you use the table editor to edit a table containing array columns, even if you _make no changes_ to the column, an update is sent to alter the array column's type to its original type. This happens because we aren't correctly checking for array column equality when we diff old/new column configs. Fixed this so no update will be sent if the column isn't changed.

## Testing
- [x] Test that actual column updates will work as expected
- [x] Test that not updating an array column will not fire a column update request

Resolves FE-2066