### PR TITLE
Revert "Revert "perf: preconnect to API domain""

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -139,6 +139,14 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                         __html: `:root{--font-custom:${customFont.style.fontFamily};--font-source-code-pro:${sourceCodePro.style.fontFamily};}`,
                       }}
                     />
+                    {/* Speed up initial API loading times by preconnecting to domain */}
+                    {IS_PLATFORM && (
+                      <link
+                        rel="preconnect"
+                        href={new URL(API_URL).origin}
+                        crossOrigin="anonymous"
+                      />
+                    )}
                   </Head>
                   <MetaFaviconsPagesRouter applicationName="Supabase Studio" includeManifest />
                   <TooltipProvider delayDuration={0}>

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -139,12 +139,12 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                         __html: `:root{--font-custom:${customFont.style.fontFamily};--font-source-code-pro:${sourceCodePro.style.fontFamily};}`,
                       }}
                     />
-                    {/* Speed up initial API loading times by preconnecting to domain */}
+                    {/* Speed up initial API loading times by pre-connecting to the API domain */}
                     {IS_PLATFORM && (
                       <link
                         rel="preconnect"
                         href={new URL(API_URL).origin}
-                        crossOrigin="anonymous"
+                        crossOrigin="use-credentials"
                       />
                     )}
                   </Head>


### PR DESCRIPTION
Reverts supabase/supabase#41063

Also switches to `crossOrigin="use-credentials"` since we're including credentials in our API requests.

To test:
- Make sure nothing breaks
- You can check in the Safari JS console as it logs when it pre-connects successfully