### PR TITLE
chore(www): update badge and Wrapped text

### DIFF
--- a/apps/www/components/Announcement/Badge.tsx
+++ b/apps/www/components/Announcement/Badge.tsx
@@ -1,7 +1,7 @@
-import React, { ReactNode } from 'react'
-import Link from 'next/link'
-import { Badge, cn } from 'ui'
 import { ChevronRightIcon } from 'lucide-react'
+import Link from 'next/link'
+import React, { ReactNode } from 'react'
+import { Badge, cn } from 'ui'
 
 interface Props {
   url: string
@@ -40,7 +40,7 @@ const AnnouncementBadge = ({
           p-1 pr-0.5
           text-sm
           w-auto
-          gap-2
+          gap-1.5
           text-left
           rounded-full
           bg-opacity-20
@@ -52,7 +52,7 @@ const AnnouncementBadge = ({
           overflow-hidden
           focus-visible:outline-none focus-visible:ring-brand-600 focus-visible:ring-2 focus-visible:rounded-full
           `,
-        !badge && 'pl-4'
+        !badge && 'pl-5'
       )}
     >
       {badge && (

--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -17,7 +17,8 @@ const Hero = () => {
               <div className="relative z-10 lg:h-auto pt-[90px] lg:pt-[90px] lg:min-h-[300px] flex flex-col items-center justify-center sm:mx-auto md:w-3/4 lg:mx-0 lg:w-full gap-4 lg:gap-8">
                 <AnnouncementBadge
                   url="/wrapped"
-                  announcement="Supabase Wrapped 2025: The year in review."
+                  announcement="Supabase Wrapped 2025: The year in review"
+                  announcementMobile="Supabase Wrapped 2025"
                 />
                 <div className="flex flex-col items-center">
                   <h1 className="text-foreground text-4xl sm:text-5xl sm:leading-none lg:text-7xl">


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI polish.

## What is the current behavior?

- Padding on the `AnnouncementBadge` component is optically off-center
- The Wrapped text finishes in a period though it’s a fragment
- The Wrapped text is a bit long on mobile

## What is the new behavior?

- Fixed optical padding
- Shortened text on mobile

| Before | After |
| --- | --- |
| <img width="462" height="850" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/7852a457-55b8-4911-b982-385fbdfda07d" /> | <img width="462" height="850" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/fffed1c8-7bc3-408c-8df4-beca49b1ef60" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-specific announcement for "Supabase Wrapped 2025"

* **Style**
  * Refined announcement badge spacing and padding for improved visual presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->