### PR TITLE
Surface error message from project clone

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/CreateNewProjectDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/CreateNewProjectDialog.tsx
@@ -76,8 +76,7 @@ export const CreateNewProjectDialog = ({
 
   const { mutate: triggerClone, isLoading: cloneMutationLoading } = useProjectCloneMutation({
     onError: (error) => {
-      console.error('error', error)
-      toast.error('Failed to restore to new project')
+      toast.error(`Failed to restore to new project: ${error.message}`)
     },
     onSuccess: () => {
       toast.success('Restoration process started')


### PR DESCRIPTION
## Context

We weren't surfacing any error messages in the toast from restore to new project leading to some UX confusions - this PR just addresses that