### PR TITLE
fix: dashboard content not filling available width on resize

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -30,7 +30,7 @@ export interface DefaultLayoutProps {
  * - Mobile navigation bar
  * - First level side navigation bar (e.g For navigating to Table Editor, SQL Editor, Database page, etc)
  */
-export const DefaultLayout = ({
+const DefaultLayout = ({
   children,
   headerTitle,
   hideMobileMenu,
@@ -53,9 +53,6 @@ export const DefaultLayout = ({
         : '/organizations'
 
   useCheckLatestDeploy()
-
-  const contentMinSizePercentage = 50
-  const contentMaxSizePercentage = 70
 
   return (
     <SidebarProvider defaultOpen={false}>
@@ -85,22 +82,10 @@ export const DefaultLayout = ({
                   className="h-full w-full overflow-x-hidden flex-1 flex flex-row gap-0"
                   autoSaveId="default-layout-content"
                 >
-                  <ResizablePanel
-                    id="panel-content"
-                    order={1}
-                    className="w-full"
-                    minSize={contentMinSizePercentage}
-                    maxSize={contentMaxSizePercentage}
-                    defaultSize={contentMaxSizePercentage}
-                  >
+                  <ResizablePanel id="panel-content" defaultSize={1} className="w-full">
                     <div className="h-full overflow-y-auto">{children}</div>
                   </ResizablePanel>
-                  <LayoutSidebar
-                    order={2}
-                    minSize={100 - contentMaxSizePercentage}
-                    maxSize={100 - contentMinSizePercentage}
-                    defaultSize={100 - contentMaxSizePercentage}
-                  />
+                  <LayoutSidebar />
                 </ResizablePanelGroup>
               </div>
             </div>

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -1,33 +1,23 @@
+import { Fragment } from 'react'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { ResizableHandle, ResizablePanel, cn } from 'ui'
 
-// Having these params as props as otherwise it's quite hard to visually check the sizes in DefaultLayout
-// as react resizeable panels requires all these values to be valid to render correctly
-interface LayoutSidebarProps {
-  order?: number
-  minSize?: number
-  maxSize?: number
-  defaultSize?: number
-}
-
-export const LayoutSidebar = ({
-  order = 2,
-  minSize = 30,
-  maxSize = 50,
-  defaultSize = 30,
-}: LayoutSidebarProps) => {
+export const LayoutSidebar = () => {
   const { activeSidebar } = useSidebarManagerSnapshot()
 
+  if (!activeSidebar?.component) {
+    return null
+  }
+
   return (
-    <>
+    <Fragment>
       <ResizableHandle withHandle />
       <ResizablePanel
         id="panel-side"
-        key={activeSidebar?.id ?? 'default'}
-        order={order}
-        defaultSize={!!activeSidebar?.component ? defaultSize : 0}
-        minSize={!!activeSidebar?.component ? minSize : 0}
-        maxSize={!!activeSidebar?.component ? maxSize : 0}
+        key={activeSidebar.id}
+        defaultSize={30}
+        minSize={30}
+        maxSize={50}
         className={cn(
           'border-l bg fixed z-40 right-0 top-0 bottom-0',
           'w-screen h-[100dvh]',
@@ -35,8 +25,8 @@ export const LayoutSidebar = ({
           'xl:relative xl:border-l-0'
         )}
       >
-        {activeSidebar?.component()}
+        {activeSidebar.component()}
       </ResizablePanel>
-    </>
+    </Fragment>
   )
 }

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -181,9 +181,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
             )}
             <ResizablePanel
               order={2}
-              minSize={100 - sidebarMaxSizePercentage}
-              maxSize={100 - sidebarMinSizePercentage}
-              defaultSize={100 - sidebarDefaultSizePercentage}
+              defaultSize={1}
               id="panel-project-content"
               className={cn('h-full flex flex-col w-full xl:min-w-[600px] bg-dash-sidebar')}
             >
@@ -312,7 +310,7 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
 
   useEffect(() => {
     if (ref) state.setSelectedDatabaseId(ref)
-  }, [ref])
+  }, [ref, state])
 
   if (isBlocking && (isLoading || (requiresProjectDetails && selectedProject === undefined))) {
     return router.pathname.endsWith('[ref]') ? <LoadingState /> : <LogoLoader />


### PR DESCRIPTION
reverts resizable panel constraints that prevented content from expanding when no sidebar is active

closes #40945 #40944 #40949 
