### PR TITLE
fix(studio): add PG_META_CRYPTO_KEY to .env example

### DIFF
--- a/apps/studio/.env
+++ b/apps/studio/.env
@@ -1,5 +1,6 @@
 STUDIO_PG_META_URL=http://localhost:8000/pg
 POSTGRES_PASSWORD=your-super-secret-and-long-postgres-password
+PG_META_CRYPTO_KEY=your-encryption-key-32-chars-min
 
 DEFAULT_ORGANIZATION_NAME=Default Organization
 DEFAULT_PROJECT_NAME=Default Project


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

If the PG_META_CRYPTO_KEY variable is not set in the .env file, the system will fall back to the default key (SAMPLE_KEY) using:
```ts
export const ENCRYPTION_KEY = process.env.PG_META_CRYPTO_KEY || 'SAMPLE_KEY'
```
This default value can lead to connection issues for the meta service.

## What is the current behavior?
It will use SAMPLE_KEY by default. 

## What is the new behavior?
Read from .env file.

## Additional context
None

