### PR TITLE
Remove use of useQueryStateWithSelect for auth users

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
@@ -1,6 +1,10 @@
-import { User } from 'data/auth/users-infinite-query'
 import { X } from 'lucide-react'
+import { parseAsString, useQueryState } from 'nuqs'
 import { useState } from 'react'
+
+import { useUserQuery } from 'data/auth/user-query'
+import { User } from 'data/auth/users-infinite-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import {
   Button,
   cn,
@@ -13,18 +17,27 @@ import {
   TabsList_Shadcn_,
   TabsTrigger_Shadcn_,
 } from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns'
 import { UserLogs } from './UserLogs'
 import { UserOverview } from './UserOverview'
 import { PANEL_PADDING } from './Users.constants'
 
-interface UserPanelProps {
-  selectedUser?: User
-  onClose: () => void
-}
+export const UserPanel = () => {
+  const { data: project } = useSelectedProjectQuery()
 
-export const UserPanel = ({ selectedUser, onClose }: UserPanelProps) => {
+  const [selectedId, setSelectedId] = useQueryState(
+    'show',
+    parseAsString.withOptions({ history: 'push', clearOnDefault: true })
+  )
+
   const [view, setView] = useState<'overview' | 'raw' | 'logs'>('overview')
   const [searchQuery, setSearchQuery] = useState('')
+
+  const { data: selectedUser, isPending } = useUserQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    userId: selectedId,
+  })
 
   const filteredProperties = selectedUser
     ? Object.entries(selectedUser)
