### PR TITLE
Fix transfer project button

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -61,7 +61,8 @@ export const TransferProjectButton = () => {
         queryKey: projectKeys.projectTransferPreview(projectRef, selectedOrg),
       })
     }
-  }, [isOpen, projectRef, selectedOrg, queryClient])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
 
   const { can: canTransferProject } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,


### PR DESCRIPTION
## Context

Transfer project button was staying disabled despite selecting an organization, bug was introduced in this [PR](https://github.com/supabase/supabase/pull/40642/files)

Realised this was because of the dependency array in the useEffect having `selectedOrg` in it, which was causing it to just get reset each time it changed within the `if (isOpen)` conditional block

Opting to only have `isOpen` within the dependency array

## To test

- [ ] Verify that you can transfer a project to another organization