### PR TITLE
feat(connect): add telemetry tracking and command menu actions

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
@@ -1,5 +1,6 @@
 import { IS_PLATFORM } from 'common'
 import { useBranchCommands } from 'components/interfaces/BranchManagement/Branch.Commands'
+import { useConnectCommands } from 'components/interfaces/Connect/Connect.Commands'
 import {
   useQueryTableCommands,
   useSnippetCommands,
@@ -20,6 +21,7 @@ import { orderCommandSectionsByPriority } from './ordering'
 export default function StudioCommandMenu() {
   useApiKeysCommands()
   useApiUrlCommand()
+  useConnectCommands()
   useProjectLevelTableEditorCommands()
   useProjectSwitchCommand()
   useConfigureOrganizationCommand()

--- a/apps/studio/components/interfaces/Connect/Connect.Commands.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.Commands.tsx
@@ -1,0 +1,60 @@
+import { Plug } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from 'lib/constants'
+import type { ICommand } from 'ui-patterns/CommandMenu'
+import { useRegisterCommands, useSetCommandMenuOpen } from 'ui-patterns/CommandMenu'
+import { COMMAND_MENU_SECTIONS } from 'components/interfaces/App/CommandMenu/CommandMenu.utils'
+import { orderCommandSectionsByPriority } from 'components/interfaces/App/CommandMenu/ordering'
+
+export function useConnectCommands() {
+  const router = useRouter()
+  const setIsOpen = useSetCommandMenuOpen()
+  const { data: selectedProject } = useSelectedProjectQuery()
+  const isActiveHealthy = selectedProject?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  useRegisterCommands(
+    COMMAND_MENU_SECTIONS.ACTIONS,
+    [
+      {
+        id: 'connect-to-project',
+        name: 'Connect to your project',
+        action: () => {
+          // Open the Connect dialog by setting the showConnect query param
+          router.push(
+            {
+              pathname: router.pathname,
+              query: { ...router.query, showConnect: 'true' },
+            },
+            undefined,
+            { shallow: true }
+          )
+          setIsOpen(false)
+        },
+        icon: () => <Plug className="rotate-90" />,
+      },
+      {
+        id: 'connect-mcp',
+        name: 'Connect via MCP',
+        action: () => {
+          // Open the Connect dialog with MCP tab
+          router.push(
+            {
+              pathname: router.pathname,
+              query: { ...router.query, showConnect: 'true', connectTab: 'mcp' },
+            },
+            undefined,
+            { shallow: true }
+          )
+          setIsOpen(false)
+        },
+        icon: () => <Plug className="rotate-90" />,
+      },
+    ] as ICommand[],
+    {
+      enabled: !!selectedProject && isActiveHealthy,
+      orderSection: orderCommandSectionsByPriority,
+      sectionMeta: { priority: 2 },
+    }
+  )
+}

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -411,7 +411,10 @@ export const Connect = () => {
               )
             }
 
-            const connectionTabMap: Record<string, 'App Frameworks' | 'Mobile Frameworks' | 'ORMs'> = {
+            const connectionTabMap: Record<
+              string,
+              'App Frameworks' | 'Mobile Frameworks' | 'ORMs'
+            > = {
               frameworks: 'App Frameworks',
               mobiles: 'Mobile Frameworks',
               orms: 'ORMs',

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -411,6 +411,15 @@ export const Connect = () => {
               )
             }
 
+            const connectionTabMap: Record<string, 'App Frameworks' | 'Mobile Frameworks' | 'ORMs'> = {
+              frameworks: 'App Frameworks',
+              mobiles: 'Mobile Frameworks',
+              orms: 'ORMs',
+            }
+            const connectionTab = connectionTabMap[type.key] || 'App Frameworks'
+            const selectedFrameworkOrTool =
+              connectionObject.find((item) => item.key === selectedParent)?.label || ''
+
             return (
               <TabsContent_Shadcn_
                 key={`content-${type.key}`}
@@ -467,6 +476,8 @@ export const Connect = () => {
                 <ConnectTabContent
                   projectKeys={projectKeys}
                   filePath={filePath}
+                  connectionTab={connectionTab}
+                  selectedFrameworkOrTool={selectedFrameworkOrTool}
                   className="rounded-b-none"
                 />
                 <Panel.Notice

--- a/apps/studio/components/interfaces/Connect/Connect.types.ts
+++ b/apps/studio/components/interfaces/Connect/Connect.types.ts
@@ -18,4 +18,6 @@ export interface ContentFileProps {
     ipv4SupportedForDedicatedPooler: boolean
     direct?: string
   }
+  connectionTab: 'App Frameworks' | 'Mobile Frameworks' | 'ORMs'
+  onCopy?: () => void
 }

--- a/apps/studio/components/interfaces/Connect/ConnectTabContent.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectTabContent.tsx
@@ -10,7 +10,7 @@ import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { pluckObjectFields } from 'lib/helpers'
 import { useTrack } from 'lib/telemetry/track'
-import { cn } from 'ui'
+import { cn, CopyCallbackContext } from 'ui'
 import { getAddons } from '../Billing/Subscription/Subscription.utils'
 import type { projectKeys } from './Connect.types'
 import { getConnectionStrings } from './DatabaseSettings.utils'
@@ -108,21 +108,23 @@ export const ConnectTabContent = forwardRef<HTMLDivElement, ConnectContentTabPro
 
     return (
       <div ref={ref} {...props} className={cn('border rounded-lg', props.className)}>
-        <ContentFile
-          projectKeys={projectKeys}
-          filePath={filePath}
-          connectionTab={connectionTab}
-          selectedFrameworkOrTool={selectedFrameworkOrTool}
-          connectionStringPooler={{
-            transactionShared: connectionStringsShared.pooler.uri,
-            sessionShared: connectionStringsShared.pooler.uri.replace('6543', '5432'),
-            transactionDedicated: connectionStringsDedicated?.pooler.uri,
-            sessionDedicated: connectionStringsDedicated?.pooler.uri.replace('6543', '5432'),
-            ipv4SupportedForDedicatedPooler: !!ipv4Addon,
-            direct: connectionStringsShared.direct.uri,
-          }}
-          onCopy={handleCopy}
-        />
+        <CopyCallbackContext.Provider value={handleCopy}>
+          <ContentFile
+            projectKeys={projectKeys}
+            filePath={filePath}
+            connectionTab={connectionTab}
+            selectedFrameworkOrTool={selectedFrameworkOrTool}
+            connectionStringPooler={{
+              transactionShared: connectionStringsShared.pooler.uri,
+              sessionShared: connectionStringsShared.pooler.uri.replace('6543', '5432'),
+              transactionDedicated: connectionStringsDedicated?.pooler.uri,
+              sessionDedicated: connectionStringsDedicated?.pooler.uri.replace('6543', '5432'),
+              ipv4SupportedForDedicatedPooler: !!ipv4Addon,
+              direct: connectionStringsShared.direct.uri,
+            }}
+            onCopy={handleCopy}
+          />
+        </CopyCallbackContext.Provider>
       </div>
     )
   }

--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -209,7 +209,7 @@ export const DatabaseConnectionString = () => {
     const lang = connectionInfo?.lang ?? 'Unknown'
     sendEvent({
       action: 'connection_string_copied',
-      properties: { connectionType, lang, connectionMethod: connectionStringMethod },
+      properties: { connectionType, lang, connectionMethod: connectionStringMethod, connectionTab: 'Connection String' },
       groups: { project: projectRef ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
     })
   }

--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -209,7 +209,12 @@ export const DatabaseConnectionString = () => {
     const lang = connectionInfo?.lang ?? 'Unknown'
     sendEvent({
       action: 'connection_string_copied',
-      properties: { connectionType, lang, connectionMethod: connectionStringMethod, connectionTab: 'Connection String' },
+      properties: {
+        connectionType,
+        lang,
+        connectionMethod: connectionStringMethod,
+        connectionTab: 'Connection String',
+      },
       groups: { project: projectRef ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
     })
   }

--- a/apps/studio/components/interfaces/Connect/McpTabContent.tsx
+++ b/apps/studio/components/interfaces/Connect/McpTabContent.tsx
@@ -2,8 +2,10 @@ import { IS_PLATFORM, useParams } from 'common'
 import Panel from 'components/ui/Panel'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { BASE_PATH } from 'lib/constants'
+import { useTrack } from 'lib/telemetry/track'
 import { useTheme } from 'next-themes'
-import { McpConfigPanel } from 'ui-patterns/McpUrlBuilder'
+import { useState } from 'react'
+import { McpConfigPanel, type McpClient } from 'ui-patterns/McpUrlBuilder'
 import type { projectKeys } from './Connect.types'
 
 export const McpTabContent = ({ projectKeys }: { projectKeys: projectKeys }) => {
@@ -37,6 +39,15 @@ const McpTabContentInnerLoaded = ({
   projectKeys: projectKeys
 }) => {
   const { resolvedTheme } = useTheme()
+  const track = useTrack()
+  const [selectedClient, setSelectedClient] = useState<McpClient | null>(null)
+
+  const handleCopy = () => {
+    track('connection_string_copied', {
+      connectionTab: 'MCP',
+      selectedItem: selectedClient?.label,
+    })
+  }
 
   return (
     <McpConfigPanel
@@ -45,6 +56,8 @@ const McpTabContentInnerLoaded = ({
       theme={resolvedTheme as 'light' | 'dark'}
       isPlatform={IS_PLATFORM}
       apiUrl={projectKeys.apiUrl ?? undefined}
+      onCopyCallback={handleCopy}
+      onClientSelect={setSelectedClient}
     />
   )
 }

--- a/apps/studio/components/interfaces/Connect/McpTabContent.tsx
+++ b/apps/studio/components/interfaces/Connect/McpTabContent.tsx
@@ -42,11 +42,34 @@ const McpTabContentInnerLoaded = ({
   const track = useTrack()
   const [selectedClient, setSelectedClient] = useState<McpClient | null>(null)
 
-  const handleCopy = () => {
+  const handleCopy = (type?: 'url' | 'json' | 'command') => {
+    let connectionType: string
+    switch (type) {
+      case 'command':
+        connectionType = 'Command Line'
+        break
+      case 'json':
+        connectionType = 'JSON'
+        break
+      case 'url':
+      default:
+        connectionType = 'MCP URL'
+        break
+    }
+
     track('connection_string_copied', {
       connectionTab: 'MCP',
       selectedItem: selectedClient?.label,
+      connectionType,
     })
+  }
+
+  const handleInstall = () => {
+    if (selectedClient?.label) {
+      track('mcp_install_button_clicked', {
+        client: selectedClient.label,
+      })
+    }
   }
 
   return (
@@ -57,6 +80,7 @@ const McpTabContentInnerLoaded = ({
       isPlatform={IS_PLATFORM}
       apiUrl={projectKeys.apiUrl ?? undefined}
       onCopyCallback={handleCopy}
+      onInstallCallback={handleInstall}
       onClientSelect={setSelectedClient}
     />
   )

--- a/apps/studio/components/interfaces/Connect/McpTabContent.tsx
+++ b/apps/studio/components/interfaces/Connect/McpTabContent.tsx
@@ -61,6 +61,7 @@ const McpTabContentInnerLoaded = ({
       connectionTab: 'MCP',
       selectedItem: selectedClient?.label,
       connectionType,
+      source: 'studio',
     })
   }
 
@@ -68,6 +69,7 @@ const McpTabContentInnerLoaded = ({
     if (selectedClient?.label) {
       track('mcp_install_button_clicked', {
         client: selectedClient.label,
+        source: 'studio',
       })
     }
   }

--- a/apps/studio/components/interfaces/Connect/content/nextjs/app/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/nextjs/app/supabasejs/content.tsx
@@ -8,7 +8,7 @@ import {
 } from 'components/interfaces/Connect/ConnectTabs'
 import { SimpleCodeBlock } from 'ui'
 
-const ContentFile = ({ projectKeys }: ContentFileProps) => {
+const ContentFile = ({ projectKeys, onCopy }: ContentFileProps) => {
   return (
     <ConnectTabs>
       <ConnectTabTriggers>
@@ -20,7 +20,7 @@ const ContentFile = ({ projectKeys }: ContentFileProps) => {
       </ConnectTabTriggers>
 
       <ConnectTabContent value=".env.local">
-        <SimpleCodeBlock className="bash" parentClassName="min-h-72">
+        <SimpleCodeBlock className="bash" parentClassName="min-h-72" onCopy={onCopy}>
           {[
             '',
             `NEXT_PUBLIC_SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}`,
@@ -33,7 +33,7 @@ const ContentFile = ({ projectKeys }: ContentFileProps) => {
       </ConnectTabContent>
 
       <ConnectTabContent value="page.tsx">
-        <SimpleCodeBlock className="tsx" parentClassName="min-h-72">
+        <SimpleCodeBlock className="tsx" parentClassName="min-h-72" onCopy={onCopy}>
           {`
 import { createClient } from '@/utils/supabase/server'
 import { cookies } from 'next/headers'
@@ -57,7 +57,7 @@ export default async function Page() {
       </ConnectTabContent>
 
       <ConnectTabContent value="utils/supabase/server.ts">
-        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72" onCopy={onCopy}>
           {`
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
@@ -91,7 +91,7 @@ export const createClient = (cookieStore: ReturnType<typeof cookies>) => {
         </SimpleCodeBlock>
       </ConnectTabContent>
       <ConnectTabContent value="utils/supabase/client.ts">
-        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72" onCopy={onCopy}>
           {`
 import { createBrowserClient } from "@supabase/ssr";
 
@@ -108,7 +108,7 @@ export const createClient = () =>
       </ConnectTabContent>
 
       <ConnectTabContent value="utils/supabase/middleware.ts">
-        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72" onCopy={onCopy}>
           {`
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";

--- a/apps/studio/components/interfaces/Connect/content/nextjs/app/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/nextjs/app/supabasejs/content.tsx
@@ -8,7 +8,7 @@ import {
 } from 'components/interfaces/Connect/ConnectTabs'
 import { SimpleCodeBlock } from 'ui'
 
-const ContentFile = ({ projectKeys, onCopy }: ContentFileProps) => {
+const ContentFile = ({ projectKeys }: ContentFileProps) => {
   return (
     <ConnectTabs>
       <ConnectTabTriggers>
@@ -20,7 +20,7 @@ const ContentFile = ({ projectKeys, onCopy }: ContentFileProps) => {
       </ConnectTabTriggers>
 
       <ConnectTabContent value=".env.local">
-        <SimpleCodeBlock className="bash" parentClassName="min-h-72" onCopy={onCopy}>
+        <SimpleCodeBlock className="bash" parentClassName="min-h-72">
           {[
             '',
             `NEXT_PUBLIC_SUPABASE_URL=${projectKeys.apiUrl ?? 'your-project-url'}`,
@@ -33,7 +33,7 @@ const ContentFile = ({ projectKeys, onCopy }: ContentFileProps) => {
       </ConnectTabContent>
 
       <ConnectTabContent value="page.tsx">
-        <SimpleCodeBlock className="tsx" parentClassName="min-h-72" onCopy={onCopy}>
+        <SimpleCodeBlock className="tsx" parentClassName="min-h-72">
           {`
 import { createClient } from '@/utils/supabase/server'
 import { cookies } from 'next/headers'
@@ -57,7 +57,7 @@ export default async function Page() {
       </ConnectTabContent>
 
       <ConnectTabContent value="utils/supabase/server.ts">
-        <SimpleCodeBlock className="ts" parentClassName="min-h-72" onCopy={onCopy}>
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
           {`
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
@@ -91,7 +91,7 @@ export const createClient = (cookieStore: ReturnType<typeof cookies>) => {
         </SimpleCodeBlock>
       </ConnectTabContent>
       <ConnectTabContent value="utils/supabase/client.ts">
-        <SimpleCodeBlock className="ts" parentClassName="min-h-72" onCopy={onCopy}>
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
           {`
 import { createBrowserClient } from "@supabase/ssr";
 
@@ -108,7 +108,7 @@ export const createClient = () =>
       </ConnectTabContent>
 
       <ConnectTabContent value="utils/supabase/middleware.ts">
-        <SimpleCodeBlock className="ts" parentClassName="min-h-72" onCopy={onCopy}>
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
           {`
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -69,17 +69,28 @@ export interface ConnectionStringCopiedEvent {
   action: 'connection_string_copied'
   properties: {
     /**
-     * Method selected by user, e.g. URI, PSQL, SQLAlchemy, etc.
+     * Method selected by user, e.g. URI, PSQL, SQLAlchemy, MCP URL, Framework snippet, etc.
+     * Required for Connection String, App Frameworks, and Mobile Frameworks tabs
      */
-    connectionType: string
+    connectionType?: string
     /**
-     * Language of the code block if selected, e.g. bash, go
+     * Language of the code block if selected, e.g. bash, go, http, typescript
+     * Required for Connection String, App Frameworks, and Mobile Frameworks tabs
      */
-    lang: string
+    lang?: string
     /**
      * Connection Method, e.g. direct, transaction_pooler, session_pooler
+     * Only used for Connection String tab
      */
-    connectionMethod: 'direct' | 'transaction_pooler' | 'session_pooler'
+    connectionMethod?: 'direct' | 'transaction_pooler' | 'session_pooler'
+    /**
+     * Tab from which the connection string was copied
+     */
+    connectionTab: 'Connection String' | 'App Frameworks' | 'Mobile Frameworks' | 'ORMs' | 'MCP'
+    /**
+     * Selected framework, tool, or client (e.g., 'Next.js', 'Prisma', 'Cursor')
+     */
+    selectedItem?: string
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -91,6 +91,10 @@ export interface ConnectionStringCopiedEvent {
      * Selected framework, tool, or client (e.g., 'Next.js', 'Prisma', 'Cursor')
      */
     selectedItem?: string
+    /**
+     * Source of the event, either 'studio' or 'docs'
+     */
+    source?: 'studio' | 'docs'
   }
   groups: TelemetryGroups
 }
@@ -99,7 +103,7 @@ export interface ConnectionStringCopiedEvent {
  * User clicked the MCP install button (one-click installation for Cursor or VS Code).
  *
  * @group Events
- * @source studio
+ * @source studio, docs
  */
 export interface McpInstallButtonClickedEvent {
   action: 'mcp_install_button_clicked'
@@ -108,6 +112,10 @@ export interface McpInstallButtonClickedEvent {
      * The MCP client that was selected (e.g., 'Cursor', 'VS Code')
      */
     client: string
+    /**
+     * Source of the event, either 'studio' or 'docs'
+     */
+    source?: 'studio' | 'docs'
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -69,7 +69,7 @@ export interface ConnectionStringCopiedEvent {
   action: 'connection_string_copied'
   properties: {
     /**
-     * Method selected by user, e.g. URI, PSQL, SQLAlchemy, MCP URL, Framework snippet, etc.
+     * Method selected by user, e.g. URI, PSQL, SQLAlchemy, MCP URL, Framework snippet, Command Line, JSON, etc.
      * Required for Connection String, App Frameworks, and Mobile Frameworks tabs
      */
     connectionType?: string
@@ -91,6 +91,23 @@ export interface ConnectionStringCopiedEvent {
      * Selected framework, tool, or client (e.g., 'Next.js', 'Prisma', 'Cursor')
      */
     selectedItem?: string
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * User clicked the MCP install button (one-click installation for Cursor or VS Code).
+ *
+ * @group Events
+ * @source studio
+ */
+export interface McpInstallButtonClickedEvent {
+  action: 'mcp_install_button_clicked'
+  properties: {
+    /**
+     * The MCP client that was selected (e.g., 'Cursor', 'VS Code')
+     */
+    client: string
   }
   groups: TelemetryGroups
 }
@@ -2331,6 +2348,7 @@ export type TelemetryEvent =
   | SignUpEvent
   | SignInEvent
   | ConnectionStringCopiedEvent
+  | McpInstallButtonClickedEvent
   | ApiDocsOpenedEvent
   | ApiDocsCodeCopyButtonClickedEvent
   | CronJobCreatedEvent

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -17,7 +17,8 @@ export interface McpConfigPanelProps {
   projectRef?: string
   initialSelectedClient?: McpClient
   onClientSelect?: (client: McpClient) => void
-  onCopyCallback?: () => void
+  onCopyCallback?: (type?: 'url' | 'json' | 'command') => void
+  onInstallCallback?: () => void
   theme?: 'light' | 'dark'
   className?: string
   isPlatform: boolean // For docs this is controlled by state, for studio by environment variable
@@ -30,6 +31,7 @@ export function McpConfigPanel({
   initialSelectedClient,
   onClientSelect,
   onCopyCallback,
+  onInstallCallback,
   className,
   theme = 'dark',
   isPlatform,
@@ -95,7 +97,7 @@ export function McpConfigPanel({
             hideLineNumbers
             language="http"
             className="max-h-64 overflow-y-auto"
-            onCopyCallback={onCopyCallback}
+            onCopyCallback={() => onCopyCallback?.('url')}
           >
             {mcpUrl}
           </CodeBlock>
@@ -126,6 +128,7 @@ export function McpConfigPanel({
           selectedClient={selectedClient}
           clientConfig={clientConfig}
           onCopyCallback={onCopyCallback}
+          onInstallCallback={onInstallCallback}
         />
       </div>
     </div>

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -17,6 +17,7 @@ export interface McpConfigPanelProps {
   projectRef?: string
   initialSelectedClient?: McpClient
   onClientSelect?: (client: McpClient) => void
+  onCopyCallback?: () => void
   theme?: 'light' | 'dark'
   className?: string
   isPlatform: boolean // For docs this is controlled by state, for studio by environment variable
@@ -28,6 +29,7 @@ export function McpConfigPanel({
   projectRef,
   initialSelectedClient,
   onClientSelect,
+  onCopyCallback,
   className,
   theme = 'dark',
   isPlatform,
@@ -93,6 +95,7 @@ export function McpConfigPanel({
             hideLineNumbers
             language="http"
             className="max-h-64 overflow-y-auto"
+            onCopyCallback={onCopyCallback}
           >
             {mcpUrl}
           </CodeBlock>
@@ -122,6 +125,7 @@ export function McpConfigPanel({
           basePath={basePath}
           selectedClient={selectedClient}
           clientConfig={clientConfig}
+          onCopyCallback={onCopyCallback}
         />
       </div>
     </div>

--- a/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
@@ -13,6 +13,7 @@ interface McpConfigurationDisplayProps {
   className?: string
   theme?: 'light' | 'dark'
   basePath: string
+  onCopyCallback?: () => void
 }
 
 export function McpConfigurationDisplay({
@@ -21,6 +22,7 @@ export function McpConfigurationDisplay({
   className,
   theme = 'dark',
   basePath,
+  onCopyCallback,
 }: McpConfigurationDisplayProps) {
   const mcpButtonData = getMcpButtonData({
     basePath,
@@ -73,6 +75,7 @@ export function McpConfigurationDisplay({
         language="json"
         className="max-h-64 overflow-y-auto"
         focusable={false}
+        onCopyCallback={onCopyCallback}
       />
 
       {selectedClient.alternateInstructions && selectedClient.alternateInstructions(clientConfig)}

--- a/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
@@ -59,7 +59,8 @@ export function McpConfigurationDisplay({
         </>
       )}
 
-      {selectedClient.primaryInstructions && selectedClient.primaryInstructions(clientConfig, onCopyCallback)}
+      {selectedClient.primaryInstructions &&
+        selectedClient.primaryInstructions(clientConfig, onCopyCallback)}
 
       {selectedClient.configFile && (
         <div className="text-xs text-foreground-light">
@@ -81,7 +82,8 @@ export function McpConfigurationDisplay({
         onCopyCallback={() => onCopyCallback?.('json')}
       />
 
-      {selectedClient.alternateInstructions && selectedClient.alternateInstructions(clientConfig, onCopyCallback)}
+      {selectedClient.alternateInstructions &&
+        selectedClient.alternateInstructions(clientConfig, onCopyCallback)}
 
       {(selectedClient.docsUrl || selectedClient.externalDocsUrl) && (
         <div className="flex items-center gap-2 text-xs text-foreground-light">

--- a/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/components/McpConfigurationDisplay.tsx
@@ -13,7 +13,8 @@ interface McpConfigurationDisplayProps {
   className?: string
   theme?: 'light' | 'dark'
   basePath: string
-  onCopyCallback?: () => void
+  onCopyCallback?: (type?: 'url' | 'json' | 'command') => void
+  onInstallCallback?: () => void
 }
 
 export function McpConfigurationDisplay({
@@ -23,6 +24,7 @@ export function McpConfigurationDisplay({
   theme = 'dark',
   basePath,
   onCopyCallback,
+  onInstallCallback,
 }: McpConfigurationDisplayProps) {
   const mcpButtonData = getMcpButtonData({
     basePath,
@@ -42,6 +44,7 @@ export function McpConfigurationDisplay({
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 [&>span]:flex [&>span]:items-center [&>span]:gap-2"
+              onClick={onInstallCallback}
             >
               <Image
                 src={mcpButtonData.imageSrc}
@@ -56,7 +59,7 @@ export function McpConfigurationDisplay({
         </>
       )}
 
-      {selectedClient.primaryInstructions && selectedClient.primaryInstructions(clientConfig)}
+      {selectedClient.primaryInstructions && selectedClient.primaryInstructions(clientConfig, onCopyCallback)}
 
       {selectedClient.configFile && (
         <div className="text-xs text-foreground-light">
@@ -75,10 +78,10 @@ export function McpConfigurationDisplay({
         language="json"
         className="max-h-64 overflow-y-auto"
         focusable={false}
-        onCopyCallback={onCopyCallback}
+        onCopyCallback={() => onCopyCallback?.('json')}
       />
 
-      {selectedClient.alternateInstructions && selectedClient.alternateInstructions(clientConfig)}
+      {selectedClient.alternateInstructions && selectedClient.alternateInstructions(clientConfig, onCopyCallback)}
 
       {(selectedClient.docsUrl || selectedClient.externalDocsUrl) && (
         <div className="flex items-center gap-2 text-xs text-foreground-light">

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -157,7 +157,13 @@ export const MCP_CLIENTS: McpClient[] = [
           After configuring the MCP server, you need to authenticate. In a regular terminal (not the
           IDE extension) run:
         </p>
-        <CodeBlock value="claude /mcp" language="bash" focusable={false} className="block" onCopyCallback={() => onCopy?.('command')} />
+        <CodeBlock
+          value="claude /mcp"
+          language="bash"
+          focusable={false}
+          className="block"
+          onCopyCallback={() => onCopy?.('command')}
+        />
         <p className="text-xs text-foreground-light">
           Select the "supabase" server, then "Authenticate" to begin the authentication flow.
         </p>

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -108,7 +108,7 @@ export const MCP_CLIENTS: McpClient[] = [
         },
       }
     },
-    alternateInstructions: () => (
+    alternateInstructions: (_config, _onCopy) => (
       <p className="text-xs text-foreground-light">
         Windsurf does not currently support remote MCP servers over HTTP transport. You need to use
         the mcp-remote package as a proxy.
@@ -131,7 +131,7 @@ export const MCP_CLIENTS: McpClient[] = [
         },
       }
     },
-    primaryInstructions: (_config) => {
+    primaryInstructions: (_config, onCopy) => {
       const config = _config as ClaudeCodeMcpConfig
       const command = `claude mcp add --scope project --transport http supabase "${config.mcpServers.supabase.url}"`
       return (
@@ -146,17 +146,18 @@ export const MCP_CLIENTS: McpClient[] = [
             // This is a no-op but the CodeBlock component is designed to output
             // inline code if no className is given
             className="block"
+            onCopyCallback={() => onCopy?.('command')}
           />
         </div>
       )
     },
-    alternateInstructions: () => (
+    alternateInstructions: (_config, onCopy) => (
       <div className="space-y-2">
         <p className="text-xs text-foreground-light">
           After configuring the MCP server, you need to authenticate. In a regular terminal (not the
           IDE extension) run:
         </p>
-        <CodeBlock value="claude /mcp" language="bash" focusable={false} className="block" />
+        <CodeBlock value="claude /mcp" language="bash" focusable={false} className="block" onCopyCallback={() => onCopy?.('command')} />
         <p className="text-xs text-foreground-light">
           Select the "supabase" server, then "Authenticate" to begin the authentication flow.
         </p>

--- a/packages/ui-patterns/src/McpUrlBuilder/types.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/types.ts
@@ -13,8 +13,8 @@ export interface McpClient {
   configFile?: string
   generateDeepLink?: (config: McpClientConfig) => string | null
   transformConfig?: (config: McpClientBaseConfig) => McpClientConfig
-  primaryInstructions?: (config: McpClientConfig) => React.ReactNode
-  alternateInstructions?: (config: McpClientConfig) => React.ReactNode
+  primaryInstructions?: (config: McpClientConfig, onCopy?: (type?: 'url' | 'json' | 'command') => void) => React.ReactNode
+  alternateInstructions?: (config: McpClientConfig, onCopy?: (type?: 'url' | 'json' | 'command') => void) => React.ReactNode
 }
 
 export interface McpUrlBuilderConfig {

--- a/packages/ui-patterns/src/McpUrlBuilder/types.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/types.ts
@@ -13,8 +13,14 @@ export interface McpClient {
   configFile?: string
   generateDeepLink?: (config: McpClientConfig) => string | null
   transformConfig?: (config: McpClientBaseConfig) => McpClientConfig
-  primaryInstructions?: (config: McpClientConfig, onCopy?: (type?: 'url' | 'json' | 'command') => void) => React.ReactNode
-  alternateInstructions?: (config: McpClientConfig, onCopy?: (type?: 'url' | 'json' | 'command') => void) => React.ReactNode
+  primaryInstructions?: (
+    config: McpClientConfig,
+    onCopy?: (type?: 'url' | 'json' | 'command') => void
+  ) => React.ReactNode
+  alternateInstructions?: (
+    config: McpClientConfig,
+    onCopy?: (type?: 'url' | 'json' | 'command') => void
+  ) => React.ReactNode
 }
 
 export interface McpUrlBuilderConfig {

--- a/packages/ui/src/components/SimpleCodeBlock/SimpleCodeBlock.tsx
+++ b/packages/ui/src/components/SimpleCodeBlock/SimpleCodeBlock.tsx
@@ -8,11 +8,14 @@
 
 import { useTheme } from 'next-themes'
 import { Highlight, Language, Prism, themes } from 'prism-react-renderer'
-import { PropsWithChildren, useEffect, useRef, useState } from 'react'
+import { PropsWithChildren, createContext, useContext, useEffect, useRef, useState } from 'react'
 import { copyToClipboard } from '../../lib/utils'
 import { cn } from './../../lib/utils/cn'
 import { Button } from './../Button'
 import { dart } from './prism'
+
+// Context for copy callback - can be provided by parent components
+export const CopyCallbackContext = createContext<(() => void) | undefined>(undefined)
 
 dart(Prism)
 
@@ -41,6 +44,7 @@ export const SimpleCodeBlock = ({
   const { resolvedTheme } = useTheme()
   const [showCopied, setShowCopied] = useState(false)
   const target = useRef(null)
+  const contextOnCopy = useContext(CopyCallbackContext)
   let highlightLines: any = []
 
   useEffect(() => {
@@ -62,7 +66,9 @@ export const SimpleCodeBlock = ({
       copyToClipboard(code)
     }
     setShowCopied(true)
-    onCopy?.()
+    // Use prop onCopy if provided, otherwise fall back to context
+    const copyCallback = onCopy || contextOnCopy
+    copyCallback?.()
   }
 
   return (


### PR DESCRIPTION
## Summary
Adds comprehensive telemetry tracking for the Connect dialog interactions and integrates Connect actions into the command menu. This enables better understanding of how users connect to their Supabase projects and provides quick access to connection options via Cmd+K. Resolves GROWTH-548

## Changes
- **Telemetry tracking**: Added `connection_string_copied` event tracking for all Connect tabs (App Frameworks, Mobile Frameworks, ORMs, MCP) with detailed properties including `connectionTab`, `selectedItem`, `connectionType`, and `source`
- **MCP install tracking**: Created new `mcp_install_button_clicked` event for tracking one-click install button clicks (Cursor/VS Code)
- **Command menu integration**: Added "Connect to your project" and "Connect via MCP" commands accessible via Cmd+K
- **Context-based architecture**: Implemented `CopyCallbackContext` to automatically provide copy tracking to all `SimpleCodeBlock` components without modifying individual content files
- **Source attribution**: Added `source` property ('studio' or 'docs') to distinguish events from Studio vs Docs pages

## Testing
Tested events locally and in preview. Shows up in posthog correctly.
**Quick test:**
1. Open Studio, press Cmd+K and search for "Connect" - verify commands appear
2. Click "Connect to your project" - verify Connect dialog opens
3. Copy connection strings from different tabs (Frameworks, Mobile, ORMs, MCP)
4. Click "Add to Cursor" or "Add to VS Code" install buttons in MCP tab
5. Check PostHog/telemetry backend for events with proper `connectionTab`, `connectionType`, and `source` properties
6. Test the same flow on docs at `/guides/getting-started/mcp`