### PR TITLE
SQL Editor MonacoEditor should invalidate when setSql on debounce called for new snippet

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -205,7 +205,8 @@ const MonacoEditor = ({
 
   useEffect(() => {
     if (debouncedValue.length > 0 && snippet) {
-      snapV2.setSql(id, value)
+      const shouldInvalidate = snippet.snippet.isNotSavedInDatabaseYet
+      snapV2.setSql({ id, sql: value, shouldInvalidate })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedValue])

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -248,7 +248,7 @@ export const SQLEditor = () => {
             range: editorModel.getFullModelRange(),
           },
         ])
-        snapV2.setSql(id, formattedSql)
+        snapV2.setSql({ id, sql: formattedSql })
       }
     }
   }, [id, isDiffOpen, project, snapV2])

--- a/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
@@ -78,7 +78,7 @@ export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
         async provideDocumentFormattingEdits(model) {
           const value = model.getValue()
           const formatted = formatSql(value)
-          if (id) snapV2.setSql(id, formatted)
+          if (id) snapV2.setSql({ id, sql: formatted })
           return [{ range: model.getFullModelRange(), text: formatted }]
         },
       })

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -115,11 +115,19 @@ export const sqlEditorState = proxy({
     }
   },
 
-  setSql: (id: string, sql: string) => {
+  setSql: ({
+    id,
+    sql,
+    shouldInvalidate = false,
+  }: {
+    id: string
+    sql: string
+    shouldInvalidate?: boolean
+  }) => {
     let snippet = sqlEditorState.snippets[id]?.snippet
     if (snippet?.content) {
       snippet.content.sql = sql
-      sqlEditorState.needsSaving.set(id, false)
+      sqlEditorState.needsSaving.set(id, shouldInvalidate)
     }
   },
 


### PR DESCRIPTION
## Context

With the changes in a previous PR [here](https://github.com/supabase/supabase/pull/41264), we simplified `handleEditorChange` to just call `setValue` irregardless if its a new snippet or not. This solves a small edge case whereby snippets would not be saved on debounce if the user has just entered a single character

However, there's yet another issue then whereby `snapV2.setSql` that we're calling on debounce doesn't invalidate the data from the content endpoints, so if you click away from the new "Untitled Query", it goes away from the UI.

A possible fix was to call `addNeedsSaving` in `handleEditorChange` if its a new snippet, but that technically results in an unnecessary API call especially if the user is typing more than one character (which is 99.99% of the time haha)

So opting to fix this with `setSql` instead so that we can purely rely on the debounce behaviour for saving

## Changes involved
- Update `setSql` from `sql-editor-v2` valtio store to accept an optional parameter `shouldInvalidate` that it'll pass into `needsSaving.set`
- Calling `setSql` on debounce within `MonacoEditor` will then pass that parameter if its a new snippet

## To test
- [ ] Verify that on a new snippet (/new), if you type one single character in the editor, it'll save after the debounce duration and the editor content data will invalidate (count number should update for e.g)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the SQL editor's internal state management system to improve how unsaved changes are tracked and handled. The updated architecture provides more granular control over save-state management, ensuring consistent and reliable change detection across all editor components and interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->