### PR TITLE
Refactor CronSyntaxChart to use SVG for rendering

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronSyntaxChart.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronSyntaxChart.tsx
@@ -1,17 +1,69 @@
 export default function CronSyntaxChart() {
+  // Cron field labels in order
+  const fields = [
+    'minute (0 - 59)',
+    'hour (0 - 23)',
+    'day of month (1 - 31)',
+    'month (1 - 12)',
+    'day of week (0 - 7)',
+  ];
+
+  // Horizontal / vertical layout spacing
+  const xGap = 28;
+  const yStep = 18;
+
+  // Bottom star-row Y position
+  const yBottom = fields.length * yStep + 20;
+
   return (
-    <div>
-      <pre className="text-xs font-mono text-foreground-light">
-        {/* prettier-ignore */}
-        {`
- ┌───────────── minute (0 - 59)
- │  ┌───────────── hour (0 - 23)
- │  │  ┌───────────── day of month (1 - 31)
- │  │  │  ┌───────────── month (1 - 12)
- │  │  │  │  ┌───────────── day of week (0 - 7)
- │  │  │  │  │
- *  *  *  *  * `}
-      </pre>
+    <div className="font-mono text-xs text-foreground-light p-2 overflow-x-auto">
+      <svg
+        width={fields.length * xGap + 160}  // Extra width so labels don’t get cut
+        height={fields.length * yStep + 40} // Enough height for labels + stars
+        aria-hidden="true"
+      >
+        {fields.map((label, i) => {
+          // X position of each column
+          const x = i * xGap + 10;
+
+          // Y position of the text label for this row
+          const yLabel = i * yStep + 10;
+
+          return (
+            <g key={i}>
+              {/* L-shaped connector line */}
+              <path
+                d={`M ${x} ${yBottom - 12} L ${x} ${yLabel} L ${x + 12} ${yLabel}`}
+                stroke="currentColor"
+                strokeWidth="1"
+                fill="none"
+                className="opacity-60"
+              />
+
+              {/* Field label */}
+              <text
+                x={x + 16}
+                y={yLabel}
+                alignmentBaseline="middle"
+                fill="currentColor"
+              >
+                {label}
+              </text>
+
+              {/* Star under each column */}
+              <text
+                x={x}
+                y={yBottom}
+                textAnchor="middle"
+                fill="currentColor"
+                className="text-sm font-bold"
+              >
+                *
+              </text>
+            </g>
+          );
+        })}
+      </svg>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
feat: replace ASCII CronSyntaxChart with minimal SVG version

Refactor `CronSyntaxChart` to render the syntax diagram using a minimal SVG
implementation instead of an ASCII <pre> block. This improves readability,
scalability, theme compatibility, and consistency across different screen sizes
and font settings while preserving the original structure and behavior.

## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Feature (UI)

## What is the current behavior?

`CronSyntaxChart` currently renders the cron syntax diagram as ASCII inside a
<pre> block. This causes alignment issues, wrapping problems, and inconsistent
rendering depending on container width, fonts, or user settings.

## What is the new behavior?

- Replaces the ASCII diagram with a minimal SVG that visually matches the
  original layout.
- Uses `currentColor` so it adapts automatically to light/dark modes and
  Supabase color tokens.
- More stable layout that doesn’t clip or shift.
- Purely a render improvement; no logic or functional behavior changed.

### Before
<img width="614" height="216" alt="Before screenshot" src="https://github.com/user-attachments/assets/f0b2baed-819f-41a2-a37b-62a81307c875" />

### After
<img width="454" height="209" alt="After screenshot" src="https://github.com/user-attachments/assets/93ddce1c-2193-4aac-aab7-05248e36af86" />

## Additional context

The updated SVG keeps the same structure as the original ASCII rendering.
If desired, I can adjust spacing, line thickness, or font sizing to match any
internal visual guidelines.
