### PR TITLE
Add note about rate limits when enabling/disabling custom smtp

### DIFF
--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -452,8 +452,10 @@ export const SmtpForm = () => {
                 <p className="text-sm text-foreground-light">
                   {enableSmtp ? (
                     <>
-                      Rate limit for sending emails will be increased to 30 and can be adjusted{' '}
-                      <InlineLink href={`/project/${projectRef}/auth/rate-limits`}>here</InlineLink>{' '}
+                      Rate limit for sending emails will be increased to 30 and{' '}
+                      <InlineLink href={`/project/${projectRef}/auth/rate-limits`}>
+                        can be adjusted
+                      </InlineLink>{' '}
                       after enabling custom SMTP
                     </>
                   ) : (

--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -25,6 +25,7 @@ import {
   Input_Shadcn_,
   PrePostTab,
   Switch,
+  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -444,20 +445,43 @@ export const SmtpForm = () => {
               </>
             )}
 
-            <CardFooter className="justify-end space-x-2">
+            <CardFooter
+              className={cn(form.formState.isDirty ? 'justify-between' : 'justify-end', 'gap-x-2')}
+            >
               {form.formState.isDirty && (
-                <Button type="default" onClick={() => form.reset()}>
-                  Cancel
-                </Button>
+                <p className="text-sm text-foreground-light">
+                  {enableSmtp ? (
+                    <>
+                      Rate limit for sending emails will be increased to 30 and can be adjusted{' '}
+                      <InlineLink href={`/project/${projectRef}/auth/rate-limits`}>here</InlineLink>{' '}
+                      after enabling custom SMTP
+                    </>
+                  ) : (
+                    'Rate limit for sending emails will be reduced to 2 after disabling custom SMTP'
+                  )}
+                </p>
               )}
-              <Button
-                type="primary"
-                htmlType="submit"
-                loading={isUpdatingConfig}
-                disabled={!canUpdateConfig || !form.formState.isDirty}
-              >
-                Save changes
-              </Button>
+              <div className="flex items-center gap-x-2">
+                {form.formState.isDirty && (
+                  <Button
+                    type="default"
+                    onClick={() => {
+                      form.reset()
+                      setEnableSmtp(isSmtpEnabled(authConfig))
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                )}
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  loading={isUpdatingConfig}
+                  disabled={!canUpdateConfig || !form.formState.isDirty}
+                >
+                  Save changes
+                </Button>
+              </div>
             </CardFooter>
           </Card>
         </form>


### PR DESCRIPTION
## Context

Just a follow up to a previous PR [here](https://github.com/supabase/supabase/pull/40638)

Adds a text to the card footer when enabling / disabling Custom SMTP regarding the rate limit for sending emails

Text shouldn't show up if editing custom SMTP fields while custom SMTP is enabled

Enabling custom SMTP:
<img width="1089" height="91" alt="image" src="https://github.com/user-attachments/assets/741b1487-883e-420a-b7b6-1064395d20e5" />

Disabling Custom SMTP:
<img width="1084" height="91" alt="image" src="https://github.com/user-attachments/assets/bb603126-3412-488d-86e4-6416ad9bb7b4" />

