### PR TITLE
Fix advisor panel header not scrollable

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -29,7 +29,7 @@ export const AIAssistantHeader = ({
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
   return (
     <div className="z-30 sticky top-0">
-      <div className="border-b border-b-muted flex items-center bg gap-x-4 px-3 h-[46px]">
+      <div className="border-b border-b-muted flex items-center bg gap-x-4 pl-4 pr-3 h-[46px]">
         <div className="text-sm flex-1 flex items-center">
           <AiIconAnimation size={20} allowHoverEffect={false} />
           <span className="text-border-stronger dark:text-border-strong ml-3">

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorFilters.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorFilters.tsx
@@ -23,7 +23,6 @@ interface AdvisorFiltersProps {
   onSeverityFiltersChange: (filters: AdvisorSeverity[]) => void
   statusFilters: string[]
   onStatusFiltersChange: (filters: string[]) => void
-  hasProjectRef?: boolean
   onClose: () => void
   isPlatform?: boolean
 }
@@ -35,14 +34,13 @@ export const AdvisorFilters = ({
   onSeverityFiltersChange,
   statusFilters,
   onStatusFiltersChange,
-  hasProjectRef = true,
   onClose,
   isPlatform = false,
 }: AdvisorFiltersProps) => {
   return (
-    <div className="border-b">
-      <div className="flex items-center justify-between gap-3 px-4 h-[46px]">
-        <Tabs_Shadcn_ value={activeTab} onValueChange={onTabChange} className="h-full">
+    <div className="border-b overflow-x-auto">
+      <div className="flex items-center justify-between gap-x-4 h-[46px]">
+        <Tabs_Shadcn_ value={activeTab} onValueChange={onTabChange} className="h-full pl-4">
           <TabsList_Shadcn_ className="border-b-0 gap-4 h-full">
             <TabsTrigger_Shadcn_ value="all" className="h-full text-xs">
               All
@@ -63,7 +61,7 @@ export const AdvisorFilters = ({
             )}
           </TabsList_Shadcn_>
         </Tabs_Shadcn_>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-x-2 pr-3">
           {isPlatform && (
             <FilterPopover
               name="Status"

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
@@ -328,7 +328,6 @@ export const AdvisorPanel = () => {
                 .filter((status) => !notificationFilterStatuses.includes(status))
                 .forEach((status) => setNotificationFilters(status, 'status'))
             }}
-            hasProjectRef={hasProjectRef}
             onClose={handleClose}
             isPlatform={IS_PLATFORM}
           />

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -150,7 +150,7 @@ export const EditorPanel = () => {
 
   return (
     <div className="flex h-full flex-col bg-background">
-      <div className="border-b border-b-muted flex items-center justify-between gap-x-4 px-4 h-[46px]">
+      <div className="border-b border-b-muted flex items-center justify-between gap-x-4 pl-4 pr-3 h-[46px]">
         <div className="text-xs">{label}</div>
         <div className="flex items-center">
           {templates.length > 0 && (


### PR DESCRIPTION
## Context

It’s possible to open the sidebar at a screen width where the close button isn’t visible, making it impossible to close. This happens specifically for the Advisor Panel as its header has quite a bit of content

## Changes involved

- Make advisor panel horizontally scrollable
- Small adjustments to paddings in the panel headers to ensure consistency across all 3 panels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed an unused public prop from the filter component and simplified how the filter panel is instantiated.

* **Style**
  * Adjusted horizontal spacing, padding, and scroll/overflow behavior across filter panels, editor header, and assistant header for more consistent layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->