### PR TITLE
docs(swift): update Swift client reference to v2.33.2

### DIFF
--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -11,7 +11,7 @@ info:
   slugPrefix: '/'
   libraries:
     - id: 'Swift'
-      version: '2.0.0'
+      version: '2.33.2'
 
 functions:
   - id: initializing
@@ -75,6 +75,24 @@ functions:
             )
           )
           ```
+      - id: initialize-client-with-oslog
+        name: Initialize Client with OSLog
+        code: |
+          ```swift
+          import Supabase
+
+          let supabase = SupabaseClient(
+            supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
+            supabaseKey: "publishable-or-anon-key",
+            options: SupabaseClientOptions(
+              global: SupabaseClientOptions.GlobalOptions(
+                logger: OSLogSupabaseLogger()
+              )
+            )
+          )
+          ```
+        description: |
+          OSLogSupabaseLogger provides native integration with Apple's unified logging system (OSLog). Available on macOS 11.0+, iOS 14.0+, tvOS 14.0+, and watchOS 7.0+.
       - id: api-schemas
         name: With custom schemas
         code: |
@@ -931,6 +949,21 @@ functions:
             // custom URL opening logic
           }
           ```
+      - id: link-identity-with-id-token
+        name: Link an identity using ID token
+        isSpotlight: true
+        code: |
+          ```swift
+          try await supabase.auth.linkIdentityWithIdToken(
+            credentials: OpenIDConnectCredentials(
+              provider: .apple,
+              idToken: "your-id-token",
+              nonce: "your-nonce"
+            )
+          )
+          ```
+        description: |
+          Link an OAuth identity to the currently signed-in user using an OpenID Connect ID token. This is useful for native Sign In With Apple or other OIDC providers.
   - id: unlink-identity
     title: 'unlinkIdentity()'
     notes: |
@@ -2307,6 +2340,19 @@ functions:
           [operators](/docs/guides/database/json#query-the-jsonb-data) for
           working with JSON data. Currently, it is only possible to update the entire JSON document.
         hideCodeBlock: true
+      - id: update-with-max-affected
+        name: Limit affected rows
+        code: |
+          ```swift
+          try await supabase
+            .from("instruments")
+            .update(["status": "archived"])
+            .eq("section_id", value: sectionId)
+            .maxAffected(10)
+            .execute()
+          ```
+        description: |
+          Use `maxAffected()` to set a maximum number of rows that can be affected by an update operation. If the operation would affect more rows than specified, it will fail with an error. This is useful for preventing accidental bulk updates.
 
   - id: upsert
     title: 'Upsert data: upsert()'
@@ -2499,6 +2545,19 @@ functions:
           ```
         hideCodeBlock: true
         isSpotlight: true
+      - id: delete-with-max-affected
+        name: Limit deleted rows
+        code: |
+          ```swift
+          try await supabase
+            .from("instruments")
+            .delete()
+            .eq("section_id", value: sectionId)
+            .maxAffected(5)
+            .execute()
+          ```
+        description: |
+          Use `maxAffected()` to set a maximum number of rows that can be deleted. If the operation would affect more rows than specified, it will fail with an error. This is useful for preventing accidental bulk deletions.
 
   - id: rpc
     title: 'Postgres functions: rpc()'


### PR DESCRIPTION
## Summary

- Updates Swift client library reference from v2.0.0 to v2.33.2
- Adds new documentation for OSLog integration with `OSLogSupabaseLogger`
- Adds documentation for linking identity using ID token via `linkIdentityWithIdToken` 
- Adds documentation for `maxAffected()` method on update and delete operations to limit affected rows

## Changes

### New Features Documented
1. **OSLog Integration**: Native integration with Apple's unified logging system (macOS 11.0+, iOS 14.0+, tvOS 14.0+, watchOS 7.0+)
2. **Link Identity with ID Token**: Support for linking OAuth identities using OpenID Connect ID tokens (useful for Sign In With Apple)
3. **MaxAffected Safety**: Protection against accidental bulk operations with `maxAffected()` on update and delete queries

### Version Update
- Updated version number from 2.0.0 to 2.33.2 in the Swift v2 spec file

## Test plan
- [ ] Verify the documentation renders correctly
- [ ] Confirm all new code examples are syntactically correct
- [ ] Check that version number displays properly in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Swift library documentation to v2.33.2
  * Added new documentation examples for client initialization with logging, identity linking with OpenID Connect tokens, and limiting affected rows in update and delete operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->