### PR TITLE
docs: add instructions for hosting Apple App Site Association file for universal deep link

### DIFF
--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -5,6 +5,7 @@ For a better user experience, you can use **Universal Links** instead of custom 
 To enable Universal Links, you need to:
 
 1. **Configure Associated Domains** in your Xcode project:
+
    - Add your domain to the Associated Domains capability
    - Format: `applinks:yourdomain.com`
 

--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -1,0 +1,37 @@
+### Universal links
+
+For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
+
+To enable Universal Links, you need to:
+
+1. **Configure Associated Domains** in your Xcode project:
+   - Add your domain to the Associated Domains capability
+   - Format: `applinks:yourdomain.com`
+
+2. **Host the Apple App Site Association (AASA) file** on your own infrastructure:
+   - The file must be accessible at `https://yourdomain.com/.well-known/apple-app-site-association` or `https://yourdomain.com/apple-app-site-association`
+   - The file must be served with `Content-Type: application/json` (or `text/json`)
+   - The file must be accessible over HTTPS without redirects
+   - The file should not have a file extension
+
+**Important**: Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+
+The AASA file format should look like this:
+
+```json
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAM_ID.BUNDLE_ID",
+        "paths": ["*"]
+      }
+    ]
+  }
+}
+```
+
+Replace `TEAM_ID` with your Apple Developer Team ID and `BUNDLE_ID` with your app's bundle identifier.
+
+For detailed setup instructions, see [Apple's documentation on supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains).

--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -17,9 +17,9 @@ To enable Universal Links, you need to:
 
 <Admonition type="caution">
 
-  Supabase does not currently support hosting the AASA file. You must host this file on your own
-  infrastructure following [Apple's best
-  practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+Supabase does not currently support hosting the AASA file. You must host this file on your own
+infrastructure following [Apple's best
+practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
 
 </Admonition>
 

--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -15,10 +15,10 @@ To enable Universal Links, you need to:
    - The file must be accessible over HTTPS without redirects
    - The file should not have a file extension
 
-<Admonition type="warning">
-      
-Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
-      
+<Admonition type="caution">
+  Supabase does not currently support hosting the AASA file. You must host this file on your own
+  infrastructure following [Apple's best
+  practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
 </Admonition>
 
 The AASA file format should look like this:

--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -16,6 +16,7 @@ To enable Universal Links, you need to:
    - The file should not have a file extension
 
 <Admonition type="caution">
+
   Supabase does not currently support hosting the AASA file. You must host this file on your own
   infrastructure following [Apple's best
   practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).

--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -20,6 +20,7 @@ To enable Universal Links, you need to:
   Supabase does not currently support hosting the AASA file. You must host this file on your own
   infrastructure following [Apple's best
   practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+
 </Admonition>
 
 The AASA file format should look like this:

--- a/apps/docs/content/_partials/universal_links_apple.mdx
+++ b/apps/docs/content/_partials/universal_links_apple.mdx
@@ -15,7 +15,11 @@ To enable Universal Links, you need to:
    - The file must be accessible over HTTPS without redirects
    - The file should not have a file extension
 
-**Important**: Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+<Admonition type="warning">
+      
+Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+      
+</Admonition>
 
 The AASA file format should look like this:
 

--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -191,7 +191,7 @@ With Deep Linking, you can configure this redirect to open a specific page. This
 
       For more info: https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app
 
-      ### Universal Links
+      ### Universal links
 
       For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
 
@@ -381,7 +381,7 @@ With Deep Linking, you can configure this redirect to open a specific page. This
       </plist>
     ```
 
-    ### Universal Links
+    ### Universal links
 
     For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
 

--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -191,43 +191,7 @@ With Deep Linking, you can configure this redirect to open a specific page. This
 
       For more info: https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app
 
-      ### Universal links
-
-      For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
-
-      To enable Universal Links, you need to:
-
-      1. **Configure Associated Domains** in your Xcode project:
-         - Add your domain to the Associated Domains capability
-         - Format: `applinks:yourdomain.com`
-
-      2. **Host the Apple App Site Association (AASA) file** on your own infrastructure:
-         - The file must be accessible at `https://yourdomain.com/.well-known/apple-app-site-association` or `https://yourdomain.com/apple-app-site-association`
-         - The file must be served with `Content-Type: application/json` (or `text/json`)
-         - The file must be accessible over HTTPS without redirects
-         - The file should not have a file extension
-
-      **Important**: Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
-
-      The AASA file format should look like this:
-
-      ```json
-      {
-        "applinks": {
-          "apps": [],
-          "details": [
-            {
-              "appID": "TEAM_ID.BUNDLE_ID",
-              "paths": ["*"]
-            }
-          ]
-        }
-      }
-      ```
-
-      Replace `TEAM_ID` with your Apple Developer Team ID and `BUNDLE_ID` with your app's bundle identifier.
-
-      For detailed setup instructions, see [Apple's documentation on supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+      <$Partial path="universal_links_apple.mdx" />
 
     </TabPanel>
     <TabPanel id="windows" label="Windows">
@@ -381,43 +345,7 @@ With Deep Linking, you can configure this redirect to open a specific page. This
       </plist>
     ```
 
-    ### Universal links
-
-    For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
-
-    To enable Universal Links, you need to:
-
-    1. **Configure Associated Domains** in your Xcode project:
-       - Add your domain to the Associated Domains capability
-       - Format: `applinks:yourdomain.com`
-
-    2. **Host the Apple App Site Association (AASA) file** on your own infrastructure:
-       - The file must be accessible at `https://yourdomain.com/.well-known/apple-app-site-association` or `https://yourdomain.com/apple-app-site-association`
-       - The file must be served with `Content-Type: application/json` (or `text/json`)
-       - The file must be accessible over HTTPS without redirects
-       - The file should not have a file extension
-
-    **Important**: Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
-
-    The AASA file format should look like this:
-
-    ```json
-    {
-      "applinks": {
-        "apps": [],
-        "details": [
-          {
-            "appID": "TEAM_ID.BUNDLE_ID",
-            "paths": ["*"]
-          }
-        ]
-      }
-    }
-    ```
-
-    Replace `TEAM_ID` with your Apple Developer Team ID and `BUNDLE_ID` with your app's bundle identifier.
-
-    For detailed setup instructions, see [Apple's documentation on supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+    <$Partial path="universal_links_apple.mdx" />
 
   </TabPanel>
   </$Show>

--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -191,6 +191,44 @@ With Deep Linking, you can configure this redirect to open a specific page. This
 
       For more info: https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app
 
+      ### Universal Links
+
+      For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
+
+      To enable Universal Links, you need to:
+
+      1. **Configure Associated Domains** in your Xcode project:
+         - Add your domain to the Associated Domains capability
+         - Format: `applinks:yourdomain.com`
+
+      2. **Host the Apple App Site Association (AASA) file** on your own infrastructure:
+         - The file must be accessible at `https://yourdomain.com/.well-known/apple-app-site-association` or `https://yourdomain.com/apple-app-site-association`
+         - The file must be served with `Content-Type: application/json` (or `text/json`)
+         - The file must be accessible over HTTPS without redirects
+         - The file should not have a file extension
+
+      **Important**: Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+
+      The AASA file format should look like this:
+
+      ```json
+      {
+        "applinks": {
+          "apps": [],
+          "details": [
+            {
+              "appID": "TEAM_ID.BUNDLE_ID",
+              "paths": ["*"]
+            }
+          ]
+        }
+      }
+      ```
+
+      Replace `TEAM_ID` with your Apple Developer Team ID and `BUNDLE_ID` with your app's bundle identifier.
+
+      For detailed setup instructions, see [Apple's documentation on supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+
     </TabPanel>
     <TabPanel id="windows" label="Windows">
 
@@ -342,6 +380,44 @@ With Deep Linking, you can configure this redirect to open a specific page. This
       </dict>
       </plist>
     ```
+
+    ### Universal Links
+
+    For a better user experience, you can use **Universal Links** instead of custom URL schemes. Universal Links allow your app to open directly from web links without showing a browser redirect prompt.
+
+    To enable Universal Links, you need to:
+
+    1. **Configure Associated Domains** in your Xcode project:
+       - Add your domain to the Associated Domains capability
+       - Format: `applinks:yourdomain.com`
+
+    2. **Host the Apple App Site Association (AASA) file** on your own infrastructure:
+       - The file must be accessible at `https://yourdomain.com/.well-known/apple-app-site-association` or `https://yourdomain.com/apple-app-site-association`
+       - The file must be served with `Content-Type: application/json` (or `text/json`)
+       - The file must be accessible over HTTPS without redirects
+       - The file should not have a file extension
+
+    **Important**: Supabase does not currently support hosting the AASA file. You must host this file on your own infrastructure following [Apple's best practices](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
+
+    The AASA file format should look like this:
+
+    ```json
+    {
+      "applinks": {
+        "apps": [],
+        "details": [
+          {
+            "appID": "TEAM_ID.BUNDLE_ID",
+            "paths": ["*"]
+          }
+        ]
+      }
+    }
+    ```
+
+    Replace `TEAM_ID` with your Apple Developer Team ID and `BUNDLE_ID` with your app's bundle identifier.
+
+    For detailed setup instructions, see [Apple's documentation on supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains).
 
   </TabPanel>
   </$Show>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The native mobile deep linking guide only covers custom URL schemes for iOS/Apple platforms. It doesn't provide information about Universal Links, which require hosting an Apple App Site Association (AASA) file.

## What is the new behavior?

Added documentation for Universal Links on iOS/Apple platforms in the native mobile deep linking guide:

- Instructions for configuring Associated Domains in Xcode
- Requirements for hosting the AASA file on customer infrastructure
- Clear note that Supabase does not currently support hosting the AASA file
- Example AASA file format
- Reference to Apple's official documentation

The documentation has been added to both the Flutter iOS section and the Swift section of the guide.

## Additional context

This addresses the need for customers to understand how to host the `apple-app-site-association` file for Universal Links, which provides a better user experience than custom URL schemes by allowing apps to open directly from web links without showing a browser redirect prompt.

Related to SDK-389.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Universal Links guidance as an alternative to custom URL schemes for native mobile deep linking.
  * Expanded guidance into additional platform sections: Expo React Native, Flutter (iOS), and Swift (iOS).
  * Added a dedicated Apple Universal Links guide covering Associated Domains, AASA hosting requirements (HTTPS, content type), and a sample AASA JSON.
  * Linked to Apple's docs for detailed setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->