### PR TITLE
fix(docs): add missing 'is' in Storage API description

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also [self-host](https://supabase.com/docs/guides/hosting/overview) and 
 - [Realtime](https://github.com/supabase/realtime) is an Elixir server that allows you to listen to PostgreSQL inserts, updates, and deletes using websockets. Realtime polls Postgres' built-in replication functionality for database changes, converts changes to JSON, then broadcasts the JSON over websockets to authorized clients.
 - [PostgREST](http://postgrest.org/) is a web server that turns your PostgreSQL database directly into a RESTful API.
 - [GoTrue](https://github.com/supabase/gotrue) is a JWT-based authentication API that simplifies user sign-ups, logins, and session management in your applications.
-- [Storage](https://github.com/supabase/storage-api) a RESTful API for managing files in S3, with Postgres handling permissions.
+- [Storage](https://github.com/supabase/storage-api) is a RESTful API for managing files in S3, with Postgres handling permissions.
 - [pg_graphql](http://github.com/supabase/pg_graphql/) a PostgreSQL extension that exposes a GraphQL API.
 - [postgres-meta](https://github.com/supabase/postgres-meta) is a RESTful API for managing your Postgres, allowing you to fetch tables, add roles, and run queries, etc.
 - [Kong](https://github.com/Kong/kong) is a cloud-native API gateway.


### PR DESCRIPTION
## Summary
Fixed a small grammatical issue in the README.

## Changes
- Added the missing word "is" in the Storage API description.

## Why
Improves readability and maintains consistency across the documentation.

## Checklist
- [x] This PR only updates documentation.
- [x] No breaking changes.
- [x] Follows CONTRIBUTING.md guidelines.
