### PR TITLE
Use totalRows if available from params to validate MAX_EXPORT_ROW_COUNT

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -1,6 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ArrowUp, ChevronDown, FileText, Trash } from 'lucide-react'
-import Link from 'next/link'
 import { ReactNode, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -22,7 +21,6 @@ import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { DOCS_URL } from 'lib/constants'
 import { RoleImpersonationState } from 'lib/role-impersonation'
 import {
   useRoleImpersonationStateSnapshot,
@@ -44,22 +42,6 @@ import { ExportDialog } from './ExportDialog'
 import { FilterPopover } from './filter/FilterPopover'
 import { formatRowsForCSV } from './Header.utils'
 import { SortPopover } from './sort/SortPopover'
-
-// [Joshen] CSV exports require this guard as a fail-safe if the table is
-// just too large for a browser to keep all the rows in memory before
-// exporting. Either that or export as multiple CSV sheets with max n rows each
-export const MAX_EXPORT_ROW_COUNT = 500000
-export const MAX_EXPORT_ROW_COUNT_MESSAGE = (
-  <>
-    Sorry! We're unable to support exporting row counts larger than{' '}
-    {MAX_EXPORT_ROW_COUNT.toLocaleString('en-US')} at the moment. Alternatively, you may consider
-    using{' '}
-    <Link href={`${DOCS_URL}/reference/cli/supabase-db-dump`} target="_blank">
-      pg_dump
-    </Link>{' '}
-    via our CLI instead.
-  </>
-)
 
 export type HeaderProps = {
   customHeader: ReactNode

--- a/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
@@ -125,8 +125,6 @@ const fetchAllRows = async ({
     }
   }
 
-  console.log({ totalRows })
-
   if (totalRows !== undefined) {
     if (totalRows > MAX_EXPORT_ROW_COUNT) {
       return {

--- a/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
@@ -1,16 +1,13 @@
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import saveAs from 'file-saver'
 import Papa from 'papaparse'
 import { useCallback, useState, type ReactNode } from 'react'
 
-import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { IS_PLATFORM } from 'common'
-import {
-  MAX_EXPORT_ROW_COUNT,
-  MAX_EXPORT_ROW_COUNT_MESSAGE,
-} from 'components/grid/components/header/Header'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import type { Filter, Sort, SupaTable } from 'components/grid/types'
 import { formatTableRowsToSQL } from 'components/interfaces/TableGridEditor/TableEntity.utils'
+import { InlineLink } from 'components/ui/InlineLink'
 import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 import type { Entity } from 'data/entity-types/entity-types-infinite-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
@@ -18,6 +15,7 @@ import { getTableEditor, type TableEditorData } from 'data/table-editor/table-ed
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { fetchAllTableRows } from 'data/table-rows/table-rows-query'
 import { useStaticEffectEvent } from 'hooks/useStaticEffectEvent'
+import { DOCS_URL } from 'lib/constants'
 import type { RoleImpersonationState } from 'lib/role-impersonation'
 import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
 import {
@@ -34,6 +32,19 @@ import {
 } from './ExportAllRows.errors'
 import { useProgressToasts } from './ExportAllRows.progress'
 
+// [Joshen] CSV exports require this guard as a fail-safe if the table is
+// just too large for a browser to keep all the rows in memory before
+// exporting. Either that or export as multiple CSV sheets with max n rows each
+const MAX_EXPORT_ROW_COUNT = 500000
+const MAX_EXPORT_ROW_COUNT_MESSAGE = (
+  <p>
+    Sorry! We're unable to support exporting row counts larger than{' '}
+    {MAX_EXPORT_ROW_COUNT.toLocaleString('en-US')} at the moment. Alternatively, you may consider
+    using <InlineLink href={`${DOCS_URL}/reference/cli/supabase-db-dump`}>pg_dump</InlineLink> via
+    our CLI instead.
+  </p>
+)
+
 type OutputCallbacks = {
   convertToOutputFormat: (formattedRows: Record<string, unknown>[], table: SupaTable) => string
   convertToBlob: (str: string) => Blob
@@ -49,6 +60,7 @@ type FetchAllRowsParams = {
   filters?: Filter[]
   sorts?: Sort[]
   roleImpersonationState?: RoleImpersonationState
+  totalRows?: number
   startCallback?: () => void
   progressCallback?: (progress: number) => void
 } & OutputCallbacks
@@ -67,6 +79,7 @@ const fetchAllRows = async ({
   filters,
   sorts,
   roleImpersonationState,
+  totalRows,
   startCallback,
   progressCallback,
   convertToOutputFormat,
@@ -112,7 +125,16 @@ const fetchAllRows = async ({
     }
   }
 
-  if (isTableLike(table) && table.live_rows_estimate > MAX_EXPORT_ROW_COUNT) {
+  console.log({ totalRows })
+
+  if (totalRows !== undefined) {
+    if (totalRows > MAX_EXPORT_ROW_COUNT) {
+      return {
+        status: 'error',
+        error: new TableTooLargeError(table.name, totalRows, MAX_EXPORT_ROW_COUNT),
+      }
+    }
+  } else if (isTableLike(table) && table.live_rows_estimate > MAX_EXPORT_ROW_COUNT) {
     return {
       status: 'error',
       error: new TableTooLargeError(table.name, table.live_rows_estimate, MAX_EXPORT_ROW_COUNT),
@@ -283,6 +305,7 @@ export const useExportAllRowsGeneric = (
               filters: params.filters,
               sorts: params.sorts,
               roleImpersonationState: params.roleImpersonationState,
+              totalRows: params.totalRows,
               startCallback: () => {
                 startProgressTracker({
                   id: entity.id,


### PR DESCRIPTION
Fixes FE-2276

## Context

When exporting all rows from the table editor, we currently have a limit of 500,000 rows to support exporting via browser - above that we show a toast error to do so via `pg_dump`

However, atm if your table has > 500k rows, but your current view has some filters applied such that the row count with the filters is < 500k rows, the UI prevents you from exporting the rows with that same toast error (which is incorrect)

The validation in the UI currently only considers the table's `live_row_estimate` ([ref](https://github.com/supabase/supabase/blob/9274b81bd76a9fa74e51d1c8577185e4db43fb29/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx#L115)) but we should also be considering the `totalRows` given that we pass that as a param (and `totalRows` should take precedence)

## To test

- [ ] Verify that for a table with > 500k, you can still export the data if you've applied filters and the row count is below 500k
  - Can also test locally to reduce that limit to something smaller like 1k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implemented a 500,000 row maximum limit for bulk data exports in CSV, SQL, and JSON formats to ensure system reliability
  * Enhanced error handling with improved user messaging that includes direct documentation references when export size limits are exceeded
  * Consolidated export validation logic for better consistency and clearer user feedback

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->