### PR TITLE
fix: align project filter popover close of the trigger

### DIFF
--- a/apps/studio/components/interfaces/HomePageActions.tsx
+++ b/apps/studio/components/interfaces/HomePageActions.tsx
@@ -83,7 +83,13 @@ export const HomePageActions = ({
               icon={<Filter />}
             />
           </PopoverTrigger_Shadcn_>
-          <PopoverContent_Shadcn_ className="p-0 w-56" side="bottom" align="center" sideOffset={6} portal={true}>
+          <PopoverContent_Shadcn_
+            className="p-0 w-56"
+            side="bottom"
+            align="center"
+            sideOffset={6}
+            portal={true}
+          >
             <div className="px-3 pt-3 pb-2 flex flex-col gap-y-2">
               <p className="text-xs">Filter projects by status</p>
               <div className="flex flex-col">

--- a/apps/studio/components/interfaces/HomePageActions.tsx
+++ b/apps/studio/components/interfaces/HomePageActions.tsx
@@ -83,7 +83,7 @@ export const HomePageActions = ({
               icon={<Filter />}
             />
           </PopoverTrigger_Shadcn_>
-          <PopoverContent_Shadcn_ className="p-0 w-56" side="bottom" align="center">
+          <PopoverContent_Shadcn_ className="p-0 w-56" side="bottom" align="center" sideOffset={6} portal={true}>
             <div className="px-3 pt-3 pb-2 flex flex-col gap-y-2">
               <p className="text-xs">Filter projects by status</p>
               <div className="flex flex-col">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The project filter popover on the Projects screen opens in the wrong position, offset and misaligned from the trigger.  
This makes the filter UI feel broken and unintuitive.

Related issue: [#40550](https://github.com/supabase/supabase/issues/40550)

## What is the new behavior?

The filter popover now opens directly **below the trigger**, aligned consistently regardless of layout or container transforms.  
Rendering the content in a portal ensures correct placement and prevents the popover from being influenced by parent element styles.

### Screenshots

<details>
  <summary>Before</summary>

<img width="1861" height="941" alt="before" src="https://github.com/user-attachments/assets/08438e8c-4a07-4c46-8301-0affbccec103" /> 
</details>

<details>
  <summary>After</summary>

<img width="1856" height="939" alt="after" src="https://github.com/user-attachments/assets/a238d655-f0ca-4173-8a50-b85763987ac7" /> 
</details>  



