### PR TITLE
chore(studio): improve Edge Functions layout

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -224,6 +224,7 @@ const AddNewSecretForm = () => {
                     type="default"
                     className="h-[34px] mt-6"
                     icon={<MinusCircle />}
+                    disabled={fields.length <= 1}
                     onClick={() => (fields.length > 1 ? remove(index) : form.reset(defaultValues))}
                   />
                 </div>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -59,7 +59,7 @@ export const EdgeFunctionSecrets = () => {
 
   const { mutate: deleteSecret, isPending: isDeleting } = useSecretsDeleteMutation({
     onSuccess: (_, variables) => {
-      toast.success(`Successfully deleted ${variables.secrets[0]}`)
+      toast.success(`Successfully deleted secret “${variables.secrets[0]}”`)
       setSelectedSecretToDelete(null)
     },
     onError: () => {
@@ -96,7 +96,7 @@ export const EdgeFunctionSecrets = () => {
 
           {isSuccess && (
             <>
-              <div className="mb-6">
+              <div className="mb-10">
                 {!canUpdateSecrets ? (
                   <NoPermission resourceText="manage this project's edge function secrets" />
                 ) : (
@@ -134,7 +134,7 @@ export const EdgeFunctionSecrets = () => {
                             />
                           ))
                         ) : secrets.length === 0 && searchString.length > 0 ? (
-                          <TableRow>
+                          <TableRow className="[&>td]:hover:bg-inherit">
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No results found</p>
                               <p className="text-sm text-foreground-light">
@@ -143,7 +143,7 @@ export const EdgeFunctionSecrets = () => {
                             </TableCell>
                           </TableRow>
                         ) : (
-                          <TableRow>
+                          <TableRow className="[&>td]:hover:bg-inherit">
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No secrets created</p>
                               <p className="text-sm text-foreground-light">
@@ -174,7 +174,7 @@ export const EdgeFunctionSecrets = () => {
         visible={!!selectedSecretToDelete}
         confirmLabel="Delete secret"
         confirmLabelLoading="Deleting secret"
-        title={`Confirm to delete secret "${selectedSecretToDelete?.name}"`}
+        title={`Delete secret “${selectedSecretToDelete?.name}”`}
         onCancel={() => setSelectedSecretToDelete(null)}
         onConfirm={() => {
           if (selectedSecretToDelete) {
@@ -184,8 +184,8 @@ export const EdgeFunctionSecrets = () => {
         }}
       >
         <p className="text-sm">
-          Before removing this secret, ensure none of your Edge Functions are actively using it.
-          This action cannot be undone.
+          Ensure none of your edge functions are actively using this secret before deleting it. This
+          action cannot be undone.
         </p>
       </ConfirmationModal>
     </>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -78,7 +78,7 @@ export const EdgeFunctionSecrets = () => {
     <TableHead key="secret-value" className="flex items-center gap-x-2">
       Digest <Badge variant="default">SHA256</Badge>
     </TableHead>,
-    <TableHead key="secret-updated-at">Updated at</TableHead>,
+    <TableHead key="secret-updated-at">Updated</TableHead>,
     <TableHead key="actions" />,
   ]
 

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
@@ -38,7 +38,7 @@ export const EdgeFunctionsListItem = ({ function: item }: EdgeFunctionsListItemP
       className="cursor-pointer"
     >
       <TableCell>
-        <p className="text-sm text-foreground whitespace-nowrap">{item.name}</p>
+        <p className="text-sm text-foreground whitespace-nowrap py-2">{item.name}</p>
       </TableCell>
       <TableCell>
         <div className="text-xs text-foreground-light flex gap-2 items-center truncate">
@@ -79,7 +79,7 @@ export const EdgeFunctionsListItem = ({ function: item }: EdgeFunctionsListItemP
       </TableCell>
       <TableCell className="lg:table-cell">
         <TimestampInfo
-          className="text-sm text-foreground-light"
+          className="text-sm text-foreground-light whitespace-nowrap"
           utcTimestamp={item.updated_at}
           label={dayjs(item.updated_at).fromNow()}
         />

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
@@ -72,7 +72,7 @@ export const EdgeFunctionsListItem = ({ function: item }: EdgeFunctionsListItemP
           </button>
         </div>
       </TableCell>
-      <TableCell className="hidden 2xl:table-cell">
+      <TableCell className="hidden 2xl:table-cell whitespace-nowrap">
         <p className="text-foreground-light">
           {dayjs(item.created_at).format('DD MMM, YYYY HH:mm')}
         </p>

--- a/apps/studio/components/ui/NoPermission.tsx
+++ b/apps/studio/components/ui/NoPermission.tsx
@@ -1,5 +1,4 @@
-import { AlertCircle } from 'lucide-react'
-import { cn } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 
 interface NoPermissionProps {
   resourceText: string
@@ -8,34 +7,17 @@ interface NoPermissionProps {
 
 export const NoPermission = ({ resourceText, isFullPage = false }: NoPermissionProps) => {
   const NoPermissionMessage = () => (
-    <div
-      className={cn(
-        'block w-full rounded border border-opacity-20 py-4 px-6',
-        'border bg-surface-200'
-      )}
-    >
-      <div className="flex space-x-3">
-        <div className="mt-1">
-          <AlertCircle size={20} />
-        </div>
-        <div className="flex w-full items-center justify-between">
-          <div className="space-y-1">
-            <p className="text-sm">You need additional permissions to {resourceText}</p>
-            <div>
-              <p className="text-sm text-foreground-light">
-                Contact your organization owner or administrator for assistance.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <Admonition
+      type="warning"
+      title={`You need additional permissions to ${resourceText}`}
+      description="Contact your organization owner or administrator for assistance."
+    />
   )
 
   if (isFullPage) {
     return (
       <div className="flex h-full items-center justify-center">
-        <div className="w-[550px]">
+        <div className="max-w-lg">
           <NoPermissionMessage />
         </div>
       </div>

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -1,15 +1,15 @@
 import { ExternalLink, Search, X } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
 import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
+import React, { useMemo } from 'react'
 
 import { useParams } from 'common'
 import { DeployEdgeFunctionButton } from 'components/interfaces/EdgeFunctions/DeployEdgeFunctionButton'
 import {
+  EDGE_FUNCTIONS_SORT_VALUES,
   EdgeFunctionsSort,
   EdgeFunctionsSortColumn,
   EdgeFunctionsSortDropdown,
   EdgeFunctionsSortOrder,
-  EDGE_FUNCTIONS_SORT_VALUES,
 } from 'components/interfaces/EdgeFunctions/EdgeFunctionsSortDropdown'
 import { EdgeFunctionsListItem } from 'components/interfaces/Functions/EdgeFunctionsListItem'
 import {
@@ -24,17 +24,8 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useEdgeFunctionsQuery } from 'data/edge-functions/edge-functions-query'
 import { DOCS_URL, IS_PLATFORM } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
-import {
-  Button,
-  Card,
-  Input_Shadcn_,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from 'ui'
+import { Button, Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
@@ -45,7 +36,6 @@ import {
   PageHeaderTitle,
 } from 'ui-patterns/PageHeader'
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
-import { Input } from 'ui-patterns/DataInputs/Input'
 
 const EdgeFunctionsPage: NextPageWithLayout = () => {
   const { ref } = useParams()
@@ -187,7 +177,7 @@ EdgeFunctionsPage.getLayout = (page: React.ReactElement) => {
               <PageHeaderSummary>
                 <PageHeaderTitle>Edge Functions</PageHeaderTitle>
                 <PageHeaderDescription>
-                  Deploy edge functions to handle complex business logic
+                  Run server-side logic close to your users
                 </PageHeaderDescription>
               </PageHeaderSummary>
               <PageHeaderAside>

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -126,7 +126,7 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
                               <TableHead>Name</TableHead>
                               <TableHead>URL</TableHead>
                               <TableHead className="hidden 2xl:table-cell">Created</TableHead>
-                              <TableHead className="lg:table-cell">Last updated</TableHead>
+                              <TableHead className="lg:table-cell">Updated</TableHead>
                               <TableHead className="lg:table-cell">Deployments</TableHead>
                             </TableRow>
                           </TableHeader>

--- a/apps/studio/pages/project/[ref]/functions/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/functions/secrets.tsx
@@ -2,18 +2,27 @@ import { EdgeFunctionSecrets } from 'components/interfaces/Functions/EdgeFunctio
 import { FunctionsSecretsEmptyStateLocal } from 'components/interfaces/Functions/FunctionsEmptyState'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import EdgeFunctionsLayout from 'components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'
-import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
-import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { IS_PLATFORM } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
+import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 
 const SecretsPage: NextPageWithLayout = () => {
   return (
-    <ScaffoldContainer size="large">
-      <ScaffoldSection isFullWidth>
-        {IS_PLATFORM ? <EdgeFunctionSecrets /> : <FunctionsSecretsEmptyStateLocal />}
-      </ScaffoldSection>
-    </ScaffoldContainer>
+    <PageContainer size="large">
+      <PageSection>
+        <PageSectionContent>
+          {IS_PLATFORM ? <EdgeFunctionSecrets /> : <FunctionsSecretsEmptyStateLocal />}
+        </PageSectionContent>
+      </PageSection>
+    </PageContainer>
   )
 }
 
@@ -21,13 +30,20 @@ SecretsPage.getLayout = (page) => {
   return (
     <DefaultLayout>
       <EdgeFunctionsLayout>
-        <PageLayout
-          size="large"
-          title="Edge Function Secrets"
-          subtitle="Manage the secrets for your project's Edge Functions"
-        >
+        <div className="w-full min-h-full flex flex-col items-stretch">
+          <PageHeader size="large">
+            <PageHeaderMeta>
+              <PageHeaderSummary>
+                <PageHeaderTitle>Edge Function Secrets</PageHeaderTitle>
+                <PageHeaderDescription>
+                  Manage encrypted values for your functions
+                </PageHeaderDescription>
+              </PageHeaderSummary>
+            </PageHeaderMeta>
+          </PageHeader>
+
           {page}
-        </PageLayout>
+        </div>
       </EdgeFunctionsLayout>
     </DefaultLayout>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI improvements. Resolves DEPR-161.

## What is the current behavior?

Edge Functions on Studio has a few rough edges:

- Inconsistent column names between the functions and secrets tables
- Delete row button that doesn’t take effect until 2+ rows added
- Vague page descriptions
- Inconsistent page compositions

Unrelated but discovered during this work

- NoPermissions banner uses bespoke styling

## What is the new behavior?

- Fixes to the above
- NoPermissions banner wraps Admonition component

| Before | After |
| --- | --- |
| <img width="1364" height="890" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/49fe72df-9dc8-4583-83db-d4d8992ef75c" /> | <img width="1364" height="890" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/9be3e4e7-214b-4b07-8a9f-2ea25af8394b" /> |
| <img width="1364" height="890" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/f068723f-cc37-4dac-ad1f-8100aa9485eb" /> | <img width="1364" height="890" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/97e65a72-e889-435e-b317-c9bc0e73c7dc" /> |
| <img width="428" height="555" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/4f84bef0-8aa2-43f2-bb29-0e66c7c0c9fa" /> | <img width="428" height="555" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/0f909f67-ee87-44dd-94d9-dece8a2c08f8" /> |