### PR TITLE
Fix: added check to ensure github is connected before showing the logo on branch

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -62,6 +62,7 @@ interface BranchRowProps {
   repo: string
   label?: string | ReactNode
   branch: Branch
+  isGithubConnected: boolean
   rowLink?: string
   external?: boolean
   rowActions?: ReactNode
@@ -69,6 +70,7 @@ interface BranchRowProps {
 
 export const BranchRow = ({
   branch,
+  isGithubConnected,
   label,
   repo,
   rowLink,
@@ -87,7 +89,7 @@ export const BranchRow = ({
   return (
     <div className="w-full flex items-center justify-between px-4 py-2.5 hover:bg-surface-100">
       <div className="flex items-center gap-x-3">
-        {branch.git_branch && (
+        {branch.git_branch && isGithubConnected && (
           <ButtonTooltip
             asChild
             type="default"

--- a/apps/studio/components/interfaces/BranchManagement/Overview.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/Overview.tsx
@@ -38,6 +38,7 @@ import { EditBranchModal } from './EditBranchModal'
 import { PreviewBranchesEmptyState } from './EmptyStates'
 
 interface OverviewProps {
+  isGithubConnected: boolean
   isLoading: boolean
   isSuccess: boolean
   repo: string
@@ -49,6 +50,7 @@ interface OverviewProps {
 }
 
 export const Overview = ({
+  isGithubConnected,
   isLoading,
   isSuccess,
   repo,
@@ -71,6 +73,7 @@ export const Overview = ({
         {isSuccess && mainBranch !== undefined && (
           <BranchRow
             branch={mainBranch}
+            isGithubConnected={isGithubConnected}
             label={
               <div className="flex items-center gap-x-2">
                 <Shield size={14} strokeWidth={1.5} className="text-warning" />
@@ -109,6 +112,7 @@ export const Overview = ({
           persistentBranches.map((branch) => {
             return (
               <BranchRow
+                isGithubConnected={isGithubConnected}
                 key={branch.id}
                 repo={repo}
                 branch={branch}
@@ -135,6 +139,7 @@ export const Overview = ({
           ephemeralBranches.map((branch) => {
             return (
               <BranchRow
+                isGithubConnected={isGithubConnected}
                 key={branch.id}
                 repo={repo}
                 branch={branch}

--- a/apps/studio/pages/project/[ref]/branches/index.tsx
+++ b/apps/studio/pages/project/[ref]/branches/index.tsx
@@ -77,6 +77,8 @@ const BranchesPage: NextPageWithLayout = () => {
   const isLoading = isLoadingConnections || isLoadingBranches
   const isSuccess = isSuccessConnections && isSuccessBranches
 
+  const isGithubConnected = githubConnection !== undefined
+
   const { mutate: deleteBranch, isPending: isDeleting } = useBranchDeleteMutation({
     onSuccess: () => {
       toast.success('Successfully deleted branch')
@@ -145,6 +147,7 @@ const BranchesPage: NextPageWithLayout = () => {
 
                   {!isError && (
                     <Overview
+                      isGithubConnected={isGithubConnected}
                       isLoading={isLoading}
                       isSuccess={isSuccess}
                       repo={repo}

--- a/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
+++ b/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
@@ -89,6 +89,8 @@ const MergeRequestsPage: NextPageWithLayout = () => {
 
   const isError = isErrorConnections || isErrorBranches
 
+  const isGithubConnected = githubConnection !== undefined
+
   const { mutate: sendEvent } = useSendEventMutation()
 
   const { mutate: updateBranch, isPending: isUpdating } = useBranchUpdateMutation({
@@ -228,6 +230,7 @@ const MergeRequestsPage: NextPageWithLayout = () => {
                             : `/project/${branch.project_ref}/merge`
                           return (
                             <BranchRow
+                              isGithubConnected={isGithubConnected}
                               key={branch.id}
                               label={
                                 <div className="flex items-center gap-x-4">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: minor change to not show Github logo if Github is not connected

## Testing

- Enable a Github integration for a branch
- Disable that integration
- The github logo should not appear next to branch

Its a hard thing to test on local, once the repo is connected I don't see a list of anything. Had to test on staging
