### PR TITLE
[FE-2147] feat(studio): maintenance mode

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -438,6 +438,22 @@ const nextConfig = {
             },
           ]
         : []),
+
+      ...(process.env.MAINTENANCE_MODE === 'true'
+        ? [
+            {
+              source: '/((?!maintenance).*)', // Redirect all paths except /maintenance
+              destination: '/maintenance',
+              permanent: false,
+            },
+          ]
+        : [
+            {
+              source: '/maintenance',
+              destination: '/',
+              permanent: false,
+            },
+          ]),
     ]
   },
   async headers() {

--- a/apps/studio/pages/maintenance.tsx
+++ b/apps/studio/pages/maintenance.tsx
@@ -1,0 +1,60 @@
+import { RefreshCw } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import Head from 'next/head'
+
+import { BASE_PATH } from 'lib/constants'
+import type { NextPageWithLayout } from 'types'
+import { Button, cn } from 'ui'
+import { useMemo } from 'react'
+
+const MaintenancePage: NextPageWithLayout = () => {
+  const { resolvedTheme } = useTheme()
+  const isDarkMode = resolvedTheme?.includes('dark')
+
+  const imgUrl = useMemo(
+    () =>
+      isDarkMode ? `${BASE_PATH}/img/supabase-dark.svg` : `${BASE_PATH}/img/supabase-light.svg`,
+    [isDarkMode]
+  )
+
+  return (
+    <>
+      <Head>
+        <title>Supabase | Under Maintenance</title>
+      </Head>
+      <div className="flex flex-col items-center gap-6 text-center">
+        <div className="flex items-center justify-center mb-4">
+          <img src={imgUrl} alt="Supabase" className="h-8" />
+        </div>
+        <div className="space-y-1">
+          <h1 className="text-2xl font-medium text-foreground">Under Maintenance</h1>
+          <p className="text-foreground-light max-w-xs mx-auto">
+            We are currently improving our services. The dashboard will be back online shortly.
+          </p>
+        </div>
+        <div className="flex flex-col items-center gap-2 mt-4">
+          <p className="text-sm text-foreground-lighter">
+            Reload the page to check if the maintenance window has ended
+          </p>
+          <Button onClick={() => window.location.reload()} type="primary" icon={<RefreshCw />}>
+            Reload
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+MaintenancePage.getLayout = (page) => (
+  <div
+    className={cn(
+      'flex h-full min-h-screen bg-studio',
+      'w-full flex-col place-items-center',
+      'items-center justify-center gap-8 px-5'
+    )}
+  >
+    {page}
+  </div>
+)
+
+export default MaintenancePage

--- a/turbo.json
+++ b/turbo.json
@@ -73,6 +73,7 @@
         "SUPABASE_URL",
         "VERCEL",
         "VERCEL_ENV",
+        "MAINTENANCE_MODE",
         // These envs are used in the packages
         "NEXT_PUBLIC_STORAGE_KEY",
         "NEXT_PUBLIC_AUTH_DEBUG_KEY",


### PR DESCRIPTION
<img width="1016" height="716" alt="Screenshot 2025-11-20 at 22 23 45" src="https://github.com/user-attachments/assets/d5c08a15-3b48-43ea-8407-3a0b91454ae0" />
<img width="916" height="696" alt="Screenshot 2025-11-20 at 22 23 38" src="https://github.com/user-attachments/assets/8ba2bdf9-32c8-4a5a-bc14-54c901466654" />


To test:

- On the staging preview ensure that you don't get redirected to the maintenance page
- Locally add `MAINTENANCE_MODE="true"` to `.env` and ensure you can't visit any pages (you get redirected)