### PR TITLE
Clean up dead telemetry code after client-side migration

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -50,8 +50,7 @@ export function handlePageTelemetry(
     [key: string]: unknown
   },
   slug?: string,
-  ref?: string,
-  telemetryDataOverride?: components['schemas']['TelemetryPageBodyV2']
+  ref?: string
 ) {
   // Send to PostHog client-side (only in browser)
   if (typeof window !== 'undefined') {
@@ -194,25 +193,11 @@ export const PageTelemetry = ({
     ) {
       const cookies = document.cookie.split(';')
       const telemetryCookie = cookies.find((cookie) => cookie.trim().startsWith(TELEMETRY_DATA))
+      handlePageTelemetry(API_URL, pathnameRef.current, featureFlagsRef.current, slug, ref)
+
+      // Delete legacy telemetry cookie (old method of passing data to backend endpoint)
       if (telemetryCookie) {
-        try {
-          const encodedData = telemetryCookie.split('=')[1]
-          const telemetryData = JSON.parse(decodeURIComponent(encodedData))
-          handlePageTelemetry(
-            API_URL,
-            pathnameRef.current,
-            featureFlagsRef.current,
-            slug,
-            ref,
-            telemetryData
-          )
-          // remove the telemetry cookie
-          document.cookie = `${TELEMETRY_DATA}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
-        } catch (error) {
-          console.error('Invalid telemetry data:', error)
-        }
-      } else {
-        handlePageTelemetry(API_URL, pathnameRef.current, featureFlagsRef.current, slug, ref)
+        document.cookie = `${TELEMETRY_DATA}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
       }
 
       hasSentInitialPageTelemetryRef.current = true


### PR DESCRIPTION
## Context

Back when we had server-side page telemetry (the `/platform/telemetry/page` endpoint), `handlePageTelemetry` accepted a `telemetryDataOverride` parameter that let callers pass extra data to the backend. We also had cookie-based logic to persist telemetry data across page loads.

Now that page telemetry goes directly to PostHog client-side (see GROWTH-562/563), that backend endpoint is gone and this code is dead.

## Changes

- Remove the unused `telemetryDataOverride` parameter from `handlePageTelemetry`
- Simplify the cookie handling — we still clear the legacy cookie if it exists, but no longer parse it since we don't send data anywhere
- Remove the try/catch block that was handling JSON parsing errors for the cookie data

## Notes

The type `TelemetryPageBodyV2` that this parameter referenced still exists in `api-types` (it'll get cleaned up whenever someone next runs codegen against the updated backend spec). This is just the frontend cleanup portion.

---

Closes GROWTH-564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified telemetry behavior: removed legacy cookie-based telemetry path, now clears any old telemetry cookie and uses a single, consistent tracking flow to improve reliability and reduce duplicate or stale telemetry data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->