### PR TITLE
fix(studio): table row focus and hover

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
@@ -125,6 +125,8 @@ export const CreateAnalyticsBucketModal = ({
 
   const config = BUCKET_TYPES['analytics']
   const isCreating = isEnablingExtension || isCreatingIcebergWrapper || isCreatingAnalyticsBucket
+  const isDisabled =
+    !canCreateBuckets || !icebergCatalogEnabled || isLoading || buckets.length >= 2 || disabled
 
   const form = useForm<CreateAnalyticsBucketForm>({
     resolver: zodResolver(FormSchema),
@@ -192,22 +194,8 @@ export const CreateAnalyticsBucketModal = ({
           type={buttonType}
           className={buttonClassName}
           icon={<Plus size={14} />}
-          disabled={
-            !canCreateBuckets ||
-            !icebergCatalogEnabled ||
-            isLoading ||
-            buckets.length >= 2 ||
-            disabled
-          }
-          tabIndex={
-            !canCreateBuckets ||
-            !icebergCatalogEnabled ||
-            isLoading ||
-            buckets.length >= 2 ||
-            disabled
-              ? -1
-              : 0
-          }
+          disabled={isDisabled}
+          tabIndex={isDisabled ? -1 : 0}
           style={{ justifyContent: 'start' }}
           onClick={() => setVisible(true)}
           tooltip={{

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
@@ -199,6 +199,15 @@ export const CreateAnalyticsBucketModal = ({
             buckets.length >= 2 ||
             disabled
           }
+          tabIndex={
+            !canCreateBuckets ||
+            !icebergCatalogEnabled ||
+            isLoading ||
+            buckets.length >= 2 ||
+            disabled
+              ? -1
+              : 0
+          }
           style={{ justifyContent: 'start' }}
           onClick={() => setVisible(true)}
           tooltip={{

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/index.tsx
@@ -163,18 +163,23 @@ export const AnalyticsBuckets = () => {
                     </TableRow>
                   )}
                   {analyticsBuckets.map((bucket) => (
-                    <TableRow key={bucket.id} className="relative cursor-pointer h-16">
+                    <TableRow
+                      key={bucket.id}
+                      className={cn('relative cursor-pointer h-16', 'inset-focus')}
+                      onClick={(event) => handleBucketNavigation(bucket.id, event)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault()
+                          handleBucketNavigation(bucket.id, event)
+                        }
+                      }}
+                      tabIndex={0}
+                    >
                       <TableCell className="w-2 pr-1">
                         <BucketIcon size={16} className="text-foreground-muted" />
                       </TableCell>
                       <TableCell>
                         <p className="whitespace-nowrap max-w-[512px] truncate">{bucket.id}</p>
-                        <button
-                          className={cn('absolute inset-0', 'inset-focus')}
-                          onClick={(event) => handleBucketNavigation(bucket.id, event)}
-                        >
-                          <span className="sr-only">Go to table details</span>
-                        </button>
                       </TableCell>
 
                       <TableCell>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/index.tsx
@@ -13,7 +13,6 @@ import {
   Badge,
   Button,
   Card,
-  cn,
   Table,
   TableBody,
   TableCell,
@@ -165,7 +164,7 @@ export const AnalyticsBuckets = () => {
                   {analyticsBuckets.map((bucket) => (
                     <TableRow
                       key={bucket.id}
-                      className={cn('relative cursor-pointer h-16', 'inset-focus')}
+                      className="relative cursor-pointer h-16 inset-focus"
                       onClick={(event) => handleBucketNavigation(bucket.id, event)}
                       onKeyDown={(event) => {
                         if (event.key === 'Enter' || event.key === ' ') {

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -214,6 +214,7 @@ export const CreateBucketModal = ({
           disabled={!canCreateBuckets}
           style={{ justifyContent: 'start' }}
           onClick={() => setVisible(true)}
+          tabIndex={!canCreateBuckets ? -1 : 0}
           tooltip={{
             content: {
               side: 'bottom',

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -103,14 +103,7 @@ export const BucketTableRow = ({
     <BucketTableRow
       key={bucket.id}
       className={cn('relative cursor-pointer h-16 group', 'inset-focus')}
-      onClick={(event) => {
-        // Don't navigate if clicking on interactive elements
-        const target = event.target as HTMLElement
-        if (target.closest('button, a, [role="button"]')) {
-          return
-        }
-        handleBucketNavigation(bucket.id, event)
-      }}
+      onClick={(event) => handleBucketNavigation(bucket.id, event)}
       onKeyDown={(event) => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault()

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -100,7 +100,25 @@ export const BucketTableRow = ({
   }
 
   return (
-    <BucketTableRow key={bucket.id} className="relative cursor-pointer h-16">
+    <BucketTableRow
+      key={bucket.id}
+      className={cn('relative cursor-pointer h-16 group', 'inset-focus')}
+      onClick={(event) => {
+        // Don't navigate if clicking on interactive elements
+        const target = event.target as HTMLElement
+        if (target.closest('button, a, [role="button"]')) {
+          return
+        }
+        handleBucketNavigation(bucket.id, event)
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          handleBucketNavigation(bucket.id, event)
+        }
+      }}
+      tabIndex={0}
+    >
       <BucketTableCell className="w-2 pr-1">
         <BucketIcon size={16} className="text-foreground-muted" />
       </BucketTableCell>
@@ -109,12 +127,6 @@ export const BucketTableRow = ({
           <p className="whitespace-nowrap max-w-[512px] truncate">{bucket.id}</p>
           {bucket.public && <Badge variant="warning">Public</Badge>}
         </div>
-        <button
-          className={cn('absolute inset-0', 'inset-focus')}
-          onClick={(event) => handleBucketNavigation(bucket.id, event)}
-        >
-          <span className="sr-only">Go to bucket details</span>
-        </button>
       </BucketTableCell>
 
       <BucketTableCell>

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -10,7 +10,7 @@ import { formatBytes } from 'lib/helpers'
 import { ChevronRight } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import type React from 'react'
-import { Badge, cn, TableCell, TableHead, TableHeader, TableRow } from 'ui'
+import { Badge, TableCell, TableHead, TableHeader, TableRow } from 'ui'
 
 type BucketTableMode = 'standard' | 'virtualized'
 
@@ -102,7 +102,7 @@ export const BucketTableRow = ({
   return (
     <BucketTableRow
       key={bucket.id}
-      className={cn('relative cursor-pointer h-16 group', 'inset-focus')}
+      className="relative cursor-pointer h-16 group inset-focus"
       onClick={(event) => handleBucketNavigation(bucket.id, event)}
       onKeyDown={(event) => {
         if (event.key === 'Enter' || event.key === ' ') {

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
@@ -80,7 +80,7 @@ export const FilesBuckets = () => {
               />
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button type="default" icon={<ArrowDownNarrowWide />}>
+                  <Button tabIndex={0} type="default" icon={<ArrowDownNarrowWide />}>
                     Sorted by {snap.sortBucket === 'alphabetical' ? 'name' : 'created at'}
                   </Button>
                 </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
@@ -150,6 +150,7 @@ export const CreateVectorBucketDialog = () => {
           className="w-fit"
           icon={<Plus size={14} />}
           disabled={!canCreateBuckets}
+          tabIndex={!canCreateBuckets ? -1 : 0}
           onClick={() => setVisible(true)}
           tooltip={{
             content: {

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
@@ -157,18 +157,23 @@ export const VectorsBuckets = () => {
                     const created = +bucket.creationTime * 1000
 
                     return (
-                      <TableRow key={id} className="relative cursor-pointer h-16">
+                      <TableRow
+                        key={id}
+                        className={cn('relative cursor-pointer h-16', 'inset-focus')}
+                        onClick={(event) => handleBucketNavigation(name, event)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault()
+                            handleBucketNavigation(name, event)
+                          }
+                        }}
+                        tabIndex={0}
+                      >
                         <TableCell className="w-2 pr-1">
                           <BucketIcon size={16} className="text-foreground-muted" />
                         </TableCell>
                         <TableCell>
                           <p className="whitespace-nowrap max-w-[512px] truncate">{name}</p>
-                          <button
-                            className={cn('absolute inset-0', 'inset-focus')}
-                            onClick={(event) => handleBucketNavigation(name, event)}
-                          >
-                            <span className="sr-only">Go to bucket details</span>
-                          </button>
                         </TableCell>
                         <TableCell>
                           <p className="text-foreground-light">

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
@@ -13,7 +13,6 @@ import {
   Badge,
   Button,
   Card,
-  cn,
   Table,
   TableBody,
   TableCell,
@@ -159,7 +158,7 @@ export const VectorsBuckets = () => {
                     return (
                       <TableRow
                         key={id}
-                        className={cn('relative cursor-pointer h-16', 'inset-focus')}
+                        className="relative cursor-pointer h-16 inset-focus"
                         onClick={(event) => handleBucketNavigation(name, event)}
                         onKeyDown={(event) => {
                           if (event.key === 'Enter' || event.key === ' ') {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for Safari

## What is the current behavior?

- Only the last table row across all three bucket types (files, analytics, vectors) are selectable by mouse
- No table rows are selectable by keyboard

## What is the new behavior?

- Fixes for the above whilst maintaining existing functionality in Chrome

## Additional context

I believe https://github.com/supabase/supabase/pull/40230/files introduced this bug with the `absolute` `button`.

## To test

Please use (at least) both Safari and Chrome to test changes.
