### PR TITLE
chore(studio) improve ClientSideExceptionHandler admonition

### DIFF
--- a/apps/studio/components/ui/ErrorBoundary/ClientSideExceptionHandler.tsx
+++ b/apps/studio/components/ui/ErrorBoundary/ClientSideExceptionHandler.tsx
@@ -48,8 +48,8 @@ export const ClientSideExceptionHandler = ({
         </p>
         <p className="text-foreground-light text-sm">{message}</p>
       </div>
-      <Admonition type="warning" showIcon={false} title="We recommend trying the following:">
-        <ul className="list-disc pl-2 list-inside text-sm space-y-1 [&_b]:font-medium [&_b]:text-foreground">
+      <Admonition type="note" showIcon={false} title="We recommend trying the following:">
+        <ul className="list-disc mt-1.5 pl-2 list-inside text-sm space-y-1">
           <li>
             <span
               className={cn(InlineLinkClassName, 'cursor-pointer')}
@@ -78,7 +78,7 @@ export const ClientSideExceptionHandler = ({
             to clean potentially outdated data
           </li>
           <li>
-            Disable browser extensions that might modify page content (e.g., Google Translate)
+            Disable browser extensions that might modify page content (e.g. Google Translate)
           </li>
           <li>If the problem persists, please contact support for assistance</li>
         </ul>

--- a/apps/studio/components/ui/ErrorBoundary/ClientSideExceptionHandler.tsx
+++ b/apps/studio/components/ui/ErrorBoundary/ClientSideExceptionHandler.tsx
@@ -77,9 +77,7 @@ export const ClientSideExceptionHandler = ({
             </span>{' '}
             to clean potentially outdated data
           </li>
-          <li>
-            Disable browser extensions that might modify page content (e.g. Google Translate)
-          </li>
+          <li>Disable browser extensions that might modify page content (e.g. Google Translate)</li>
           <li>If the problem persists, please contact support for assistance</li>
         </ul>
       </Admonition>


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI polish.

## What is the current behavior?

Our `ClientSideExceptionHandler` uses the `Admonition` in the `warning` variant. This makes it needlessly orange and alarming.

`warning` should be for true warnings, usually before the user does something dangerous.

## What is the new behavior?

Changed the variant to `note`.

| Before | After |
| --- | --- |
| <img width="1069" height="820" alt="MJAO0GKXQVKBA" src="https://github.com/user-attachments/assets/2ecd4ed4-0435-4e26-a48e-39224da69772" /> | <img width="1018" height="820" alt="MJANZGIYHGQ2J" src="https://github.com/user-attachments/assets/6cad76b8-7c3d-4727-9dc8-3c75e9552211" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style & UI Improvements**
  * Enhanced error message presentation with updated visual styling for improved readability and consistency.
  * Consolidated troubleshooting instructions in exception handler guidance for clearer user communication.
  * Refined text formatting and wording to provide more concise, actionable error information.
  * Improved list styling in exception handling messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->