### PR TITLE
docs: Use getClaims instead of getUser in Next.js Auth prompt

### DIFF
--- a/examples/prompts/nextjs-supabase-auth.md
+++ b/examples/prompts/nextjs-supabase-auth.md
@@ -149,17 +149,16 @@ export async function middleware(request: NextRequest) {
   )
 
   // Do not run code between createServerClient and
-  // supabase.auth.getUser(). A simple mistake could make it very hard to debug
+  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
   // issues with users being randomly logged out.
 
-  // IMPORTANT: DO NOT REMOVE auth.getUser()
+  // IMPORTANT: DO NOT REMOVE auth.getClaims()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data } = await supabase.auth.getClaims()
+  const claims = data?.claims
 
   if (
-    !user &&
+    !claims &&
     !request.nextUrl.pathname.startsWith('/login') &&
     !request.nextUrl.pathname.startsWith('/auth')
   ) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR updates the Next.js Supabase Auth AI tools prompt to use `supabase.auth.getClaims()` from the Supabase SDK instead of `supabase.auth.getUser()`. This is generally good practice, as `getClaims` does not make network calls unless the user's session is invalid or uses a symmetric signing key.

## What is the current behavior?

This prompt instructs the AI tool to use `getUser`, which always makes a network call to the project's Auth API.

## What is the new behavior?

The prompt instructs the AI tool to use `getClaims`, which is generally faster as long as a user has migrated their JWT signing keys.
