### PR TITLE
chore: custom domain entitlement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -69,7 +69,7 @@ const CustomDomainSidePanel = () => {
     (addons?.available_addons ?? []).find((addon) => addon.type === 'custom_domain')?.variants ?? []
 
   const { hasAccess: hasAccessToCustomDomain, isLoading: isLoadingEntitlement } =
-    useCheckEntitlements('custom_domain.enable')
+    useCheckEntitlements('custom_domain')
   const hasChanges = selectedOption !== (subscriptionCDOption?.variant.identifier ?? 'cd_none')
   const selectedCustomDomain = availableOptions.find(
     (option) => option.identifier === selectedOption

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -24,6 +24,7 @@ import {
   SidePanel,
   cn,
 } from 'ui'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 
 const CustomDomainSidePanel = () => {
   const { ref: projectRef } = useParams()
@@ -67,7 +68,8 @@ const CustomDomainSidePanel = () => {
   const availableOptions =
     (addons?.available_addons ?? []).find((addon) => addon.type === 'custom_domain')?.variants ?? []
 
-  const isFreePlan = organization?.plan?.id === 'free'
+  const { hasAccess: hasAccessToCustomDomain, isLoading: isLoadingEntitlement } =
+    useCheckEntitlements('custom_domain.enable')
   const hasChanges = selectedOption !== (subscriptionCDOption?.variant.identifier ?? 'cd_none')
   const selectedCustomDomain = availableOptions.find(
     (option) => option.identifier === selectedOption
@@ -98,9 +100,10 @@ const CustomDomainSidePanel = () => {
       visible={visible}
       onCancel={closePanel}
       onConfirm={onConfirm}
-      loading={isLoading || isSubmitting}
+      loading={isLoading || isSubmitting || isLoadingEntitlement}
       disabled={
-        isFreePlan ||
+        !hasAccessToCustomDomain ||
+        isLoadingEntitlement ||
         isLoading ||
         !hasChanges ||
         isSubmitting ||
@@ -109,7 +112,7 @@ const CustomDomainSidePanel = () => {
         (subscriptionCDOption === undefined && customDomainsDisabledDueToQuota)
       }
       tooltip={
-        isFreePlan
+        !hasAccessToCustomDomain
           ? 'Unable to enable custom domain on a Free Plan'
           : !canUpdateCustomDomain
             ? 'You do not have permission to update custom domain'
@@ -155,7 +158,7 @@ const CustomDomainSidePanel = () => {
             page after enabling the add-on.
           </p>
 
-          <div className={cn('!mt-8 pb-4', isFreePlan && 'opacity-75')}>
+          <div className={cn('!mt-8 pb-4', !hasAccessToCustomDomain && 'opacity-75')}>
             <Radio.Group
               type="large-cards"
               size="tiny"
@@ -191,7 +194,7 @@ const CustomDomainSidePanel = () => {
                   className="col-span-4 !p-0"
                   name="custom-domain"
                   key={option.identifier}
-                  disabled={isFreePlan}
+                  disabled={!hasAccessToCustomDomain}
                   checked={selectedOption === option.identifier}
                   label={option.name}
                   value={option.identifier}
@@ -224,7 +227,7 @@ const CustomDomainSidePanel = () => {
             </p>
           )}
 
-          {isFreePlan && (
+          {!hasAccessToCustomDomain && (
             <Alert
               withIcon
               variant="info"


### PR DESCRIPTION
This PR replaces the `isFreePlan` check with the Entitlements API for the Custom Domain management panel.

### Testing
- With an org on the Free Plan, head to `dashboard/project/_/settings/addons?panel=customDomain`
- Assert that you see the "Unavailable on the Free Plan" banner

<img width="662" height="592" alt="image" src="https://github.com/user-attachments/assets/ebfa7b98-dcae-40a0-8db9-b29a0a110976" />

- Assert that you can't select the custom domain option or confirm the change

- With orgs on the Pro, Team and Enterprise Plans, assert that you don't see the banner above and that you're able to enable the add-on.
