### PR TITLE
chore: improve readme for self-hosted configuration

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -37,13 +37,34 @@ This Docker Compose configuration includes the following services:
 - **[CHANGELOG.md](./CHANGELOG.md)** - Track recent updates and changes to services
 - **[versions.md](./versions.md)** - Complete history of Docker image versions for rollback reference
 
+## Updates
+
+To update your self-hosted Supabase instance:
+
+1. Review [CHANGELOG.md](./CHANGELOG.md) for breaking changes
+2. Check [versions.md](./versions.md) for new image versions
+3. Update `docker-compose.yml` if there are configuration changes
+4. Pull the latest images: `docker compose pull`
+5. Stop services: `docker compose down`
+6. Start services with new configuration: `docker compose up -d`
+
+**Note:** Consider to always backup your database before updating.
+
 ## Community & Support
+
+For troubleshooting common issues, see:
+- [GitHub Discussions](https://github.com/orgs/supabase/discussions?discussions_q=is%3Aopen+label%3Aself-hosted) - Questions, feature requests, and workarounds
+- [GitHub Issues](https://github.com/supabase/supabase/issues?q=is%3Aissue%20state%3Aopen%20label%3Aself-hosted) - Known issues
+- [Documentation](https://supabase.com/docs/guides/self-hosting) - Setup and configuration guides
 
 Self-hosted Supabase is community-supported. Get help and connect with other users:
 
 - **[Discord](https://discord.supabase.com)** - Real-time chat and community support
 - **[Reddit](https://www.reddit.com/r/Supabase/)** - Community forum
-- **[GitHub Discussions](https://github.com/orgs/supabase/discussions/39820)** - Self-hosted community discussion
+
+Share your self-hosting experience and read what's working for other users:
+
+- **[GitHub Discussions](https://github.com/orgs/supabase/discussions/39820)** - Self-hosting: What's working (and what's not)?)
 
 ## Important Notes
 
@@ -60,26 +81,6 @@ Before deploying to production, you must:
 - Set up proper backup procedures
 
 See the [security section](https://supabase.com/docs/guides/self-hosting/docker#securing-your-services) in the documentation.
-
-### Updates
-
-To update your self-hosted Supabase instance:
-
-1. Review [CHANGELOG.md](./CHANGELOG.md) for breaking changes
-2. Check [versions.md](./versions.md) for new image versions
-3. Update `docker-compose.yml` if there are configuration changes
-4. Pull the latest images: `docker compose pull`
-5. Stop services: `docker compose down`
-6. Start services with new configuration: `docker compose up -d`
-
-**Note:** Consider to always backup your database before updating.
-
-### Common Issues
-
-For troubleshooting common issues, see:
-- [GitHub Discussions](https://github.com/orgs/supabase/discussions?discussions_q=is%3Aopen+label%3Aself-hosted) - Questions, feature requests, and workarounds
-- [GitHub Issues](https://github.com/supabase/supabase/issues?q=is%3Aissue%20state%3Aopen%20label%3Aself-hosted) - Known issues
-- [Documentation](https://supabase.com/docs/guides/self-hosting) - Setup and configuration guides
 
 ## License
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -59,12 +59,12 @@ For troubleshooting common issues, see:
 
 Self-hosted Supabase is community-supported. Get help and connect with other users:
 
-- **[Discord](https://discord.supabase.com)** - Real-time chat and community support
-- **[Reddit](https://www.reddit.com/r/Supabase/)** - Community forum
+- [Discord](https://discord.supabase.com) - Real-time chat and community support
+- [Reddit](https://www.reddit.com/r/Supabase/) - Community forum
 
 Share your self-hosting experience and read what's working for other users:
 
-- **[GitHub Discussions](https://github.com/orgs/supabase/discussions/39820)** - Self-hosting: What's working (and what's not)?)
+- [GitHub Discussions](https://github.com/orgs/supabase/discussions/39820) - Self-hosting: What's working (and what's not)?)
 
 ## Important Notes
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,86 @@
-# Supabase Docker
+# Self-Hosted Supabase with Docker
 
-This is a minimal Docker Compose setup for self-hosting Supabase. Follow the steps [here](https://supabase.com/docs/guides/hosting/docker) to get started.
+This is the official Docker Compose setup for self-hosted Supabase. It provides a complete stack with all Supabase services running locally or on your infrastructure.
+
+## Getting Started
+
+Follow the detailed setup guide in our documentation: [Self-Hosting with Docker](https://supabase.com/docs/guides/self-hosting/docker)
+
+The guide covers:
+- Prerequisites (Git and Docker)
+- Initial setup and configuration
+- Securing your installation
+- Accessing services
+- Updating your instance
+
+## What's Included
+
+This Docker Compose configuration includes the following services:
+
+- **[Studio](https://github.com/supabase/supabase/tree/master/apps/studio)** - A dashboard for managing your self-hosted Supabase project
+- **[Kong](https://github.com/Kong/kong)** - Kong API gateway
+- **[GoTrue](https://github.com/supabase/auth)** - JWT-based authentication API for user sign-ups, logins, and session management
+- **[PostgREST](https://github.com/PostgREST/postgrest)** - Web server that turns your PostgreSQL database directly into a RESTful API
+- **[Realtime](https://github.com/supabase/realtime)** - Elixir server that listens to PostgreSQL database changes and broadcasts them over websockets
+- **[Storage](https://github.com/supabase/storage)** - RESTful API for managing files in S3, with Postgres handling permissions
+- **[ImgProxy](https://github.com/imgproxy/imgproxy)** - Fast and secure image processing server
+- **[postgres-meta](https://github.com/supabase/postgres-meta)** - RESTful API for managing Postgres (fetch tables, add roles, run queries)
+- **[PostgreSQL](https://github.com/supabase/postgres)** - Object-relational database with over 30 years of active development
+- **[Edge Runtime](https://github.com/supabase/edge-runtime)** - Web server based on Deno runtime for running JavaScript, TypeScript, and WASM services
+- **[Logflare](https://github.com/Logflare/logflare)** - Log management and event analytics platform
+- **[Vector](https://github.com/vectordotdev/vector)** - High-performance observability data pipeline for logs
+- **[Supavisor](https://github.com/supabase/supavisor)** - Supabase's Postgres connection pooler
+
+## Documentation
+
+- **[Documentation](https://supabase.com/docs/guides/self-hosting/docker)** - Setup and configuration guides
+- **[CHANGELOG.md](./CHANGELOG.md)** - Track recent updates and changes to services
+- **[versions.md](./versions.md)** - Complete history of Docker image versions for rollback reference
+
+## Community & Support
+
+Self-hosted Supabase is community-supported. Get help and connect with other users:
+
+- **[Discord](https://discord.supabase.com)** - Real-time chat and community support
+- **[Reddit](https://www.reddit.com/r/Supabase/)** - Community forum
+- **[GitHub Discussions](https://github.com/orgs/supabase/discussions/39820)** - Self-hosted community discussion
+
+## Important Notes
+
+### Security
+
+⚠️ **The default configuration is not secure for production use.**
+
+Before deploying to production, you must:
+- Update all default passwords and secrets in the `.env` file
+- Generate new JWT secrets
+- Review and update CORS settings
+- Consider setting up a secure proxy in front of self-hosted Supabase
+- Review and adjust network security configuration (ACLs, etc.)
+- Set up proper backup procedures
+
+See the [security section](https://supabase.com/docs/guides/self-hosting/docker#securing-your-services) in the documentation.
+
+### Updates
+
+To update your self-hosted Supabase instance:
+
+1. Review [CHANGELOG.md](./CHANGELOG.md) for breaking changes
+2. Check [versions.md](./versions.md) for new image versions
+3. Update `docker-compose.yml` if there are configuration changes
+4. Pull the latest images: `docker compose pull`
+5. Stop services: `docker compose down`
+6. Start services with new configuration: `docker compose up -d`
+
+**Note:** Consider to always backup your database before updating.
+
+### Common Issues
+
+For troubleshooting common issues, see:
+- [GitHub Discussions](https://github.com/orgs/supabase/discussions?discussions_q=is%3Aopen+label%3Aself-hosted) - Questions, feature requests, and workarounds
+- [GitHub Issues](https://github.com/supabase/supabase/issues?q=is%3Aissue%20state%3Aopen%20label%3Aself-hosted) - Known issues
+- [Documentation](https://supabase.com/docs/guides/self-hosting) - Setup and configuration guides
+
+## License
+
+This repository is licensed under the Apache 2.0 License. See the main [Supabase repository](https://github.com/supabase/supabase) for details.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds additional details about the Docker-based self-hosting option for Supabase.

Previous README was a bit minimal.
