### PR TITLE
docs: fix grammatical error in generate-text-embeddings guide

### DIFF
--- a/apps/docs/content/guides/ai/quickstarts/generate-text-embeddings.mdx
+++ b/apps/docs/content/guides/ai/quickstarts/generate-text-embeddings.mdx
@@ -110,7 +110,7 @@ Let's build an Edge Function that will accept an input string and generate an em
       Note the two options we pass to `session.run()`:
 
       - `mean_pool`: The first option sets `pooling` to `mean`. Pooling refers to how token-level embedding representations are compressed into a single sentence embedding that reflects the meaning of the entire sentence. Average pooling is the most common type of pooling for sentence embeddings.
-      - `normalize`: The second option tells to normalize the embedding vector so that it can be used with distance measures like dot product. A normalized vector means its length (magnitude) is 1 - also referred to as a unit vector. A vector is normalized by dividing each element by the vector's length (magnitude), which maintains its direction but changes its length to 1.
+      - `normalize`: The second option tells the system to normalize the embedding vector so that it can be used with distance measures like dot product. A normalized vector means its length (magnitude) is 1 - also referred to as a unit vector. A vector is normalized by dividing each element by the vector's length (magnitude), which maintains its direction but changes its length to 1.
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/ai/quickstarts/generate-text-embeddings.mdx
+++ b/apps/docs/content/guides/ai/quickstarts/generate-text-embeddings.mdx
@@ -110,7 +110,7 @@ Let's build an Edge Function that will accept an input string and generate an em
       Note the two options we pass to `session.run()`:
 
       - `mean_pool`: The first option sets `pooling` to `mean`. Pooling refers to how token-level embedding representations are compressed into a single sentence embedding that reflects the meaning of the entire sentence. Average pooling is the most common type of pooling for sentence embeddings.
-      - `normalize`: The second option tells the system to normalize the embedding vector so that it can be used with distance measures like dot product. A normalized vector means its length (magnitude) is 1 - also referred to as a unit vector. A vector is normalized by dividing each element by the vector's length (magnitude), which maintains its direction but changes its length to 1.
+      - `normalize`: The second option normalizes the embedding vector so that it can be used with distance measures like dot product. A normalized vector means its length (magnitude) is 1 - also referred to as a unit vector. A vector is normalized by dividing each element by the vector's length (magnitude), which maintains its direction but changes its length to 1.
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update - grammatical fix

## What is the current behavior?

In the "Generate text embeddings" guide (`apps/docs/content/guides/ai/quickstarts/generate-text-embeddings.mdx`), Step 4 contains a grammatical error:

> "The second option tells to normalize the embedding vector..."

The phrase "tells to normalize" is missing an object.

## What is the new behavior?

Updated to grammatically correct phrasing:

> "The second option tells the system to normalize the embedding vector..."

## Additional context

Minor documentation improvement for better readability.
