### PR TITLE
Update docs link for analytics buckets

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTableInstructions/index.tsx
@@ -255,7 +255,7 @@ export const CreateTableInstructions = ({
       <CardFooter className="bg">
         <p className="text-xs text-foreground-light">
           Connecting to bucket with other Iceberg clients? Read more in our{' '}
-          <InlineLink href={`${DOCS_URL}/guides/storage/analytics/connecting-to-analytics-bucket`}>
+          <InlineLink href={`${DOCS_URL}/guides/storage/analytics/examples/pyiceberg`}>
             documentation
           </InlineLink>
           .

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/InitializeForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/InitializeForeignSchemaDialog.tsx
@@ -5,10 +5,12 @@ import { toast } from 'sonner'
 import z from 'zod'
 
 import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
 import { useSchemaCreateMutation } from 'data/database/schema-create-mutation'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useFDWImportForeignSchemaMutation } from 'data/fdw/fdw-import-foreign-schema-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { DOCS_URL } from 'lib/constants'
 import {
   Button,
   Dialog,
@@ -113,13 +115,16 @@ export const InitializeForeignSchemaDialog = ({ namespace }: { namespace: string
                 )}
               />
             </DialogSection>
-            <DialogFooter>
-              <Button type="default" disabled={isCreating} onClick={() => setIsOpen(false)}>
-                Cancel
-              </Button>
-              <Button htmlType="submit" type="primary" loading={isCreating}>
-                Create schema
-              </Button>
+            <DialogFooter className="!justify-between">
+              <DocsButton href={`${DOCS_URL}/guides/storage/analytics/query-with-postgres`} />
+              <div className="flex items-center gap-x-2">
+                <Button type="default" disabled={isCreating} onClick={() => setIsOpen(false)}>
+                  Cancel
+                </Button>
+                <Button htmlType="submit" type="primary" loading={isCreating}>
+                  Create schema
+                </Button>
+              </div>
             </DialogFooter>
           </form>
         </Form_Shadcn_>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/UpdateForeignSchemaDialog.tsx
@@ -5,9 +5,11 @@ import { toast } from 'sonner'
 import z from 'zod'
 
 import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
 import { InlineLinkClassName } from 'components/ui/InlineLink'
 import { useFDWImportForeignSchemaMutation } from 'data/fdw/fdw-import-foreign-schema-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { DOCS_URL } from 'lib/constants'
 import {
   Button,
   Dialog,
@@ -153,13 +155,16 @@ export const UpdateForeignSchemaDialog = ({
                 </p>
               )}
             </DialogSection>
-            <DialogFooter>
-              <Button type="default" disabled={isUpdating} onClick={() => setIsOpen(false)}>
-                Cancel
-              </Button>
-              <Button htmlType="submit" type="primary" loading={isUpdating}>
-                Update schema
-              </Button>
+            <DialogFooter className="!justify-between">
+              <DocsButton href={`${DOCS_URL}/guides/storage/analytics/query-with-postgres`} />
+              <div className="flex items-center gap-x-2">
+                <Button type="default" disabled={isUpdating} onClick={() => setIsOpen(false)}>
+                  Cancel
+                </Button>
+                <Button htmlType="submit" type="primary" loading={isUpdating}>
+                  Update schema
+                </Button>
+              </div>
             </DialogFooter>
           </form>
         </Form_Shadcn_>


### PR DESCRIPTION
## Context

Just updating some docs links for analytics bucket

The docs changes are in a PR here: https://github.com/supabase/supabase/pull/39716
Understandably they're in a draft but reckon this change can still go through since the UI isn't live yet

Including a link about "Querying from Postgres" in this modal as well
<img width="540" height="313" alt="image" src="https://github.com/user-attachments/assets/767d0740-a4e2-4084-855e-7f443a1ef75a" />
