### PR TITLE
Fix: updated expiry to be 60 seconds

### DIFF
--- a/apps/studio/data/api-keys/temp-api-keys-utils.test.ts
+++ b/apps/studio/data/api-keys/temp-api-keys-utils.test.ts
@@ -32,7 +32,7 @@ describe('createTemporaryUploadKey', () => {
 
     const result = createTemporaryApiKey(apiKey, expiryInSeconds)
 
-    expect(result.expiryTime).toBe(now + 3600 * 1000)
+    expect(result.expiryTimeMs).toBe(now + 3600 * 1000)
   })
 
   it('should handle short expiry durations', () => {
@@ -44,7 +44,7 @@ describe('createTemporaryUploadKey', () => {
 
     const result = createTemporaryApiKey(apiKey, expiryInSeconds)
 
-    expect(result.expiryTime).toBe(now + 60 * 1000)
+    expect(result.expiryTimeMs).toBe(now + 60 * 1000)
   })
 
   it('should create keys with different expiry times when called at different times', () => {
@@ -59,9 +59,9 @@ describe('createTemporaryUploadKey', () => {
     vi.setSystemTime(now2)
     const result2 = createTemporaryApiKey(apiKey, expiryInSeconds)
 
-    expect(result1.expiryTime).toBe(now1 + expiryInSeconds * 1000)
-    expect(result2.expiryTime).toBe(now2 + expiryInSeconds * 1000)
-    expect(result1.expiryTime).not.toBe(result2.expiryTime)
+    expect(result1.expiryTimeMs).toBe(now1 + expiryInSeconds * 1000)
+    expect(result2.expiryTimeMs).toBe(now2 + expiryInSeconds * 1000)
+    expect(result1.expiryTimeMs).not.toBe(result2.expiryTimeMs)
   })
 })
 
@@ -92,7 +92,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 120000, // 2 minutes from now
+      expiryTimeMs: now + 120000, // 2 minutes from now
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -106,7 +106,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 20000, // Exactly 20 seconds
+      expiryTimeMs: now + 20000, // Exactly 20 seconds
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -120,7 +120,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 10000, // 10 seconds from now
+      expiryTimeMs: now + 10000, // 10 seconds from now
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -134,7 +134,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now - 1000, // 1 second ago
+      expiryTimeMs: now - 1000, // 1 second ago
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -148,7 +148,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now - 3600000, // 1 hour ago
+      expiryTimeMs: now - 3600000, // 1 hour ago
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -162,7 +162,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 21000, // 21 seconds from now
+      expiryTimeMs: now + 21000, // 21 seconds from now
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -176,7 +176,7 @@ describe('isTemporaryUploadKeyValid', () => {
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 120000, // 2 minutes from now
+      expiryTimeMs: now + 120000, // 2 minutes from now
     }
 
     // Initially valid
@@ -196,7 +196,7 @@ describe('isTemporaryUploadKeyValid', () => {
     vi.setSystemTime(now)
 
     const key = {
-      expiryTime: now + 120000,
+      expiryTimeMs: now + 120000,
     } as TemporaryApiKey
 
     const result = isTemporaryApiKeyValid(key)

--- a/apps/studio/data/api-keys/temp-api-keys-utils.test.ts
+++ b/apps/studio/data/api-keys/temp-api-keys-utils.test.ts
@@ -86,7 +86,7 @@ describe('isTemporaryUploadKeyValid', () => {
     expect(result).toBe(false)
   })
 
-  it('should return true for a key with more than 60 seconds remaining', () => {
+  it('should return true for a key with more than 20 seconds remaining', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
@@ -100,13 +100,13 @@ describe('isTemporaryUploadKeyValid', () => {
     expect(result).toBe(true)
   })
 
-  it('should return false for a key with exactly 60 seconds remaining', () => {
+  it('should return false for a key with exactly 20 seconds remaining', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 60000, // Exactly 60 seconds
+      expiryTime: now + 20000, // Exactly 20 seconds
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -114,13 +114,13 @@ describe('isTemporaryUploadKeyValid', () => {
     expect(result).toBe(false)
   })
 
-  it('should return false for a key with less than 60 seconds remaining', () => {
+  it('should return false for a key with less than 20 seconds remaining', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 30000, // 30 seconds from now
+      expiryTime: now + 10000, // 10 seconds from now
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -156,13 +156,13 @@ describe('isTemporaryUploadKeyValid', () => {
     expect(result).toBe(false)
   })
 
-  it('should return true for a key with exactly 61 seconds remaining', () => {
+  it('should return true for a key with exactly 21 seconds remaining', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
     const key: TemporaryApiKey = {
       apiKey: 'test-key',
-      expiryTime: now + 61000, // 61 seconds from now
+      expiryTime: now + 21000, // 21 seconds from now
     }
 
     const result = isTemporaryApiKeyValid(key)
@@ -182,11 +182,11 @@ describe('isTemporaryUploadKeyValid', () => {
     // Initially valid
     expect(isTemporaryApiKeyValid(key)).toBe(true)
 
-    // Advance time by 59 seconds (should still be valid - 61 seconds remaining)
-    vi.advanceTimersByTime(59000)
+    // Advance time by 99 seconds (should still be valid - 21 seconds remaining)
+    vi.advanceTimersByTime(99000)
     expect(isTemporaryApiKeyValid(key)).toBe(true)
 
-    // Advance time by 2 more seconds (should be invalid - 59 seconds remaining)
+    // Advance time by 2 more seconds (should be invalid - 19 seconds remaining)
     vi.advanceTimersByTime(2000)
     expect(isTemporaryApiKeyValid(key)).toBe(false)
   })
@@ -238,7 +238,7 @@ describe('integration: createTemporaryUploadKey and isTemporaryUploadKeyValid', 
     expect(isTemporaryApiKeyValid(key)).toBe(true)
   })
 
-  it('should create a key that becomes invalid after expiry time minus 60 seconds', () => {
+  it('should create a key that becomes invalid after expiry time minus 20 seconds', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
@@ -248,11 +248,11 @@ describe('integration: createTemporaryUploadKey and isTemporaryUploadKeyValid', 
     // Initially valid
     expect(isTemporaryApiKeyValid(key)).toBe(true)
 
-    // Advance to 59 seconds before expiry (should still be valid - 61 seconds remaining)
-    vi.advanceTimersByTime((expiryInSeconds - 61) * 1000)
+    // Advance to 19 seconds before expiry (should still be valid - 21 seconds remaining)
+    vi.advanceTimersByTime((expiryInSeconds - 21) * 1000)
     expect(isTemporaryApiKeyValid(key)).toBe(true)
 
-    // Advance to 60 seconds before expiry (should be invalid - 60 seconds remaining)
+    // Advance to 20 seconds before expiry (should be invalid - 20 seconds remaining)
     vi.advanceTimersByTime(1000)
     expect(isTemporaryApiKeyValid(key)).toBe(false)
   })
@@ -261,38 +261,38 @@ describe('integration: createTemporaryUploadKey and isTemporaryUploadKeyValid', 
     const now = Date.now()
     vi.setSystemTime(now)
 
-    // Create a key that expires in 30 seconds (less than the 60 second buffer)
-    const key = createTemporaryApiKey('test-api-key', 30)
+    // Create a key that expires in 10 seconds (less than the 20 second buffer)
+    const key = createTemporaryApiKey('test-api-key', 10)
 
-    // Should be invalid immediately because it will expire in less than 60 seconds
+    // Should be invalid immediately because it will expire in less than 20 seconds
     expect(isTemporaryApiKeyValid(key)).toBe(false)
   })
 
-  it('should handle expiry duration of exactly 60 seconds', () => {
+  it('should handle expiry duration of exactly 20 seconds', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
-    // Create a key that expires in exactly 60 seconds
-    const key = createTemporaryApiKey('test-api-key', 60)
+    // Create a key that expires in exactly 20 seconds
+    const key = createTemporaryApiKey('test-api-key', 20)
 
-    // Should be invalid because it has exactly 60 seconds remaining (not more than 60)
+    // Should be invalid because it has exactly 20 seconds remaining (not more than 20)
     expect(isTemporaryApiKeyValid(key)).toBe(false)
   })
 
-  it('should handle expiry duration of 61 seconds', () => {
+  it('should handle expiry duration of 21 seconds', () => {
     const now = Date.now()
     vi.setSystemTime(now)
 
-    // Create a key that expires in 61 seconds
-    const key = createTemporaryApiKey('test-api-key', 61)
+    // Create a key that expires in 21 seconds
+    const key = createTemporaryApiKey('test-api-key', 21)
 
-    // Should be valid because it has 61 seconds remaining (more than 60)
+    // Should be valid because it has 21 seconds remaining (more than 20)
     expect(isTemporaryApiKeyValid(key)).toBe(true)
 
     // Advance by 1 second
     vi.advanceTimersByTime(1000)
 
-    // Should now be invalid because it has exactly 60 seconds remaining
+    // Should now be invalid because it has exactly 20 seconds remaining
     expect(isTemporaryApiKeyValid(key)).toBe(false)
   })
 })

--- a/apps/studio/data/api-keys/temp-api-keys-utils.ts
+++ b/apps/studio/data/api-keys/temp-api-keys-utils.ts
@@ -23,7 +23,7 @@ export function isTemporaryApiKeyValid(
 
   const now = Date.now()
   const timeRemaining = key.expiryTime - now
-  return timeRemaining > 60000 // More than 60 seconds remaining
+  return timeRemaining > 20_000 // More than 20 seconds remaining
 }
 
 const checkOrRefreshTemporaryApiKey = async (
@@ -35,7 +35,7 @@ const checkOrRefreshTemporaryApiKey = async (
     return resolvedKey
   }
 
-  const expiryInSeconds = 600
+  const expiryInSeconds = 60
   const fetchedKey = getTemporaryAPIKey({
     projectRef,
     expiry: expiryInSeconds,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: We found out the management API is not respecting the expiry that well (aside from realtime).

## What is the current behavior?

Failure of downloads/uploads due to tokens expiring

## What is the new behavior?

Files should download correctly

