### PR TITLE
docs: Add SELinux instructions to quickstart

### DIFF
--- a/apps/docs/content/guides/functions/quickstart.mdx
+++ b/apps/docs/content/guides/functions/quickstart.mdx
@@ -99,6 +99,17 @@ The `supabase start` command downloads Docker images, which can take a few minut
 
 </Admonition>
 
+<Admonition type="note">
+
+**Using Linux with SELinux?**
+
+If you're on Fedora, RHEL, or another distro with SELinux enabled, Docker may not have permission to access your project files. Allow Docker to access your project files by updating their SELinux labels:
+
+```bash
+sudo chcon -Rt container_file_t $(pwd)
+```
+</Admonition>
+
 Your function is now running at [`http://localhost:54321/functions/v1/hello-world`](http://localhost:54321/functions/v1/hello-world). Hot reloading is enabled, which means that the server will automatically reload when you save changes to your function code.
 
 <Admonition type="note">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Docker configuration does not include the `:z` flag for SELinux compatibility:

https://github.com/supabase/cli/blob/2b7134a/internal/start/start.go

## What is the new behavior?

See changes.

## Additional context

https://github.com/supabase/supabase/issues/39671

https://github.com/supabase/cli/issues/4190