### PR TITLE
Add enable selection prop to FormLabel component

### DIFF
--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -161,13 +161,13 @@ export const TextConfirmModal = forwardRef<
                 name="confirmValue"
                 render={({ field }) => (
                   <FormItem_Shadcn_ className="flex flex-col gap-y-2">
-                    <span className="text-sm text-foreground-lighter">
+                    <FormLabel_Shadcn_ {...label} enableSelection>
                       Type{' '}
                       <span className="text-foreground break-all whitespace-pre">
                         {confirmString}
                       </span>{' '}
                       to confirm.
-                    </span>
+                    </FormLabel_Shadcn_>
                     <FormControl_Shadcn_>
                       <Input_Shadcn_
                         autoComplete="off"

--- a/packages/ui/src/components/shadcn/ui/form.tsx
+++ b/packages/ui/src/components/shadcn/ui/form.tsx
@@ -13,9 +13,9 @@ import {
   useWatch,
 } from 'react-hook-form'
 
+import { AnimatePresence, motion } from 'framer-motion'
 import { cn } from '../../../lib/utils/cn'
 import { Label } from './label'
-import { motion, AnimatePresence } from 'framer-motion'
 
 const Form = FormProvider
 
@@ -88,15 +88,17 @@ FormItem.displayName = 'FormItem'
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & { enableSelection?: boolean }
+>(({ className, enableSelection = false, ...props }, ref) => {
   const { error, formItemId } = useFormField()
 
+  const Comp = enableSelection ? 'label' : Label
+
   return (
-    <Label
+    <Comp
       ref={ref}
       className={cn(
-        'text-foreground-light',
+        'text-foreground-light text-sm',
         'transition-colors',
         error && '!text-destructive',
         className,


### PR DESCRIPTION
## Context

Just realised that my previous fix [here](https://github.com/supabase/supabase/pull/40552) will break unit tests with the `DeleteBucketConfirmationModal`, and rightfully so as its technically not semantically correct using a `span` for a input label

Opting to do this properly within the ui packages instead by passing a `enableSelection` flag into the `FormLabel` component - which will then render a native `label` element instead of radix's label component and hence will support double clicking on the label to copy and paste