### PR TITLE
Use timestamp info for api keys last used

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
+++ b/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
@@ -1,7 +1,8 @@
-import { TextConfirmModal } from 'components/ui/TextConfirmModalWrapper'
-import type { APIKeysData } from 'data/api-keys/api-keys-query'
 import { motion } from 'framer-motion'
 import { MoreVertical } from 'lucide-react'
+
+import { TextConfirmModal } from 'components/ui/TextConfirmModalWrapper'
+import type { APIKeysData } from 'data/api-keys/api-keys-query'
 import {
   Button,
   DropdownMenu,
@@ -10,6 +11,7 @@ import {
   TableCell,
   TableRow,
 } from 'ui'
+import { ShimmeringLoader, TimestampInfo } from 'ui-patterns'
 import { APIKeyDeleteDialog } from './APIKeyDeleteDialog'
 import { ApiKeyPill } from './ApiKeyPill'
 
@@ -17,16 +19,18 @@ export const APIKeyRow = ({
   apiKey,
   lastSeen,
   isDeleting,
+  isDeleteModalOpen,
+  isLoadingLastSeen,
   onDelete,
   setKeyToDelete,
-  isDeleteModalOpen,
 }: {
   apiKey: Extract<APIKeysData[number], { type: 'secret' | 'publishable' }>
-  lastSeen?: { timestamp: string }
+  lastSeen?: { timestamp: number; relative: string }
   isDeleting: boolean
+  isDeleteModalOpen: boolean
+  isLoadingLastSeen: boolean
   onDelete: () => void
   setKeyToDelete: (id: string | null) => void
-  isDeleteModalOpen: boolean
 }) => {
   const MotionTableRow = motion.create(TableRow)
 
@@ -59,8 +63,18 @@ export const APIKeyRow = ({
         </TableCell>
 
         <TableCell className="py-2 min-w-0 whitespace-nowrap hidden lg:table-cell">
-          <div className="truncate" title={lastSeen?.timestamp || 'Never used'}>
-            {lastSeen?.timestamp ?? <span className="text-foreground-lighter">Never used</span>}
+          <div className="truncate" title={lastSeen?.timestamp.toString() || 'Never used'}>
+            {isLoadingLastSeen ? (
+              <ShimmeringLoader />
+            ) : lastSeen?.timestamp ? (
+              <TimestampInfo
+                className="text-sm"
+                utcTimestamp={lastSeen?.timestamp}
+                label={lastSeen.relative}
+              />
+            ) : (
+              <span className="text-foreground-lighter">Never used</span>
+            )}
           </div>
         </TableCell>
 


### PR DESCRIPTION
## Context

Came across the API keys page and realised this can be improved slightly.

- Update column "Last seen" to "Last used"
- Show a loader when loading last used data
- Use `TimestampInfo` component to render Last used value

## To test

I don't really have usage data on staging/local to test this though, but I did hardcode data locally to test if that's an option
Can hardcode the value returned from `useLastSeen` in `SecretAPIKeys.tsx` to return for e.g 
```{hash: the API key's hash value, timestamp: 1765206756196 }```

Once changes are through though, we can test on the Misc Use prod project