### PR TITLE
chore: ipv4 entitlement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -94,7 +94,7 @@ const IPv4SidePanel = () => {
       visible={visible}
       onCancel={closePanel}
       onConfirm={onConfirm}
-      loading={isLoading || isSubmitting || isLoadingEntitlement }
+      loading={isLoading || isSubmitting || isLoadingEntitlement}
       disabled={
         !hasAccessToIPv4 ||
         isLoadingEntitlement ||

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -67,7 +67,7 @@ const IPv4SidePanel = () => {
     useCheckEntitlements('ipv4')
   const hasChanges = selectedOption !== (subscriptionIpV4Option?.variant.identifier ?? 'ipv4_none')
   const selectedIPv4 = availableOptions.find((option) => option.identifier === selectedOption)
-  const isPgBouncerEnabled = isFreePlan
+  const isPgBouncerEnabled = !isFreePlan
 
   useEffect(() => {
     if (visible) {

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -94,7 +94,7 @@ const IPv4SidePanel = () => {
       visible={visible}
       onCancel={closePanel}
       onConfirm={onConfirm}
-      loading={isLoading || isSubmitting}
+      loading={isLoading || isSubmitting || isLoadingEntitlement }
       disabled={
         !hasAccessToIPv4 ||
         isLoadingEntitlement ||

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -18,6 +18,7 @@ import { formatCurrency } from 'lib/helpers'
 import { useAddonsPagePanel } from 'state/addons-page'
 import { Button, Radio, SidePanel, cn } from 'ui'
 import { Admonition } from 'ui-patterns'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 
 const IPv4SidePanel = () => {
   const isAws = useIsAwsCloudProvider()
@@ -62,9 +63,11 @@ const IPv4SidePanel = () => {
     (addons?.available_addons ?? []).find((addon) => addon.type === 'ipv4')?.variants ?? []
 
   const isFreePlan = organization?.plan?.id === 'free'
+  const { hasAccess: hasAccessToIPv4, isLoading: isLoadingEntitlement } =
+    useCheckEntitlements('ipv4')
   const hasChanges = selectedOption !== (subscriptionIpV4Option?.variant.identifier ?? 'ipv4_none')
   const selectedIPv4 = availableOptions.find((option) => option.identifier === selectedOption)
-  const isPgBouncerEnabled = !isFreePlan
+  const isPgBouncerEnabled = isFreePlan
 
   useEffect(() => {
     if (visible) {
@@ -92,9 +95,17 @@ const IPv4SidePanel = () => {
       onCancel={closePanel}
       onConfirm={onConfirm}
       loading={isLoading || isSubmitting}
-      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting || !canUpdateIPv4 || !isAws}
+      disabled={
+        !hasAccessToIPv4 ||
+        isLoadingEntitlement ||
+        isLoading ||
+        !hasChanges ||
+        isSubmitting ||
+        !canUpdateIPv4 ||
+        !isAws
+      }
       tooltip={
-        isFreePlan
+        !hasAccessToIPv4
           ? 'Unable to enable IPv4 on a Free Plan'
           : !canUpdateIPv4
             ? 'You do not have permission to update IPv4'
@@ -147,7 +158,7 @@ const IPv4SidePanel = () => {
             </p>
           )}
 
-          <div className={cn('!mt-8 pb-4', isFreePlan && 'opacity-75')}>
+          <div className={cn('!mt-8 pb-4', !hasAccessToIPv4 && 'opacity-75')}>
             <Radio.Group
               type="large-cards"
               size="tiny"
@@ -181,7 +192,7 @@ const IPv4SidePanel = () => {
                   className="col-span-4 !p-0"
                   name="ipv4"
                   key={option.identifier}
-                  disabled={isFreePlan || !isAws}
+                  disabled={!hasAccessToIPv4 || !isAws}
                   checked={selectedOption === option.identifier}
                   label={option.name}
                   value={option.identifier}
@@ -239,7 +250,7 @@ const IPv4SidePanel = () => {
             </>
           )}
 
-          {isFreePlan && (
+          {!hasAccessToIPv4 && (
             <Admonition type="note" title="IPv4 add-on is unavailable on the Free Plan">
               <p>Upgrade your plan to enable a IPv4 address for your project</p>
               <Button asChild type="default">


### PR DESCRIPTION
Depends on https://github.com/supabase/infrastructure/pull/27553

This PR replaces the `isFreePlan` check with the Entitlements API for the IPv4 management panel.

### Testing

- With an org on the Free Plan, head to `/project/_/settings/addons?panel=ipv4`
- Assert that you can't enable the add-on
- Assert that you see the "Unavailable on the Free Plan" banner

<img width="662" height="543" alt="image" src="https://github.com/user-attachments/assets/5485b27e-3567-4ebb-bcfc-b70908fa3747" />



- With orgs on the Pro, Team and Enterprise Plans, assert that you don't see the banner above and that you're able to enable the add-on.
