### PR TITLE
Fix creating users not invalidating users list and count

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Lock, Mail } from 'lucide-react'
-import { useForm } from 'react-hook-form'
+import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
 
@@ -51,9 +51,8 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
     },
   })
 
-  const onCreateUser = async (values: any) => {
+  const onCreateUser: SubmitHandler<z.infer<typeof CreateUserFormSchema>> = async (values) => {
     if (!projectRef) return console.error('Project ref is required')
-
     createUser({ projectRef, user: values })
   }
 

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -1,3 +1,4 @@
+import pgMeta from '@supabase/pg-meta'
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
 import {
@@ -12,18 +13,22 @@ import {
 import { UIEvent, useEffect, useMemo, useRef, useState } from 'react'
 import DataGrid, { Column, DataGridHandle, Row } from 'react-data-grid'
 import { toast } from 'sonner'
-import pgMeta from '@supabase/pg-meta'
 
 import type { OptimizedSearchColumns } from '@supabase/pg-meta/src/sql/studio/get-users-types'
 import { LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
 import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import AlertError from 'components/ui/AlertError'
+import { AlertError } from 'components/ui/AlertError'
 import { APIDocsButton } from 'components/ui/APIDocsButton'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { FilterPopover } from 'components/ui/FilterPopover'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
+import { InlineLink } from 'components/ui/InlineLink'
+import { useAuthConfigQuery } from 'data/auth/auth-config-query'
+import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
+import { useIndexWorkerStatusQuery } from 'data/auth/index-worker-status-query'
 import { authKeys } from 'data/auth/keys'
 import { useUserDeleteMutation } from 'data/auth/user-delete-mutation'
+import { useUserIndexStatusesQuery } from 'data/auth/user-search-indexes-query'
 import { useUsersCountQuery } from 'data/auth/users-count-query'
 import { User, useUsersInfiniteQuery } from 'data/auth/users-infinite-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -33,6 +38,7 @@ import { useQueryStateWithSelect } from 'hooks/misc/useQueryStateWithSelect'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { cleanPointerEventsNoneOnBody, isAtBottom } from 'lib/helpers'
+import Link from 'next/link'
 import { parseAsArrayOf, parseAsString, parseAsStringEnum, useQueryState } from 'nuqs'
 import {
   Alert_Shadcn_,
@@ -69,12 +75,6 @@ import {
 import { formatUserColumns, formatUsersData } from './Users.utils'
 import { UsersFooter } from './UsersFooter'
 import { UsersSearch } from './UsersSearch'
-import { useAuthConfigQuery } from 'data/auth/auth-config-query'
-import { useUserIndexStatusesQuery } from 'data/auth/user-search-indexes-query'
-import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
-import { useIndexWorkerStatusQuery } from 'data/auth/index-worker-status-query'
-import { InlineLink } from 'components/ui/InlineLink'
-import Link from 'next/link'
 
 const SORT_BY_VALUE_COUNT_THRESHOLD = 10_000
 const IMPROVED_SEARCH_COUNT_THRESHOLD = 10_000

--- a/apps/studio/data/auth/keys.ts
+++ b/apps/studio/data/auth/keys.ts
@@ -28,7 +28,7 @@ export const authKeys = {
       order?: string
       column?: OptimizedSearchColumns
     }
-  ) => ['projects', projectRef, 'users-infinite', params] as const,
+  ) => ['projects', projectRef, 'users-infinite', params].filter(Boolean),
   usersCount: (
     projectRef: string | undefined,
     params?: {
@@ -38,7 +38,7 @@ export const authKeys = {
       forceExactCount?: boolean
       column?: OptimizedSearchColumns
     }
-  ) => ['projects', projectRef, 'users-count', params] as const,
+  ) => ['projects', projectRef, 'users-count', params].filter(Boolean),
 
   usersIndexStatuses: (projectRef: string | undefined) =>
     ['projects', projectRef, 'users-index-statuses'] as const,

--- a/apps/studio/data/auth/user-create-mutation.ts
+++ b/apps/studio/data/auth/user-create-mutation.ts
@@ -46,6 +46,7 @@ export const useUserCreateMutation = ({
 
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: authKeys.usersCount(projectRef) }),
       ])
 
       await onSuccess?.(data, variables, context)


### PR DESCRIPTION
## Context

Creating a new user from the auth users UI in the dashboard doesn't invalidate the list of users at the moment - I'm actually not too sure when this broke, but it was due to the react query keys.

`create-user-mutation` will invalidate the `usersinfinite` key without params, but because the key itself doesn't have a `.filter(Boolean)`, the invalidation from the mutation is hence trying to invalidate `['projects', projectRef, 'users-infinite', undefined]` then.

Adding a `.filter(Boolean)` should do the trick, including for user counts

## To test

- [ ] Verify that creating a new user in the auth users UI should invalidate the list of users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user search and indexing capabilities for improved user management.
  * Enhanced authentication configuration update workflows.

* **Improvements**
  * Strengthened type safety in user creation forms.
  * Improved data consistency through enhanced cache management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->