### PR TITLE
Update service status checks text note when some services are unhealthy

### DIFF
--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -3,8 +3,8 @@ import { AlertTriangle, CheckCircle2, ChevronRight, Loader2 } from 'lucide-react
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
-import { PopoverSeparator } from '@ui/components/shadcn/ui/popover'
 import { useParams } from 'common'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useBranchesQuery } from 'data/branches/branches-query'
 import { useEdgeFunctionServiceStatusQuery } from 'data/service-status/edge-functions-status-query'
 import {
@@ -335,16 +335,27 @@ export const ServiceStatus = () => {
             </div>
           </Link>
         ))}
-        {allServicesOperational ? null : (
-          <>
-            <PopoverSeparator />
-            <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
-              <div className="mt-0.5">
-                <InfoIcon />
-              </div>
-              Recently restored projects can take up to 5 minutes to become fully operational.
+        {!allServicesOperational && (
+          <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
+            <div className="mt-0.5">
+              <InfoIcon />
             </div>
-          </>
+            <div className="flex flex-col gap-y-1">
+              <p>
+                {isProjectNew ? 'New' : 'Recently restored'} projects can take up to{' '}
+                {SERVICE_STATUS_THRESHOLD} minutes to become fully operational.
+              </p>
+              <p>
+                If services stay unhealthy, refer to our{' '}
+                <InlineLink
+                  href={`${DOCS_URL}/guides/troubleshooting/project-status-reports-unhealthy-services`}
+                >
+                  docs
+                </InlineLink>{' '}
+                for more information.
+              </p>
+            </div>
+          </div>
         )}
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
@@ -1,8 +1,9 @@
+import dayjs from 'dayjs'
 import { AlertTriangle, CheckCircle2, ChevronRight, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
-import { PopoverSeparator } from '@ui/components/shadcn/ui/popover'
 import { useParams } from 'common'
+import { InlineLink } from 'components/ui/InlineLink'
 import { SingleStat } from 'components/ui/SingleStat'
 import { useBranchesQuery } from 'data/branches/branches-query'
 import { useEdgeFunctionServiceStatusQuery } from 'data/service-status/edge-functions-status-query'
@@ -14,6 +15,8 @@ import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
 import { InfoIcon, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Popover_Shadcn_, cn } from 'ui'
+
+const SERVICE_STATUS_THRESHOLD = 5 // minutes
 
 /**
  * [Joshen] JFYI before we go live with this, we need to revisit the migrations section
@@ -248,6 +251,7 @@ export const ServiceStatus = () => {
 
   // Check if project or branch is in a startup state
   const isProjectNew =
+    dayjs.utc().diff(dayjs.utc(project?.inserted_at), 'minute') < SERVICE_STATUS_THRESHOLD ||
     project?.status === 'COMING_UP' ||
     (isBranch &&
       (currentBranch?.status === 'CREATING_PROJECT' ||
@@ -269,6 +273,8 @@ export const ServiceStatus = () => {
   }
 
   const overallStatusLabel = getOverallStatusLabel()
+
+  console.log({ project })
 
   return (
     <Popover_Shadcn_>
@@ -301,7 +307,7 @@ export const ServiceStatus = () => {
           value={<span>{overallStatusLabel}</span>}
         />
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ portal className="p-0 w-56" side="bottom" align="start">
+      <PopoverContent_Shadcn_ portal className="p-0 w-60" side="bottom" align="start">
         {services.map((service) => (
           <Link
             href={`/project/${ref}${service.logsUrl}`}
@@ -333,16 +339,28 @@ export const ServiceStatus = () => {
             </div>
           </Link>
         ))}
-        {allServicesOperational ? null : (
-          <>
-            <PopoverSeparator />
-            <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
-              <div className="mt-0.5">
-                <InfoIcon />
-              </div>
-              Recently restored projects can take up to 5 minutes to become fully operational.
+        {/* !allServicesOperational */}
+        {true && (
+          <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
+            <div className="mt-0.5">
+              <InfoIcon />
             </div>
-          </>
+            <div className="flex flex-col gap-y-1">
+              <p>
+                {isProjectNew ? 'New' : 'Recently restored'} projects can take up to{' '}
+                {SERVICE_STATUS_THRESHOLD} minutes to become fully operational.
+              </p>
+              <p>
+                If services stay unhealthy, refer to our{' '}
+                <InlineLink
+                  href={`${DOCS_URL}/guides/troubleshooting/project-status-reports-unhealthy-services`}
+                >
+                  docs
+                </InlineLink>{' '}
+                for more information.
+              </p>
+            </div>
+          </div>
         )}
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
@@ -339,8 +339,7 @@ export const ServiceStatus = () => {
             </div>
           </Link>
         ))}
-        {/* !allServicesOperational */}
-        {true && (
+        {!allServicesOperational && (
           <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
             <div className="mt-0.5">
               <InfoIcon />

--- a/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ServiceStatus.tsx
@@ -274,8 +274,6 @@ export const ServiceStatus = () => {
 
   const overallStatusLabel = getOverallStatusLabel()
 
-  console.log({ project })
-
   return (
     <Popover_Shadcn_>
       <PopoverTrigger_Shadcn_>


### PR DESCRIPTION
## Changes involved

- Improve granularity for "... projects can take up to n minutes" text depending on whether project is newly created
- Adds a text to direct users to our documentation for troubleshooting
  <img width="283" height="134" alt="image" src="https://github.com/user-attachments/assets/931ce7e0-eb84-43ca-9f8c-6662cfcdc5cd" />
- Adds `SERVICE_STATUS_THRESHOLD` check for `project.inserted_at` in `HomeNew` (align with `Home`)
