### PR TITLE
Analytics and Vector buckets should not be visible for CLI or self host dashboard

### DIFF
--- a/apps/studio/components/interfaces/Storage/Storage.constants.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.constants.ts
@@ -62,7 +62,6 @@ export const CONTEXT_MENU_KEYS = {
 
 export const BUCKET_TYPES = {
   files: {
-    platformOnly: false,
     displayName: 'Files',
     singularName: 'file',
     article: 'a',
@@ -71,7 +70,6 @@ export const BUCKET_TYPES = {
     docsUrl: `${DOCS_URL}/guides/storage/buckets/fundamentals`,
   },
   analytics: {
-    platformOnly: true,
     displayName: 'Analytics',
     singularName: 'analytics',
     article: 'an',
@@ -80,7 +78,6 @@ export const BUCKET_TYPES = {
     docsUrl: `${DOCS_URL}/guides/storage/analytics/introduction`,
   },
   vectors: {
-    platformOnly: true,
     displayName: 'Vectors',
     singularName: 'vector',
     article: 'a',

--- a/apps/studio/components/interfaces/Storage/StorageMenuV2.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageMenuV2.tsx
@@ -22,10 +22,10 @@ export const StorageMenuV2 = () => {
   const isAnalyticsBucketsEnabled = useIsAnalyticsBucketsEnabled({ projectRef: ref })
   const isVectorBucketsEnabled = useIsVectorBucketsEnabled({ projectRef: ref })
 
-  const bucketTypes = Object.entries(BUCKET_TYPES).filter(([key, config]) => {
-    if (key === 'analytics') return storageAnalytics
-    if (key === 'vectors') return storageVectors
-    return IS_PLATFORM || (!IS_PLATFORM && !config.platformOnly)
+  const bucketTypes = Object.entries(BUCKET_TYPES).filter(([key]) => {
+    if (key === 'analytics') return IS_PLATFORM && storageAnalytics
+    if (key === 'vectors') return IS_PLATFORM && storageVectors
+    return true
   })
 
   return (


### PR DESCRIPTION
## Context

As per PR title - regression when I added `enabled-features` for analytics and vector buckets 🤦 

## To test

- [ ] Verify that hosted dashboard shows analytics and vector buckets
- [ ] Verify that CLI / self-host dashboard doesn't show analytics and vector buckets