### PR TITLE
chore: uniform card and panel padding-x

### DIFF
--- a/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -93,7 +93,7 @@ export const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps
               <button
                 id="collapsible-trigger"
                 type="button"
-                className="group flex w-full items-center justify-between rounded py-3 px-4 md:px-6 text-foreground"
+                className="group flex w-full items-center justify-between rounded py-3 px-[var(--card-padding-x)] text-foreground"
                 onClick={(event: any) => {
                   if (event.target.id === 'collapsible-trigger') setIsExpanded(!isExpanded)
                 }}

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -186,7 +186,7 @@ export const RolesList = () => {
 
       <div className="space-y-4">
         <div>
-          <div className="bg-surface-100 border border-default px-4 md:px-6 py-3 rounded-t flex items-center space-x-4">
+          <div className="bg-surface-100 border border-default px-[var(--card-padding-x)] py-3 rounded-t flex items-center space-x-4">
             <p className="text-sm text-foreground-light">Roles managed by Supabase</p>
             <Badge variant="success">Protected</Badge>
           </div>
@@ -204,7 +204,7 @@ export const RolesList = () => {
         </div>
 
         <div>
-          <div className="bg-surface-100 border border-default px-4 md:px-6 py-3 rounded-t">
+          <div className="bg-surface-100 border border-default px-[var(--card-padding-x)] py-3 rounded-t">
             <p className="text-sm text-foreground-light">Other database roles</p>
           </div>
 

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -441,7 +441,7 @@ export function DiskManagementForm() {
                   open={advancedSettingsOpen}
                   onOpenChange={() => setAdvancedSettingsOpenState((prev) => !prev)}
                 >
-                  <CollapsibleTrigger_Shadcn_ className="px-8 py-3 w-full border flex items-center gap-6 rounded-t data-[state=closed]:rounded-b group justify-between">
+                  <CollapsibleTrigger_Shadcn_ className="px-[var(--card-padding-x)] py-3 w-full border flex items-center gap-6 rounded-t data-[state=closed]:rounded-b group justify-between">
                     <div className="flex flex-col items-start">
                       <span className="text-sm text-foreground">Advanced disk settings</span>
                       <span className="text-sm text-foreground-light text-left">
@@ -462,11 +462,11 @@ export function DiskManagementForm() {
                     )}
                   >
                     <div className="flex flex-col gap-y-8 py-8">
-                      <div className="px-8 flex flex-col gap-y-8">
+                      <div className="px-[var(--card-padding-x)] flex flex-col gap-y-8">
                         <AutoScaleFields form={form} />
                       </div>
                       <Separator />
-                      <div className="px-8 flex flex-col gap-y-8">
+                      <div className="px-[var(--card-padding-x)] flex flex-col gap-y-8">
                         <NoticeBar
                           type="default"
                           visible={disableIopsThroughputConfig}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -117,7 +117,7 @@ const BillingEmail = () => {
             <form id={FORM_ID} onSubmit={form.handleSubmit(onUpdateOrganizationEmail)}>
               <FormPanel
                 footer={
-                  <div className="flex py-4 px-8">
+                  <div className="flex py-4 px-[var(--card-padding-x)]">
                     <FormActions
                       form={FORM_ID}
                       isSubmitting={isUpdating}

--- a/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
@@ -180,7 +180,7 @@ export const SSOConfig = () => {
               <Form_Shadcn_ {...form}>
                 <form id={FORM_ID} onSubmit={form.handleSubmit(onSubmit)}>
                   <Card>
-                    <CardContent className="py-8">
+                    <CardContent>
                       <FormField_Shadcn_
                         control={form.control}
                         name="enabled"

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -206,7 +206,7 @@ export const PostgrestConfig = () => {
                   render={({ field }) => (
                     <FormItem_Shadcn_ className="w-full">
                       <FormItemLayout
-                        className="w-full px-8 py-8"
+                        className="w-full px-[var(--card-padding-x)] py-4"
                         layout="flex"
                         label="Enable Data API"
                         description="When enabled you will be able to use any Supabase client library and PostgREST endpoints with any schema configured below."
@@ -269,7 +269,7 @@ export const PostgrestConfig = () => {
                             description="The schemas to expose in your API. Tables, views and stored procedures in
                           these schemas will get API endpoints."
                             layout="horizontal"
-                            className="px-8 py-8"
+                            className="px-[var(--card-padding-x)] py-4"
                           >
                             {isLoadingSchemas ? (
                               <div className="col-span-12 flex flex-col gap-2 lg:col-span-7">
@@ -348,7 +348,7 @@ export const PostgrestConfig = () => {
                       render={({ field }) => (
                         <FormItem_Shadcn_ className="w-full">
                           <FormItemLayout
-                            className="w-full px-8 py-8"
+                            className="w-full px-[var(--card-padding-x)] py-4"
                             layout="horizontal"
                             label="Extra search path"
                             description="Extra schemas to add to the search path of every request."
@@ -399,7 +399,7 @@ export const PostgrestConfig = () => {
                       render={({ field }) => (
                         <FormItem_Shadcn_ className="w-full">
                           <FormItemLayout
-                            className="w-full px-8 py-8"
+                            className="w-full px-[var(--card-padding-x)] py-4"
                             layout="horizontal"
                             label="Max rows"
                             description="The maximum number of rows returned from a view, table, or stored procedure. Limits payload size for accidental or malicious requests."
@@ -426,7 +426,7 @@ export const PostgrestConfig = () => {
                       render={({ field }) => (
                         <FormItem_Shadcn_ className="w-full">
                           <FormItemLayout
-                            className="w-full px-8 py-8"
+                            className="w-full px-[var(--card-padding-x)] py-4"
                             layout="horizontal"
                             label="Pool size"
                             description="Number of maximum connections to keep open in the Data API server's database pool. Unset to let it be configured automatically based on compute size."

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
@@ -66,7 +66,7 @@ const CustomDomainsConfigureHostname = () => {
             <FormPanel
               disabled={!canConfigureCustomDomain}
               footer={
-                <div className="flex py-4 px-8">
+                <div className="flex py-4 px-[var(--card-padding-x)]">
                   <FormActions
                     form={FORM_ID}
                     isSubmitting={isCheckingRecord || isCreating}

--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -101,7 +101,7 @@ export const General = () => {
               <FormPanel
                 disabled={!canUpdateProject}
                 footer={
-                  <div className="flex py-4 px-8">
+                  <div className="flex py-4 px-[var(--card-padding-x)]">
                     <FormActions
                       form={formId}
                       isSubmitting={isUpdating}
@@ -139,7 +139,7 @@ export const General = () => {
       )}
       <div className="mt-6" id="restart-project">
         <FormPanel>
-          <div className="flex flex-col px-8 py-4">
+          <div className="flex flex-col py-4 px-[var(--card-padding-x)]">
             <div className="flex flex-col @lg:flex-row @lg:justify-between @lg:items-center gap-4">
               <div>
                 <p className="text-sm">
@@ -155,7 +155,7 @@ export const General = () => {
             </div>
           </div>
           <div
-            className="flex w-full flex-col @lg:flex-row @lg:justify-between @lg:items-center gap-4 px-8 py-4"
+            className="flex w-full flex-col @lg:flex-row @lg:justify-between @lg:items-center gap-4 px-[var(--card-padding-x)] py-4"
             id="pause-project"
           >
             <div>

--- a/apps/studio/components/ui/Forms/FormSection.tsx
+++ b/apps/studio/components/ui/Forms/FormSection.tsx
@@ -16,7 +16,7 @@ export const FormSection = ({
   className?: string
 }) => {
   const classes = [
-    'grid grid-cols-12 gap-6 px-4 md:px-8 py-4 md:py-8',
+    'grid grid-cols-12 gap-6 px-[var(--card-padding-x)] py-4 md:py-8',
     `${disabled ? ' opacity-30' : ' opacity-100'}`,
     `${className}`,
   ]

--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -34,7 +34,7 @@ function Panel(props: PropsWithChildren<PanelProps>) {
       {props.title && (
         <div
           className={cn(
-            'bg-surface-100 border-b border-default flex items-center px-4 py-4',
+            'bg-surface-100 border-b border-default flex items-center px-[var(--card-padding-x)] py-4',
             props.titleClasses
           )}
         >
@@ -54,13 +54,13 @@ function Panel(props: PropsWithChildren<PanelProps>) {
 }
 
 function Content({ children, className }: { children: ReactNode; className?: string | false }) {
-  return <div className={cn('px-4 py-4', className)}>{children}</div>
+  return <div className={cn('px-[var(--card-padding-x)] py-4', className)}>{children}</div>
 }
 
 function Footer({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <div className={cn('bg-surface-100 border-t border-default', className)}>
-      <div className="flex h-12 items-center px-4">{children}</div>
+      <div className="flex h-12 items-center px-[var(--card-padding-x)]">{children}</div>
     </div>
   )
 }
@@ -95,7 +95,7 @@ const PanelNotice = forwardRef<
         ref={ref}
         {...props}
         className={cn(
-          'relative px-4 py-5 bg-studio flex flex-col lg:flex-row lg:justify-between gap-6 overflow-hidden lg:items-center',
+          'relative px-[var(--card-padding-x)] py-5 bg-studio flex flex-col lg:flex-row lg:justify-between gap-6 overflow-hidden lg:items-center',
           layout === 'vertical' && '!flex-col !items-start gap-y-2',
           className
         )}

--- a/packages/ui/build/css/source/global.css
+++ b/packages/ui/build/css/source/global.css
@@ -126,7 +126,10 @@
   --icon-md: 18px;
   --iconwidth-default: 1px;
   --panel: 2px;
-  --card-padding-x: 1rem;
+  --padding-x-sm: 1rem; /* px-4 */
+  --padding-x-md: 1.5rem; /* px-6 */
+  --card-padding-x: var(--padding-x-sm);
+  --card-padding-x-md: var(--padding-x-md);
   --datatable-headericon: 16px;
   --datatable-rowheight: 28px;
   --options-icon: 18px;

--- a/packages/ui/build/css/source/global.css
+++ b/packages/ui/build/css/source/global.css
@@ -126,6 +126,7 @@
   --icon-md: 18px;
   --iconwidth-default: 1px;
   --panel: 2px;
+  --card-padding-x: 1rem;
   --datatable-headericon: 16px;
   --datatable-rowheight: 28px;
   --options-icon: 18px;

--- a/packages/ui/src/components/shadcn/ui/card.tsx
+++ b/packages/ui/src/components/shadcn/ui/card.tsx
@@ -20,7 +20,10 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('flex flex-col space-y-1.5 py-4 px-6 border-b', className)}
+      className={cn(
+        'flex flex-col space-y-1.5 py-4 px-[var(--card-padding-x)] border-b',
+        className
+      )}
       {...props}
     />
   )
@@ -44,14 +47,22 @@ CardDescription.displayName = 'CardDescription'
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('py-4 px-6 border-b last:border-none', className)} {...props} />
+    <div
+      ref={ref}
+      className={cn('py-4 px-[var(--card-padding-x)] border-b last:border-none', className)}
+      {...props}
+    />
   )
 )
 CardContent.displayName = 'CardContent'
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn(' flex items-center py-4 px-6', className)} {...props} />
+    <div
+      ref={ref}
+      className={cn('flex items-center py-4 px-[var(--card-padding-x)]', className)}
+      {...props}
+    />
   )
 )
 CardFooter.displayName = 'CardFooter'


### PR DESCRIPTION
Adding a global css `--card-padding-x` variable to centralize the horizontal spacing for cards and panels and other layouts that commonly should align to these.

## Some examples

|  Before  |  After |
|---|---|
| <img width="503" height="720" alt="Screenshot 2025-12-10 at 16 10 06" src="https://github.com/user-attachments/assets/6d16e481-97b6-4452-afe1-2b53118024c8" />  |  <img width="651" height="779" alt="Screenshot 2025-12-10 at 16 07 35" src="https://github.com/user-attachments/assets/35bf4553-9b66-48d6-aeb0-aa1b631f97b5" /> | 

|  Before  |  After |
|---|---|
| <img width="609" height="774" alt="Screenshot 2025-12-09 at 12 28 43" src="https://github.com/user-attachments/assets/35f3f374-d761-4ce6-8d40-2e40bf842179" />  | <img width="451" height="756" alt="Screenshot 2025-12-10 at 16 10 28" src="https://github.com/user-attachments/assets/9ff7ea0f-3d96-4c61-833b-1eb1c9146170" /> | 






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated horizontal padding across UI components to use standardized CSS design tokens instead of fixed pixel values. Changes ensure consistent spacing throughout panels, forms, cards, and interface elements while improving maintainability and flexibility of the design system for future adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->