### PR TITLE
fix(docs): add missing variables to api_settings_steps partial calls

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
@@ -67,7 +67,7 @@ hideToc: true
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_... or anon key
       ```
 
-      <$Partial path="api_settings_steps.mdx" />
+      <$Partial path="api_settings_steps.mdx" variables={{ "framework": "nextjs", "tab": "frameworks" }} />
 
     </StepHikeCompact.Code>
 

--- a/apps/docs/content/guides/auth/quickstarts/react-native.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react-native.mdx
@@ -108,7 +108,7 @@ hideToc: true
         })
       }
       ```
-      <$Partial path="api_settings_steps.mdx" />
+      <$Partial path="api_settings_steps.mdx" variables={{ "framework": "exporeactnative", "tab": "mobiles" }} />
 
     </StepHikeCompact.Code>
 

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -78,7 +78,7 @@ hideToc: true
       VITE_SUPABASE_URL=your-project-url
       VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_... or anon key
       ```
-      <$Partial path="api_settings_steps.mdx" />
+      <$Partial path="api_settings_steps.mdx" variables={{ "framework": "react", "tab": "frameworks" }} />
 
     </StepHikeCompact.Code>
 

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -45,7 +45,7 @@ Create a `.env.local` file in the project root directory. In the file, set the p
 <ProjectConfigVariables variable="publishable" />
 <ProjectConfigVariables variable="anon" />
 
-<$Partial path="api_settings_steps.mdx" />
+<$Partial path="api_settings_steps.mdx" variables={{ "framework": "nextjs", "tab": "frameworks" }} />
 
 <Tabs scrollable size="small" type="underlined" defaultActiveId="nextjs" queryGroup="framework">
 


### PR DESCRIPTION
## Summary

PR #41200 introduced template variables 9` {{ .tab }}, {{ .framework }}` to `api_settings_steps.mdx` for deep linking to the Connect dialog. However, 4 auth docs pages were calling the partial without passing the required variables prop, causing MDX parsing errors.

## Problem

The following pages returned 404 errors due to MDX parsing failure:
`- /docs/guides/auth/server-side/creating-a-client`
`- /docs/guides/auth/quickstarts/nextjs`
`- /docs/guides/auth/quickstarts/react-native`
`- /docs/guides/auth/quickstarts/react`

Error: `Could not parse expression with acorn: Unexpected token`

## Fix

Added the `variables` prop to match the pattern used in other quickstart pages that already work correctly.

Closes https://github.com/supabase/supabase/issues/41359 
Closes  https://github.com/supabase/supabase/issues/41356
Closes https://github.com/supabase/supabase/issues/41367
closes https://github.com/supabase/supabase/issues/41372
closes https://github.com/supabase/supabase/issues/41374
closes https://github.com/supabase/supabase/issues/41375

cc @awaseem @saltcod 