### PR TITLE
chore(studio): better vector put docs and comment

### DIFF
--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
@@ -154,8 +154,8 @@ values
 
   const jsCode = `import { createClient } from '@supabase/supabase-js'
 
-// Adding vector data needs a secret or service role key. 
-// This code SHOULD NOT be run on the client side, you'll be vulnerable to a data leak.
+// Adding vector data requires a secret or service role key 
+// This code SHOULD NOT be run on the client side as you will be vulnerable to a data leak
 const client = createClient(
   process.env.SUPABASE_URL,
   process.env.${secretKey ? 'SUPABASE_SECRET_KEY' : 'SUPABASE_SERVICE_ROLE_KEY'},
@@ -236,7 +236,7 @@ const result = await index.putVectors({
             <Link
               target="_blank"
               rel="noreferrer"
-              href={`${DOCS_URL}/reference/javascript/vectorindex-putvectors`}
+              href={`${DOCS_URL}/guides/storage/vector/storing-vectors?queryGroups=language&language=${language}#basic-vector-insertion`}
             >
               Docs
             </Link>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor improvement to inline documentation.

## What is the current behavior?

- Docs button goes to JavaScript docs even if SQL is selected

## What is the new behavior?

- Smarter Docs button that goes to the right documentation based on whatever language is selected
	- Goes to same docs page, just maps 1:1 to selected language
- Minor copywriting changes for clarity in code comments

## Additional context

Those copywriting changes in JavaScript code snippet:

| Before | After |
| --- | --- |
| <img width="786" height="771" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/ac81d6ae-5bcd-4abf-b425-79feaf27b2c9" /> | <img width="786" height="771" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/36af81c3-c814-41e1-a89a-d0eb34a65cf7" /> |
