### PR TITLE
FE-2293 Fix query performance timeouts

### DIFF
--- a/apps/studio/pages/project/[ref]/observability/query-performance.tsx
+++ b/apps/studio/pages/project/[ref]/observability/query-performance.tsx
@@ -62,18 +62,6 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
 
   const isPgStatMonitorEnabled = project?.dbVersion === '17.4.1.076-psml-1'
 
-  if (!ref) {
-    return (
-      <div className="h-full flex flex-col p-6">
-        <Admonition
-          type="destructive"
-          title="Invalid project reference"
-          description="Unable to load query performance data. Please ensure you have selected a valid project."
-        />
-      </div>
-    )
-  }
-
   if (!isLoadingProject && !project) {
     return (
       <div className="h-full flex flex-col p-6">


### PR DESCRIPTION
- users are seeing query timeouts in the query performance page
- Wrapped avg_rows in coalesce(rows::numeric / nullif(calls, 0), 0) to avoid division-by-zero
- Wrapped prop_total_time in coalesce(... / nullif(sum(...), 0) * 100, 0) to avoid division-by-zero and default to 0%.
- Refactored unified query to use a base CTE, then select from it; index-advisor now reads from base.query and the same filtering/ordering/limit apply once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented division-by-zero and improved handling of missing/zero values in report calculations, returning sensible defaults.
  * Removed an early error notice for a missing project reference so the page now renders using a default reference instead of showing an admonition.

* **Refactor**
  * Reworked the report query pipeline into a two-stage base-and-final layering and expanded the base result window to improve consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->