### PR TITLE
feat: allow data api cors to be limited

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -56,6 +56,7 @@ const formSchema = z
   .object({
     dbSchema: z.array(z.string()),
     dbExtraSearchPath: z.array(z.string()),
+    serverCorsAllowedOrigins: z.string(),
     maxRows: z.number().max(1000000, "Can't be more than 1,000,000"),
     dbPool: z
       .number()
@@ -128,6 +129,7 @@ export const PostgrestConfig = () => {
       .map((x) => x.trim())
       .filter((x) => x.length > 0 && allSchemas.find((y) => y.name === x)),
     dbPool: config?.db_pool,
+    serverCorsAllowedOrigins: config?.server_cors_allowed_origins,
   }
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -165,6 +167,7 @@ export const PostgrestConfig = () => {
       maxRows: values.maxRows,
       dbExtraSearchPath: values.dbExtraSearchPath.join(','),
       dbPool: values.dbPool ? values.dbPool : null,
+      serverCorsAllowedOrigins: values.serverCorsAllowedOrigins,
     })
   }
 
@@ -387,6 +390,29 @@ export const PostgrestConfig = () => {
                                 </MultiSelectorContent>
                               </MultiSelector>
                             )}
+                          </FormItemLayout>
+                        </FormItem_Shadcn_>
+                      )}
+                    />
+
+                    <FormField_Shadcn_
+                      control={form.control}
+                      name="serverCorsAllowedOrigins"
+                      render={({ field }) => (
+                        <FormItem_Shadcn_ className="w-full">
+                          <FormItemLayout
+                            className="w-full px-8 py-8"
+                            layout="horizontal"
+                            label="Allowed CORS origins"
+                            description="List of CORS origin domains that will be able to call the Data API."
+                          >
+                            <FormControl_Shadcn_>
+                              <Input_Shadcn_
+                                size="small"
+                                disabled={!canUpdatePostgrestConfig || !isDataApiEnabledInForm}
+                                {...field}
+                              />
+                            </FormControl_Shadcn_>
                           </FormItemLayout>
                         </FormItem_Shadcn_>
                       )}

--- a/apps/studio/data/config/project-postgrest-config-update-mutation.ts
+++ b/apps/studio/data/config/project-postgrest-config-update-mutation.ts
@@ -12,6 +12,7 @@ export type ProjectPostgrestConfigUpdateVariables = {
   maxRows: number
   dbExtraSearchPath: string
   dbPool: number | null
+  serverCorsAllowedOrigins: string
 }
 
 type UpdatePostgrestConfigResponse = components['schemas']['UpdatePostgrestConfigBody']
@@ -22,11 +23,13 @@ export async function updateProjectPostgrestConfig({
   maxRows,
   dbExtraSearchPath,
   dbPool,
+  serverCorsAllowedOrigins,
 }: ProjectPostgrestConfigUpdateVariables) {
   const payload: UpdatePostgrestConfigResponse = {
     db_schema: dbSchema,
     max_rows: maxRows,
     db_extra_search_path: dbExtraSearchPath,
+    server_cors_allowed_origins: serverCorsAllowedOrigins,
   }
   if (dbPool) payload.db_pool = dbPool
 

--- a/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
@@ -20,6 +20,7 @@ const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
   const responseObj: components['schemas']['GetPostgrestConfigResponse'] = {
     db_anon_role: 'anon',
     db_extra_search_path: 'public',
+    server_cors_allowed_origins: '',
     db_schema: 'public, storage',
     jwt_secret:
       process.env.AUTH_JWT_SECRET ?? 'super-secret-jwt-token-with-at-least-32-characters-long',

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -6160,6 +6160,7 @@ export interface components {
       jwt_secret: string
       max_rows: number
       role_claim_key: string
+      server_cors_allowed_origins: string
     }
     GetPrivateLinkResponse: {
       private_link_associations: {
@@ -10007,6 +10008,7 @@ export interface components {
       db_pool?: number
       db_schema?: string
       max_rows?: number
+      server_cors_allowed_origins?: string
     }
     UpdatePostgrestConfigResponse: {
       db_extra_search_path: string


### PR DESCRIPTION
part of https://linear.app/supabase/issue/INFRA-1178/expose-control-over-cors-policy-per-project

related API/Worker changes https://github.com/supabase/infrastructure/pull/27716

~Currently blocked and status updates will be included in linear.~

TBD whether this will be needed, as we might end up doing it globally in API Gateway v2 https://linear.app/supabase/issue/INEDGE-87/expose-control-over-cors-policy-per-project