### PR TITLE
Patch org audit logs

### DIFF
--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -69,7 +69,9 @@ export const AuditLogs = () => {
     )
     ?.filter((log) => {
       if (filters.projects.length > 0) {
-        return filters.projects.includes(log.target.metadata.project_ref || '')
+        return filters.projects.includes(
+          log.target.metadata.project_ref || log.target.metadata.ref || ''
+        )
       } else {
         return log
       }
@@ -220,12 +222,12 @@ export const AuditLogs = () => {
                   ]}
                   body={
                     sortedLogs?.map((log) => {
-                      const project = projects?.find(
-                        (project) => project.ref === log.target.metadata.project_ref
-                      )
-                      const organization = organizations?.find(
-                        (org) => org.slug === log.target.metadata.org_slug
-                      )
+                      const logProjectRef =
+                        log.target.metadata.project_ref || log.target.metadata.ref
+                      const logOrgSlug = log.target.metadata.org_slug || log.target.metadata.slug
+
+                      const project = projects?.find((project) => project.ref === logProjectRef)
+                      const organization = organizations?.find((org) => org.slug === logOrgSlug)
 
                       const hasStatusCode = log.action.metadata[0]?.status !== undefined
 
@@ -261,16 +263,10 @@ export const AuditLogs = () => {
                             </p>
                             <p
                               className="text-foreground-light text-xs mt-0.5 truncate"
-                              title={
-                                log.target.metadata.project_ref ?? log.target.metadata.org_slug
-                              }
+                              title={logProjectRef ?? logOrgSlug ?? ''}
                             >
-                              {log.target.metadata.project_ref
-                                ? 'Ref: '
-                                : log.target.metadata.org_slug
-                                  ? 'Slug: '
-                                  : null}
-                              {log.target.metadata.project_ref ?? log.target.metadata.org_slug}
+                              {logProjectRef ? 'Ref: ' : logOrgSlug ? 'Slug: ' : null}
+                              {logProjectRef ?? logOrgSlug}
                             </p>
                           </Table.td>
                           <Table.td>

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -24,6 +24,7 @@ import {
 import { useOrganizationMembersQuery } from 'data/organizations/organization-members-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useOrgProjectsInfiniteQuery } from 'data/projects/org-projects-infinite-query'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import {
   AlertDescription_Shadcn_,
@@ -32,7 +33,6 @@ import {
   Button,
   WarningIcon,
 } from 'ui'
-import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 
 const logsUpgradeError = 'upgrade to Team or Enterprise Plan to access audit logs.'
 
@@ -348,12 +348,12 @@ export const AuditLogs = () => {
                           (member) => member.gotrue_id === log.actor.id
                         )
                         const role = roles.find((role) => user?.role_ids?.[0] === role.id)
-                        const project = projects?.find(
-                          (project) => project.ref === log.target.metadata.project_ref
-                        )
-                        const organization = organizations?.find(
-                          (org) => org.slug === log.target.metadata.org_slug
-                        )
+                        const logProjectRef =
+                          log.target.metadata.project_ref ?? log.target.metadata.ref
+                        const logOrgSlug = log.target.metadata.org_slug ?? log.target.metadata.slug
+
+                        const project = projects?.find((project) => project.ref === logProjectRef)
+                        const organization = organizations?.find((org) => logOrgSlug)
 
                         const hasStatusCode = log.action.metadata[0]?.status !== undefined
                         const userIcon =
@@ -420,16 +420,10 @@ export const AuditLogs = () => {
                               </p>
                               <p
                                 className="text-foreground-light text-xs mt-0.5 truncate"
-                                title={
-                                  log.target.metadata.project_ref ?? log.target.metadata.org_slug
-                                }
+                                title={logProjectRef ?? logOrgSlug ?? ''}
                               >
-                                {log.target.metadata.project_ref
-                                  ? 'Ref: '
-                                  : log.target.metadata.org_slug
-                                    ? 'Slug: '
-                                    : null}
-                                {log.target.metadata.project_ref ?? log.target.metadata.org_slug}
+                                {logProjectRef ? 'Ref: ' : logOrgSlug ? 'Slug: ' : null}
+                                {logProjectRef ?? logOrgSlug}
                               </p>
                             </Table.td>
                             <Table.td>

--- a/apps/studio/data/organizations/organization-audit-logs-query.ts
+++ b/apps/studio/data/organizations/organization-audit-logs-query.ts
@@ -8,6 +8,7 @@ export type AuditLog = {
   action: {
     metadata: {
       method?: string
+      route?: string
       status?: number
     }[]
     name: string
@@ -17,13 +18,17 @@ export type AuditLog = {
     type: 'user' | string
     metadata: {
       email?: string
+      ip?: string
+      tokenType?: string
     }[]
   }
   target: {
     description: string
     metadata: {
       org_slug?: string
-      project_ref?: string
+      project_ref?: string | null
+      ref?: string | null
+      slug?: string | null
     }
   }
   occurred_at: string


### PR DESCRIPTION
## Context

There's some issues with the both organization audit logs and profile audit logs:
- Dashboard is using the `project_ref` property from the audit logs to determine if the log's target is a project
- However, we noticed that each audit log has "duplicate" properties - `project_ref` and `ref`, and `org_slug` and `slug`
  <img width="352" height="146" alt="image" src="https://github.com/user-attachments/assets/971ca4aa-4428-496b-bf6d-a8f632e81490" />
- This leads to some discrepancy as FE was originally using `project_ref` which is now returning `null`, whereas `ref` has the right value instead
- A couple more factors that caused us to overlook this includes:
  - API types are also not properly typed
  - FE isn't receiving the right types from the API types codegen
    <img width="631" height="192" alt="image" src="https://github.com/user-attachments/assets/b4f8310d-1b4c-4758-913f-ceb1f7f9d6f9" />
- Note that this is merely a patch and the proper fix needs to be done on the API end

## To test
- [ ] Verify that the audit logs on both org and account shows the right target if its supposed to be targeting a project (currently org audit logs defaults to showing the organization as the target, while profile audit logs default to just `-`)