### PR TITLE
fix(studio): boolean editor in table editor

### DIFF
--- a/apps/studio/components/grid/components/editor/BooleanEditor.tsx
+++ b/apps/studio/components/grid/components/editor/BooleanEditor.tsx
@@ -32,7 +32,7 @@ export const BooleanEditor = <TRow, TSummaryRow = unknown>({
       size="small"
       onBlur={onBlur}
       onChange={onChange}
-      defaultValue={!!value ? value.toString() : 'null'}
+      defaultValue={value === null || value === undefined ? 'null' : value.toString()}
       style={{ width: `${column.width}px` }}
     >
       <Select.Option value="true">TRUE</Select.Option>


### PR DESCRIPTION
With the current version of the code, `false` gets converted to `null`. This is an alternative fix to https://github.com/supabase/supabase/pull/40875