### PR TITLE
fix: Deduplicate foreign schema nodes in Schema Visualizer

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -69,21 +69,26 @@ export async function getGraphDataFromTables(
 
     // Create additional [this->foreign] node that we can point to on the graph.
     if (rel.target_table_schema !== currentSchema) {
-      const data: TableNodeData = {
-        id: rel.id,
-        ref: ref!,
-        schema: rel.target_table_schema,
-        name: `${rel.target_table_schema}.${rel.target_table_name}.${rel.target_column_name}`,
-        isForeign: true,
-        columns: [],
-      }
+      const targetId = `${rel.target_table_schema}.${rel.target_table_name}.${rel.target_column_name}`
 
-      nodes.push({
-        data,
-        id: rel.constraint_name,
-        type: 'table',
-        position: { x: 0, y: 0 },
-      })
+      const targetNode = nodes.find((n) => n.id === targetId)
+      if (!targetNode) {
+        const data: TableNodeData = {
+          id: rel.id,
+          ref: ref!,
+          schema: rel.target_table_schema,
+          name: targetId,
+          isForeign: true,
+          columns: [],
+        }
+
+        nodes.push({
+          id: targetId,
+          type: 'table',
+          data: data,
+          position: { x: 0, y: 0 },
+        })
+      }
 
       const [source, sourceHandle] = findTablesHandleIds(
         tables,
@@ -96,8 +101,8 @@ export async function getGraphDataFromTables(
           id: String(rel.id),
           source,
           sourceHandle,
-          target: rel.constraint_name,
-          targetHandle: rel.constraint_name,
+          target: targetId,
+          targetHandle: targetId,
         })
       }
 


### PR DESCRIPTION
This PR removes duplicate entries in the Schema Visualizer for foreign tables. 

For example, previously you would have two blocks for `auth.users.id` if it's referenced from two tables:
<img width="888" height="759" alt="Screenshot 2025-12-17 at 14 15 54" src="https://github.com/user-attachments/assets/4977afd0-4859-457a-b5a2-dc8158f9da80" />

After this PR it looks like this:
<img width="882" height="724" alt="Screenshot 2025-12-17 at 14 16 43" src="https://github.com/user-attachments/assets/00ab67ee-45c3-49d6-b225-e7b40d52854e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreign key relationship visualization across different schemas by eliminating duplicate nodes and ensuring proper connections to referenced tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->