### PR TITLE
fix: do not override authorization header for self-hosted in ai assistant

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -220,7 +220,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             orgSlug: selectedOrganizationRef.current?.slug,
             model: selectedModel,
           },
-          headers: { Authorization: authorizationHeader ?? '' },
+          headers: IS_PLATFORM ? { Authorization: authorizationHeader ?? '' } : {},
         }
       },
     }),

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -220,7 +220,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             orgSlug: selectedOrganizationRef.current?.slug,
             model: selectedModel,
           },
-          headers: IS_PLATFORM ? { Authorization: authorizationHeader ?? '' } : {},
+          ...(IS_PLATFORM ? { headers: { Authorization: authorizationHeader ?? '' } } : {}),
         }
       },
     }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes authentication for AI assistant in self-hosted configuration.

Closes #39664.

## What is the current behavior?

AI assistant is sending an empty `Authorization` header, overriding browser authentication.

- IS_PLATFORM → Include proper `Authorization` header (or fallback to an empty value that would make the request fail)
- !IS_PLATFORM (self-hosted) → Do not include any headers (will not override browser authentication)
