### PR TITLE
chore: hide additional schemas from data API

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -112,7 +112,17 @@ export const PostgrestConfig = () => {
     })
 
   const formId = 'project-postgres-config'
-  const hiddenSchema = ['auth', 'pgbouncer', 'hooks', 'extensions']
+  const hiddenSchema = [
+    'auth',
+    'pgbouncer',
+    'hooks',
+    'extensions',
+    'vault',
+    'storage',
+    'realtime',
+    'pgsodium',
+    'pgsodium_masks',
+  ]
   const { can: canUpdatePostgrestConfig, isSuccess: isPermissionsLoaded } =
     useAsyncCheckPermissions(PermissionAction.UPDATE, 'custom_config_postgrest')
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Some schemas that shouldn't be shared via the data API are selectable 

<img width="1115" height="506" alt="Screenshot 2025-12-10 at 14 38 27" src="https://github.com/user-attachments/assets/69f22526-0899-4678-836a-bdf3448c02c7" />


## What is the new behavior?

Schemas are no longer in the list

<img width="788" height="367" alt="Screenshot 2025-12-10 at 14 45 37" src="https://github.com/user-attachments/assets/cd248997-af75-473a-ac53-7d31554ab34d" />

