### PR TITLE
Adding CTA for S3 Vector FDW to the blogpost

### DIFF
--- a/apps/www/_blog/2025-12-01-vector-buckets.mdx
+++ b/apps/www/_blog/2025-12-01-vector-buckets.mdx
@@ -29,7 +29,7 @@ Conceptually:
 - A **Vector Bucket** is where your vector indexes live.
 - Inside each bucket, you define one or more **vector indexes** (for example: `documents-openai`).
 - Each index stores high-dimensional vectors plus optional metadata.
-- You query those indexes using Supabase clients or directly from Postgres via a foreign data wrapper.
+- You query those indexes using Supabase clients or directly from Postgres via a [foreign data wrapper](/docs/guides/database/extensions/wrappers/s3_vectors).
 
 ## What do Vector Buckets bring to the table?
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Blog post update 

## What is the current behavior?

Referencing a table created by FDW in SQL code snippet without linking FDW guide.

## What is the new behavior?

CTA to the FDW guide.

## Additional context
