### PR TITLE
Fix typo in replication error message

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ErrorDetailsButton.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ErrorDetailsButton.tsx
@@ -39,7 +39,7 @@ export const ErrorDetailsButton = ({ tableName, reason, solution }: ErrorDetails
         <DialogSection className="!p-0">
           <div className="px-4 py-3">
             <p className="text-sm text-foreground-light">
-              The following error occured during replication:
+              The following error occurred during replication:
             </p>
           </div>
           <CodeBlock


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Typo fix

## What is the current behavior?

The replication error message contains a typo: "occured"

## What is the new behavior?

The replication error message now reads correctly with the proper spelling: "occurred"

## Additional context

No functional changes. Small text correction for readability.