### PR TITLE
fix(www): fix Realtime 3.0 announcement URL

### DIFF
--- a/apps/www/components/Wrapped/Pages/ProductAnnouncements.tsx
+++ b/apps/www/components/Wrapped/Pages/ProductAnnouncements.tsx
@@ -159,7 +159,7 @@ const months: Month[] = [
       { title: 'JWT Signing Keys', url: 'https://supabase.com/blog/jwt-signing-keys' },
       { title: 'Automatic Embeddings', url: 'https://supabase.com/blog/automatic-embeddings' },
       { title: 'Storage v4', url: 'https://supabase.com/blog/storage-v4' },
-      { title: 'Realtime 3.0', url: 'https://supabase.com/blog/realtime-broadcast-authorization' },
+      { title: 'Realtime 3.0', url: 'https://supabase.com/blog/supabase-realtime-broadcast-and-presence-authorization' },
       {
         title: 'pg_replicate: Build Postgres Replicas',
         url: 'https://supabase.com/blog/pg-replicate',

--- a/apps/www/components/Wrapped/Pages/ProductAnnouncements.tsx
+++ b/apps/www/components/Wrapped/Pages/ProductAnnouncements.tsx
@@ -159,7 +159,10 @@ const months: Month[] = [
       { title: 'JWT Signing Keys', url: 'https://supabase.com/blog/jwt-signing-keys' },
       { title: 'Automatic Embeddings', url: 'https://supabase.com/blog/automatic-embeddings' },
       { title: 'Storage v4', url: 'https://supabase.com/blog/storage-v4' },
-      { title: 'Realtime 3.0', url: 'https://supabase.com/blog/supabase-realtime-broadcast-and-presence-authorization' },
+      {
+        title: 'Realtime 3.0',
+        url: 'https://supabase.com/blog/supabase-realtime-broadcast-and-presence-authorization',
+      },
       {
         title: 'pg_replicate: Build Postgres Replicas',
         url: 'https://supabase.com/blog/pg-replicate',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?



https://supabase.com/blog/realtime-broadcast-authorization -> blog post not found


I think it should be this one: https://supabase.com/blog/supabase-realtime-broadcast-and-presence-authorization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated August 2025 product announcements: the Realtime 3.0 entry now links to expanded blog content covering broadcast and presence authorization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->