### PR TITLE
Fix deleting a user shows User not found toast error

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -236,8 +236,8 @@ export const UsersV2 = () => {
 
   const { setValue: setSelectedUser, value: selectedUser } = useQueryStateWithSelect({
     urlKey: 'show',
+    enabled: users.length > 0 && isSuccess,
     select: (id: string) => (id ? users?.find((u) => u.id === id)?.id : undefined),
-    enabled: !!users && !isLoading,
     onError: () => toast.error(`User not found`),
   })
 

--- a/apps/studio/data/auth/user-delete-mutation.ts
+++ b/apps/studio/data/auth/user-delete-mutation.ts
@@ -36,13 +36,13 @@ export const useUserDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, skipInvalidation = false } = variables
 
+      await onSuccess?.(data, variables, context)
+
       if (!skipInvalidation) {
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
         ])
       }
-
-      await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {
       if (onError === undefined) {


### PR DESCRIPTION
## Context

Deleting a user will render a "User not found" error toast, along with the deletion success toast

This is due to the `useQueryStateWithSelect` hook which i've started an internal discussion on how to improve the DX - the changes here fixes the immediate issue, but we may change the fix depending on the outcome of the discussion

## To test

- [ ] Verify that there's no error toast when deleting a user in the Auth Users page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced user data loading reliability by tightening query activation conditions to confirm data presence
* Corrected callback execution sequence in user deletion operations to maintain proper ordering before cache updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->