### PR TITLE
fix(studio): bucket naming

### DIFF
--- a/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
@@ -7,7 +7,7 @@ import { BUCKET_TYPES } from './Storage.constants'
 export const BucketsUpgradePlan = ({ type }: { type: 'analytics' | 'vector' }) => {
   return (
     <ScaffoldSection isFullWidth>
-      <AlphaNotice type="analytics" />
+      <AlphaNotice type={type} />
       <aside className="border border-dashed w-full bg-surface-100 rounded-lg px-4 py-10 flex flex-col gap-y-4 items-center text-center gap-1 text-balance">
         <Bucket size={24} strokeWidth={1.5} className="text-foreground-light" />
         <div className="flex flex-col gap-y-1 items-center text-center">
@@ -19,8 +19,7 @@ export const BucketsUpgradePlan = ({ type }: { type: 'analytics' | 'vector' }) =
                 : undefined}
           </h3>
           <p className="text-foreground-light text-sm">
-            Upgrade to the Pro plan to use <span className="capitalize">{type}</span> Buckets for
-            your project
+            Upgrade to Pro to use {type} buckets for your project
           </p>
         </div>
         <div className="flex items-center gap-x-2">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Going to the `/storage/vectors` page shows a _Introducing analytics buckets_ admonition
	- This page also capitalises the phrase _Analytics Buckets_

## What is the new behavior?

- Correctly refers to _vector_ buckets on the `/vectors` page
- Uses sentence case like we do elsewhere, since they aren’t proper nouns (or branded terms)
