### PR TITLE
Fix log drains error handling

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -82,6 +82,10 @@ export function LogDrains({
     return <LogDrainsEmpty />
   }
 
+  if (isError) {
+    return <AlertError subject="Failed to load log drains" error={error}></AlertError>
+  }
+
   if (!isLoading && !hasLogDrains) {
     return (
       <>
@@ -102,10 +106,6 @@ export function LogDrains({
         <VoteLink />
       </>
     )
-  }
-
-  if (isError) {
-    return <AlertError error={error}></AlertError>
   }
 
   return (

--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -7,16 +7,7 @@ import { generateSettingsMenu } from 'components/layouts/ProjectSettingsLayout/S
 import type { Route } from 'components/ui/ui.types'
 import { EditorIndexPageLink } from 'data/prefetchers/project.$ref.editor'
 import type { Project } from 'data/projects/project-detail-query'
-import {
-  Auth,
-  Database,
-  EdgeFunctions,
-  Realtime,
-  Reports,
-  SqlEditor,
-  Storage,
-  TableEditor,
-} from 'icons'
+import { Auth, Database, EdgeFunctions, Realtime, SqlEditor, Storage, TableEditor } from 'icons'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
 
 export const generateToolRoutes = (ref?: string, project?: Project, features?: {}): Route[] => {
@@ -193,7 +184,9 @@ export const generateSettingsRoutes = (ref?: string, project?: Project): Route[]
       key: 'settings',
       label: 'Project Settings',
       icon: <Settings size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-      link: ref && `/project/${ref}/settings/general`,
+      link:
+        ref &&
+        (IS_PLATFORM ? `/project/${ref}/settings/general` : `/project/${ref}/settings/log-drains`),
       items: settingsMenu,
     },
   ]

--- a/apps/studio/data/log-drains/log-drains-query.ts
+++ b/apps/studio/data/log-drains/log-drains-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
+import { MAX_RETRY_FAILURE_COUNT } from 'data/query-client'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { logDrainsKeys } from './keys'
 
@@ -37,5 +38,12 @@ export const useLogDrainsQuery = <TData = LogDrainsData>(
     queryFn: ({ signal }) => getLogDrains({ ref }, signal),
     enabled: enabled && !!ref,
     refetchOnMount: false,
+    retry: (failureCount, error) => {
+      if (error.code === 500 || error.message.includes('API error happened')) return false
+      if (failureCount < MAX_RETRY_FAILURE_COUNT) {
+        return true
+      }
+      return false
+    },
     ...options,
   })


### PR DESCRIPTION
## Context

Realised that the UI error handling for log drains doesn't render due to the early return statement by another conditional

## Changes involved

- [ ] Update side nav to link to settings/log-drains instead of settings/general if `IS_PLATFORM` is `false`
- [ ] Shift UI error handler for log drains up so that `isError` will render the error UI
- [ ] Skip retrying fetching log drains if the API returns either a 500 or an internal API error (for self host)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error messages for log drains now display earlier with descriptive context.
  * Navigation links for editor, SQL, and settings adapt based on project building state and platform configuration.
  * Log drains request handling improved to skip unnecessary retries on specific error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->