### PR TITLE
refactor: infra queries to use `attributes`

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { useRouter } from 'next/router'
-import { ReactNode, useCallback, useEffect, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from 'ui'
 
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
@@ -9,8 +9,9 @@ import NoDataPlaceholder from 'components/ui/Charts/NoDataPlaceholder'
 import { AnalyticsInterval } from 'data/analytics/constants'
 import {
   InfraMonitoringAttribute,
-  useInfraMonitoringQuery,
+  useInfraMonitoringAttributesQuery,
 } from 'data/analytics/infra-monitoring-query'
+import { mapMultiResponseToAnalyticsData } from 'data/analytics/infra-monitoring-queries'
 import {
   ProjectDailyStatsAttribute,
   useProjectDailyStatsQuery,
@@ -81,13 +82,13 @@ export const ChartBlock = ({
   )
 
   const {
-    data: infraMonitoringData,
+    data: infraMonitoringRawData,
     isFetching: isFetchingInfraMonitoring,
     isLoading: isLoadingInfraMonitoring,
-  } = useInfraMonitoringQuery(
+  } = useInfraMonitoringAttributesQuery(
     {
       projectRef: ref as string,
-      attribute: attribute as InfraMonitoringAttribute,
+      attributes: [attribute as InfraMonitoringAttribute],
       startDate,
       endDate,
       interval: interval as AnalyticsInterval,
@@ -95,6 +96,14 @@ export const ChartBlock = ({
     },
     { enabled: provider === 'infra-monitoring' }
   )
+
+  const infraMonitoringData = useMemo(() => {
+    if (!infraMonitoringRawData) return undefined
+    const mapped = mapMultiResponseToAnalyticsData(infraMonitoringRawData, [
+      attribute as InfraMonitoringAttribute,
+    ])
+    return mapped[attribute]
+  }, [infraMonitoringRawData, attribute])
 
   const chartData =
     provider === 'infra-monitoring'

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -25,7 +25,7 @@ import {
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import ShimmeringLoader, { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
-import { useInfraMonitoringQuery } from 'data/analytics/infra-monitoring-query'
+import { useInfraMonitoringAttributesQuery } from 'data/analytics/infra-monitoring-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useProjectDetailQuery } from 'data/projects/project-detail-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
@@ -82,14 +82,18 @@ export const Addons = () => {
   // I tried setting the interval to 1m but no data was returned, may need to experiment
   const startDate = useMemo(() => dayjs().subtract(15, 'minutes').millisecond(0).toISOString(), [])
   const endDate = useMemo(() => dayjs().millisecond(0).toISOString(), [])
-  const { data: ioBudgetData } = useInfraMonitoringQuery({
+  const { data: ioBudgetData } = useInfraMonitoringAttributesQuery({
     projectRef,
-    attribute: 'disk_io_budget',
+    attributes: ['disk_io_budget'],
     interval: '5m',
     startDate,
     endDate,
   })
-  const [mostRecentRemainingIOBudget] = (ioBudgetData?.data ?? []).slice(-1)
+  const mostRecentRemainingIOBudget = useMemo(() => {
+    if (!ioBudgetData?.data?.length) return undefined
+    const lastPoint = ioBudgetData.data[ioBudgetData.data.length - 1]
+    return { disk_io_budget: lastPoint.values?.disk_io_budget }
+  }, [ioBudgetData])
 
   const {
     data: addons,

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -25,6 +25,7 @@ import {
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import ShimmeringLoader, { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
+import { mapResponseToAnalyticsData } from 'data/analytics/infra-monitoring-queries'
 import { useInfraMonitoringAttributesQuery } from 'data/analytics/infra-monitoring-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useProjectDetailQuery } from 'data/projects/project-detail-query'
@@ -90,9 +91,12 @@ export const Addons = () => {
     endDate,
   })
   const mostRecentRemainingIOBudget = useMemo(() => {
-    if (!ioBudgetData?.data?.length) return undefined
-    const lastPoint = ioBudgetData.data[ioBudgetData.data.length - 1]
-    return { disk_io_budget: lastPoint.values?.disk_io_budget }
+    if (!ioBudgetData) return undefined
+    const mapped = mapResponseToAnalyticsData(ioBudgetData, ['disk_io_budget'])
+    const data = mapped['disk_io_budget']?.data
+    if (!data?.length) return undefined
+    const lastPoint = data[data.length - 1]
+    return { disk_io_budget: lastPoint?.disk_io_budget }
   }, [ioBudgetData])
 
   const {

--- a/apps/studio/components/ui/Charts/ChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ChartHandler.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { PropsWithChildren, useState } from 'react'
+import { PropsWithChildren, useMemo, useState } from 'react'
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import AreaChart from 'components/ui/Charts/AreaChart'
@@ -7,8 +7,9 @@ import BarChart from 'components/ui/Charts/BarChart'
 import { AnalyticsInterval } from 'data/analytics/constants'
 import {
   InfraMonitoringAttribute,
-  useInfraMonitoringQuery,
+  useInfraMonitoringAttributesQuery,
 } from 'data/analytics/infra-monitoring-query'
+import { mapMultiResponseToAnalyticsData } from 'data/analytics/infra-monitoring-queries'
 import {
   ProjectDailyStatsAttribute,
   useProjectDailyStatsQuery,
@@ -83,10 +84,10 @@ const ChartHandler = ({
   )
 
   const { data: infraMonitoringData, isLoading: isFetchingInfraMonitoring } =
-    useInfraMonitoringQuery(
+    useInfraMonitoringAttributesQuery(
       {
         projectRef: ref as string,
-        attribute: attribute as InfraMonitoringAttribute,
+        attributes: [attribute as InfraMonitoringAttribute],
         startDate,
         endDate,
         interval: interval as AnalyticsInterval,
@@ -95,10 +96,18 @@ const ChartHandler = ({
       { enabled: provider === 'infra-monitoring' && data === undefined }
     )
 
+  const transformedInfraData = useMemo(() => {
+    if (!infraMonitoringData) return undefined
+    const mapped = mapMultiResponseToAnalyticsData(infraMonitoringData, [
+      attribute as InfraMonitoringAttribute,
+    ])
+    return mapped[attribute]
+  }, [infraMonitoringData, attribute])
+
   const chartData =
     data ||
     (provider === 'infra-monitoring'
-      ? infraMonitoringData
+      ? transformedInfraData
       : provider === 'daily-stats'
         ? dailyStatsData
         : undefined)

--- a/apps/studio/data/analytics/infra-monitoring-queries.test.ts
+++ b/apps/studio/data/analytics/infra-monitoring-queries.test.ts
@@ -69,4 +69,14 @@ describe('mapMultiResponseToAnalyticsData', () => {
 
     expect(result.max_cpu_usage?.data[0].periodStartFormatted).toBe('2024/01/02')
   })
+
+  it('handles single attribute the same as multiple attributes', () => {
+    const singleResult = mapMultiResponseToAnalyticsData(mockResponse, ['max_cpu_usage'])
+    const multiResult = mapMultiResponseToAnalyticsData(mockResponse, [
+      'max_cpu_usage',
+      'ram_usage',
+    ])
+
+    expect(singleResult.max_cpu_usage).toStrictEqual(multiResult.max_cpu_usage)
+  })
 })

--- a/apps/studio/data/analytics/infra-monitoring-queries.test.ts
+++ b/apps/studio/data/analytics/infra-monitoring-queries.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import type { InfraMonitoringMultiData } from './infra-monitoring-query'
-import { mapMultiResponseToAnalyticsData } from './infra-monitoring-queries'
+import type {
+  InfraMonitoringMultiData,
+  InfraMonitoringMultiResponse,
+  InfraMonitoringSingleResponse,
+} from './infra-monitoring-query'
+import {
+  mapResponseToAnalyticsData,
+  mapMultiResponseToAnalyticsData,
+} from './infra-monitoring-queries'
 
-const mockResponse: InfraMonitoringMultiData = {
+const mockMultiResponse: InfraMonitoringMultiResponse = {
   data: [
     {
       period_start: '2024-01-02 03:04:00',
@@ -26,57 +33,140 @@ const mockResponse: InfraMonitoringMultiData = {
   },
 }
 
-describe('mapMultiResponseToAnalyticsData', () => {
-  it('maps attribute series and coerces values to numbers', () => {
-    const result = mapMultiResponseToAnalyticsData(mockResponse, ['max_cpu_usage', 'ram_usage'])
+// TODO(raulb): Remove this mock once API always returns multi-attribute format
+const mockSingleResponse: InfraMonitoringSingleResponse = {
+  data: [
+    {
+      period_start: '2024-01-02 03:04:00',
+      disk_io_budget: '75.5',
+    },
+    {
+      period_start: '2024-01-02 04:04:00',
+      disk_io_budget: '80.2',
+    },
+  ],
+  format: 'percent',
+  total: 155.7,
+  totalAverage: 77.85,
+  yAxisLimit: 100,
+}
 
-    expect(result.max_cpu_usage?.data).toStrictEqual([
-      {
-        period_start: '2024-01-02 03:04:00',
-        periodStartFormatted: '03:04 02 Jan',
-        max_cpu_usage: 1.5,
-      },
-      {
-        period_start: '2024-01-02 04:04:00',
-        periodStartFormatted: '04:04 02 Jan',
-        max_cpu_usage: 0,
-      },
-    ])
+describe('mapResponseToAnalyticsData', () => {
+  describe('multi-attribute response format', () => {
+    it('maps attribute series and coerces values to numbers', () => {
+      const result = mapResponseToAnalyticsData(mockMultiResponse, ['max_cpu_usage', 'ram_usage'])
 
-    expect(result.ram_usage?.data[0].ram_usage).toBe(0)
-    expect(result.ram_usage?.data[1].ram_usage).toBe(3)
-    expect(result.max_cpu_usage).toMatchObject({
-      format: 'percent',
-      total: 2.5,
-      yAxisLimit: 100,
+      expect(result.max_cpu_usage?.data).toStrictEqual([
+        {
+          period_start: '2024-01-02 03:04:00',
+          periodStartFormatted: '03:04 02 Jan',
+          max_cpu_usage: 1.5,
+        },
+        {
+          period_start: '2024-01-02 04:04:00',
+          periodStartFormatted: '04:04 02 Jan',
+          max_cpu_usage: 0,
+        },
+      ])
+
+      expect(result.ram_usage?.data[0].ram_usage).toBe(0)
+      expect(result.ram_usage?.data[1].ram_usage).toBe(3)
+      expect(result.max_cpu_usage).toMatchObject({
+        format: 'percent',
+        total: 2.5,
+        yAxisLimit: 100,
+      })
+    })
+
+    it('omits attributes that are missing series metadata', () => {
+      const result = mapResponseToAnalyticsData(mockMultiResponse, [
+        'max_cpu_usage',
+        'ram_usage',
+        'pg_stat_database_num_backends',
+      ])
+
+      expect(result.max_cpu_usage).toBeDefined()
+      expect(result.ram_usage).toBeDefined()
+      expect(result.pg_stat_database_num_backends).toBeUndefined()
+    })
+
+    it('handles single attribute the same as multiple attributes', () => {
+      const singleResult = mapResponseToAnalyticsData(mockMultiResponse, ['max_cpu_usage'])
+      const multiResult = mapResponseToAnalyticsData(mockMultiResponse, [
+        'max_cpu_usage',
+        'ram_usage',
+      ])
+
+      expect(singleResult.max_cpu_usage).toStrictEqual(multiResult.max_cpu_usage)
     })
   })
 
-  it('omits attributes that are missing series metadata', () => {
-    const result = mapMultiResponseToAnalyticsData(mockResponse, [
-      'max_cpu_usage',
-      'ram_usage',
-      'pg_stat_database_num_backends',
-    ])
+  // TODO(raulb): Remove this test block once API always returns multi-attribute format
+  describe('single-attribute response format (legacy)', () => {
+    it('maps single-attribute response and coerces values to numbers', () => {
+      const result = mapResponseToAnalyticsData(mockSingleResponse as InfraMonitoringMultiData, [
+        'disk_io_budget',
+      ])
 
-    expect(result.max_cpu_usage).toBeDefined()
-    expect(result.ram_usage).toBeDefined()
-    expect(result.pg_stat_database_num_backends).toBeUndefined()
+      expect(result.disk_io_budget?.data).toStrictEqual([
+        {
+          period_start: '2024-01-02 03:04:00',
+          periodStartFormatted: '03:04 02 Jan',
+          disk_io_budget: 75.5,
+        },
+        {
+          period_start: '2024-01-02 04:04:00',
+          periodStartFormatted: '04:04 02 Jan',
+          disk_io_budget: 80.2,
+        },
+      ])
+
+      expect(result.disk_io_budget).toMatchObject({
+        format: 'percent',
+        total: 155.7,
+        yAxisLimit: 100,
+      })
+    })
+
+    it('returns empty object when no attributes provided', () => {
+      const result = mapResponseToAnalyticsData(mockSingleResponse as InfraMonitoringMultiData, [])
+
+      expect(result).toStrictEqual({})
+    })
   })
 
-  it('uses a custom date format when provided', () => {
-    const result = mapMultiResponseToAnalyticsData(mockResponse, ['max_cpu_usage'], 'YYYY/MM/DD')
+  describe('output format consistency', () => {
+    it('produces the same output structure for both response formats', () => {
+      // Create equivalent responses in both formats for the same data
+      const multiFormat: InfraMonitoringMultiResponse = {
+        data: [{ period_start: '2024-01-02 03:04:00', values: { disk_io_budget: '75.5' } }],
+        series: {
+          disk_io_budget: { format: 'percent', total: 75.5, totalAverage: 75.5, yAxisLimit: 100 },
+        },
+      }
 
-    expect(result.max_cpu_usage?.data[0].periodStartFormatted).toBe('2024/01/02')
+      const singleFormat: InfraMonitoringSingleResponse = {
+        data: [{ period_start: '2024-01-02 03:04:00', disk_io_budget: '75.5' }],
+        format: 'percent',
+        total: 75.5,
+        totalAverage: 75.5,
+        yAxisLimit: 100,
+      }
+
+      const multiResult = mapResponseToAnalyticsData(multiFormat, ['disk_io_budget'])
+      const singleResult = mapResponseToAnalyticsData(singleFormat as InfraMonitoringMultiData, [
+        'disk_io_budget',
+      ])
+
+      // Both should produce identical output
+      expect(singleResult.disk_io_budget).toStrictEqual(multiResult.disk_io_budget)
+    })
   })
+})
 
-  it('handles single attribute the same as multiple attributes', () => {
-    const singleResult = mapMultiResponseToAnalyticsData(mockResponse, ['max_cpu_usage'])
-    const multiResult = mapMultiResponseToAnalyticsData(mockResponse, [
-      'max_cpu_usage',
-      'ram_usage',
-    ])
-
-    expect(singleResult.max_cpu_usage).toStrictEqual(multiResult.max_cpu_usage)
+// Test deprecated alias still works
+describe('mapMultiResponseToAnalyticsData (deprecated)', () => {
+  it('is an alias for mapResponseToAnalyticsData', () => {
+    expect(mapMultiResponseToAnalyticsData).toBe(mapResponseToAnalyticsData)
   })
 })

--- a/apps/studio/data/analytics/infra-monitoring-query.ts
+++ b/apps/studio/data/analytics/infra-monitoring-query.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
-import dayjs from 'dayjs'
 
 import { get, handleError } from 'data/fetchers'
-import type { AnalyticsData, AnalyticsInterval } from './constants'
+import type { AnalyticsInterval } from './constants'
 import { analyticsKeys } from './keys'
 import { UseCustomQueryOptions } from 'types'
 
@@ -25,17 +24,6 @@ export type InfraMonitoringAttribute =
   | 'realtime_sum_connections_connected'
   | 'realtime_replication_connection_lag'
 
-export type InfraMonitoringVariables = {
-  projectRef?: string
-  attribute: InfraMonitoringAttribute
-  startDate?: string
-  endDate?: string
-  interval?: AnalyticsInterval
-  dateFormat?: string
-  databaseIdentifier?: string
-  modifier?: (x: number) => number
-}
-
 export type InfraMonitoringSeriesMetadata = {
   yAxisLimit: number
   format: string
@@ -51,45 +39,13 @@ export type InfraMonitoringMultiResponse = {
   series: Record<string, InfraMonitoringSeriesMetadata>
 }
 
-export type InfraMonitoringMultiVariables = Omit<
-  InfraMonitoringVariables,
-  'attribute' | 'modifier'
-> & {
+export type InfraMonitoringMultiVariables = {
+  projectRef?: string
   attributes: InfraMonitoringAttribute[]
-}
-
-export async function getInfraMonitoring(
-  {
-    projectRef,
-    attribute,
-    startDate,
-    endDate,
-    interval = '1h',
-    databaseIdentifier,
-  }: InfraMonitoringVariables,
-  signal?: AbortSignal
-) {
-  if (!projectRef) throw new Error('Project ref is required')
-  if (!attribute) throw new Error('Attribute is required')
-  if (!startDate) throw new Error('Start date is required')
-  if (!endDate) throw new Error('End date is required')
-
-  const { data, error } = await get('/platform/projects/{ref}/infra-monitoring', {
-    params: {
-      path: { ref: projectRef },
-      query: {
-        attribute,
-        startDate,
-        endDate,
-        interval,
-        databaseIdentifier,
-      },
-    },
-    signal,
-  })
-
-  if (error) handleError(error)
-  return data as unknown as AnalyticsData
+  startDate?: string
+  endDate?: string
+  interval?: AnalyticsInterval
+  databaseIdentifier?: string
 }
 
 export async function getInfraMonitoringAttributes(
@@ -127,61 +83,8 @@ export async function getInfraMonitoringAttributes(
   return data as unknown as InfraMonitoringMultiResponse
 }
 
-export type InfraMonitoringData = Awaited<ReturnType<typeof getInfraMonitoring>>
 export type InfraMonitoringError = unknown
 export type InfraMonitoringMultiData = Awaited<ReturnType<typeof getInfraMonitoringAttributes>>
-
-export const useInfraMonitoringQuery = <TData = InfraMonitoringData>(
-  {
-    projectRef,
-    attribute,
-    startDate,
-    endDate,
-    interval = '1h',
-    dateFormat = 'HH:mm DD MMM',
-    databaseIdentifier,
-    modifier,
-  }: InfraMonitoringVariables,
-  {
-    enabled = true,
-    ...options
-  }: UseCustomQueryOptions<InfraMonitoringData, InfraMonitoringError, TData> = {}
-) =>
-  useQuery<InfraMonitoringData, InfraMonitoringError, TData>({
-    queryKey: analyticsKeys.infraMonitoring(projectRef, {
-      attribute,
-      startDate,
-      endDate,
-      interval,
-      databaseIdentifier,
-    }),
-    queryFn: ({ signal }) =>
-      getInfraMonitoring(
-        { projectRef, attribute, startDate, endDate, interval, databaseIdentifier },
-        signal
-      ),
-    enabled:
-      enabled &&
-      typeof projectRef !== 'undefined' &&
-      typeof attribute !== 'undefined' &&
-      typeof startDate !== 'undefined' &&
-      typeof endDate !== 'undefined',
-    select(data) {
-      return {
-        ...data,
-        data: data.data.map((x) => {
-          return {
-            ...x,
-            [attribute]:
-              modifier !== undefined ? modifier(Number(x[attribute])) : Number(x[attribute]),
-            periodStartFormatted: dayjs(x.period_start).format(dateFormat),
-          }
-        }),
-      } as TData
-    },
-    staleTime: 1000 * 60,
-    ...options,
-  })
 
 export const useInfraMonitoringAttributesQuery = <TData = InfraMonitoringMultiData>(
   {

--- a/apps/studio/data/analytics/infra-monitoring-query.ts
+++ b/apps/studio/data/analytics/infra-monitoring-query.ts
@@ -31,6 +31,16 @@ export type InfraMonitoringSeriesMetadata = {
   totalAverage: number
 }
 
+// TODO(raulb): Remove InfraMonitoringSingleResponse once API always returns multi-attribute format.
+// Single-attribute response shape (when API receives 1 attribute)
+export type InfraMonitoringSingleResponse = InfraMonitoringSeriesMetadata & {
+  data: {
+    period_start: string
+    [attribute: string]: string | undefined
+  }[]
+}
+
+// Multi-attribute response shape (when API receives 2+ attributes)
 export type InfraMonitoringMultiResponse = {
   data: {
     period_start: string
@@ -38,6 +48,10 @@ export type InfraMonitoringMultiResponse = {
   }[]
   series: Record<string, InfraMonitoringSeriesMetadata>
 }
+
+// TODO(raulb): Simplify to just InfraMonitoringMultiResponse once API always returns multi-attribute format.
+// API returns different shapes based on attribute count
+export type InfraMonitoringResponse = InfraMonitoringSingleResponse | InfraMonitoringMultiResponse
 
 export type InfraMonitoringMultiVariables = {
   projectRef?: string
@@ -80,7 +94,7 @@ export async function getInfraMonitoringAttributes(
   })
 
   if (error) handleError(error)
-  return data as unknown as InfraMonitoringMultiResponse
+  return data as unknown as InfraMonitoringResponse
 }
 
 export type InfraMonitoringError = unknown


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR refactors the infrastructure monitoring query code reducing duplication and unifying the API request to always be `attributes`.

## What is the current behavior?

There's duplicated code and in some situations we request for `infra-monitoring?attributes` and in some others `infra-monitoring?attribute` which makes some code a bit redundant. 

## What is the new behavior?

> [!NOTE]  
> No functional changes.

**Code changes**

- Removed the separate useInfraMonitoringQuery hook and getInfraMonitoring function that handled a single monitoring query
- Consolidated all infrastructure monitoring queries into a unified `useInfraMonitoringAttributesQuery` hook that handles multi-attribute requests
- Moved interval selection logic from the query layer to the consumer `InfrastructureActivity.tsx`, where it can be computed dynamically based on user-selected date ranges
- Simplified query types by removing intermediate InfraMonitoringData and InfraMonitoringVariables types
- Interval is now computed in the component (defaults to 1d, switches to 1h for date ranges ≤48 hours) rather than hardcoded in the query layer
- All queries now use the unified multi-attribute endpoint with explicit parameter passing

## Additional context

Working on https://github.com/supabase/platform/pull/28021, I noticed we were still making these single attribute requests.

This is take II of https://github.com/supabase/supabase/pull/40473.