### PR TITLE
fix: boolean editor can't change value from false to true

### DIFF
--- a/apps/studio/components/grid/components/editor/BooleanEditor.tsx
+++ b/apps/studio/components/grid/components/editor/BooleanEditor.tsx
@@ -18,7 +18,9 @@ export const BooleanEditor = <TRow, TSummaryRow = unknown>({
   const value = row[column.key as keyof TRow] as boolean | null
 
   const onChange = (newValue: boolean | null) => {
-    onRowChange({ ...row, [column.key]: newValue }, true)
+    if (newValue !== value) {
+      onRowChange({ ...row, [column.key]: newValue }, true)
+    }
   }
 
   return (

--- a/apps/studio/components/grid/components/editor/BooleanEditor.tsx
+++ b/apps/studio/components/grid/components/editor/BooleanEditor.tsx
@@ -1,5 +1,7 @@
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { useState } from 'react'
 import type { RenderEditCellProps } from 'react-data-grid'
-import { Select } from 'ui'
+import { Button, Command_Shadcn_, CommandItem_Shadcn_, CommandList_Shadcn_, Popover_Shadcn_, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, ScrollArea } from 'ui'
 
 interface Props<TRow, TSummaryRow = unknown> extends RenderEditCellProps<TRow, TSummaryRow> {
   isNullable?: boolean
@@ -10,34 +12,94 @@ export const BooleanEditor = <TRow, TSummaryRow = unknown>({
   column,
   isNullable,
   onRowChange,
-  onClose,
 }: Props<TRow, TSummaryRow>) => {
-  const value = row[column.key as keyof TRow] as unknown as string
+  const [open, setOpen] = useState(true)
 
-  const onBlur = () => onClose(false)
-  const onChange = (event: any) => {
-    const value = event.target.value
-    if (value === 'null') {
-      onRowChange({ ...row, [column.key]: null }, true)
-    } else {
-      onRowChange({ ...row, [column.key]: value === 'true' }, true)
-    }
+  const value = row[column.key as keyof TRow] as boolean | null
+
+  const onChange = (newValue: boolean | null) => {
+    onRowChange({ ...row, [column.key]: newValue }, true)
   }
 
   return (
-    <Select
-      autoFocus
-      id="boolean-editor"
-      name="boolean-editor"
-      size="small"
-      onBlur={onBlur}
-      onChange={onChange}
-      defaultValue={!!value ? value.toString() : 'null'}
-      style={{ width: `${column.width}px` }}
-    >
-      <Select.Option value="true">TRUE</Select.Option>
-      <Select.Option value="false">FALSE</Select.Option>
-      {isNullable && <Select.Option value="null">NULL</Select.Option>}
-    </Select>
+    <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
+      <PopoverTrigger_Shadcn_ asChild>
+        <Button
+          type="default"
+          data-testid="schema-selector"
+          className={`w-full h-full [&>span]:w-full rounded-none !pr-1 space-x-1`}
+          iconRight={
+            <ChevronsUpDown strokeWidth={3} size={18} />
+          }
+        >
+          <div className="w-full flex gap-1">
+            <p>{value === null ? 'NULL' : value ? 'TRUE' : 'FALSE'}</p>
+          </div>
+        </Button>
+      </PopoverTrigger_Shadcn_>
+      <PopoverContent_Shadcn_
+        className="p-0 rounded-none pointer-events-auto"
+        side="bottom"
+        sameWidthAsTrigger
+      >
+        <Command_Shadcn_>
+          <CommandList_Shadcn_>
+              <ScrollArea>
+                <CommandItem_Shadcn_
+                  key="TRUE"
+                  className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                  onSelect={() => {
+                    onChange(true)
+                    setOpen(false)
+                  }}
+                  onClick={() => {
+                    onChange(true)
+                    setOpen(false)
+                  }}
+                >
+                  <span className="text-foreground">TRUE</span>
+                  {value === true && (
+                    <Check className="text-brand" strokeWidth={2} size={16} />
+                  )}
+                </CommandItem_Shadcn_>
+                <CommandItem_Shadcn_
+                  key="FALSE"
+                  className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                  onSelect={() => {
+                    onChange(false)
+                    setOpen(false)
+                  }}
+                  onClick={() => {
+                    onChange(false)
+                    setOpen(false)
+                  }}
+                >
+                  <span className="text-foreground">FALSE</span>
+                  {value === false && (
+                    <Check className="text-brand" strokeWidth={2} size={16} />
+                  )}
+                </CommandItem_Shadcn_>
+                {isNullable && <CommandItem_Shadcn_
+                  key="NULL"
+                  className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                  onSelect={() => {
+                    onChange(null)
+                    setOpen(false)
+                  }}
+                  onClick={() => {
+                    onChange(null)
+                    setOpen(false)
+                  }}
+                >
+                  <span className="text-foreground">NULL</span>
+                  {value === null && (
+                    <Check className="text-brand" strokeWidth={2} size={16} />
+                  )}
+                </CommandItem_Shadcn_>}
+              </ScrollArea>
+          </CommandList_Shadcn_>
+        </Command_Shadcn_>
+      </PopoverContent_Shadcn_>
+    </Popover_Shadcn_>
   )
 }


### PR DESCRIPTION
Fixes #40930 

Rather than investigate the bug, I took it as an opportunity to refactor `BooleanEditor` component to use Shadcn components instead of the deprecated `Select` component.

Also, before changing the column value, I checked whether the new value matches the old one, saving us from repeat HTTP requests.