### PR TITLE
docs: fix silent 404/build error on SSR guide (missing partial)

### DIFF
--- a/apps/docs/content/guides/auth/server-side.mdx
+++ b/apps/docs/content/guides/auth/server-side.mdx
@@ -17,10 +17,6 @@ Make sure to use the PKCE flow instructions where those differ from the implicit
 
 We have developed an [`@supabase/ssr`](https://www.npmjs.com/package/@supabase/ssr) package to make setting up the Supabase client as simple as possible. This package is currently in beta. Adoption is recommended but be aware that the API is still unstable and may have breaking changes in the future.
 
-<$Partial
-path="auth_helpers.mdx"
-/>
-
 ## Framework quickstarts
 
 <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-6 mb-6 not-prose">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Bug fix / Docs update.

## What is the current behavior?
The `/auth/server-side` guide is currently returning a 404 error.

This is related to issue #41467. While some redirects have been proposed, the root cause is not a missing mdx file but a silent build-time error caused by a reference to a partial that was removed in #41441.

## What is the new behavior?
This PR removes the obsolete reference to the missing partial, restoring the page generation and the full UI layout.

Unlike a redirect, this fix preserves the original page (from [this page](https://supabase.com/docs/guides/auth/server-side/creating-a-client), clicking on the breadcrumb shows a 404)

## Additional context
Technical Root Cause: The build process currently allows for "silent failures" when a partial is missing, it does not differentiate whether the missing file is the targeted `.mdx` or one of its partial dependencies. You can see the logic that swallows these errors here: https://github.com/supabase/supabase/blob/f0acececce4b216ae9dfd11bffee5df165b238e8/apps/docs/features/docs/GuidesMdx.utils.tsx#L91-L94.

This is why the regression in #41441 passed CI without alerts. I'd recommend making this a "hard error" if it's a missing dependency in the future to ensure integrity.

Fixes #41467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured authentication guide documentation to streamline content organization and layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->