### PR TITLE
Improve experiment telemetry for generate policies A/B test

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -553,7 +553,7 @@ export const SidePanelEditor = ({
         // Track experiment conversion if user is in the experiment
         if (generatePoliciesFlag !== undefined) {
           track('table_create_generate_policies_experiment_converted', {
-            experiment_id: 'table_create_generate_policies',
+            experiment_id: 'tableCreateGeneratePolicies',
             variant: generatePoliciesFlag ? 'treatment' : 'control',
             has_rls_enabled: isRLSEnabled,
             has_rls_policies: generatedPolicies.length > 0,

--- a/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
+++ b/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
@@ -63,7 +63,8 @@ export function useTableCreateGeneratePolicies({
       const daysSinceCreation = dayjs.utc().diff(insertedDate, 'day')
 
       track('table_create_generate_policies_experiment_exposed', {
-        enabled: tableCreateGeneratePoliciesFlag,
+        experiment_id: 'table_create_generate_policies',
+        variant: tableCreateGeneratePoliciesFlag ? 'treatment' : 'control',
         days_since_project_creation: daysSinceCreation,
       })
     } catch {

--- a/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
+++ b/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
@@ -63,7 +63,7 @@ export function useTableCreateGeneratePolicies({
       const daysSinceCreation = dayjs.utc().diff(insertedDate, 'day')
 
       track('table_create_generate_policies_experiment_exposed', {
-        experiment_id: 'table_create_generate_policies',
+        experiment_id: 'tableCreateGeneratePolicies',
         variant: tableCreateGeneratePoliciesFlag ? 'treatment' : 'control',
         days_since_project_creation: daysSinceCreation,
       })

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1942,6 +1942,42 @@ export interface RLSGeneratedPoliciesCreatedEvent {
 }
 
 /**
+ * Conversion event for the generate policies experiment.
+ * Fires when a user in the experiment creates a new table via table editor.
+ * This is separate from TableCreatedEvent to keep experiment tracking isolated.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/editor
+ */
+export interface TableCreateGeneratePoliciesExperimentConvertedEvent {
+  action: 'table_create_generate_policies_experiment_converted'
+  properties: {
+    /**
+     * Experiment identifier for tracking
+     */
+    experiment_id: 'table_create_generate_policies'
+    /**
+     * Experiment variant: 'control' (feature disabled) or 'treatment' (feature enabled)
+     */
+    variant: 'control' | 'treatment'
+    /**
+     * Whether RLS was enabled on the table
+     */
+    has_rls_enabled: boolean
+    /**
+     * Whether the table was created with any RLS policies (manual or generated)
+     */
+    has_rls_policies: boolean
+    /**
+     * Whether AI-generated policies were used (only possible in treatment)
+     */
+    has_generated_policies: boolean
+  }
+  groups: TelemetryGroups
+}
+
+/**
  * User was exposed to the generate policies experiment (shown or not shown the Generate Policies button).
  *
  * @group Events
@@ -1952,9 +1988,13 @@ export interface TableCreateGeneratePoliciesExperimentExposedEvent {
   action: 'table_create_generate_policies_experiment_exposed'
   properties: {
     /**
-     * Whether the generate policies feature is enabled
+     * Experiment identifier for tracking
      */
-    enabled: boolean
+    experiment_id: 'table_create_generate_policies'
+    /**
+     * Experiment variant: 'control' (feature disabled) or 'treatment' (feature enabled)
+     */
+    variant: 'control' | 'treatment'
     /**
      * Days since project creation (to segment by new user cohorts)
      */
@@ -2538,6 +2578,7 @@ export type TelemetryEvent =
   | RLSGeneratedPolicyRemovedEvent
   | RLSGeneratedPoliciesCreatedEvent
   | TableCreateGeneratePoliciesExperimentExposedEvent
+  | TableCreateGeneratePoliciesExperimentConvertedEvent
   | TableQuickstartOpenedEvent
   | TableQuickstartAIPromptSubmittedEvent
   | TableQuickstartAIGenerationCompletedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1956,7 +1956,7 @@ export interface TableCreateGeneratePoliciesExperimentConvertedEvent {
     /**
      * Experiment identifier for tracking
      */
-    experiment_id: 'table_create_generate_policies'
+    experiment_id: 'tableCreateGeneratePolicies'
     /**
      * Experiment variant: 'control' (feature disabled) or 'treatment' (feature enabled)
      */
@@ -1990,7 +1990,7 @@ export interface TableCreateGeneratePoliciesExperimentExposedEvent {
     /**
      * Experiment identifier for tracking
      */
-    experiment_id: 'table_create_generate_policies'
+    experiment_id: 'tableCreateGeneratePolicies'
     /**
      * Experiment variant: 'control' (feature disabled) or 'treatment' (feature enabled)
      */


### PR DESCRIPTION
## Problem

The generate policies experiment telemetry wasn't set up in a way that makes PostHog analysis straightforward. We learned from the table quickstart experiment that having concrete exposure and conversion events with consistent `experiment_id` and `variant` properties makes analyzing results way cleaner directly in PostHog.

## Changes

- Updated the exposure event to use `experiment_id` and `variant` props instead of just an `enabled` boolean
- Added a dedicated conversion event that fires when a user in the experiment creates a table
- Both events share the same structure so we can easily build funnels in PostHog

The conversion event is technically redundant with `table_created`, but having a dedicated experiment event is temporary (just for the life of this A/B test, same as the exposure event) and makes the analysis much cleaner since we don't have to filter/join against a more generic event.

## Testing

Verified TypeScript compiles, checked that both track calls match their type definitions. The exposure event fires via the existing hook when the table editor renders for new tables, and the conversion event fires after successful table creation.