### PR TITLE
fix: remove toast based verification for deleted auth users

### DIFF
--- a/e2e/studio/features/auth-users.spec.ts
+++ b/e2e/studio/features/auth-users.spec.ts
@@ -13,29 +13,16 @@ test.describe('auth users list refresh', () => {
     const testEmail = `test-create-${Date.now()}@example.com`
     const testPassword = 'testpassword123'
 
-    // Create user via UI
+    // Create user via UI - this verifies the user appears in the table
     await createUserViaUI(page, ref, testEmail, testPassword)
 
-    // Verify the user appears in the table WITHOUT manually refreshing the page
-    const userRow = page.getByRole('row').filter({ hasText: testEmail })
-    await expect(
-      userRow,
-      'User should appear in the table immediately after creation without manual refresh'
-    ).toBeVisible({ timeout: 10_000 })
-
     // Verify the user details are correct
+    const userRow = page.getByRole('row').filter({ hasText: testEmail })
     await expect(userRow.getByText(testEmail)).toBeVisible()
     await expect(userRow.getByText('Email')).toBeVisible()
 
-    // Clean up: delete the user
+    // Clean up: delete the user - this verifies the user is removed from the table
     await deleteUserViaUI(page, ref, testEmail)
-
-    // Verify the user is removed from the table
-    await expect
-      .poll(async () => {
-        return await page.getByRole('row').filter({ hasText: testEmail }).count()
-      }, 'User should be removed from the table after deletion')
-      .toBe(0)
   })
 
   test('should automatically refresh users list after creating multiple users', async ({
@@ -48,27 +35,14 @@ test.describe('auth users list refresh', () => {
       { email: `test-multi-3-${Date.now()}@example.com`, password: 'testpassword123' },
     ]
 
-    // Create multiple users
+    // Create multiple users - each creation verifies the user appears in the table
     for (const user of testUsers) {
       await createUserViaUI(page, ref, user.email, user.password)
-
-      // Verify each user appears in the table
-      await expect(
-        page.getByRole('row').filter({ hasText: user.email }),
-        `User ${user.email} should appear in the table after creation`
-      ).toBeVisible()
     }
 
-    // Clean up: delete all test users
+    // Clean up: delete all test users - each deletion verifies the user is removed
     for (const user of testUsers) {
       await deleteUserViaUI(page, ref, user.email)
-
-      // Verify each user is removed
-      await expect
-        .poll(async () => {
-          return await page.getByRole('row').filter({ hasText: user.email }).count()
-        }, `User ${user.email} should be removed from the table after deletion`)
-        .toBe(0)
     }
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Instead of using the toasts to verify if a user exists, rather check the table itself. Fixes flakiness with toast checking logic. Updated test as well 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test verification methods for user management workflows, replacing toast-based assertions with table state validation.
  * Streamlined test flow by reducing intermediate assertions while maintaining creation and deletion verification.
  * No changes to user-facing functionality or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->