### PR TITLE
chore: realtime max message size entitlement

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -20,6 +20,7 @@ import {
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import {
   Button,
   Card,
@@ -89,6 +90,11 @@ export const RealtimeSettings = () => {
       },
     })
 
+  const { getEntitlementNumericValue: getEntitledMaxPayloadSize } = useCheckEntitlements(
+    'realtime.max_message_size'
+  )
+  const entitledMaxPayloadSize = getEntitledMaxPayloadSize() ?? 3000
+
   const FormSchema = z.object({
     connection_pool: z.coerce
       .number()
@@ -97,7 +103,7 @@ export const RealtimeSettings = () => {
     max_concurrent_users: z.coerce.number().min(1).max(50000),
     max_events_per_second: z.coerce.number().min(1).max(10000),
     max_presence_events_per_second: z.coerce.number().min(1).max(10000),
-    max_payload_size_in_kb: z.coerce.number().min(1).max(3000),
+    max_payload_size_in_kb: z.coerce.number().min(1).max(entitledMaxPayloadSize),
     suspend: z.boolean(),
     // [Joshen] These fields are temporarily hidden from the UI
     // max_bytes_per_second: z.coerce.number().min(1).max(10000000),

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -90,24 +90,37 @@ export const RealtimeSettings = () => {
       },
     })
 
-  const { getEntitlementNumericValue: getEntitledMaxPayloadSize } = useCheckEntitlements(
-    'realtime.max_payload_size_in_kb'
-  )
-  const entitledMaxPayloadSize = getEntitledMaxPayloadSize() ?? 3000
+  const {
+    getEntitlementNumericValue: getEntitledMaxPayloadSize,
+    isEntitlementUnlimited: isMaxPayloadSizeUnlimited,
+  } = useCheckEntitlements('realtime.max_payload_size_in_kb')
+  const entitledMaxPayloadSize = isMaxPayloadSizeUnlimited()
+    ? Number.MAX_SAFE_INTEGER
+    : getEntitledMaxPayloadSize() ?? 3000
 
-  const { getEntitlementNumericValue: getEntitledMaxConcurrentUsers } = useCheckEntitlements(
-    'realtime.max_concurrent_users'
-  )
-  const entitledMaxConcurrentUsers = getEntitledMaxConcurrentUsers() ?? 50000
+  const {
+    getEntitlementNumericValue: getEntitledMaxConcurrentUsers,
+    isEntitlementUnlimited: isMaxConcurrentUsersUnlimited,
+  } = useCheckEntitlements('realtime.max_concurrent_users')
+  const entitledMaxConcurrentUsers = isMaxConcurrentUsersUnlimited()
+    ? Number.MAX_SAFE_INTEGER
+    : getEntitledMaxConcurrentUsers() ?? 50000
 
-  const { getEntitlementNumericValue: getEntitledMaxEventsPerSecond } = useCheckEntitlements(
-    'realtime.max_events_per_second'
-  )
-  const entitledMaxEventsPerSecond = getEntitledMaxEventsPerSecond() ?? 10000
+  const {
+    getEntitlementNumericValue: getEntitledMaxEventsPerSecond,
+    isEntitlementUnlimited: isMaxEventsPerSecondUnlimited,
+  } = useCheckEntitlements('realtime.max_events_per_second')
+  const entitledMaxEventsPerSecond = isMaxEventsPerSecondUnlimited()
+    ? Number.MAX_SAFE_INTEGER
+    : getEntitledMaxEventsPerSecond() ?? 10000
 
-  const { getEntitlementNumericValue: getEntitledMaxPresenceEventsPerSecond } =
-    useCheckEntitlements('realtime.max_presence_events_per_second')
-  const entitledMaxPresenceEventsPerSecond = getEntitledMaxPresenceEventsPerSecond() ?? 10000
+  const {
+    getEntitlementNumericValue: getEntitledMaxPresenceEventsPerSecond,
+    isEntitlementUnlimited: isMaxPresenceEventsPerSecondUnlimited,
+  } = useCheckEntitlements('realtime.max_presence_events_per_second')
+  const entitledMaxPresenceEventsPerSecond = isMaxPresenceEventsPerSecondUnlimited()
+    ? Number.MAX_SAFE_INTEGER
+    : getEntitledMaxPresenceEventsPerSecond() ?? 10000
 
   const FormSchema = z.object({
     connection_pool: z.coerce

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -91,18 +91,35 @@ export const RealtimeSettings = () => {
     })
 
   const { getEntitlementNumericValue: getEntitledMaxPayloadSize } = useCheckEntitlements(
-    'realtime.max_message_size'
+    'realtime.max_payload_size_in_kb'
   )
   const entitledMaxPayloadSize = getEntitledMaxPayloadSize() ?? 3000
+
+  const { getEntitlementNumericValue: getEntitledMaxConcurrentUsers } = useCheckEntitlements(
+    'realtime.max_concurrent_users'
+  )
+  const entitledMaxConcurrentUsers = getEntitledMaxConcurrentUsers() ?? 50000
+
+  const { getEntitlementNumericValue: getEntitledMaxEventsPerSecond } = useCheckEntitlements(
+    'realtime.max_events_per_second'
+  )
+  const entitledMaxEventsPerSecond = getEntitledMaxEventsPerSecond() ?? 10000
+
+  const { getEntitlementNumericValue: getEntitledMaxPresenceEventsPerSecond } =
+    useCheckEntitlements('realtime.max_presence_events_per_second')
+  const entitledMaxPresenceEventsPerSecond = getEntitledMaxPresenceEventsPerSecond() ?? 10000
 
   const FormSchema = z.object({
     connection_pool: z.coerce
       .number()
       .min(1)
       .max(maxConn?.maxConnections ?? 100),
-    max_concurrent_users: z.coerce.number().min(1).max(50000),
-    max_events_per_second: z.coerce.number().min(1).max(10000),
-    max_presence_events_per_second: z.coerce.number().min(1).max(10000),
+    max_concurrent_users: z.coerce.number().min(1).max(entitledMaxConcurrentUsers),
+    max_events_per_second: z.coerce.number().min(1).max(entitledMaxEventsPerSecond),
+    max_presence_events_per_second: z.coerce
+      .number()
+      .min(1)
+      .max(entitledMaxPresenceEventsPerSecond),
     max_payload_size_in_kb: z.coerce.number().min(1).max(entitledMaxPayloadSize),
     suspend: z.boolean(),
     // [Joshen] These fields are temporarily hidden from the UI

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -90,37 +90,25 @@ export const RealtimeSettings = () => {
       },
     })
 
-  const {
-    getEntitlementNumericValue: getEntitledMaxPayloadSize,
-    isEntitlementUnlimited: isMaxPayloadSizeUnlimited,
-  } = useCheckEntitlements('realtime.max_payload_size_in_kb')
-  const entitledMaxPayloadSize = isMaxPayloadSizeUnlimited()
-    ? Number.MAX_SAFE_INTEGER
-    : getEntitledMaxPayloadSize() ?? 3000
+  const { getEntitlementMax: getEntitledMaxPayloadSize } = useCheckEntitlements(
+    'realtime.max_payload_size_in_kb'
+  )
+  const entitledMaxPayloadSize = getEntitledMaxPayloadSize() ?? 3000
 
-  const {
-    getEntitlementNumericValue: getEntitledMaxConcurrentUsers,
-    isEntitlementUnlimited: isMaxConcurrentUsersUnlimited,
-  } = useCheckEntitlements('realtime.max_concurrent_users')
-  const entitledMaxConcurrentUsers = isMaxConcurrentUsersUnlimited()
-    ? Number.MAX_SAFE_INTEGER
-    : getEntitledMaxConcurrentUsers() ?? 50000
+  const { getEntitlementMax: getEntitledMaxConcurrentUsers } = useCheckEntitlements(
+    'realtime.max_concurrent_users'
+  )
+  const entitledMaxConcurrentUsers = getEntitledMaxConcurrentUsers() ?? 50000
 
-  const {
-    getEntitlementNumericValue: getEntitledMaxEventsPerSecond,
-    isEntitlementUnlimited: isMaxEventsPerSecondUnlimited,
-  } = useCheckEntitlements('realtime.max_events_per_second')
-  const entitledMaxEventsPerSecond = isMaxEventsPerSecondUnlimited()
-    ? Number.MAX_SAFE_INTEGER
-    : getEntitledMaxEventsPerSecond() ?? 10000
+  const { getEntitlementMax: getEntitledMaxEventsPerSecond } = useCheckEntitlements(
+    'realtime.max_events_per_second'
+  )
+  const entitledMaxEventsPerSecond = getEntitledMaxEventsPerSecond() ?? 10000
 
-  const {
-    getEntitlementNumericValue: getEntitledMaxPresenceEventsPerSecond,
-    isEntitlementUnlimited: isMaxPresenceEventsPerSecondUnlimited,
-  } = useCheckEntitlements('realtime.max_presence_events_per_second')
-  const entitledMaxPresenceEventsPerSecond = isMaxPresenceEventsPerSecondUnlimited()
-    ? Number.MAX_SAFE_INTEGER
-    : getEntitledMaxPresenceEventsPerSecond() ?? 10000
+  const { getEntitlementMax: getEntitledMaxPresenceEventsPerSecond } = useCheckEntitlements(
+    'realtime.max_presence_events_per_second'
+  )
+  const entitledMaxPresenceEventsPerSecond = getEntitledMaxPresenceEventsPerSecond() ?? 10000
 
   const FormSchema = z.object({
     connection_pool: z.coerce

--- a/apps/studio/hooks/misc/useCheckEntitlements.ts
+++ b/apps/studio/hooks/misc/useCheckEntitlements.ts
@@ -55,6 +55,12 @@ function getEntitlementSetValues(entitlement: Entitlement | null): string[] {
     : []
 }
 
+function getEntitlementMax(entitlement: Entitlement | null): Number | undefined {
+  return isEntitlementUnlimited(entitlement)
+    ? Number.MAX_SAFE_INTEGER
+    : getEntitlementNumericValue(entitlement)
+}
+
 export function useCheckEntitlements(
   featureKey: FeatureKey,
   organizationSlug?: string,
@@ -110,5 +116,6 @@ export function useCheckEntitlements(
     getEntitlementNumericValue: () => getEntitlementNumericValue(entitlement),
     isEntitlementUnlimited: () => isEntitlementUnlimited(entitlement),
     getEntitlementSetValues: () => getEntitlementSetValues(entitlement),
+    getEntitlementMax: () => getEntitlementMax(entitlement),
   }
 }

--- a/apps/studio/hooks/misc/useCheckEntitlements.ts
+++ b/apps/studio/hooks/misc/useCheckEntitlements.ts
@@ -55,7 +55,7 @@ function getEntitlementSetValues(entitlement: Entitlement | null): string[] {
     : []
 }
 
-function getEntitlementMax(entitlement: Entitlement | null): Number | undefined {
+function getEntitlementMax(entitlement: Entitlement | null): number | undefined {
   return isEntitlementUnlimited(entitlement)
     ? Number.MAX_SAFE_INTEGER
     : getEntitlementNumericValue(entitlement)


### PR DESCRIPTION
Adds the Realtime max message size entitlement

### Testing
- Head to `project/_/realtime/settings` with an Org on the Pro with the Spend Cap disabled
- Assert that the `Max payload size in KB` cannot exceed 3000
- Repeat the steps for max concurrent users and max presense events per second

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Realtime settings now automatically reflect your subscription entitlements with dynamic maximums for payload size, concurrent user limits, and event rates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->