### PR TITLE
Enable or disable Data API access per table

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
   type SetStateAction,
 } from 'react'
+import { usePreviousDistinct } from 'react-use'
 
 import { useTableApiAccessQuery } from '@/data/privileges/table-api-access-query'
 import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
@@ -30,7 +31,6 @@ import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { useIsSchemaExposed } from 'hooks/misc/useIsSchemaExposed'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { usePreviousDistinct } from 'react-use'
 import { Button, Popover_Shadcn_, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Switch } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -469,7 +469,7 @@ const SchemaExposureOptions = ({
         />
       )}
 
-      {!isPending && !isSchemaExposed && (
+      {!isPending && !isError && !isSchemaExposed && (
         <Admonition
           type="default"
           title={`The "${schemaName}" schema is not exposed via the Data API`}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -1,0 +1,493 @@
+import { Settings } from 'lucide-react'
+import Link from 'next/link'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react'
+
+import { useTableApiAccessQuery } from '@/data/privileges/table-api-access-query'
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
+import {
+  API_ACCESS_ROLES,
+  API_PRIVILEGE_TYPES,
+  checkDataApiPrivilegesNonEmpty,
+  DEFAULT_DATA_API_PRIVILEGES,
+  EMPTY_DATA_API_PRIVILEGES,
+  isApiPrivilegeType,
+  type ApiAccessRole,
+  type ApiPrivilegesByRole,
+} from '@/lib/data-api-types'
+import type { DeepReadonly, Prettify } from '@/lib/type-helpers'
+import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
+import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
+import { useLoadBalancersQuery } from 'data/read-replicas/load-balancers-query'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { useIsSchemaExposed } from 'hooks/misc/useIsSchemaExposed'
+import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { usePreviousDistinct } from 'react-use'
+import { Button, Popover_Shadcn_, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Switch } from 'ui'
+import { Admonition } from 'ui-patterns'
+import { Input } from 'ui-patterns/DataInputs/Input'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
+import {
+  MultiSelector,
+  MultiSelectorContent,
+  MultiSelectorItem,
+  MultiSelectorList,
+  MultiSelectorTrigger,
+} from 'ui-patterns/multi-select'
+
+const ROLE_LABELS: Record<ApiAccessRole, string> = {
+  anon: 'Anonymous (anon)',
+  authenticated: 'Authenticated',
+}
+
+namespace ApiAccessToggleProps {
+  type New = {
+    type: 'new'
+  }
+  type Duplicate = {
+    type: 'duplicate'
+    templateSchemaName: string
+    templateTableName: string
+  }
+  type Edit = {
+    type: 'edit'
+    schemaName: string
+    tableName: string
+  }
+  export type Option = New | Duplicate | Edit
+}
+
+export type TableApiAccessParams = ApiAccessToggleProps.Option
+
+type FetchState<T> =
+  | { isError: true; isPending: false; isSuccess: false; data: undefined }
+  | {
+      isError: false
+      isPending: true
+      isSuccess: false
+      data: undefined
+    }
+  | {
+      isError: false
+      isPending: false
+      isSuccess: true
+      data: Prettify<T>
+    }
+
+type TableApiAccessHandlerResult =
+  | { schemaExposed: false }
+  | {
+      schemaExposed: true
+      privileges: DeepReadonly<ApiPrivilegesByRole>
+      setPrivileges: Dispatch<SetStateAction<DeepReadonly<ApiPrivilegesByRole>>>
+    }
+
+type TableApiAccessHandlerReturn = FetchState<TableApiAccessHandlerResult>
+
+const useTableApiAccessHandler = (
+  params: ApiAccessToggleProps.Option,
+  { enabled = true } = {}
+): TableApiAccessHandlerReturn => {
+  const isNewTable = params.type === 'new'
+  const isDuplicate = params.type === 'duplicate'
+  const isExisting = params.type === 'edit'
+
+  const { selectedSchema } = useQuerySchemaState()
+  const currentTableSchema = isNewTable
+    ? selectedSchema
+    : isDuplicate
+      ? params.templateSchemaName
+      : params.schemaName
+
+  const { data: project } = useSelectedProjectQuery({ enabled })
+  const schemaExposure = useIsSchemaExposed(
+    {
+      projectRef: project?.ref,
+      schemaName: currentTableSchema,
+    },
+    { enabled }
+  )
+
+  const shouldReadExistingGrants = isDuplicate || isExisting
+  const permissionsTemplateSchema = !shouldReadExistingGrants
+    ? undefined
+    : isDuplicate
+      ? params.templateSchemaName
+      : params.schemaName
+  const permissionsTemplateTable = !shouldReadExistingGrants
+    ? undefined
+    : isDuplicate
+      ? params.templateTableName
+      : params.tableName
+  const canResolvePrivilegeParams = Boolean(
+    shouldReadExistingGrants &&
+      project?.ref &&
+      permissionsTemplateSchema &&
+      permissionsTemplateTable
+  )
+  const isPrivilegesQueryEnabled = enabled && canResolvePrivilegeParams
+  const apiAccessStatus = useTableApiAccessQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString ?? undefined,
+      schemaName: permissionsTemplateSchema ?? '',
+      tableNames: permissionsTemplateTable ? [permissionsTemplateTable] : [],
+    },
+    { enabled: isPrivilegesQueryEnabled }
+  )
+
+  const privilegesForTable = permissionsTemplateTable
+    ? apiAccessStatus.data?.[permissionsTemplateTable]
+    : undefined
+
+  const [privileges, setPrivileges] = useState<DeepReadonly<ApiPrivilegesByRole>>(
+    DEFAULT_DATA_API_PRIVILEGES
+  )
+
+  const hasLoadedInitialData = useRef(false)
+
+  const resetState = useStaticEffectEvent(() => {
+    hasLoadedInitialData.current = !shouldReadExistingGrants
+    setPrivileges(DEFAULT_DATA_API_PRIVILEGES)
+  })
+  useEffect(() => {
+    resetState()
+  }, [params.type, selectedSchema, permissionsTemplateSchema, permissionsTemplateTable, resetState])
+
+  const syncApiPrivileges = useStaticEffectEvent(() => {
+    if (hasLoadedInitialData.current) return
+    if (!apiAccessStatus.isSuccess) return
+    if (!privilegesForTable) return
+
+    hasLoadedInitialData.current = true
+    if (privilegesForTable.apiAccessType === 'access') {
+      setPrivileges(privilegesForTable.privileges)
+    } else if (privilegesForTable.apiAccessType === 'exposed-schema-no-grants') {
+      setPrivileges(EMPTY_DATA_API_PRIVILEGES)
+    } else {
+      // Used as a dummy default value but is never exposed since the schema is
+      // not exposed
+      setPrivileges(DEFAULT_DATA_API_PRIVILEGES)
+    }
+  })
+  useEffect(() => {
+    syncApiPrivileges()
+  }, [apiAccessStatus.status, syncApiPrivileges])
+
+  const isPending =
+    !enabled ||
+    schemaExposure.status === 'pending' ||
+    (shouldReadExistingGrants && apiAccessStatus.isPending)
+  if (isPending) {
+    return { isError: false, isPending: true, isSuccess: false, data: undefined }
+  }
+
+  const isError = schemaExposure.isError || (shouldReadExistingGrants && apiAccessStatus.isError)
+  if (isError) {
+    return { isError: true, isPending: false, isSuccess: false, data: undefined }
+  }
+
+  const isSchemaExposed = schemaExposure.data === true
+  if (!isSchemaExposed) {
+    return {
+      isError: false,
+      isPending: false,
+      isSuccess: true,
+      data: { schemaExposed: false },
+    }
+  }
+
+  return {
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    data: {
+      schemaExposed: true,
+      privileges,
+      setPrivileges,
+    },
+  }
+}
+
+export type TableApiAccessHandlerWithHistoryReturn = FetchState<
+  TableApiAccessHandlerResult & {
+    clearAllPrivileges: () => void
+    restorePreviousPrivileges: () => void
+  }
+>
+
+export const useTableApiAccessHandlerWithHistory = (
+  params: ApiAccessToggleProps.Option,
+  { enabled = true } = {}
+): TableApiAccessHandlerWithHistoryReturn => {
+  const innerResult = useTableApiAccessHandler(params, { enabled })
+
+  const privileges = innerResult.data?.schemaExposed ? innerResult.data.privileges : undefined
+  const previous = usePreviousDistinct(privileges)
+
+  const clearAllPrivileges = useStaticEffectEvent(() => {
+    if (!innerResult.isSuccess) return
+    if (!innerResult.data.schemaExposed) return
+    innerResult.data?.setPrivileges(EMPTY_DATA_API_PRIVILEGES)
+  })
+
+  const restorePreviousPrivileges = useStaticEffectEvent(() => {
+    if (!innerResult.isSuccess) return
+    if (!innerResult.data.schemaExposed) return
+    innerResult.data?.setPrivileges(previous ?? DEFAULT_DATA_API_PRIVILEGES)
+  })
+
+  if (!innerResult.isSuccess) {
+    return innerResult
+  }
+
+  return {
+    ...innerResult,
+    data: { ...innerResult.data, clearAllPrivileges, restorePreviousPrivileges },
+  }
+}
+
+type ApiAccessToggleProps = {
+  projectRef?: string
+  schemaName?: string
+  tableName?: string
+  handler: TableApiAccessHandlerWithHistoryReturn
+}
+
+export const ApiAccessToggle = ({
+  projectRef,
+  schemaName,
+  tableName,
+  handler,
+}: ApiAccessToggleProps): ReactNode => {
+  const [isPrivilegesPopoverOpen, setIsPrivilegesPopoverOpen] = useState(false)
+
+  const isPending = handler.isPending
+  const isError = handler.isError
+  const isSchemaExposed = handler.data?.schemaExposed
+  const isDisabled = isPending || isError || !isSchemaExposed
+
+  const privileges =
+    handler.isSuccess && handler.data.schemaExposed ? handler.data.privileges : undefined
+  const hasNonEmptyPrivileges = checkDataApiPrivilegesNonEmpty(privileges)
+
+  const handleMasterToggle = (checked: boolean) => {
+    if (!handler.isSuccess) return
+    if (!isSchemaExposed) return
+
+    if (checked) {
+      handler.data?.restorePreviousPrivileges()
+    } else {
+      handler.data?.clearAllPrivileges()
+    }
+  }
+
+  const handlePrivilegesChange = (role: ApiAccessRole) => (values: string[]) => {
+    if (!handler.isSuccess) return
+    if (!isSchemaExposed) return
+    if (!privileges) return
+
+    handler.data?.setPrivileges((oldPrivileges) => {
+      return {
+        ...oldPrivileges,
+        [role]: values.filter(isApiPrivilegeType),
+      }
+    })
+  }
+
+  const totalAvailablePrivileges = API_ACCESS_ROLES.length * API_PRIVILEGE_TYPES.length
+  const totalSelectedPrivileges = Object.values(privileges ?? {}).reduce(
+    (sum, rolePrivileges) => sum + rolePrivileges.length,
+    0
+  )
+  const hasPartialPrivileges =
+    totalSelectedPrivileges > 0 && totalSelectedPrivileges < totalAvailablePrivileges
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-sm text-foreground flex items-center gap-1.5">
+              Data API Access
+              <InfoTooltip side="top" className="max-w-80">
+                This controls which operations the <code className="text-xs">anon</code> and{' '}
+                <code className="text-xs">authenticated</code> roles can perform on this table via
+                the Data API. Unselected privileges are revoked from these roles.
+              </InfoTooltip>
+            </p>
+            <p className="text-sm text-foreground-lighter">
+              Allow this table to be queried via Supabase client libraries or the API directly
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Popover_Shadcn_
+              open={isPrivilegesPopoverOpen}
+              onOpenChange={setIsPrivilegesPopoverOpen}
+            >
+              <PopoverTrigger_Shadcn_ asChild disabled={isDisabled || !hasNonEmptyPrivileges}>
+                <Button type="text" className="w-6 h-6 p-0 text-foreground-light">
+                  <Settings strokeWidth={1.5} size={16} />
+                  {hasPartialPrivileges && (
+                    <span className="absolute right-0 top-0 h-1.5 w-1.5 rounded-full bg-foreground shadow-sm" />
+                  )}
+                </Button>
+              </PopoverTrigger_Shadcn_>
+              <PopoverContent_Shadcn_ align="end" className="w-[420px] space-y-3">
+                {!isDisabled && (
+                  <>
+                    <p className="text-sm text-foreground">Adjust API privileges per role</p>
+                    <div className="space-y-2">
+                      {API_ACCESS_ROLES.map((role) => (
+                        <div key={role} className="space-y-2">
+                          <p className="text-sm text-foreground flex items-center gap-1.5">
+                            {ROLE_LABELS[role]}
+                          </p>
+                          <MultiSelector
+                            values={(privileges?.[role] as string[]) ?? []}
+                            onValuesChange={handlePrivilegesChange(role)}
+                          >
+                            <MultiSelectorTrigger
+                              label="Select privileges"
+                              badgeLimit={4}
+                              deletableBadge={true}
+                            />
+                            <MultiSelectorContent>
+                              <MultiSelectorList>
+                                {API_PRIVILEGE_TYPES.map((privilege) => (
+                                  <MultiSelectorItem key={privilege} value={privilege}>
+                                    {privilege}
+                                  </MultiSelectorItem>
+                                ))}
+                              </MultiSelectorList>
+                            </MultiSelectorContent>
+                          </MultiSelector>
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </PopoverContent_Shadcn_>
+            </Popover_Shadcn_>
+            <Switch
+              checked={hasNonEmptyPrivileges}
+              onCheckedChange={handleMasterToggle}
+              disabled={isDisabled}
+            />
+          </div>
+        </div>
+      </div>
+      <SchemaExposureOptions
+        projectRef={projectRef}
+        schemaName={schemaName}
+        tableName={tableName}
+        isPending={isPending}
+        isError={isError}
+        isSchemaExposed={isSchemaExposed}
+        hasNonEmptyPrivileges={!!privileges ? hasNonEmptyPrivileges : undefined}
+      />
+    </div>
+  )
+}
+
+const SchemaExposureOptions = ({
+  projectRef,
+  schemaName,
+  tableName,
+  isPending,
+  isError,
+  isSchemaExposed,
+  hasNonEmptyPrivileges,
+}: {
+  projectRef?: string
+  schemaName?: string
+  tableName?: string
+  isPending: boolean
+  isError: boolean
+  isSchemaExposed?: boolean
+  hasNonEmptyPrivileges?: boolean
+}): ReactNode => {
+  const { selectedDatabaseId } = useDatabaseSelectorStateSnapshot()
+
+  const { data: customDomainData } = useCustomDomainsQuery({ projectRef })
+  const { data: loadBalancers } = useLoadBalancersQuery({ projectRef })
+  const { data: databases } = useReadReplicasQuery({ projectRef })
+
+  const apiEndpoint = useMemo(() => {
+    const isCustomDomainActive = customDomainData?.customDomain?.status === 'active'
+    if (isCustomDomainActive && selectedDatabaseId === projectRef) {
+      return `https://${customDomainData.customDomain.hostname}`
+    }
+
+    const loadBalancerSelected = selectedDatabaseId === 'load-balancer'
+    if (loadBalancerSelected) {
+      return loadBalancers?.[0]?.endpoint
+    }
+
+    const selectedDatabase = databases?.find((db) => db.identifier === selectedDatabaseId)
+    return selectedDatabase?.restUrl
+  }, [
+    projectRef,
+    databases,
+    selectedDatabaseId,
+    customDomainData?.customDomain?.status,
+    customDomainData?.customDomain?.hostname,
+    loadBalancers,
+  ])
+  const apiBaseUrl = useMemo(() => {
+    if (!apiEndpoint) return undefined
+    return apiEndpoint.endsWith('/') ? apiEndpoint.slice(0, -1) : apiEndpoint
+  }, [apiEndpoint])
+
+  const tablePath = !(schemaName && tableName)
+    ? undefined
+    : schemaName === 'public'
+      ? tableName
+      : `${schemaName}.${tableName}`
+  const apiUrl = apiBaseUrl && tablePath ? `${apiBaseUrl}/${tablePath}` : undefined
+
+  return (
+    <>
+      {isError && (
+        <Admonition type="warning" title="An error occurred while fetching Data API settings." />
+      )}
+
+      {isSchemaExposed && apiUrl && hasNonEmptyPrivileges && (
+        <Input
+          copy
+          readOnly
+          className="font-mono text-xs p-3 text-foreground-lighter"
+          value={apiUrl}
+        />
+      )}
+
+      {!isPending && !isSchemaExposed && (
+        <Admonition
+          type="default"
+          title={`The "${schemaName}" schema is not exposed via the Data API`}
+          description={
+            <>
+              To enable API access for this table, you need to first expose the{' '}
+              <code className="text-xs">{schemaName}</code> schema in your{' '}
+              <Link
+                href={`/project/${projectRef}/settings/api`}
+                className="text-foreground hover:underline"
+              >
+                API settings
+              </Link>
+              .
+            </>
+          }
+        />
+      )}
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/RLSManagement/RLSManagement.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/RLSManagement/RLSManagement.tsx
@@ -25,7 +25,7 @@ interface RLSManagementProps {
   foreignKeyRelations?: ForeignKey[] // For new tables
   isNewRecord: boolean
   isDuplicating: boolean
-  isExposed: boolean
+  isExposed?: boolean
   generatedPolicies?: GeneratedPolicy[]
   onRLSUpdate?: (isEnabled: boolean) => void
   onGeneratedPoliciesChange?: (policies: GeneratedPolicy[]) => void
@@ -164,7 +164,10 @@ export const RLSManagement = ({
       <Admonition
         // [Joshen] Using CSS to determine visibility here as the onSuccess within ToggleRLSButton doesn't get triggered
         // if we dynamically render this component, since this admonition gets unmounted from the DOM once RLS is updated
-        className={cn('mb-0', !isNewRecord && !isRLSEnabled && isExposed ? 'block' : 'hidden')}
+        className={cn(
+          'mb-0',
+          !isNewRecord && !isRLSEnabled && isExposed !== false ? 'block' : 'hidden'
+        )}
         type="warning"
         title="Row Level Security is currently disabled"
         description="Your table is currently accessible by anyone on the internet. We recommend enabling RLS to restrict access."

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/RLSManagement/RLSManagement.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/RLSManagement/RLSManagement.tsx
@@ -25,6 +25,7 @@ interface RLSManagementProps {
   foreignKeyRelations?: ForeignKey[] // For new tables
   isNewRecord: boolean
   isDuplicating: boolean
+  isExposed: boolean
   generatedPolicies?: GeneratedPolicy[]
   onRLSUpdate?: (isEnabled: boolean) => void
   onGeneratedPoliciesChange?: (policies: GeneratedPolicy[]) => void
@@ -36,6 +37,7 @@ export const RLSManagement = ({
   foreignKeyRelations = [],
   isNewRecord,
   isDuplicating,
+  isExposed,
   generatedPolicies = [],
   onRLSUpdate,
   onGeneratedPoliciesChange,
@@ -162,7 +164,7 @@ export const RLSManagement = ({
       <Admonition
         // [Joshen] Using CSS to determine visibility here as the onSuccess within ToggleRLSButton doesn't get triggered
         // if we dynamically render this component, since this admonition gets unmounted from the DOM once RLS is updated
-        className={cn('mb-0', !isNewRecord && !isRLSEnabled ? 'block' : 'hidden')}
+        className={cn('mb-0', !isNewRecord && !isRLSEnabled && isExposed ? 'block' : 'hidden')}
         type="warning"
         title="Row Level Security is currently disabled"
         description="Your table is currently accessible by anyone on the internet. We recommend enabling RLS to restrict access."

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -3,6 +3,7 @@ import { isEmpty, noop } from 'lodash'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
+import { useDataApiGrantTogglesEnabled } from '@/hooks/misc/useDataApiGrantTogglesEnabled'
 import type { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import { DocsButton } from 'components/ui/DocsButton'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
@@ -31,6 +32,7 @@ import { formatForeignKeys } from '../ForeignKeySelector/ForeignKeySelector.util
 import type { SaveTableParams } from '../SidePanelEditor'
 import type { ColumnField } from '../SidePanelEditor.types'
 import { SpreadsheetImport } from '../SpreadsheetImport/SpreadsheetImport'
+import { ApiAccessToggle, type TableApiAccessHandlerWithHistoryReturn } from './ApiAccessToggle'
 import ColumnManagement from './ColumnManagement'
 import { ForeignKeysManagement } from './ForeignKeysManagement/ForeignKeysManagement'
 import { HeaderTitle } from './HeaderTitle'
@@ -61,6 +63,7 @@ export interface TableEditorProps {
   closePanel: () => void
   saveChanges: (params: SaveTableParams) => void
   updateEditorDirty: () => void
+  apiAccessToggleHandler: TableApiAccessHandlerWithHistoryReturn
 }
 
 export const TableEditor = ({
@@ -71,12 +74,15 @@ export const TableEditor = ({
   closePanel = noop,
   saveChanges = noop,
   updateEditorDirty = noop,
+  apiAccessToggleHandler,
 }: TableEditorProps) => {
   const track = useTrack()
   const snap = useTableEditorStateSnapshot()
   const tableEditorApi = useContext(TableEditorStateContext)
   const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
   const { docsRowLevelSecurityGuidePath } = useCustomContent(['docs:row_level_security_guide_path'])
+
+  const isApiGrantTogglesEnabled = useDataApiGrantTogglesEnabled()
 
   const [params, setParams] = useUrlState()
   const { data: project } = useSelectedProjectQuery()
@@ -339,6 +345,8 @@ export const TableEditor = ({
 
   if (!tableFields) return null
 
+  const isApiAccessAndPoliciesSectionShown = isApiGrantTogglesEnabled || generatePoliciesEnabled
+
   return (
     <SidePanel
       data-testid="table-editor-side-panel"
@@ -542,22 +550,35 @@ export const TableEditor = ({
         </>
       )}
 
-      {/* [Joshen] Temporarily hide this section if duplicating, as we aren't duplicating policies atm when duplicating tables */}
-      {/* We should do this thought, but let's do this in another PR as the current one is already quite big */}
-      {generatePoliciesEnabled && !isDuplicating && (
+      {isApiAccessAndPoliciesSectionShown && (
         <>
           <SidePanel.Separator />
-          <SidePanel.Content className="space-y-10 py-6">
-            <RLSManagement
-              table={table}
-              tableFields={tableFields}
-              foreignKeyRelations={isNewRecord ? fkRelations : undefined}
-              isNewRecord={isNewRecord}
-              isDuplicating={isDuplicating}
-              generatedPolicies={generatedPolicies}
-              onGeneratedPoliciesChange={setGeneratedPolicies}
-              onRLSUpdate={(value) => onUpdateField({ isRLSEnabled: value })}
-            />
+          <SidePanel.Content className="py-6 space-y-6">
+            {isApiGrantTogglesEnabled && (
+              <ApiAccessToggle
+                projectRef={project?.ref}
+                schemaName={isNewRecord ? selectedSchema : table?.schema}
+                tableName={
+                  isNewRecord || isDuplicating ? tableFields.name : tableFields.name || table?.name
+                }
+                handler={apiAccessToggleHandler}
+              />
+            )}
+
+            {/* [Joshen] Temporarily hide this section if duplicating, as we aren't duplicating policies atm when duplicating tables */}
+            {/* We should do this thought, but let's do this in another PR as the current one is already quite big */}
+            {generatePoliciesEnabled && !isDuplicating && (
+              <RLSManagement
+                table={table}
+                tableFields={tableFields}
+                foreignKeyRelations={isNewRecord ? fkRelations : undefined}
+                isNewRecord={isNewRecord}
+                isDuplicating={isDuplicating}
+                generatedPolicies={generatedPolicies}
+                onGeneratedPoliciesChange={setGeneratedPolicies}
+                onRLSUpdate={(value) => onUpdateField({ isRLSEnabled: value })}
+              />
+            )}
           </SidePanel.Content>
         </>
       )}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useDataApiGrantTogglesEnabled } from '@/hooks/misc/useDataApiGrantTogglesEnabled'
+import { checkDataApiPrivilegesNonEmpty } from '@/lib/data-api-types'
 import type { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import { DocsButton } from 'components/ui/DocsButton'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
@@ -346,6 +347,9 @@ export const TableEditor = ({
   if (!tableFields) return null
 
   const isApiAccessAndPoliciesSectionShown = isApiGrantTogglesEnabled || generatePoliciesEnabled
+  const isExposed =
+    !!apiAccessToggleHandler.data?.schemaExposed &&
+    checkDataApiPrivilegesNonEmpty(apiAccessToggleHandler.data?.privileges)
 
   return (
     <SidePanel
@@ -574,6 +578,7 @@ export const TableEditor = ({
                 foreignKeyRelations={isNewRecord ? fkRelations : undefined}
                 isNewRecord={isNewRecord}
                 isDuplicating={isDuplicating}
+                isExposed={isExposed}
                 generatedPolicies={generatedPolicies}
                 onGeneratedPoliciesChange={setGeneratedPolicies}
                 onRLSUpdate={(value) => onUpdateField({ isRLSEnabled: value })}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -347,9 +347,10 @@ export const TableEditor = ({
   if (!tableFields) return null
 
   const isApiAccessAndPoliciesSectionShown = isApiGrantTogglesEnabled || generatePoliciesEnabled
-  const isExposed =
-    !!apiAccessToggleHandler.data?.schemaExposed &&
-    checkDataApiPrivilegesNonEmpty(apiAccessToggleHandler.data?.privileges)
+  const isExposed = isApiGrantTogglesEnabled
+    ? !!apiAccessToggleHandler.data?.schemaExposed &&
+      checkDataApiPrivilegesNonEmpty(apiAccessToggleHandler.data.privileges)
+    : undefined
 
   return (
     <SidePanel

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
@@ -1,14 +1,15 @@
+import type { Prettify } from '@/lib/type-helpers'
 import type { Dictionary } from 'types'
 import type { ColumnField } from '../SidePanelEditor.types'
 
-export interface TableField {
+export type TableField = Prettify<{
   id: number
   name: string
   comment?: string | null
   columns: ColumnField[]
   isRLSEnabled: boolean
   isRealtimeEnabled: boolean
-}
+}>
 
 export interface ImportContent {
   file?: File

--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -472,13 +472,11 @@ const EntityTooltipTrigger = ({
     )
   }
 
-  // Show warning for tables with RLS enabled but no policies
-  if (
-    isDataApiExposedBadgeEnabled &&
+  const isRlsEnabledNoPolicies =
     entity.type === ENTITY_TYPE.TABLE &&
-    apiAccessData?.hasApiAccess &&
+    apiAccessData?.apiAccessType === 'access' &&
     tableHasRlsEnabledNoPolicyLint
-  ) {
+  if (isDataApiExposedBadgeEnabled && isRlsEnabledNoPolicies) {
     return (
       <Tooltip>
         <TooltipTrigger className="min-w-4" aria-label="Table exposed via Data API">
@@ -492,8 +490,9 @@ const EntityTooltipTrigger = ({
     )
   }
 
-  // Show globe icon for tables with API access, RLS enabled and policies
-  if (isDataApiExposedBadgeEnabled && apiAccessData?.hasApiAccess) {
+  const isApiExposedWithRlsAndPolicies =
+    apiAccessData?.apiAccessType === 'access' && !tableHasRlsEnabledNoPolicyLint
+  if (isDataApiExposedBadgeEnabled && isApiExposedWithRlsAndPolicies) {
     return (
       <Tooltip>
         <TooltipTrigger className="min-w-4" aria-label="Table exposed via Data API">

--- a/apps/studio/data/config/project-postgrest-config-query.ts
+++ b/apps/studio/data/config/project-postgrest-config-query.ts
@@ -5,6 +5,18 @@ import { get, handleError } from 'data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { configKeys } from './keys'
 
+/**
+ * Parses the exposed schema string returned from PostgREST config.
+ *
+ * @param schemaString - e.g., `public,graphql_public`
+ */
+export const parseDbSchemaString = (schemaString: string): string[] => {
+  return schemaString
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
 export type ProjectPostgrestConfigVariables = {
   projectRef?: string
 }

--- a/apps/studio/data/privileges/table-api-access-mutation.ts
+++ b/apps/studio/data/privileges/table-api-access-mutation.ts
@@ -7,6 +7,7 @@ import {
   API_PRIVILEGE_TYPES,
   type ApiPrivilegesByRole,
 } from '@/lib/data-api-types'
+import type { DeepReadonly } from '@/lib/type-helpers'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { UseCustomMutationOptions } from 'types'
 import type { ConnectionVars } from '../common.types'
@@ -14,7 +15,7 @@ import { invalidateTablePrivilegesQuery } from './table-privileges-query'
 
 export type TableApiAccessPrivilegesVariables = ConnectionVars & {
   relationId: number
-  privileges: ApiPrivilegesByRole
+  privileges: DeepReadonly<ApiPrivilegesByRole>
 }
 
 export async function updateTableApiAccessPrivileges({

--- a/apps/studio/data/privileges/table-api-access-mutation.ts
+++ b/apps/studio/data/privileges/table-api-access-mutation.ts
@@ -1,0 +1,105 @@
+import pgMeta from '@supabase/pg-meta'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import {
+  API_ACCESS_ROLES,
+  API_PRIVILEGE_TYPES,
+  type ApiPrivilegesByRole,
+} from '@/lib/data-api-types'
+import { executeSql } from 'data/sql/execute-sql-query'
+import type { UseCustomMutationOptions } from 'types'
+import type { ConnectionVars } from '../common.types'
+import { invalidateTablePrivilegesQuery } from './table-privileges-query'
+
+export type TableApiAccessPrivilegesVariables = ConnectionVars & {
+  relationId: number
+  privileges: ApiPrivilegesByRole
+}
+
+export async function updateTableApiAccessPrivileges({
+  projectRef,
+  connectionString,
+  relationId,
+  privileges,
+}: TableApiAccessPrivilegesVariables) {
+  const sqlStatements: string[] = []
+
+  for (const role of API_ACCESS_ROLES) {
+    const rolePrivileges = privileges[role]
+
+    // Determine which privileges to grant and revoke for this role
+    const privilegesToGrant = rolePrivileges
+    const privilegesToRevoke = API_PRIVILEGE_TYPES.filter((p) => !rolePrivileges.includes(p))
+
+    // Revoke privileges that should be removed
+    if (privilegesToRevoke.length > 0) {
+      const revokeGrants = privilegesToRevoke.map((privilegeType) => ({
+        grantee: role,
+        privilegeType,
+        relationId,
+      }))
+      const revokeSql = pgMeta.tablePrivileges.revoke(revokeGrants).sql.trim()
+      if (revokeSql) sqlStatements.push(revokeSql)
+    }
+
+    // Grant privileges that should be added
+    if (privilegesToGrant.length > 0) {
+      const grantGrants = privilegesToGrant.map((privilegeType) => ({
+        grantee: role,
+        privilegeType,
+        relationId,
+      }))
+      const grantSql = pgMeta.tablePrivileges.grant(grantGrants).sql.trim()
+      if (grantSql) sqlStatements.push(grantSql)
+    }
+  }
+
+  if (sqlStatements.length === 0) {
+    return null
+  }
+
+  const { result } = await executeSql<[]>({
+    projectRef,
+    connectionString,
+    sql: sqlStatements.join('\n'),
+    queryKey: ['table-api-access', 'update-privileges'],
+  })
+
+  return result
+}
+
+type UpdateTableApiAccessPrivilegesData = Awaited<ReturnType<typeof updateTableApiAccessPrivileges>>
+
+export const useTableApiAccessPrivilegesMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseCustomMutationOptions<
+    UpdateTableApiAccessPrivilegesData,
+    Error,
+    TableApiAccessPrivilegesVariables
+  >,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<UpdateTableApiAccessPrivilegesData, Error, TableApiAccessPrivilegesVariables>({
+    mutationFn: (vars) => updateTableApiAccessPrivileges(vars),
+    async onSuccess(data, variables, context) {
+      const { projectRef } = variables
+      await invalidateTablePrivilegesQuery(queryClient, projectRef)
+
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(data, variables, context) {
+      if (onError === undefined) {
+        toast.error(`Failed to update API access privileges: ${data.message}`)
+      } else {
+        onError(data, variables, context)
+      }
+    },
+    ...options,
+  })
+}

--- a/apps/studio/hooks/misc/useDataApiGrantTogglesEnabled.ts
+++ b/apps/studio/hooks/misc/useDataApiGrantTogglesEnabled.ts
@@ -1,0 +1,14 @@
+import { useFlag } from 'common'
+import { usePHFlag } from '../ui/useFlag'
+
+/**
+ * Determine whether a user has access to Data API grant toggles.
+ *
+ * Requires that the ConfigCat flag for Data API badges and the PostHog flag
+ * for Table Editor API access are both enabled.
+ */
+export const useDataApiGrantTogglesEnabled = (): boolean => {
+  const isDataApiBadgesEnabled = useFlag('dataApiExposedBadge')
+  const isTableEditorApiAccessEnabled = usePHFlag<boolean>('tableEditorApiAccessToggle')
+  return isDataApiBadgesEnabled && !!isTableEditorApiAccessEnabled
+}

--- a/apps/studio/hooks/misc/useIsSchemaExposed.ts
+++ b/apps/studio/hooks/misc/useIsSchemaExposed.ts
@@ -1,0 +1,74 @@
+import { useMemo } from 'react'
+
+import {
+  parseDbSchemaString,
+  useProjectPostgrestConfigQuery,
+} from 'data/config/project-postgrest-config-query'
+
+type UseIsSchemaExposedParams = {
+  projectRef?: string
+  schemaName?: string
+}
+
+type UseIsSchemaExposedOptions = {
+  enabled?: boolean
+}
+
+export type UseIsSchemaExposedReturn =
+  | {
+      status: 'pending'
+      data: undefined
+      isPending: true
+      isError: false
+      isSuccess: false
+    }
+  | {
+      status: 'error'
+      data: undefined
+      isPending: false
+      isError: true
+      isSuccess: false
+    }
+  | {
+      status: 'success'
+      data: boolean
+      isPending: false
+      isError: false
+      isSuccess: true
+    }
+
+export const useIsSchemaExposed = (
+  { projectRef, schemaName }: UseIsSchemaExposedParams,
+  { enabled = true }: UseIsSchemaExposedOptions = {}
+): UseIsSchemaExposedReturn => {
+  const shouldQueryConfig = enabled && !!projectRef && !!schemaName
+  const {
+    data: dbSchemaString,
+    isPending: isConfigPending,
+    isError: isConfigError,
+  } = useProjectPostgrestConfigQuery(
+    { projectRef },
+    { enabled: shouldQueryConfig, select: ({ db_schema }) => db_schema }
+  )
+
+  const exposedSchemas = useMemo(() => {
+    if (!dbSchemaString) return []
+    return parseDbSchemaString(dbSchemaString)
+  }, [dbSchemaString])
+
+  if (!shouldQueryConfig || isConfigPending) {
+    return { status: 'pending', data: undefined, isPending: true, isError: false, isSuccess: false }
+  }
+
+  if (isConfigError) {
+    return { status: 'error', data: undefined, isPending: false, isError: true, isSuccess: false }
+  }
+
+  return {
+    status: 'success',
+    data: exposedSchemas.includes(schemaName),
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+  }
+}

--- a/apps/studio/lib/data-api-types.ts
+++ b/apps/studio/lib/data-api-types.ts
@@ -1,4 +1,5 @@
 import type { TablePrivilegesGrant } from 'data/privileges/table-privileges-grant-mutation'
+import type { DeepReadonly } from './type-helpers'
 
 export const API_ACCESS_ROLES = ['anon', 'authenticated'] as const
 export type ApiAccessRole = (typeof API_ACCESS_ROLES)[number]
@@ -23,3 +24,20 @@ export const isApiPrivilegeType = (value: string): value is ApiPrivilegeType => 
 }
 
 export type ApiPrivilegesByRole = Record<ApiAccessRole, ApiPrivilegeType[]>
+
+export const DEFAULT_DATA_API_PRIVILEGES: DeepReadonly<ApiPrivilegesByRole> = {
+  anon: [...API_PRIVILEGE_TYPES],
+  authenticated: [...API_PRIVILEGE_TYPES],
+}
+
+export const EMPTY_DATA_API_PRIVILEGES: DeepReadonly<ApiPrivilegesByRole> = {
+  anon: [],
+  authenticated: [],
+}
+
+export const checkDataApiPrivilegesNonEmpty = (
+  privileges: DeepReadonly<ApiPrivilegesByRole> | undefined
+): boolean => {
+  if (!privileges) return false
+  return Object.values(privileges).some((privs) => privs.length > 0)
+}

--- a/apps/studio/lib/type-helpers.ts
+++ b/apps/studio/lib/type-helpers.ts
@@ -1,3 +1,9 @@
 export type PlainObject<Value = unknown> = Record<string | number | symbol, Value>
 
 export type Prettify<T> = { [K in keyof T]: T[K] } & {}
+
+export type DeepReadonly<T> = T extends (infer R)[]
+  ? ReadonlyArray<DeepReadonly<R>>
+  : T extends Object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -95,7 +95,7 @@ function MultiSelector({
   // detect clicks from outside
   useOnClickOutside(ref, () => {
     if (open) {
-      setOpen(!open)
+      setOpen(false)
     }
   })
 
@@ -183,7 +183,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
     },
     ref
   ) => {
-    const { activeIndex, values, setInputValue, toggleValue, disabled, setOpen } = useMultiSelect()
+    const { activeIndex, values, setInputValue, toggleValue, disabled, open, setOpen } =
+      useMultiSelect()
 
     const inputRef = React.useRef<HTMLButtonElement>(null)
 
@@ -216,10 +217,11 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
 
     const handleTriggerClick: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
       (event) => {
-        setOpen(true)
-        setInputValue('')
+        const willOpen = !open
+        setOpen(willOpen)
+        if (willOpen) setInputValue('')
 
-        if (IS_INLINE_MODE) {
+        if (IS_INLINE_MODE && willOpen) {
           event.stopPropagation()
           event.preventDefault()
 
@@ -228,7 +230,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
           }, 100)
         }
       },
-      []
+      [open, setOpen, setInputValue, IS_INLINE_MODE]
     )
 
     return (

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -259,18 +259,25 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
 
     const handleTriggerClick: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
       (event) => {
-        const willOpen = !open
-        setOpen(willOpen)
-        if (willOpen) setInputValue('')
+        if (IS_INLINE_MODE) {
+          if (!open) {
+            setOpen(true)
+            setInputValue('')
+          }
 
-        if (IS_INLINE_MODE && willOpen) {
           event.stopPropagation()
           event.preventDefault()
 
           setTimeout(() => {
             inlineInputRef.current?.focus()
           }, 100)
+
+          return
         }
+
+        const willOpen = !open
+        setOpen(willOpen)
+        if (willOpen) setInputValue('')
       },
       [open, setOpen, setInputValue, IS_INLINE_MODE]
     )

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -27,9 +27,14 @@ interface MultiSelectContextProps {
   setActiveIndex: React.Dispatch<React.SetStateAction<number>>
   size: MultiSelectorProps['size']
   disabled?: boolean
+  dropdownPlacement: 'top' | 'bottom'
+  dropdownMaxHeight: number
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextProps | null>(null)
+
+const DROPDOWN_MAX_HEIGHT = 300
+const DROPDOWN_GAP = 8
 
 const commandItemClass = cn(
   'relative text-foreground-lighter text-left px-2 py-1.5 rounded',
@@ -81,6 +86,9 @@ function MultiSelector({
   const [inputValue, setInputValue] = React.useState<string>('')
   const [activeIndex, setActiveIndex] = React.useState<number>(-1)
 
+  const [dropdownPlacement, setDropdownPlacement] = React.useState<'top' | 'bottom'>('bottom')
+  const [dropdownMaxHeight, setDropdownMaxHeight] = React.useState<number>(DROPDOWN_MAX_HEIGHT)
+
   const toggleValue = React.useCallback(
     (toggledValue: string) => {
       if (values.includes(toggledValue)) {
@@ -91,6 +99,38 @@ function MultiSelector({
     },
     [values]
   )
+
+  const updateDropdownMetrics = React.useCallback(() => {
+    if (typeof window === 'undefined') return
+    const triggerEl = ref.current as HTMLDivElement | null
+    if (!triggerEl) return
+
+    const rect = triggerEl.getBoundingClientRect()
+    const viewportHeight = window.innerHeight
+    const spaceBelow = viewportHeight - rect.bottom - DROPDOWN_GAP
+    const spaceAbove = rect.top - DROPDOWN_GAP
+    const shouldDropUp = spaceBelow < DROPDOWN_MAX_HEIGHT && spaceAbove > spaceBelow
+    const placement = shouldDropUp ? 'top' : 'bottom'
+    const availableSpace = Math.max(placement === 'top' ? spaceAbove : spaceBelow, 0)
+    const nextHeight =
+      availableSpace > 0 ? Math.min(DROPDOWN_MAX_HEIGHT, availableSpace) : DROPDOWN_MAX_HEIGHT
+
+    setDropdownPlacement(placement)
+    setDropdownMaxHeight(nextHeight)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const controller = new AbortController()
+    const { signal } = controller
+
+    const handleUpdate = updateDropdownMetrics
+    handleUpdate()
+    window.addEventListener('resize', handleUpdate, { signal })
+    window.addEventListener('scroll', handleUpdate, { capture: true, passive: true, signal })
+
+    return () => controller.abort()
+  }, [open, updateDropdownMetrics])
 
   // detect clicks from outside
   useOnClickOutside(ref, () => {
@@ -143,6 +183,8 @@ function MultiSelector({
         setActiveIndex,
         size: size || 'small',
         disabled,
+        dropdownPlacement,
+        dropdownMaxHeight,
       }}
     >
       <Command
@@ -406,16 +448,21 @@ MultiSelector.Input = MultiSelectorInput
 
 const MultiSelectorContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, children }, ref) => {
-    const { open } = useMultiSelect()
+    const { open, dropdownPlacement } = useMultiSelect()
+
+    const closedTranslationClass = dropdownPlacement === 'top' ? 'translate-y-3' : '-translate-y-3'
 
     return (
       <div
         ref={ref}
         className={cn(
-          'absolute w-full bg-overlay shadow-md z-10 border border-overlay top-[calc(100%+0.25rem)] rounded-md transition-all -translate-y-3',
+          'absolute w-full bg-overlay shadow-md z-10 border border-overlay rounded-md transition-all',
+          dropdownPlacement === 'top'
+            ? 'bottom-[calc(100%+0.25rem)] origin-bottom'
+            : 'top-[calc(100%+0.25rem)] origin-top',
           open
             ? 'opacity-100 translate-y-0 visible duration-150 ease-[.76,0,.23,1]'
-            : 'opacity-0 -translate-y-3 invisible duration-0',
+            : cn('opacity-0 invisible duration-0', closedTranslationClass),
           className
         )}
       >
@@ -434,7 +481,7 @@ const MultiSelectorList = React.forwardRef<
     creatable?: boolean
   }
 >(({ className, children, creatable = false }, ref) => {
-  const { open, inputValue, setInputValue, toggleValue } = useMultiSelect()
+  const { open, inputValue, setInputValue, toggleValue, dropdownMaxHeight } = useMultiSelect()
 
   const options = !!children
     ? Array.isArray(children)
@@ -454,9 +501,10 @@ const MultiSelectorList = React.forwardRef<
       className={cn(
         'p-2 flex flex-col gap-2 scrollbar-thin scrollbar-track-transparent transition-colors',
         'scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted',
-        'scrollbar-thumb-rounded-lg w-full max-h-[300px] overflow-y-auto',
+        'scrollbar-thumb-rounded-lg w-full overflow-y-auto',
         className
       )}
+      style={{ maxHeight: dropdownMaxHeight }}
     >
       {children}
       {creatable && inputValue.length > 0 && !isOptionExists ? (


### PR DESCRIPTION
<img width="1189" height="1106" alt="image" src="https://github.com/user-attachments/assets/1f64f160-e7a6-4838-b55c-64f77ff485d7" />

This adds an enable/disable switch to table creation/editing panel via the table editor. The purpose is to give users more control and visibility over which tables are exposed via the Data API. This works in conjunction with exposed schemas so the setting is disabled if a schema is not exposed via the API.

Under the hood this just grants or revokes all privilages to anon and authenticated roles. 

Note: We need to investigate other possible side effects of revoking access beyond API.

To test:
1. Create a new table to public schema without touching the new setting
2. Notice its enabled by default ie no badge in table list in editor
3. Create a new table to public schema and disable setting
4. Notice badge shows on that table
5. Create a new schema
6. Create a new table under that schema and notice switch is disabled
7. Add new schema to exposed schemas list in API settings
8. Return and notice you can enable/disable API access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-table API access privileges management with role-based control (anonymous and authenticated users)
  * New API access toggle in table editor for enabling/disabling Data API exposure
  * Visual globe indicator shows tables exposed via the Data API in table list

* **Bug Fixes**
  * Fixed multi-select component closing behavior to properly close on outside clicks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->