### PR TITLE
ci: add contents-write to fix-typos

### DIFF
--- a/.github/workflows/fix-typos.yml
+++ b/.github/workflows/fix-typos.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`fix-typos.yml` workflow keeps failing on `master` due to permission errors: https://github.com/supabase/supabase/actions/runs/19673882279/job/56349573261

```
  remote: Permission to supabase/supabase.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/supabase/supabase/': The requested URL returned error: 403
```

## What is the new behavior?

It needs `contents: write` instead of `contents: read`. Ref: https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#token
