### PR TITLE
docs: Add critical steps for changing Postgres password in Docker sel…

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -37,6 +37,36 @@ This Docker Compose configuration includes the following services:
 - **[CHANGELOG.md](./CHANGELOG.md)** - Track recent updates and changes to services
 - **[versions.md](./versions.md)** - Complete history of Docker image versions for rollback reference
 
+## Critical Note: Changing Database Passwords and Sensitive Variables
+
+Simply changing sensitive variables, such as the `POSTGRES_PASSWORD` in the `.env` file, and then running `docker compose up -d` **will cause a connection error**.
+
+This happens because the persistent database volume was initialized with the old credentials.
+
+**To successfully apply a new database password or other volume-dependent variables, you MUST destroy the existing database volume so it can be re-initialized.**
+
+1.  Update the new password in your `.env` file.
+2.  **STOP and REMOVE** containers and volumes (this destroys the volume):
+
+    ```bash
+    docker compose down -v
+    ```
+
+3.  **Ensure all residual database data is cleared** (this step is sometimes necessary if the volume isn't fully removed):
+
+    ```bash
+    # Run this command from the root of your Supabase self-hosting directory:
+    rm -rf volumes/db/data/
+    ```
+
+4.  Start services again. A new database volume will be created with the new password:
+
+    ```bash
+    docker compose up -d
+    ```
+
+**DATA LOSS WARNING:** Performing these steps will **PERMANENTLY DELETE ALL DATA** in your self-hosted database. **Always back up your data** before performing this procedure.
+
 ## Updates
 
 To update your self-hosted Supabase instance:


### PR DESCRIPTION
…f-hosting guide

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update / Bug fix (in documentation)

## What is the current behavior?

The current self-hosting Docker README and setup documentation does not provide clear guidance on how to change sensitive configuration variables, such as the POSTGRES_PASSWORD, after initial setup.

If a user updates the password in the .env file and runs docker compose up -d, the services fail to start due to a conflict with the persistent database volume, which retains the old credentials. This leads to user frustration and failure to reconfigure the instance securely.

## What is the new behavior?

This PR adds a new section, "Critical Note: Changing Database Passwords and Sensitive Variables," to the Docker self-hosting README.

This new section:

Clearly warns the user about the conflict between the new password and the existing volume.

Provides the necessary steps: docker compose down -v and rm -rf volumes/db/data/ to reset the data volume.

Includes a strong DATA LOSS WARNING, emphasizing the need for backups before performing this destructive action.

This ensures users can securely update their secrets without facing unexpected startup errors

