### PR TITLE
chore: backups entitlement

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -16,11 +16,13 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { BackupItem } from './BackupItem'
 import { BackupsEmpty } from './BackupsEmpty'
 import { BackupsStorageAlert } from './BackupsStorageAlert'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 
 export const BackupsList = () => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const [selectedBackup, setSelectedBackup] = useState<DatabaseBackup>()
+  const { hasAccess: hasAccessToBackups } = useCheckEntitlements('backup.retention_days')
 
   const { setProjectStatus } = useSetProjectStatus()
   const { data: selectedProject } = useSelectedProjectQuery()
@@ -53,7 +55,7 @@ export const BackupsList = () => {
   )
   const isPitrEnabled = backups?.pitr_enabled
 
-  if (planKey === 'FREE') {
+  if (!hasAccessToBackups) {
     return (
       <UpgradeToPro
         addon="pitr"
@@ -62,6 +64,7 @@ export const BackupsList = () => {
         icon={<Clock size={20} strokeWidth={1.5} />}
         primaryText="Free Plan does not include project backups."
         secondaryText="Upgrade to the Pro Plan for up to 7 days of scheduled backups."
+        buttonText="Upgrade"
       />
     )
   }


### PR DESCRIPTION
Depends on https://github.com/supabase/platform/pull/28151

### Changes
- Replaces the hardcoded plan check with the entitlement system for backups access control
- Uses `useCheckEntitlements('backup.retention_days')` to determine if a user has access to backups



### Testing

- Head to `/project/_/database/backups/pitr` with an org on the Free Plan
- Assert that you're not able to see any backups
<img width="2380" height="652" alt="image" src="https://github.com/user-attachments/assets/3c03c674-379b-46ab-8c58-110dd9329763" />


- Head to `/project/_/database/backups/pitr` with an org on the Pro Plan
- Assert that you're able to see backups up to 7 days

- Head to `/project/_/database/backups/pitr` with an org on the Team Plan
- Assert that you're able to see backups up to 30 days


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced backup access control to validate user entitlements for more accurate feature availability.
  * Updated backup upgrade prompt with clearer call-to-action messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->