### PR TITLE
fix: add WebGL safety checks to prevent globe crash on /careers 

### DIFF
--- a/apps/www/components/Globe.tsx
+++ b/apps/www/components/Globe.tsx
@@ -12,9 +12,7 @@ const Globe = () => {
   const supportsWebGL = () => {
     try {
       const canvas = document.createElement('canvas')
-      const gl =
-        canvas.getContext('webgl') ||
-        canvas.getContext('experimental-webgl' as 'webgl')
+      const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl' as 'webgl')
       return !!gl
     } catch {
       return false

--- a/apps/www/components/Globe.tsx
+++ b/apps/www/components/Globe.tsx
@@ -1,70 +1,101 @@
 import createGlobe from 'cobe'
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTheme } from 'next-themes'
 import { debounce } from 'lib/helpers'
 
 const Globe = () => {
   const { resolvedTheme } = useTheme()
-  const canvasRef = useRef<any>()
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const rotationRef = useRef(0)
+  const widthRef = useRef(0)
 
-  let rotation: number = 0
-  let width: number = 0
-  const onResize = useCallback(
-    () => canvasRef.current && (width = canvasRef.current.offsetWidth),
-    [resolvedTheme]
-  )
+  const supportsWebGL = () => {
+    try {
+      const canvas = document.createElement('canvas')
+      const gl =
+        canvas.getContext('webgl') ||
+        canvas.getContext('experimental-webgl' as 'webgl')
+      return !!gl
+    } catch {
+      return false
+    }
+  }
 
   useEffect(() => {
-    const debouncedResize = debounce(onResize, 10)
-    window.addEventListener('resize', debouncedResize)
-    onResize()
-    const cobe = createGlobe(canvasRef.current, {
-      devicePixelRatio: 2,
-      width: width * 2,
-      height: width * 2,
-      phi: 0,
-      theta: 0.3,
-      dark: resolvedTheme?.includes('dark') ? 1 : 0,
-      diffuse: 3,
-      scale: 1,
-      opacity: 0.8,
-      mapSamples: 20000,
-      mapBrightness: 4,
-      baseColor: [255 / 255, 255 / 255, 255 / 255],
-      markerColor: [62 / 255, 207 / 255, 142 / 255],
-      glowColor: [255 / 255, 255 / 255, 255 / 255],
-      markers: [
-        { location: [53.4084, 2.9916], size: 0.06 },
-        { location: [1.3521, 103.8198], size: 0.06 },
-        { location: [-40.9006, 174.886], size: 0.06 },
-        { location: [14.0583, 108.2772], size: 0.06 },
-        { location: [37.7749, -122.4194], size: 0.06 },
-        { location: [41.3874, 2.1686], size: 0.06 },
-        { location: [49.2827, -123.1207], size: 0.06 },
-        { location: [-36.9848, 143.3906], size: 0.06 },
-        { location: [42.3601, -71.0589], size: 0.06 },
-        { location: [52.52, 13.405], size: 0.06 },
-        { location: [33.749, -84.388], size: 0.06 },
-        { location: [35.6762, 139.6503], size: 0.06 },
-        { location: [9.19, -75.0152], size: 0.06 },
-        { location: [-25.2521, -52.0215], size: 0.06 },
-      ],
-      onRender: (state) => {
-        state.phi = rotation
-        rotation += 0.0025
-        state.width = width * 2
-        state.height = width * 2
-      },
-    })
-    setTimeout(() => (canvasRef.current.style.opacity = '0.8'), 10)
+    const canvas = canvasRef.current
+    if (!canvas || !supportsWebGL()) return
+
+    widthRef.current = canvas.offsetWidth
+
+    let globe: ReturnType<typeof createGlobe> | null = null
+
+    try {
+      globe = createGlobe(canvas, {
+        devicePixelRatio: window.devicePixelRatio || 1,
+        width: widthRef.current * 2,
+        height: widthRef.current * 2,
+        phi: 0,
+        theta: 0.3,
+        dark: resolvedTheme?.includes('dark') ? 1 : 0,
+        diffuse: 3,
+        scale: 1,
+        opacity: 0.8,
+        mapSamples: 20000,
+        mapBrightness: 4,
+        baseColor: [1, 1, 1],
+        markerColor: [62 / 255, 207 / 255, 142 / 255],
+        glowColor: [1, 1, 1],
+        markers: [
+          { location: [53.4084, 2.9916], size: 0.06 },
+          { location: [1.3521, 103.8198], size: 0.06 },
+          { location: [-40.9006, 174.886], size: 0.06 },
+          { location: [14.0583, 108.2772], size: 0.06 },
+          { location: [37.7749, -122.4194], size: 0.06 },
+          { location: [41.3874, 2.1686], size: 0.06 },
+          { location: [49.2827, -123.1207], size: 0.06 },
+          { location: [-36.9848, 143.3906], size: 0.06 },
+          { location: [42.3601, -71.0589], size: 0.06 },
+          { location: [52.52, 13.405], size: 0.06 },
+          { location: [33.749, -84.388], size: 0.06 },
+          { location: [35.6762, 139.6503], size: 0.06 },
+          { location: [9.19, -75.0152], size: 0.06 },
+          { location: [-25.2521, -52.0215], size: 0.06 },
+        ],
+        onRender: (state) => {
+          state.phi = rotationRef.current
+          rotationRef.current += 0.0025
+          state.width = widthRef.current * 2
+          state.height = widthRef.current * 2
+        },
+      })
+    } catch (err) {
+      return
+    }
+
+    const handleResize = debounce(() => {
+      if (canvasRef.current) {
+        widthRef.current = canvasRef.current.offsetWidth
+      }
+    }, 10)
+
+    window.addEventListener('resize', handleResize)
+
+    const timeoutId = window.setTimeout(() => {
+      if (canvasRef.current) {
+        canvasRef.current.style.opacity = '0.8'
+      }
+    }, 10)
+
     return () => {
-      window.removeEventListener('resize', onResize)
-      cobe.destroy()
+      window.clearTimeout(timeoutId)
+      window.removeEventListener('resize', handleResize)
+      globe?.destroy()
     }
   }, [resolvedTheme])
 
   return (
     <canvas
+      aria-label="Interactive 3D globe"
       ref={canvasRef}
       className="absolute inset-0 w-full h-full opacity-0 transition-opacity object-contain"
     />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The /careers page crashes once visited. This causes COBE to call `gl.enable(...)` on a null WebGL context and throws this error:
Cannot read properties of null (reading 'enable') : 

<img width="1906" height="866" alt="image" src="https://github.com/user-attachments/assets/4323d7f8-7cfc-4f50-ae03-194eb836a7bd" />

## What is the new behavior?

The Globe component now safely checks for WebGL availability before initializing COBE. 
If WebGL is unavailable, the component simply does not render the globe and the page continues loading normally.

- No crashes when `canvas.getContext('webgl')` returns null
- Added WebGL capability guard
- Wrapped `createGlobe` in try/catch to prevent runtime errors
- Proper cleanup of listeners and globe instance
- Improved type safety by removing `any` and using stable refs
- Added aria-label to the canvas

## Additional context

This will fix similar issues where ever this component is used.