### PR TITLE
fix(studio): use Realtime 1.0.0 version for now

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -104,7 +104,7 @@ export const useRealtimeMessages = (
     const realtimeOptions = merge(DEFAULT_REALTIME_OPTIONS, { params: { log_level: logLevel } })
 
     const options = {
-      vsn: '2.0.0',
+      vsn: '1.0.0',
       headers: DEFAULT_GLOBAL_OPTIONS.headers,
       ...realtimeOptions,
       params: { apikey: token, ...realtimeOptions.params },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

We are tweaking 2.0.0 so rolling back to 1.0.0 for now


