### PR TITLE
fix: update wording in support ticket confirmation

### DIFF
--- a/apps/studio/components/interfaces/Support/Success.tsx
+++ b/apps/studio/components/interfaces/Support/Success.tsx
@@ -47,7 +47,7 @@ export const Success = ({
         {selectedProject !== NO_PROJECT_MARKER && (
           <p className="text-sm text-foreground-light">
             Your ticket has been logged for the project{' '}
-            <span className="text-foreground">{projectName}</span>, reference ID:{' '}
+            <span className="text-foreground">{projectName}</span> with project ID:{' '}
             <span className="text-foreground">{selectedProject}</span>.
           </p>
         )}

--- a/apps/studio/components/interfaces/Support/Success.tsx
+++ b/apps/studio/components/interfaces/Support/Success.tsx
@@ -47,7 +47,7 @@ export const Success = ({
         {selectedProject !== NO_PROJECT_MARKER && (
           <p className="text-sm text-foreground-light">
             Your ticket has been logged for the project{' '}
-            <span className="text-foreground">{projectName}</span> with project ID:{' '}
+            <span className="text-foreground">{projectName}</span> with Project ID:{' '}
             <span className="text-foreground">{selectedProject}</span>.
           </p>
         )}


### PR DESCRIPTION
I asked a friend to create a support ticket, and he sent me back the project ref. Then he sent me the screenshot. The wording is definitely confusing and can be easily interpreted to mean that is the ticket ID.