### PR TITLE
Previous commit details

### DIFF
--- a/apps/studio/evals/scorer.ts
+++ b/apps/studio/evals/scorer.ts
@@ -1,7 +1,29 @@
 import { EvalCase, EvalScorer } from 'braintrust'
 import { ClosedQA, Sql } from 'autoevals'
 
-const LLM_AS_A_JUDGE_MODEL = 'gpt-5'
+// `autoevals` relies on tool-calling for some graders. Some newer models can
+// occasionally return non-tool responses, which surfaces as:
+// "no tool call in the OpenAI response".
+//
+// Keep the preferred judge model, but fall back to a very reliable tool-calling model
+// to prevent eval runs from hard-failing due to transient/non-deterministic outputs.
+const PRIMARY_JUDGE_MODEL = 'gpt-5'
+const FALLBACK_JUDGE_MODEL = 'gpt-4o-mini-2024-07-18'
+
+function shouldFallbackJudgeModel(error: unknown) {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  return message.includes('no tool call')
+}
+
+async function withJudgeFallback<T>(run: (model: string) => Promise<T>): Promise<T> {
+  try {
+    return await run(PRIMARY_JUDGE_MODEL)
+  } catch (error) {
+    if (!shouldFallbackJudgeModel(error)) throw error
+    return await run(FALLBACK_JUDGE_MODEL)
+  }
+}
 
 type Input = string
 
@@ -66,12 +88,14 @@ export const sqlSimilarityScorer: EvalScorer<Input, Output, Expected> = async ({
     }
   }
 
-  const sqlResult = await Sql({
-    input,
-    output: sqlQuery,
-    expected: expected.sqlQuery,
-    model: LLM_AS_A_JUDGE_MODEL,
-  })
+  const sqlResult = await withJudgeFallback((model) =>
+    Sql({
+      input,
+      output: sqlQuery,
+      expected: expected.sqlQuery,
+      model,
+    })
+  )
 
   return {
     name: 'sql_similarity',
@@ -85,12 +109,14 @@ export const criteriaMetScorer: EvalScorer<Input, Output, Expected> = async ({
 }) => {
   if (!expected.criteria) return null
 
-  const qaResult = await ClosedQA({
-    input: 'According to the provided criterion is the submission correct?',
-    output: output.text,
-    criteria: expected.criteria,
-    model: LLM_AS_A_JUDGE_MODEL,
-  })
+  const qaResult = await withJudgeFallback((model) =>
+    ClosedQA({
+      input: 'According to the provided criterion is the submission correct?',
+      output: output.text,
+      criteria: expected.criteria,
+      model,
+    })
+  )
 
   return {
     name: 'criteria_met',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, reliability improvement

## What is the current behavior?

`autoevals` judge models (e.g., `gpt-5`) can occasionally fail to return a tool call, causing the evaluation run to hard-fail with an error like "no tool call in the OpenAI response". This can happen even with newer models if the specific model/endpoint combination doesn't reliably honor tool-calling for the `autoevals` harness.

## What is the new behavior?

Introduces a fallback mechanism for `autoevals` judge models in `apps/studio/evals/scorer.ts`. The system will first attempt to use `gpt-5` as the primary judge. If a "no tool call" error is encountered, it will automatically retry the evaluation with `gpt-4o-mini-2024-07-18`, a model known for reliable tool-calling, to prevent hard failures.

## Additional context

This change addresses an observed instability where `autoevals` would fail due to the judge model not emitting expected tool calls. Analysis confirmed that underlying `autoevals`, `openai`, and `zod` dependency versions did not change across recent merges, suggesting the issue is related to model behavior rather than a dependency regression. The fallback ensures evaluation runs are more robust.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe4aea1c-ae28-4235-b5b2-652a0f77b18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe4aea1c-ae28-4235-b5b2-652a0f77b18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

