### PR TITLE
chore(studio): title to sentence case on auth

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -179,7 +179,7 @@ export const SignInForm = () => {
             href={forgotPasswordUrl}
             className="absolute top-0 right-0 text-sm text-foreground-lighter"
           >
-            Forgot Password?
+            Forgot password?
           </Link>
         </div>
 
@@ -199,7 +199,7 @@ export const SignInForm = () => {
 
         <LastSignInWrapper type="email">
           <Button block form={formId} htmlType="submit" size="large" loading={isSubmitting}>
-            Sign In
+            Sign in
           </Button>
         </LastSignInWrapper>
       </form>

--- a/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
@@ -33,7 +33,7 @@ export const SignInPartner = () => {
       <Loader2 className="animate-spin" />
       <h2 className="text-lg text-center">Signing in to Supabase Dashboard</h2>
       <p className="text-xs text-foreground-lighter text-center max-w-[220px] sm:max-w-full">
-        By continuing, you agree to Supabase's{' '}
+        By continuing, you agree to Supabase’s{' '}
         <InlineLink
           href="https://supabase.com/terms"
           className="text-foreground-lighter hover:text-foreground"

--- a/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -108,7 +108,7 @@ export const SignInSSOForm = () => {
         </div>
 
         <Button block form={formId} htmlType="submit" size="large" loading={isSubmitting}>
-          Sign In
+          Sign in
         </Button>
       </form>
     </Form_Shadcn_>

--- a/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -222,7 +222,7 @@ export const SignUpForm = () => {
               disabled={password.length === 0 || isSubmitting}
               loading={isSubmitting}
             >
-              Sign Up
+              Sign up
             </Button>
           </form>
         </Form_Shadcn_>

--- a/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
+++ b/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
@@ -149,9 +149,9 @@ const SignInLayout = ({
             </div>
 
             {showDisclaimer && showTos && (
-              <div className="sm:text-center">
+              <div className="text-center text-balance">
                 <p className="text-xs text-foreground-lighter sm:mx-auto sm:max-w-sm">
-                  By continuing, you agree to Supabase's{' '}
+                  By continuing, you agree to Supabase’s{' '}
                   <Link
                     href="https://supabase.com/terms"
                     className="underline hover:text-foreground-light"

--- a/apps/studio/pages/sign-in-fly-tos.tsx
+++ b/apps/studio/pages/sign-in-fly-tos.tsx
@@ -112,9 +112,9 @@ const SignInFlyTos = () => {
           )}
         </div>
       )}
-      <div className="sm:text-center">
+      <div className="text-center text-balance">
         <p className="text-xs text-foreground-lighter sm:mx-auto sm:max-w-sm">
-          By continuing, you agree to Supabase's{' '}
+          By continuing, you agree to Supabase’s{' '}
           <Link href="https://supabase.com/terms" className="underline hover:text-foreground-light">
             Terms of Service
           </Link>{' '}

--- a/apps/studio/pages/sign-in-sso.tsx
+++ b/apps/studio/pages/sign-in-sso.tsx
@@ -25,7 +25,7 @@ const SignInSSOPage: NextPageWithLayout = () => {
             rel="noopener noreferrer"
             className="underline text-foreground hover:text-foreground-light transition"
           >
-            Let Us Know
+            Let us know
           </a>
         </div>
       </div>

--- a/apps/studio/pages/sign-in.tsx
+++ b/apps/studio/pages/sign-in.tsx
@@ -86,7 +86,7 @@ const SignInPage: NextPageWithLayout = () => {
       {signUpEnabled && (
         <div className="self-center my-8 text-sm">
           <div>
-            <span className="text-foreground-light">Don't have an account?</span>{' '}
+            <span className="text-foreground-light">Don’t have an account?</span>{' '}
             <Link
               href={{
                 pathname: '/sign-up',
@@ -94,7 +94,7 @@ const SignInPage: NextPageWithLayout = () => {
               }}
               className="underline transition text-foreground hover:text-foreground-light"
             >
-              Sign Up Now
+              Sign up
             </Link>
           </div>
         </div>

--- a/apps/studio/pages/sign-up.tsx
+++ b/apps/studio/pages/sign-up.tsx
@@ -44,7 +44,7 @@ const SignUpPage: NextPageWithLayout = () => {
           href="/sign-in"
           className="underline text-foreground hover:text-foreground-light transition"
         >
-          Sign In Now
+          Sign in
         </Link>
       </div>
     </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Copywriting tweak.

## What is the current behavior?

Our sign up and sign in forms have Title Case links and buttons. It looks a bit odd, and we use sentence case everywhere else. 

## What is the new behavior?

- Sentence case instead
- Minor alignment fix on legal text
- Minor fix to use `utf-8`-safe [smart quotes](https://smartquotesforsmartpeople.com/)

| Before | After |
| --- | --- |
| <img width="574" height="837" alt="Supabase" src="https://github.com/user-attachments/assets/e6a316aa-652c-4ed1-b8e9-6ff1d7a29ff8" /> | <img width="574" height="837" alt="Supabase" src="https://github.com/user-attachments/assets/1cbef57c-6df1-4eef-8873-6ad6ba503012" /> |
| <img width="574" height="837" alt="Supabase" src="https://github.com/user-attachments/assets/d158ac4a-6ee7-45dc-865b-39ffdd913201" /> | <img width="574" height="837" alt="Supabase" src="https://github.com/user-attachments/assets/fe8c8585-e4e9-4d62-ab97-e45c1bcd36af" /> |
