### PR TITLE
fix(bucket table): a11y

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -113,7 +113,7 @@ export const BucketTableRow = ({
       tabIndex={0}
     >
       <BucketTableCell className="w-2 pr-1">
-        <BucketIcon size={16} className="text-foreground-muted" />
+        <BucketIcon aria-label="bucket icon" size={16} className="text-foreground-muted" />
       </BucketTableCell>
       <BucketTableCell className="flex-1">
         <div className="flex items-center gap-2.5">
@@ -146,8 +146,11 @@ export const BucketTableRow = ({
 
       <BucketTableCell>
         <div className="flex justify-end items-center h-full">
-          <ChevronRight size={14} className="text-foreground-muted/60" />
+          <ChevronRight aria-hidden={true} size={14} className="text-foreground-muted/60" />
         </div>
+        <button tabIndex={-1} className="sr-only">
+          Go to bucket details
+        </button>
       </BucketTableCell>
     </BucketTableRow>
   )


### PR DESCRIPTION
Fix a11y so screen readers can navigate to bucket details from the bucket overview table