### PR TITLE
Update UI to de-couple ETL replication context from Analytics Buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/AnalyticsBucketDetails.constants.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/AnalyticsBucketDetails.constants.ts
@@ -24,3 +24,9 @@ export const DESCRIPTIONS: Record<string, string> = {
   's3.endpoint': '',
   catalog_uri: '',
 }
+
+// [Joshen] For context we've decided to decouple ETL from Analytics Buckets for now
+// So this flag just hides all "connect table" ETL flow related UI
+// Depending on future decision if we intend to keep it that way, then we might be able
+// to clean up + deprecate ConnectTablesDialog and other ETL related UI within Analytics Buckets
+export const HIDE_REPLICATION_USER_FLOW = true

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/BucketHeader.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/BucketHeader.tsx
@@ -1,15 +1,14 @@
 import { noop } from 'lodash'
 
-import { useParams } from 'common'
 import { FormattedWrapperTable } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
 import {
   ScaffoldHeader,
   ScaffoldSectionDescription,
   ScaffoldSectionTitle,
 } from 'components/layouts/Scaffold'
-import { useReplicationPipelineStatusQuery } from 'data/etl/pipeline-status-query'
+import { HIDE_REPLICATION_USER_FLOW } from './AnalyticsBucketDetails.constants'
 import { ConnectTablesDialog } from './ConnectTablesDialog'
