### PR TITLE
chore: Fix failing Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "sass": "^1.72.0",
     "supabase": "^2.58.5",
     "supports-color": "^8.0.0",
+    "tailwindcss": "catalog:",
     "turbo": "2.3.3",
     "typescript": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       supports-color:
         specifier: ^8.0.0
         version: 8.1.1
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.9.2))
       turbo:
         specifier: 2.3.3
         version: 2.3.3


### PR DESCRIPTION
This PR tries to fix the Vercel builds by moving the `tailwindcss` package into regular deps.

Some links from the research:
- https://github.com/tailwindlabs/tailwindcss-forms/issues/31
- https://github.com/vercel/next.js/discussions/67607