### PR TITLE
fix(studio): escape enum identifiers and values

### DIFF
--- a/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
@@ -1,3 +1,4 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -23,11 +24,13 @@ export async function createEnumeratedType({
   description,
   values,
 }: EnumeratedTypeCreateVariables) {
-  const createSql = `create type "${schema}"."${name}" as enum (${values
-    .map((x) => `'${x}'`)
+  const createSql = `create type ${ident(schema)}.${ident(name)} as enum (${values
+    .map((x) => `${literal(x)}`)
     .join(', ')});`
   const commentSql =
-    description !== undefined ? `comment on type "${schema}"."${name}" is '${description}';` : ''
+    description !== undefined
+      ? `comment on type ${ident(schema)}.${ident(name)} is ${literal(description)};`
+      : ''
   const sql = wrapWithTransaction(`${createSql} ${commentSql}`)
   const { result } = await executeSql({ projectRef, connectionString, sql })
   return result

--- a/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
@@ -45,7 +45,7 @@ export const useEnumeratedTypeDeleteMutation = ({
     },
     async onError(data, variables, context) {
       if (onError === undefined) {
-        toast.error(`Failed to create enumerated type: ${data.message}`)
+        toast.error(`Failed to delete enumerated type: ${data.message}`)
       } else {
         onError(data, variables, context)
       }

--- a/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-delete-mutation.ts
@@ -1,3 +1,4 @@
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -18,7 +19,7 @@ export async function deleteEnumeratedType({
   name,
   schema,
 }: EnumeratedTypeDeleteVariables) {
-  const sql = `drop type if exists ${schema}."${name}"`
+  const sql = `drop type if exists ${ident(schema)}.${ident(name)}`
   const { result } = await executeSql({ projectRef, connectionString, sql })
   return result
 }

--- a/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
@@ -1,3 +1,4 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -25,7 +26,9 @@ export async function updateEnumeratedType({
 }: EnumeratedTypeUpdateVariables) {
   const statements: string[] = []
   if (name.original !== name.updated) {
-    statements.push(`alter type "${schema}"."${name.original}" rename to "${name.updated}";`)
+    statements.push(
+      `alter type ${ident(schema)}.${ident(name.original)} rename to ${ident(name.updated)};`
+    )
   }
   if (values.length > 0) {
     values.forEach((x, idx) => {
@@ -34,24 +37,30 @@ export async function updateEnumeratedType({
           // Consider if any new enums were added before any existing enums
           const firstExistingEnumValue = values.find((x) => !x.isNew)
           statements.push(
-            `alter type "${schema}"."${name.updated}" add value '${x.updated}' before '${firstExistingEnumValue?.original}';`
+            `alter type ${ident(schema)}.${ident(name.updated)} add value ${literal(
+              x.updated
+            )} before ${literal(firstExistingEnumValue?.original)};`
           )
         } else {
           statements.push(
-            `alter type "${schema}"."${name.updated}" add value '${x.updated}' after '${
+            `alter type ${ident(schema)}.${ident(name.updated)} add value ${literal(x.updated)} after ${literal(
               values[idx - 1].updated
-            }';`
+            )};`
           )
         }
       } else if (x.original !== x.updated) {
         statements.push(
-          `alter type "${schema}"."${name.updated}" rename value '${x.original}' to '${x.updated}';`
+          `alter type ${ident(schema)}.${ident(name.updated)} rename value ${literal(x.original)} to ${literal(
+            x.updated
+          )};`
         )
       }
     })
   }
   if (description !== undefined) {
-    statements.push(`comment on type "${schema}"."${name.updated}" is '${description}';`)
+    statements.push(
+      `comment on type ${ident(schema)}.${ident(name.updated)} is ${literal(description)};`
+    )
   }
 
   const sql = wrapWithTransaction(statements.join(' '))

--- a/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
@@ -89,7 +89,7 @@ export const useEnumeratedTypeUpdateMutation = ({
     },
     async onError(data, variables, context) {
       if (onError === undefined) {
-        toast.error(`Failed to add value to enumerated type: ${data.message}`)
+        toast.error(`Failed to update enumerated type: ${data.message}`)
       } else {
         onError(data, variables, context)
       }


### PR DESCRIPTION
Resolves #41371 

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Enum identifiers (name and schema) are fully escaped by adding a double quote next to every double at SQL level.

Same for literals (enum description and values).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized SQL formatting for enumerated type create/update/delete operations to improve consistency and reliability.
* **Bug Fix**
  * Corrected and clarified error messages for enumerated type update and delete actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->