### PR TITLE
perf: preconnect to API domain

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -139,6 +139,10 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                         __html: `:root{--font-custom:${customFont.style.fontFamily};--font-source-code-pro:${sourceCodePro.style.fontFamily};}`,
                       }}
                     />
+                    {/* Speed up initial API loading times by preconnecting to domain */}
+                    {IS_PLATFORM && (
+                      <link rel="preconnect" href={new URL(API_URL).origin} crossOrigin="" />
+                    )}
                   </Head>
                   <MetaFaviconsPagesRouter applicationName="Supabase Studio" includeManifest />
                   <TooltipProvider delayDuration={0}>

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -141,7 +141,11 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                     />
                     {/* Speed up initial API loading times by preconnecting to domain */}
                     {IS_PLATFORM && (
-                      <link rel="preconnect" href={new URL(API_URL).origin} crossOrigin="" />
+                      <link
+                        rel="preconnect"
+                        href={new URL(API_URL).origin}
+                        crossOrigin="anonymous"
+                      />
                     )}
                   </Head>
                   <MetaFaviconsPagesRouter applicationName="Supabase Studio" includeManifest />


### PR DESCRIPTION
This change adds a <link rel="preconnect"> for our API domain. Because the application makes several client-side requests to https://api.supabase.com shortly after page load, the browser currently has to perform DNS lookup, TCP handshake, and TLS negotiation only when the first API call happens.

By preconnecting, we let the browser complete these expensive operations ahead of time, in parallel with page rendering. This reduces the latency of the first API request and improves overall perceived performance, especially for users on slower networks or with high latency to the API host.
