### PR TITLE
fix(studio): assistant undefined connection string on self-hosted

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -129,7 +129,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     state.setContext({
       projectRef: project?.ref,
       orgSlug: selectedOrganizationRef.current?.slug,
-      connectionString: project?.connectionString || undefined,
+      connectionString: project?.connectionString ?? '',
     })
   }, [project?.ref, project?.connectionString, selectedOrganizationRef.current?.slug, state])
 


### PR DESCRIPTION
Self hosted requires a connection string (even a blank string). This change reverts a small change made in https://github.com/supabase/supabase/pull/40673 which broke the assistant on self hosted.

To test:
- make sure assistant functions on the self-hosted preview