### PR TITLE
fix: Clear the feedback text area after sending

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
@@ -72,6 +72,7 @@ export const FeedbackWidget = ({ onClose }: FeedbackWidgetProps) => {
     onSuccess: () => {
       setIsFeedbackSent(true)
       setFeedback('')
+      setStoredFeedback(null)
       setScreenshot(null)
       setSending(false)
     },

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
@@ -295,9 +295,9 @@ export const FeedbackWidget = ({ onClose }: FeedbackWidgetProps) => {
 
 const ThanksMessage = ({ onClose }: { onClose: () => void }) => {
   return (
-    <div className="px-0 pt-3 pb-0">
-      <div className="grid gap-3">
-        <div className="px-6 grid gap-4 py-3 text-center text-foreground-light">
+    <div>
+      <div className="grid gap-3 py-3">
+        <div className="px-6 grid gap-4 text-center text-foreground-light">
           <CircleCheck className="mx-auto text-brand-500" size={24} />
           <div className="text-center flex flex-col">
             <p className="text-foreground text-base">Your feedback has been sent. Thanks!</p>


### PR DESCRIPTION
The text area in the feedback widget kept the same value after sending the feedback. The value was stored in local storage and loaded upon reopening. 

This PR clears the value from local storage when the feedback has been sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Feedback data is now properly cleared from local storage after successful submission.

* **Style**
  * Refined layout and spacing of the feedback submission confirmation message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->