### PR TITLE
docs: Fix horizontal scroll from new word wrap feature

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -64,7 +64,7 @@ export async function CodeBlock({
         'group',
         'relative',
         'not-prose',
-        'w-full overflow-hidden',
+        'w-full overflow-x-auto',
         'border border-default rounded-lg',
         'bg-200',
         'text-sm',

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -359,8 +359,11 @@ th code {
 }
 
 /* Word wrap styles for code blocks */
-.shiki[data-wrapped='true'] .code-content {
+.shiki[data-wrapped='true'] {
   overflow-x: hidden !important;
+}
+
+.shiki[data-wrapped='true'] .code-content {
   white-space: pre-wrap !important;
   word-break: break-word !important;
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Code blocks now feature horizontal scrolling for content exceeding display width, eliminating text truncation. This ensures all code remains visible while preserving text wrapping behavior, allowing users to easily view lengthy code snippets without losing content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->