### PR TITLE
Increase the max file size for Functions code editor to 20MB

### DIFF
--- a/apps/studio/data/edge-functions/edge-function-body-query.ts
+++ b/apps/studio/data/edge-functions/edge-function-body-query.ts
@@ -33,7 +33,10 @@ export async function getEdgeFunctionBody(
 
   if (!data || !boundary) return { files: [] }
 
-  for await (let part of parseMultipartStream(data, { boundary })) {
+  for await (let part of parseMultipartStream(data, {
+    boundary,
+    maxFileSize: 20 * 1024 * 1024,
+  })) {
     if (part.isFile) {
       files.push({
         name: part.filename,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The default was 2MB, which was causing errors when loading large files like images, wasm.
