### PR TITLE
Change localhost to storage in Health Check test

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -50,7 +50,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:5000/status"
+          "http://storage:5000/status"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When self hosting Supabase with s3 enabled, the storage service health check was failing silently. Although the service was starting, the health-check was failing. This causes additional issues, for example if a different service adds storage as a dependency, that service will never start, since it is unhealthy.

### To reproduce this issue 

Compose up with s3 enabled

```
docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d  
```

wait until all services are up

Inspect supabase storage

```
docker inspect supabase-storage 
```

The health check logs are showing that connection is refused

```
            "Health": {
                "Status": "unhealthy",
                "FailingStreak": 16,
                "Log": [
                    {
                        "Start": "2025-12-03T23:27:15.388546802Z",
                        "End": "2025-12-03T23:27:15.423392594Z",
                        "ExitCode": 1,
                        "Output": "Connecting to localhost:5000 ([::1]:5000)\nwget: can't connect to remote host: Connection refused\n"
                    },
                    {
                        "Start": "2025-12-03T23:27:20.425335263Z",
                        "End": "2025-12-03T23:27:20.453573221Z",
                        "ExitCode": 1,
                        "Output": "Connecting to localhost:5000 ([::1]:5000)\nwget: can't connect to remote host: Connection refused\n"
                    },
                    {
                        "Start": "2025-12-03T23:27:25.454186001Z",
                        "End": "2025-12-03T23:27:25.506007668Z",
                        "ExitCode": 1,
                        "Output": "Connecting to localhost:5000 ([::1]:5000)\nwget: can't connect to remote host: Connection refused\n"
                    },
                    {
                        "Start": "2025-12-03T23:27:30.507230795Z",
                        "End": "2025-12-03T23:27:30.566108379Z",
                        "ExitCode": 1,
                        "Output": "Connecting to localhost:5000 ([::1]:5000)\nwget: can't connect to remote host: Connection refused\n"
                    },
                    {
                        "Start": "2025-12-03T23:27:35.567425839Z",
                        "End": "2025-12-03T23:27:35.605966506Z",
                        "ExitCode": 1,
                        "Output": "Connecting to localhost:5000 ([::1]:5000)\nwget: can't connect to remote host: Connection refused\n"
                    }
                ]
            }
        },
 ```



## What is the new behavior?

With this new set up, suprabe storage health check is healthy

```
            "Health": {
                "Status": "healthy",
                "FailingStreak": 0,
                "Log": [
                    {
                        "Start": "2025-12-03T23:29:48.727627095Z",
                        "End": "2025-12-03T23:29:48.762048762Z",
                        "ExitCode": 0,
                        "Output": "Connecting to storage:5000 (172.21.0.15:5000)\nremote file exists\n"
                    },
                    {
                        "Start": "2025-12-03T23:29:53.763479667Z",
                        "End": "2025-12-03T23:29:53.796114125Z",
                        "ExitCode": 0,
                        "Output": "Connecting to storage:5000 (172.21.0.15:5000)\nremote file exists\n"
                    },
                    {
                        "Start": "2025-12-03T23:29:58.797529086Z",
                        "End": "2025-12-03T23:29:58.813767586Z",
                        "ExitCode": 0,
                        "Output": "Connecting to storage:5000 (172.21.0.15:5000)\nremote file exists\n"
                    },
                    {
                        "Start": "2025-12-03T23:30:03.815448922Z",
                        "End": "2025-12-03T23:30:03.854237463Z",
                        "ExitCode": 0,
                        "Output": "Connecting to storage:5000 (172.21.0.15:5000)\nremote file exists\n"
                    },
                    {
                        "Start": "2025-12-03T23:30:08.856479174Z",
                        "End": "2025-12-03T23:30:08.909150674Z",
                        "ExitCode": 0,
                        "Output": "Connecting to storage:5000 (172.21.0.15:5000)\nremote file exists\n"
                    }
                ]
            }
        },

```



