### PR TITLE
chore: Align profile endpoint usage with api schema corrections

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/ProfileInformation.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/ProfileInformation.tsx
@@ -69,7 +69,12 @@ export const ProfileInformation = () => {
     onSuccess: (data) => {
       toast.success('Successfully saved profile')
       const { first_name, last_name, username, primary_email } = data
-      form.reset({ first_name, last_name, username, primary_email })
+      form.reset({
+        first_name: first_name ?? undefined,
+        last_name: last_name ?? undefined,
+        username,
+        primary_email,
+      })
     },
     onError: (error) => toast.error(`Failed to update profile: ${error.message}`),
   })

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -2094,6 +2094,10 @@ export interface components {
       external_workos_enabled: boolean | null
       external_workos_secret: string | null
       external_workos_url: string | null
+      external_x_client_id: string | null
+      external_x_email_optional: boolean | null
+      external_x_enabled: boolean | null
+      external_x_secret: string | null
       external_zoom_client_id: string | null
       external_zoom_email_optional: boolean | null
       external_zoom_enabled: boolean | null
@@ -3676,6 +3680,10 @@ export interface components {
       external_workos_enabled?: boolean | null
       external_workos_secret?: string | null
       external_workos_url?: string | null
+      external_x_client_id?: string | null
+      external_x_email_optional?: boolean | null
+      external_x_enabled?: boolean | null
+      external_x_secret?: string | null
       external_zoom_client_id?: string | null
       external_zoom_email_optional?: boolean | null
       external_zoom_enabled?: boolean | null

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -885,8 +885,11 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** Gets a specific organization that belongs to the authenticated user */
-    get: operations['OrganizationSlugController_getOrganization']
+    /**
+     * Get entitlements for an organization
+     * @description Returns the entitlements available to the organization based on their plan and any overrides.
+     */
+    get: operations['OrganizationEntitlementsController_getEntitlements']
     put?: never
     post?: never
     /** Deletes organization */
@@ -1207,26 +1210,6 @@ export interface paths {
     trace?: never
   }
   '/platform/organizations/{slug}/entitlements': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Get entitlements for an organization
-     * @description Returns the entitlements available to the organization based on their plan and any overrides.
-     */
-    get: operations['OrganizationEntitlementsController_getEntitlements']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/organizations/{slug}/entitlements/entitlements': {
     parameters: {
       query?: never
       header?: never
@@ -7871,14 +7854,14 @@ export interface components {
         | 'billing:payment_methods'
         | 'realtime:all'
       )[]
-      first_name: string
-      free_project_limit: number
+      first_name: string | null
+      free_project_limit: number | null
       gotrue_id: string
       id: number
       is_alpha_user: boolean
       is_sso_user: boolean
-      last_name: string
-      mobile: string
+      last_name: string | null
+      mobile: string | null
       primary_email: string
       username: string
     }
@@ -9218,8 +9201,6 @@ export interface components {
       reset_project?: boolean
     }
     TelemetryIdentifyBodyV2: {
-      /** PostHog JS SDK's distinct_id - used for aliasing anonymous → authenticated users */
-      anonymous_id?: string
       organization_slug?: string
       project_ref?: string
       user_id: string
@@ -12806,7 +12787,7 @@ export interface operations {
       }
     }
   }
-  OrganizationSlugController_getOrganization: {
+  OrganizationEntitlementsController_getEntitlements: {
     parameters: {
       query?: never
       header?: never
@@ -12823,7 +12804,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['OrganizationSlugResponse']
+          'application/json': components['schemas']['ListEntitlementsResponse']
         }
       }
       /** @description Unauthorized */
@@ -14000,49 +13981,6 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['OrgDocumentUrlResponse']
-        }
-      }
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Forbidden action */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Rate limit exceeded */
-      429: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  OrganizationEntitlementsController_getEntitlements: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /** @description Organization slug */
-        slug: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ListEntitlementsResponse']
         }
       }
       /** @description Unauthorized */

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -885,11 +885,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /**
-     * Get entitlements for an organization
-     * @description Returns the entitlements available to the organization based on their plan and any overrides.
-     */
-    get: operations['OrganizationEntitlementsController_getEntitlements']
+    /** Gets a specific organization that belongs to the authenticated user */
+    get: operations['OrganizationSlugController_getOrganization']
     put?: never
     post?: never
     /** Deletes organization */
