### PR TITLE
Simplify realtime experiment to rely on PostHog targeting

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -113,7 +113,6 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const isRealtimeEnabled = realtimeEnabledTables.some((t) => t.id === table?.id)
 
   const { activeVariant: activeRealtimeVariant } = useRealtimeExperiment({
-    projectInsertedAt: project?.inserted_at,
     isTable,
     isRealtimeEnabled,
   })

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -130,7 +130,6 @@ export const TableEditor = ({
     : realtimeEnabledTables.some((t) => t.id === table?.id)
 
   const { activeVariant: activeRealtimeVariant } = useRealtimeExperiment({
-    projectInsertedAt: project?.inserted_at,
     isTable: !isNewRecord,
     isRealtimeEnabled,
   })

--- a/apps/studio/hooks/misc/useRealtimeExperiment.ts
+++ b/apps/studio/hooks/misc/useRealtimeExperiment.ts
@@ -1,17 +1,8 @@
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
 import { useEffect, useMemo, useRef } from 'react'
 
 import { usePHFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM } from 'lib/constants'
 import { useTrack } from 'lib/telemetry/track'
-
-dayjs.extend(utc)
-
-/**
- * Days after project creation to be considered "new" for experiment targeting
- */
-export const NEW_PROJECT_THRESHOLD_DAYS = 7
 
 export enum RealtimeButtonVariant {
   CONTROL = 'control',
@@ -20,40 +11,22 @@ export enum RealtimeButtonVariant {
 }
 
 interface UseRealtimeExperimentOptions {
-  /**
-   * Project creation timestamp
-   */
-  projectInsertedAt?: string
-  /**
-   * Whether the current context is a table (not a view/foreign table)
-   */
+  /** Whether the current context is a table (not a view/foreign table) */
   isTable?: boolean
-  /**
-   * Whether realtime is currently enabled for the table
-   */
+  /** Whether realtime is currently enabled for the table */
   isRealtimeEnabled?: boolean
 }
 
 interface UseRealtimeExperimentResult {
-  /**
-   * The active variant for this user/project, or null if not in experiment
-   */
+  /** The active variant for this user, or null if not in experiment */
   activeVariant: RealtimeButtonVariant | null
-  /**
-   * Whether this project is considered "new" for experiment targeting
-   */
-  isNewProject: boolean
 }
 
 /**
- * Hook to manage the realtime button A/B experiment logic.
- * Handles variant determination, exposure tracking, and date validation.
- *
- * @param options Configuration for experiment targeting
- * @returns Experiment state including active variant and project age
+ * Hook to manage the realtime button A/B experiment.
+ * User targeting is handled via PostHog experiment configuration.
  */
 export function useRealtimeExperiment({
-  projectInsertedAt,
   isTable = false,
   isRealtimeEnabled = false,
 }: UseRealtimeExperimentOptions): UseRealtimeExperimentResult {
@@ -61,52 +34,35 @@ export function useRealtimeExperiment({
   const realtimeButtonVariant = usePHFlag<RealtimeButtonVariant>('realtimeButtonVariant')
   const hasTrackedExposure = useRef(false)
 
-  const isNewProject = useMemo(() => {
-    if (!projectInsertedAt) return false
-
-    const insertedDate = dayjs.utc(projectInsertedAt)
-    if (!insertedDate.isValid()) {
-      return false
-    }
-
-    return dayjs.utc().diff(insertedDate, 'day') < NEW_PROJECT_THRESHOLD_DAYS
-  }, [projectInsertedAt])
-
   const activeVariant = useMemo(() => {
     if (!IS_PLATFORM) return null
-    if (!isTable || !isNewProject) return null
-    if (!realtimeButtonVariant || realtimeButtonVariant === RealtimeButtonVariant.CONTROL) {
-      return null
-    }
+    if (!isTable) return null
+    if (!realtimeButtonVariant) return null
+    if (realtimeButtonVariant === RealtimeButtonVariant.CONTROL) return null
     return realtimeButtonVariant
-  }, [isTable, isNewProject, realtimeButtonVariant])
+  }, [isTable, realtimeButtonVariant])
 
   useEffect(() => {
     if (!IS_PLATFORM) return
     if (hasTrackedExposure.current) return
-    if (!isTable || !isNewProject || !projectInsertedAt) return
-    if (!realtimeButtonVariant) return
+    if (!isTable || !realtimeButtonVariant) return
 
     hasTrackedExposure.current = true
 
     try {
-      const insertedDate = dayjs.utc(projectInsertedAt)
-      if (!insertedDate.isValid()) return
-
-      const daysSinceCreation = dayjs.utc().diff(insertedDate, 'day')
-
       track('realtime_experiment_exposed', {
+        experiment_id: 'realtimeButtonVariant',
         variant: realtimeButtonVariant,
         table_has_realtime_enabled: isRealtimeEnabled,
-        days_since_project_creation: daysSinceCreation,
       })
-    } catch {
+    } catch (error) {
+      // Reset tracking flag on error to allow retry
       hasTrackedExposure.current = false
+      console.error('Failed to track realtime experiment exposure:', error)
     }
-  }, [isTable, isNewProject, realtimeButtonVariant, projectInsertedAt, isRealtimeEnabled, track])
+  }, [isTable, realtimeButtonVariant, isRealtimeEnabled, track])
 
   return {
     activeVariant,
-    isNewProject,
   }
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1716,18 +1716,12 @@ export interface HomeActivityStatClickedEvent {
 export interface RealtimeExperimentExposedEvent {
   action: 'realtime_experiment_exposed'
   properties: {
-    /**
-     * The experiment variant shown to the user
-     */
+    /** The PostHog experiment/feature flag name */
+    experiment_id: 'realtimeButtonVariant'
+    /** The experiment variant shown to the user */
     variant: 'control' | 'hide-button' | 'triggers'
-    /**
-     * Whether the table already has realtime enabled
-     */
+    /** Whether the table already has realtime enabled */
     table_has_realtime_enabled: boolean
-    /**
-     * Days since project creation (to segment by new user cohorts)
-     */
-    days_since_project_creation: number
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
The original PR (#39748) had the experiment targeting "new projects" (created in the last 7 days) with date logic baked into the hook. We actually want to target new *users* instead, and it makes more sense to handle that targeting entirely in PostHog rather than duplicating cohort logic in the codebase.

**Why user-level targeting?**

We learned from the table quickstart experiment that project-level targeting causes problems: users with multiple projects can get bucketed into different variants as they switch between projects, which breaks the analytics. By targeting at the user level in PostHog, each user gets a consistent variant across all their projects.

This simplifies `useRealtimeExperiment` pretty significantly - we removed all the dayjs date math, the `isNewProject` tracking, and the `projectInsertedAt` prop that call sites had to pass. The hook now just checks the PostHog flag and fires an exposure event.

**Changes**

- Removed date-based targeting from `useRealtimeExperiment` (PostHog handles user cohort targeting)
- Removed `projectInsertedAt` prop from hook - call sites no longer need to pass project data
- Added `experiment_id` to the exposure event for easier querying
- Removed `days_since_project_creation` from telemetry since we're not tracking that anymore
- Cleaned up verbose JSDoc comments

The conversion event is `table_realtime_enabled` which was already instrumented.

**Testing**

Verified types pass and the hook still returns the correct variant based on the PostHog flag. The exposure event fires once per session when viewing a table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified realtime experiment variant selection by removing date-based "new project" gating.
  * Kept realtime enablement logic intact while reducing inputs to the experiment decision.

* **Chores**
  * Updated experiment telemetry: added an experiment identifier and removed legacy project-age metric; exposure tracking now handles errors more robustly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->