### PR TITLE
feature: add explain with AI in query performance

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -72,7 +72,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
       initialInput: prompt,
     })
 
-    // Close the query detail panel
+    // Close the query detail panel since we need to see the AI assistant panel
     onClose?.()
   }
 

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -2,6 +2,9 @@ import { Lightbulb, ChevronsUpDown } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 
+import { useParams } from 'common'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { formatSql } from 'lib/formatSql'
 import {
   AlertDescription_Shadcn_,
@@ -44,6 +47,9 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
   const report = QUERY_PERFORMANCE_COLUMNS
   const [query, setQuery] = useState(selectedRow?.['query'])
 
+  const { ref } = useParams()
+  const { data: org } = useSelectedOrganizationQuery()
+  const { mutate: sendEvent } = useSendEventMutation()
   const { openSidebar } = useSidebarManagerSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
 
@@ -70,6 +76,14 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
         },
       ],
       initialMessage: prompt,
+    })
+
+    sendEvent({
+      action: 'query_performance_ai_explanation_clicked',
+      groups: {
+        project: ref ?? 'Unknown',
+        organization: org?.slug ?? 'Unknown',
+      },
     })
 
     // Close the query detail panel since we need to see the AI assistant panel

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -77,7 +77,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
       initialMessage: prompt,
     })
 
-    track('query_performance_ai_explanation_clicked')
+    track('query_performance_explain_with_ai_button_clicked')
 
     // Close the query detail panel since we need to see the AI assistant panel
     onClose?.()

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -69,7 +69,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
           content: query,
         },
       ],
