### PR TITLE
chore(www): clarify Discord as community support option

### DIFF
--- a/apps/www/data/support.tsx
+++ b/apps/www/data/support.tsx
@@ -11,11 +11,26 @@ const data = {
   },
   cards: [
     {
-      title: 'Issues',
-      paragraph: "Found a bug? We'd love to hear about it in our GitHub issues.",
+      title: 'Community support',
+      paragraph:
+        'Our Discord community can help with code-related issues. Many questions are answered in minutes.',
       links: [
         {
-          label: 'Open GitHub Issue',
+          label: 'Join us on Discord',
+          link: 'https://discord.supabase.com/',
+          target: '_blank',
+          icon: <IconDiscord fill="hsl(var(--background-default))" />,
+          type: 'secondary',
+        },
+      ],
+      className: 'col-span-full xl:col-span-1',
+    },
+    {
+      title: 'Issues',
+      paragraph: 'Found a bug? We’d love to hear about it in our GitHub issues.',
+      links: [
+        {
+          label: 'Report an issue',
           link: 'https://github.com/supabase/supabase/issues',
           target: '_blank',
           icon: <IconGitHubSolid />,
@@ -25,42 +40,20 @@ const data = {
     },
     {
       title: 'Feature requests',
-      paragraph: 'Want to suggest a new feature? Share it with us and the community.',
+      paragraph: 'Want to suggest a new feature? Share it with us on GitHub discussions.',
       links: [
         {
-          label: 'Request feature',
+          label: 'Suggest a feature',
           link: 'https://github.com/orgs/supabase/discussions/categories/feature-requests',
-          target: '_blank',
-          icon: <IconGitHubSolid />,
-          type: 'default',
-        },
-      ],
-    },
-    {
-      title: 'Ask the Community',
-      paragraph:
-        'Join our GitHub discussions or our Discord server to browse for help and best practices.',
-      links: [
-        {
-          label: 'Ask a question',
-          link: 'https://github.com/supabase/supabase/discussions',
           target: '_blank',
           icon: <IconDiscussions />,
           type: 'default',
         },
-        {
-          label: 'Join Discord',
-          link: 'https://discord.supabase.com/',
-          target: '_blank',
-          icon: <IconDiscord fill="hsl(var(--background-default))" />,
-          type: 'secondary',
-        },
       ],
-      className: 'col-span-full xl:col-span-1',
     },
   ],
   banner: {
-    title: "Can't find what you're looking for?",
+    title: 'Can’t find what you’re looking for?',
     paragraph: (
       <>
         <p className="text-foreground-light">The Supabase Support Team is ready to help.</p>
@@ -72,13 +65,13 @@ const data = {
     ),
     links: [
       {
-        label: 'Contact Enterprise Sales',
+        label: 'Contact enterprise sales',
         link: 'https://forms.supabase.com/enterprise',
         target: '_blank',
         type: 'default',
       },
       {
-        label: 'Open Ticket',
+        label: 'Open support ticket',
         link: 'https://supabase.com/dashboard/support/new',
         target: '_blank',
         icon: <ArrowUpRight />,


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI update to `www`. Resolves DEPR-143.

## What is the current behavior?

We link out to both GitHub Discussions and Discord for community support, without a clear differentiation between them.

## What is the new behavior?

- We clearly mark Discord as our community support channel of choice (with GitHub Discussions for feature requests).
- Reordered to match desired hierarchy.

| Before | After |
| --- | --- |
| <img width="1728" height="993" alt="Help  Support  Supabase" src="https://github.com/user-attachments/assets/2ba51918-133b-4702-92fc-4b7c6ca04d75" /> | <img width="1728" height="993" alt="Help  Support  Supabase" src="https://github.com/user-attachments/assets/be6bffba-1373-447b-8c3e-b9c17f860c39" /> |

## Additional context

Minor copywriting improvements made throughout page.