@@ -49,71 +62,92 @@ export const UserPanel = ({ selectedUser, onClose }: UserPanelProps) => {
           type="text"
           className="absolute top-3 right-3 px-1"
           icon={<X />}
-          onClick={() => onClose()}
+          onClick={() => setSelectedId(null)}
         />
         <Tabs_Shadcn_
           value={view}
           className="flex flex-col h-full"
-          onValueChange={(value: any) => setView(value)}
+          onValueChange={(value) => setView(value as 'overview' | 'raw' | 'logs')}
         >
-          <TabsList_Shadcn_ className="px-5 flex gap-x-4 min-h-[46px]">
-            <TabsTrigger_Shadcn_
-              value="overview"
-              className="px-0 pb-0 h-full text-xs  data-[state=active]:bg-transparent !shadow-none"
-            >
-              Overview
-            </TabsTrigger_Shadcn_>
-            <TabsTrigger_Shadcn_
-              value="logs"
-              className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent !shadow-none"
-            >
-              Logs
-            </TabsTrigger_Shadcn_>
-            <TabsTrigger_Shadcn_
-              value="raw"
-              className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent !shadow-none"
-            >
-              Raw JSON
-            </TabsTrigger_Shadcn_>
-          </TabsList_Shadcn_>
-          <TabsContent_Shadcn_
-            value="overview"
-            className={cn('mt-0 flex-grow min-h-0 overflow-y-auto')}
-          >
-            {selectedUser && <UserOverview user={selectedUser} onDeleteSuccess={onClose} />}
-          </TabsContent_Shadcn_>
-          <TabsContent_Shadcn_
-            value="logs"
-            className={cn('mt-0 flex-grow min-h-0 overflow-y-auto')}
-          >
-            {selectedUser && <UserLogs user={selectedUser} />}
-          </TabsContent_Shadcn_>
-          <TabsContent_Shadcn_
-            value="raw"
-            className={cn('mt-0 flex-grow min-h-0 overflow-y-auto', PANEL_PADDING)}
-          >
-            <div className="flex items-center mb-2">
-              <Input_Shadcn_
-                autoFocus
-                type="text"
-                placeholder="Filter..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="mr-2"
-              />
-              <Button
-                type="text"
-                disabled={!searchQuery}
-                onClick={() => setSearchQuery('')}
-                className="text-xs"
-              >
-                Clear
-              </Button>
+          {isPending ? (
+            <div>
+              <div className="min-h-[46px] border-b" />
+              <div className="p-5">
+                <GenericSkeletonLoader />
+              </div>
             </div>
-            <SimpleCodeBlock className="javascript" parentClassName="[&>*>span]:text-xs">
-              {JSON.stringify(filteredProperties, null, 2)}
-            </SimpleCodeBlock>
-          </TabsContent_Shadcn_>
+          ) : !!selectedUser ? (
+            <>
+              <TabsList_Shadcn_ className="px-5 flex gap-x-4 min-h-[46px]">
+                <TabsTrigger_Shadcn_
+                  value="overview"
+                  className="px-0 pb-0 h-full text-xs  data-[state=active]:bg-transparent !shadow-none"
+                >
+                  Overview
+                </TabsTrigger_Shadcn_>
+                <TabsTrigger_Shadcn_
+                  value="logs"
+                  className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent !shadow-none"
+                >
+                  Logs
+                </TabsTrigger_Shadcn_>
+                <TabsTrigger_Shadcn_
+                  value="raw"
+                  className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent !shadow-none"
+                >
+                  Raw JSON
+                </TabsTrigger_Shadcn_>
+              </TabsList_Shadcn_>
+
+              <TabsContent_Shadcn_
+                value="overview"
+                className={cn('mt-0 flex-grow min-h-0 overflow-y-auto')}
+              >
+                {selectedUser && (
+                  <UserOverview user={selectedUser} onDeleteSuccess={() => setSelectedId(null)} />
+                )}
+              </TabsContent_Shadcn_>
+              <TabsContent_Shadcn_
+                value="logs"
+                className={cn('mt-0 flex-grow min-h-0 overflow-y-auto')}
+              >
+                {selectedUser && <UserLogs user={selectedUser} />}
+              </TabsContent_Shadcn_>
+              <TabsContent_Shadcn_
+                value="raw"
+                className={cn('mt-0 flex-grow min-h-0 overflow-y-auto', PANEL_PADDING)}
+              >
+                <div className="flex items-center mb-2">
+                  <Input_Shadcn_
+                    autoFocus
+                    type="text"
+                    placeholder="Filter..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="mr-2"
+                  />
+                  <Button
+                    type="text"
+                    disabled={!searchQuery}
+                    onClick={() => setSearchQuery('')}
+                    className="text-xs"
+                  >
+                    Clear
+                  </Button>
+                </div>
+                <SimpleCodeBlock className="javascript" parentClassName="[&>*>span]:text-xs">
+                  {JSON.stringify(filteredProperties, null, 2)}
+                </SimpleCodeBlock>
+              </TabsContent_Shadcn_>
+            </>
+          ) : (
+            <div className="flex items-center justify-center w-full h-full flex-col gap-y-2">
+              <p className="text-foreground-light text-sm">
+                Unable to find user with the following ID in project
+              </p>
+              <p className="text-foreground-lighter text-xs">ID: {selectedId}</p>
+            </div>
+          )}
         </Tabs_Shadcn_>
       </ResizablePanel>
     </>

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -1,4 +1,5 @@
 import pgMeta from '@supabase/pg-meta'
+import type { OptimizedSearchColumns } from '@supabase/pg-meta/src/sql/studio/get-users-types'
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
 import {
@@ -10,11 +11,12 @@ import {
   WandSparklesIcon,
   X,
 } from 'lucide-react'
+import Link from 'next/link'
+import { parseAsArrayOf, parseAsString, parseAsStringEnum, useQueryState } from 'nuqs'
 import { UIEvent, useEffect, useMemo, useRef, useState } from 'react'
 import DataGrid, { Column, DataGridHandle, Row } from 'react-data-grid'
 import { toast } from 'sonner'
 
-import type { OptimizedSearchColumns } from '@supabase/pg-meta/src/sql/studio/get-users-types'
 import { LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
 import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { AlertError } from 'components/ui/AlertError'
@@ -34,12 +36,9 @@ import { User, useUsersInfiniteQuery } from 'data/auth/users-infinite-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
-import { useQueryStateWithSelect } from 'hooks/misc/useQueryStateWithSelect'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { cleanPointerEventsNoneOnBody, isAtBottom } from 'lib/helpers'
-import Link from 'next/link'
-import { parseAsArrayOf, parseAsString, parseAsStringEnum, useQueryState } from 'nuqs'
 import {
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
@@ -142,6 +141,10 @@ export const UsersV2 = () => {
     'providers',
     parseAsArrayOf(parseAsString, ',').withDefault([])
   )
+  const [selectedId, setSelectedId] = useQueryState(
+    'show',
+    parseAsString.withOptions({ history: 'push', clearOnDefault: true })
+  )
 
   // [Joshen] Opting to store filter column, into local storage for now, which will initialize
   // the page when landing on auth users page only if no query params for filter column provided
@@ -233,13 +236,7 @@ export const UsersV2 = () => {
   const { mutateAsync: deleteUser } = useUserDeleteMutation()
 
   const users = useMemo(() => data?.pages.flatMap((page) => page.result) ?? [], [data?.pages])
-
-  const { setValue: setSelectedUser, value: selectedUser } = useQueryStateWithSelect({
-    urlKey: 'show',
-    enabled: users.length > 0 && isSuccess,
-    select: (id: string) => (id ? users?.find((u) => u.id === id)?.id : undefined),
-    onError: () => toast.error(`User not found`),
-  })
+  const selectedUser = users?.find((u) => u.id === selectedId)?.id
 
   // [Joshen] Only relevant for when selecting one user only
   const selectedUserFromCheckbox = users.find((u) => u.id === [...selectedUsers][0])
@@ -345,7 +342,7 @@ export const UsersV2 = () => {
       setShowDeleteModal(false)
       setSelectedUsers(new Set([]))
 
-      if (userIds.includes(selectedUser)) setSelectedUser(null)
+      if (userIds.includes(selectedUser)) setSelectedId(null)
     } catch (error: any) {
       toast.error(`Failed to delete selected users: ${error.message}`)
     } finally {
@@ -468,6 +465,7 @@ export const UsersV2 = () => {
         setSortByValue(localStorageSortByValue)
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLocalStorageFilterLoaded, isLocalStorageSortByValueLoaded, isCountLoaded])
 
   return (
@@ -542,7 +540,7 @@ export const UsersV2 = () => {
                   setSearch={setSearch}
                   setFilterKeywords={(s) => {
                     setFilterKeywords(s)
-                    setSelectedUser(null)
+                    setSelectedId(null)
                     sendEvent({
                       action: 'auth_users_search_submitted',
                       properties: {
@@ -788,7 +786,7 @@ export const UsersV2 = () => {
                           if (user) {
                             const idx = users.indexOf(user)
                             if (props.row.id) {
-                              setSelectedUser(props.row.id)
+                              setSelectedId(props.row.id)
                               gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
                             }
                           }
@@ -825,12 +823,7 @@ export const UsersV2 = () => {
               />
             </div>
           </ResizablePanel>
-          {selectedUser !== undefined && (
-            <UserPanel
-              selectedUser={users.find((u) => u.id === selectedUser)}
-              onClose={() => setSelectedUser(null)}
-            />
-          )}
+          {!!selectedId && <UserPanel />}
         </ResizablePanelGroup>
 
         <UsersFooter
@@ -943,7 +936,7 @@ export const UsersV2 = () => {
           cleanPointerEventsNoneOnBody()
         }}
         onDeleteSuccess={() => {
-          if (selectedUserToDelete?.id === selectedUser) setSelectedUser(null)
+          if (selectedUserToDelete?.id === selectedUser) setSelectedId(null)
           setSelectedUserToDelete(undefined)
           cleanPointerEventsNoneOnBody(500)
         }}

--- a/apps/studio/data/auth/keys.ts
+++ b/apps/studio/data/auth/keys.ts
@@ -1,23 +1,8 @@
 import type { OptimizedSearchColumns } from '@supabase/pg-meta/src/sql/studio/get-users-types'
 
 export const authKeys = {
-  users: (
-    projectRef: string | undefined,
-    params?: {
-      page: number | undefined
-      keywords: string | undefined
-      filter: string | undefined
-    }
-  ) => ['projects', projectRef, 'users', ...(params ? [params] : [])] as const,
-
-  usersQuery: (
-    projectRef: string | undefined,
-    params?: {
-      query: string
-      startAt: string
-    }
-  ) => ['projects', projectRef, 'users-query', ...(params ? [params] : [])] as const,
-
+  user: (projectRef: string | undefined, userId?: string | null) =>
+    ['projects', projectRef, 'user', userId] as const,
   usersInfinite: (
     projectRef: string | undefined,
     params?: {

--- a/apps/studio/data/auth/user-delete-mutation.ts
+++ b/apps/studio/data/auth/user-delete-mutation.ts
@@ -36,13 +36,13 @@ export const useUserDeleteMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef, skipInvalidation = false } = variables
 
-      await onSuccess?.(data, variables, context)
-
       if (!skipInvalidation) {
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: authKeys.usersInfinite(projectRef) }),
         ])
       }
+
+      await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {
       if (onError === undefined) {

--- a/apps/studio/data/auth/user-query.ts
+++ b/apps/studio/data/auth/user-query.ts
@@ -6,6 +6,8 @@ import { UseCustomQueryOptions } from 'types'
 import { authKeys } from './keys'
 import { User } from './users-infinite-query'
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 type UserVariables = {
   projectRef?: string
   connectionString?: string | null
@@ -17,6 +19,7 @@ export async function getUser(
   signal?: AbortSignal
 ) {
   if (!userId) throw new Error('UserID is required')
+  if (!UUID_REGEX.test(userId)) throw new Error('Invalid user ID format')
 
   const sql = getUserSQL(userId)
   const { result } = await executeSql(

--- a/apps/studio/data/auth/user-query.ts
+++ b/apps/studio/data/auth/user-query.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { executeSql, type ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { getUserSQL } from 'data/sql/queries/get-user'
+import { UseCustomQueryOptions } from 'types'
+import { authKeys } from './keys'
+import { User } from './users-infinite-query'
+
+type UserVariables = {
+  projectRef?: string
+  connectionString?: string | null
+  userId?: string | null
+}
+
+export async function getUser(
+  { projectRef, connectionString, userId }: UserVariables,
+  signal?: AbortSignal
+) {
+  if (!userId) throw new Error('UserID is required')
+
+  const sql = getUserSQL(userId)
+  const { result } = await executeSql(
+    { projectRef, connectionString, sql, queryKey: [`user-${userId}`] },
+    signal
+  )
+
+  const user = result[0] as User | undefined
+  return user
+}
+
+export type UserData = Awaited<ReturnType<typeof getUser>>
+export type UserError = ExecuteSqlError
+
+export const useUserQuery = <TData = UserData>(
+  { projectRef, connectionString, userId }: UserVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<UserData, UserError, TData> = {}
+) =>
+  useQuery<UserData, UserError, TData>({
+    queryKey: authKeys.user(projectRef, userId),
+    queryFn: ({ signal }) => getUser({ projectRef, connectionString, userId }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined',
+    ...options,
+  })

--- a/apps/studio/data/sql/queries/get-user.ts
+++ b/apps/studio/data/sql/queries/get-user.ts
@@ -1,0 +1,35 @@
+export const getUserSQL = (userId: string) => {
+  const sql = /* SQL */ `
+select
+  auth.users.id,
+  auth.users.email,
+  auth.users.banned_until,
+  auth.users.created_at,
+  auth.users.confirmed_at,
+  auth.users.confirmation_sent_at,
+  auth.users.is_anonymous,
+  auth.users.is_sso_user,
+  auth.users.invited_at,
+  auth.users.last_sign_in_at,
+  auth.users.phone,
+  auth.users.raw_app_meta_data,
+  auth.users.raw_user_meta_data,
+  auth.users.updated_at,
+  coalesce(
+    (
+      select
+        array_agg(distinct i.provider)
+      from
+        auth.identities i
+      where
+        i.user_id = users.id
+    ),
+    '{}'::text[]
+  ) as providers
+from
+  auth.users
+where id = '${userId}';
+`.trim()
+
+  return sql
+}


### PR DESCRIPTION
## Context

We've come to a consensus to move away from using the `useQueryStateWithSelect` hook, so just incrementally doing the required refactors, starting with the Auth users page

## Changes involved
- Revert change to `user-delete-mutation` (Shift `onSuccess` to after data invalidation)
- Use `nuqs` directly for URL state
- Create a new `get-user-query` to fetch individual users
  - Realised this is necessary as the users page is paginated, and the selected ID in the URL might be one from a page that's not yet rendered in the UI
- Also added empty state if the selected user doesn't exist in the project
  <img width="1143" height="709" alt="image" src="https://github.com/user-attachments/assets/023d0915-4995-4a17-aeb7-5e7e29a364d9" />

## To test
- [ ] Verify that deleting a user from the User Panel doesn't show any toast error
- [ ] Verify that you can select a user to view details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed user details (Overview, Logs, Raw) and a loading skeleton while fetching user data.
  * Inline search/filter and Clear button for the Raw JSON view.

* **Improvements**
  * Persistent selection state (URL-driven) and cleared selection after deletion.
  * More resilient user retrieval and conditional rendering for loading/empty states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->