### PR TITLE
fix(studio): delegate check for expired token to gotrue

### DIFF
--- a/packages/common/auth.tsx
+++ b/packages/common/auth.tsx
@@ -159,27 +159,21 @@ gotrueClient.onAuthStateChange((event, session) => {
 })
 
 /**
- * Grabs the currently available access token, or calls getSession.
+ * Gets a current access token.
+ *
+ * Calls getSession, which will refresh the token if needed.
  */
 export async function getAccessToken() {
   // ignore if server-side
   if (typeof window === 'undefined') return undefined
 
-  const aboutToExpire = currentSession?.expires_at
-    ? currentSession.expires_at - Math.ceil(Date.now() / 1000) < 30
-    : false
-
-  if (!currentSession || aboutToExpire) {
-    const {
-      data: { session },
-      error,
-    } = await gotrueClient.getSession()
-    if (error) {
-      throw error
-    }
-
-    return session?.access_token
+  const {
+    data: { session },
+    error,
+  } = await gotrueClient.getSession()
+  if (error) {
+    throw error
   }
 
-  return currentSession.access_token
+  return session?.access_token
 }


### PR DESCRIPTION
Gotrue already does the work of using the cached token if possible/refreshing if about to expire (and uses a different expiry period from what we have -- 90 seconds vs. 30 seconds). We can delegate this work to Gotrue to avoid the expiry check mismatch

Related to FE-2179