### PR TITLE
chore: oauth apps update

### DIFF
--- a/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
@@ -55,7 +55,6 @@ const FormSchema = z.object({
     .min(1, 'Please provide a name for your OAuth app')
     .max(100, 'Name must be less than 100 characters'),
   type: z.enum(['manual', 'dynamic']).default('manual'),
-  // scope: z.string().min(1, 'Please select a scope'),
   redirect_uris: z
     .object({
       value: z.string().trim().url('Please provide a valid URL'),

--- a/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
@@ -264,7 +264,7 @@ export const CreateOrUpdateOAuthAppSheet = ({
                           <FormField_Shadcn_
                             control={form.control}
                             name="client_id"
-                            render={({ field }) => (
+                            render={() => (
                               <FormItemLayout label="Client ID">
                                 <FormControl_Shadcn_>
                                   <Input
@@ -283,7 +283,7 @@ export const CreateOrUpdateOAuthAppSheet = ({
                           <FormField_Shadcn_
                             control={form.control}
                             name="client_secret"
-                            render={({ field }) => (
+                            render={() => (
                               <FormItemLayout
                                 label="Client Secret"
                                 description="Client secret is hidden for security. Use the regenerate button to create a new one."

--- a/apps/studio/components/interfaces/Auth/OAuthApps/NewOAuthAppBanner.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/NewOAuthAppBanner.tsx
@@ -23,23 +23,23 @@ export const NewOAuthAppBanner = ({ oauthApp, onClose }: NewOAuthAppBannerProps)
             Do copy this client id and client secret and store it in a secure place - you will not
             be able to see it again.
           </p>
-          <div className="max-w-xl">
+          <div className="">
             <Input
               copy
               readOnly
               size="small"
-              className="max-w-xl input-mono"
+              className="input-mono"
               value={oauthApp?.client_id}
               onChange={() => {}}
               onCopy={() => toast.success('Client Id copied to clipboard')}
             />
           </div>
-          <div className="max-w-xl">
+          <div className="">
             <Input
               copy
               readOnly
               size="small"
-              className="max-w-xl input-mono"
+              className=" input-mono"
               value={oauthApp?.client_secret}
               onChange={() => {}}
               onCopy={() => toast.success('Client secret copied to clipboard')}
@@ -51,7 +51,7 @@ export const NewOAuthAppBanner = ({ oauthApp, onClose }: NewOAuthAppBannerProps)
       <Button
         type="text"
         icon={<X />}
-        className="w-7 h-7 absolute top-3 right-3"
+        className="w-7 h-7 absolute top-0 right-0"
         onClick={onClose}
       />
     </Admonition>

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -240,7 +240,7 @@ export const OAuthAppsList = () => {
                   <TableHead>Registration Type</TableHead>
                   <TableHead>Created</TableHead>
                   <TableHead className="w-8 px-0">
-                    <div className="!bg-200 px-4 w-full h-full flex items-center border-l @[904px]:border-l-0" />
+                    <div className="!bg-200 px-4 w-full h-full flex items-center border-l @[944px]:border-l-0" />
                   </TableHead>
                 </TableRow>
               </TableHeader>
@@ -255,10 +255,10 @@ export const OAuthAppsList = () => {
                 {filteredOAuthApps.length > 0 &&
                   filteredOAuthApps.map((app) => (
                     <TableRow key={app.client_id} className="w-full">
-                      <TableCell className="w-100 max-w-64 truncate" title={app.client_name}>
+                      <TableCell className="w-48 max-w-48 flex" title={app.client_name}>
                         <Button
                           type="text"
-                          className="text-link-table-cell text-sm p-0 hover:bg-transparent title"
+                          className="text-link-table-cell text-sm p-0 hover:bg-transparent title [&>span]:!w-full"
                           onClick={() => handleEditClick(app)}
                           title={app.client_name}
                         >
@@ -277,8 +277,8 @@ export const OAuthAppsList = () => {
                       <TableCell className="text-xs text-foreground-light min-w-28 max-w-40 w-1/6">
                         <TimestampInfo utcTimestamp={app.created_at} labelFormat="D MMM, YYYY" />
                       </TableCell>
-                      <TableCell className="max-w-20 bg-surface-100 @[904px]:hover:bg-surface-200 px-6">
-                        <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[904px]:border-l-0">
+                      <TableCell className="max-w-20 bg-surface-100 @[944px]:hover:bg-surface-200 px-6">
+                        <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[944px]:border-l-0">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button type="default" className="px-1" icon={<MoreVertical />} />

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -236,8 +236,8 @@ export const OAuthAppsList = () => {
                 <TableRow>
                   <TableHead>Name</TableHead>
                   <TableHead>Client ID</TableHead>
-                  <TableHead>Registration Type</TableHead>
                   <TableHead>Client Type</TableHead>
+                  <TableHead>Registration Type</TableHead>
                   <TableHead>Created</TableHead>
                   <TableHead className="w-8 px-0">
                     <div className="!bg-200 px-4 w-full h-full flex items-center border-l @[904px]:border-l-0" />
@@ -269,10 +269,10 @@ export const OAuthAppsList = () => {
                         <Badge className="font-mono">{app.client_id}</Badge>
                       </TableCell>
                       <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
-                        {app.registration_type}
+                        {app.client_type}
                       </TableCell>
                       <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
-                        {app.client_type}
+                        {app.registration_type}
                       </TableCell>
                       <TableCell className="text-xs text-foreground-light min-w-28 max-w-40 w-1/6">
                         <TimestampInfo utcTimestamp={app.created_at} labelFormat="D MMM, YYYY" />

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -250,7 +250,7 @@ export const OAuthAppsList = () => {
                           {app.client_name}
                         </Button>
                       </TableCell>
-                      <TableCell className="max-w-40" title={app.client_id}>
+                      <TableCell title={app.client_id}>
                         <Badge className="font-mono">{app.client_id}</Badge>
                       </TableCell>
                       <TableCell className="max-w-40">

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -270,7 +270,7 @@ export const OAuthAppsList = () => {
                       <TableCell className="text-xs text-foreground-light min-w-28 max-w-40 w-1/6">
                         <TimestampInfo utcTimestamp={app.created_at} labelFormat="D MMM, YYYY" />
                       </TableCell>
-                      <TableCell className="max-w-20 sticky bg-surface-100 right-0 px-6">
+                      <TableCell className="max-w-20 bg-surface-100 @[954px]:hover:bg-surface-200 px-6">
                         <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[954px]:border-l-0">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -223,10 +223,9 @@ export const OAuthAppsList = () => {
                   <TableHead>Client ID</TableHead>
                   <TableHead>Registration</TableHead>
                   <TableHead>Type</TableHead>
-                  <TableHead>Scope</TableHead>
                   <TableHead>Created</TableHead>
                   <TableHead className="w-8 px-0">
-                    <div className="!bg-200 px-4 w-full h-full flex items-center border-l @[954px]:border-l-0" />
+                    <div className="!bg-200 px-4 w-full h-full flex items-center border-l @[846px]:border-l-0" />
                   </TableHead>
                 </TableRow>
               </TableHeader>
@@ -260,18 +259,11 @@ export const OAuthAppsList = () => {
                       <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
                         {app.client_type}
                       </TableCell>
-                      <TableCell className="min-w-28 max-w-40">
-                        {app.scope ? (
-                          <Badge>{app.scope}</Badge>
-                        ) : (
-                          <span className="text-xs text-foreground-light">N/A</span>
-                        )}
-                      </TableCell>
                       <TableCell className="text-xs text-foreground-light min-w-28 max-w-40 w-1/6">
                         <TimestampInfo utcTimestamp={app.created_at} labelFormat="D MMM, YYYY" />
                       </TableCell>
-                      <TableCell className="max-w-20 bg-surface-100 @[954px]:hover:bg-surface-200 px-6">
-                        <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[954px]:border-l-0">
+                      <TableCell className="max-w-20 bg-surface-100 @[846px]:hover:bg-surface-200 px-6">
+                        <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[846px]:border-l-0">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button type="default" className="px-1" icon={<MoreVertical />} />
@@ -319,10 +311,14 @@ export const OAuthAppsList = () => {
         visible={showCreateSheet || !!appToEdit}
         appToEdit={appToEdit}
         onSuccess={(app) => {
+          const isCreating = !appToEdit
           setShowCreateSheet(false)
           setSelectedAppToEdit(null)
           setSelectedApp(undefined)
-          setNewOAuthApp(app)
+          // Only show banner for new apps or regenerated secrets, not for simple edits
+          if (isCreating || app.client_secret) {
+            setNewOAuthApp(app)
+          }
         }}
         onCancel={() => {
           setShowCreateSheet(false)

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -283,7 +283,7 @@ export const OAuthAppsList = () => {
                             <DropdownMenuTrigger asChild>
                               <Button type="default" className="px-1" icon={<MoreVertical />} />
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent side="bottom" align="end" className="w-52">
+                            <DropdownMenuContent side="bottom" align="end" className="w-48">
                               <DropdownMenuItem
                                 className="space-x-2"
                                 onClick={() => {
@@ -293,16 +293,18 @@ export const OAuthAppsList = () => {
                                 <Edit size={12} />
                                 <p>Update</p>
                               </DropdownMenuItem>
-                              <DropdownMenuItem
-                                className="space-x-2"
-                                onClick={() => {
-                                  setSelectedApp(app)
-                                  setShowRegenerateDialog(true)
-                                }}
-                              >
-                                <RotateCw size={12} />
-                                <p>Regenerate client secret</p>
-                              </DropdownMenuItem>
+                              {app.client_type === 'confidential' && (
+                                <DropdownMenuItem
+                                  className="space-x-2"
+                                  onClick={() => {
+                                    setSelectedApp(app)
+                                    setShowRegenerateDialog(true)
+                                  }}
+                                >
+                                  <RotateCw size={12} />
+                                  <p>Regenerate client secret</p>
+                                </DropdownMenuItem>
+                              )}
                               <DropdownMenuItem
                                 className="space-x-2"
                                 onClick={() => handleDeleteClick(app)}

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -142,7 +142,7 @@ export const OAuthAppsList = () => {
   return (
     <>
       <div className="space-y-4">
-        {newOAuthApp && (
+        {newOAuthApp?.client_secret && (
           <NewOAuthAppBanner oauthApp={newOAuthApp} onClose={() => setNewOAuthApp(undefined)} />
         )}
         {!isOAuthServerEnabled && (

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -241,7 +241,14 @@ export const OAuthAppsList = () => {
                   oAuthApps.map((app) => (
                     <TableRow key={app.client_id} className="w-full">
                       <TableCell className="w-100 max-w-64 truncate" title={app.client_name}>
-                        {app.client_name}
+                        <Button
+                          type="text"
+                          className="text-link-table-cell text-sm p-0 hover:bg-transparent title"
+                          onClick={() => handleEditClick(app)}
+                          title={app.client_name}
+                        >
+                          {app.client_name}
+                        </Button>
                       </TableCell>
                       <TableCell className="max-w-40" title={app.client_id}>
                         <Badge className="font-mono">{app.client_id}</Badge>

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -82,8 +82,6 @@ export const OAuthAppsList = () => {
 
   const oAuthApps = data?.clients || []
 
-  console.log('oAuthApps', oAuthApps)
-
   const [showCreateSheet, setShowCreateSheet] = useQueryState(
     'new',
     parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
@@ -217,16 +215,19 @@ export const OAuthAppsList = () => {
         </div>
 
         <div className="w-full overflow-hidden overflow-x-auto">
-          <Card>
-            <Table>
+          <Card className="@container">
+            <Table containerProps={{ stickyLastColumn: true }}>
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
                   <TableHead>Client ID</TableHead>
+                  <TableHead>Registration</TableHead>
                   <TableHead>Type</TableHead>
                   <TableHead>Scope</TableHead>
                   <TableHead>Created</TableHead>
-                  <TableHead className="w-8"></TableHead>
+                  <TableHead className="w-8 px-0">
+                    <div className="!bg-200 px-4 w-full h-full flex items-center border-l @[954px]:border-l-0" />
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -253,21 +254,24 @@ export const OAuthAppsList = () => {
                       <TableCell title={app.client_id}>
                         <Badge className="font-mono">{app.client_id}</Badge>
                       </TableCell>
-                      <TableCell className="max-w-40">
-                        {app.client_type === 'public' ? 'Public' : 'Private'}
+                      <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
+                        {app.registration_type}
                       </TableCell>
-                      <TableCell className="max-w-40">
+                      <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
+                        {app.client_type}
+                      </TableCell>
+                      <TableCell className="min-w-28 max-w-40">
                         {app.scope ? (
                           <Badge>{app.scope}</Badge>
                         ) : (
                           <span className="text-xs text-foreground-light">N/A</span>
                         )}
                       </TableCell>
-                      <TableCell className="text-xs text-foreground-light w-1/6">
+                      <TableCell className="text-xs text-foreground-light min-w-28 max-w-40 w-1/6">
                         <TimestampInfo utcTimestamp={app.created_at} labelFormat="D MMM, YYYY" />
                       </TableCell>
-                      <TableCell>
-                        <div className="flex justify-end items-center">
+                      <TableCell className="max-w-20 sticky bg-surface-100 right-0 px-6">
+                        <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[954px]:border-l-0">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button type="default" className="px-1" icon={<MoreVertical />} />

--- a/apps/studio/components/interfaces/Auth/OAuthApps/oauthApps.utils.ts
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/oauthApps.utils.ts
@@ -1,0 +1,53 @@
+import type { OAuthClient } from '@supabase/supabase-js'
+
+export const OAUTH_APP_REGISTRATION_TYPE_OPTIONS = [
+  { name: 'Manual', value: 'manual' },
+  { name: 'Dynamic', value: 'dynamic' },
+]
+
+export const OAUTH_APP_CLIENT_TYPE_OPTIONS = [
+  { name: 'Public', value: 'public' },
+  { name: 'Confidential', value: 'confidential' },
+]
+
+interface FilterOAuthAppsParams {
+  apps: OAuthClient[]
+  searchString?: string
+  registrationTypes?: string[]
+  clientTypes?: string[]
+}
+
+export function filterOAuthApps({
+  apps,
+  searchString,
+  registrationTypes = [],
+  clientTypes = [],
+}: FilterOAuthAppsParams): OAuthClient[] {
+  return apps.filter((app) => {
+    // Filter by search string
+    if (searchString) {
+      const searchLower = searchString.toLowerCase()
+      const matchesName = app.client_name.toLowerCase().includes(searchLower)
+      const matchesClientId = app.client_id.toLowerCase().includes(searchLower)
+      if (!matchesName && !matchesClientId) {
+        return false
+      }
+    }
+
+    // Filter by registration type
+    if (registrationTypes.length > 0) {
+      if (!registrationTypes.includes(app.registration_type)) {
+        return false
+      }
+    }
+
+    // Filter by client type
+    if (clientTypes.length > 0) {
+      if (!clientTypes.includes(app.client_type)) {
+        return false
+      }
+    }
+
+    return true
+  })
+}

--- a/apps/studio/data/oauth-server-apps/oauth-server-app-update-mutation.ts
+++ b/apps/studio/data/oauth-server-apps/oauth-server-app-update-mutation.ts
@@ -1,0 +1,60 @@
+import { UpdateOAuthClientParams, SupabaseClient } from '@supabase/supabase-js'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from 'types'
+import { oauthServerAppKeys } from './keys'
+
+export type OAuthServerAppUpdateVariables = UpdateOAuthClientParams & {
+  clientId: string
+  projectRef?: string
+  supabaseClient?: SupabaseClient<any>
+}
+
+export async function updateOAuthServerApp({
+  clientId,
+  projectRef,
+  supabaseClient,
+  ...params
+}: OAuthServerAppUpdateVariables) {
+  if (!projectRef) throw new Error('Project reference is required')
+  if (!supabaseClient) throw new Error('Supabase client is required')
+
+  const { data, error } = await supabaseClient.auth.admin.oauth.updateClient(clientId, params)
+
+  if (error) return handleError(error)
+  return data
+}
+
+type OAuthAppUpdateData = Awaited<ReturnType<typeof updateOAuthServerApp>>
+
+export const useOAuthServerAppUpdateMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseCustomMutationOptions<OAuthAppUpdateData, ResponseError, OAuthServerAppUpdateVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<OAuthAppUpdateData, ResponseError, OAuthServerAppUpdateVariables>({
+    mutationFn: (vars) => updateOAuthServerApp(vars),
+    onSuccess: async (data, variables, context) => {
+      const { projectRef } = variables
+      await queryClient.invalidateQueries({
+        queryKey: oauthServerAppKeys.list(projectRef),
+      })
+      await onSuccess?.(data, variables, context)
+    },
+    onError: async (data, variables, context) => {
+      if (onError === undefined) {
+        toast.error(`Failed to update OAuth Server application: ${data.message}`)
+      } else {
+        onError(data, variables, context)
+      }
+    },
+    ...options,
+  })
+}

--- a/apps/studio/pages/project/[ref]/auth/oauth-apps.tsx
+++ b/apps/studio/pages/project/[ref]/auth/oauth-apps.tsx
@@ -3,16 +3,14 @@ import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
+import { DOCS_URL } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
 
 const OAuthApps: NextPageWithLayout = () => (
   <ScaffoldContainer>
     <ScaffoldSection>
       <div className="col-span-12">
-        <FormHeader
-          title="OAuth Apps"
-          docsUrl="https://supabase.com/docs/guides/auth/oauth-server"
-        />
+        <FormHeader title="OAuth Apps" docsUrl={`${DOCS_URL}/guides/auth/oauth-server`} />
         <OAuthAppsList />
       </div>
     </ScaffoldSection>

--- a/apps/studio/pages/project/[ref]/auth/oauth-server.tsx
+++ b/apps/studio/pages/project/[ref]/auth/oauth-server.tsx
@@ -2,7 +2,9 @@ import { OAuthServerSettingsForm } from 'components/interfaces/Auth/OAuthApps/OA
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
+import { DocsButton } from 'components/ui/DocsButton'
 import { ScaffoldContainer } from 'components/layouts/Scaffold'
+import { DOCS_URL } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
 
 const ProvidersPage: NextPageWithLayout = () => {
@@ -13,12 +15,15 @@ const ProvidersPage: NextPageWithLayout = () => {
   )
 }
 
+const secondaryActions = [<DocsButton key="docs" href={`${DOCS_URL}/guides/auth/oauth-server`} />]
+
 ProvidersPage.getLayout = (page) => (
   <DefaultLayout>
     <AuthLayout>
       <PageLayout
         title="OAuth Server"
         subtitle="Configure your project to act as an identity provider for third-party applications"
+        secondaryActions={secondaryActions}
       >
         {page}
       </PageLayout>


### PR DESCRIPTION
- Add OAuth Apps update panel
- Add uploadable logo via _logo_uri_ to oauth app form
- Make secrets regenerateable from update panel
- Hide client_secret logic if oauth app is confidential
- Fix _public client_ toggle on oauth app form (readonly on edit)
- Implement proper filtering on OAuth Apps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a unified create/update OAuth app sheet with logo upload and secret regeneration, add client/registration-type filtering and edit flows, plus update mutation and docs links.
> 
> - **OAuth Apps UI**:
>   - **Unified Sheet**: Replace `CreateOAuthAppSheet` with `CreateOrUpdateOAuthAppSheet` supporting create and update flows, logo upload (`logo_uri`), and public/confidential client handling (PKCE toggle read-only on edit).
>   - **Secret Management**: Add client secret regeneration from the update panel with confirmation modal; banner only shows when new secret exists.
>   - **Table & Actions**: Add inline “Update” action; conditional “Regenerate client secret” for confidential clients; table shows `client_type` and `registration_type`; sticky last column; name is clickable to edit.
>   - **Filtering**: Implement search and filters by registration type and client type with reset; extracted helpers in `oauthApps.utils` (`filterOAuthApps`, option constants).
> - **Data Layer**:
>   - Add `useOAuthServerAppUpdateMutation` (`oauth-server-app-update-mutation.ts`) to update OAuth clients and invalidate list cache.
> - **Docs & Layout**:
>   - Use `DOCS_URL` for OAuth docs links and add `DocsButton` on OAuth Server page.
> - **Polish**:
>   - Minor banner and UI refinements (copy inputs, spacing, table container).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 828d42ba2e159bfcab4bae2b567355c9118e9f1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->