### PR TITLE
Fix broken link to Declarative Schemas documentation

### DIFF
--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -2399,7 +2399,7 @@ Yes. You can pull your production schema into declarative files by running \`sup
 
 The schema diff tool handles most Postgres objects, but some entities (like DML statements) are not captured and may still require manual migrations.
 
-For detailed instructions and best practices, see the [Declarative Schemas documentation](https://supabase.com/docs/guides/database/declarative-schemas).
+For detailed instructions and best practices, see the [Declarative Schemas documentation](https://supabase.com/docs/guides/local-development/declarative-database-schemas).
 `,
     icon: Database,
     products: [PRODUCT_SHORTNAMES.DATABASE],


### PR DESCRIPTION
Fixed broken link to docs

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Small feature page patch to redirect to the correct docs link

## What is the current behavior?

The current link runs into a 404.

## What is the new behavior?

It redirects to the correct docs page for declarative schemas.
