### PR TITLE
feat(storage): use pagination for storage bucket list

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.LoadMoreRow.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.LoadMoreRow.tsx
@@ -1,0 +1,46 @@
+import { useIntersectionObserver } from '@uidotdev/usehooks'
+import { VirtualizedTableCell, VirtualizedTableRow } from 'components/ui/VirtualizedTable'
+import { useEffect, type ReactNode } from 'react'
+import { TableCell, TableRow } from 'ui'
+import { ShimmeringLoader } from 'ui-patterns'
+import type { BucketsTablePaginationProps } from './BucketsTable.types'
+
+type LoadMoreRowProps = {
+  mode: 'standard' | 'virtualized'
+  colSpan: number
+} & BucketsTablePaginationProps
+
+export const LoadMoreRow = ({
+  mode,
+  colSpan,
+
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
+}: LoadMoreRowProps): ReactNode => {
+  const [sentinelRef, entry] = useIntersectionObserver({
+    threshold: 0,
+    rootMargin: '200px 0px 200px 0px',
+  })
+
+  useEffect(() => {
+    if (entry?.isIntersecting && hasMore && !isLoadingMore) {
+      onLoadMore?.()
+    }
+  }, [entry?.isIntersecting, hasMore, isLoadingMore, onLoadMore])
+
+  if (!hasMore && !isLoadingMore) return null
+
+  const RowComponent = mode === 'standard' ? TableRow : VirtualizedTableRow
+  const CellComponent = mode === 'standard' ? TableCell : VirtualizedTableCell
+
+  return (
+    <RowComponent ref={sentinelRef}>
+      {Array.from({ length: colSpan }, (_, idx) => (
+        <CellComponent key={idx}>
+          {idx !== 0 && idx !== colSpan - 1 && <ShimmeringLoader className="w-3/4" />}
+        </CellComponent>
+      ))}
+    </RowComponent>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.tsx
@@ -1,13 +1,18 @@
+import { useRef } from 'react'
+
 import { VirtualizedTable, VirtualizedTableBody } from 'components/ui/VirtualizedTable'
 import { Bucket } from 'data/storage/buckets-query'
 import { Table, TableBody } from 'ui'
 import { BucketTableEmptyState, BucketTableHeader, BucketTableRow } from './BucketTable'
+import { LoadMoreRow } from './BucketsTable.LoadMoreRow'
+import type { BucketsTablePaginationProps } from './BucketsTable.types'
 
 type BucketsTableProps = {
   buckets: Bucket[]
   projectRef: string
   filterString: string
   formattedGlobalUploadLimit: string
+  pagination: BucketsTablePaginationProps
 }
 
 export const BucketsTable = (props: BucketsTableProps) => {
@@ -24,12 +29,16 @@ const BucketsTableUnvirtualized = ({
   projectRef,
   filterString,
   formattedGlobalUploadLimit,
+  pagination: { hasMore = false, isLoadingMore = false, onLoadMore },
 }: BucketsTableProps) => {
   const showSearchEmptyState = buckets.length === 0 && filterString.length > 0
 
   return (
     <Table
-      containerProps={{ containerClassName: 'h-full overflow-auto', className: 'overflow-visible' }}
+      containerProps={{
+        containerClassName: 'h-full overflow-auto',
+        className: 'overflow-visible',
+      }}
     >
       <BucketTableHeader mode="standard" hasBuckets={buckets.length > 0} />
       <TableBody>
@@ -46,6 +55,13 @@ const BucketsTableUnvirtualized = ({
             />
           ))
         )}
+        <LoadMoreRow
+          mode="standard"
+          colSpan={6}
+          hasMore={hasMore}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={onLoadMore}
+        />
       </TableBody>
     </Table>
   )
@@ -56,11 +72,18 @@ const BucketsTableVirtualized = ({
   projectRef,
   filterString,
   formattedGlobalUploadLimit,
+  pagination: { hasMore = false, isLoadingMore = false, onLoadMore },
 }: BucketsTableProps) => {
   const showSearchEmptyState = buckets.length === 0 && filterString.length > 0
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   return (
-    <VirtualizedTable data={buckets} estimateSize={() => 59} getItemKey={(bucket) => bucket.id}>
+    <VirtualizedTable
+      data={buckets}
+      estimateSize={() => 59}
+      getItemKey={(bucket) => bucket.id}
+      scrollContainerRef={scrollContainerRef}
+    >
       <BucketTableHeader mode="virtualized" hasBuckets={buckets.length > 0} />
       <VirtualizedTableBody<Bucket>
         paddingColSpan={5}
@@ -68,6 +91,15 @@ const BucketsTableVirtualized = ({
           showSearchEmptyState ? (
             <BucketTableEmptyState mode="virtualized" filterString={filterString} />
           ) : undefined
+        }
+        trailingContent={
+          <LoadMoreRow
+            mode="virtualized"
+            colSpan={6}
+            hasMore={hasMore}
+            isLoadingMore={isLoadingMore}
+            onLoadMore={onLoadMore}
+          />
         }
       >
         {(bucket) => (

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.types.ts
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketsTable.types.ts
@@ -1,0 +1,5 @@
+export type BucketsTablePaginationProps = {
+  hasMore?: boolean
+  isLoadingMore?: boolean
+  onLoadMore?: () => void
+}

--- a/apps/studio/components/ui/VirtualizedTable.tsx
+++ b/apps/studio/components/ui/VirtualizedTable.tsx
@@ -29,6 +29,7 @@ type TableComponentProps = React.ComponentProps<typeof Table>
 
 interface VirtualizedTableProps<TItem> extends TableComponentProps {
   scrollContainerProps?: HTMLAttributes<HTMLDivElement>
+  scrollContainerRef: React.Ref<HTMLDivElement>
   data: TItem[]
   children: ReactNode
   overscan?: number
@@ -57,6 +58,7 @@ const useVirtualizedTableContext = <TItem,>() => {
 
 export const VirtualizedTable = <TItem,>({
   scrollContainerProps,
+  scrollContainerRef: externalScrollContainerRef,
   containerProps,
   data,
   children,
@@ -66,6 +68,7 @@ export const VirtualizedTable = <TItem,>({
   ...tableProps
 }: VirtualizedTableProps<TItem>) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const scrollContainerMergedRef = mergeRefs(scrollContainerRef, externalScrollContainerRef)
 
   const rowKeyGetter = useCallback(
     (item: TItem, index: number) => {
@@ -121,7 +124,7 @@ export const VirtualizedTable = <TItem,>({
 
   return (
     <div
-      ref={scrollContainerRef}
+      ref={scrollContainerMergedRef}
       className={cn('h-full overflow-auto', scrollClassName)}
       {...restScrollContainerProps}
     >

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -1,11 +1,15 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import { MAX_RETRY_FAILURE_COUNT } from 'data/query-client'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import { ResponseError, type UseCustomQueryOptions } from 'types'
+import {
+  ResponseError,
+  type UseCustomInfiniteQueryOptions,
+  type UseCustomQueryOptions,
+} from 'types'
 import { storageKeys } from './keys'
 
 export type BucketsVariables = { projectRef?: string }
@@ -18,15 +22,70 @@ export async function getBuckets({ projectRef }: BucketsVariables, signal?: Abor
   if (!projectRef) throw new Error('projectRef is required')
 
   const { data, error } = await get('/platform/storage/{ref}/buckets', {
-    params: { path: { ref: projectRef } },
+    params: {
+      path: { ref: projectRef },
+    },
     signal,
   })
 
   if (error) handleError(error)
-  return data as Bucket[]
+  return data
+}
+
+type BucketSortColumn = 'id' | 'name' | 'updated_at' | 'created_at'
+type BucketSortOrder = 'asc' | 'desc'
+
+type BucketListPagination = {
+  page?: number
+  limit?: number
+  sortColumn?: BucketSortColumn
+  sortOrder?: BucketSortOrder
+  search?: string
+}
+
+export type BucketsListPaginatedVariables = BucketsVariables & BucketListPagination
+
+const DEFAULT_PAGE_SIZE = 100
+const DEFAULT_SORT_COLUMN: BucketSortColumn = 'created_at'
+const DEFAULT_SORT_ORDER: BucketSortOrder = 'desc'
+
+const getBucketsPaginated = async (
+  {
+    projectRef,
+    page = 0,
+    limit = DEFAULT_PAGE_SIZE,
+    sortColumn = DEFAULT_SORT_COLUMN,
+    sortOrder = DEFAULT_SORT_ORDER,
+    search,
+  }: BucketsListPaginatedVariables,
+  signal?: AbortSignal
+) => {
+  if (!projectRef) throw new Error('projectRef is required')
+
+  const offset = page * limit
+  const trimmedSearch = search?.trim()
+  const resolvedSearch = !!trimmedSearch && trimmedSearch.length > 0 ? trimmedSearch : undefined
+
+  const { data, error } = await get('/platform/storage/{ref}/buckets', {
+    params: {
+      path: { ref: projectRef },
+      query: {
+        limit,
+        offset,
+        sortColumn,
+        sortOrder,
+        search: resolvedSearch,
+      },
+    },
+    signal,
+  })
+
+  if (error) handleError(error)
+  return data
 }
 
 export type BucketsData = Awaited<ReturnType<typeof getBuckets>>
+export type BucketsWithPaginationData = Awaited<ReturnType<typeof getBucketsPaginated>>
 export type BucketsError = ResponseError
 
 export const useBucketsQuery = <TData = BucketsData>(
@@ -41,21 +100,55 @@ export const useBucketsQuery = <TData = BucketsData>(
     queryFn: ({ signal }) => getBuckets({ projectRef }, signal),
     enabled: enabled && typeof projectRef !== 'undefined' && isActive,
     ...options,
-    retry: (failureCount, error) => {
-      if (error instanceof ResponseError) {
-        if (
-          error.message.includes('Missing tenant config') ||
-          error.message.includes('Project has no active API keys')
-        ) {
-          return false
-        }
-      }
-
-      if (failureCount < MAX_RETRY_FAILURE_COUNT) {
-        return true
-      }
-
-      return false
-    },
+    retry: shouldRetryBucketsQuery,
   })
+}
+
+export const usePaginatedBucketsQuery = <TData = BucketsWithPaginationData>(
+  { projectRef, ...params }: Omit<BucketsListPaginatedVariables, 'page'>,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomInfiniteQueryOptions<BucketsWithPaginationData, BucketsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  const { keepPreviousData, ...restOptions } = options
+  const resolvedKeepPreviousData = keepPreviousData ?? true
+
+  return useInfiniteQuery<BucketsWithPaginationData, BucketsError, TData>({
+    queryKey: storageKeys.bucketsList(projectRef, params),
+    queryFn: ({ signal, pageParam }) =>
+      getBucketsPaginated({ projectRef, page: pageParam, ...params }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    getNextPageParam: (lastPage, pages) => {
+      const nextPageNumber = pages.length
+      const limit = params.limit ?? DEFAULT_PAGE_SIZE
+
+      const lastPageCount = lastPage.length
+      if (lastPageCount < limit) return undefined
+      return nextPageNumber
+    },
+    ...restOptions,
+    keepPreviousData: resolvedKeepPreviousData,
+    retry: shouldRetryBucketsQuery,
+  })
+}
+
+const shouldRetryBucketsQuery = (failureCount: number, error: unknown) => {
+  if (error instanceof ResponseError) {
+    if (
+      error.message.includes('Missing tenant config') ||
+      error.message.includes('Project has no active API keys')
+    ) {
+      return false
+    }
+  }
+
+  if (failureCount < MAX_RETRY_FAILURE_COUNT) {
+    return true
+  }
+
+  return false
 }

--- a/apps/studio/data/storage/keys.ts
+++ b/apps/studio/data/storage/keys.ts
@@ -1,5 +1,26 @@
 export const storageKeys = {
   buckets: (projectRef: string | undefined) => ['projects', projectRef, 'buckets'] as const,
+  bucketsList: (
+    projectRef: string | undefined,
+    params: {
+      limit?: number
+      search?: string
+      sortColumn?: string
+      sortOrder?: string
+    } = {}
+  ) =>
+    [
+      'projects',
+      projectRef,
+      'buckets',
+      'list',
+      {
+        limit: params.limit,
+        search: params.search,
+        sortColumn: params.sortColumn,
+        sortOrder: params.sortOrder,
+      },
+    ] as const,
   analyticsBuckets: (projectRef: string | undefined) =>
     ['projects', projectRef, 'analytics-buckets'] as const,
   vectorBuckets: (projectRef: string | undefined) =>

--- a/e2e/studio/utils/storage-helpers.ts
+++ b/e2e/studio/utils/storage-helpers.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from '@playwright/test'
-import { waitForApiResponse } from './wait-for-response'
-import { toUrl } from './to-url'
+import { toUrl } from './to-url.js'
+import { waitForApiResponse } from './wait-for-response.js'
 
 /**
  * Dismisses any visible toast notifications
@@ -95,7 +95,9 @@ export const deleteBucket = async (page: Page, ref: string, bucketName: string) 
 
   // Type bucket name in the confirmation textbox (placeholder: "Type bucket name")
   const confirmInput = page.getByPlaceholder('Type bucket name')
-  await expect(confirmInput, 'Confirmation input should be visible').toBeVisible()
+  await expect(confirmInput, 'Confirmation input should be visible').toBeVisible({
+    timeout: 15_000,
+  })
   await confirmInput.fill(bucketName)
 
   // Wait for API call and click Delete bucket button
@@ -124,13 +126,26 @@ export const deleteBucket = async (page: Page, ref: string, bucketName: string) 
  * @param bucketName - Name of the bucket to navigate to
  */
 export const navigateToBucket = async (page: Page, ref: string, bucketName: string) => {
-  // Click on the bucket row to navigate
+  // Identify the bucket row to click
   const bucketRow = page.getByRole('row').filter({ hasText: bucketName })
   await expect(bucketRow, `Bucket row for ${bucketName} should be visible`).toBeVisible()
-  await bucketRow.click()
 
-  // Wait for navigation to complete
-  await page.waitForURL(new RegExp(`/storage/files/buckets/${encodeURIComponent(bucketName)}`))
+  // Click the bucket and wait for page to load
+  const navigationPromise = page.waitForURL(
+    new RegExp(`/storage/files/buckets/${encodeURIComponent(bucketName)}`)
+  )
+  const apiPromise = waitForApiResponse(
+    page,
+    'storage',
+    ref,
+    `buckets/${bucketName}/objects/list`,
+    {
+      method: 'POST',
+    }
+  )
+  await bucketRow.click()
+  await navigationPromise
+  await apiPromise
 
   // Verify we're in the bucket by checking the breadcrumb or "Edit bucket" button
   await expect(
@@ -181,7 +196,7 @@ export const uploadFile = async (page: Page, filePath: string, fileName: string)
   await expect(
     page.getByTitle(fileName),
     `File ${fileName} should be visible in explorer after upload`
-  ).toBeVisible({ timeout: 15_000 })
+  ).toBeVisible()
 }
 
 /**
@@ -234,7 +249,7 @@ export const renameItem = async (page: Page, oldName: string, newName: string) =
 
   // Verify item was renamed
   await expect(page.getByTitle(newName), `Item should be renamed to ${newName}`).toBeVisible({
-    timeout: 10_000,
+    timeout: 30_000,
   })
   await expect(
     page.getByTitle(oldName),

--- a/packages/ui/src/components/ShadowScrollArea/index.tsx
+++ b/packages/ui/src/components/ShadowScrollArea/index.tsx
@@ -7,6 +7,7 @@ interface ShadowScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   containerClassName?: string
   stickyLastColumn?: boolean
+  outerContainerRef?: React.Ref<HTMLDivElement>
 }
 
 /**
@@ -16,7 +17,10 @@ interface ShadowScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 
 const ShadowScrollArea = React.forwardRef<HTMLDivElement, ShadowScrollAreaProps>(
-  ({ className, containerClassName, children, stickyLastColumn, ...props }, ref) => {
+  (
+    { className, containerClassName, children, stickyLastColumn, outerContainerRef, ...props },
+    ref
+  ) => {
     const containerRef = React.useRef<HTMLDivElement>(null)
     const { hasHorizontalScroll, canScrollLeft, canScrollRight } = useHorizontalScroll(containerRef)
 
@@ -34,7 +38,7 @@ const ShadowScrollArea = React.forwardRef<HTMLDivElement, ShadowScrollAreaProps>
     )
 
     return (
-      <div className={cn(containerClassName, 'relative')}>
+      <div ref={outerContainerRef} className={cn(containerClassName, 'relative')}>
         <div
           className={cn(
             'absolute inset-0 pointer-events-none z-[38]',


### PR DESCRIPTION
The bucket list endpoint now accepts pagination options. Adapting the storage buckets table UI to paginate in pages of 100 buckets at a time, with infinite loading/scrolling.

Towards FE-2118