### PR TITLE
fix(telemetry): pass PostHog distinct_id in identify request

### DIFF
--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -9418,6 +9418,8 @@ export interface components {
       reset_project?: boolean
     }
     TelemetryIdentifyBodyV2: {
+      /** PostHog JS SDK's distinct_id - used for aliasing anonymous → authenticated users */
+      anonymous_id?: string
       organization_slug?: string
       project_ref?: string
       user_id: string

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -156,6 +156,25 @@ class PostHogClient {
       console.error('PostHog reset failed:', error)
     }
   }
+
+  /**
+   * Returns the current PostHog distinct_id for the user.
+   * This is the anonymous ID that PostHog uses to track the user before they are identified,
+   * and contains all first-touch attribution data ($initial_referrer, $initial_utm_source, etc.).
+   *
+   * We need to pass this to the backend identify endpoint so that the backend's alias() call
+   * uses the correct anonymous ID to link the anonymous profile to the authenticated user.
+   */
+  getDistinctId(): string | undefined {
+    if (!this.initialized) return undefined
+
+    try {
+      return posthog.get_distinct_id()
+    } catch (error) {
+      console.error('PostHog getDistinctId failed:', error)
+      return undefined
+    }
+  }
 }
 
 export const posthogClient = new PostHogClient()

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -76,7 +76,6 @@ class PostHogClient {
         })
         this.pendingEvents = []
 
-        // Mark as fully initialized now that PostHog has bootstrapped
         this.initialized = true
       },
     }
@@ -164,16 +163,8 @@ class PostHogClient {
   }
 
   /**
-   * Returns the current PostHog distinct_id for the user.
-   * This is the anonymous ID that PostHog uses to track the user before they are identified,
-   * and contains all first-touch attribution data ($initial_referrer, $initial_utm_source, etc.).
-   *
-   * We need to pass this to the backend identify endpoint so that the backend's alias() call
-   * uses the correct anonymous ID to link the anonymous profile to the authenticated user.
-   *
-   * Returns undefined if PostHog hasn't fully bootstrapped yet (i.e., before the `loaded`
-   * callback fires). This avoids a race condition where get_distinct_id() might return
-   * undefined during the async initialization window.
+   * Returns PostHog's distinct_id, which holds first-touch attribution data.
+   * Returns undefined until PostHog's `loaded` callback fires.
    */
   getDistinctId(): string | undefined {
     if (!this.initialized) return undefined

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -320,9 +320,16 @@ export function useTelemetryIdentify(API_URL: string) {
 
   useEffect(() => {
     if (user?.id) {
-      // Send to backend
+      // Get the PostHog distinct_id (anonymous ID) before identification.
+      // This is the ID that holds all first-touch attribution data.
+      const anonymousId = posthogClient.getDistinctId()
+
+      // Send to backend with anonymous_id so the backend alias() call
+      // uses the correct PostHog ID instead of generating a new one
       sendTelemetryIdentify(API_URL, {
         user_id: user.id,
+        // Pass the PostHog distinct_id as anonymous_id for proper attribution linking
+        ...(anonymousId && { anonymous_id: anonymousId }),
       })
 
       // Also identify in PostHog client-side

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -320,19 +320,13 @@ export function useTelemetryIdentify(API_URL: string) {
 
   useEffect(() => {
     if (user?.id) {
-      // Get the PostHog distinct_id (anonymous ID) before identification.
-      // This is the ID that holds all first-touch attribution data.
       const anonymousId = posthogClient.getDistinctId()
 
-      // Send to backend with anonymous_id so the backend alias() call
-      // uses the correct PostHog ID instead of generating a new one
       sendTelemetryIdentify(API_URL, {
         user_id: user.id,
-        // Pass the PostHog distinct_id as anonymous_id for proper attribution linking
         ...(anonymousId && { anonymous_id: anonymousId }),
       })
 
-      // Also identify in PostHog client-side
       posthogClient.identify(user.id)
     }
   }, [API_URL, user?.id])


### PR DESCRIPTION
## Problem

Our first-touch attribution data in PostHog stopped working after a Dec 3rd change. The root cause: the backend identify endpoint generates its own `anonymous_id` cookie value instead of using the actual PostHog JS SDK's `distinct_id`.

When PostHog's `alias()` is called, it links this server-generated ID (which has no attribution data) to the authenticated user, instead of linking the real PostHog anonymous profile (which contains `$initial_referrer`, `$initial_utm_source`, etc.).

## Changes

- Added `getDistinctId()` method to `PostHogClient` to expose the underlying `posthog.get_distinct_id()` value
- Updated `useTelemetryIdentify` to pass this value as `anonymous_id` in the identify request
- Updated the `TelemetryIdentifyBodyV2` type to include `anonymous_id` (will be regenerated when backend PR merges)

This is the frontend counterpart to https://github.com/supabase/platform/pull/28375 which adds support for accepting `anonymous_id` in the backend identify endpoint.

## Testing

- Verified TypeScript passes
- Will need manual testing after both PRs are deployed: confirm that logging in preserves first-touch attribution data on the user profile in PostHog

Fixes GROWTH-567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Telemetry identify payloads now include an optional anonymous identifier when available to better preserve first-touch attribution and link analytics across systems.
  * Client initialization flow hardened to prevent double-initialization and ensure pending telemetry (groups, identifications, events) is applied once ready.
  * Backend identify calls now attach the client anonymous ID when present to improve cross-system attribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->