### PR TITLE
chore: add self-hosted team to codeowners and remove aantti

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /apps/www/public/images/blog @supabase/marketing
 /apps/www/lib/redirects.js
 
-/docker/ @supabase/dev-workflows @aantti
+/docker/ @supabase/dev-workflows @supabase/self-hosted
 
 /apps/studio/csp.js                                                 @supabase/security
 /apps/studio/components/interfaces/Billing/Payment                  @supabase/security


### PR DESCRIPTION
## What kind of change does this PR introduce?

There's `self-hosted` team now:
https://github.com/orgs/supabase/teams/self-hosted

This change removes @aantti as an individual and adds the team.