-      initialInput: prompt,
+      initialMessage: prompt,
     })
 
     // Close the query detail panel since we need to see the AI assistant panel

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -2,9 +2,7 @@ import { Lightbulb, ChevronsUpDown } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 
-import { useParams } from 'common'
-import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useFlag } from 'common'
 import { formatSql } from 'lib/formatSql'
 import {
   AlertDescription_Shadcn_,
@@ -52,6 +50,8 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
   const aiSnap = useAiAssistantStateSnapshot()
   const track = useTrack()
 
+  const showExplainWithAiInQueryPerformance = useFlag('ShowExplainWithAiInQueryPerformance')
+
   useEffect(() => {
     if (selectedRow !== undefined) {
       const formattedQuery = formatSql(selectedRow['query'])
@@ -88,14 +88,16 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
       <QueryPanelSection className="pt-2 border-b relative">
         <div className="flex items-center justify-between mb-4">
           <h4>Query pattern</h4>
-          <Button
-            type="default"
-            size="tiny"
-            icon={<AiIconAnimation size={14} />}
-            onClick={handleExplainQuery}
-          >
-            Explain with AI
-          </Button>
+          {showExplainWithAiInQueryPerformance && (
+            <Button
+              type="default"
+              size="tiny"
+              icon={<AiIconAnimation size={14} />}
+              onClick={handleExplainQuery}
+            >
+              Explain with AI
+            </Button>
+          )}
         </div>
         <div
           className={cn(

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -26,8 +26,7 @@ import { formatDuration } from './QueryPerformance.utils'
 import { useTrack } from 'lib/telemetry/track'
 
 interface QueryDetailProps {
-  reportType: QUERY_PERFORMANCE_REPORT_TYPES
-  selectedRow: QueryPerformanceRow
+  selectedRow?: QueryPerformanceRow
   onClickViewSuggestion: () => void
   onClose?: () => void
 }

--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -25,6 +25,7 @@ import {
 import { QueryPerformanceRow } from './QueryPerformance.types'
 import { buildQueryExplanationPrompt } from './QueryPerformance.ai'
 import { formatDuration } from './QueryPerformance.utils'
+import { useTrack } from 'lib/telemetry/track'
 
 interface QueryDetailProps {
   reportType: QUERY_PERFORMANCE_REPORT_TYPES
@@ -47,11 +48,9 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
   const report = QUERY_PERFORMANCE_COLUMNS
   const [query, setQuery] = useState(selectedRow?.['query'])
 
-  const { ref } = useParams()
-  const { data: org } = useSelectedOrganizationQuery()
-  const { mutate: sendEvent } = useSendEventMutation()
   const { openSidebar } = useSidebarManagerSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
+  const track = useTrack()
 
   useEffect(() => {
     if (selectedRow !== undefined) {
@@ -78,13 +77,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
       initialMessage: prompt,
     })
 
-    sendEvent({
-      action: 'query_performance_ai_explanation_clicked',
-      groups: {
-        project: ref ?? 'Unknown',
-        organization: org?.slug ?? 'Unknown',
-      },
-    })
+    track('query_performance_ai_explanation_clicked')
 
     // Close the query detail panel since we need to see the AI assistant panel
     onClose?.()

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.ai.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.ai.ts
@@ -1,0 +1,48 @@
+import { QueryPerformanceRow } from './QueryPerformance.types'
+
+export interface QueryExplanationPrompt {
+  query: string
+  prompt: string
+}
+
+export function buildQueryExplanationPrompt(
+  selectedRow: QueryPerformanceRow
+): QueryExplanationPrompt {
+  const metadata = [
+    `Total Time: ${selectedRow.total_time.toLocaleString()}`,
+    `Calls: ${selectedRow.calls.toLocaleString()}`,
+    `Mean Time: ${selectedRow.mean_time.toLocaleString()}`,
+    `Max Time: ${selectedRow.max_time.toLocaleString()}`,
+    `Min Time: ${selectedRow.min_time.toLocaleString()}`,
+    `Rows Read: ${selectedRow.rows_read.toLocaleString()}`,
+    `Cache Hit Rate: ${selectedRow.cache_hit_rate.toLocaleString()}%`,
+    `Role: ${selectedRow.rolname}`,
+  ].join('\n')
+
+  let additionalContext = ''
+  if (selectedRow.index_advisor_result) {
+    const indexResult = selectedRow.index_advisor_result
+
+    if (indexResult.index_statements.length > 0) {
+      additionalContext = `\n\nIndex Advisor Recommendations:\n${indexResult.index_statements.join('\n')}\n\nCost Analysis:\n- Startup Cost Before: ${indexResult.startup_cost_before}\n- Startup Cost After: ${indexResult.startup_cost_after}\n- Total Cost Before: ${indexResult.total_cost_before}\n- Total Cost After: ${indexResult.total_cost_after}`
+    }
+  }
+
+  const prompt = `Explain this query from my database performance metrics:
+
+1. What does it do?
+2. Should I be concerned about its performance?
+3. What can I do to optimize it, if anything?
+
+Performance Metrics:
+${metadata}
+
+${additionalContext}
+
+Be specific about whether this is within my control to optimize.`
+
+  return {
+    query: selectedRow.query,
+    prompt,
+  }
+}

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.ai.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.ai.ts
@@ -28,18 +28,19 @@ export function buildQueryExplanationPrompt(
     }
   }
 
-  const prompt = `Explain this query from my database performance metrics:
+  const prompt = `Analyze this database query and provide a brief, concise explanation:
 
-1. What does it do?
-2. Should I be concerned about its performance?
-3. What can I do to optimize it, if anything?
-
-Performance Metrics:
+**Performance Metrics:**
 ${metadata}
 
 ${additionalContext}
 
-Be specific about whether this is within my control to optimize.`
+Provide a short response covering:
+1. What the query does (1-2 sentences)
+2. Performance assessment (good/concerning and why)
+3. Actionable optimization suggestions (if any)
+
+Keep your response concise and focused on actionable insights. We can continue the conversation if needed to get more details.`
 
   return {
     query: selectedRow.query,

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.ai.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.ai.ts
@@ -37,8 +37,8 @@ ${additionalContext}
 
 Provide a short response covering:
 1. What the query does (1-2 sentences)
-2. Performance assessment (good/concerning and why)
-3. Actionable optimization suggestions (if any)
+2. Performance assessment (good/concerning and why, keep it brief 2-3 sentences)
+3. Actionable optimization suggestions (if any, keep it brief 2-3 sentences)
 
 Keep your response concise and focused on actionable insights. We can continue the conversation if needed to get more details.`
 

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -611,7 +611,6 @@ export const QueryPerformanceGrid = ({
             <TabsContent_Shadcn_ value="details" className="mt-0 flex-grow min-h-0 overflow-y-auto">
               {selectedRow !== undefined && (
                 <QueryDetail
-                  reportType={reportType}
                   selectedRow={reportData[selectedRow]}
                   onClickViewSuggestion={() => setView('suggestion')}
                   onClose={() => setSelectedRow(undefined)}

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -614,6 +614,7 @@ export const QueryPerformanceGrid = ({
                   reportType={reportType}
                   selectedRow={reportData[selectedRow]}
                   onClickViewSuggestion={() => setView('suggestion')}
+                  onClose={() => setSelectedRow(undefined)}
                 />
               )}
             </TabsContent_Shadcn_>

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2556,8 +2556,8 @@ export interface AdvisorAssistantButtonClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/observability/query-performance
  */
-export interface QueryPerformanceAIExplanationClickedEvent {
-  action: 'query_performance_ai_explanation_clicked'
+export interface QueryPerformanceAIExplanationButtonClickedEvent {
+  action: 'query_performance_explain_with_ai_button_clicked'
   groups: TelemetryGroups
 }
 
@@ -2743,6 +2743,6 @@ export type TelemetryEvent =
   | LogDrainConfirmButtonSubmittedEvent
   | AdvisorDetailOpenedEvent
   | AdvisorAssistantButtonClickedEvent
-  | QueryPerformanceAIExplanationClickedEvent
+  | QueryPerformanceAIExplanationButtonClickedEvent
   | RequestUpgradeModalOpenedEvent
   | RequestUpgradeSubmittedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2550,6 +2550,18 @@ export interface AdvisorAssistantButtonClickedEvent {
 }
 
 /**
+ * User clicked on "Explain with AI" button in Query Performance detail panel
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/query-performance
+ */
+export interface QueryPerformanceAIExplanationClickedEvent {
+  action: 'query_performance_ai_explanation_clicked'
+  groups: TelemetryGroups
+}
+
+/**
  * User opened the request upgrade modal (for users without billing permissions).
  *
  * @group Events
@@ -2731,5 +2743,6 @@ export type TelemetryEvent =
   | LogDrainConfirmButtonSubmittedEvent
   | AdvisorDetailOpenedEvent
   | AdvisorAssistantButtonClickedEvent
+  | QueryPerformanceAIExplanationClickedEvent
   | RequestUpgradeModalOpenedEvent
   | RequestUpgradeSubmittedEvent


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Simple button to add context of query performance into the AI chat


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Explain with AI" button in query performance details that opens the AI assistant, sends the query plus execution metrics, index-advisor recommendations and cost/context, and starts a focused chat with concise, actionable suggestions.
  * Query detail panel now closes automatically when invoking the AI explanation.

* **Chores**
  * Added telemetry to track usage of the AI explanation feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->