### PR TITLE
fix(studio): entity type color contrast

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -204,13 +204,13 @@ export const PlanUpdateSidePanel = () => {
                 >
                   <div className="w-full">
                     <div className="flex items-center space-x-2">
-                      <p className="text-brand text-sm uppercase">{plan.name}</p>
+                      <p className="text-brand-link text-sm uppercase">{plan.name}</p>
                       {isCurrentPlan ? (
                         <div className="text-xs bg-surface-300 text-foreground-light rounded px-2 py-0.5">
                           Current plan
                         </div>
                       ) : plan.nameBadge ? (
-                        <div className="text-xs bg-brand-400 text-brand-600 rounded px-2 py-0.5">
+                        <div className="text-xs bg-brand-300 dark:bg-brand-400 text-brand-600 rounded px-2 py-0.5">
                           {plan.nameBadge}
                         </div>
                       ) : null}

--- a/apps/studio/components/ui/EntityTypeIcon.tsx
+++ b/apps/studio/components/ui/EntityTypeIcon.tsx
@@ -70,7 +70,8 @@ export const EntityTypeIcon = ({
         type === ENTITY_TYPE.FOREIGN_TABLE &&
           'text-warning-600/80 dark:text-yellow-900 bg-yellow-500',
         type === ENTITY_TYPE.MATERIALIZED_VIEW && 'text-purple-1000 bg-purple-500',
-        type === ENTITY_TYPE.PARTITIONED_TABLE && 'text-foreground-light bg-border-stronger'
+        type === ENTITY_TYPE.PARTITIONED_TABLE &&
+          'text-foreground-light bg-surface-400 dark:bg-border-stronger'
       )}
     >
       {Object.entries(ENTITY_TYPE)

--- a/apps/studio/components/ui/EntityTypeIcon.tsx
+++ b/apps/studio/components/ui/EntityTypeIcon.tsx
@@ -69,7 +69,7 @@ export const EntityTypeIcon = ({
         'flex items-center justify-center text-xs h-4 w-4 rounded-[2px] font-bold',
         type === ENTITY_TYPE.FOREIGN_TABLE &&
           'text-warning-600/80 dark:text-yellow-900 bg-yellow-500',
-        type === ENTITY_TYPE.MATERIALIZED_VIEW && 'text-purple-1000 bg-purple-500',
+        type === ENTITY_TYPE.MATERIALIZED_VIEW && 'text-purple-1100 bg-purple-500',
         type === ENTITY_TYPE.PARTITIONED_TABLE &&
           'text-foreground-light bg-surface-400 dark:bg-border-stronger'
       )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI fix

## What is the current behavior?

- Many entity type icons aren’t legible on light mode
- Similar issue on plan upgrade sheet

## What is the new behavior?

- Minor updates to the above to increase contrast

## Additional context

| Before | After |
| --- | --- |
| <img width="500" height="496" alt="Inventory  Nuts  Bolts  Supabase" src="https://github.com/user-attachments/assets/dcf6493e-46d5-489a-90d7-98b55831fcf8" /> | <img width="500" height="496" alt="Inventory  Nuts  Bolts  Supabase" src="https://github.com/user-attachments/assets/da81ab85-d318-4394-8e5c-d14e389c7663" /> |
| <img width="500" height="789" alt="Supabase" src="https://github.com/user-attachments/assets/ce433423-6770-42df-837c-ab29612d7d92" /> | <img width="500" height="789" alt="Supabase" src="https://github.com/user-attachments/assets/2978d2dd-fdf6-4b5c-827b-33ddd9702a0c" /> |
