### PR TITLE
fix(studio): mobile scroll on subscription update dialog

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -243,7 +243,7 @@ export const SubscriptionPlanUpdateDialog = ({
       <DialogContent
         onOpenAutoFocus={(event) => event.preventDefault()}
         size="xlarge"
-        className="p-0 overflow-y-auto max-h-[1000px]"
+        className="p-0"
       >
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 h-full items-stretch">
           {/* Left Column */}


### PR DESCRIPTION
Scrolling on mobile was janky due to a scroll container inside a scroll container. This delegates the scrolling logic back to the dialog.

To test:
- make sure on mobile the update subscription dialog works without jank