### PR TITLE
fix: update name and description to be selectable in secrets

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretRow.tsx
@@ -26,7 +26,7 @@ interface SecretRowProps {
   onSelectRemove: (secret: VaultSecret) => void
 }
 
-const SecretRow = ({ row, col, onSelectEdit, onSelectRemove }: SecretRowProps) => {
+export const SecretRow = ({ row, col, onSelectEdit, onSelectRemove }: SecretRowProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [revealSecret, setRevealSecret] = useState(false)
@@ -142,16 +142,16 @@ const SecretRow = ({ row, col, onSelectEdit, onSelectRemove }: SecretRowProps) =
 
   return (
     <div className="w-full flex flex-col justify-center">
-      <p className="text-xs text-foreground truncate" title={name}>
+      <p className="text-xs text-foreground truncate select-text" title={name}>
         {name}
       </p>
       {row.description !== undefined && row.description !== '' && (
         <div>
-          <p className="text-xs text-foreground-lighter w-full truncate">{row.description}</p>
+          <p className="text-xs text-foreground-lighter w-full truncate select-text">
+            {row.description}
+          </p>
         </div>
       )}
     </div>
   )
 }
-
-export default SecretRow

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/Secrets.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/Secrets.utils.tsx
@@ -2,7 +2,7 @@ import type { Column } from 'react-data-grid'
 
 import type { VaultSecret } from 'types'
 import { cn } from 'ui'
-import SecretRow from './SecretRow'
+import { SecretRow } from './SecretRow'
 import { SecretTableColumn } from './Secrets.types'
 
 export const SECRET_TABLE_COLUMNS: SecretTableColumn[] = [


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Minor: make name and description to be select-able in secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text selection styling for secret names and descriptions in the Vault Secrets interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->