### PR TITLE
Swap label for span in TextConfirmModal to support double clicking label

### DIFF
--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -161,13 +161,13 @@ export const TextConfirmModal = forwardRef<
                 name="confirmValue"
                 render={({ field }) => (
                   <FormItem_Shadcn_ className="flex flex-col gap-y-2">
-                    <FormLabel_Shadcn_ {...label}>
+                    <span className="text-sm text-foreground-lighter">
                       Type{' '}
                       <span className="text-foreground break-all whitespace-pre">
                         {confirmString}
                       </span>{' '}
                       to confirm.
-                    </FormLabel_Shadcn_>
+                    </span>
                     <FormControl_Shadcn_>
                       <Input_Shadcn_
                         autoComplete="off"


### PR DESCRIPTION
## Context

As per PR title - no UI changes, just swapping the `FormLabel_Shadcn` element out with a `span` to support double clicking within the `TextConfirmModal` as its common user behaviour to want to double click on the value in the label to copy and paste into the text input field

## To test
Can check in the delete project modal
- [ ] Verify that label looks alright
- [ ] Verify that you can double click to copy the project name