### PR TITLE
Fix typo for entitlement check for persistent branching

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/Overview.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/Overview.tsx
@@ -23,6 +23,7 @@ import { useBranchResetMutation } from 'data/branches/branch-reset-mutation'
 import { useBranchUpdateMutation } from 'data/branches/branch-update-mutation'
 import type { Branch } from 'data/branches/branches-query'
 import { branchKeys } from 'data/branches/keys'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { IS_PLATFORM } from 'lib/constants'
@@ -38,7 +39,6 @@ import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
 import { BranchLoader, BranchManagementSection, BranchRow, BranchRowLoader } from './BranchPanels'
 import { EditBranchModal } from './EditBranchModal'
 import { PreviewBranchesEmptyState } from './EmptyStates'
-import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 
 interface OverviewProps {
   isGithubConnected: boolean
@@ -71,7 +71,7 @@ export const Overview = ({
   const { data: selectedOrg } = useSelectedOrganizationQuery()
 
   const { hasAccess: hasAccessToPersistentBranching, isLoading: isLoadingEntitlement } =
-    useCheckEntitlements('persistent_branching')
+    useCheckEntitlements('branching_persistent')
 
   return (
     <>
@@ -219,7 +219,7 @@ const PreviewBranchActions = ({
   const isPersistentBranch = branch.persistent
 
   const { hasAccess: hasAccessToPersistentBranching, isLoading: isLoadingEntitlement } =
-    useCheckEntitlements('persistent_branching')
+    useCheckEntitlements('branching_persistent')
 
   const [showConfirmResetModal, setShowConfirmResetModal] = useState(false)
   const [showBranchModeSwitch, setShowBranchModeSwitch] = useState(false)


### PR DESCRIPTION
## Context

There seems to be a typo for the entitlement check for persistent branching from this [PR](https://github.com/supabase/supabase/pull/40703)
<img width="321" height="107" alt="image" src="https://github.com/user-attachments/assets/118b0e74-f84d-470a-bad5-11c600922a9a" />

Which causes the Upgrade CTA to show up in the branch management page, despite being on a Pro plan

## To test
- [ ] Free org: Will see upgrade CTA in manage branches page for persistent branch
- [ ] Pro org: WIll not see upgrade CTA in manage branches page for persistent branch