### PR TITLE
feat(studio): add comparisons to query perf calls filter

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
@@ -1,6 +1,6 @@
 import { useDebounce } from '@uidotdev/usehooks'
 import { Search, X } from 'lucide-react'
-import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from 'nuqs'
+import { parseAsArrayOf, parseAsString, useQueryStates, parseAsJson } from 'nuqs'
 import { ChangeEvent, ReactNode, useEffect, useState } from 'react'
 
 import { FilterPopover } from 'components/ui/FilterPopover'
@@ -9,6 +9,10 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { useQueryPerformanceSort } from './hooks/useQueryPerformanceSort'
+import {
+  ReportsNumericFilter,
+  NumericFilter,
+} from 'components/interfaces/Reports/v2/ReportsNumericFilter'
 
 export const QueryPerformanceFilterBar = ({
   actions,
@@ -20,11 +24,14 @@ export const QueryPerformanceFilterBar = ({
   const { data: project } = useSelectedProjectQuery()
   const { sort, clearSort } = useQueryPerformanceSort()
 
-  const [{ search: searchQuery, roles: defaultFilterRoles, minCalls }, setSearchParams] =
+  const [{ search: searchQuery, roles: defaultFilterRoles, callsFilter }, setSearchParams] =
     useQueryStates({
       search: parseAsString.withDefault(''),
       roles: parseAsArrayOf(parseAsString).withDefault([]),
-      minCalls: parseAsInteger,
+      callsFilter: parseAsJson((value) => value as NumericFilter | null).withDefault({
+        operator: '>=',
+        value: 0,
+      } as NumericFilter),
     })
   const { data, isLoading: isLoadingRoles } = useDatabaseRolesQuery({
     projectRef: project?.ref,
@@ -36,51 +43,23 @@ export const QueryPerformanceFilterBar = ({
     roles: defaultFilterRoles,
   })
   const [inputValue, setInputValue] = useState(searchQuery)
-  const [minCallsInput, setMinCallsInput] = useState(
-    typeof minCalls === 'number' && Number.isFinite(minCalls) && minCalls >= 0
-      ? String(minCalls)
-      : ''
-  )
   const debouncedInputValue = useDebounce(inputValue, 500)
-  const debouncedMinCalls = useDebounce(minCallsInput, 300)
+  // const debouncedMinCalls = useDebounce(minCallsInput, 300)
   const searchValue = inputValue.length === 0 ? inputValue : debouncedInputValue
 
   const onSearchQueryChange = (value: string) => {
-    const sanitizedMinCalls =
-      typeof minCalls === 'number' && Number.isFinite(minCalls) && minCalls >= 0
-        ? Math.floor(minCalls)
-        : undefined
-    setSearchParams({ search: value || '', minCalls: sanitizedMinCalls })
+    setSearchParams({ search: value || '' })
   }
 
   const onFilterRolesChange = (roles: string[]) => {
     setFilters({ ...filters, roles })
-    const sanitizedMinCalls =
-      typeof minCalls === 'number' && Number.isFinite(minCalls) && minCalls >= 0
-        ? Math.floor(minCalls)
-        : undefined
-    setSearchParams({ roles, minCalls: sanitizedMinCalls })
+    setSearchParams({ roles })
   }
 
   useEffect(() => {
     onSearchQueryChange(searchValue)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchValue])
-
-  useEffect(() => {
-    const value = debouncedMinCalls.trim()
-    if (value === '') {
-      setSearchParams({ minCalls: undefined })
-      return
-    }
-    const parsed = Number(value)
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      setSearchParams({ minCalls: Math.floor(parsed) })
-    } else {
-      setSearchParams({ minCalls: undefined })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedMinCalls])
 
   return (
     <div className="px-4 py-1.5 bg-surface-200 border-t -mt-px flex justify-between items-center overflow-x-auto overflow-y-hidden w-full flex-shrink-0">
@@ -109,28 +88,15 @@ export const QueryPerformanceFilterBar = ({
             ]}
           />
 
-          <Input
-            size="tiny"
-            type="number"
-            autoComplete="off"
-            value={minCallsInput}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setMinCallsInput(e.target.value)}
-            name="minCalls"
-            id="minCalls"
+          <ReportsNumericFilter
+            label="Calls"
+            value={callsFilter}
+            onChange={(value) => setSearchParams({ callsFilter: value })}
+            operators={['=', '>=', '<=', '>', '<', '!=']}
+            defaultOperator=">="
+            placeholder="e.g. 100"
             min={0}
-            placeholder="Min. calls (e.g. 100)"
-            className="w-32"
-            actions={[
-              minCallsInput && (
-                <Button
-                  size="tiny"
-                  type="text"
-                  icon={<X />}
-                  onClick={() => setMinCallsInput('')}
-                  className="p-0 h-5 w-5"
-                />
-              ),
-            ]}
+            className="w-auto"
           />
 
           {showRolesFilter && (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This replaces the minimum call input on Query Performance and brings in the numeric filter with comparisons (e.g. less than, greater than, equals etc). 
