### PR TITLE
chore: remove tierKey from backups

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -49,7 +49,6 @@ export const BackupsList = () => {
     },
   })
 
-  const planKey = backups?.tierKey ?? ''
   const sortedBackups = (backups?.backups ?? []).sort(
     (a, b) => new Date(b.inserted_at).valueOf() - new Date(a.inserted_at).valueOf()
   )
@@ -74,7 +73,7 @@ export const BackupsList = () => {
   return (
     <>
       <div className="space-y-6">
-        {sortedBackups.length === 0 && planKey !== 'FREE' ? (
+        {sortedBackups.length === 0 ? (
           <BackupsEmpty />
         ) : (
           <>


### PR DESCRIPTION
Just removes a leftover plan check from backups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backup empty state message to display consistently for all users when no backups are available, improving the backup management experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->