### PR TITLE
fix(studio): include DELETE in Allow header for users API route

### DIFF
--- a/apps/studio/pages/api/platform/auth/[ref]/users/[id]/index.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/users/[id]/index.ts
@@ -16,7 +16,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     case 'DELETE':
       return handleDelete(req, res)
     default:
-      res.setHeader('Allow', ['PATCH'])
+      res.setHeader('Allow', ['PATCH', 'DELETE'])
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
   }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This pull request makes a minor update to the allowed HTTP methods in the API route handler. The change ensures that the endpoint correctly advertises support for both `PATCH` and `DELETE` methods.

* Updated the `Allow` response header to include both `PATCH` and `DELETE`, reflecting the actual supported methods for this route. 

