### PR TITLE
Fix: Resumable Storage uploads on self‑hosted by using Docker named volumes for /var/lib/storage

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -245,7 +245,7 @@ services:
     image: supabase/storage-api:v1.28.2
     restart: unless-stopped
     volumes:
-      - ./volumes/storage:/var/lib/storage:z
+      - storage_data:/var/lib/storage
     healthcheck:
       test:
         [
@@ -288,7 +288,7 @@ services:
     image: darthsim/imgproxy:v3.8.0
     restart: unless-stopped
     volumes:
-      - ./volumes/storage:/var/lib/storage:z
+      - storage_data:/var/lib/storage
     healthcheck:
       test:
         [
@@ -539,3 +539,4 @@ services:
 
 volumes:
   db-config:
+  storage_data:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Resumable uploads (tus) fail on some self-hosted setups with the error: “The file system does not support extended attributes or has the feature disabled.” This happens when Storage writes upload metadata via extended attributes (xattrs) to a bind-mounted host directory that does not support xattrs (common on Docker Desktop bind mounts, some network filesystems, or mounts without user_xattr).

This PR switches the Storage data path from a host bind mount to a Docker named volume by default. Docker named volumes typically run on ext4 inside the VM and support extended attributes, allowing tus to store metadata and complete uploads successfully.

## What is the current behavior?
In some self-hosted deployments that bind-mount the host filesystem for Storage data (e.g., ./volumes/storage:/var/lib/storage), resumable uploads to /storage/v1/upload/resumable fail with HTTP 500.
The error returned is: “The file system does not support extended attributes or has the feature disabled.”
Root cause: the resumable upload server (tusd) stores upload metadata via extended attributes (xattrs). Many host bind mounts (Docker Desktop on Mac/Windows, some network mounts, or Linux mounts without user_xattr) do not support xattrs, causing tusd to error.
Example symptom:

Attempting to upload a file in Studio’s Storage Explorer results in “Something went wrong with that request” and 500 from /storage/v1/upload/resumable.
Related discussion/evidence:

Studio constructs and uses the resumable endpoint (apps/studio/state/storage-explorer.tsx), but the failure occurs in the Storage service due to the underlying filesystem not supporting xattrs.

<img width="1103" height="718" alt="Screenshot 2025-11-17 at 5 21 44 PM" src="https://github.com/user-attachments/assets/e06363ef-fd14-4d14-9569-a75e383f37fc" />


## What is the new behavior?

The docker-compose configuration is updated to use a Docker named volume for /var/lib/storage (and for Imgproxy) instead of a host bind mount by default.
Docker named volumes typically use xattr-capable filesystems inside the Docker VM (ext4-like), allowing tusd to persist upload metadata and complete resumable uploads.
Result: resumable uploads succeed by default on self-hosted deployments, without requiring users to manually ensure xattrs support on bind-mounted host directories.
Existing functionality (Storage/Imgproxy) continues to work as expected, but now with a filesystem that supports resumable upload metadata out-of-the-box.
<img width="1103" height="115" alt="Screenshot 2025-11-17 at 6 24 11 PM" src="https://github.com/user-attachments/assets/bd037d42-cbcd-45d6-a11d-9b6535053aa0" />


## Additional context

### Symptoms:
500 error on POST /storage/v1/upload/resumable
“Something went wrong with that request”
“The file system does not support extended attributes or has the feature disabled.”

### Root cause:
tusd (resumable upload server) stores in-progress metadata via xattrs. The bind-mounted host path does not support xattrs.
Studio only constructs the upload endpoint and uses tus; the failure occurs in the storage backend due to the filesystem.
Reference in Studio:

const resumableUploadUrl = `${IS_PLATFORM ? 'https' : protocol}://${endpoint}/storage/v1/upload/resumable`

### Changes
Update docker-compose to use a named volume for Storage and Imgproxy instead of a host bind mount for /var/lib/storage.
Define a new named volume storage_data.
