### PR TITLE
Fix resizeable panels

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -27,9 +27,9 @@ export const LayoutSidebar = ({
         id="panel-side"
         key={activeSidebar?.id ?? 'default'}
         order={order}
-        defaultSize={!!activeSidebar?.component ? defaultSize : 0}
-        minSize={!!activeSidebar?.component ? minSize : 0}
-        maxSize={!!activeSidebar?.component ? maxSize : 0}
+        defaultSize={defaultSize}
+        minSize={minSize}
+        maxSize={maxSize}
         className={cn(
           'border-l bg fixed z-40 right-0 top-0 bottom-0',
           'h-[100dvh]',

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -18,6 +18,8 @@ export const LayoutSidebar = ({
 }: LayoutSidebarProps) => {
   const { activeSidebar } = useSidebarManagerSnapshot()
 
+  if (!activeSidebar?.component) return null
+
   return (
     <>
       <ResizableHandle withHandle />
@@ -30,8 +32,9 @@ export const LayoutSidebar = ({
         maxSize={!!activeSidebar?.component ? maxSize : 0}
         className={cn(
           'border-l bg fixed z-40 right-0 top-0 bottom-0',
-          'w-screen h-[100dvh]',
-          'md:absolute md:h-auto md:w-3/4',
+          'h-[100dvh]',
+          'md:absolute md:h-auto md:w-1/2',
+          'lg:w-2/5',
           'xl:relative xl:border-l-0'
         )}
       >


### PR DESCRIPTION
## Context

Bug was introduced [here](https://github.com/supabase/supabase/pull/40940) - attempted to resolve some console warnings from resizeable panel in `DefaultLayout` as we were dynamically rendering the other panel, by adjusting the size of the panel dynamically instead. While it was alright on normal viewports, because of the responsive tailwind classes applying a fixed width to the panels, hence why the panels ended up persisting on smaller viewports.

Am hence reverting to just keep the dynamic rendering - console warnings are likely safe to ignore either way in this case 🙏 

Fixes https://github.com/supabase/supabase/issues/40945

## To test

- [ ] Verify that the panel which houses inline SQL editor, assistant AI, or advisor center doesn't load with no content on smaller viewports
- [ ] Verify that the panels should only load when being opened from buttons in the top nav