@@ -4328,40 +4325,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/platform/telemetry/page': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Send server page event */
-    post: operations['TelemetryPageController_sendServerPageV2']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/telemetry/page-leave': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Send analytics page leave event */
-    post: operations['TelemetryPageLeaveController_trackPageLeave']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/platform/telemetry/reset': {
     parameters: {
       query?: never
@@ -5406,15 +5369,17 @@ export interface components {
       name: string
       organization_slugs?: string[]
       permissions: (
-        | 'organizations_read'
-        | 'organizations_write'
-        | 'projects_read'
         | 'available_regions_read'
+        | 'organizations_read'
+        | 'organizations_create'
+        | 'projects_read'
         | 'snippets_read'
         | 'organization_admin_read'
         | 'organization_admin_write'
         | 'members_read'
         | 'members_write'
+        | 'organization_projects_read'
+        | 'organization_projects_create'
         | 'project_admin_read'
         | 'project_admin_write'
         | 'advisors_read'
@@ -6949,6 +6914,7 @@ export interface components {
             | 'branching_limit'
             | 'branching_persistent'
             | 'auth.mfa_phone'
+            | 'auth.mfa_web_authn'
             | 'auth.hooks'
             | 'auth.platform.sso'
             | 'backup.retention_days'
@@ -9201,37 +9167,10 @@ export interface components {
       reset_project?: boolean
     }
     TelemetryIdentifyBodyV2: {
+      anonymous_id?: string
       organization_slug?: string
       project_ref?: string
       user_id: string
-    }
-    TelemetryPageBodyV2: {
-      feature_flags?: {
-        [key: string]: unknown
-      }
-      groups?: {
-        organization?: string
-        project?: string
-      }
-      page_title: string
-      page_url: string
-      pathname: string
-      ph: {
-        language: string
-        referrer: string
-        search: string
-        user_agent: string
-        viewport_height: number
-        viewport_width: number
-      }
-    }
-    TelemetryPageLeaveBody: {
-      feature_flags?: {
-        [key: string]: unknown
-      }
-      page_title: string
-      page_url: string
-      pathname: string
     }
     TemporaryApiKeyResponse: {
       api_key: string
@@ -9639,6 +9578,10 @@ export interface components {
       EXTERNAL_WORKOS_ENABLED?: boolean | null
       EXTERNAL_WORKOS_SECRET?: string | null
       EXTERNAL_WORKOS_URL?: string | null
+      EXTERNAL_X_CLIENT_ID?: string | null
+      EXTERNAL_X_EMAIL_OPTIONAL?: boolean | null
+      EXTERNAL_X_ENABLED?: boolean | null
+      EXTERNAL_X_SECRET?: string | null
       EXTERNAL_ZOOM_CLIENT_ID?: string | null
       EXTERNAL_ZOOM_EMAIL_OPTIONAL?: boolean | null
       EXTERNAL_ZOOM_ENABLED?: boolean | null
@@ -12787,7 +12730,7 @@ export interface operations {
       }
     }
   }
-  OrganizationEntitlementsController_getEntitlements: {
+  OrganizationSlugController_getOrganization: {
     parameters: {
       query?: never
       header?: never
@@ -12804,7 +12747,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['ListEntitlementsResponse']
+          'application/json': components['schemas']['OrganizationSlugResponse']
         }
       }
       /** @description Unauthorized */
@@ -25743,63 +25686,6 @@ export interface operations {
         content?: never
       }
       /** @description Failed to send analytics identify event */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  TelemetryPageController_sendServerPageV2: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['TelemetryPageBodyV2']
-      }
-    }
-    responses: {
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to send server page event */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  TelemetryPageLeaveController_trackPageLeave: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['TelemetryPageLeaveBody']
-      }
-    }
-    responses: {
-      /** @description Page leave event sent */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to send analytics page leave event */
       500: {
         headers: {
           [name: string]: unknown

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -43,7 +43,7 @@ export const TelemetryTagManager = () => {
 //---
 // PAGE TELEMETRY
 //---
-export function handlePageTelemetry(
+function handlePageTelemetry(
   API_URL: string,
   pathname?: string,
   featureFlags?: {

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -50,8 +50,7 @@ export function handlePageTelemetry(
     [key: string]: unknown
   },
   slug?: string,
-  ref?: string,
-  telemetryDataOverride?: components['schemas']['TelemetryPageBodyV2']
+  ref?: string
 ) {
   // Send to PostHog client-side (only in browser)
   if (typeof window !== 'undefined') {
@@ -197,15 +196,7 @@ export const PageTelemetry = ({
       if (telemetryCookie) {
         try {
           const encodedData = telemetryCookie.split('=')[1]
-          const telemetryData = JSON.parse(decodeURIComponent(encodedData))
-          handlePageTelemetry(
-            API_URL,
-            pathnameRef.current,
-            featureFlagsRef.current,
-            slug,
-            ref,
-            telemetryData
-          )
+          handlePageTelemetry(API_URL, pathnameRef.current, featureFlagsRef.current, slug, ref)
           // remove the telemetry cookie
           document.cookie = `${TELEMETRY_DATA}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
         } catch (error) {


### PR DESCRIPTION
Just a small change where we align the usage of the create profile endpoint data with a small schema correction on the API: https://github.com/supabase/platform/pull/28362

Also, because I bumped the schema and we removed some telemetry endpoints, I removed an unused parameter from the telemetry connection because the type was no longer available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form reset so optional profile fields restore correctly after updates.

* **Updates**
  * Profile fields (first name, last name, mobile, free project limit) can be nullable/left empty.
  * Organization entitlements route consolidated and response adds auth.mfa_web_authn.
  * New external provider configuration fields added (client id, secret, enabled, email optional).
  * Removed two telemetry page endpoints from the public API.

* **Refactor**
  * Simplified page telemetry handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->