### PR TITLE
fix(studio): storage policy editor auto-selects select when update or delete is chose

### DIFF
--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditPolicyModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditPolicyModal.tsx
@@ -102,9 +102,25 @@ const StoragePoliciesEditPolicyModal = ({
         allowedOperations: [operation],
       })
     }
-    const updatedAllowedOperations = policyFormFields.allowedOperations.includes(operation)
-      ? pull(policyFormFields.allowedOperations.slice(), operation)
-      : policyFormFields.allowedOperations.concat([operation])
+
+    const currentOps = policyFormFields.allowedOperations
+    const isRemoving = currentOps.includes(operation)
+    let updatedAllowedOperations = isRemoving
+      ? pull(currentOps.slice(), operation)
+      : currentOps.concat([operation])
+
+    if (!isRemoving && (operation === 'UPDATE' || operation === 'DELETE')) {
+      if (!updatedAllowedOperations.includes('SELECT')) {
+        updatedAllowedOperations = updatedAllowedOperations.concat(['SELECT'])
+      }
+    }
+
+    if (isRemoving && operation === 'SELECT') {
+      updatedAllowedOperations = updatedAllowedOperations.filter(
+        (op: string) => op !== 'UPDATE' && op !== 'DELETE'
+      )
+    }
+
     return setPolicyFormFields({
       ...policyFormFields,
       allowedOperations: updatedAllowedOperations,

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
@@ -75,7 +75,7 @@ const PolicyAllowedOperations = ({ allowedOperations = [], onToggleOperation = (
         </div>
         {hasUpdateOrDelete && (
           <p className="text-sm text-foreground-lighter mt-3">
-            SELECT has been auto selected as UPDATE and DELETE require it
+            <code>SELECT</code> has been auto selected as <code>UPDATE</code> and <code>DELETE</code> require it
           </p>
         )}
         <div className="flex w-5/6 flex-wrap">

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
@@ -74,8 +74,9 @@ const PolicyAllowedOperations = ({ allowedOperations = [], onToggleOperation = (
           />
         </div>
         {hasUpdateOrDelete && (
-          <p className="text-sm text-foreground-lighter mt-3">
-            <code>SELECT</code> has been auto selected as <code>UPDATE</code> and <code>DELETE</code> require it
+          <p className="text-sm text-foreground-light mt-3 prose [&>code]:text-xs">
+            <code>SELECT</code> has been auto selected as <code>UPDATE</code> and{' '}
+            <code>DELETE</code> require it
           </p>
         )}
         <div className="flex w-5/6 flex-wrap">

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
@@ -28,6 +28,9 @@ const PolicyDefinition = ({ definition = '', onUpdatePolicyDefinition = () => {}
 
 const PolicyAllowedOperations = ({ allowedOperations = [], onToggleOperation = () => {} }: any) => {
   const allowedClientLibraryMethods = deriveAllowedClientLibraryMethods(allowedOperations)
+  const hasUpdateOrDelete =
+    allowedOperations.includes('UPDATE') || allowedOperations.includes('DELETE')
+
   return (
     <div className="flex flex-col md:flex-row justify-between gap-4 md:gap-12">
       <div className="flex md:w-1/3 flex-col space-y-2">
@@ -70,6 +73,11 @@ const PolicyAllowedOperations = ({ allowedOperations = [], onToggleOperation = (
             checked={allowedOperations.includes('DELETE')}
           />
         </div>
+        {hasUpdateOrDelete && (
+          <p className="text-sm text-foreground-lighter mt-3">
+            SELECT has been auto selected as UPDATE and DELETE require it
+          </p>
+        )}
         <div className="flex w-5/6 flex-wrap">
           {Object.keys(STORAGE_CLIENT_LIBRARY_MAPPINGS).map((method) => (
             <div key={method} className="mr-2 mt-2 font-mono">


### PR DESCRIPTION
## what kind of change does this pr introduce?

bug fix

## what is the current behavior?

update/delete doesnt highlight anything. 

## what is the new behavior?

when selecting update or delete, the select permission is automatically selected since these operations require it. when deselecting select, update and delete are automatically deselected to maintain consistency.
this ensures the correct client library methods are highlighted based on the selected permissions.

fixes #40923