### PR TITLE
docs: fix grammatical error in password-security guide

### DIFF
--- a/apps/docs/content/guides/auth/password-security.mdx
+++ b/apps/docs/content/guides/auth/password-security.mdx
@@ -20,7 +20,7 @@ There are hundreds of millions (and growing!) known passwords out there. Malicio
 
 ## Password strength and leaked password protection
 
-To help protect your users, Supabase Auth allows you fine-grained control over the strength of the passwords used on your project. You can configure these in your project's [Auth settings](/dashboard/project/_/auth/providers?provider=Email):
+To help protect your users, Supabase Auth gives you fine-grained control over the strength of the passwords used on your project. You can configure these in your project's [Auth settings](/dashboard/project/_/auth/providers?provider=Email):
 
 - Set a large minimum password length. Anything less than 8 characters is not recommended.
 - Set the required characters that must appear at least once in a user's password. Use the strongest option of requiring digits, lowercase and uppercase letters, and symbols. The allowed symbols are: ``!@#$%^&*()_+-=[]{};'\:"|<>?,./`~``


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update - grammatical fix

## What is the current behavior?

In the "Password Security" guide (`apps/docs/content/guides/auth/password-security.mdx`), there is a grammatical error:

> "Supabase Auth allows you fine-grained control"

The phrase is missing a preposition/verb structure.

## What is the new behavior?

Updated to grammatically correct phrasing:

> "Supabase Auth gives you fine-grained control"

## Additional context

Minor documentation improvement for better readability.
