### PR TITLE
Chore/fix storage upload sanitize duplicate name

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -6,6 +6,7 @@ import {
 } from 'components/ui/VirtualizedTable'
 import { Bucket } from 'data/storage/buckets-query'
 import { FilesBucket as FilesBucketIcon } from 'icons'
+import { BASE_PATH } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
 import { ChevronRight } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -93,7 +94,7 @@ export const BucketTableRow = ({
   ) => {
     const url = `/project/${projectRef}/storage/files/buckets/${encodeURIComponent(bucketId)}`
     if (event.metaKey || event.ctrlKey) {
-      window.open(url, '_blank')
+      window.open(`${BASE_PATH}${url}`, '_blank')
     } else {
       router.push(url)
     }

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/index.tsx
@@ -8,6 +8,7 @@ import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useVectorBucketsQuery } from 'data/storage/vector-buckets-query'
 import { VectorBucket as VectorBucketIcon } from 'icons'
+import { BASE_PATH } from 'lib/constants'
 import { Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
@@ -45,7 +46,7 @@ export const VectorsBuckets = () => {
   const handleBucketNavigation = (bucketName: string, event: MouseEvent | KeyboardEvent) => {
     const url = `/project/${projectRef}/storage/vectors/buckets/${encodeURIComponent(bucketName)}`
     if (event.metaKey || event.ctrlKey) {
-      window.open(url, '_blank')
+      window.open(`${BASE_PATH}${url}`, '_blank')
     } else {
       router.push(url)
     }

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -313,8 +313,6 @@ function createStorageExplorerState({
       columnIndex: number
       onError?: () => void
     }) => {
-      const supabaseClient = await createSupabaseClient(state.projectRef, clientEndpoint)
-
       const autofix = false
       const formattedName = state.sanitizeNameForDuplicateInColumn({
         name: folderName,
@@ -1758,7 +1756,10 @@ function createStorageExplorerState({
 
       if (hasSameNameInColumn) {
         if (autofix) {
-          const [fileName, fileExt] = name.split('.')
+          const fileNameSegments = name.split('.')
+          const fileName = fileNameSegments.slice(0, fileNameSegments.length - 1).join('.')
+          const fileExt = fileNameSegments[fileNameSegments.length - 1]
+
           const dupeNameRegex = new RegExp(
             `${fileName} \\([-0-9]+\\)${fileExt ? '.' + fileExt : ''}$`
           )


### PR DESCRIPTION
## Context

Changes here cover an edge case to have `sanitizeNameForDuplicateInColumn` extract the extension of a file if the file has `.` in its name - e.g `file.md.mdx`

In this case - the file name should be `file.md` and the extension is `mdx`

## To test
Just an example:
- [ ] Have a `md` file named `test.md.mdx`
  <img width="97" height="107" alt="image" src="https://github.com/user-attachments/assets/64bee693-75c9-4650-a0c6-97360a309d43" />
- [ ] Upload that file to a bucket twice in the storage explorer
- [ ] First file should retain the original name - `test.md.mdx.md` (when you name a file with multiple `.`s, MacOS treats that as the file name, and the extension is "hidden")
- [ ] Second file should be `test.md.mdx (1).md`
