### PR TITLE
fix: allow /img paths in maintenance mode

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -442,7 +442,7 @@ const nextConfig = {
       ...(process.env.MAINTENANCE_MODE === 'true'
         ? [
             {
-              source: '/((?!maintenance).*)', // Redirect all paths except /maintenance
+              source: '/((?!maintenance|img).*)', // Redirect all paths except /maintenance and /img
               destination: '/maintenance',
               permanent: false,
             },


### PR DESCRIPTION
In maintenance mode, the logo can't load due to the `/img` path also being redirected

<img width="708" height="534" alt="Screenshot 2025-11-22 at 20 30 04" src="https://github.com/user-attachments/assets/ef09863a-6381-493e-aa07-b4e6017fa863" />
