### PR TITLE
fix: use deno2 entrypoint when it's available

### DIFF
--- a/apps/studio/data/edge-functions/edge-function-body-query.ts
+++ b/apps/studio/data/edge-functions/edge-function-body-query.ts
@@ -33,6 +33,10 @@ export async function getEdgeFunctionBody(
 
   if (!data || !boundary) return { files: [] }
 
+  let metadata: {
+    deno2_entrypoint_path?: string | null
+  } = {}
+
   for await (let part of parseMultipartStream(data, {
     boundary,
     maxFileSize: 20 * 1024 * 1024,
@@ -42,10 +46,16 @@ export async function getEdgeFunctionBody(
         name: part.filename,
         content: part.text,
       })
+    } else {
+      // treat it as metadata
+      metadata = JSON.parse(part.text)
     }
   }
 
-  return { files: files as Omit<EdgeFunctionFile, 'id' | 'selected'>[] }
+  return {
+    metadata,
+    files: files as Omit<EdgeFunctionFile, 'id' | 'selected'>[],
+  }
 }
 
 export type EdgeFunctionBodyData = Awaited<ReturnType<typeof getEdgeFunctionBody>>

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/code.tsx
@@ -76,7 +76,9 @@ const CodePage = () => {
     if (isDeploying || !ref || !functionSlug || !selectedFunction || files.length === 0) return
 
     try {
-      const newEntrypointPath = selectedFunction.entrypoint_path?.split('/').pop()
+      const entrypoint_path =
+        functionBody?.metadata?.deno2_entrypoint_path ?? selectedFunction.entrypoint_path
+      const newEntrypointPath = entrypoint_path?.split('/').pop()
       const newImportMapPath = selectedFunction.import_map_path?.split('/').pop()
 
       const entrypointExists = fileExists(newEntrypointPath)
@@ -143,10 +145,17 @@ const CodePage = () => {
   }
 
   useEffect(() => {
+    if (!functionBody) {
+      return
+    }
+
+    const entrypoint_path =
+      functionBody.metadata?.deno2_entrypoint_path ?? selectedFunction?.entrypoint_path
+
     // Set files from API response when available
-    if (selectedFunction?.entrypoint_path && functionBody) {
+    if (entrypoint_path) {
       const base_path = getBasePath(
-        selectedFunction?.entrypoint_path,
+        entrypoint_path,
         functionBody.files.map((file) => file.name)
       )
       const filesWithRelPath = functionBody.files


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This uses entrypoint in eszip bundle if it's availble (only for deno2 bundles)