### PR TITLE
fix: add request_allow_x_forwarded_path to fix tus in self-hosted

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -273,6 +273,7 @@ services:
       POSTGREST_URL: http://rest:3000
       PGRST_JWT_SECRET: ${JWT_SECRET}
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      REQUEST_ALLOW_X_FORWARDED_PATH: "true"
       FILE_SIZE_LIMIT: 52428800
       STORAGE_BACKEND: file
       FILE_STORAGE_BACKEND_PATH: /var/lib/storage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `REQUEST_ALLOW_X_FORWARDED_PATH: "true"` to docker compose configuration.

This fixes resumable uploads for files larger than 6MB in self-hosted Supabase.

More context:

After the initial `POST` with resumable uploads, the response contains a `location` header with the URL that the client will use for uploading subsequent chunks via `PATCH`. Without `REQUEST_ALLOW_X_FORWARDED_PATH` the returned location doesn't have the `/storage/v1` part of the URI, and the upload request fails.

Related code in Storage:

- https://github.com/supabase/storage/blob/b9acc7ca1ad73cfaece9f4d2c1830b505656f644/src/config.ts#L271
- https://github.com/supabase/storage/blob/5008f65162a9ab6d4548f3d4aa571b13e6a41288/src/http/routes/tus/lifecycle.ts#L128
- https://github.com/supabase/storage/blob/90250f2a50526926330ce43c78342c574c026048/src/http/routes/tus/index.ts#L143

There's also a functional workaround with setting `TUS_URL_PATH` (see related code [here](https://github.com/supabase/storage/blob/5008f65162a9ab6d4548f3d4aa571b13e6a41288/src/config.ts#L310)) - however, the **preferred fix** is to use `REQUEST_ALLOW_X_FORWARDED_PATH`.

`REQUEST_ALLOW_X_FORWARDED_PATH: "true"` _and_ `TUS_URL_PATH: "/storage/v1/upload/resumable"` are mutually exclusive. If both are configured, the location URL will be malformed.