### PR TITLE
React Router V7 Authentication Docs Fix #41156

### DIFF
--- a/apps/ui-library/registry/default/blocks/social-auth-react-router/app/routes/login.tsx
+++ b/apps/ui-library/registry/default/blocks/social-auth-react-router/app/routes/login.tsx
@@ -10,7 +10,7 @@ import {
 import { type ActionFunctionArgs, redirect, useFetcher } from 'react-router'
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { supabase } = createClient(request)
+  const { supabase, headers } = createClient(request);
   const origin = new URL(request.url).origin
 
   const { data, error } = await supabase.auth.signInWithOAuth({
@@ -21,7 +21,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   if (data.url) {
-    return redirect(data.url)
+    return redirect(data.url, { headers });
   }
 
   if (error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Without passing the headers in the request we would get the following error:

invalid request: both auth code and code verifier should be non-empty

<img width="682" height="452" alt="image" src="https://github.com/user-attachments/assets/fd3c6077-ce3f-46e0-8433-a9c61296c444" />


## What is the new behavior?

Authentication succeeds without any issues, it is essential to pass in the headers from the supabase server file we created
