### PR TITLE
Update upgrading.mdx

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -93,7 +93,7 @@ After the 90-day restore window, you can download your project's backup file, an
   src="/docs/img/guides/platform/paused-dl-backup.png"
 />
 
-If you upgrade to a paid plan while your project is paused, any expired one-click restore options are reenabled. Since the backup was taken outside the backwards compatibility window, it may fail to restore. If you have a problem restoring your backup after upgrading, contact [Support](/support).
+If you upgrade to a paid plan while your project is paused within the 90-day restore window, any expired one-click restore options are reenabled. Since the backup was taken outside the backwards compatibility window, it may fail to restore. If you have a problem restoring your backup after upgrading, contact [Support](/support).
 
 <Image
   zoomable


### PR DESCRIPTION
I think the existing sentence may cause people to believe that they can access one-click restore if they upgrade to a paid plan outside the 90 day restore window - I do not believe this is accurate. 

I added the mention that if you upgrade within the 90 days period, they you may have one-click restore options

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
