### PR TITLE
Disable 'New table' button in schema visualizer page if schema is pro…

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -14,11 +14,13 @@ import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import SchemaSelector from 'components/ui/SchemaSelector'
+import { ProtectedSchemaWarning } from 'components/interfaces/Database/ProtectedSchemaWarning'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { tablesToSQL } from 'lib/helpers'
 import {
   copyToClipboard,
@@ -89,6 +91,8 @@ export const SchemaGraph = () => {
     LOCAL_STORAGE_KEYS.SCHEMA_VISUALIZER_POSITIONS(ref as string, schema?.id ?? 0),
     {}
   )
+
+  const { isSchemaLocked } = useIsProtectedSchema({ schema: selectedSchema })
 
   const resetLayout = () => {
     const nodes = reactFlowInstance.getNodes()
@@ -290,9 +294,36 @@ export const SchemaGraph = () => {
                 title="No tables in schema"
                 description={`The “${selectedSchema}” schema doesn’t have any tables.`}
               >
-                <Button asChild className="mt-2" type="default" icon={<Plus />}>
-                  <Link href={`/project/${ref}/editor?create=table`}>New table</Link>
-                </Button>
+                {!isSchemaLocked ? (
+                  <Button asChild className="mt-2" type="default" icon={<Plus />}>
+                    <Link href={`/project/${ref}/editor?create=table`}>New table</Link>
+                  </Button>
+                ) : (
+                  <ButtonTooltip
+                    asChild
+                    type="default"
+                    className="group"
+                    icon={<Plus />}
+                    disabled
+                    tooltip={{
+                      content: {
+                        side: 'bottom',
+                        className: 'w-[280px]',
+                        text: (
+                          <ProtectedSchemaWarning
+                            size="sm"
+                            schema={selectedSchema}
+                            entity="table"
+                          />
+                        ),
+                      },
+                    }}
+                  >
+                    <Link passHref href={`/project/${ref}/editor?create=table`}>
+                      New table
+                    </Link>
+                  </ButtonTooltip>
+                )}
               </Admonition>
             </div>
           ) : (

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -15,7 +15,6 @@ import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import SchemaSelector from 'components/ui/SchemaSelector'
-import { ProtectedSchemaWarning } from 'components/interfaces/Database/ProtectedSchemaWarning'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
@@ -301,34 +300,20 @@ export const SchemaGraph = () => {
                 type="default"
                 className="max-w-md"
                 title="No tables in schema"
-                description={`The “${selectedSchema}” schema doesn’t have any tables.`}
+                description={
+                  isSchemaLocked
+                    ? `The “${selectedSchema}” schema is managed by Supabase and is read-only through
+                    the dashboard.`
+                    : !canUpdateTables
+                      ? 'You need additional permissions to create tables'
+                      : `The “${selectedSchema}” schema doesn’t have any tables.`
+                }
               >
-                <ButtonTooltip
-                  asChild
-                  type="default"
-                  className="group"
-                  icon={<Plus />}
-                  disabled={!canAddTables}
-                  tooltip={{
-                    content: {
-                      side: 'bottom',
-                      className: 'w-[280px]',
-                      text: isSchemaLocked ? (
-                        <ProtectedSchemaWarning
-                          size="sm"
-                          schema={selectedSchema}
-                          entity="table"
-                        />
-                      ) : !canUpdateTables ? (
-                        'You need additional permissions to create tables'
-                      ) : undefined,
-                    },
-                  }}
-                >
-                  <Link passHref href={`/project/${ref}/editor?create=table`}>
-                    New table
-                  </Link>
-                </ButtonTooltip>
+                {canAddTables && (
+                  <Button asChild className="mt-2" type="default" icon={<Plus />}>
+                    <Link href={`/project/${ref}/editor?create=table`}>New table</Link>
+                  </Button>
+                )}
               </Admonition>
             </div>
           ) : (

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -303,38 +303,32 @@ export const SchemaGraph = () => {
                 title="No tables in schema"
                 description={`The “${selectedSchema}” schema doesn’t have any tables.`}
               >
-                {canAddTables ? (
-                  <Button asChild className="mt-2" type="default" icon={<Plus />}>
-                    <Link href={`/project/${ref}/editor?create=table`}>New table</Link>
-                  </Button>
-                ) : (
-                  <ButtonTooltip
-                    asChild
-                    type="default"
-                    className="group"
-                    icon={<Plus />}
-                    disabled
-                    tooltip={{
-                      content: {
-                        side: 'bottom',
-                        className: 'w-[280px]',
-                        text: isSchemaLocked ? (
-                          <ProtectedSchemaWarning
-                            size="sm"
-                            schema={selectedSchema}
-                            entity="table"
-                          />
-                        ) : (
-                          'You need additional permissions to create tables'
-                        ),
-                      },
-                    }}
-                  >
-                    <Link passHref href={`/project/${ref}/editor?create=table`}>
-                      New table
-                    </Link>
-                  </ButtonTooltip>
-                )}
+                <ButtonTooltip
+                  asChild
+                  type="default"
+                  className="group"
+                  icon={<Plus />}
+                  disabled={!canAddTables}
+                  tooltip={{
+                    content: {
+                      side: 'bottom',
+                      className: 'w-[280px]',
+                      text: isSchemaLocked ? (
+                        <ProtectedSchemaWarning
+                          size="sm"
+                          schema={selectedSchema}
+                          entity="table"
+                        />
+                      ) : !canUpdateTables ? (
+                        'You need additional permissions to create tables'
+                      ) : undefined,
+                    },
+                  }}
+                >
+                  <Link passHref href={`/project/${ref}/editor?create=table`}>
+                    New table
+                  </Link>
+                </ButtonTooltip>
               </Admonition>
             </div>
           ) : (


### PR DESCRIPTION
Fixes #40982 

I checked if the selected schema is protected, and if so, make "New Table" button disabled with a tooltip explaining why.

<img width="1920" height="1080" alt="Screenshot (1)" src="https://github.com/user-attachments/assets/edce7897-d74f-48eb-bf58-e300ef56f952" />

This effectively prevents the navigation to the editor table and the opening of the table editor on the protected schema.

Still doesn't fix the issue of `extensions` schema though, I'll try to fix in another PR.

Edit: I made a change to check if the user is allowed to create tables as well, otherwise the button will be disabled!

<img width="1920" height="1080" alt="Screenshot (4)" src="https://github.com/user-attachments/assets/7277c91d-26c2-49fe-bc97-7bd3ffe77d5d" />
