### PR TITLE
chore(studio): show toast after copying strings to clipboard

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.tsx
@@ -16,6 +16,7 @@ import {
 } from 'ui-patterns/CommandMenu'
 import { COMMAND_MENU_SECTIONS } from './CommandMenu.utils'
 import { orderCommandSectionsByPriority } from './ordering'
+import { toast } from 'sonner'
 
 const API_KEYS_PAGE_NAME = 'API Keys'
 
@@ -46,7 +47,9 @@ export function useApiKeysCommands() {
           id: 'publishable-key',
           name: `Copy publishable key`,
           action: () => {
-            copyToClipboard(publishableKey.api_key ?? '')
+            copyToClipboard(publishableKey.api_key ?? '', () => {
+              toast.success('Publishable key copied to clipboard')
+            })
             setIsOpen(false)
           },
           badge: () => (
@@ -62,7 +65,9 @@ export function useApiKeysCommands() {
             id: key.id,
             name: `Copy secret key (${key.name})`,
             action: () => {
-              copyToClipboard(key.api_key ?? '')
+              copyToClipboard(key.api_key ?? '', () => {
+                toast.success('Secret key copied to clipboard')
+              })
               setIsOpen(false)
             },
             badge: () => (
@@ -79,7 +84,9 @@ export function useApiKeysCommands() {
           id: 'anon-key',
           name: `Copy anonymous API key`,
           action: () => {
-            copyToClipboard(anonKey.api_key ?? '')
+            copyToClipboard(anonKey.api_key ?? '', () => {
+              toast.success('Anonymous API key copied to clipboard')
+            })
             setIsOpen(false)
           },
           badge: () => (
@@ -96,7 +103,9 @@ export function useApiKeysCommands() {
           id: 'service-key',
           name: `Copy service API key`,
           action: () => {
-            copyToClipboard(serviceKey.api_key ?? '')
+            copyToClipboard(serviceKey.api_key ?? '', () => {
+              toast.success('Service key copied to clipboard')
+            })
             setIsOpen(false)
           },
           badge: () => (

--- a/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
@@ -6,6 +6,7 @@ import { Badge, copyToClipboard } from 'ui'
 import { useRegisterCommands, useSetCommandMenuOpen } from 'ui-patterns/CommandMenu'
 import { COMMAND_MENU_SECTIONS } from './CommandMenu.utils'
 import { orderCommandSectionsByPriority } from './ordering'
+import { toast } from 'sonner'
 
 export function useApiUrlCommand() {
   const setIsOpen = useSetCommandMenuOpen()
@@ -27,7 +28,9 @@ export function useApiUrlCommand() {
         id: 'api-url',
         name: 'Copy API URL',
         action: () => {
-          copyToClipboard(apiUrl ?? '')
+          copyToClipboard(apiUrl ?? '', () => {
+            toast.success('API URL copied to clipboard')
+          })
           setIsOpen(false)
         },
         icon: () => <Link />,


### PR DESCRIPTION
Add toast message after successfully copying a string from the command menu options.

<img width="765" height="656" alt="Screenshot 2025-12-16 at 17 08 46" src="https://github.com/user-attachments/assets/59af2dbc-95bb-4188-8129-80d3a8f5ed59" />

toast:
<img width="403" height="96" alt="Screenshot 2025-12-16 at 17 08 51" src="https://github.com/user-attachments/assets/0b42874f-11c9-47f5-b641-e74147fb044f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success notifications when copying API keys and API URLs to clipboard. Users now receive instant visual confirmation confirming successful copy operations for all key types, enhancing the user experience with clear action acknowledgment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->