### PR TITLE
chore(studio): bump lint rule to error

### DIFF
--- a/apps/studio/.github/eslint-rule-baselines.json
+++ b/apps/studio/.github/eslint-rule-baselines.json
@@ -3,7 +3,6 @@
     "react-hooks/exhaustive-deps": 226,
     "import/no-anonymous-default-export": 62,
     "@tanstack/query/exhaustive-deps": 18,
-    "@tanstack/query/no-deprecated-options": 0,
     "@typescript-eslint/no-explicit-any": 1452
   },
   "ruleFiles": {
@@ -255,7 +254,6 @@
       "hooks/analytics/useProjectUsageStats.tsx": 1,
       "hooks/analytics/useSingleLog.tsx": 1
     },
-    "@tanstack/query/no-deprecated-options": {},
     "@typescript-eslint/no-explicit-any": {
       "components/grid/SupabaseGrid.tsx": 1,
       "components/grid/SupabaseGrid.utils.ts": 4,

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -8,7 +8,7 @@
     "build": "next build && if [ \"$SKIP_ASSET_UPLOAD\" != \"1\" ]; then ./../../scripts/upload-static-assets.sh; fi",
     "start": "next start -p 8082",
     "lint": "eslint .",
-    "lint:ratchet": "tsx scripts/ratchet-eslint-rules.ts --rule react-hooks/exhaustive-deps --rule import/no-anonymous-default-export --rule @tanstack/query/exhaustive-deps --rule @tanstack/query/no-deprecated-options --rule @typescript-eslint/no-explicit-any",
+    "lint:ratchet": "tsx scripts/ratchet-eslint-rules.ts --rule react-hooks/exhaustive-deps --rule import/no-anonymous-default-export --rule @tanstack/query/exhaustive-deps --rule @typescript-eslint/no-explicit-any",
     "clean": "rimraf node_modules tsconfig.tsbuildinfo .next .turbo",
     "test": "vitest --run --coverage",
     "test:watch": "vitest watch",

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -21,7 +21,7 @@ const tanstackQueryConfig = {
   plugins: { '@tanstack/query': fixupPluginRules(tanstackQuery) },
   rules: {
     '@tanstack/query/exhaustive-deps': 'warn',
-    '@tanstack/query/no-deprecated-options': 'warn',
+    '@tanstack/query/no-deprecated-options': 'error',
     '@tanstack/query/prefer-query-object-syntax': 'warn',
     '@tanstack/query/stable-query-client': 'warn',
   },


### PR DESCRIPTION
We've removed all violation of @tanstack/query/no-deprecated-options, so we can bump that lint rule up to an error.