### PR TITLE
docs: fix incorrect reference link in storage quickstart (Swift section)

### DIFF
--- a/apps/docs/content/guides/storage/quickstart.mdx
+++ b/apps/docs/content/guides/storage/quickstart.mdx
@@ -222,7 +222,7 @@ void main() async {
 let response = try await supabase.storage.from("avatars").download(path: "public/avatar1.png")
 ```
 
-[Reference.](/docs/reference/python/storage-from-download)
+[Reference.](/docs/reference/swift/storage-from-download)
 
 </TabPanel>
 </$Show>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update - incorrect link fix

## What is the current behavior?

In the "Storage Quickstart" guide (`apps/docs/content/guides/storage/quickstart.mdx`), the Swift code example for downloading a file references the wrong documentation link:

The reference points to `/docs/reference/python/storage-from-download` (Python docs) but the code example is for Swift.

## What is the new behavior?

Updated to point to the correct Swift documentation:

`/docs/reference/swift/storage-from-download`

## Additional context

This appears to be a copy-paste error when adding SDK examples. Users following the Swift example would be directed to incorrect Python documentation.
