### PR TITLE
fix: compute upgrades for v3

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
@@ -50,8 +50,9 @@ export const CreateDiskStorageSchema = ({
 }) => {
   const isFlyProject = cloudProvider === 'FLY'
   const isAwsNimbusProject = cloudProvider === 'AWS_NIMBUS'
+  const isAwsK8sProject = cloudProvider === 'AWS_K8S'
 
-  const validateDiskConfiguration = !isFlyProject && !isAwsNimbusProject
+  const validateDiskConfiguration = !isFlyProject && !isAwsNimbusProject && !isAwsK8sProject
 
   const schema = baseSchema.superRefine((data, ctx) => {
     const { storageType, totalSize, provisionedIOPS, throughput, maxSizeGb } = data

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -256,6 +256,7 @@ export function DiskManagementForm() {
     // [Joshen] Skip disk configuration related stuff for AWS Nimbus
     try {
       if (
+        !isAwsK8s &&
         !isAwsNimbus &&
         (payload.storageType !== form.formState.defaultValues?.storageType ||
           payload.provisionedIOPS !== form.formState.defaultValues?.provisionedIOPS ||
@@ -274,6 +275,7 @@ export function DiskManagementForm() {
       }
 
       if (
+        !isAwsK8s &&
         !isAwsNimbus &&
         (payload.growthPercent !== form.formState.defaultValues?.growthPercent ||
           payload.minIncrementGb !== form.formState.defaultValues?.minIncrementGb ||

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx
@@ -152,6 +152,8 @@ export const DiskManagementReviewAndSubmitDialog = ({
   const { data: org } = useSelectedOrganizationQuery()
   const isAwsNimbus = useIsAwsNimbusCloudProvider()
 
+  const isAwsK8sProject = project?.cloud_provider === 'AWS_K8S'
+
   const { formState, getValues } = form
 
   const { can: canUpdateDiskConfiguration } = useAsyncCheckPermissions(
@@ -214,22 +216,34 @@ export const DiskManagementReviewAndSubmitDialog = ({
   const hasComputeChanges =
     form.formState.defaultValues?.computeSize !== form.getValues('computeSize')
   const hasTotalSizeChanges =
-    !isAwsNimbus && form.formState.defaultValues?.totalSize !== form.getValues('totalSize')
+    !isAwsK8sProject &&
+    !isAwsNimbus &&
+    form.formState.defaultValues?.totalSize !== form.getValues('totalSize')
   const hasStorageTypeChanges =
-    !isAwsNimbus && form.formState.defaultValues?.storageType !== form.getValues('storageType')
+    !isAwsK8sProject &&
+    !isAwsNimbus &&
+    form.formState.defaultValues?.storageType !== form.getValues('storageType')
   const hasThroughputChanges =
-    !isAwsNimbus && form.formState.defaultValues?.throughput !== form.getValues('throughput')
+    !isAwsK8sProject &&
+    !isAwsNimbus &&
+    form.formState.defaultValues?.throughput !== form.getValues('throughput')
   const hasIOPSChanges =
+    !isAwsK8sProject &&
     !isAwsNimbus &&
     form.formState.defaultValues?.provisionedIOPS !== form.getValues('provisionedIOPS')
 
   const hasGrowthPercentChanges =
-    !isAwsNimbus && form.formState.defaultValues?.growthPercent !== form.getValues('growthPercent')
+    !isAwsK8sProject &&
+    !isAwsNimbus &&
+    form.formState.defaultValues?.growthPercent !== form.getValues('growthPercent')
   const hasMinIncrementChanges =
+    !isAwsK8sProject &&
     !isAwsNimbus &&
     form.formState.defaultValues?.minIncrementGb !== form.getValues('minIncrementGb')
   const hasMaxSizeChanges =
-    !isAwsNimbus && form.formState.defaultValues?.maxSizeGb !== form.getValues('maxSizeGb')
+    !isAwsK8sProject &&
+    !isAwsNimbus &&
+    form.formState.defaultValues?.maxSizeGb !== form.getValues('maxSizeGb')
 
   const hasDiskConfigChanges =
     hasIOPSChanges ||


### PR DESCRIPTION
Currently not working as it tries to modify disk which is not supported for v3. PR unblocks compute size changes for v3 projects