### PR TITLE
fix(codeblock): restore horizontal scrolling by removing overflow-hidden

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -64,7 +64,7 @@ export async function CodeBlock({
         'group',
         'relative',
         'not-prose',
-        'w-full overflow-hidden',
+        'w-full overflow-x-auto',
         'border border-default rounded-lg',
         'bg-200',
         'text-sm',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

restore horizontal scrolling

## What is the current behavior?
This PR is a continuation of https://github.com/supabase/supabase/pull/39689
The previous change introduced the code-wrap button, which unintentionally disabled horizontal scrolling.

## What is the new behavior?
This update restores that scrolling by replacing overflow-hidden with overflow-x-auto.

https://github.com/user-attachments/assets/a6980d1e-bb3b-4628-82ea-9601975887cd

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code blocks now support horizontal scrolling for content that exceeds the available width, preventing clipped text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->