### PR TITLE
Joshen/depr 253 tighten field validation for bucket name and table name

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
@@ -52,7 +52,7 @@ const FormSchema = z
       .string()
       .trim()
       .min(3, 'Bucket name should be at least 3 characters')
-      .max(63, 'Bucket name should be below 63 characters')
+      .max(63, 'Bucket name should be up to 63 characters')
       .refine(
         (value) => !value.endsWith(' '),
         'The name of the bucket cannot end with a whitespace'
@@ -78,6 +78,14 @@ const FormSchema = z
         path: ['name'],
         code: z.ZodIssueCode.custom,
         message: `Bucket name cannot end with "${match}"`,
+      })
+    }
+
+    if (/[A-Z]/.test(data.name)) {
+      return ctx.addIssue({
+        path: ['name'],
+        code: z.ZodIssueCode.custom,
+        message: 'Bucket name can only be lowercase characters',
       })
     }
 

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.utils.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.utils.ts
@@ -1,24 +1,15 @@
-// [Joshen] These are referenced from the storage API directly here
-// https://github.com/supabase/storage/blob/69e4a40799a9d10be0a63a37cbb46d7d9bea0e17/src/storage/limits.ts#L59
-
-// only allow s3 safe characters and characters which require special handling for now
-// the slash restriction come from bucket naming rules
-// and the rest of the validation rules are based on S3 object key validation.
-// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-
+/**
+ * Rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets-naming.html?i
+ * Bucket names must be between 3 and 63 characters long.
+ * Bucket names can consist only of lowercase letters, numbers, and hyphens (-).
+ * Bucket names must begin and end with a letter or number.
+ * Bucket names must not contain any underscores (_) or periods (.).
+ * Bucket names must not start with any of the following reserved prefixes: 
+    xn--, sthree-, amzn-s3-demo-, aws
+ * Bucket names must not end with any of the following reserved suffixes:
+    -s3alias, --ol-s3, --x-s3, --table-s3
+ */
 export const reservedPrefixes = /^(?:xn--|sthree-|amzn-s3-demo-|aws)/
 export const reservedSuffixes = /(?:-s3alias|--ol-s3|--x-s3|--table-s3)$/
-
-// 1) only lowercase letters, digits, hyphens
-// 2) must start and end with a letter or digit
 export const validBucketNameRegex = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 export const invalidBucketNameRegex = /[^a-z0-9-]/
