### PR TITLE
fix: Sort the folders in the SQL Editor

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -407,7 +407,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
         page.folders?.forEach((folder) => snapV2.addFolder({ projectRef, folder }))
       })
     }
-  }, [projectRef, privateSnippetsPages?.pages, snapV2])
+  }, [projectRef, privateSnippetsPages?.pages])
 
   useEffect(() => {
     if (projectRef === undefined || !isFavoriteSnippetsSuccess) return

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -399,15 +399,15 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
   }, [id])
 
   useEffect(() => {
-    if (projectRef && privateSnippetsPages) {
+    if (projectRef && privateSnippetsPages?.pages) {
       privateSnippetsPages.pages.forEach((page) => {
         page.contents?.forEach((snippet: Snippet) => {
           snapV2.addSnippet({ projectRef, snippet })
         })
-        page.folders?.forEach((folder: SnippetFolder) => snapV2.addFolder({ projectRef, folder }))
+        page.folders?.forEach((folder) => snapV2.addFolder({ projectRef, folder }))
       })
     }
-  }, [projectRef, privateSnippetsPages?.pages])
+  }, [projectRef, privateSnippetsPages?.pages, snapV2])
 
   useEffect(() => {
     if (projectRef === undefined || !isFavoriteSnippetsSuccess) return

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -145,7 +145,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
         }) ?? [],
     [filteredSnippets.snippets, sort]
   )
-  const folders = useSnippetFolders(projectRef as string)
+  const folders = useSnippetFolders(projectRef!)
 
   const { data: snippetCountData } = useContentCountQuery({
     projectRef,

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -262,7 +262,8 @@ export const useSnippetFolders = (projectRef: string) => {
     () =>
       Object.values(snapshot.folders)
         .filter((x) => x.projectRef === projectRef)
-        .map((x) => x.folder),
+        .map((x) => x.folder)
+        .sort((a, b) => a.name.localeCompare(b.name)),
     [projectRef, snapshot.folders]
   )
 }

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -263,6 +263,7 @@ export const useSnippetFolders = (projectRef: string) => {
       Object.values(snapshot.folders)
         .filter((x) => x.projectRef === projectRef)
         .map((x) => x.folder)
+        // folders don't have created_at or inserted_at, so we always sort by name
         .sort((a, b) => a.name.localeCompare(b.name)),
     [projectRef, snapshot.folders]
   )


### PR DESCRIPTION
This PR fixes the folders to be always sorted by name. Folders don't have `created_at` or `inserted_at` attributes so they're always sorted by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Snippet folders are now sorted alphabetically for more consistent organization and easier navigation.
  * Snippet loading/initialization is more robust, reducing stale data and ensuring updates are reflected reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->