### PR TITLE
docs: remove incorrect claim for support of clone of clone

### DIFF
--- a/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
+++ b/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
@@ -182,8 +182,7 @@ export const RestoreToNewProject = () => {
       <Admonition type="default" title="This project cannot be restored to a new project">
         <Markdown
           className="max-w-full [&>p]:!leading-normal"
-          content={`This is a temporary limitation whereby projects that were originally restored from another project cannot be restored to yet another project. 
-          If you need to restore from a restored project, please reach out via [support](/support/new?projectRef=${project?.ref}).`}
+          content={`This is a temporary limitation whereby projects that were originally restored from another project cannot be restored to yet another project.`}
         />
         <Button asChild type="default">
           <Link href={`/project/${cloneStatus?.cloned_from?.source_project?.ref || ''}`}>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

We incorrectly suggest we support cloning clones with the help of support team.

## What is the new behavior?

Remove this statement, as while Restore To New Project is in public beta, we do
not support cloning clones

## Additional context

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the project restoration warning message by removing support contact guidance and project reference links. The notification now focuses solely on the temporary limitation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->