### PR TITLE
Feature/lint action

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
@@ -3,27 +3,30 @@ import { noop } from 'lodash'
 import { Lock, Table } from 'lucide-react'
 
 import { useParams } from 'common'
+import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { ToggleRlsButton } from 'components/ui/ToggleRlsButton'
 import { EditorTablePageLink } from 'data/prefetchers/project.$ref.editor.$id'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
+import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { AiIconAnimation, Badge, CardTitle } from 'ui'
 import type { PolicyTable } from './PolicyTableRow.types'
-import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
-import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 
 interface PolicyTableRowHeaderProps {
   table: PolicyTable
   isLocked: boolean
-  onSelectToggleRLS: (table: PolicyTable) => void
+  projectRef?: string
+  connectionString?: string | null
   onSelectCreatePolicy: (table: PolicyTable) => void
 }
 
 export const PolicyTableRowHeader = ({
   table,
   isLocked,
-  onSelectToggleRLS = noop,
-  onSelectCreatePolicy,
+  projectRef,
+  connectionString,
+  onSelectCreatePolicy = noop,
 }: PolicyTableRowHeaderProps) => {
   const { ref } = useParams()
   const aiSnap = useAiAssistantStateSnapshot()
@@ -69,22 +72,34 @@ export const PolicyTableRowHeader = ({
       {!isTableLocked && (
         <div className="flex-1">
           <div className="flex flex-row justify-end gap-x-2">
-            {!isRealtimeMessagesTable && (
-              <ButtonTooltip
-                type="default"
+            {!isRealtimeMessagesTable && !!projectRef && (
+              <ToggleRlsButton
+                asChild
+                projectRef={projectRef}
+                connectionString={connectionString ?? null}
+                schema={table.schema}
+                tableName={table.name}
+                isRlsEnabled={table.rls_enabled}
                 disabled={!canToggleRLS}
-                onClick={() => onSelectToggleRLS(table)}
-                tooltip={{
-                  content: {
-                    side: 'bottom',
-                    text: !canToggleRLS
-                      ? 'You need additional permissions to toggle RLS'
-                      : undefined,
-                  },
-                }}
               >
-                {table.rls_enabled ? 'Disable RLS' : 'Enable RLS'}
-              </ButtonTooltip>
+                {({ onClick, isRlsEnabled, disabled }) => (
+                  <ButtonTooltip
+                    type="default"
+                    disabled={disabled}
+                    onClick={onClick}
+                    tooltip={{
+                      content: {
+                        side: 'bottom',
+                        text: !canToggleRLS
+                          ? 'You need additional permissions to toggle RLS'
+                          : undefined,
+                      },
+                    }}
+                  >
+                    {isRlsEnabled ? 'Disable RLS' : 'Enable RLS'}
+                  </ButtonTooltip>
+                )}
+              </ToggleRlsButton>
             )}
             <ButtonTooltip
               type="default"

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -30,7 +30,6 @@ import { PolicyTableRowHeader } from './PolicyTableRowHeader'
 export interface PolicyTableRowProps {
   table: PolicyTable
   isLocked: boolean
-  onSelectToggleRLS: (table: PolicyTable) => void
   onSelectCreatePolicy: (table: PolicyTable) => void
   onSelectEditPolicy: (policy: PostgresPolicy) => void
   onSelectDeletePolicy: (policy: PostgresPolicy) => void
@@ -39,7 +38,6 @@ export interface PolicyTableRowProps {
 const PolicyTableRowComponent = ({
   table,
   isLocked,
-  onSelectToggleRLS = noop,
   onSelectCreatePolicy = noop,
   onSelectEditPolicy = noop,
   onSelectDeletePolicy = noop,
@@ -96,7 +94,8 @@ const PolicyTableRowComponent = ({
         <PolicyTableRowHeader
           table={table}
           isLocked={isLocked}
-          onSelectToggleRLS={onSelectToggleRLS}
+          projectRef={project?.ref}
+          connectionString={project?.connectionString}
           onSelectCreatePolicy={onSelectCreatePolicy}
         />
       </CardHeader>

--- a/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
+++ b/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
@@ -1,104 +1,33 @@
-import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { LintActionArgs } from 'components/interfaces/Linter/Linter.constants'
-import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
-import { useTablesQuery } from 'data/tables/tables-query'
-import { Button } from 'ui'
-import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { ToggleRlsButton } from 'components/ui/ToggleRlsButton'
 
-const EnableRLSAction = ({ projectRef, connectionString, metadata }: LintActionArgs) => {
-  const [isConfirmVisible, setIsConfirmVisible] = useState(false)
+export const EnableRLSAction = ({ projectRef, connectionString, metadata }: LintActionArgs) => {
+  const tableSchema = metadata?.schema
+  const tableName = metadata?.name
 
-  const tableSchema = (metadata as { schema?: string })?.schema
-  const tableName = (metadata as { name?: string })?.name
-
-  // Query tables to find the table ID
-  const { data: table, isLoading } = useTablesQuery(
-    {
-      projectRef,
-      connectionString,
-      schema: tableSchema,
-      includeColumns: false,
-    },
-    {
-      enabled: !!projectRef && !!tableSchema && !!tableName,
-      select: (tables) => {
-        // Find the table by name
-        return tables.find((table) => table.name === tableName)
-      },
-    }
-  )
-
-  const { mutate: updateTable, isLoading: isExecuting } = useTableUpdateMutation({
-    onSuccess: () => {
-      toast.success('Enable RLS successful')
-      setIsConfirmVisible(false)
-    },
-    onError: (error) => {
-      const message = error?.message || 'Failed to enable RLS'
-      toast.error(message)
-    },
-  })
-
-  const handleEnableRLS = () => {
-    if (!projectRef) {
-      toast.error('Project ref is required')
-      return
-    }
-
-    if (!tableSchema || !tableName) {
-      toast.error('Table information is required to enable RLS')
-      return
-    }
-
-    if (!table?.id) {
-      toast.error('Table ID not found')
-      return
-    }
-
-    updateTable({
-      projectRef,
-      connectionString,
-      id: table.id,
-      name: tableName,
-      schema: tableSchema,
-      payload: {
-        id: table.id,
-        rls_enabled: true,
-      },
-    })
+  if (!tableSchema || !tableName) {
+    return null
   }
 
-  const title = tableName
-    ? `Enable Row Level Security for ${tableName}?`
-    : 'Enable Row Level Security for this table?'
-  const description =
-    tableSchema && tableName
-      ? `Are you sure you want to enable Row Level Security for "${tableSchema}.${tableName}"?`
-      : 'Are you sure you want to enable Row Level Security for this table?'
-
   return (
-    <div>
-      <Button
-        type="primary"
-        loading={isExecuting}
-        disabled={isLoading || isExecuting || !table?.id}
-        onClick={() => setIsConfirmVisible(true)}
-      >
-        Enable RLS
-      </Button>
-      <ConfirmationModal
-        visible={isConfirmVisible}
-        loading={isExecuting}
-        title={title}
-        description={description}
-        confirmLabel="Enable"
-        onCancel={() => setIsConfirmVisible(false)}
-        onConfirm={handleEnableRLS}
-      />
-    </div>
+    <ToggleRlsButton
+      type="primary"
+      projectRef={projectRef}
+      connectionString={connectionString ?? null}
+      schema={tableSchema}
+      tableName={tableName}
+      isRlsEnabled={false}
+      onSuccess={() => {
+        toast.success('Enable RLS successful')
+      }}
+      onError={(error: unknown) => {
+        const message =
+          (!!error && typeof error === 'object' && 'message' in error && String(error.message)) ||
+          'Failed to enable RLS'
+        toast.error(message)
+      }}
+    />
   )
 }
-
-export default EnableRLSAction

--- a/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
+++ b/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { LintActionArgs } from 'components/interfaces/Linter/Linter.constants'
+import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
+import { useTablesQuery } from 'data/tables/tables-query'
+import { Button } from 'ui'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
+const EnableRLSAction = ({ projectRef, connectionString, metadata }: LintActionArgs) => {
+  const [isConfirmVisible, setIsConfirmVisible] = useState(false)
+
+  const tableSchema = (metadata as { schema?: string })?.schema
+  const tableName = (metadata as { name?: string })?.name
+
+  // Query tables to find the table ID
+  const { data: table } = useTablesQuery(
+    {
+      projectRef,
+      connectionString,
+      schema: tableSchema,
+      includeColumns: false,
+    },
+    {
+      enabled: !!projectRef && !!tableSchema && !!tableName,
+      select: (tables) => {
+        // Find the table by name
+        return tables.find((table) => table.name === tableName)
+      },
+    }
+  )
+
+  const { mutate: updateTable, isLoading: isExecuting } = useTableUpdateMutation({
+    onSuccess: () => {
+      toast.success('Enable RLS successful')
+      setIsConfirmVisible(false)
+    },
+    onError: (error) => {
+      const message = error?.message || 'Failed to enable RLS'
+      toast.error(message)
+    },
+  })
+
+  const handleEnableRLS = () => {
+    if (!projectRef) {
+      toast.error('Project ref is required')
+      return
+    }
+
+    if (!tableSchema || !tableName) {
+      toast.error('Table information is required to enable RLS')
+      return
+    }
+
+    if (!table?.id) {
+      toast.error('Table ID not found')
+      return
+    }
+
+    updateTable({
+      projectRef,
+      connectionString,
+      id: table.id,
+      name: tableName,
+      schema: tableSchema,
+      payload: {
+        id: table.id,
+        rls_enabled: true,
+      },
+    })
+  }
+
+  const title = tableName
+    ? `Enable Row Level Security for ${tableName}?`
+    : 'Enable Row Level Security for this table?'
+  const description =
+    tableSchema && tableName
+      ? `Are you sure you want to enable Row Level Security for "${tableSchema}.${tableName}"?`
+      : 'Are you sure you want to enable Row Level Security for this table?'
+
+  return (
+    <div>
+      <Button type="primary" loading={isExecuting} onClick={() => setIsConfirmVisible(true)}>
+        Enable RLS
+      </Button>
+      <ConfirmationModal
+        visible={isConfirmVisible}
+        loading={isExecuting}
+        title={title}
+        description={description}
+        confirmLabel="Enable"
+        onCancel={() => setIsConfirmVisible(false)}
+        onConfirm={handleEnableRLS}
+      />
+    </div>
+  )
+}
+
+export default EnableRLSAction

--- a/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
+++ b/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
@@ -80,7 +80,12 @@ const EnableRLSAction = ({ projectRef, connectionString, metadata }: LintActionA
 
   return (
     <div>
-      <Button type="primary" loading={isExecuting} disabled={isLoading || isExecuting || !table?.id} onClick={() => setIsConfirmVisible(true)}>
+      <Button
+        type="primary"
+        loading={isExecuting}
+        disabled={isLoading || isExecuting || !table?.id}
+        onClick={() => setIsConfirmVisible(true)}
+      >
         Enable RLS
       </Button>
       <ConfirmationModal

--- a/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
+++ b/apps/studio/components/interfaces/Linter/LintActions/EnableRLSAction.tsx
@@ -14,7 +14,7 @@ const EnableRLSAction = ({ projectRef, connectionString, metadata }: LintActionA
   const tableName = (metadata as { name?: string })?.name
 
   // Query tables to find the table ID
-  const { data: table } = useTablesQuery(
+  const { data: table, isLoading } = useTablesQuery(
     {
       projectRef,
       connectionString,
@@ -80,7 +80,7 @@ const EnableRLSAction = ({ projectRef, connectionString, metadata }: LintActionA
 
   return (
     <div>
-      <Button type="primary" loading={isExecuting} onClick={() => setIsConfirmVisible(true)}>
+      <Button type="primary" loading={isExecuting} disabled={isLoading || isExecuting || !table?.id} onClick={() => setIsConfirmVisible(true)}>
         Enable RLS
       </Button>
       <ConfirmationModal

--- a/apps/studio/components/interfaces/Linter/LintDetail.tsx
+++ b/apps/studio/components/interfaces/Linter/LintDetail.tsx
@@ -46,7 +46,7 @@ const LintDetail = ({ lint, projectRef, onAskAssistant }: LintDetailProps) => {
       <h3 className="text-sm mb-2">Resolve</h3>
       <div className="flex items-center gap-2">
         <LintAction
-          title={lint.name}
+          id={lint.name}
           projectRef={projectRef}
           connectionString={project?.connectionString}
           metadata={lint.metadata}

--- a/apps/studio/components/interfaces/Linter/Linter.constants.ts
+++ b/apps/studio/components/interfaces/Linter/Linter.constants.ts
@@ -1,8 +1,16 @@
 import { Lint } from 'data/lint/lint-query'
+import { ComponentType } from 'react'
+
 export enum LINTER_LEVELS {
   ERROR = 'ERROR',
   WARN = 'WARN',
   INFO = 'INFO',
+}
+
+export type LintActionArgs = {
+  projectRef: string
+  connectionString?: string | null
+  metadata: Lint['metadata']
 }
 
 export type LintInfo = {
@@ -13,6 +21,7 @@ export type LintInfo = {
   linkText: string
   docsLink: string
   category: 'security' | 'performance'
+  action?: ComponentType<LintActionArgs>
 }
 
 export const LINT_TABS = [

--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 
-import EnableRLSAction from 'components/interfaces/Linter/LintActions/EnableRLSAction'
+import { EnableRLSAction } from 'components/interfaces/Linter/LintActions/EnableRLSAction'
 import { LINTER_LEVELS, LintInfo } from 'components/interfaces/Linter/Linter.constants'
 import { LINT_TYPES, Lint } from 'data/lint/lint-query'
 import { DOCS_URL } from 'lib/constants'
@@ -322,17 +322,17 @@ export const LintCTA = ({
 }
 
 export const LintAction = ({
-  title,
+  id,
   projectRef,
   connectionString,
   metadata,
 }: {
-  title: LINT_TYPES
+  id: LINT_TYPES
   projectRef: string
   connectionString?: string | null
   metadata: Lint['metadata']
 }) => {
-  const lintInfo = lintInfoMap.find((item) => item.name === title)
+  const lintInfo = lintInfoMap.find((item) => item.name === id)
   const ActionComponent = lintInfo?.action
 
   if (!ActionComponent) {

--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 
+import EnableRLSAction from 'components/interfaces/Linter/LintActions/EnableRLSAction'
 import { LINTER_LEVELS, LintInfo } from 'components/interfaces/Linter/Linter.constants'
 import { LINT_TYPES, Lint } from 'data/lint/lint-query'
 import { DOCS_URL } from 'lib/constants'
@@ -134,6 +135,7 @@ export const lintInfoMap: LintInfo[] = [
     linkText: 'View policies',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0013_rls_disabled_in_public`,
     category: 'security',
+    action: EnableRLSAction,
   },
   {
     name: 'extension_in_public',
@@ -319,6 +321,33 @@ export const LintCTA = ({
   )
 }
 
+export const LintAction = ({
+  title,
+  projectRef,
+  connectionString,
+  metadata,
+}: {
+  title: LINT_TYPES
+  projectRef: string
+  connectionString?: string | null
+  metadata: Lint['metadata']
+}) => {
+  const lintInfo = lintInfoMap.find((item) => item.name === title)
+  const ActionComponent = lintInfo?.action
+
+  if (!ActionComponent) {
+    return null
+  }
+
+  return (
+    <ActionComponent
+      projectRef={projectRef}
+      connectionString={connectionString}
+      metadata={metadata}
+    />
+  )
+}
+
 export const EntityTypeIcon = ({ type }: { type: string | undefined }) => {
   switch (type) {
     case 'table':
@@ -376,7 +405,7 @@ export const createLintSummaryPrompt = (lint: Lint) => {
   const schema = lint.metadata?.schema ?? 'N/A'
   const issue = lint.detail ? lint.detail.replace(/\\`/g, '`') : 'N/A'
   const description = lint.description ? lint.description.replace(/\\`/g, '`') : 'N/A'
-  return `Summarize the issue and suggest fixes for the following lint item:
+  return `Execute the fix for the following issue with a brief one sentence explanation:
 Title: ${title}
 Entity: ${entity}
 Schema: ${schema}

--- a/apps/studio/components/interfaces/Linter/LinterDataGrid.tsx
+++ b/apps/studio/components/interfaces/Linter/LinterDataGrid.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import DataGrid, { Column, DataGridHandle, Row } from 'react-data-grid'
 import ReactMarkdown from 'react-markdown'
 
@@ -15,8 +15,8 @@ import { Lint } from 'data/lint/lint-query'
 import { useRouter } from 'next/router'
 import { Button, ResizableHandle, ResizablePanel, ResizablePanelGroup, cn } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
-import { EntityTypeIcon } from './Linter.utils'
 import LintDetail from './LintDetail'
+import { EntityTypeIcon } from './Linter.utils'
 
 interface LinterDataGridProps {
   isLoading: boolean

--- a/apps/studio/components/ui/ToggleRlsButton.tsx
+++ b/apps/studio/components/ui/ToggleRlsButton.tsx
@@ -1,0 +1,139 @@
+import { ReactNode, useState } from 'react'
+
+import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
+import type { ResponseError } from 'types'
+import { Button, type ButtonProps } from 'ui'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
+export type ToggleRlsButtonChildProps = {
+  onClick: () => void
+  isRlsEnabled: boolean
+  isLoading: boolean
+  disabled: boolean
+}
+
+type ToggleRlsButtonBaseProps = {
+  schema: string
+  tableName: string
+  /**
+   * Whether RLS is enabled before the action is taken.
+   */
+  isRlsEnabled: boolean
+
+  disabled?: boolean
+  showDefaultConfirmModal?: boolean
+
+  projectRef: string
+  connectionString: string | null
+
+  onSuccess?: (nextIsEnabled: boolean) => void
+  onError?: (error: ResponseError) => void
+  onSettled?: () => void
+}
+
+type ToggleRlsButtonDefaultProps = ToggleRlsButtonBaseProps &
+  Omit<ButtonProps, 'children' | 'asChild' | 'onClick' | 'disabled'>
+
+type ToggleRlsButtonCustomChildProps = ToggleRlsButtonBaseProps & {
+  asChild: true
+  children: (props: ToggleRlsButtonChildProps) => ReactNode
+}
+
+export type ToggleRlsButtonProps = ToggleRlsButtonDefaultProps | ToggleRlsButtonCustomChildProps
+
+export const ToggleRlsButton = (props: ToggleRlsButtonProps): ReactNode => {
+  const {
+    // Query information
+    schema,
+    tableName,
+    isRlsEnabled,
+
+    // UI state
+    disabled = false,
+    showDefaultConfirmModal = true,
+
+    // Database connection information
+    projectRef,
+    connectionString,
+
+    // Callbacks
+    onSuccess,
+    onError,
+    onSettled,
+
+    ...restProps
+  } = props
+
+  const [isConfirmationModalVisible, setIsConfirmationModalVisible] = useState(false)
+  const closeConfirmationModal = () => setIsConfirmationModalVisible(false)
+
+  const nextIsEnabled = !isRlsEnabled
+
+  const { mutate: updateTable, isLoading } = useTableUpdateMutation()
+
+  const handleUpdate = () => {
+    updateTable(
+      {
+        projectRef,
+        connectionString,
+        schema,
+        name: tableName,
+        payload: { rls_enabled: nextIsEnabled },
+      },
+      {
+        onSuccess: () => onSuccess?.(nextIsEnabled),
+        onError: (error) => onError?.(error),
+        onSettled: () => {
+          if (showDefaultConfirmModal) closeConfirmationModal()
+          onSettled?.()
+        },
+      }
+    )
+  }
+
+  const handleClick = () => {
+    if (isLoading || disabled) return
+    if (showDefaultConfirmModal) {
+      return setIsConfirmationModalVisible(true)
+    }
+    handleUpdate()
+  }
+
+  const action = nextIsEnabled ? 'enable' : 'disable'
+  const confirmModal = showDefaultConfirmModal ? (
+    <ConfirmationModal
+      visible={isConfirmationModalVisible}
+      loading={isLoading}
+      title={`Confirm to ${action} Row Level Security`}
+      description={`Are you sure you want to ${action} Row Level Security for this table?`}
+      confirmLabel={nextIsEnabled ? 'Enable RLS' : 'Disable RLS'}
+      onCancel={closeConfirmationModal}
+      onConfirm={handleUpdate}
+    />
+  ) : null
+
+  if ('asChild' in props) {
+    const child = props.children({
+      onClick: handleClick,
+      isRlsEnabled,
+      isLoading,
+      disabled,
+    })
+
+    return (
+      <>
+        {child}
+        {confirmModal}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Button {...restProps} loading={isLoading} disabled={disabled} onClick={handleClick}>
+        {nextIsEnabled ? 'Enable RLS' : 'Disable RLS'}
+      </Button>
+      {confirmModal}
+    </>
+  )
+}


### PR DESCRIPTION
<img width="1767" height="875" alt="image" src="https://github.com/user-attachments/assets/8c26e512-2e0e-43d9-b652-43c7fa10f7f0" />

We want to start gradually making it easier for people to resolve advisor issues without having to leave advisor. We already do some aspect of this for index advisor. The first step is allowing people to enable RLS on a table directly from the advisor for public rls issues. 

This PR introduces an optional action prop to the lint info map which renders a component to perform some sort of an action. In this case just a simple enable button with a confirm modal, copying the logic from our policies page.