### PR TITLE
Support copying by clicking string in TextConfirmationModal

### DIFF
--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { ReactNode, forwardRef, useEffect } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { ReactNode, forwardRef, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import {
   Alert_Shadcn_,
@@ -20,6 +21,7 @@ import {
   Form_Shadcn_,
   Input_Shadcn_,
   cn,
+  copyToClipboard,
 } from 'ui'
 import { DialogHeader } from 'ui/src/components/shadcn/ui/dialog'
 import { z } from 'zod'
@@ -81,6 +83,8 @@ export const TextConfirmModal = forwardRef<
     },
     ref
   ) => {
+    const [showCopied, setShowCopied] = useState(false)
+
     const formSchema = z.object({
       confirmValue: z.preprocess(
         (val) => (typeof val === 'string' ? val.trim() : val),
@@ -111,6 +115,12 @@ export const TextConfirmModal = forwardRef<
     useEffect(() => {
       if (confirmString) form.reset()
     }, [confirmString])
+
+    useEffect(() => {
+      if (!showCopied) return
+      const timer = setTimeout(() => setShowCopied(false), 2000)
+      return () => clearTimeout(timer)
+    }, [showCopied])
 
     return (
       <Dialog
@@ -163,9 +173,19 @@ export const TextConfirmModal = forwardRef<
                   <FormItem_Shadcn_ className="flex flex-col gap-y-2">
                     <FormLabel_Shadcn_ {...label} enableSelection>
                       Type{' '}
-                      <span className="text-foreground break-all whitespace-pre">
+                      <Button
+                        type="default"
+                        className="h-[23px] px-1.5 py-0 border-muted text-sm whitespace-pre break-all"
+                        iconRight={
+                          showCopied ? <Check strokeWidth={2} className="text-brand" /> : <Copy />
+                        }
+                        onClick={() => {
+                          setShowCopied(true)
+                          copyToClipboard(confirmString)
+                        }}
+                      >
                         {confirmString}
-                      </span>{' '}
+                      </Button>{' '}
                       to confirm.
                     </FormLabel_Shadcn_>
                     <FormControl_Shadcn_>

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -171,7 +171,7 @@ export const TextConfirmModal = forwardRef<
                 name="confirmValue"
                 render={({ field }) => (
                   <FormItem_Shadcn_ className="flex flex-col gap-y-2">
-                    <FormLabel_Shadcn_ {...label} enableSelection>
+                    <FormLabel_Shadcn_ {...label}>
                       Type{' '}
                       <Button
                         type="default"


### PR DESCRIPTION
## Context

Nit UX improvement to support copying the confirmation string by clicking in `TextConfirmationModal`

<img width="533" height="371" alt="image" src="https://github.com/user-attachments/assets/0d8152b4-2a9b-40cb-bca0-c42bfd8d8d8f" />
