### PR TITLE
fix(studio): invoke function snippet overflows 

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -367,7 +367,7 @@ export const EdgeFunctionDetails = () => {
                         <TabsContent key={tab.id} value={tab.id} className="mt-4 px-6">
                           <CodeBlock
                             value={code}
-                            className="p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap [&>code]:break-words"
+                            className="p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap [&>code]:break-all"
                             language={tab.language}
                             wrapLines={true}
                             hideLineNumbers={tab.hideLineNumbers}

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -367,7 +367,7 @@ export const EdgeFunctionDetails = () => {
                         <TabsContent key={tab.id} value={tab.id} className="mt-4 px-6">
                           <CodeBlock
                             value={code}
-                            className="p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap [&>code]:break-all"
+                            className={cn("p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap", showKey ? "[&>code]:break-all" : "[&>code]:break-words")}
                             language={tab.language}
                             wrapLines={true}
                             hideLineNumbers={tab.hideLineNumbers}

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -367,7 +367,10 @@ export const EdgeFunctionDetails = () => {
                         <TabsContent key={tab.id} value={tab.id} className="mt-4 px-6">
                           <CodeBlock
                             value={code}
-                            className={cn("p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap", showKey ? "[&>code]:break-all" : "[&>code]:break-words")}
+                            className={cn(
+                              'p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap',
+                              showKey ? '[&>code]:break-all' : '[&>code]:break-words'
+                            )}
                             language={tab.language}
                             wrapLines={true}
                             hideLineNumbers={tab.hideLineNumbers}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When click "Show anon key" the function code snippet overflows

https://github.com/user-attachments/assets/912d3ff7-626d-4cd4-9095-b335d0998088

## What is the new behavior?

This PR fixex this UI issue

## Additional context

Would like if may someone could just check in the staging environment, cause this issue only happen for `IS_PLATFORM` so I'd to simulate the page layout and code block.
