### PR TITLE
fix: organization usage page

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/Activity.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Activity.tsx
@@ -19,8 +19,6 @@ const Activity = ({
   orgSlug,
   projectRef,
   subscription,
-  startDate,
-  endDate,
   currentBillingCycleSelected,
   orgDailyStats,
   isLoadingOrgDailyStats,

--- a/apps/studio/components/interfaces/Organization/Usage/Egress.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Egress.tsx
@@ -11,6 +11,8 @@ export interface EgressProps {
   currentBillingCycleSelected: boolean
   orgDailyStats: OrgDailyUsageResponse | undefined
   isLoadingOrgDailyStats: boolean
+  startDate: string | undefined
+  endDate: string | undefined
 }
 
 const Egress = ({
@@ -20,6 +22,8 @@ const Egress = ({
   currentBillingCycleSelected,
   orgDailyStats,
   isLoadingOrgDailyStats,
+  startDate,
+  endDate,
 }: EgressProps) => {
   const chartMeta: {
     [key: string]: { data: DataPoint[]; margin: number; isLoading: boolean }
@@ -47,6 +51,8 @@ const Egress = ({
       chartMeta={chartMeta}
       subscription={subscription}
       currentBillingCycleSelected={currentBillingCycleSelected}
+      startDate={startDate}
+      endDate={endDate}
     />
   )
 }

--- a/apps/studio/components/interfaces/Organization/Usage/SizeAndCounts.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/SizeAndCounts.tsx
@@ -15,6 +15,8 @@ export interface SizeAndCountsProps {
   currentBillingCycleSelected: boolean
   orgDailyStats: OrgDailyUsageResponse | undefined
   isLoadingOrgDailyStats: boolean
+  startDate: string | undefined
+  endDate: string | undefined
 }
 
 const SizeAndCounts = ({
@@ -24,6 +26,8 @@ const SizeAndCounts = ({
   currentBillingCycleSelected,
   orgDailyStats,
   isLoadingOrgDailyStats,
+  startDate,
+  endDate,
 }: SizeAndCountsProps) => {
   const chartMeta: {
     [key: string]: { data: DataPoint[]; margin: number; isLoading: boolean }
@@ -46,6 +50,8 @@ const SizeAndCounts = ({
       chartMeta={chartMeta}
       subscription={subscription}
       currentBillingCycleSelected={currentBillingCycleSelected}
+      startDate={startDate}
+      endDate={endDate}
     />
   )
 }

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -32,7 +32,7 @@ import SizeAndCounts from './SizeAndCounts'
 import { TotalUsage } from './TotalUsage'
 
 export const Usage = () => {
-  const { slug, projectRef } = useParams()
+  const { slug } = useParams()
 
   const [dateRange, setDateRange] = useState<any>()
 
@@ -106,7 +106,7 @@ export const Usage = () => {
     isError: isErrorOrgDailyStats,
   } = useOrgDailyStatsQuery({
     orgSlug: slug,
-    projectRef,
+    projectRef: selectedProjectRef ?? undefined,
     startDate,
     endDate,
   })
@@ -299,6 +299,8 @@ export const Usage = () => {
         currentBillingCycleSelected={currentBillingCycleSelected}
         orgDailyStats={orgDailyStats}
         isLoadingOrgDailyStats={isLoadingOrgDailyStats}
+        startDate={startDate}
+        endDate={endDate}
       />
 
       <SizeAndCounts
@@ -308,6 +310,8 @@ export const Usage = () => {
         currentBillingCycleSelected={currentBillingCycleSelected}
         orgDailyStats={orgDailyStats}
         isLoadingOrgDailyStats={isLoadingOrgDailyStats}
+        startDate={startDate}
+        endDate={endDate}
       />
 
       <Activity

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/UsageSection.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/UsageSection.tsx
@@ -20,6 +20,8 @@ export interface UsageSectionProps {
   subscription?: OrgSubscription
   chartMeta: ChartMeta
   currentBillingCycleSelected: boolean
+  startDate?: string
+  endDate?: string
 }
 
 const UsageSection = ({
@@ -29,6 +31,8 @@ const UsageSection = ({
   chartMeta,
   subscription,
   currentBillingCycleSelected,
+  startDate,
+  endDate,
 }: UsageSectionProps) => {
   const {
     data: usage,
@@ -36,7 +40,12 @@ const UsageSection = ({
     isLoading: isLoadingUsage,
     isError: isErrorUsage,
     isSuccess: isSuccessUsage,
-  } = useOrgUsageQuery({ orgSlug })
+  } = useOrgUsageQuery({
+    orgSlug,
+    projectRef,
+    start: !currentBillingCycleSelected && startDate ? new Date(startDate) : undefined,
+    end: !currentBillingCycleSelected && endDate ? new Date(endDate) : undefined,
+  })
 
   const categoryMeta = USAGE_CATEGORIES(subscription).find(
     (category) => category.key === categoryKey

--- a/apps/studio/data/analytics/org-daily-stats-query.test.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOrgDailyStats } from './org-daily-stats-query'
+
+vi.mock('data/fetchers', () => ({
+  get: vi.fn(),
+  handleError: vi.fn((error) => {
+    throw error
+  }),
+}))
+
+describe('org-daily-stats-query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getOrgDailyStats', () => {
+    it('throws error when orgSlug is not provided', async () => {
+      await expect(
+        getOrgDailyStats({
+          orgSlug: undefined,
+          startDate: '2025-01-01',
+          endDate: '2025-01-31',
+        })
+      ).rejects.toThrow('Org slug is required')
+    })
+
+    it('throws error when startDate is not provided', async () => {
+      await expect(
+        getOrgDailyStats({
+          orgSlug: 'test-org',
+          startDate: undefined,
+          endDate: '2025-01-31',
+        })
+      ).rejects.toThrow('Start date is required')
+    })
+
+    it('throws error when endDate is not provided', async () => {
+      await expect(
+        getOrgDailyStats({
+          orgSlug: 'test-org',
+          startDate: '2025-01-01',
+          endDate: undefined,
+        })
+      ).rejects.toThrow('Start date is required')
+    })
+
+    it('calls API with correct parameters including project_ref', async () => {
+      const { get } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+
+      const mockResponse = { usages: [] }
+      mockGet.mockResolvedValueOnce({ data: mockResponse, error: null })
+
+      const result = await getOrgDailyStats({
+        orgSlug: 'test-org',
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        projectRef: 'test-project-ref',
+      })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/platform/organizations/{slug}/usage/daily',
+        expect.objectContaining({
+          params: {
+            path: { slug: 'test-org' },
+            query: {
+              start: '2025-01-01',
+              end: '2025-01-31',
+              project_ref: 'test-project-ref',
+            },
+          },
+        })
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('calls API without project_ref when not provided', async () => {
+      const { get } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+
+      const mockResponse = { usages: [] }
+      mockGet.mockResolvedValueOnce({ data: mockResponse, error: null })
+
+      await getOrgDailyStats({
+        orgSlug: 'test-org',
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+      })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/platform/organizations/{slug}/usage/daily',
+        expect.objectContaining({
+          params: {
+            path: { slug: 'test-org' },
+            query: {
+              start: '2025-01-01',
+              end: '2025-01-31',
+              project_ref: undefined,
+            },
+          },
+        })
+      )
+    })
+
+    it('handles API errors correctly', async () => {
+      const { get, handleError } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+      const mockHandleError = handleError as unknown as ReturnType<typeof vi.fn>
+
+      const mockError = { message: 'API Error' }
+      mockGet.mockResolvedValueOnce({ data: null, error: mockError })
+      mockHandleError.mockImplementation((error) => {
+        throw new Error(error.message)
+      })
+
+      await expect(
+        getOrgDailyStats({
+          orgSlug: 'test-org',
+          startDate: '2025-01-01',
+          endDate: '2025-01-31',
+        })
+      ).rejects.toThrow('API Error')
+    })
+  })
+})

--- a/apps/studio/data/analytics/org-daily-stats-query.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.ts
@@ -137,7 +137,7 @@ export async function getOrgDailyStats(
       query: {
         start: startDate,
         end: endDate,
-        projectRef,
+        project_ref: projectRef,
       },
     },
     signal,

--- a/apps/studio/data/usage/org-usage-query.test.ts
+++ b/apps/studio/data/usage/org-usage-query.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOrgUsage } from './org-usage-query'
+
+vi.mock('data/fetchers', () => ({
+  get: vi.fn(),
+  handleError: vi.fn((error) => {
+    throw error
+  }),
+}))
+
+describe('org-usage-query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getOrgUsage', () => {
+    it('throws error when orgSlug is not provided', async () => {
+      await expect(getOrgUsage({ orgSlug: undefined })).rejects.toThrow('orgSlug is required')
+    })
+
+    it('calls API with correct parameters including project_ref', async () => {
+      const { get } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+
+      const mockResponse = { usages: [] }
+      mockGet.mockResolvedValueOnce({ data: mockResponse, error: null })
+
+      const startDate = new Date('2025-01-01T00:00:00.000Z')
+      const endDate = new Date('2025-01-31T23:59:59.000Z')
+
+      const result = await getOrgUsage({
+        orgSlug: 'test-org',
+        projectRef: 'test-project-ref',
+        start: startDate,
+        end: endDate,
+      })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/platform/organizations/{slug}/usage',
+        expect.objectContaining({
+          params: {
+            path: { slug: 'test-org' },
+            query: {
+              project_ref: 'test-project-ref',
+              start: '2025-01-01T00:00:00.000Z',
+              end: '2025-01-31T23:59:59.000Z',
+            },
+          },
+        })
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('calls API without project_ref when projectRef is null', async () => {
+      const { get } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+
+      const mockResponse = { usages: [] }
+      mockGet.mockResolvedValueOnce({ data: mockResponse, error: null })
+
+      await getOrgUsage({
+        orgSlug: 'test-org',
+        projectRef: null,
+      })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/platform/organizations/{slug}/usage',
+        expect.objectContaining({
+          params: {
+            path: { slug: 'test-org' },
+            query: {
+              project_ref: undefined,
+              start: undefined,
+              end: undefined,
+            },
+          },
+        })
+      )
+    })
+
+    it('calls API without date params when start and end are undefined', async () => {
+      const { get } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+
+      const mockResponse = { usages: [] }
+      mockGet.mockResolvedValueOnce({ data: mockResponse, error: null })
+
+      await getOrgUsage({
+        orgSlug: 'test-org',
+      })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/platform/organizations/{slug}/usage',
+        expect.objectContaining({
+          params: {
+            path: { slug: 'test-org' },
+            query: {
+              project_ref: undefined,
+              start: undefined,
+              end: undefined,
+            },
+          },
+        })
+      )
+    })
+
+    it('handles API errors correctly', async () => {
+      const { get, handleError } = await import('data/fetchers')
+      const mockGet = get as unknown as ReturnType<typeof vi.fn>
+      const mockHandleError = handleError as unknown as ReturnType<typeof vi.fn>
+
+      const mockError = { message: 'API Error' }
+      mockGet.mockResolvedValueOnce({ data: null, error: mockError })
+      mockHandleError.mockImplementation((error) => {
+        throw new Error(error.message)
+      })
+
+      await expect(
+        getOrgUsage({
+          orgSlug: 'test-org',
+        })
+      ).rejects.toThrow('API Error')
+    })
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

https://uploads.linear.app/32b6a9b3-608b-4812-b1da-bae67a83abb7/b7c28bd4-e6ab-4e08-be03-c4665d5dea07/38196f24-0712-403e-9458-df56f1899974

## What is the new behavior?

https://supabase.slack.com/archives/C0161K73J1J/p1764605119189729?thread_ts=1764107520.246509&cid=C0161K73J1J

## Additional context

Fixes https://linear.app/supabase/issue/API-759/egress-graph-does-not-change-when-filtering-by-project
