### PR TITLE
fix: use refs for rows, don't create proxy object for each row

### DIFF
--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -1,7 +1,7 @@
 import { debounce, memoize } from 'lodash'
 import { useMemo } from 'react'
 import { toast } from 'sonner'
-import { proxy, snapshot, subscribe, useSnapshot } from 'valtio'
+import { proxy, ref, snapshot, subscribe, useSnapshot } from 'valtio'
 import { devtools, proxyMap } from 'valtio/utils'
 
 import { DiffType } from 'components/interfaces/SQLEditor/SQLEditor.types'
@@ -237,13 +237,16 @@ export const sqlEditorState = proxy({
 
   addResult: (id: string, results: any[], autoLimit?: number) => {
     if (sqlEditorState.results[id]) {
-      sqlEditorState.results[id].unshift({ rows: results, autoLimit })
+      // Use ref() to prevent Valtio from creating proxies for each row object.
+      // This is critical for large result sets - without ref(), Valtio wraps every
+      // row and nested property in a Proxy, causing massive memory overhead.
+      sqlEditorState.results[id] = [{ rows: ref(results), autoLimit }]
     }
   },
 
   addResultError: (id: string, error: any, autoLimit?: number) => {
     if (sqlEditorState.results[id]) {
-      sqlEditorState.results[id].unshift({ rows: [], error, autoLimit })
+      sqlEditorState.results[id] = [{ rows: ref([]), error, autoLimit }]
     }
   },
 

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -240,6 +240,8 @@ export const sqlEditorState = proxy({
       // Use ref() to prevent Valtio from creating proxies for each row object.
       // This is critical for large result sets - without ref(), Valtio wraps every
       // row and nested property in a Proxy, causing massive memory overhead.
+      // Alright to use ref() in this case as the data is meant to be read-only and we
+      // don't need to track changes to the underlying data
       sqlEditorState.results[id] = [{ rows: ref(results), autoLimit }]
     }
   },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Reduce memory bandwidth on rows being rendered in SQL editor but using `ref` and not creating proxy objects

## How to test

Try generating this SQL query in the SQL editor, nothing should freeze up:

```
SELECT 
  random()::text AS first_val, 
  random()::text AS second_val, 
  id 
FROM generate_series(1,300_000) as id;
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced memory usage in the SQL editor when processing large query results, improving performance and responsiveness during heavy data operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->