### PR TITLE
fix(docs): remove unnecessary network restriction section

### DIFF
--- a/apps/docs/content/guides/deployment/branching/troubleshooting.mdx
+++ b/apps/docs/content/guides/deployment/branching/troubleshooting.mdx
@@ -35,22 +35,6 @@ A deployment might fail for various reasons, including invalid SQL statements an
 
 To check the error message, see the Supabase workflow run for your branch under the [View logs](/dashboard/project/_/branches) section.
 
-### Network restrictions
-
-If you enable [network restrictions](/docs/guides/platform/network-restrictions) on your project, the branching cluster will be blocked from connecting to your project by default. This often results in database connection failures when migrating your production project after merging a development branch.
-
-The workaround is to explicitly allow the IPv6 CIDR range of the branching cluster in your project's [Database Settings](/dashboard/project/_/database/settings) page: `2600:1f18:2b7d:f600::/56`
-
-<Image
-  alt="Network restrictions to allow connections from branching cluster"
-  src={{
-    dark: '/docs/img/guides/branching/cidr-dark.png',
-    light: '/docs/img/guides/branching/cidr-light.png',
-  }}
-  className="max-w-[550px] !mx-auto border rounded-md"
-  zoomable
-/>
-
 ### Schema drift between preview branches
 
 If multiple preview branches exist, each preview branch might contain different schema changes. This is similar to Git branches, where each branch might contain different code changes.


### PR DESCRIPTION
Branching executors are now part of the supabase systems allowed lists