### PR TITLE
docs: warn for local development on public networks

### DIFF
--- a/apps/docs/content/guides/local-development.mdx
+++ b/apps/docs/content/guides/local-development.mdx
@@ -123,7 +123,7 @@ docker network create -o 'com.docker.network.bridge.host_binding_ipv4=127.0.0.1'
 npx supabase start --network-id local-network
 ```
 
-Note that you should never expose your local development stack publicly.
+You should never expose your local development stack publicly.
 
 </Admonition>
 

--- a/apps/docs/content/guides/local-development.mdx
+++ b/apps/docs/content/guides/local-development.mdx
@@ -123,6 +123,8 @@ docker network create -o 'com.docker.network.bridge.host_binding_ipv4=127.0.0.1'
 npx supabase start --network-id local-network
 ```
 
+Note that you should never expose your local development stack publicly.
+
 </Admonition>
 
 ## Local development

--- a/apps/docs/content/guides/local-development.mdx
+++ b/apps/docs/content/guides/local-development.mdx
@@ -114,6 +114,17 @@ As a prerequisite, you must install a container runtime compatible with Docker A
 
 4.  View your local Supabase instance at [http://localhost:54323](http://localhost:54323).
 
+<Admonition type="caution">
+
+If your local development machine is connected to an untrusted public network, you should create a separate docker network and bind to 127.0.0.1 before starting the local development stack. This restricts network access to only your localhost machine.
+
+```sh
+docker network create -o 'com.docker.network.bridge.host_binding_ipv4=127.0.0.1' local-network
+npx supabase start --network-id local-network
+```
+
+</Admonition>
+
 ## Local development
 
 Local development with Supabase allows you to work on your projects in a self-contained environment on your local machine. Working locally has several advantages:


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Users should never expose the local development stack publicly.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced local development guide with security guidance for untrusted networks: added a caution, instructions and example commands to create a dedicated Docker network bound to localhost and to run the local stack using that network, plus an explicit note to avoid exposing the local environment publicly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->