### PR TITLE
Chore/add missing error handler for buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
@@ -3,9 +3,11 @@ import { useMemo, useState } from 'react'
 
 import { useParams } from 'common'
 import { ScaffoldSection } from 'components/layouts/Scaffold'
+import AlertError from 'components/ui/AlertError'
+import { InlineLink } from 'components/ui/InlineLink'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
-import { Bucket, useBucketsQuery } from 'data/storage/buckets-query'
+import { useBucketsQuery } from 'data/storage/buckets-query'
 import { useStoragePolicyCounts } from 'hooks/storage/useStoragePolicyCounts'
 import { IS_PLATFORM } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
@@ -19,11 +21,9 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { CreateBucketModal } from '../CreateBucketModal'
-import { DeleteBucketModal } from '../DeleteBucketModal'
-import { EditBucketModal } from '../EditBucketModal'
-import { EmptyBucketModal } from '../EmptyBucketModal'
 import { EmptyBucketState } from '../EmptyBucketState'
 import { STORAGE_BUCKET_SORT } from '../Storage.constants'
 import { BucketsTable } from './BucketsTable'
@@ -31,13 +31,16 @@ import { BucketsTable } from './BucketsTable'
 export const FilesBuckets = () => {
   const { ref } = useParams()
   const snap = useStorageExplorerStateSnapshot()
-
-  const [modal, setModal] = useState<'edit' | 'empty' | 'delete' | null>(null)
-  const [selectedBucket, setSelectedBucket] = useState<Bucket>()
   const [filterString, setFilterString] = useState('')
 
   const { data } = useProjectStorageConfigQuery({ projectRef: ref }, { enabled: IS_PLATFORM })
-  const { data: buckets = [], isLoading: isLoadingBuckets } = useBucketsQuery({ projectRef: ref })
+  const {
+    data: buckets = [],
+    error: bucketsError,
+    isError: isErrorBuckets,
+    isLoading: isLoadingBuckets,
+    isSuccess: isSuccessBuckets,
+  } = useBucketsQuery({ projectRef: ref })
   const { getPolicyCount, isLoading: isLoadingPolicies } = useStoragePolicyCounts(buckets)
 
   const formattedGlobalUploadLimit = formatBytes(data?.fileSizeLimit ?? 0)
@@ -50,6 +53,10 @@ export const FilesBuckets = () => {
         ? true
         : bucket.id.toLowerCase().includes(filterString.toLowerCase())
     )
+  const hasNoBuckets =
+    buckets.filter((bucket) => !('type' in bucket) || bucket.type === 'STANDARD').length === 0
+  const hasNoApiKeys =
+    isErrorBuckets && bucketsError.message.includes('Project has no active API keys')
 
   const sortedFilesBuckets = useMemo(
     () =>
@@ -62,79 +69,76 @@ export const FilesBuckets = () => {
   )
 
   return (
-    <>
-      {!isLoading &&
-      buckets.filter((bucket) => !('type' in bucket) || bucket.type === 'STANDARD').length === 0 ? (
-        <EmptyBucketState bucketType="files" className="mt-12" />
-      ) : (
-        <ScaffoldSection isFullWidth className="h-full gap-y-4">
-          <div className="flex flex-grow justify-between gap-x-2 items-center">
-            <div className="flex items-center gap-x-2">
-              <Input
-                size="tiny"
-                className="flex-grow lg:flex-grow-0 w-52"
-                placeholder="Search for a bucket"
-                value={filterString}
-                onChange={(e) => setFilterString(e.target.value)}
-                icon={<Search size={12} />}
-              />
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button tabIndex={0} type="default" icon={<ArrowDownNarrowWide />}>
-                    Sorted by {snap.sortBucket === 'alphabetical' ? 'name' : 'created at'}
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start" className="w-40">
-                  <DropdownMenuRadioGroup
-                    value={snap.sortBucket}
-                    onValueChange={(value) => snap.setSortBucket(value as STORAGE_BUCKET_SORT)}
-                  >
-                    <DropdownMenuRadioItem value="alphabetical">Sort by name</DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="created_at">
-                      Sort by created at
-                    </DropdownMenuRadioItem>
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-            <CreateBucketModal buttonType="primary" buttonClassName="w-fit" />
-          </div>
-
-          {isLoading ? (
-            <GenericSkeletonLoader />
-          ) : (
-            <Card>
-              <BucketsTable
-                buckets={sortedFilesBuckets}
-                projectRef={ref ?? '_'}
-                filterString={filterString}
-                formattedGlobalUploadLimit={formattedGlobalUploadLimit}
-                getPolicyCount={getPolicyCount}
-              />
-            </Card>
-          )}
-        </ScaffoldSection>
-      )}
-
-      {selectedBucket && (
+    <ScaffoldSection isFullWidth className="h-full gap-y-4">
+      {isLoading && <GenericSkeletonLoader />}
+      {isErrorBuckets && (
         <>
-          <EditBucketModal
-            visible={modal === 'edit'}
-            bucket={selectedBucket}
-            onClose={() => setModal(null)}
-          />
-          <EmptyBucketModal
-            visible={modal === 'empty'}
-            bucket={selectedBucket}
-            onClose={() => setModal(null)}
-          />
-          <DeleteBucketModal
-            visible={modal === `delete`}
-            bucket={selectedBucket}
-            onClose={() => setModal(null)}
-          />
+          {hasNoApiKeys ? (
+            <Admonition type="warning" title="Project has no active API keys enabled">
+              <p className="!leading-normal text-sm">
+                The dashboard relies on having active API keys on the project to function. If you'd
+                like to use Storage through the dashboard, create a set of API keys{' '}
+                <InlineLink href={`/project/${ref}/settings/api-keys/new`}>here</InlineLink>.
+              </p>
+            </Admonition>
+          ) : (
+            <AlertError error={bucketsError} subject="Failed to retrieve buckets" />
+          )}
         </>
       )}
-    </>
+      {isSuccessBuckets && (
+        <>
+          {hasNoBuckets ? (
+            <EmptyBucketState bucketType="files" />
+          ) : (
+            <>
+              <div className="flex flex-grow justify-between gap-x-2 items-center">
+                <div className="flex items-center gap-x-2">
+                  <Input
+                    size="tiny"
+                    className="flex-grow lg:flex-grow-0 w-52"
+                    placeholder="Search for a bucket"
+                    value={filterString}
+                    onChange={(e) => setFilterString(e.target.value)}
+                    icon={<Search size={12} />}
+                  />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button tabIndex={0} type="default" icon={<ArrowDownNarrowWide />}>
+                        Sorted by {snap.sortBucket === 'alphabetical' ? 'name' : 'created at'}
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="w-40">
+                      <DropdownMenuRadioGroup
+                        value={snap.sortBucket}
+                        onValueChange={(value) => snap.setSortBucket(value as STORAGE_BUCKET_SORT)}
+                      >
+                        <DropdownMenuRadioItem value="alphabetical">
+                          Sort by name
+                        </DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="created_at">
+                          Sort by created at
+                        </DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                <CreateBucketModal buttonType="primary" buttonClassName="w-fit" />
+              </div>
+
+              <Card>
+                <BucketsTable
+                  buckets={sortedFilesBuckets}
+                  projectRef={ref ?? '_'}
+                  filterString={filterString}
+                  formattedGlobalUploadLimit={formattedGlobalUploadLimit}
+                  getPolicyCount={getPolicyCount}
+                />
+              </Card>
+            </>
+          )}
+        </>
+      )}
+    </ScaffoldSection>
   )
 }

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
@@ -76,8 +76,8 @@ export const FilesBuckets = () => {
           {hasNoApiKeys ? (
             <Admonition type="warning" title="Project has no active API keys enabled">
               <p className="!leading-normal text-sm">
-                The dashboard relies on having active API keys on the project to function. If you'd
-                like to use Storage through the dashboard, create a set of API keys{' '}
+                The Dashboard relies on having active API keys on the project to function. If you'd
+                like to use Storage through the Dashboard, create a set of API keys{' '}
                 <InlineLink href={`/project/${ref}/settings/api-keys/new`}>here</InlineLink>.
               </p>
             </Admonition>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
@@ -5,6 +5,7 @@ import { useState, type KeyboardEvent, type MouseEvent } from 'react'
 
 import { useParams } from 'common'
 import { ScaffoldHeader, ScaffoldSection, ScaffoldSectionTitle } from 'components/layouts/Scaffold'
+import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useVectorBucketsQuery } from 'data/storage/vector-buckets-query'
 import { Bucket as BucketIcon } from 'icons'
@@ -37,7 +38,13 @@ export const VectorsBuckets = () => {
 
   const [filterString, setFilterString] = useState('')
 
-  const { data, isLoading: isLoadingBuckets } = useVectorBucketsQuery({ projectRef })
+  const {
+    data,
+    error: bucketsError,
+    isError: isErrorBuckets,
+    isLoading: isLoadingBuckets,
+    isSuccess: isSuccessBuckets,
+  } = useVectorBucketsQuery({ projectRef })
   const bucketsList = data?.vectorBuckets ?? []
 
   const filteredBuckets =
@@ -100,101 +107,111 @@ export const VectorsBuckets = () => {
         </div>
       </Admonition>
 
-      {!isLoadingBuckets && bucketsList.length === 0 ? (
-        <EmptyBucketState bucketType="vectors" />
-      ) : (
-        <div className="flex flex-col gap-y-4">
-          <ScaffoldHeader className="py-0">
-            <ScaffoldSectionTitle>Buckets</ScaffoldSectionTitle>
-          </ScaffoldHeader>
-          <div className="flex flex-grow justify-between gap-x-2 items-center">
-            <Input
-              size="tiny"
-              className="flex-grow lg:flex-grow-0 w-52"
-              placeholder="Search for a bucket"
-              value={filterString}
-              onChange={(e) => setFilterString(e.target.value)}
-              icon={<Search size={12} />}
-            />
-            <CreateVectorBucketDialog />
-          </div>
+      {isLoadingBuckets && <GenericSkeletonLoader />}
 
-          {isLoadingBuckets ? (
-            <GenericSkeletonLoader />
+      {isErrorBuckets && (
+        <AlertError error={bucketsError} subject="Failed to retrieve vector buckets" />
+      )}
+
+      {isSuccessBuckets && (
+        <>
+          {bucketsList.length === 0 ? (
+            <EmptyBucketState bucketType="vectors" />
           ) : (
-            <Card>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    {filteredBuckets.length > 0 && (
-                      <TableHead className="w-2 pr-1">
-                        <span className="sr-only">Icon</span>
-                      </TableHead>
-                    )}
-                    <TableHead>Name</TableHead>
-                    <TableHead>Created at</TableHead>
-                    <TableHead>
-                      <span className="sr-only">Actions</span>
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredBuckets.length === 0 && filterString.length > 0 && (
-                    <TableRow className="[&>td]:hover:bg-inherit">
-                      <TableCell colSpan={3}>
-                        <p className="text-sm text-foreground">No results found</p>
-                        <p className="text-sm text-foreground-lighter">
-                          Your search for "{filterString}" did not return any results
-                        </p>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {filteredBuckets.map((bucket, idx: number) => {
-                    const id = `bucket-${idx}`
-                    const name = bucket.vectorBucketName
-                    // the creation time is in seconds, convert it to milliseconds
-                    const created = +bucket.creationTime * 1000
+            <div className="flex flex-col gap-y-4">
+              <ScaffoldHeader className="py-0">
+                <ScaffoldSectionTitle>Buckets</ScaffoldSectionTitle>
+              </ScaffoldHeader>
+              <div className="flex flex-grow justify-between gap-x-2 items-center">
+                <Input
+                  size="tiny"
+                  className="flex-grow lg:flex-grow-0 w-52"
+                  placeholder="Search for a bucket"
+                  value={filterString}
+                  onChange={(e) => setFilterString(e.target.value)}
+                  icon={<Search size={12} />}
+                />
+                <CreateVectorBucketDialog />
+              </div>
 
-                    return (
-                      <TableRow
-                        key={id}
-                        className="relative cursor-pointer h-16 inset-focus"
-                        onClick={(event) => handleBucketNavigation(name, event)}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter' || event.key === ' ') {
-                            event.preventDefault()
-                            handleBucketNavigation(name, event)
-                          }
-                        }}
-                        tabIndex={0}
-                      >
-                        <TableCell className="w-2 pr-1">
-                          <BucketIcon size={16} className="text-foreground-muted" />
-                        </TableCell>
-                        <TableCell>
-                          <p className="whitespace-nowrap max-w-[512px] truncate">{name}</p>
-                        </TableCell>
-                        <TableCell>
-                          <p className="text-foreground-light">
-                            <TimestampInfo
-                              utcTimestamp={created}
-                              className="text-sm text-foreground-light"
-                            />
-                          </p>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex justify-end items-center h-full">
-                            <ChevronRight size={14} className="text-foreground-muted/60" />
-                          </div>
-                        </TableCell>
+              {isLoadingBuckets ? (
+                <GenericSkeletonLoader />
+              ) : (
+                <Card>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        {filteredBuckets.length > 0 && (
+                          <TableHead className="w-2 pr-1">
+                            <span className="sr-only">Icon</span>
+                          </TableHead>
+                        )}
+                        <TableHead>Name</TableHead>
+                        <TableHead>Created at</TableHead>
+                        <TableHead>
+                          <span className="sr-only">Actions</span>
+                        </TableHead>
                       </TableRow>
-                    )
-                  })}
-                </TableBody>
-              </Table>
-            </Card>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredBuckets.length === 0 && filterString.length > 0 && (
+                        <TableRow className="[&>td]:hover:bg-inherit">
+                          <TableCell colSpan={3}>
+                            <p className="text-sm text-foreground">No results found</p>
+                            <p className="text-sm text-foreground-lighter">
+                              Your search for "{filterString}" did not return any results
+                            </p>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                      {filteredBuckets.map((bucket, idx: number) => {
+                        const id = `bucket-${idx}`
+                        const name = bucket.vectorBucketName
+                        // the creation time is in seconds, convert it to milliseconds
+                        const created = +bucket.creationTime * 1000
+
+                        return (
+                          <TableRow
+                            key={id}
+                            className="relative cursor-pointer h-16 inset-focus"
+                            onClick={(event) => handleBucketNavigation(name, event)}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault()
+                                handleBucketNavigation(name, event)
+                              }
+                            }}
+                            tabIndex={0}
+                          >
+                            <TableCell className="w-2 pr-1">
+                              <BucketIcon size={16} className="text-foreground-muted" />
+                            </TableCell>
+                            <TableCell>
+                              <p className="whitespace-nowrap max-w-[512px] truncate">{name}</p>
+                            </TableCell>
+                            <TableCell>
+                              <p className="text-foreground-light">
+                                <TimestampInfo
+                                  utcTimestamp={created}
+                                  className="text-sm text-foreground-light"
+                                />
+                              </p>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex justify-end items-center h-full">
+                                <ChevronRight size={14} className="text-foreground-muted/60" />
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })}
+                    </TableBody>
+                  </Table>
+                </Card>
+              )}
+            </div>
           )}
-        </div>
+        </>
       )}
     </ScaffoldSection>
   )

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -42,8 +42,13 @@ export const useBucketsQuery = <TData = BucketsData>(
     enabled: enabled && typeof projectRef !== 'undefined' && isActive,
     ...options,
     retry: (failureCount, error) => {
-      if (error instanceof ResponseError && error.message.includes('Missing tenant config')) {
-        return false
+      if (error instanceof ResponseError) {
+        if (
+          error.message.includes('Missing tenant config') ||
+          error.message.includes('Project has no active API keys')
+        ) {
+          return false
+        }
       }
 
       if (failureCount < MAX_RETRY_FAILURE_COUNT) {


### PR DESCRIPTION
## Context

Realised that the bucket home pages for files, analytics and vectors were missing error state handlers - more importantly for files buckets. There's currently a footgun whereby if you were to disable legacy API keys without having created a new set of API keys, the Storage UI would silently fail (since it depends on the API keys on the BE)

PR here adds error state handlers for all 3 types of buckets, and also contextually renders this error for files buckets if the error returned is about missing API keys

<img width="1092" height="128" alt="image" src="https://github.com/user-attachments/assets/88b72497-9c53-4afd-b860-bc3dba9326fa" />

## To test

Just a code review will do as this error doesn't surface on local/staging, only production so its not possible to reproduce in the preview. Although please do a quick check to verify everything else tho (loading state, success states)
