### PR TITLE
docs: update React Auth quickstart to use @supabase/auth-ui-react-router (#40388)

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -21,7 +21,6 @@ hideToc: true
      ```sql name=SQL_EDITOR
       select * from auth.users;
       ````
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -29,16 +28,20 @@ hideToc: true
   <StepHikeCompact.Step step={2}>
   <StepHikeCompact.Details title="Create a React app">
 
-    Select React from the [list of UI Library quickstarts](/ui/docs/getting-started/quickstart) and follow the instructions to create a new project.
+    Create a React app using [Vite](https://vitejs.dev/).
 
   </StepHikeCompact.Details>
 
+  <StepHikeCompact.Code>
+
+    ```bash name=Terminal
+    npm create vite@latest my-app -- --template react
+    ```
+  </StepHikeCompact.Code>
 </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Install the Supabase client library">
-
-    The fastest way to get started is to use Supabase's `auth-ui-react` library which provides a convenient interface for working with Supabase Auth from a React app.
 
     Navigate to the React app and install the Supabase libraries.
 
@@ -47,9 +50,8 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react @supabase/auth-ui-shared
+      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react-router
       ```
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -57,13 +59,9 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Set up your login component">
 
-    <$Partial path="uiLibCta.mdx" />
-
     In `App.jsx`, create a Supabase client using your Project URL and key.
 
     <$Partial path="api_settings_steps.mdx" />
-
-    You can configure the Auth component to display whenever there is no session inside `supabase.auth.getSession()`
 
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>
@@ -72,8 +70,7 @@ hideToc: true
         import './index.css'
         import { useState, useEffect } from 'react'
         import { createClient } from '@supabase/supabase-js'
-        import { Auth } from '@supabase/auth-ui-react'
-        import { ThemeSupa } from '@supabase/auth-ui-shared'
+        import { PasswordAuth } from '@supabase/auth-ui-react-router'
 
         const supabase = createClient('https://<project>.supabase.co', '<sb_publishable_... or anon key>')
 
@@ -95,14 +92,13 @@ hideToc: true
           }, [])
 
           if (!session) {
-            return (<Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} />)
+            return (<PasswordAuth supabaseClient={supabase} />)
           }
           else {
             return (<div>Logged in!</div>)
           }
         }
       ```
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
@@ -119,7 +115,6 @@ hideToc: true
       ```bash name=Terminal
       npm run dev
       ```
-
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>


### PR DESCRIPTION
Summary
This PR updates the React Auth quickstart guide to use the correct Auth components from the Supabase UI React Router library, as requested in issue #40388.

What was changed

Replaced deprecated auth-ui-react references

Updated installation command

Updated import to PasswordAuth from @supabase/auth-ui-react-router

Updated example to correctly render <PasswordAuth />

No other text or sections were modified

Why
The Supabase team clarified that the intended library is:
https://supabase.com/ui/docs/react-router/password-based-auth

This PR aligns the documentation with Supabase’s current UI Auth guidance.

Linked issue
Fixes #40388