### PR TITLE
feat: bind cli services to local ip

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -8,6 +8,8 @@ project_id = "xguihxuzqibwxjnimxev"
 [api]
 # Port to use for the API URL.
 port = 54321
+# Host to bind to for the API.
+host = "127.0.0.1"
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "content", "storage", "graphql_public"]
@@ -23,6 +25,8 @@ schemas = ["public", "content", "storage", "graphql_public"]
 [db]
 # Port to use for the local database URL.
 port = 54322
+# Host to bind to for the local database.
+host = "127.0.0.1"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
 major_version = 15
@@ -30,6 +34,8 @@ major_version = 15
 [studio]
 # Port to use for Supabase Studio.
 port = 54323
+# Host to bind to for Supabase Studio.
+host = "127.0.0.1"
 
 openai_api_key = "env(OPENAI_API_KEY)"
 
@@ -38,6 +44,8 @@ openai_api_key = "env(OPENAI_API_KEY)"
 [inbucket]
 # Port to use for the email testing server web interface.
 port = 54324
+# Host to bind to for the email testing server web interface.
+host = "127.0.0.1"
 
 [storage]
 # The maximum file size allowed (e.g. "5MB", "500KB").


### PR DESCRIPTION
Proposal to bind CLI hosts to local ip ranges. See Linear ticket for context.

Fixes SEC-620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to explicitly bind local development services (API, database, Supabase Studio, and email testing) to the loopback address, ensuring proper local service connectivity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->