### PR TITLE
fix(docs): add missing variables to api_settings partial in getting_started

### DIFF
--- a/apps/docs/content/guides/realtime/getting_started.mdx
+++ b/apps/docs/content/guides/realtime/getting_started.mdx
@@ -83,7 +83,7 @@ conda install -c conda-forge supabase
 ### 2. Initialize the client
 
 Get your project URL and key.
-<$Partial path="api_settings.mdx" />
+<$Partial path="api_settings.mdx" variables={{ "framework": "js", "tab": "api-keys" }} />
 
 <Tabs
   scrollable

--- a/apps/docs/content/guides/realtime/getting_started.mdx
+++ b/apps/docs/content/guides/realtime/getting_started.mdx
@@ -83,7 +83,7 @@ conda install -c conda-forge supabase
 ### 2. Initialize the client
 
 Get your project URL and key.
-<$Partial path="api_settings.mdx" variables={{ "framework": "js", "tab": "api-keys" }} />
+<$Partial path="api_settings.mdx" variables={{ "framework": "", "tab": "" }} />
 
 <Tabs
   scrollable


### PR DESCRIPTION
## Summary

The Realtime Getting Started page was returning 404 due to an MDX parsing error. PR #41200 introduced template variables to `api_settings.mdx`, but this page was calling the partial without the required `variables` prop.

## Problem

`/docs/guides/realtime/getting_started` returned 404 because the `api_settings.mdx` partial now expects `framework` and `tab` variables to be passed in.

## Fix

Added the `variables` prop to the partial call, matching the pattern used in other pages.

Closes https://github.com/supabase/supabase/issues/41385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the realtime getting-started guide so the API settings panel now renders with explicit (empty) framework and tab variables in the "Initialize the client" step, improving consistency and predictable UI behavior during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->