-import { useAnalyticsBucketAssociatedEntities } from './useAnalyticsBucketAssociatedEntities'
+import { CreateTableInstructionsDialog } from './CreateTableInstructions/CreateTableInstructionsDialog'
 
 interface BucketHeaderProps {
   showActions?: boolean
@@ -26,13 +25,6 @@ export const BucketHeader = ({
   namespaces = [],
   onSuccessConnectTables = noop,
 }: BucketHeaderProps) => {
-  const { ref: projectRef, bucketId } = useParams()
-
-  const { pipeline } = useAnalyticsBucketAssociatedEntities({ projectRef, bucketId })
-  const { data } = useReplicationPipelineStatusQuery({ projectRef, pipelineId: pipeline?.id })
-  const pipelineStatus = data?.status.name
-  const isPipelineRunning = pipelineStatus === 'started'
-
   return (
     <ScaffoldHeader className="pt-0 flex flex-row justify-between items-end gap-x-8">
       <div>
@@ -44,7 +36,13 @@ export const BucketHeader = ({
       {showActions && (
         <div className="flex items-center gap-x-2">
           {namespaces.length > 0 && (
-            <ConnectTablesDialog onSuccessConnectTables={onSuccessConnectTables} />
+            <>
+              {HIDE_REPLICATION_USER_FLOW ? (
+                <CreateTableInstructionsDialog />
+              ) : (
+                <ConnectTablesDialog onSuccessConnectTables={onSuccessConnectTables} />
+              )}
+            </>
           )}
         </div>
       )}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/CreateTableInstructions.constants.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/CreateTableInstructions.constants.ts
@@ -1,0 +1,88 @@
+export const getPyicebergSnippet = ({
+  ref,
+  warehouse,
+  catalogUri,
+  s3Endpoint,
+  s3Region,
+  s3AccessKey,
+  s3SecretKey,
+  token,
+}: {
+  ref?: string
+  warehouse?: string
+  catalogUri?: string
+  s3Endpoint?: string
+  s3Region?: string
+  s3AccessKey?: string
+  s3SecretKey?: string
+  token?: string
+}) =>
+  `
+from pyiceberg.catalog import load_catalog
+import pyarrow as pa
+import datetime
+
+# Supabase project ref
+PROJECT_REF = "${ref ?? '<your-supabase-project-ref>'}"
+
+# Configuration for Iceberg REST Catalog
+WAREHOUSE = "${warehouse ?? 'your-analytics-bucket-name'}"
+TOKEN = "${token ?? '•••••••••••••'}"
+
+# Configuration for S3-Compatible Storage
+S3_ACCESS_KEY = "${s3AccessKey ?? '•••••••••••••'}"
+S3_SECRET_KEY = "${s3SecretKey ?? '•••••••••••••'}"
+S3_REGION = "${s3Region}"
+S3_ENDPOINT = f"${s3Endpoint ?? 'https://{PROJECT_REF}.supabase.co/storage/v1/s3'}"
+CATALOG_URI = f"${catalogUri ?? 'https://{PROJECT_REF}.supabase.co/storage/v1/iceberg'}"
+
+# Load the Iceberg catalog
+catalog = load_catalog(
+    "supabase",
+    type="rest",
+    warehouse=WAREHOUSE,
+    uri=CATALOG_URI,
+    token=TOKEN,
+    **{
+        "py-io-impl": "pyiceberg.io.pyarrow.PyArrowFileIO",
+        "s3.endpoint": S3_ENDPOINT,
+        "s3.access-key-id": S3_ACCESS_KEY,
+        "s3.secret-access-key": S3_SECRET_KEY,
+        "s3.region": S3_REGION,
+        "s3.force-virtual-addressing": False,
+    },
+)
+
+# Create namespace if it doesn't exist
+print("Creating catalog 'default'...")
+catalog.create_namespace_if_not_exists("default")
+
+# Define schema for your Iceberg table
+schema = pa.schema([
+    pa.field("event_id", pa.int64()),
+    pa.field("event_name", pa.string()),
+    pa.field("event_timestamp", pa.timestamp("ms")),
+])
+
+# Create table (if it doesn't exist already)
+print("Creating table 'events'...")
+table = catalog.create_table_if_not_exists(("default", "events"), schema=schema)
+
+# Generate and insert sample data
+print("Preparing sample data to be inserted...")
+current_time = datetime.datetime.now()
+data = pa.table({
+    "event_id": [1, 2, 3],
+    "event_name": ["login", "logout", "purchase"],
+    "event_timestamp": [current_time, current_time, current_time],
+})
+
+# Append data to the Iceberg table
+print("Inserting data into 'events'...")
+table.append(data)
+
+print("Completed!")
+# Scan table and print data as pandas DataFrame
+df = table.scan().to_pandas()
+print(df)
+`.trim()

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/CreateTableInstructionsDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/CreateTableInstructionsDialog.tsx
@@ -1,0 +1,32 @@
+import { Plus } from 'lucide-react'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+import { CreateTableInstructions } from '.'
+
+export const CreateTableInstructionsDialog = () => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="primary" icon={<Plus />}>
+          Create table
+        </Button>
+      </DialogTrigger>
+      <DialogContent size="xlarge">
+        <DialogHeader>
+          <DialogTitle>Adding tables to your Analytics Bucket</DialogTitle>
+          <DialogDescription>
+            Tables can be created or added to your bucket via Pyiceberg
+          </DialogDescription>
+        </DialogHeader>
+        <CreateTableInstructions hideHeader className="rounded-t-none border-x-0 border-b-0" />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
@@ -5,6 +5,7 @@ import CommandRender from 'components/interfaces/Functions/CommandRender'
 import { convertKVStringArrayToJson } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import CopyButton from 'components/ui/CopyButton'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import {
   getDecryptedValues,
@@ -18,6 +19,7 @@ import {
   AccordionItem_Shadcn_,
   AccordionTrigger_Shadcn_,
   Card,
+  CardFooter,
   CardHeader,
   CardTitle,
   CodeBlock,
@@ -226,7 +228,7 @@ export const CreateTableInstructions = ({
           </AccordionContent_Shadcn_>
         </AccordionItem_Shadcn_>
 
-        <AccordionItem_Shadcn_ value="step-3" className="border-0">
+        <AccordionItem_Shadcn_ value="step-3">
           <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
             <div className="flex items-center gap-x-4">
               <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
@@ -248,6 +250,16 @@ export const CreateTableInstructions = ({
           </AccordionContent_Shadcn_>
         </AccordionItem_Shadcn_>
       </Accordion_Shadcn_>
+
+      <CardFooter className="bg">
+        <p className="text-xs text-foreground-light">
+          Connecting to bucket with other Iceberg clients? Read more in our{' '}
+          <InlineLink href="https://supabase.com/docs/guides/storage/analytics/connecting-to-analytics-bucket">
+            documentation
+          </InlineLink>
+          .
+        </p>
+      </CardFooter>
     </Card>
   )
 }

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
@@ -12,6 +12,7 @@ import {
   useVaultSecretDecryptedValueQuery,
 } from 'data/vault/vault-secret-decrypted-value-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { DOCS_URL } from 'lib/constants'
 import { Eye, EyeOff } from 'lucide-react'
 import {
   Accordion_Shadcn_,
@@ -254,7 +255,7 @@ export const CreateTableInstructions = ({
       <CardFooter className="bg">
         <p className="text-xs text-foreground-light">
           Connecting to bucket with other Iceberg clients? Read more in our{' '}
-          <InlineLink href="https://supabase.com/docs/guides/storage/analytics/connecting-to-analytics-bucket">
+          <InlineLink href={`${DOCS_URL}/guides/storage/analytics/connecting-to-analytics-bucket`}>
             documentation
           </InlineLink>
           .

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
@@ -1,0 +1,253 @@
+import { useMemo, useState } from 'react'
+
+import { useParams } from 'common'
+import CommandRender from 'components/interfaces/Functions/CommandRender'
+import { convertKVStringArrayToJson } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import CopyButton from 'components/ui/CopyButton'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import {
+  getDecryptedValues,
+  useVaultSecretDecryptedValueQuery,
+} from 'data/vault/vault-secret-decrypted-value-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { Eye, EyeOff } from 'lucide-react'
+import {
+  Accordion_Shadcn_,
+  AccordionContent_Shadcn_,
+  AccordionItem_Shadcn_,
+  AccordionTrigger_Shadcn_,
+  Card,
+  CardHeader,
+  CardTitle,
+  CodeBlock,
+} from 'ui'
+import { useAnalyticsBucketWrapperInstance } from '../useAnalyticsBucketWrapperInstance'
+import { getPyicebergSnippet } from './CreateTableInstructions.constants'
+
+export const CreateTableInstructions = ({
+  hideHeader = false,
+  className,
+}: {
+  hideHeader?: boolean
+  className?: string
+}) => {
+  const { ref, bucketId } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+  const [showKeys, setShowKeys] = useState(false)
+  const [isFetchingSecretsOnCopy, setIsFetchingSecretsOnCopy] = useState(false)
+
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
+  const { data: wrapperInstance } = useAnalyticsBucketWrapperInstance({ bucketId })
+  const wrapperValues = convertKVStringArrayToJson(wrapperInstance?.server_options ?? [])
+
+  const s3AccessKeyVaultID = wrapperValues.vault_aws_access_key_id
+  const s3SecretKeyVaultID = wrapperValues.vault_aws_secret_access_key
+  const tokenVaultID = wrapperValues.vault_token
+
+  const { data: decryptedS3AccessKey, isLoading: isDecryptingS3AccessKey } =
+    useVaultSecretDecryptedValueQuery(
+      {
+        projectRef: project?.ref,
+        connectionString: project?.connectionString,
+        id: s3AccessKeyVaultID,
+      },
+      { enabled: showKeys }
+    )
+
+  const { data: decryptedS3SecretKey, isLoading: isDecryptingS3SecretKey } =
+    useVaultSecretDecryptedValueQuery(
+      {
+        projectRef: project?.ref,
+        connectionString: project?.connectionString,
+        id: s3SecretKeyVaultID,
+      },
+      { enabled: showKeys }
+    )
+
+  const { data: decryptedToken, isLoading: isDecryptingToken } = useVaultSecretDecryptedValueQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      id: tokenVaultID,
+    },
+    { enabled: showKeys }
+  )
+
+  const isFetchingSecretValues =
+    showKeys && (isDecryptingS3AccessKey || isDecryptingS3SecretKey || isDecryptingToken)
+
+  const snippetContent = useMemo(
+    () =>
+      getPyicebergSnippet({
+        ref,
+        warehouse: wrapperValues.warehouse,
+        catalogUri: wrapperValues.catalog_uri,
+        s3Endpoint: wrapperValues['s3.endpoint'],
+        s3Region: projectSettings?.region,
+        s3AccessKey: showKeys ? decryptedS3AccessKey : undefined,
+        s3SecretKey: showKeys ? decryptedS3SecretKey : undefined,
+        token: showKeys ? decryptedToken : undefined,
+      }),
+    [
+      decryptedS3AccessKey,
+      decryptedS3SecretKey,
+      decryptedToken,
+      projectSettings?.region,
+      ref,
+      showKeys,
+      wrapperValues,
+    ]
+  )
+
+  return (
+    <Card className={className}>
+      {!hideHeader && (
+        <CardHeader>
+          <CardTitle>Create your first table via Pyiceberg</CardTitle>
+        </CardHeader>
+      )}
+
+      <Accordion_Shadcn_ defaultValue={['step-1']} type="multiple">
+        <AccordionItem_Shadcn_ value="step-1">
+          <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
+            <div className="flex items-center gap-x-4">
+              <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
+                1
+              </div>
+              <p className="prose text-sm font-normal">
+                Set up Python project with <code>uv</code>
+              </p>
+            </div>
+          </AccordionTrigger_Shadcn_>
+          <AccordionContent_Shadcn_ className="border-0 px-6 pt-1">
+            <CommandRender
+              commands={[
+                {
+                  comment: '1. Install uv as a preferred package manager',
+                  command: 'curl -LsSf https://astral.sh/uv/install.sh | sh',
+                  jsx: () => 'curl -LsSf https://astral.sh/uv/install.sh | sh',
+                },
+                {
+                  comment: '2. Initialize a new Python project with uv',
+                  command: 'uv init <project-name>',
+                  jsx: () => 'uv init <project-name>',
+                },
+                {
+                  comment: '3. Install required packages',
+                  command: 'uv add pyiceberg pyarrow pandas',
+                  jsx: () => 'uv add pyiceberg pyarrow pandas',
+                },
+              ]}
+            />
+          </AccordionContent_Shadcn_>
+        </AccordionItem_Shadcn_>
+
+        <AccordionItem_Shadcn_ value="step-2">
+          <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
+            <div className="flex items-center gap-x-4">
+              <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
+                2
+              </div>
+              <p className="prose text-sm font-normal">
+                Replace <code>main.py</code> with the following snippet
+              </p>
+            </div>
+          </AccordionTrigger_Shadcn_>
+          <AccordionContent_Shadcn_ className="border-0 px-6 pt-2">
+            <p className="text-foreground mb-3 prose max-w-full text-sm">
+              The following snippet creates a namespace <code>default</code>, then creates a sample
+              table
+              <code>events</code> into that namespace.
+            </p>
+            <div className="relative group">
+              <CodeBlock
+                hideCopy
+                language="python"
+                className="max-h-[330px]"
+                value={snippetContent}
+              />
+              <div className="flex items-center gap-x-1.5 absolute top-2 right-2">
+                <CopyButton
+                  type="default"
+                  loading={isFetchingSecretsOnCopy}
+                  asyncText={async () => {
+                    if (!!decryptedS3AccessKey && !!decryptedS3SecretKey && !!decryptedToken) {
+                      return getPyicebergSnippet({
+                        ref,
+                        warehouse: wrapperValues.warehouse,
+                        catalogUri: wrapperValues.catalog_uri,
+                        s3Endpoint: wrapperValues['s3.endpoint'],
+                        s3Region: projectSettings?.region,
+                        s3AccessKey: decryptedS3AccessKey,
+                        s3SecretKey: decryptedS3SecretKey,
+                        token: decryptedToken,
+                      })
+                    } else {
+                      setIsFetchingSecretsOnCopy(true)
+                      const decryptedSecrets = await getDecryptedValues({
+                        projectRef: project?.ref,
+                        connectionString: project?.connectionString,
+                        ids: [s3AccessKeyVaultID, s3SecretKeyVaultID, tokenVaultID],
+                      })
+                      setIsFetchingSecretsOnCopy(false)
+                      return getPyicebergSnippet({
+                        ref,
+                        warehouse: wrapperValues.warehouse,
+                        catalogUri: wrapperValues.catalog_uri,
+                        s3Endpoint: wrapperValues['s3.endpoint'],
+                        s3Region: projectSettings?.region,
+                        s3AccessKey: decryptedSecrets[s3AccessKeyVaultID],
+                        s3SecretKey: decryptedSecrets[s3SecretKeyVaultID],
+                        token: decryptedSecrets[tokenVaultID],
+                      })
+                    }
+                  }}
+                />
+                <ButtonTooltip
+                  type="default"
+                  className="w-7"
+                  loading={isFetchingSecretValues}
+                  onClick={() => setShowKeys(!showKeys)}
+                  icon={showKeys ? <EyeOff /> : <Eye />}
+                  tooltip={{
+                    content: {
+                      side: 'bottom',
+                      text: showKeys
+                        ? 'Hide keys'
+                        : isFetchingSecretValues
+                          ? 'Retrieving keys'
+                          : 'Reveal keys',
+                    },
+                  }}
+                />
+              </div>
+            </div>
+          </AccordionContent_Shadcn_>
+        </AccordionItem_Shadcn_>
+
+        <AccordionItem_Shadcn_ value="step-3" className="border-0">
+          <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
+            <div className="flex items-center gap-x-4">
+              <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
+                3
+              </div>
+              <p className="prose text-sm font-normal">Run the Python script</p>
+            </div>
+          </AccordionTrigger_Shadcn_>
+          <AccordionContent_Shadcn_ className="border-0 px-6 pt-2">
+            <CommandRender
+              commands={[
+                {
+                  comment: 'Run the main.py script with uv',
+                  command: 'uv run main.py',
+                  jsx: () => 'uv run main.py',
+                },
+              ]}
+            />
+          </AccordionContent_Shadcn_>
+        </AccordionItem_Shadcn_>
+      </Accordion_Shadcn_>
+    </Card>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/InitializeForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/InitializeForeignSchemaDialog.tsx
@@ -1,0 +1,133 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import z from 'zod'
+
+import { useParams } from 'common'
+import { useSchemaCreateMutation } from 'data/database/schema-create-mutation'
+import { useSchemasQuery } from 'data/database/schemas-query'
+import { useFDWImportForeignSchemaMutation } from 'data/fdw/fdw-import-foreign-schema-mutation'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+  Form_Shadcn_,
+  FormField_Shadcn_,
+  Input_Shadcn_,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { getAnalyticsBucketFDWServerName } from './AnalyticsBucketDetails.utils'
+
+// Create foreign tables for namespace tables
+export const InitializeForeignSchemaDialog = ({ namespace }: { namespace: string }) => {
+  const { ref: projectRef, bucketId } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+  const { data: schemas } = useSchemasQuery({ projectRef })
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
+
+  const serverName = getAnalyticsBucketFDWServerName(bucketId ?? '')
+
+  const FormSchema = z.object({
+    schema: z
+      .string()
+      .trim()
+      .min(1, 'Schema name is required')
+      .refine((val) => !schemas?.find((s) => s.name === val), {
+        message: 'This schema already exists. Please specify a unique schema name.',
+      }),
+  })
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { schema: '' },
+  })
+
+  const { mutateAsync: createSchema } = useSchemaCreateMutation()
+  const { mutateAsync: importForeignSchema } = useFDWImportForeignSchemaMutation()
+
+  const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
+    if (!projectRef) return console.error('Project ref is required')
+
+    try {
+      setIsCreating(true)
+
+      await createSchema({
+        projectRef,
+        connectionString: project?.connectionString,
+        name: values.schema,
+      })
+
+      await importForeignSchema({
+        projectRef,
+        connectionString: project?.connectionString,
+        serverName: serverName,
+        sourceSchema: namespace,
+        targetSchema: values.schema,
+      })
+
+      toast.success(
+        `Successfully created "${values.schema}" schema! Data from tables in the "${namespace}" namespace can now be queried from there.`
+      )
+      setIsOpen(false)
+    } catch (error: any) {
+      toast.error(`Failed to expose tables: ${error.message}`)
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button type="default">Query from Postgres</Button>
+      </DialogTrigger>
+      <DialogContent size="medium" aria-describedby={undefined}>
+        <Form_Shadcn_ {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogHeader>
+              <DialogTitle>Query this namespace from Postgres</DialogTitle>
+            </DialogHeader>
+            <DialogSectionSeparator />
+            <DialogSection className="flex flex-col gap-y-4">
+              <p className="text-sm">
+                Iceberg data can be queried from Postgres with the Iceberg Foreign Data Wrapper.
+                Create a Postgres schema to expose tables from the "{namespace}" namespace as
+                foreign tables.
+              </p>
+              <FormField_Shadcn_
+                control={form.control}
+                name="schema"
+                render={({ field }) => (
+                  <FormItemLayout
+                    layout="vertical"
+                    label="Schema name"
+                    description="You can then query data by selecting from ..."
+                  >
+                    <Input_Shadcn_ {...field} placeholder="Provide a name for your schema" />
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogFooter>
+              <Button type="default" disabled={isCreating} onClick={() => setIsOpen(false)}>
+                Cancel
+              </Button>
+              <Button htmlType="submit" type="primary" loading={isCreating}>
+                Create schema
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form_Shadcn_>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/InitializeForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/InitializeForeignSchemaDialog.tsx
@@ -107,11 +107,7 @@ export const InitializeForeignSchemaDialog = ({ namespace }: { namespace: string
                 control={form.control}
                 name="schema"
                 render={({ field }) => (
-                  <FormItemLayout
-                    layout="vertical"
-                    label="Schema name"
-                    description="You can then query data by selecting from ..."
-                  >
+                  <FormItemLayout layout="vertical" label="Schema name">
                     <Input_Shadcn_ {...field} placeholder="Provide a name for your schema" />
                   </FormItemLayout>
                 )}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -242,10 +242,12 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
   }
 
   const connectedForeignTablesInNamespace =
-    icebergWrapper?.tables.filter((x) => x.options[0].includes(`table=${namespace}.`)) ?? []
+    (icebergWrapper?.tables ?? []).filter((x) => x.options[0].includes(`table=${namespace}.`)) ?? []
 
   const connectedForeignTables =
-    icebergWrapper?.tables.filter((x) => x.options[0] === `table=${namespace}.${table.name}`) ?? []
+    (icebergWrapper?.tables ?? []).filter(
+      (x) => x.options[0] === `table=${namespace}.${table.name}`
+    ) ?? []
 
   // [Joshen] For purely Analytics Bucket context
   const onConfirmRemoveNamespaceTable = async () => {

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -241,11 +241,13 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
     }
   }
 
-  const connectedForeignTablesInNamespace =
-    icebergWrapper?.tables.filter((x) => x.options[0].includes(`table=${namespace}.`)) ?? []
+  const connectedForeignTablesInNamespace = (icebergWrapper?.tables ?? []).filter((x) =>
+    x.options[0].includes(`table=${namespace}.`)
+  )
 
-  const connectedForeignTables =
-    icebergWrapper?.tables.filter((x) => x.options[0] === `table=${namespace}.${table.name}`) ?? []
+  const connectedForeignTables = (icebergWrapper?.tables ?? []).filter(
+    (x) => x.options[0] === `table=${namespace}.${table.name}`
+  )
 
   // [Joshen] For purely Analytics Bucket context
   const onConfirmRemoveNamespaceTable = async () => {

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -289,7 +289,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
             <p>{table.name}</p>
           </div>
         </TableCell>
-        {!!hasReplication && (
+        {!HIDE_REPLICATION_USER_FLOW && !!hasReplication && (
           <TableCell colSpan={table.isConnected ? 1 : 2} className="min-w-[150px]">
             <div className="flex items-center">
               <Tooltip>
@@ -322,7 +322,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
           </TableCell>
         )}
 
-        {table.isConnected ? (
+        {!HIDE_REPLICATION_USER_FLOW && table.isConnected ? (
           // [Joshen] These are if there's the context of replication which we're currently not doing
           // May need to clean up if we decided to move forward de-coupling replication and Analytics Buckets
           <TableCell className="text-right flex flex-row items-center gap-x-2 justify-end">

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -242,12 +242,10 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
   }
 
   const connectedForeignTablesInNamespace =
-    (icebergWrapper?.tables ?? []).filter((x) => x.options[0].includes(`table=${namespace}.`)) ?? []
+    icebergWrapper?.tables.filter((x) => x.options[0].includes(`table=${namespace}.`)) ?? []
 
   const connectedForeignTables =
-    (icebergWrapper?.tables ?? []).filter(
-      (x) => x.options[0] === `table=${namespace}.${table.name}`
-    ) ?? []
+    icebergWrapper?.tables.filter((x) => x.options[0] === `table=${namespace}.${table.name}`) ?? []
 
   // [Joshen] For purely Analytics Bucket context
   const onConfirmRemoveNamespaceTable = async () => {
@@ -414,7 +412,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
 
       {/* [Joshen] Render each foreign table associated to the namespace table as its own row */}
       {connectedForeignTables?.map((x) => (
-        <TableRow>
+        <TableRow key={x.id}>
           <TableCell className="pl-6">
             <div className="flex items-center gap-x-2 rounded">
               <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-copntrol -translate-y-1.5" />
@@ -464,7 +462,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
             <Tooltip>
               <TooltipTrigger>
                 <div className="flex items-center gap-x-2 rounded">
-                  <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-copntrol -translate-y-1.5" />
+                  <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-control -translate-y-1.5" />
                   <div
                     className={cn(
                       'flex items-center justify-center text-xs h-4 w-4 rounded-[2px]',

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -417,7 +417,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
         <TableRow key={x.id}>
           <TableCell className="pl-6">
             <div className="flex items-center gap-x-2 rounded">
-              <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-copntrol -translate-y-1.5" />
+              <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-control -translate-y-1.5" />
               <div
                 className={cn(
                   'flex items-center justify-center text-xs h-4 w-4 rounded-[2px] font-bold',

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -1,5 +1,5 @@
 import { uniq } from 'lodash'
-import { Eye, Loader2, MoreVertical, Pause, Play, Trash } from 'lucide-react'
+import { Eye, Loader2, MoreVertical, Pause, Play, Table2, Trash } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -16,12 +16,14 @@ import { useReplicationPipelineStatusQuery } from 'data/etl/pipeline-status-quer
 import { useUpdatePublicationMutation } from 'data/etl/publication-update-mutation'
 import { useStartPipelineMutation } from 'data/etl/start-pipeline-mutation'
 import { useReplicationTablesQuery } from 'data/etl/tables-query'
+import { useFDWDropForeignTableMutation } from 'data/fdw/fdw-drop-foreign-table-mutation'
 import { useFDWUpdateMutation } from 'data/fdw/fdw-update-mutation'
 import { useIcebergNamespaceTableDeleteMutation } from 'data/storage/iceberg-namespace-table-delete-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { SqlEditor } from 'icons'
+import { SqlEditor, TableEditor } from 'icons'
 import {
   Button,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -34,6 +36,7 @@ import {
   TooltipTrigger,
 } from 'ui'
 import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
+import { HIDE_REPLICATION_USER_FLOW } from '../AnalyticsBucketDetails.constants'
 import {
   getAnalyticsBucketFDWServerName,
   getNamespaceTableNameFromPostgresTableName,
@@ -46,15 +49,9 @@ interface TableRowComponentProps {
   table: { id: number; name: string; isConnected: boolean }
   schema: string
   namespace: string
-  isLoading?: boolean
 }
 
-export const TableRowComponent = ({
-  table,
-  schema,
-  namespace,
-  isLoading,
-}: TableRowComponentProps) => {
+export const TableRowComponent = ({ table, schema, namespace }: TableRowComponentProps) => {
   const { ref: projectRef, bucketId } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
@@ -64,7 +61,7 @@ export const TableRowComponent = ({
   const [isUpdatingReplication, setIsUpdatingReplication] = useState(false)
   const [isRemovingTable, setIsRemovingTable] = useState(false)
 
-  const { sourceId, publication, pipeline } = useAnalyticsBucketAssociatedEntities({
+  const { sourceId, publication, pipeline, icebergWrapper } = useAnalyticsBucketAssociatedEntities({
     projectRef,
     bucketId,
   })
@@ -80,9 +77,9 @@ export const TableRowComponent = ({
   })
 
   const { mutateAsync: updateFDW } = useFDWUpdateMutation()
-  const { mutateAsync: deleteNamespaceTable } = useIcebergNamespaceTableDeleteMutation({
-    projectRef,
-  })
+  const { mutateAsync: dropForeignTable } = useFDWDropForeignTableMutation()
+  const { mutateAsync: deleteNamespaceTable, isLoading: isDeletingNamespaceTable } =
+    useIcebergNamespaceTableDeleteMutation({ projectRef, onError: () => {} })
   const { mutateAsync: updatePublication } = useUpdatePublicationMutation()
   const { mutateAsync: startPipeline } = useStartPipelineMutation()
 
@@ -179,6 +176,7 @@ export const TableRowComponent = ({
     }
   }
 
+  // [Joshen] For ETL replication context
   const onConfirmRemoveTable = async () => {
     if (!bucketId) return console.error('Bucket ID is required')
     if (!wrapperInstance || !wrapperMeta) return toast.error('Unable to find wrapper')
@@ -243,10 +241,54 @@ export const TableRowComponent = ({
     }
   }
 
+  const connectedForeignTablesInNamespace =
+    icebergWrapper?.tables.filter((x) => x.options[0].includes(`table=${namespace}.`)) ?? []
+
+  const connectedForeignTables =
+    icebergWrapper?.tables.filter((x) => x.options[0] === `table=${namespace}.${table.name}`) ?? []
+
+  // [Joshen] For purely Analytics Bucket context
+  const onConfirmRemoveNamespaceTable = async () => {
+    try {
+      setIsRemovingTable(true)
+      const wrapperValues = convertKVStringArrayToJson(wrapperInstance?.server_options ?? [])
+      await deleteNamespaceTable({
+        catalogUri: wrapperValues.catalog_uri,
+        warehouse: wrapperValues.warehouse,
+        namespace: namespace,
+        table: table.name,
+      })
+
+      await Promise.all(
+        connectedForeignTables.map((x) =>
+          dropForeignTable({
+            projectRef,
+            connectionString: project?.connectionString,
+            schemaName: x.schema,
+            tableName: x.name,
+          })
+        )
+      )
+
+      toast.success(`Successfully removed table "${table.name}"!`)
+    } catch (error: any) {
+      toast.error(`Failed to remove table: ${error.message}`)
+    } finally {
+      setIsRemovingTable(false)
+    }
+  }
+
   return (
     <>
       <TableRow>
-        <TableCell className="min-w-[120px]">{table.name}</TableCell>
+        <TableCell className="min-w-[120px]">
+          <div className="flex items-center gap-x-3">
+            <div className="w-5 flex justify-center items-center">
+              <Table2 size={16} />
+            </div>
+            <p>{table.name}</p>
+          </div>
+        </TableCell>
         {!!hasReplication && (
           <TableCell colSpan={table.isConnected ? 1 : 2} className="min-w-[150px]">
             <div className="flex items-center">
@@ -280,29 +322,17 @@ export const TableRowComponent = ({
           </TableCell>
         )}
 
-        {table.isConnected && (
+        {table.isConnected ? (
+          // [Joshen] These are if there's the context of replication which we're currently not doing
+          // May need to clean up if we decided to move forward de-coupling replication and Analytics Buckets
           <TableCell className="text-right flex flex-row items-center gap-x-2 justify-end">
             <>
-              <Button asChild type="default" size="tiny">
-                <Link href={`/project/${project?.ref}/editor/${table.id}?schema=${schema}`}>
-                  <p>View table</p>
-                </Link>
-              </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button type="default" className="px-1" icon={<MoreVertical />} />
+                  <Button type="default" className="w-7" icon={<MoreVertical />} />
                 </DropdownMenuTrigger>
 
                 <DropdownMenuContent side="bottom" align="end" className="w-fit min-w-[180px]">
-                  <DropdownMenuItem asChild className="flex items-center gap-x-2">
-                    <Link
-                      href={`/project/${projectRef}/sql/new?content=${encodeURIComponent(`select * from ${schema}.${table.name};`)}`}
-                    >
-                      <SqlEditor size={12} className="text-foreground-lighter" />
-                      <p>Query in SQL Editor</p>
-                    </Link>
-                  </DropdownMenuItem>
-
                   {!!publication && (
                     <>
                       {!!inferredPostgresTable && (
@@ -332,10 +362,9 @@ export const TableRowComponent = ({
                           <p>Enable replication</p>
                         </DropdownMenuItem>
                       )}
+                      <DropdownMenuSeparator />
                     </>
                   )}
-
-                  <DropdownMenuSeparator />
 
                   <DropdownMenuItemTooltip
                     disabled={isReplicating}
@@ -349,14 +378,111 @@ export const TableRowComponent = ({
                     }}
                   >
                     <Trash size={12} className="text-foreground-lighter" />
-                    <p>Remove table</p>
+                    <p>Delete table</p>
                   </DropdownMenuItemTooltip>
                 </DropdownMenuContent>
               </DropdownMenu>
             </>
           </TableCell>
+        ) : (
+          // [Joshen] These are for purely Analytics Bucket context
+          <TableCell className="text-right flex flex-row items-center gap-x-2 justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  loading={isDeletingNamespaceTable}
+                  type="default"
+                  className="w-7"
+                  icon={<MoreVertical />}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-fit min-w-[180px]">
+                <DropdownMenuItem
+                  className="flex items-center gap-x-2"
+                  onClick={() => setShowRemoveTableModal(true)}
+                >
+                  <Trash size={12} className="text-foreground-lighter" />
+                  <p>Delete table</p>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </TableCell>
         )}
       </TableRow>
+
+      {/* [Joshen] Render each foreign table associated to the namespace table as its own row */}
+      {connectedForeignTables?.map((x) => (
+        <TableRow>
+          <TableCell className="pl-6">
+            <div className="flex items-center gap-x-2 rounded">
+              <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-copntrol -translate-y-1.5" />
+              <div
+                className={cn(
+                  'flex items-center justify-center text-xs h-4 w-4 rounded-[2px] font-bold',
+                  'text-warning-600/80 dark:text-yellow-900 bg-yellow-500'
+                )}
+              >
+                F
+              </div>
+              <p>
+                {x.schema}.{x.name}
+              </p>
+            </div>
+          </TableCell>
+          <TableCell className="flex flex-row justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="default" className="w-7" icon={<MoreVertical />} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-fit min-w-[180px]" align="end">
+                <DropdownMenuItem asChild className="flex items-center gap-x-2">
+                  <Link
+                    href={`/project/${projectRef}/sql/new?content=${encodeURIComponent(`select * from ${schema}.${table.name};`)}`}
+                  >
+                    <SqlEditor size={12} className="text-foreground-lighter" />
+                    <p>Query in SQL Editor</p>
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild className="flex items-center gap-x-2">
+                  <Link href={`/project/${projectRef}/editor/${x.id}?schema=${x.schema}`}>
+                    <TableEditor size={12} className="text-foreground-lighter" />
+                    <p>View in Table Editor</p>
+                  </Link>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </TableCell>
+        </TableRow>
+      ))}
+
+      {/* [Joshen] If the iceberg table doesn't have a corresponding namespace table, but the namespace itself already has some tables connected */}
+      {connectedForeignTablesInNamespace.length > 0 && connectedForeignTables.length === 0 && (
+        <TableRow>
+          <TableCell className="pl-6">
+            <Tooltip>
+              <TooltipTrigger>
+                <div className="flex items-center gap-x-2 rounded">
+                  <div className="w-4 h-4 rounded-bl-lg border-l-2 border-b-2 border-copntrol -translate-y-1.5" />
+                  <div
+                    className={cn(
+                      'flex items-center justify-center text-xs h-4 w-4 rounded-[2px]',
+                      'font-bold border border-dashed border-control text-foreground-lighter'
+                    )}
+                  >
+                    ?
+                  </div>
+                  <p className="text-foreground-lighter">No matching foreign table in schema</p>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                Update the schema tables if you'd like to query this table from Postgres
+              </TooltipContent>
+            </Tooltip>
+          </TableCell>
+          <TableCell className="flex flex-row justify-end"></TableCell>
+        </TableRow>
+      )}
+
       <ConfirmationModal
         size="medium"
         variant="warning"
@@ -390,17 +516,25 @@ export const TableRowComponent = ({
       </ConfirmationModal>
 
       <ConfirmationModal
-        size="small"
+        size="medium"
         variant="warning"
         visible={showRemoveTableModal}
         loading={isRemovingTable}
-        title="Confirm to remove table"
-        description="Data from the analytics table will be lost"
-        confirmLabel="Remove table"
+        title={`Confirm to delete table "${table.name}"`}
+        description="This action cannot be undone."
+        confirmLabel="Delete table"
         onCancel={() => setShowRemoveTableModal(false)}
-        onConfirm={() => onConfirmRemoveTable()}
+        onConfirm={() => {
+          if (HIDE_REPLICATION_USER_FLOW) {
+            onConfirmRemoveNamespaceTable()
+          } else {
+            onConfirmRemoveTable()
+          }
+        }}
       >
-        <p className="text-sm text-foreground-light">Are you sure? This action cannot be undone.</p>
+        <p className="text-sm text-foreground-light">
+          Data from this Iceberg table will be permanently lost. Are you sure?
+        </p>
       </ConfirmationModal>
     </>
   )

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
@@ -103,7 +103,8 @@ export const NamespaceWithTables = ({
   )
 
   const connectedForeignTablesForNamespace =
-    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
+    (icebergWrapper?.tables ?? []).filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ??
+    []
   const tablesWithConnectedForeignTables = connectedForeignTablesForNamespace.reduce((a, b) => {
     const table = b.options[0].split(`table=${namespace}.`)[1]
     if (!a.find((x) => x === table)) a.push(table)

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
@@ -102,8 +102,9 @@ export const NamespaceWithTables = ({
     }
   )
 
-  const connectedForeignTablesForNamespace =
-    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
+  const connectedForeignTablesForNamespace = (icebergWrapper?.tables ?? []).filter((x) =>
+    x.options[0].startsWith(`table=${namespace}.`)
+  )
   const tablesWithConnectedForeignTables = connectedForeignTablesForNamespace.reduce((a, b) => {
     const table = b.options[0].split(`table=${namespace}.`)[1]
     a.add(table)

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
@@ -103,14 +103,13 @@ export const NamespaceWithTables = ({
   )
 
   const connectedForeignTablesForNamespace =
-    (icebergWrapper?.tables ?? []).filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ??
-    []
+    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
   const tablesWithConnectedForeignTables = connectedForeignTablesForNamespace.reduce((a, b) => {
     const table = b.options[0].split(`table=${namespace}.`)[1]
-    if (!a.find((x) => x === table)) a.push(table)
+    a.add(table)
     return a
-  }, [] as string[])
-  const unconnectedTables = tablesData.filter((x) => !tablesWithConnectedForeignTables.includes(x))
+  }, new Set<string>())
+  const unconnectedTables = tablesData.filter((x) => !tablesWithConnectedForeignTables.has(x))
   const hasUnconnectedForeignTablesForNamespace = unconnectedTables.length > 0
 
   const publicationTables = publication?.tables ?? []
@@ -120,7 +119,7 @@ export const NamespaceWithTables = ({
   const isSyncedPublicationTablesAndNamespaceTables =
     publicationTablesNotSyncedToNamespaceTables.length === 0
 
-  const { mutateAsync: importForeignSchema, isLoading: isImportingForeignSchema } =
+  const { mutateAsync: importForeignSchema, isPending: isImportingForeignSchema } =
     useFDWImportForeignSchemaMutation()
   const { mutateAsync: deleteNamespace } = useIcebergNamespaceDeleteMutation({ projectRef })
   const { mutateAsync: dropForeignTable } = useFDWDropForeignTableMutation()

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/index.tsx
@@ -1,19 +1,28 @@
-import { ChevronRight, Info, Loader2, Plus, RefreshCw } from 'lucide-react'
+import { ChevronRight, Info, Loader2, MoreVertical, Plus, RefreshCw, Trash } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
 
 import { useParams } from 'common'
-import type { WrapperMeta } from 'components/interfaces/Integrations/Wrappers/Wrappers.types'
 import { FormattedWrapperTable } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
 import { ImportForeignSchemaDialog } from 'components/interfaces/Storage/ImportForeignSchemaDialog'
+import { getCatalogURI } from 'components/interfaces/Storage/StorageSettings/StorageSettings.utils'
+import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { useFDWDropForeignTableMutation } from 'data/fdw/fdw-drop-foreign-table-mutation'
 import { useFDWImportForeignSchemaMutation } from 'data/fdw/fdw-import-foreign-schema-mutation'
-import { FDW } from 'data/fdw/fdws-query'
+import { useIcebergNamespaceDeleteMutation } from 'data/storage/iceberg-namespace-delete-mutation'
+import { useIcebergNamespaceTableDeleteMutation } from 'data/storage/iceberg-namespace-table-delete-mutation'
 import { useIcebergNamespaceTablesQuery } from 'data/storage/iceberg-namespace-tables-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { BASE_PATH } from 'lib/constants'
 import {
   Button,
   Card,
   CardHeader,
   CardTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   LoadingLine,
   Table,
   TableBody,
@@ -25,40 +34,44 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from 'ui'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { HIDE_REPLICATION_USER_FLOW } from '../AnalyticsBucketDetails.constants'
 import { getNamespaceTableNameFromPostgresTableName } from '../AnalyticsBucketDetails.utils'
+import { InitializeForeignSchemaDialog } from '../InitializeForeignSchemaDialog'
+import { UpdateForeignSchemaDialog } from '../UpdateForeignSchemaDialog'
 import { useAnalyticsBucketAssociatedEntities } from '../useAnalyticsBucketAssociatedEntities'
 import { TableRowComponent } from './TableRowComponent'
 
 type NamespaceWithTablesProps = {
-  bucketName?: string
   namespace: string
   sourceType: 'replication' | 'direct'
   schema: string
   tables: (FormattedWrapperTable & { id: number })[]
-  wrapperInstance: FDW
   wrapperValues: Record<string, string>
-  wrapperMeta: WrapperMeta
   pollIntervalNamespaceTables: number
   setPollIntervalNamespaceTables: (value: number) => void
 }
 
 export const NamespaceWithTables = ({
-  bucketName,
   namespace,
   sourceType = 'direct',
   schema,
   tables,
-  wrapperInstance,
   wrapperValues,
-  wrapperMeta,
   pollIntervalNamespaceTables,
   setPollIntervalNamespaceTables,
 }: NamespaceWithTablesProps) => {
   const { ref: projectRef, bucketId } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [importForeignSchemaShown, setImportForeignSchemaShown] = useState(false)
+  const [showConfirmDeleteNamespace, setShowConfirmDeleteNamespace] = useState(false)
+  const [isDeletingNamespace, setIsDeletingNamespace] = useState(false)
 
-  const { publication } = useAnalyticsBucketAssociatedEntities({ projectRef, bucketId })
+  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef })
+  const { publication, icebergWrapper } = useAnalyticsBucketAssociatedEntities({
+    projectRef,
+    bucketId,
+  })
 
   const {
     data: tablesData = [],
@@ -89,6 +102,16 @@ export const NamespaceWithTables = ({
     }
   )
 
+  const connectedForeignTablesForNamespace =
+    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
+  const tablesWithConnectedForeignTables = connectedForeignTablesForNamespace.reduce((a, b) => {
+    const table = b.options[0].split(`table=${namespace}.`)[1]
+    if (!a.find((x) => x === table)) a.push(table)
+    return a
+  }, [] as string[])
+  const unconnectedTables = tablesData.filter((x) => !tablesWithConnectedForeignTables.includes(x))
+  const hasUnconnectedForeignTablesForNamespace = unconnectedTables.length > 0
+
   const publicationTables = publication?.tables ?? []
   const publicationTablesNotSyncedToNamespaceTables = publicationTables.filter(
     (x) => !tablesData.includes(getNamespaceTableNameFromPostgresTableName(x))
@@ -98,12 +121,19 @@ export const NamespaceWithTables = ({
 
   const { mutateAsync: importForeignSchema, isLoading: isImportingForeignSchema } =
     useFDWImportForeignSchemaMutation()
+  const { mutateAsync: deleteNamespace } = useIcebergNamespaceDeleteMutation({ projectRef })
+  const { mutateAsync: dropForeignTable } = useFDWDropForeignTableMutation()
+  const { mutateAsync: deleteNamespaceTable } = useIcebergNamespaceTableDeleteMutation({
+    projectRef,
+  })
 
   const rescanNamespace = async () => {
+    if (!icebergWrapper) return console.error('Iceberg wrapper cannot be found')
+
     await importForeignSchema({
       projectRef: project?.ref,
       connectionString: project?.connectionString,
-      serverName: wrapperInstance.server_name,
+      serverName: icebergWrapper.server_name,
       sourceSchema: namespace,
       targetSchema: schema,
     })
@@ -141,14 +171,57 @@ export const NamespaceWithTables = ({
     return !hasClashes
   }, [schema, tables.length])
 
-  // Determine what schema name to display
   const displaySchema = useMemo(() => {
-    // If we have a target schema, use it
+    // If we have a target schema, use it, otherwise show the incoming schema (namespace name)
     if (schema) return schema
-
-    // Otherwise, show the incoming schema (namespace name)
     return `fdw_analytics_${namespace.replaceAll('-', '_')}`
   }, [schema, namespace])
+
+  const onConfirmDeleteNamespace = async () => {
+    if (!bucketId) return console.error('Bucket ID is required')
+    // Construct catalog URI for namespace creation
+    const protocol = projectSettings?.app_config?.protocol ?? 'https'
+    const endpoint =
+      projectSettings?.app_config?.storage_endpoint || projectSettings?.app_config?.endpoint
+    const catalogUri = getCatalogURI(project?.ref ?? '', protocol, endpoint)
+
+    try {
+      setIsDeletingNamespace(true)
+
+      // [Joshen] Delete all namespace tables
+      await Promise.all(
+        allTables.map((table) =>
+          deleteNamespaceTable({
+            catalogUri,
+            warehouse: bucketId,
+            namespace,
+            table: table.name,
+          })
+        )
+      )
+
+      // Delete all foreign tables that corresponding to the namespace tables
+      await Promise.all(
+        tables.map((table) =>
+          dropForeignTable({
+            projectRef,
+            connectionString: project?.connectionString,
+            schemaName: table.schema_name,
+            tableName: table.table_name,
+          })
+        )
+      )
+
+      await deleteNamespace({ catalogUri, warehouse: bucketId, namespace })
+
+      toast.success(`Successfully deleted namespace "${namespace}"`)
+      setShowConfirmDeleteNamespace(false)
+    } catch (error: any) {
+      toast.error(`Failed to delete namespace: ${error.message}`)
+    } finally {
+      setIsDeletingNamespace(false)
+    }
+  }
 
   useEffect(() => {
     if (isSuccessNamespaceTables && !isSyncedPublicationTablesAndNamespaceTables) {
@@ -159,40 +232,46 @@ export const NamespaceWithTables = ({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row justify-between items-center px-4 py-5 space-y-0">
+      <CardHeader className="flex flex-row justify-between items-center px-4 py-4 space-y-0">
         <CardTitle className="text-sm font-normal font-sans normal-case leading-none flex flex-row items-center gap-x-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="flex flex-row items-center gap-x-1 text-foreground-lighter">
-                {sourceType === 'direct' ? namespace : 'public'}
-                <ChevronRight size={12} className="text-foreground-muted" />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p>{sourceType === 'direct' ? 'Analytics' : 'Postgres'} schema</p>
-            </TooltipContent>
-          </Tooltip>
-          {validSchema && (
-            <Tooltip>
-              <TooltipTrigger
-                asChild
-                className={tables.length === 0 ? `flex flex-row items-center gap-x-1` : undefined}
-              >
-                <span
-                  className={
-                    tables.length > 0
-                      ? `text-foreground`
-                      : `text-foreground-muted flex flex-row items-center gap-x-1`
-                  }
+          <div className="flex flex-row items-center gap-x-3 text-foreground">
+            <img
+              src={`${BASE_PATH}/img/icons/iceberg-icon.svg`}
+              alt="Apache Iceberg icon"
+              className="w-5 h-5"
+            />
+            <div className="flex flex-col gap-y-0.5">
+              <p className="text-xs font-mono uppercase text-foreground-lighter">
+                Iceberg namespace
+              </p>
+              <p className="text-sm">{namespace}</p>
+            </div>
+          </div>
+
+          {!HIDE_REPLICATION_USER_FLOW && validSchema && (
+            <>
+              <ChevronRight size={12} className="text-foreground-muted" />
+              <Tooltip>
+                <TooltipTrigger
+                  asChild
+                  className={tables.length === 0 ? `flex flex-row items-center gap-x-1` : undefined}
                 >
-                  {displaySchema}
-                  {tables.length === 0 && <Info size={12} />}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p>Postgres schema{tables.length === 0 && ' that will be created'}</p>
-              </TooltipContent>
-            </Tooltip>
+                  <span
+                    className={
+                      tables.length > 0
+                        ? `text-foreground`
+                        : `text-foreground-muted flex flex-row items-center gap-x-1`
+                    }
+                  >
+                    {displaySchema}
+                    {tables.length === 0 && <Info size={12} />}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p>Postgres schema{tables.length === 0 && ' that will be created'}</p>
+                </TooltipContent>
+              </Tooltip>
+            </>
           )}
         </CardTitle>
 
@@ -219,17 +298,43 @@ export const NamespaceWithTables = ({
               </TooltipContent>
             </Tooltip>
           )}
-          {missingTables.length > 0 && (
-            <Button
-              type={schema ? 'default' : 'warning'}
-              size="tiny"
-              icon={schema ? <RefreshCw /> : <Plus size={14} />}
-              onClick={() => (schema ? rescanNamespace() : setImportForeignSchemaShown(true))}
-              loading={isImportingForeignSchema || isLoadingNamespaceTables}
-            >
-              {schema ? 'Sync tables' : `Connect to table${missingTables.length > 1 ? 's' : ''}`}
-            </Button>
-          )}
+
+          <div className="flex items-center gap-x-2">
+            {HIDE_REPLICATION_USER_FLOW ? (
+              <>
+                {/* Is this just the import foreign schema dialog then? */}
+                {connectedForeignTablesForNamespace.length === 0 ? (
+                  <InitializeForeignSchemaDialog namespace={namespace} />
+                ) : hasUnconnectedForeignTablesForNamespace ? (
+                  <UpdateForeignSchemaDialog namespace={namespace} tables={unconnectedTables} />
+                ) : null}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button type="default" className="w-7" icon={<MoreVertical />} />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-fit min-w-[180px]">
+                    <DropdownMenuItem
+                      className="flex items-center gap-x-2"
+                      onClick={() => setShowConfirmDeleteNamespace(true)}
+                    >
+                      <Trash size={12} className="text-foreground-lighter" />
+                      <p>Delete namespace</p>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            ) : missingTables.length > 0 ? (
+              <Button
+                type={schema ? 'default' : 'warning'}
+                size="tiny"
+                icon={schema ? <RefreshCw /> : <Plus size={14} />}
+                onClick={() => (schema ? rescanNamespace() : setImportForeignSchemaShown(true))}
+                loading={isImportingForeignSchema || isLoadingNamespaceTables}
+              >
+                {schema ? 'Sync tables' : `Connect to table${missingTables.length > 1 ? 's' : ''}`}
+              </Button>
+            ) : null}
+          </div>
         </div>
       </CardHeader>
 
@@ -239,7 +344,7 @@ export const NamespaceWithTables = ({
         <TableHeader>
           <TableRow>
             <TableHead className={allTables.length === 0 ? 'text-foreground-muted' : undefined}>
-              Name
+              <span className="pl-8">Table name</span>
             </TableHead>
             {!!publication && (
               <TableHead className={allTables.length === 0 ? 'hidden' : undefined}>
@@ -268,20 +373,34 @@ export const NamespaceWithTables = ({
                 table={table}
                 namespace={namespace}
                 schema={displaySchema}
-                isLoading={isImportingForeignSchema || isLoadingNamespaceTables}
               />
             ))
           )}
         </TableBody>
       </Table>
+
       <ImportForeignSchemaDialog
-        bucketName={bucketName ?? ''}
         namespace={namespace}
         circumstance="clash"
-        wrapperMeta={wrapperMeta}
         visible={importForeignSchemaShown}
         onClose={() => setImportForeignSchemaShown(false)}
       />
+
+      <ConfirmationModal
+        size="medium"
+        variant="warning"
+        loading={isDeletingNamespace}
+        title={`Confirm to delete "${namespace}"`}
+        description="This action cannot be undone."
+        visible={showConfirmDeleteNamespace}
+        onCancel={() => setShowConfirmDeleteNamespace(false)}
+        onConfirm={() => onConfirmDeleteNamespace()}
+      >
+        <p className="text-sm">
+          This will remove all Iceberg tables under the namespace, as well as any associated foreign
+          tables. Are you sure?
+        </p>
+      </ConfirmationModal>
     </Card>
   )
 }

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
@@ -1,0 +1,168 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import z from 'zod'
+
+import { useParams } from 'common'
+import { InlineLinkClassName } from 'components/ui/InlineLink'
+import { useFDWImportForeignSchemaMutation } from 'data/fdw/fdw-import-foreign-schema-mutation'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+  Form_Shadcn_,
+  FormField_Shadcn_,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { getAnalyticsBucketFDWServerName } from './AnalyticsBucketDetails.utils'
+import { useAnalyticsBucketAssociatedEntities } from './useAnalyticsBucketAssociatedEntities'
+
+export const UpdateForeignSchemaDialog = ({
+  namespace,
+  tables,
+}: {
+  namespace: string
+  tables: string[]
+}) => {
+  const { ref: projectRef, bucketId } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { icebergWrapper } = useAnalyticsBucketAssociatedEntities({ bucketId })
+  const connectedForeignTablesForNamespace =
+    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
+  const schemasAssociatedWithNamespace = [
+    ...new Set(connectedForeignTablesForNamespace.map((x) => x.schema)),
+  ]
+
+  const serverName = getAnalyticsBucketFDWServerName(bucketId ?? '')
+
+  const FormSchema = z.object({
+    schema: z.string().trim().min(1, 'Schema name is required'),
+  })
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { schema: schemasAssociatedWithNamespace[0] },
+    values: { schema: schemasAssociatedWithNamespace[0] },
+  })
+
+  const { mutateAsync: importForeignSchema, isLoading: isUpdating } =
+    useFDWImportForeignSchemaMutation()
+
+  const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
+    if (!projectRef) return console.error('Project ref is required')
+
+    try {
+      await importForeignSchema({
+        projectRef,
+        connectionString: project?.connectionString,
+        serverName: serverName,
+        sourceSchema: namespace,
+        targetSchema: values.schema,
+      })
+
+      toast.success(`Successfully updated "${values.schema}" schema!`)
+      setIsOpen(false)
+    } catch (error: any) {
+      toast.error(`Failed to update schema: ${error.message}`)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button type="default">Update schema tables</Button>
+      </DialogTrigger>
+      <DialogContent size="medium" aria-describedby={undefined}>
+        <Form_Shadcn_ {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogHeader>
+              <DialogTitle>Update schema to expose foreign tables</DialogTitle>
+            </DialogHeader>
+            <DialogSectionSeparator />
+            <DialogSection className="flex flex-col gap-y-4">
+              <p className="text-sm">
+                {tables.length > 1 ? (
+                  <>
+                    There are{' '}
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span className={InlineLinkClassName}>{tables.length} tables</span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-64 text-center" side="bottom">
+                        {tables.join(', ')}
+                      </TooltipContent>
+                    </Tooltip>{' '}
+                    that have yet to be included in the Iceberg Foreign Data Wrapper. The wrapper
+                    can be updated to expose these tables as foreign tables where you then can query
+                    data from.
+                  </>
+                ) : (
+                  `The table "${tables[0]}" in the "${namespace}" namespace is not yet included in the Iceberg Foreign Data Wrapper. The schema can be updated to expose this table as a foreign table.`
+                )}
+              </p>
+
+              {schemasAssociatedWithNamespace.length > 1 ? (
+                <FormField_Shadcn_
+                  control={form.control}
+                  name="schema"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      layout="vertical"
+                      label="Select which Postgres schema to update"
+                    >
+                      <Select_Shadcn_
+                        value={field.value}
+                        onValueChange={(val) => field.onChange(val)}
+                      >
+                        <SelectTrigger_Shadcn_>
+                          <SelectValue_Shadcn_ />
+                        </SelectTrigger_Shadcn_>
+                        <SelectContent_Shadcn_>
+                          {schemasAssociatedWithNamespace.map((x) => (
+                            <SelectItem_Shadcn_ key={x} value={x}>
+                              {x}
+                            </SelectItem_Shadcn_>
+                          ))}
+                        </SelectContent_Shadcn_>
+                      </Select_Shadcn_>
+                    </FormItemLayout>
+                  )}
+                />
+              ) : (
+                <p className="text-sm">
+                  Confirm to update foreign schema on the "{namespace}" namespace?
+                </p>
+              )}
+            </DialogSection>
+            <DialogFooter>
+              <Button type="default" disabled={isUpdating} onClick={() => setIsOpen(false)}>
+                Cancel
+              </Button>
+              <Button htmlType="submit" type="primary" loading={isUpdating}>
+                Update schema
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form_Shadcn_>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
@@ -47,7 +47,8 @@ export const UpdateForeignSchemaDialog = ({
 
   const { icebergWrapper } = useAnalyticsBucketAssociatedEntities({ bucketId })
   const connectedForeignTablesForNamespace =
-    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
+    (icebergWrapper?.tables ?? []).filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ??
+    []
   const schemasAssociatedWithNamespace = [
     ...new Set(connectedForeignTablesForNamespace.map((x) => x.schema)),
   ]

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
@@ -46,8 +46,9 @@ export const UpdateForeignSchemaDialog = ({
   const [isOpen, setIsOpen] = useState(false)
 
   const { icebergWrapper } = useAnalyticsBucketAssociatedEntities({ bucketId })
-  const connectedForeignTablesForNamespace =
-    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
+  const connectedForeignTablesForNamespace = (icebergWrapper?.tables ?? []).filter((x) =>
+    x.options[0].startsWith(`table=${namespace}.`)
+  )
   const schemasAssociatedWithNamespace = [
     ...new Set(connectedForeignTablesForNamespace.map((x) => x.schema)),
   ]

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
@@ -47,8 +47,7 @@ export const UpdateForeignSchemaDialog = ({
 
   const { icebergWrapper } = useAnalyticsBucketAssociatedEntities({ bucketId })
   const connectedForeignTablesForNamespace =
-    (icebergWrapper?.tables ?? []).filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ??
-    []
+    icebergWrapper?.tables.filter((x) => x.options[0].startsWith(`table=${namespace}.`)) ?? []
   const schemasAssociatedWithNamespace = [
     ...new Set(connectedForeignTablesForNamespace.map((x) => x.schema)),
   ]
@@ -111,9 +110,9 @@ export const UpdateForeignSchemaDialog = ({
                         {tables.join(', ')}
                       </TooltipContent>
                     </Tooltip>{' '}
-                    that have yet to be included in the Iceberg Foreign Data Wrapper. The wrapper
-                    can be updated to expose these tables as foreign tables where you then can query
-                    data from.
+                    that aren't included in the Iceberg Foreign Data Wrapper. Update the wrapper to
+                    create foreign tables for all unexposed tables. This will let you query the
+                    tables from Postgres.
                   </>
                 ) : (
                   `The table "${tables[0]}" in the "${namespace}" namespace is not yet included in the Iceberg Foreign Data Wrapper. The schema can be updated to expose this table as a foreign table.`

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/index.tsx
@@ -33,8 +33,10 @@ import { Admonition } from 'ui-patterns/admonition'
 import { GenericTableLoader } from 'ui-patterns/ShimmeringLoader'
 import { DeleteAnalyticsBucketModal } from '../DeleteAnalyticsBucketModal'
 import { useSelectedAnalyticsBucket } from '../useSelectedAnalyticsBucket'
+import { HIDE_REPLICATION_USER_FLOW } from './AnalyticsBucketDetails.constants'
 import { BucketHeader } from './BucketHeader'
 import { ConnectTablesDialog } from './ConnectTablesDialog'
+import { CreateTableInstructions } from './CreateTableInstructions'
 import { NamespaceWithTables } from './NamespaceWithTables'
 import { SimpleConfigurationDetails } from './SimpleConfigurationDetails'
 import { useAnalyticsBucketAssociatedEntities } from './useAnalyticsBucketAssociatedEntities'
@@ -107,10 +109,8 @@ export const AnalyticBucketDetails = () => {
 
   const {
     data: namespacesData = [],
-    error: namespacesError,
     isLoading: isLoadingNamespaces,
     isSuccess: isSuccessNamespaces,
-    isError: isErrorNamespaces,
   } = useIcebergNamespacesQuery(
     {
       projectRef,
@@ -174,7 +174,7 @@ export const AnalyticBucketDetails = () => {
           {state === 'loading' ? (
             <ScaffoldSection isFullWidth>
               <BucketHeader showActions={false} />
-              <GenericTableLoader headers={['Name']} />
+              <GenericTableLoader />
             </ScaffoldSection>
           ) : state === 'not-installed' ? (
             <ExtensionNotInstalled
@@ -205,11 +205,11 @@ export const AnalyticBucketDetails = () => {
 
                 {isLoadingNamespaces || isLoadingWrapperInstance ? (
                   <GenericTableLoader headers={['Name']} />
-                ) : isErrorNamespaces ? (
-                  <AlertError subject="Failed to retrieve namespaces" error={namespacesError} />
                 ) : namespaces.length === 0 ? (
                   <>
-                    {isPollingForData ? (
+                    {HIDE_REPLICATION_USER_FLOW ? (
+                      <CreateTableInstructions />
+                    ) : isPollingForData ? (
                       <aside className="border border-dashed w-full bg-surface-100 rounded-lg px-4 py-10 flex flex-col gap-y-3 items-center text-center gap-1 text-balance">
                         <Loader2
                           size={24}
@@ -294,14 +294,11 @@ export const AnalyticBucketDetails = () => {
                       {namespaces.map(({ namespace, schema, tables }) => (
                         <NamespaceWithTables
                           key={namespace}
-                          bucketName={bucket?.name}
                           namespace={namespace}
                           sourceType="direct"
                           schema={schema}
                           tables={tables as any}
-                          wrapperInstance={wrapperInstance}
                           wrapperValues={wrapperValues}
-                          wrapperMeta={wrapperMeta}
                           pollIntervalNamespaceTables={pollIntervalNamespaceTables}
                           setPollIntervalNamespaceTables={setPollIntervalNamespaceTables}
                         />

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/index.tsx
@@ -40,7 +40,6 @@ import { CreateTableInstructions } from './CreateTableInstructions'
 import { NamespaceWithTables } from './NamespaceWithTables'
 import { SimpleConfigurationDetails } from './SimpleConfigurationDetails'
 import { useAnalyticsBucketAssociatedEntities } from './useAnalyticsBucketAssociatedEntities'
-import { useAnalyticsBucketWrapperInstance } from './useAnalyticsBucketWrapperInstance'
 import { useIcebergWrapperExtension } from './useIcebergWrapper'
 
 export const AnalyticBucketDetails = () => {
@@ -65,10 +64,12 @@ export const AnalyticBucketDetails = () => {
 
   const { mutateAsync: startPipeline, isLoading: isStartingPipeline } = useStartPipelineMutation()
 
-  /** The wrapper instance is the wrapper that is installed for this Analytics bucket. */
-  const { data: wrapperInstance, isLoading: isLoadingWrapperInstance } =
-    useAnalyticsBucketWrapperInstance({ bucketId: bucket?.name })
-  const { publication, pipeline } = useAnalyticsBucketAssociatedEntities({
+  const {
+    publication,
+    pipeline,
+    icebergWrapper: wrapperInstance,
+    isLoadingWrapperInstance,
+  } = useAnalyticsBucketAssociatedEntities({
     projectRef,
     bucketId: bucket?.name,
   })

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities.tsx
@@ -31,10 +31,11 @@ export const useAnalyticsBucketAssociatedEntities = (
     '*'
   )
 
-  const { data: icebergWrapper, meta: icebergWrapperMeta } = useAnalyticsBucketWrapperInstance(
-    { bucketId },
-    { enabled: options.enabled }
-  )
+  const {
+    data: icebergWrapper,
+    meta: icebergWrapperMeta,
+    isLoading: isLoadingWrapperInstance,
+  } = useAnalyticsBucketWrapperInstance({ bucketId }, { enabled: options.enabled })
 
   const { data: s3AccessKeys } = useStorageCredentialsQuery(
     { projectRef },
@@ -75,6 +76,7 @@ export const useAnalyticsBucketAssociatedEntities = (
     publication,
     pipeline,
     destination,
+    isLoadingWrapperInstance,
   }
 }
 

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities.tsx
@@ -50,8 +50,10 @@ export const useAnalyticsBucketAssociatedEntities = (
   )
   const sourceId = sourcesData?.sources.find((s) => s.name === projectRef)?.id
 
-  const { data: publications = [], isLoading: isLoadingPublications } =
-    useReplicationPublicationsQuery({ projectRef, sourceId }, { enabled: options.enabled })
+  const { data: publications = [] } = useReplicationPublicationsQuery(
+    { projectRef, sourceId },
+    { enabled: options.enabled }
+  )
   const publication = publications.find(
     (p) => p.name === getAnalyticsBucketPublicationName(bucketId ?? '')
   )

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
@@ -258,10 +258,10 @@ export const CreateAnalyticsBucketModal = ({
                   title="Wrappers extension must be updated for Iceberg Wrapper support"
                 >
                   <p className="prose max-w-full text-sm !leading-normal">
-                    Update the <code className="text-xs">wrappers</code> extension by disabling and
-                    enabling it in{' '}
-                    <InlineLink href={`/project/${ref}/database/extensions?filter=wrappers`}>
-                      database extensions
+                    Update the <code className="text-xs">wrappers</code> extension by upgrading your
+                    project from your{' '}
+                    <InlineLink href={`/project/${ref}/settings/infrastructure`}>
+                      project settings
                     </InlineLink>{' '}
                     before creating an Analytics bucket.{' '}
                     <InlineLink href={`${DOCS_URL}/guides/database/extensions/wrappers/iceberg`}>

--- a/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
@@ -14,35 +14,35 @@ import { getFDWs } from 'data/fdw/fdws-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Button, Form_Shadcn_, FormField_Shadcn_, Input_Shadcn_, Modal, Separator } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import type { WrapperMeta } from '../Integrations/Wrappers/Wrappers.types'
 import { formatWrapperTables } from '../Integrations/Wrappers/Wrappers.utils'
 import SchemaEditor from '../TableGridEditor/SidePanelEditor/SchemaEditor'
 import { getAnalyticsBucketFDWServerName } from './AnalyticsBuckets/AnalyticsBucketDetails/AnalyticsBucketDetails.utils'
+import { useAnalyticsBucketAssociatedEntities } from './AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities'
 import { getDecryptedParameters } from './ImportForeignSchemaDialog.utils'
 
 export interface ImportForeignSchemaDialogProps {
-  bucketName: string
   namespace: string
-  wrapperMeta: WrapperMeta
   circumstance?: 'fresh' | 'clash'
   visible: boolean
   onClose: () => void
 }
 
 export const ImportForeignSchemaDialog = ({
-  bucketName,
   namespace,
-  wrapperMeta,
   visible,
   onClose,
   circumstance = 'fresh',
 }: ImportForeignSchemaDialogProps) => {
-  const { ref } = useParams()
+  const { ref, bucketId: bucketName } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [loading, setLoading] = useState(false)
   const [createSchemaSheetOpen, setCreateSchemaSheetOpen] = useState(false)
 
   const { data: schemas } = useSchemasQuery({ projectRef: project?.ref! })
+  const { icebergWrapperMeta: wrapperMeta } = useAnalyticsBucketAssociatedEntities({
+    projectRef: ref,
+    bucketId: bucketName,
+  })
 
   const { mutateAsync: createSchema } = useSchemaCreateMutation()
   const { mutateAsync: importForeignSchema } = useFDWImportForeignSchemaMutation({})
@@ -83,6 +83,7 @@ export const ImportForeignSchemaDialog = ({
     const serverName = getAnalyticsBucketFDWServerName(values.bucketName)
 
     if (!ref) return console.error('Project ref is required')
+    if (!wrapperMeta) return console.error('Wrapper meta is required')
     setLoading(true)
 
     try {

--- a/apps/studio/data/config/project-storage-config-query.ts
+++ b/apps/studio/data/config/project-storage-config-query.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 import { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
@@ -54,13 +55,15 @@ export const useProjectStorageConfigQuery = <TData = ProjectStorageConfigData>(
   })
 
 export const useIsAnalyticsBucketsEnabled = ({ projectRef }: { projectRef?: string }) => {
+  const { storageAnalytics } = useIsFeatureEnabled(['storage:analytics'])
   const { data } = useProjectStorageConfigQuery({ projectRef })
   const isIcebergCatalogEnabled = !!data?.features.icebergCatalog?.enabled
-  return isIcebergCatalogEnabled
+  return storageAnalytics && isIcebergCatalogEnabled
 }
 
 export const useIsVectorBucketsEnabled = ({ projectRef }: { projectRef?: string }) => {
+  const { storageVectors } = useIsFeatureEnabled(['storage:vectors'])
   // [Joshen] Temp using feature flag - will need to shift to storage config like analytics bucket once ready
   const isVectorBucketsEnabled = useFlag('storageAnalyticsVector')
-  return isVectorBucketsEnabled
+  return storageVectors && isVectorBucketsEnabled
 }

--- a/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
+++ b/apps/studio/data/storage/iceberg-namespace-table-delete-mutation.ts
@@ -40,12 +40,6 @@ async function deleteIcebergNamespaceTable({
       )
 
     const response = await fetchHandler(url, { headers, method: 'DELETE' })
-    const result = await response.json()
-    if (result.error) {
-      if (result.error.message) throw new Error(`${errorPrefix}: ${result.error.message}`)
-      else throw new Error(errorPrefix)
-    }
-
     return response.status === 204
   } catch (error) {
     handleError(error)
@@ -79,11 +73,12 @@ export const useIcebergNamespaceTableDeleteMutation = ({
     mutationFn: (vars) => deleteIcebergNamespaceTable({ ...vars, tempApiKey }),
     async onSuccess(data, variables, context) {
       await queryClient.invalidateQueries({
-        queryKey: storageKeys.icebergNamespace(
-          variables.catalogUri,
-          variables.warehouse,
-          variables.namespace
-        ),
+        queryKey: storageKeys.icebergNamespace({
+          projectRef,
+          catalog: variables.catalogUri,
+          warehouse: variables.warehouse,
+          namespace: variables.namespace,
+        }),
       })
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/storage/iceberg-namespaces-query.ts
+++ b/apps/studio/data/storage/iceberg-namespaces-query.ts
@@ -11,14 +11,13 @@ type GetNamespacesVariables = {
   projectRef?: string
 }
 
-const errorPrefix = 'Failed to delete Iceberg namespaces'
+const errorPrefix = 'Failed to retrieve Iceberg namespaces'
 
 async function getNamespaces({
   catalogUri,
   warehouse,
   tempApiKey,
 }: GetNamespacesVariables & { tempApiKey?: string }) {
-  console.log('getNamespaces', { warehouse })
   try {
     if (!tempApiKey) throw new Error(`${errorPrefix}: API Key missing`)
 

--- a/apps/studio/data/storage/keys.ts
+++ b/apps/studio/data/storage/keys.ts
@@ -18,8 +18,17 @@ export const storageKeys = {
     catalog: string
     warehouse: string
   }) => [projectRef, 'catalog', catalog, 'warehouse', warehouse, 'namespaces'] as const,
-  icebergNamespace: (catalog: string, warehouse: string, namespace: string) =>
-    ['catalog', catalog, 'warehouse', warehouse, 'namespaces', namespace] as const,
+  icebergNamespace: ({
+    projectRef,
+    catalog,
+    warehouse,
+    namespace,
+  }: {
+    projectRef?: string
+    catalog: string
+    warehouse: string
+    namespace: string
+  }) => [projectRef, 'catalog', catalog, 'warehouse', warehouse, 'namespaces', namespace] as const,
   icebergNamespaceTables: ({
     projectRef,
     catalog,

--- a/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
+++ b/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
@@ -1,8 +1,8 @@
 import { Query } from '@supabase/pg-meta/src/query'
 import { useQuery } from '@tanstack/react-query'
+import { UseCustomQueryOptions } from 'types'
 import { executeSql } from '../sql/execute-sql-query'
 import { vaultSecretsKeys } from './keys'
-import { UseCustomQueryOptions } from 'types'
 
 const vaultSecretDecryptedValueQuery = (id: string) => {
   const sql = new Query()
@@ -64,7 +64,7 @@ export const useVaultSecretDecryptedValueQuery = <TData = string>(
     select(data) {
       return (data[0]?.decrypted_secret ?? '') as TData
     },
-    enabled: enabled && typeof projectRef !== 'undefined',
+    enabled: enabled && typeof projectRef !== 'undefined' && typeof id !== 'undefined',
     ...options,
   })
 

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -121,6 +121,9 @@
   "sdk:python": true,
   "sdk:swift": true,
 
+  "storage:analytics": true,
+  "storage:vectors": false,
+
   "search:fullIndex": true,
 
   "support:show_client_libraries": true

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -409,6 +409,15 @@
       "description": "Enable the Swift SDK"
     },
 
+    "storage:analytics": {
+      "type": "boolean",
+      "description": "Enable Analytics Buckets in Storage"
+    },
+    "storage:vectors": {
+      "type": "boolean",
+      "description": "Enable Vector Buckets in Storage"
+    },
+
     "search:fullIndex": {
       "type": "boolean",
       "description": "Enable the full search index. When true, uses the  full search; when false, uses the alternate search index."
@@ -509,6 +518,8 @@
     "sdk:kotlin",
     "sdk:python",
     "sdk:swift",
+    "storage:analytics",
+    "storage:vectors",
     "search:fullIndex"
   ],
   "additionalProperties": false

--- a/packages/ui-patterns/src/ShimmeringLoader/index.tsx
+++ b/packages/ui-patterns/src/ShimmeringLoader/index.tsx
@@ -35,10 +35,10 @@ export const GenericSkeletonLoader = ({ className }: GenericSkeletonLoaderProps)
 )
 
 export const GenericTableLoader = ({
-  headers,
+  headers = [],
   numRows = 3,
 }: {
-  headers: (string | null)[]
+  headers?: (string | null)[]
   numRows?: number
 }) => {
   return (
@@ -46,9 +46,11 @@ export const GenericTableLoader = ({
       <Table>
         <TableHeader>
           <TableRow>
-            {headers.map((h, i) => (
-              <TableHead key={`${h}_${i}`}>{h}</TableHead>
-            ))}
+            {headers.length === 0 ? (
+              <TableHead />
+            ) : (
+              headers.map((h, i) => <TableHead key={`${h}_${i}`}>{h}</TableHead>)
+            )}
           </TableRow>
         </TableHeader>
         <TableBody>


### PR DESCRIPTION
## Context

We're scoping down the technicalities of Analytics Buckets by de-coupling it from ETL replication (so Analytics Bucket will just be about the buckets themselves), which helps us simplify a lot of the complexities around the UI + makes the UI behaviour a lot more deterministic and fault tolerant.

Main user flows covered will be: 
- Creating namespaces/tables
- Viewing data from tables
- Deleting namespaces/tables

The decision of whether to fully de-couple ETL from Analytics Bucket is still in the air, so decided to leave all of the relevant code as is for now, in case we'll revisit them again down the road. On that note though, the code might be a little messy but I hope to clean things up bit by bit in subsequent PRs.

## Changes involved

Our primary CTA of creating tables in a bucket will be to do so through an external Iceberg client - so the empty state is a set of instructions for Pyiceberg which should work out of the box.
<img width="1099" height="655" alt="image" src="https://github.com/user-attachments/assets/35a03208-3aa4-40e5-966c-16686a7b46a2" />

The sample snippet here will create a namespace called `default` and a table `events` within that namespace. (There's no automatic polling so you'll need to refresh the browser here)
<img width="1096" height="208" alt="image" src="https://github.com/user-attachments/assets/b762d721-80eb-40d3-a1a3-cb30977ebeec" />

You can opt to view the data in the Iceberg table via Postgres by following the "Query from Postgres" which then explains + prompts you to do so via Foreign Data Wrappers. At this step you just need to specify which schema you'd want to have the foreign tables in.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b19274ea-5b68-49f9-bff2-b5ea29f78b42" />

This then creates the foreign tables and shows you how you can view the data of your iceberg table from
<img width="1087" height="319" alt="image" src="https://github.com/user-attachments/assets/3e47939b-8b9b-4cb2-8816-a1650ecc4a4b" />

From here that's pretty much it in terms of functionality. You can then choose to delete individual iceberg tables (which also cleans up any associated foreign tables), or delete the whole namespace (which will also clean up any associated foreign tables for iceberg tables in the namespace)

Past the empty state, the "Create table" CTA then shifts up to the header section (as per Vector Buckets), where clicking just opens the set of instructions within a Dialog. (The relevancy of these instructions at this state is up for future debate but good for now)

## Known issues

- [ ] We're using the temporary API keys for all iceberg related requests, and it's currently a known issue that we'll run into 403s rather often (Especially when deleting namespaces / tables). Currently being discussed with Auth team, so if you run into any network request issues because of this, best bet is to just try again for now. (e.g Refresh browser)

## To test

- [ ] Validate that the empty state instructions work, let me know if there's any confusion
- [ ] Generally, validate how the UX feels like, if there's any confusion, any copy writing improvements
