### PR TITLE
fix(docs): make code blocks overflow scrollable.

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -64,7 +64,7 @@ export async function CodeBlock({
         'group',
         'relative',
         'not-prose',
-        'w-full overflow-hidden',
+        'w-full overflow-auto',
         'border border-default rounded-lg',
         'bg-200',
         'text-sm',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In the docs, text overflow in code blocks is hidden and cannot be scrolled, thus making them unusable on mobile.

<img width="369" height="458" alt="Screenshot 2025-12-11 at 16 49 42" src="https://github.com/user-attachments/assets/5715ba8a-54be-41f3-8ea9-ec0ca2d77b50" />

## What is the new behavior?

Code blocks now have `overflow: auto` so that all their content can be accessed on smaller devices.

<img width="369" height="458" alt="Screenshot 2025-12-11 at 16 51 00" src="https://github.com/user-attachments/assets/8c50df75-6d65-4a32-9cf3-6f11a76eb8d5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code blocks now support horizontal and vertical scrolling for content overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->