### PR TITLE
fix: allow using .tsx and .jsx as entrypoints in functions

### DIFF
--- a/apps/studio/components/interfaces/EdgeFunctions/EdgeFunctions.utils.ts
+++ b/apps/studio/components/interfaces/EdgeFunctions/EdgeFunctions.utils.ts
@@ -10,7 +10,10 @@ export const getFallbackEntrypointPath = (files: Omit<EdgeFunctionFile, 'id' | '
   // when there's no matching entrypoint path is set,
   // we use few heuristics to find an entrypoint file
   // 1. If the function has only a single TS / JS file, if so set it as entrypoint
-  const jsFiles = files.filter(({ name }) => name.endsWith('.js') || name.endsWith('.ts'))
+  const jsFiles = files.filter(
+    ({ name }) =>
+      name.endsWith('.js') || name.endsWith('.ts') || name.endsWith('.jsx') || name.endsWith('.tsx')
+  )
   if (jsFiles.length === 1) {
     return jsFiles[0].name
   } else if (jsFiles.length) {

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
@@ -68,6 +68,10 @@ const CodePage = () => {
     },
   })
 
+  const fileExists = (filePath: string | undefined): boolean => {
+    return filePath ? files.some((file) => file.name === filePath) : false
+  }
+
   const onUpdate = async () => {
     if (isDeploying || !ref || !functionSlug || !selectedFunction || files.length === 0) return
 
@@ -75,14 +79,17 @@ const CodePage = () => {
       const newEntrypointPath = selectedFunction.entrypoint_path?.split('/').pop()
       const newImportMapPath = selectedFunction.import_map_path?.split('/').pop()
 
+      const entrypointExists = fileExists(newEntrypointPath)
+      const importMapExists = fileExists(newImportMapPath)
+
       deployFunction({
         projectRef: ref,
         slug: selectedFunction.slug,
         metadata: {
           name: selectedFunction.name,
           verify_jwt: selectedFunction.verify_jwt,
-          entrypoint_path: newEntrypointPath,
-          import_map_path: newImportMapPath,
+          ...(entrypointExists && { entrypoint_path: newEntrypointPath }),
+          ...(importMapExists && { import_map_path: newImportMapPath }),
         },
         files: files.map(({ name, content }) => ({ name, content })),
       })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

This PR adds support for using .tsx and .jsx files as entrypoints for functions deployed via dashboard.
