### PR TITLE
feat(studio): use version 2.0.0 serializer on Realtime for inspector

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/SelectedRealtimeMessagePanel.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SelectedRealtimeMessagePanel.tsx
@@ -23,7 +23,7 @@ export const SelectedRealtimeMessagePanel = ({ log }: { log: LogData }) => {
       </div>
       <LogsDivider />
       <div className="px-8">
-        <h3 className="mb-4 text-sm text-foreground-lighter">Metadata</h3>
+        <h3 className="mb-4 text-sm text-foreground-lighter">Payload</h3>
         <pre className="syntax-highlight overflow-x-auto text-sm">
           <div
             className="text-wrap"

--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -104,6 +104,7 @@ export const useRealtimeMessages = (
     const realtimeOptions = merge(DEFAULT_REALTIME_OPTIONS, { params: { log_level: logLevel } })
 
     const options = {
+      vsn: '2.0.0',
       headers: DEFAULT_GLOBAL_OPTIONS.headers,
       ...realtimeOptions,
       params: { apikey: token, ...realtimeOptions.params },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Realtime [recently implemented a new version](https://github.com/supabase/supabase-js/pull/1829) for its protocol. Soon enough it will be the default value but we want to start using internally 🐶 🥫 

I've also updated the text for messages to show "payload" instead of `metadata` as this is term we mainly use for realtime messages

<img width="1759" height="476" alt="Realtime_Inspector___Supabase" src="https://github.com/user-attachments/assets/083efaf7-a02a-4d08-8428-83989ed091bb" />

