### PR TITLE
blog: Add warning to pricing blog

### DIFF
--- a/apps/www/_blog/2021-03-29-pricing.mdx
+++ b/apps/www/_blog/2021-03-29-pricing.mdx
@@ -11,6 +11,12 @@ tags:
 date: '03-29-2021'
 ---
 
+<Admonition type="warning" title="Out of date blog">
+
+Pricing is now generally available. See [www.supabase.com/pricing](https://www.supabase.com/pricing).
+
+</Admonition>
+
 ## Pricing is hard
 
 Many developers have been waiting for [pricing](/pricing) before building on Supabase. It has taken this long to announce pricing for one simple reason: pricing is hard. We've spent countless hours discussing and testing different models. We consulted users, OSS veterans, and SaaS Gurus. We explored and ruled out a number of options including: no Free Plan, pure usage based, pay-per-seat, pay-per-row, and "bolt-on" feature based pricing.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Blog post updated with a notification alerting readers that pricing is now generally available, including a link to the pricing page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->