### PR TITLE
Remove GOING DOWN to determine if project is pausing

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -289,9 +289,7 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
   const isProjectBuilding =
     selectedProject?.status === PROJECT_STATUS.COMING_UP ||
     selectedProject?.status === PROJECT_STATUS.UNKNOWN
-  const isProjectPausing =
-    selectedProject?.status === PROJECT_STATUS.GOING_DOWN ||
-    selectedProject?.status === PROJECT_STATUS.PAUSING
+  const isProjectPausing = selectedProject?.status === PROJECT_STATUS.PAUSING
   const isProjectPauseFailed = selectedProject?.status === PROJECT_STATUS.PAUSE_FAILED
   const isProjectOffline = selectedProject?.postgrestStatus === 'OFFLINE'
 


### PR DESCRIPTION
## Context

We were using the project's `GOING_DOWN` status to determine is the project is pausing which I think might be old code.
Have verified that project's status will be swapped to `GOING_DOWN` when we're deleting the project ([ref](https://github.com/supabase/infrastructure/blob/develop/api/packages/core/src/lib/projects/project.ts#L667)) and that project's status will be swapped to `PAUSING` when we're pausing a project ([ref](https://github.com/supabase/infrastructure/blob/develop/api/packages/core/src/lib/projects/project-pause.ts#L51))

So safe to remove the check for `GOING_DOWN` in FE