### PR TITLE
fix: change realtime healthcheck to cmdshell for podman compat

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -208,15 +208,8 @@ services:
     healthcheck:
       test:
         [
-          "CMD",
-          "curl",
-          "-sSfL",
-          "--head",
-          "-o",
-          "/dev/null",
-          "-H",
-          "Authorization: Bearer ${ANON_KEY}",
-          "http://localhost:4000/api/tenants/realtime-dev/health"
+          "CMD-SHELL",
+          "curl -sSfL --head -o /dev/null -H \"Authorization: Bearer ${ANON_KEY}\" http://localhost:4000/api/tenants/realtime-dev/health"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes healthcheck for Realtime to use CMD-SHELL.

## What is the current behavior?

Current healthcheck is CMD, which with arguments and variable substitution apparently breaks easily with Podman.

Closes #40326