### PR TITLE
docs: add document minimum Node.js version for CLI

### DIFF
--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -66,6 +66,8 @@ Run the CLI by prefixing each command with `npx` or `bunx`:
 npx supabase --help
 ```
 
+**Note:** The Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`. Older Node.js versions such as 16 are not supported and may fail to start the CLI.
+
 You can also install the CLI as dev dependency via [npm](https://www.npmjs.com/package/supabase):
 
 ```sh

--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -67,7 +67,9 @@ npx supabase --help
 ```
 
 <Admonition type="warning">
-The Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`. Older Node.js versions such as 16 are not supported and may fail to start the CLI.
+
+The Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`. Older Node.js versions, such as 16, are not supported and fail to start the CLI.
+
 </Admonition>
 
 You can also install the CLI as dev dependency via [npm](https://www.npmjs.com/package/supabase):

--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -66,7 +66,9 @@ Run the CLI by prefixing each command with `npx` or `bunx`:
 npx supabase --help
 ```
 
-**Note:** The Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`. Older Node.js versions such as 16 are not supported and may fail to start the CLI.
+<Admonition type="warning">
+The Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`. Older Node.js versions such as 16 are not supported and may fail to start the CLI.
+</Admonition>
 
 You can also install the CLI as dev dependency via [npm](https://www.npmjs.com/package/supabase):
 

--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -66,7 +66,7 @@ Run the CLI by prefixing each command with `npx` or `bunx`:
 npx supabase --help
 ```
 
-<Admonition type="warning">
+<Admonition type="caution">
 
 The Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`. Older Node.js versions, such as 16, are not supported and fail to start the CLI.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes.

## What kind of change does this PR introduce?

Docs update – clarifies the minimum Node.js version required to run the Supabase CLI via `npx` or `npm`.

## What is the current behavior?

The docs do not specify a minimum Node.js version.  
Users running `npx supabase` with Node.js 16 may encounter errors (as reported in supabase/cli#4487).

## What is the new behavior?

Adds a short note under the `nodejs` tab stating that the Supabase CLI requires **Node.js 20 or later** when run via `npx` or `npm`, and that older versions such as Node 16 are not supported.

### Screenshot

Here is how the updated note renders locally:

<img width="877" height="408" alt="Screenshot 2025-11-27 at 14 04 33" src="https://github.com/user-attachments/assets/c0b5cf58-6afb-44e5-8a64-1dd2fd9c8313" />


## Additional context

Tested with:
- Node.js 16 → CLI fails to start  
- Node.js 20.19.6 → works  
- Node.js 22.9.0 → works

@Sweatybridge This PR follows up on your note in supabase/cli#4487.  
Happy to adjust the wording if needed! 