### PR TITLE
fix(studio): context menu actions fail on first row

### DIFF
--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -22,7 +22,7 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
 
   function onDeleteRow(p: RowContextMenuItemProps) {
     const rowIdx = p.props?.rowIdx
-    if (!rowIdx) return
+    if (rowIdx == null) return
 
     const row = rows[rowIdx]
     if (row) tableEditorSnap.onDeleteRows([row])
@@ -30,7 +30,7 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
 
   function onEditRowClick(p: RowContextMenuItemProps) {
     const rowIdx = p.props?.rowIdx
-    if (!rowIdx) return
+    if (rowIdx == null) return
 
     const row = rows[rowIdx]
     tableEditorSnap.onEditRow(row)
@@ -39,7 +39,7 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
   const onCopyCellContent = useCallback(
     (p: RowContextMenuItemProps) => {
       const rowIdx = p.props?.rowIdx
-      if (!snap.selectedCellPosition || !rowIdx) return
+      if (!snap.selectedCellPosition || rowIdx == null) return
 
       const row = rows[rowIdx]
       const columnKey = snap.gridColumns[snap.selectedCellPosition.idx as number].key
@@ -56,7 +56,7 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
   const onCopyRowContent = useCallback(
     (p: RowContextMenuItemProps) => {
       const rowIdx = p.props?.rowIdx
-      if (!rowIdx) return
+      if (rowIdx == null) return
 
       const row = rows[rowIdx]
       copyToClipboard(JSON.stringify(row))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Context menu actions (Copy cell, Copy row, Edit row, Delete row) fail silently on the first row (index 0) in the Table Editor.

## What is the new behavior?

All context menu actions work correctly on all rows including the first row.

## Root cause

The row index validation used `!rowIdx` which returns `true` when `rowIdx` is `0` because `0` is falsy. This caused the functions to return early without performing any action.

## Fix

Changed `!rowIdx` to `rowIdx == null` to correctly check for missing values while allowing `0` as a valid row index.

Fixes #40914