### PR TITLE
fix policy panel condition

### DIFF
--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -190,7 +190,6 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
 
   const handleSelectEditPolicy = useCallback(
     (policy: PostgresPolicy) => {
-      setSelectedPolicyIdToEdit(policy.id.toString())
       setSelectedTable(undefined)
 
       if (isInlineEditorEnabled) {


### PR DESCRIPTION

<img width="1072" height="566" alt="image" src="https://github.com/user-attachments/assets/6c87aedf-e7e4-4f65-80eb-35c6b9ba13aa" />

When edit entities in SQL is enabled and you click a policy it triggers both the UI panel and opens the SQL editor.