### PR TITLE
feat: add auth db connection strategy linter

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -5,6 +5,7 @@ import {
   Lock,
   LockIcon,
   Ruler,
+  Scaling,
   Table2,
   TextSearch,
   Unlock,
@@ -162,6 +163,15 @@ export const lintInfoMap: LintInfo[] = [
     linkText: 'View settings',
     docsLink: `${DOCS_URL}/guides/platform/going-into-prod#security`,
     category: 'security',
+  },
+  {
+    name: 'auth_db_connections_absolute',
+    title: 'Auth Absolute Connection Management Strategy',
+    icon: <Scaling className="text-foreground-muted" size={15} strokeWidth={1} />,
+    link: ({ projectRef }) => `/project/${projectRef}/auth/performance`,
+    linkText: 'View settings',
+    docsLink: `${DOCS_URL}/guides/platform/going-into-prod`,
+    category: 'performance',
   },
   {
     name: 'rls_references_user_metadata',


### PR DESCRIPTION
Adds a new informational performance lint rule that checks the Auth server's connection pooling strategy. If it's not percent then it shows up on projects that aren't on free plan and have at least one user.

<img width="500" height="464" alt="image" src="https://github.com/user-attachments/assets/b6511048-60cc-4d32-96f6-3b52f7f84cfe" />