-
-// export const validBucketNameRegex = /^(\w|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/
-// export const inverseValidBucketNameRegex = /[^A-Za-z0-9_!\-.*'() &$@=;:+,?]/
-
-// only allow s3 safe characters and characters which require special handling for now
-// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-export const validObjectKeyRegex = /^(\w|\/|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/
-export const inverseValidObjectKeyRegex = /[^A-Za-z0-9_\/!\-.*'() &$@=;:+,?]/

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.utils.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.utils.ts
@@ -1,0 +1,24 @@
+// [Joshen] These are referenced from the storage API directly here
+// https://github.com/supabase/storage/blob/69e4a40799a9d10be0a63a37cbb46d7d9bea0e17/src/storage/limits.ts#L59
+
+// only allow s3 safe characters and characters which require special handling for now
+// the slash restriction come from bucket naming rules
+// and the rest of the validation rules are based on S3 object key validation.
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+
+export const reservedPrefixes = /^(?:xn--|sthree-|amzn-s3-demo-|aws)/
+export const reservedSuffixes = /(?:-s3alias|--ol-s3|--x-s3|--table-s3)$/
+
+// 1) only lowercase letters, digits, hyphens
+// 2) must start and end with a letter or digit
+export const validBucketNameRegex = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+export const invalidBucketNameRegex = /[^a-z0-9-]/
+
+// export const validBucketNameRegex = /^(\w|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/
+// export const inverseValidBucketNameRegex = /[^A-Za-z0-9_!\-.*'() &$@=;:+,?]/
+
+// only allow s3 safe characters and characters which require special handling for now
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+export const validObjectKeyRegex = /^(\w|\/|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/
+export const inverseValidObjectKeyRegex = /[^A-Za-z0-9_\/!\-.*'() &$@=;:+,?]/

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.utils.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.utils.ts
@@ -12,4 +12,3 @@
 export const reservedPrefixes = /^(?:xn--|sthree-|amzn-s3-demo-|aws)/
 export const reservedSuffixes = /(?:-s3alias|--ol-s3|--x-s3|--table-s3)$/
 export const validBucketNameRegex = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
-export const invalidBucketNameRegex = /[^a-z0-9-]/

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
@@ -1,11 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Plus } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import z from 'zod'
-import { parseAsBoolean, useQueryState } from 'nuqs'
 
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
@@ -36,7 +36,7 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import { inverseValidBucketNameRegex, validBucketNameRegex } from '../CreateBucketModal.utils'
+import { validVectorBucketName } from './CreateVectorBucketDialog.utils'
 import { useS3VectorsWrapperExtension } from './useS3VectorsWrapper'
 import { getVectorBucketFDWSchemaName } from './VectorBuckets.utils'
 
@@ -44,12 +44,36 @@ const FormSchema = z.object({
   name: z
     .string()
     .trim()
-    .min(1, 'Please provide a name for your bucket')
-    .max(100, 'Bucket name should be below 100 characters')
+    .min(3, 'Bucket name should be at least 3 characters')
+    .max(63, 'Bucket name should be up to 63 characters')
     .superRefine((name, ctx) => {
-      if (!validBucketNameRegex.test(name)) {
-        const [match] = name.match(inverseValidBucketNameRegex) ?? []
-        ctx.addIssue({
+      if (!validVectorBucketName.test(name)) {
+        if (/[A-Z]/.test(name)) {
+          return ctx.addIssue({
+            path: [],
+            code: z.ZodIssueCode.custom,
+            message: 'Bucket name can only be lowercase characters',
+          })
+        }
+
+        if (!/^[a-z0-9]/.test(name)) {
+          return ctx.addIssue({
+            path: [],
+            code: z.ZodIssueCode.custom,
+            message: 'Bucket name must start with a lowercase letter or number.',
+          })
+        }
+
+        if (!/[a-z0-9]$/.test(name)) {
+          return ctx.addIssue({
+            path: [],
+            code: z.ZodIssueCode.custom,
+            message: 'Bucket name must end with a lowercase letter or number.',
+          })
+        }
+
+        const [match] = name.match(/[^a-z0-9-]/) ?? []
+        return ctx.addIssue({
           path: [],
           code: z.ZodIssueCode.custom,
           message: !!match

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.utils.ts
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-buckets-naming.html?icmpid=docs_amazons3_console
+ * Vector bucket names must be between 3 and 63 characters long.
+ * Vector bucket names can consist only of lowercase letters (a-z), numbers (0-9), and hyphens (-).
+ * Vector bucket names must begin and end with a letter or number.
+ */
+export const validVectorBucketName = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/


### PR DESCRIPTION
## Context

Updates the validation for bucket names for Analytics and Vector Buckets

Analytics:
- Bucket names must be between 3 and 63 characters long.
- Bucket names can consist only of lowercase letters, numbers, and hyphens (-).
- Bucket names must begin and end with a letter or number.
- Bucket names must not contain any underscores (_) or periods (.).
- Bucket names must not start with any of the following reserved prefixes: 
  - `xn--`
  - `sthree-`
  - `amzn-s3-demo-`
  - `aws`
- Bucket names must not end with any of the following reserved suffixes:
  - `-s3alias`
  - `--ol-s3`
  - `--x-s3`
  - `--table-s3`

Vectors:
- Vector bucket names must be between 3 and 63 characters long.
- Vector bucket names can consist only of lowercase letters (a-z), numbers (0-9), and hyphens (-).
- Vector bucket names must begin and end with a letter or number.

## To test

- [ ] Just double check that the above validation rules are working in the dashboard with appropriate UX response (e.g error messages)