### PR TITLE
chore: Simplify environment approval for tests

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -17,8 +17,6 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Require approval only for pull requests from forks
-    environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'Studio E2E Tests' || '' }}
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
This PR will (hopefully) remove the extra "approve and deploy" step from e2e tests for external contributors. We already have a "Approve and run" action for all actions so it's not needed (see screenshot).

<img width="990" height="238" alt="Screenshot 2025-11-27 at 16 10 43" src="https://github.com/user-attachments/assets/4ee4ee2a-77a0-4f74-ba21-cb009d045292" />
