### PR TITLE
fix(edge functions secrets): allow read-only role to read secrets metadata

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -18,22 +18,25 @@ import AddNewSecretForm from './AddNewSecretForm'
 import EdgeFunctionSecret from './EdgeFunctionSecret'
 import { EditSecretSheet } from './EditSecretSheet'
 
-const EdgeFunctionSecrets = () => {
+export const EdgeFunctionSecrets = () => {
   const { ref: projectRef } = useParams()
   const [searchString, setSearchString] = useState('')
 
   // Track the ID being deleted to exclude it from error checking
   const deletingSecretNameRef = useRef<string | null>(null)
 
-  const { can: canReadSecrets, isLoading: isLoadingPermissions } = useAsyncCheckPermissions(
-    PermissionAction.SECRETS_READ,
+  const { can: canReadSecrets, isLoading: isLoadingSecretsPermissions } = useAsyncCheckPermissions(
+    PermissionAction.FUNCTIONS_SECRET_READ,
     '*'
   )
   const { can: canUpdateSecrets } = useAsyncCheckPermissions(PermissionAction.SECRETS_WRITE, '*')
 
-  const { data, error, isLoading, isSuccess, isError } = useSecretsQuery({
-    projectRef: projectRef,
-  })
+  const { data, error, isLoading, isSuccess, isError } = useSecretsQuery(
+    {
+      projectRef: projectRef,
+    },
+    { enabled: canReadSecrets }
+  )
 
   const { setValue: setSelectedSecretToEdit, value: selectedSecretToEdit } =
     useQueryStateWithSelect({
@@ -82,10 +85,14 @@ const EdgeFunctionSecrets = () => {
     <TableHead key="actions" />,
   ]
 
+  const showLoadingState = isLoadingSecretsPermissions || (canReadSecrets && isLoading)
+
   return (
     <>
-      {isLoading || isLoadingPermissions ? (
+      {showLoadingState ? (
         <GenericSkeletonLoader />
+      ) : !canReadSecrets ? (
+        <NoPermission resourceText="view this project's edge function secrets" />
       ) : (
         <>
           {isError && <AlertError error={error} subject="Failed to retrieve project secrets" />}
@@ -187,5 +194,3 @@ const EdgeFunctionSecrets = () => {
     </>
   )
 }
-
-export default EdgeFunctionSecrets

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -62,7 +62,7 @@
     "@supabase/mcp-utils": "^0.2.0",
     "@supabase/pg-meta": "workspace:*",
     "@supabase/realtime-js": "catalog:",
-    "@supabase/shared-types": "0.1.80",
+    "@supabase/shared-types": "0.1.83",
     "@supabase/sql-to-rest": "^0.1.6",
     "@supabase/supabase-js": "catalog:",
     "@tanstack/react-query": "^4.42.0",

--- a/apps/studio/pages/project/[ref]/functions/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/functions/secrets.tsx
@@ -1,4 +1,4 @@
-import EdgeFunctionSecrets from 'components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets'
+import { EdgeFunctionSecrets } from 'components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets'
 import { FunctionsSecretsEmptyStateLocal } from 'components/interfaces/Functions/FunctionsEmptyState'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import EdgeFunctionsLayout from 'components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,8 +859,8 @@ importers:
         specifier: 'catalog:'
         version: 2.83.0
       '@supabase/shared-types':
-        specifier: 0.1.80
-        version: 0.1.80
+        specifier: 0.1.83
+        version: 0.1.83
       '@supabase/sql-to-rest':
         specifier: ^0.1.6
         version: 0.1.6(encoding@0.1.13)(supports-color@8.1.1)
@@ -8856,8 +8856,8 @@ packages:
     resolution: {integrity: sha512-mT+QeXAD2gLoqNeQFLjTloDM62VR+VFV8OVdF8RscYpXZriBhabTLE2Auff5lkEJetFFclP1B8j+YtgrWqSmeA==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/shared-types@0.1.80':
-    resolution: {integrity: sha512-U2ACit34Up5OzB53dthb50YVGcAUzkuWn0Wq9fXWDdfl4Wlp+euWKSSVUMUIQo+bf2phu3V/PmVHEWR6dpls1g==}
+  '@supabase/shared-types@0.1.83':
+    resolution: {integrity: sha512-hKXExQKLU9FvUCpDsMKtP/EN+qma5SL+pxd44D06OmwV1UnOUqBwgUvO0nUyF2vV32jKRNaWsf2o+IDJ3pATJA==}
 
   '@supabase/sql-to-rest@0.1.6':
     resolution: {integrity: sha512-06KgjeINtc6405XQvfnchBE1azEsU8G2NElfadmvVHKmHa5l2bFzjbtFbpaYgpgTzccHlcDmBaCgedVf2Gyl8Q==}
@@ -28456,7 +28456,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@supabase/shared-types@0.1.80': {}
+  '@supabase/shared-types@0.1.83': {}
 
   '@supabase/sql-to-rest@0.1.6(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:


### PR DESCRIPTION
According to our API permissions model, the read-only role can also read secrets metadata (the actual secret itself is not viewable by anybody). Updating the frontend UI to match.

Testing:
- [ ] Secrets display looks the same for non-readonly role
- [ ] Secrets metadata now viewable for readonly role

Resolves FE-2118