### PR TITLE
fix: bucket delete wait for all files to be deleted

### DIFF
--- a/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
@@ -90,12 +90,18 @@ describe(`DeleteBucketModal`, () => {
         },
       ],
     })
-    // useBucketDeleteMutation
+    // useBucketDeleteMutation - empty bucket
     addAPIMock({
       method: `post`,
       path: `/platform/storage/:ref/buckets/:id/empty`,
     })
-    // useDatabasePolicyDeleteMutation
+    // useBucketDeleteMutation - poll for empty bucket
+    addAPIMock({
+      method: `post`,
+      path: `/platform/storage/:ref/buckets/:id/objects/list`,
+      response: [], // Return empty array to indicate bucket is empty
+    })
+    // useBucketDeleteMutation - delete bucket
     addAPIMock({
       method: `delete`,
       path: `/platform/storage/:ref/buckets/:id`,

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { del, handleError, post } from 'data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { storageKeys } from './keys'
+import { pollUntilBucketEmpty } from './bucket-util'
 
 type BucketDeleteVariables = {
   projectRef: string
@@ -18,6 +19,8 @@ async function deleteBucket({ projectRef, id }: BucketDeleteVariables) {
     params: { path: { ref: projectRef, id } },
   })
   if (emptyBucketError) handleError(emptyBucketError)
+
+  await pollUntilBucketEmpty({ projectRef, bucketId: id })
 
   const { data, error: deleteBucketError } = await del('/platform/storage/{ref}/buckets/{id}', {
     params: { path: { ref: projectRef, id } },

--- a/apps/studio/data/storage/bucket-util.ts
+++ b/apps/studio/data/storage/bucket-util.ts
@@ -1,0 +1,35 @@
+import { listBucketObjects } from './bucket-objects-list-mutation'
+
+const DEFAULT_INTERVAL_MS = 3000
+const DEFAULT_MAX_ATTEMPTS = 60
+
+export async function pollUntilBucketEmpty({
+  projectRef,
+  bucketId,
+  intervalMs = DEFAULT_INTERVAL_MS,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+}: {
+  projectRef: string
+  bucketId: string
+  intervalMs?: number
+  maxAttempts?: number
+}): Promise<void> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const objects = await listBucketObjects({
+      projectRef,
+      bucketId,
+      path: '',
+      options: {
+        limit: 10,
+      },
+    })
+
+    if (objects.length === 0) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+
+  throw new Error('Timeout waiting for bucket to empty')
+}

--- a/apps/studio/data/storage/bucket-util.ts
+++ b/apps/studio/data/storage/bucket-util.ts
@@ -31,5 +31,5 @@ export async function pollUntilBucketEmpty({
     await new Promise((resolve) => setTimeout(resolve, intervalMs))
   }
 
-  throw new Error('Timeout waiting for bucket to empty')
+  throw new Error('Failed to empty bucket. Please try again in a few minutes.')
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: poll till files are deleted then remove the bucket. Otherwise files get deleted (async operation) and bucket fails to delete. Adds a bit of delay

Workaround until we have a better endpoint ready