### PR TITLE
fix(studio): flash of sign in for join organization page

### DIFF
--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
-import { useParams } from 'common'
+import { useIsLoggedIn, useParams } from 'common'
 import { useOrganizationAcceptInvitationMutation } from 'data/organization-members/organization-invitation-accept-mutation'
 import { useOrganizationInvitationTokenQuery } from 'data/organization-members/organization-invitation-token-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
@@ -14,7 +14,8 @@ import { OrganizationInviteError } from './OrganizationInviteError'
 
 export const OrganizationInvite = () => {
   const router = useRouter()
-  const { profile } = useProfile()
+  const isLoggedIn = useIsLoggedIn()
+  const { profile, isLoading: isLoadingProfile } = useProfile()
   const { slug, token } = useParams()
 
   const isSignUpEnabled = useIsFeatureEnabled('dashboard_auth:sign_up')
@@ -67,7 +68,7 @@ export const OrganizationInvite = () => {
         'md:w-[400px]'
       )}
     >
-      {!profile ? (
+      {!isLoggedIn || (!profile && !isLoadingProfile) ? (
         <>
           <Admonition
             showIcon={false}
@@ -86,7 +87,7 @@ export const OrganizationInvite = () => {
             )}
           </div>
         </>
-      ) : isLoadingInvitation ? (
+      ) : isLoadingProfile || isLoadingInvitation ? (
         <div className="p-5">
           <GenericSkeletonLoader />
         </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The join organization page flashes the sign in screen briefly because it does not check for loading status.

## What is the new behavior?

Fixed so it goes directly from loading skeleton to join confirmation view.

## Additional context

Resolves FE-2220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication state detection in the organization invite flow, ensuring sign-in prompts display correctly when users are not logged in
  * Enhanced loading state handling to provide better visual feedback while profile information is being retrieved
  * Fixed edge cases in conditional rendering for improved reliability during authentication transitions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->