### PR TITLE
feat(studio): recommended schemas for extensions

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
@@ -26,6 +26,11 @@ import { Admonition } from 'ui-patterns'
 
 const orioleExtCallOuts = ['vector', 'postgis']
 
+// Extensions that have recommended schemas (rather than required schemas)
+const extensionsWithRecommendedSchemas: Record<string, string> = {
+  wrappers: 'extensions',
+}
+
 interface EnableExtensionModalProps {
   visible: boolean
   extension: PostgresExtension
@@ -88,6 +93,20 @@ const EnableExtensionModal = ({ visible, extension, onCancel }: EnableExtensionM
       cancel = true
     }
   }, [visible, extension.name])
+
+  const getSchemaDescriptionText = (extensionName: string, schema: string | null | undefined) => {
+    // Prioritize defaultSchema (required/forced) over recommended schema
+    if (schema) {
+      return `Extension must be installed in the “${schema}” schema.`
+    }
+
+    const recommendedSchema = extensionsWithRecommendedSchemas[extensionName]
+    if (recommendedSchema) {
+      return `Use the “${recommendedSchema}” schema for full compatibility with related features.`
+    }
+
+    return undefined
+  }
 
   const validate = (values: any) => {
     const errors: any = {}
@@ -165,17 +184,14 @@ const EnableExtensionModal = ({ visible, extension, onCancel }: EnableExtensionM
                     name="schema"
                     value={defaultSchema}
                     label="Select a schema to enable the extension for"
-                    descriptionText={
-                      extension.name === 'wrappers'
-                        ? 'Recommended schema is “extensions”.'
-                        : `Extension must be installed in “${defaultSchema}”.`
-                    }
+                    descriptionText={getSchemaDescriptionText(extension.name, defaultSchema)}
                   />
                 ) : (
                   <Listbox
                     size="small"
                     name="schema"
                     label="Select a schema to enable the extension for"
+                    descriptionText={getSchemaDescriptionText(extension.name, null)}
                   >
                     <Listbox.Option
                       key="custom"

--- a/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
@@ -165,7 +165,11 @@ const EnableExtensionModal = ({ visible, extension, onCancel }: EnableExtensionM
                     name="schema"
                     value={defaultSchema}
                     label="Select a schema to enable the extension for"
-                    descriptionText={`Extension must be installed in ${defaultSchema}.`}
+                    descriptionText={
+                      extension.name === 'wrappers'
+                        ? 'Recommended schema is “extensions”.'
+                        : `Extension must be installed in “${defaultSchema}”.`
+                    }
                   />
                 ) : (
                   <Listbox

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
@@ -327,7 +327,9 @@ export const CreateVectorTableSheet = ({ bucketName }: CreateVectorTableSheetPro
             <SheetSection className="space-y-4">
               <div className="flex items-center justify-between">
                 <label className="text-sm text-foreground">Metadata keys</label>
-                <DocsButton href={`${DOCS_URL}/guides/storage/vector/introduction`} />
+                <DocsButton
+                  href={`${DOCS_URL}/guides/storage/vector/storing-vectors#metadata-best-practices`}
+                />
               </div>
               <div className="space-y-2">
                 {fields.map((field, index) => (


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI update that resolves STORAGE-346.

## What is the current behavior?

- The `wrappers` extension can be installed in any extension, even though things break when it _isn’t_ installed inside of the `extensions` schema

## What is the new behavior?

- New `extensionsWithRecommendedSchemas` list which includes `wrappers`
- Anything in this list will show the following `descriptionText` under the select element

| Before | After |
| --- | --- |
| <img width="792" height="520" alt="Metals  Nuts  Bolts  Supabase" src="https://github.com/user-attachments/assets/9bddeef6-5d4e-4288-96b9-588b615957ba" /> | <img width="792" height="520" alt="Metals  Nuts  Bolts  Supabase" src="https://github.com/user-attachments/assets/440cf7bb-4231-470f-9e9d-9a878f4f597c" /> |

## Additional context

We use a client-side list for recommended schemas instead of one on the backend because:

- The `extensions` schema is user-managed and may never exist
- FDW are agnostic where `wrappers` are installed
 
Some (advanced) developers might have good reason to enable that extension in another schema. More context [here](https://linear.app/supabase/issue/STORAGE-346/prevent-installing-wrappers-in-supabase-owned-schemas#comment-a34f9d01).
