### PR TITLE
Remove unused old env var

### DIFF
--- a/apps/studio/lib/api/apiHelpers.test.ts
+++ b/apps/studio/lib/api/apiHelpers.test.ts
@@ -15,7 +15,6 @@ vi.mock('lib/constants', () => ({
 describe('apiHelpers', () => {
   describe('constructHeaders', () => {
     beforeEach(() => {
-      process.env.READ_ONLY_API_KEY = 'test-readonly-key'
       process.env.SUPABASE_SERVICE_KEY = 'test-service-key'
     })
 

--- a/apps/studio/lib/api/apiHelpers.ts
+++ b/apps/studio/lib/api/apiHelpers.ts
@@ -25,7 +25,7 @@ export function constructHeaders(headers: { [prop: string]: any }) {
     )
     return {
       ...cleansedHeaders,
-      ...(IS_PLATFORM ? {} : { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
+      ...(IS_PLATFORM && { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
     }
   } else {
     return {

--- a/apps/studio/lib/api/apiHelpers.ts
+++ b/apps/studio/lib/api/apiHelpers.ts
@@ -25,9 +25,7 @@ export function constructHeaders(headers: { [prop: string]: any }) {
     )
     return {
       ...cleansedHeaders,
-      ...(IS_PLATFORM
-        ? { apiKey: `${process.env.READ_ONLY_API_KEY}` }
-        : { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
+      ...(IS_PLATFORM ? {} : { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
     }
   } else {
     return {

--- a/apps/studio/lib/api/apiHelpers.ts
+++ b/apps/studio/lib/api/apiHelpers.ts
@@ -25,7 +25,7 @@ export function constructHeaders(headers: { [prop: string]: any }) {
     )
     return {
       ...cleansedHeaders,
-      ...(IS_PLATFORM && { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
+      ...(!IS_PLATFORM && { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
     }
   } else {
     return {

--- a/apps/studio/lib/api/apiHelpers.ts
+++ b/apps/studio/lib/api/apiHelpers.ts
@@ -25,6 +25,8 @@ export function constructHeaders(headers: { [prop: string]: any }) {
     )
     return {
       ...cleansedHeaders,
+      // [Joshen] JFYI both Alaister and I checked on this and realised this might not be used actually
+      // Could be safe to remove but leaving it here for now
       ...(!IS_PLATFORM && { apiKey: `${process.env.SUPABASE_SERVICE_KEY}` }),
     }
   } else {

--- a/apps/studio/pages/api/platform/auth/[ref]/invite.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/invite.ts
@@ -1,11 +1,8 @@
-import { createClient } from '@supabase/supabase-js'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchPost } from 'data/fetchers'
 import { constructHeaders } from 'lib/api/apiHelpers'
 import apiWrapper from 'lib/api/apiWrapper'
-
-const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!)
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 


### PR DESCRIPTION
## Context

We no longer need this particular env var `READ_ONLY_API_KEY` - it's being used in `constructHeaders` under `apiHelpers`, and this method is only being used for the internal next API endpoints listed here:
```
lib/api/apiHelpers.test.ts:5
lib/api/self-hosted/query.ts:2
pages/api/platform/auth/[ref]/invite.ts:5
pages/api/platform/auth/[ref]/magiclink.ts:4
pages/api/platform/auth/[ref]/otp.ts:4
pages/api/platform/auth/[ref]/recover.ts:4
pages/api/platform/pg-meta/[ref]/column-privileges.ts:4
pages/api/platform/pg-meta/[ref]/extensions.ts:4
pages/api/platform/pg-meta/[ref]/foreign-tables.ts:4
pages/api/platform/pg-meta/[ref]/materialized-views.ts:4
pages/api/platform/pg-meta/[ref]/policies.ts:4
pages/api/platform/pg-meta/[ref]/publications.ts:4
pages/api/platform/pg-meta/[ref]/query/index.ts:1
pages/api/platform/pg-meta/[ref]/tables.ts:4
pages/api/platform/pg-meta/[ref]/triggers.ts:4
pages/api/platform/pg-meta/[ref]/types.ts:4
pages/api/platform/pg-meta/[ref]/views.ts:4
pages/api/platform/projects/[ref]/run-lints.ts:3
pages/api/v1/projects/[ref]/database/migrations.ts:3
pages/api/v1/projects/[ref]/types/typescript.ts:3
```

AFAICT, all these routes have their Mgmt API equivalent endpoints which means that staging / prod do not ping these next.js API endpoints. There's no change for self-hosted as well so all should be alright 