### PR TITLE
fix(docs): remove duplicate Pricing header from storage-image-transformations

### DIFF
--- a/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
@@ -66,8 +66,6 @@ For simplicity, let's assume a package size of 1,000 and a charge of <Price pric
 
 Usage is shown as "Storage Image Transformations" on your invoice.
 
-## Pricing
-
 <$Partial path="billing/pricing/pricing_storage_image_transformations.mdx" />
 
 ## Billing examples


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix - Documentation

## What is the current behavior?
On the [Storage Image Transformations usage page](https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#pricing), there are duplicate "## Pricing" headers:
- One from the main document
- One from the included partial

Fixes #41316

## What is the new behavior?
Only a single "## Pricing" header is displayed, coming from the partial file.

## Why this approach?
The partial [pricing_storage_image_transformations.mdx](cci:7://file:///home/nayan-ai4m/Desktop/NK/Open_source/supabase/apps/docs/content/_partials/billing/pricing/pricing_storage_image_transformations.mdx:0:0-0:0) is used in **2 places**:
1. [manage-your-usage/storage-image-transformations.mdx](cci:7://file:///home/nayan-ai4m/Desktop/NK/Open_source/supabase/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx:0:0-0:0) - had duplicate header
2. [storage/serving/image-transformations.mdx](cci:7://file:///home/nayan-ai4m/Desktop/NK/Open_source/supabase/apps/docs/content/guides/storage/serving/image-transformations.mdx:0:0-0:0) - relies on partial's header

By removing the header from the **main document** (not the partial), we:
- ✅ Fix the double header issue on page 1
- ✅ Preserve the partial's `## Pricing` header for page 2

## Additional context
There's an existing PR #41315 that removes the header from the partial instead. However, that approach would break the second page which relies on the partial's header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed pricing information from the storage image transformations guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->