### PR TITLE
fix(studio): use older supported syntax rather than Map.groupBy

### DIFF
--- a/apps/studio/components/interfaces/Storage/Storage.utils.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.utils.ts
@@ -90,7 +90,13 @@ export const extractBucketNameFromDefinition = (definition: string | null) => {
 }
 
 const groupPoliciesByBucket = (policies: (PostgresPolicy & { bucket: string | Symbol })[]) => {
-  const policiesByBucket = Map.groupBy(policies, (policy) => policy.bucket)
+  const policiesByBucket = new Map<string | Symbol, PostgresPolicy[]>()
+  policies.forEach((policy) => {
+    if (!policiesByBucket.has(policy.bucket)) {
+      policiesByBucket.set(policy.bucket, [])
+    }
+    policiesByBucket.get(policy.bucket)?.push(policy)
+  })
   return [
     ...policiesByBucket.entries().map(([bucketName, policies]) => ({ name: bucketName, policies })),
   ]


### PR DESCRIPTION
Some users' browsers do not support Map.groupBy (used in Storage.utils.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the internal logic for grouping storage policies by bucket.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->