### PR TITLE
feat: adds success message to link support query

### DIFF
--- a/apps/studio/components/interfaces/Support/CategoryAndSeverityInfo.tsx
+++ b/apps/studio/components/interfaces/Support/CategoryAndSeverityInfo.tsx
@@ -27,8 +27,10 @@ import { NO_PROJECT_MARKER } from './SupportForm.utils'
 interface CategoryAndSeverityInfoProps {
   form: UseFormReturn<SupportFormValues>
   category: ExtendedSupportCategories
-  severity: string
+  severity?: string
   projectRef: string
+  showSeverity?: boolean
+  showIssueSuggestion?: boolean
 }
 
 export function CategoryAndSeverityInfo({
@@ -36,14 +38,19 @@ export function CategoryAndSeverityInfo({
   category,
   severity,
   projectRef,
+  showSeverity = true,
+  showIssueSuggestion = true,
 }: CategoryAndSeverityInfoProps) {
   return (
-    <div className={cn('grid sm:grid-cols-2 sm:grid-rows-1 gap-4 grid-cols-1 grid-rows-2')}>
+    <div
+      className={cn(
+        'grid sm:grid-rows-1 gap-4 grid-cols-1 grid-rows-2',
+        showSeverity ? 'sm:grid-cols-2' : 'sm:grid-cols-1'
+      )}
+    >
       <CategorySelector form={form} />
-      <SeveritySelector form={form} />
-
-      <IssueSuggestion category={category} projectRef={projectRef} />
-
+      {showSeverity && <SeveritySelector form={form} />}
+      {showIssueSuggestion && <IssueSuggestion category={category} projectRef={projectRef} />}
       {(severity === 'Urgent' || severity === 'High') && (
         <Admonition
           type="default"

--- a/apps/studio/components/interfaces/Support/LinkSupportTicketForm.schema.ts
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketForm.schema.ts
@@ -11,7 +11,7 @@ export const LinkSupportTicketFormSchema = z.object({
     .refine((val) => val !== NO_ORG_MARKER, {
       message: 'Please select an organization',
     }),
-  projectRef: z.string().optional(),
+  projectRef: z.string().min(1, 'Please select a project'),
   category: z.enum(
     CATEGORY_OPTIONS.map((opt) => opt.value) as [
       ExtendedSupportCategories,

--- a/apps/studio/components/interfaces/Support/LinkSupportTicketForm.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketForm.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Check, ChevronsUpDown, ChevronRight } from 'lucide-react'
+import { Check, ChevronsUpDown, ChevronRight, Link2 } from 'lucide-react'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import type { SubmitHandler } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -42,10 +41,10 @@ import { NO_ORG_MARKER, NO_PROJECT_MARKER } from './SupportForm.utils'
 
 interface LinkSupportTicketFormProps {
   conversationId: string
+  onSuccess: () => void
 }
 
-export function LinkSupportTicketForm({ conversationId }: LinkSupportTicketFormProps) {
-  const router = useRouter()
+export function LinkSupportTicketForm({ conversationId, onSuccess }: LinkSupportTicketFormProps) {
   const { data: organizations } = useOrganizationsQuery()
 
   const form = useForm<LinkSupportTicketFormValues>({
@@ -64,10 +63,17 @@ export function LinkSupportTicketForm({ conversationId }: LinkSupportTicketFormP
   const { mutate: linkSupportTicket, isLoading } = useLinkSupportTicketMutation({
     onSuccess: () => {
       toast.success('Support ticket linked successfully!')
-      router.push('/')
+      onSuccess()
     },
     onError: (error) => {
-      toast.error(`Failed to link support ticket: ${error.message}`)
+      let errorMessage = error.message
+      try {
+        const parsed = JSON.parse(error.message)
+        errorMessage = parsed?._error?.message || parsed?.message || error.message
+      } catch {
+        // If parsing fails, use the original message
+      }
+      toast.error(`Failed to link support ticket: ${errorMessage}`)
     },
   })
 
@@ -350,6 +356,7 @@ export function LinkSupportTicketForm({ conversationId }: LinkSupportTicketFormP
             htmlType="submit"
             size="large"
             block
+            icon={<Link2 />}
             disabled={isLoading}
             loading={isLoading}
           >

--- a/apps/studio/components/interfaces/Support/LinkSupportTicketForm.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Check, ChevronsUpDown, ChevronRight, Link2 } from 'lucide-react'
-import Link from 'next/link'
+import { Link2 } from 'lucide-react'
+import { useEffect } from 'react'
 import type { SubmitHandler } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -8,44 +8,37 @@ import { toast } from 'sonner'
 import { useLinkSupportTicketMutation } from 'data/feedback/link-support-ticket-mutation'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import {
-  Badge,
   Button,
-  Collapsible_Shadcn_,
-  CollapsibleContent_Shadcn_,
-  CollapsibleTrigger_Shadcn_,
-  CommandGroup_Shadcn_,
-  CommandItem_Shadcn_,
   DialogSectionSeparator,
+  Form_Shadcn_,
   FormControl_Shadcn_,
   FormField_Shadcn_,
-  Form_Shadcn_,
   Input_Shadcn_,
-  Select_Shadcn_,
-  SelectContent_Shadcn_,
-  SelectGroup_Shadcn_,
-  SelectItem_Shadcn_,
-  SelectTrigger_Shadcn_,
-  SelectValue_Shadcn_,
-  Switch,
-  cn,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import { OrganizationProjectSelector } from 'components/ui/OrganizationProjectSelector'
-import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
-import { CATEGORY_OPTIONS, type ExtendedSupportCategories } from './Support.constants'
+import { CategoryAndSeverityInfo } from './CategoryAndSeverityInfo'
 import {
   LinkSupportTicketFormSchema,
   type LinkSupportTicketFormValues,
 } from './LinkSupportTicketForm.schema'
-import { NO_ORG_MARKER, NO_PROJECT_MARKER } from './SupportForm.utils'
+import { OrganizationSelector } from './OrganizationSelector'
+import { ProjectAndPlanInfo } from './ProjectAndPlanInfo'
+import { SUPPORT_ACCESS_CATEGORIES, SupportAccessToggle } from './SupportAccessToggle'
+import { getOrgSubscriptionPlan, NO_ORG_MARKER, NO_PROJECT_MARKER } from './SupportForm.utils'
 
 interface LinkSupportTicketFormProps {
   conversationId: string
   onSuccess: () => void
 }
 
-export function LinkSupportTicketForm({ conversationId, onSuccess }: LinkSupportTicketFormProps) {
-  const { data: organizations } = useOrganizationsQuery()
+// [Joshen] Am reusing the SupportFormV2 components here but am not sure how to type things properly
+// hence marking all the `form` as `any` when passing as props to the components for now
+
+export const LinkSupportTicketForm = ({
+  conversationId,
+  onSuccess,
+}: LinkSupportTicketFormProps) => {
+  const { data: organizations, isSuccess } = useOrganizationsQuery()
 
   const form = useForm<LinkSupportTicketFormValues>({
     resolver: zodResolver(LinkSupportTicketFormSchema),
@@ -60,7 +53,12 @@ export function LinkSupportTicketForm({ conversationId, onSuccess }: LinkSupport
     reValidateMode: 'onBlur',
   })
 
-  const { mutate: linkSupportTicket, isLoading } = useLinkSupportTicketMutation({
+  const { category, organizationSlug, projectRef } = form.watch()
+  const selectedOrgSlug = organizationSlug === NO_ORG_MARKER ? null : organizationSlug
+  const selectedProjectRef = projectRef === NO_PROJECT_MARKER ? null : projectRef
+  const subscriptionPlanId = getOrgSubscriptionPlan(organizations, selectedOrgSlug)
+
+  const { mutate: linkSupportTicket, isPending } = useLinkSupportTicketMutation({
     onSuccess: () => {
       toast.success('Support ticket linked successfully!')
       onSuccess()
@@ -70,27 +68,17 @@ export function LinkSupportTicketForm({ conversationId, onSuccess }: LinkSupport
       try {
         const parsed = JSON.parse(error.message)
         errorMessage = parsed?._error?.message || parsed?.message || error.message
-      } catch {
-        // If parsing fails, use the original message
-      }
+      } catch {}
+      // If parsing fails, use the original message
       toast.error(`Failed to link support ticket: ${errorMessage}`)
     },
   })
 
-  const organizationSlug = form.watch('organizationSlug')
-  const selectedOrgSlug = organizationSlug === NO_ORG_MARKER ? null : organizationSlug
-
   const onSubmit: SubmitHandler<LinkSupportTicketFormValues> = (values) => {
-    if (!organizations) {
-      toast.error('Organizations not loaded. Please try again.')
-      return
-    }
+    if (!organizations) return toast.error('Organizations not loaded. Please try again.')
 
     const selectedOrg = organizations.find((org) => org.slug === values.organizationSlug)
-    if (!selectedOrg) {
-      toast.error('Selected organization not found. Please try again.')
-      return
-    }
+    if (!selectedOrg) return toast.error('Selected organization not found. Please try again.')
 
     linkSupportTicket({
       conversation_id: values.conversation_id,
@@ -100,265 +88,88 @@ export function LinkSupportTicketForm({ conversationId, onSuccess }: LinkSupport
           ? values.projectRef
           : undefined,
       category: values.category,
-      allow_support_access: values.allowSupportAccess,
+      allow_support_access: SUPPORT_ACCESS_CATEGORIES.includes(values.category)
+        ? values.allowSupportAccess
+        : false,
     })
   }
+
+  useEffect(() => {
+    if (!!organizations && organizations.length > 0) {
+      form.reset({
+        conversation_id: conversationId,
+        organizationSlug: organizations[0].slug,
+        projectRef: NO_PROJECT_MARKER,
+        category: '' as any,
+        allowSupportAccess: true,
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess])
 
   return (
     <Form_Shadcn_ {...form}>
       <form
         id="link-support-ticket-form"
         onSubmit={form.handleSubmit(onSubmit)}
-        className="flex flex-col gap-y-6"
+        className="flex flex-col"
       >
-        <h3 className="px-6 text-xl">Link support ticket to account</h3>
-
-        <div className="px-6 flex flex-col gap-y-8">
-          <FormField_Shadcn_
-            control={form.control}
-            name="conversation_id"
-            render={({ field }) => (
-              <FormItemLayout hideMessage layout="vertical" label="Conversation ID">
-                <FormControl_Shadcn_>
-                  <Input_Shadcn_ {...field} disabled readOnly />
-                </FormControl_Shadcn_>
-              </FormItemLayout>
-            )}
-          />
-
-          <FormField_Shadcn_
-            control={form.control}
-            name="organizationSlug"
-            render={({ field }) => {
-              const { ref: _ref, ...fieldWithoutRef } = field
-              return (
-                <FormItemLayout layout="vertical" label="Which organization is affected?">
+        <div className="flex flex-col py-6 gap-y-6">
+          <h3 className="px-6 text-xl">Link support ticket to account</h3>
+          <div className="px-6 flex flex-col gap-y-8">
+            <FormField_Shadcn_
+              control={form.control}
+              name="conversation_id"
+              render={({ field }) => (
+                <FormItemLayout hideMessage layout="vertical" label="Conversation ID">
                   <FormControl_Shadcn_>
-                    <Select_Shadcn_
-                      {...fieldWithoutRef}
-                      disabled={!organizations}
-                      defaultValue={field.value}
-                      onValueChange={(value) => {
-                        const previousOrgSlug = form.getValues('organizationSlug')
-                        field.onChange(value)
-                        if (previousOrgSlug !== value) {
-                          form.resetField('projectRef', { defaultValue: NO_PROJECT_MARKER })
-                        }
-                      }}
-                    >
-                      <SelectTrigger_Shadcn_ className="w-full" aria-label="Select an organization">
-                        <SelectValue_Shadcn_ placeholder="Select an organization">
-                          {organizationSlug === NO_ORG_MARKER
-                            ? 'Select an organization'
-                            : organizations?.find((o) => o.slug === field.value)?.name}
-                        </SelectValue_Shadcn_>
-                      </SelectTrigger_Shadcn_>
-                      <SelectContent_Shadcn_>
-                        <SelectGroup_Shadcn_>
-                          {organizations?.map((org) => (
-                            <SelectItem_Shadcn_ key={org.slug} value={org.slug}>
-                              {org.name}
-                            </SelectItem_Shadcn_>
-                          ))}
-                        </SelectGroup_Shadcn_>
-                      </SelectContent_Shadcn_>
-                    </Select_Shadcn_>
+                    <Input_Shadcn_ {...field} readOnly />
                   </FormControl_Shadcn_>
                 </FormItemLayout>
-              )
-            }}
-          />
+              )}
+            />
 
-          <FormField_Shadcn_
-            control={form.control}
-            name="projectRef"
-            render={({ field }) => (
-              <FormItemLayout hideMessage layout="vertical" label="Which project is affected?">
-                <FormControl_Shadcn_>
-                  <OrganizationProjectSelector
-                    key={selectedOrgSlug}
-                    sameWidthAsTrigger
-                    fetchOnMount
-                    checkPosition="left"
-                    slug={
-                      !selectedOrgSlug || selectedOrgSlug === NO_ORG_MARKER
-                        ? undefined
-                        : selectedOrgSlug
-                    }
-                    selectedRef={field.value}
-                    onSelect={(project) => field.onChange(project.ref)}
-                    renderTrigger={({ isLoading, project }) => {
-                      return (
-                        <Button
-                          block
-                          type="default"
-                          role="combobox"
-                          aria-label="Select a project"
-                          size="small"
-                          className="justify-between"
-                          iconRight={
-                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                          }
-                          disabled={!selectedOrgSlug}
-                        >
-                          {!selectedOrgSlug ? (
-                            'Select an organization first'
-                          ) : isLoading ? (
-                            <ShimmeringLoader className="w-44 py-2" />
-                          ) : !field.value || field.value === NO_PROJECT_MARKER ? (
-                            'No specific project'
-                          ) : (
-                            project?.name ?? 'Unknown project'
-                          )}
-                        </Button>
-                      )
-                    }}
-                    renderActions={(setOpen) => (
-                      <CommandGroup_Shadcn_>
-                        <CommandItem_Shadcn_
-                          className="w-full gap-x-2"
-                          onSelect={() => {
-                            field.onChange(NO_PROJECT_MARKER)
-                            setOpen(false)
-                          }}
-                        >
-                          {field.value === NO_PROJECT_MARKER && <Check size={16} />}
-                          <p className={field.value !== NO_PROJECT_MARKER ? 'ml-6' : ''}>
-                            No specific project
-                          </p>
-                        </CommandItem_Shadcn_>
-                      </CommandGroup_Shadcn_>
-                    )}
-                  />
-                </FormControl_Shadcn_>
-              </FormItemLayout>
+            <OrganizationSelector form={form as any} orgSlug={organizationSlug} />
+            {organizationSlug !== NO_ORG_MARKER && (
+              <ProjectAndPlanInfo
+                form={form as any}
+                orgSlug={selectedOrgSlug}
+                projectRef={selectedProjectRef}
+                subscriptionPlanId={subscriptionPlanId}
+                category={category}
+                showPlanExpectationInfo={false}
+              />
             )}
-          />
 
-          <FormField_Shadcn_
-            control={form.control}
-            name="category"
-            render={({ field }) => {
-              const { ref: _ref, ...fieldWithoutRef } = field
-              return (
-                <FormItemLayout
-                  hideMessage
-                  layout="vertical"
-                  label="What are you having issues with?"
-                >
-                  <FormControl_Shadcn_>
-                    <Select_Shadcn_
-                      {...fieldWithoutRef}
-                      defaultValue={field.value}
-                      onValueChange={field.onChange}
-                    >
-                      <SelectTrigger_Shadcn_ aria-label="Select an issue" className="w-full">
-                        <SelectValue_Shadcn_ placeholder="Select an issue">
-                          {field.value
-                            ? CATEGORY_OPTIONS.find((o) => o.value === field.value)?.label
-                            : null}
-                        </SelectValue_Shadcn_>
-                      </SelectTrigger_Shadcn_>
-                      <SelectContent_Shadcn_>
-                        <SelectGroup_Shadcn_>
-                          {CATEGORY_OPTIONS.filter((option) => !option.hidden).map((option) => (
-                            <SelectItem_Shadcn_ key={option.value} value={option.value}>
-                              {option.label}
-                              <span className="block text-xs text-foreground-lighter">
-                                {option.description}
-                              </span>
-                            </SelectItem_Shadcn_>
-                          ))}
-                        </SelectGroup_Shadcn_>
-                      </SelectContent_Shadcn_>
-                    </Select_Shadcn_>
-                  </FormControl_Shadcn_>
-                </FormItemLayout>
-              )
-            }}
-          />
+            <CategoryAndSeverityInfo
+              showSeverity={false}
+              showIssueSuggestion={false}
+              form={form as any}
+              category={category}
+              projectRef={projectRef}
+            />
+          </div>
         </div>
 
         <DialogSectionSeparator />
 
-        <FormField_Shadcn_
-          control={form.control}
-          name="allowSupportAccess"
-          render={({ field }) => {
-            return (
-              <FormItemLayout
-                hideMessage
-                name="allowSupportAccess"
-                className="px-6"
-                layout="flex"
-                label={
-                  <div className="flex items-center gap-x-2">
-                    <span className="text-foreground">Allow support access to your project</span>
-                    <Badge className="bg-opacity-100">Recommended</Badge>
-                  </div>
-                }
-                description={
-                  <div className="flex flex-col">
-                    <span className="text-foreground-light">
-                      Human support and AI diagnostic access.
-                    </span>
-                    <Collapsible_Shadcn_ className="mt-2">
-                      <CollapsibleTrigger_Shadcn_
-                        className={
-                          'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
-                        }
-                      >
-                        <ChevronRight
-                          size={14}
-                          className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
-                        />
-                        <span className="text-sm">More information</span>
-                      </CollapsibleTrigger_Shadcn_>
-                      <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
-                        <p>
-                          By enabling this, you grant permission for our support team to access your
-                          project temporarily and, if applicable, to use AI tools to assist in
-                          diagnosing and resolving issues. This access may involve analyzing
-                          database configurations, query performance, and other relevant data to
-                          expedite troubleshooting and enhance support accuracy.
-                        </p>
-                        <p>
-                          We are committed to maintaining strict data privacy and security standards
-                          in all support activities.{' '}
-                          <Link
-                            href="https://supabase.com/privacy"
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-foreground-light underline hover:text-foreground transition"
-                          >
-                            Privacy Policy
-                          </Link>
-                        </p>
-                      </CollapsibleContent_Shadcn_>
-                    </Collapsible_Shadcn_>
-                  </div>
-                }
-              >
-                <Switch
-                  size="large"
-                  id="allowSupportAccess"
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
-              </FormItemLayout>
-            )
-          }}
-        />
+        {SUPPORT_ACCESS_CATEGORIES.includes(category) && (
+          <>
+            <div className="py-4">
+              <SupportAccessToggle form={form as any} />
+            </div>
+            <DialogSectionSeparator />
+          </>
+        )}
 
-        <div className="px-6 pt-2">
+        <div className="px-6 py-8">
           <Button
+            block
             type="primary"
             htmlType="submit"
             size="large"
-            block
             icon={<Link2 />}
-            disabled={isLoading}
-            loading={isLoading}
+            loading={isPending}
           >
             Link support ticket to account
           </Button>

--- a/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
@@ -42,7 +42,10 @@ function LinkSupportTicketPageContent() {
       {isSuccess ? (
         <LinkSupportTicketSuccess />
       ) : (
-        <LinkSupportTicketForm conversationId={conversationId} onSuccess={() => setIsSuccess(true)} />
+        <LinkSupportTicketForm
+          conversationId={conversationId}
+          onSuccess={() => setIsSuccess(true)}
+        />
       )}
     </div>
   )

--- a/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
@@ -1,17 +1,22 @@
 import { Check, Mail } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { type PropsWithChildren, useState } from 'react'
+import { useState } from 'react'
 
-import { Button, Separator } from 'ui'
+import { Button, cn, DialogSectionSeparator } from 'ui'
 import { Admonition } from 'ui-patterns'
+import { HighlightProjectRefProvider } from './HighlightContext'
 import { LinkSupportTicketForm } from './LinkSupportTicketForm'
 
 export function LinkSupportTicketPage() {
   return (
-    <LinkSupportTicketPageWrapper>
-      <LinkSupportTicketPageContent />
-    </LinkSupportTicketPageWrapper>
+    <div className="h-full relative overflow-y-auto overflow-x-hidden">
+      <div className="h-full flex flex-col gap-y-8 items-center justify-center mx-auto max-w-2xl w-full px-4 lg:px-6">
+        <HighlightProjectRefProvider>
+          <LinkSupportTicketPageContent />
+        </HighlightProjectRefProvider>
+      </div>
+    </div>
   )
 }
 
@@ -37,7 +42,9 @@ function LinkSupportTicketPageContent() {
 
   return (
     <div
-      className={`min-w-full w-full space-y-12 rounded border bg-panel-body-light shadow-md ${isSuccess ? 'pt-8' : 'py-8'} border-default`}
+      className={cn(
+        'min-w-full w-full space-y-12 rounded border bg-panel-body-light shadow-md border-default'
+      )}
     >
       {isSuccess ? (
         <LinkSupportTicketSuccess />
@@ -53,36 +60,26 @@ function LinkSupportTicketPageContent() {
 
 function LinkSupportTicketSuccess() {
   return (
-    <div className="w-full flex flex-col items-center space-y-4">
-      <div className="relative">
-        <Mail strokeWidth={1.5} size={60} className="text-brand" />
-        <div className="h-6 w-6 rounded-full bg-brand absolute bottom-1 -right-1.5 flex items-center justify-center">
-          <Check strokeWidth={4} size={18} />
+    <div className="w-full flex flex-col items-center">
+      <div className="flex flex-col items-center gap-y-4 py-8">
+        <div className="relative">
+          <Mail strokeWidth={1.5} size={60} className="text-brand" />
+          <div className="h-6 w-6 rounded-full bg-brand absolute bottom-1 -right-1.5 flex items-center justify-center">
+            <Check strokeWidth={4} size={18} />
+          </div>
+        </div>
+        <div className="flex items-center flex-col gap-y-2 text-center">
+          <h3 className="text-xl">Support ticket linked successfully!</h3>
+          <p className="text-sm text-foreground-light">
+            Your support conversation has been linked to your account.
+          </p>
         </div>
       </div>
-      <div className="flex items-center flex-col space-y-2 text-center p-4">
-        <h3 className="text-xl">Support ticket linked successfully!</h3>
-        <p className="text-sm text-foreground-light">
-          Your support conversation has been linked to your account.
-        </p>
-      </div>
-      <div className="w-full">
-        <Separator />
-      </div>
-      <div className="w-full pb-4 px-4 flex items-center justify-end">
+      <DialogSectionSeparator />
+      <div className="w-full py-4 px-4 flex items-center justify-end">
         <Link href="/">
           <Button>Go back</Button>
         </Link>
-      </div>
-    </div>
-  )
-}
-
-function LinkSupportTicketPageWrapper({ children }: PropsWithChildren) {
-  return (
-    <div className="relative overflow-y-auto overflow-x-hidden">
-      <div className="mx-auto my-16 max-w-2xl w-full px-4 lg:px-6">
-        <div className="flex flex-col gap-y-8">{children}</div>
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketPage.tsx
@@ -1,6 +1,9 @@
+import { Check, Mail } from 'lucide-react'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
-import type { PropsWithChildren } from 'react'
+import { type PropsWithChildren, useState } from 'react'
 
+import { Button, Separator } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { LinkSupportTicketForm } from './LinkSupportTicketForm'
 
@@ -15,6 +18,12 @@ export function LinkSupportTicketPage() {
 function LinkSupportTicketPageContent() {
   const router = useRouter()
   const conversationId = router.query.conversationId as string | undefined
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  // Wait for router to be ready before checking for conversationId
+  if (!router.isReady) {
+    return null
+  }
 
   if (!conversationId) {
     return (
@@ -27,8 +36,41 @@ function LinkSupportTicketPageContent() {
   }
 
   return (
-    <div className="min-w-full w-full space-y-12 rounded border bg-panel-body-light shadow-md py-8 border-default">
-      <LinkSupportTicketForm conversationId={conversationId} />
+    <div
+      className={`min-w-full w-full space-y-12 rounded border bg-panel-body-light shadow-md ${isSuccess ? 'pt-8' : 'py-8'} border-default`}
+    >
+      {isSuccess ? (
+        <LinkSupportTicketSuccess />
+      ) : (
+        <LinkSupportTicketForm conversationId={conversationId} onSuccess={() => setIsSuccess(true)} />
+      )}
+    </div>
+  )
+}
+
+function LinkSupportTicketSuccess() {
+  return (
+    <div className="w-full flex flex-col items-center space-y-4">
+      <div className="relative">
+        <Mail strokeWidth={1.5} size={60} className="text-brand" />
+        <div className="h-6 w-6 rounded-full bg-brand absolute bottom-1 -right-1.5 flex items-center justify-center">
+          <Check strokeWidth={4} size={18} />
+        </div>
+      </div>
+      <div className="flex items-center flex-col space-y-2 text-center p-4">
+        <h3 className="text-xl">Support ticket linked successfully!</h3>
+        <p className="text-sm text-foreground-light">
+          Your support conversation has been linked to your account.
+        </p>
+      </div>
+      <div className="w-full">
+        <Separator />
+      </div>
+      <div className="w-full pb-4 px-4 flex items-center justify-end">
+        <Link href="/">
+          <Button>Go back</Button>
+        </Link>
+      </div>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -32,6 +32,7 @@ interface ProjectAndPlanProps {
   projectRef: string | null
   category: ExtendedSupportCategories
   subscriptionPlanId: string | undefined
+  showPlanExpectationInfo?: boolean
 }
 
 export function ProjectAndPlanInfo({
@@ -40,6 +41,7 @@ export function ProjectAndPlanInfo({
   projectRef,
   category,
   subscriptionPlanId,
+  showPlanExpectationInfo = true,
 }: ProjectAndPlanProps) {
   const { ref } = useHighlightProjectRefContext()
   const hasProjectSelected = projectRef && projectRef !== NO_PROJECT_MARKER
@@ -50,12 +52,19 @@ export function ProjectAndPlanInfo({
       <ProjectRefHighlighted projectRef={projectRef} />
 
       {!hasProjectSelected && (
-        <Admonition type="default" title="Please note that no project has been selected" />
+        <Admonition
+          type="default"
+          className="mb-0"
+          title="Please note that no project has been selected"
+        />
       )}
 
-      {orgSlug && subscriptionPlanId !== 'enterprise' && category !== 'Login_issues' && (
-        <PlanExpectationInfoBox orgSlug={orgSlug} planId={subscriptionPlanId} />
-      )}
+      {showPlanExpectationInfo &&
+        orgSlug &&
+        subscriptionPlanId !== 'enterprise' &&
+        category !== 'Login_issues' && (
+          <PlanExpectationInfoBox orgSlug={orgSlug} planId={subscriptionPlanId} />
+        )}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
@@ -31,7 +31,7 @@ export function SupportAccessToggle({ form }: SupportAccessToggleProps) {
   return (
     <FormField_Shadcn_
       name="allowSupportAccess"
-      control={form.control}
+      control={form.control as any}
       render={({ field }) => {
         return (
           <FormItemLayout

--- a/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
@@ -31,7 +31,7 @@ export function SupportAccessToggle({ form }: SupportAccessToggleProps) {
   return (
     <FormField_Shadcn_
       name="allowSupportAccess"
-      control={form.control as any}
+      control={form.control}
       render={({ field }) => {
         return (
           <FormItemLayout

--- a/apps/studio/hooks/misc/useHideSidebar.ts
+++ b/apps/studio/hooks/misc/useHideSidebar.ts
@@ -6,7 +6,7 @@ export function useHideSidebar() {
   const shouldHide =
     pathname.startsWith('/account') ||
     pathname.startsWith('/new') ||
-    pathname === '/support/new' ||
+    pathname.startsWith('/support') ||
     pathname === '/organizations' ||
     pathname === '/sign-in'
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Upon success the link conversation support form auto redirected back to the dashboard.

## What is the new behavior?

The link form shows a success message with a back button to improve the user experience.

<img width="1504" height="801" alt="image" src="https://github.com/user-attachments/assets/924d77d7-9458-469f-baf8-c415f2149f94" />
