### PR TITLE
Joshen/fe 2285 shift read replicas into database replication section

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { DestinationForm } from './DestinationForm'
 import { DestinationType } from './DestinationPanel.types'
 import { DestinationTypeSelection } from './DestinationTypeSelection'
+import { ReadReplicaForm } from './ReadReplicaForm'
 
 interface DestinationPanelProps {
   visible: boolean
@@ -66,9 +67,7 @@ export const DestinationPanel = ({
             <DialogSectionSeparator />
 
             {selectedType === 'Read Replica' ? (
-              <div className="w-full h-full flex items-center justify-center">
-                <p className="text-foreground-lighter text-sm">Coming soon</p>
-              </div>
+              <ReadReplicaForm onClose={onClose} />
             ) : (
               <DestinationForm
                 visible={visible}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
@@ -52,10 +52,6 @@ export const ReadReplicaEligibilityWarnings = () => {
         )
         setRefetchInterval(5000)
       },
-      onError: () => {
-        toast('test')
-        setRefetchInterval(5000)
-      },
     }
   )
 
@@ -113,7 +109,7 @@ export const ReadReplicaEligibilityWarnings = () => {
         title="Read replicas can only be deployed with projects on Postgres version 15 and above"
       >
         <p>If you'd like to use read replicas, please contact us via support</p>
-        <Button type="default" className="mt-2">
+        <Button asChild type="default" className="mt-2">
           <SupportLink
             queryParams={{
               projectRef,

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
@@ -1,0 +1,251 @@
+import { SupportCategories } from '@supabase/shared-types/out/constants'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import { useParams } from 'common'
+import { SupportLink } from 'components/interfaces/Support/SupportLink'
+import { DocsButton } from 'components/ui/DocsButton'
+import { UpgradePlanButton } from 'components/ui/UpgradePlanButton'
+import { useEnablePhysicalBackupsMutation } from 'data/database/enable-physical-backups-mutation'
+import { useProjectDetailQuery } from 'data/projects/project-detail-query'
+import { MAX_REPLICAS_ABOVE_XL, MAX_REPLICAS_BELOW_XL } from 'data/read-replicas/replicas-query'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { DOCS_URL } from 'lib/constants'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns'
+import { useCheckEligibilityDeployReplica } from './useCheckEligibilityDeployReplica'
+
+export const ReadReplicaEligibilityWarnings = () => {
+  const { ref: projectRef } = useParams()
+  const { data: org } = useSelectedOrganizationQuery()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [refetchInterval, setRefetchInterval] = useState<number | false>(false)
+
+  const {
+    hasOverdueInvoices,
+    isAWSProvider,
+    isAwsK8s,
+    isPgVersionBelow15,
+    isBelowSmallCompute,
+    isWalgNotEnabled,
+    isProWithSpendCapEnabled,
+    isReachedMaxReplicas,
+    maxNumberOfReplicas,
+  } = useCheckEligibilityDeployReplica()
+
+  const { data: projectDetail, isSuccess: isProjectDetailSuccess } = useProjectDetailQuery(
+    { ref: projectRef },
+    {
+      refetchInterval,
+      refetchOnWindowFocus: false,
+    }
+  )
+
+  const { mutate: enablePhysicalBackups, isPending: isEnabling } = useEnablePhysicalBackupsMutation(
+    {
+      onSuccess: () => {
+        toast.success(
+          'Physical backups are currently being enabled, please check back in a few minutes!'
+        )
+        setRefetchInterval(5000)
+      },
+      onError: () => {
+        toast('test')
+        setRefetchInterval(5000)
+      },
+    }
+  )
+
+  useEffect(() => {
+    if (!isProjectDetailSuccess) return
+    if (projectDetail.is_physical_backups_enabled) {
+      setRefetchInterval(false)
+    }
+  }, [projectDetail?.is_physical_backups_enabled, isProjectDetailSuccess])
+
+  if (hasOverdueInvoices) {
+    return (
+      <Admonition type="warning" title="Your organization has overdue invoices">
+        <p>Please resolve all outstanding invoices first before deploying a new read replica</p>
+        <Button asChild type="default" className="mt-2">
+          <Link href={`/org/${org?.slug}/billing#invoices`}>View invoices</Link>
+        </Button>
+      </Admonition>
+    )
+  }
+
+  if (!isAWSProvider) {
+    return (
+      <Admonition
+        type="warning"
+        title="Read replicas are only supported for projects provisioned via AWS"
+      >
+        <p>
+          Projects provisioned by other cloud providers currently will not be able to use read
+          replicas
+        </p>
+        <DocsButton
+          abbrev={false}
+          className="mt-2"
+          href={`${DOCS_URL}/guides/platform/read-replicas#prerequisites`}
+        />
+      </Admonition>
+    )
+  }
+
+  if (isAwsK8s) {
+    return (
+      <Admonition
+        type="warning"
+        title="Read replicas are not supported for AWS (Revamped) projects"
+        description="Projects provisioned by other cloud providers currently will not be able to use read replicas"
+      />
+    )
+  }
+
+  if (isPgVersionBelow15) {
+    return (
+      <Admonition
+        type="warning"
+        title="Read replicas can only be deployed with projects on Postgres version 15 and above"
+      >
+        <p>If you'd like to use read replicas, please contact us via support</p>
+        <Button type="default" className="mt-2">
+          <SupportLink
+            queryParams={{
+              projectRef,
+              category: SupportCategories.SALES_ENQUIRY,
+              subject: 'Enquiry on read replicas',
+              message: `Project DB version: ${project?.dbVersion}`,
+            }}
+          >
+            Contact support
+          </SupportLink>
+        </Button>
+      </Admonition>
+    )
+  }
+
+  if (isBelowSmallCompute) {
+    return (
+      <Admonition type="warning" title="Project required to at least be on a Small compute">
+        <p>
+          This is to ensure that read replicas can keep up with the primary databases' activities.
+        </p>
+        <div className="flex items-center gap-x-2 mt-2">
+          <UpgradePlanButton
+            type="default"
+            plan="Pro"
+            addon="computeSize"
+            source="read-replicas"
+            featureProposition="deploy Read Replicas"
+          >
+            Change compute size
+          </UpgradePlanButton>
+          <DocsButton href={`${DOCS_URL}/guides/platform/read-replicas#prerequisites`} />
+        </div>
+      </Admonition>
+    )
+  }
+
+  if (isWalgNotEnabled) {
+    return (
+      <Admonition
+        type="warning"
+        title={
+          refetchInterval === false
+            ? 'Physical backups are required to deploy replicas'
+            : 'Physical backups are currently being enabled'
+        }
+      >
+        {refetchInterval === false ? (
+          <>
+            <p>
+              Physical backups are used under the hood to spin up read replicas for your project.
+            </p>
+            <p>
+              Enabling physical backups will take a few minutes, after which you will be able to
+              deploy read replicas.
+            </p>
+          </>
+        ) : (
+          <>
+            <p>
+              This warning will go away once physical backups have been enabled - check back in a
+              few minutes!
+            </p>
+            <p>You may start deploying read replicas thereafter once this is completed.</p>
+          </>
+        )}
+        {refetchInterval === false && (
+          <div className="flex items-center gap-x-2 mt-2">
+            <Button
+              type="default"
+              loading={isEnabling}
+              disabled={isEnabling}
+              onClick={() => {
+                if (projectRef) enablePhysicalBackups({ ref: projectRef })
+              }}
+            >
+              Enable physical backups
+            </Button>
+            <DocsButton
+              abbrev={false}
+              href={`${DOCS_URL}/guides/platform/read-replicas#how-are-read-replicas-made`}
+            />
+          </div>
+        )}
+      </Admonition>
+    )
+  }
+
+  if (isProWithSpendCapEnabled) {
+    return (
+      <Admonition type="warning" title="Spend cap needs to be disabled to deploy replicas">
+        <p>
+          Launching a replica incurs additional disk size that will exceed the plan's quota. Disable
+          the spend cap first to allow overages before launching a replica.
+        </p>
+        <UpgradePlanButton
+          type="default"
+          source="read-replicas"
+          addon="spendCap"
+          className="mt-2"
+        />
+      </Admonition>
+    )
+  }
+
+  if (isReachedMaxReplicas) {
+    return (
+      <Admonition
+        type="warning"
+        title={`You can only deploy up to ${maxNumberOfReplicas} read replicas at once`}
+      >
+        <p>If you'd like to spin up another read replica, please drop an existing replica first.</p>
+        {maxNumberOfReplicas === MAX_REPLICAS_BELOW_XL && (
+          <>
+            <p>
+              Alternatively, you may deploy up to{' '}
+              <span className="text-foreground">{MAX_REPLICAS_ABOVE_XL}</span> replicas if your
+              project is on an XL compute or higher.
+            </p>
+            <UpgradePlanButton
+              type="default"
+              plan="Pro"
+              addon="computeSize"
+              source="read-replicas"
+              featureProposition="deploy Read Replicas"
+              className="mt-2"
+            >
+              Change compute size
+            </UpgradePlanButton>
+          </>
+        )}
+      </Admonition>
+    )
+  }
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaPricingDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaPricingDialog.tsx
@@ -1,0 +1,114 @@
+import { DocsButton } from 'components/ui/DocsButton'
+import { InlineLinkClassName } from 'components/ui/InlineLink'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { DOCS_URL } from 'lib/constants'
+import {
+  cn,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from 'ui'
+import { useGetReplicaCost } from './useGetReplicaCost'
+
+export const ReadReplicaPricingDialog = () => {
+  const { data: project } = useSelectedProjectQuery()
+  const { compute, disk, iops, throughput } = useGetReplicaCost()
+
+  const showNewDiskManagementUI = project?.cloud_provider === 'AWS'
+
+  return (
+    <Dialog>
+      <DialogTrigger>
+        <p className={cn(InlineLinkClassName, 'text-sm text-foreground-light cursor-pointer')}>
+          Learn more
+        </p>
+      </DialogTrigger>
+      <DialogContent
+        size={showNewDiskManagementUI ? 'medium' : 'small'}
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle>Calculating costs for a new read replica</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection>
+          {showNewDiskManagementUI ? (
+            <>
+              <p className="text-foreground-light text-sm mb-2">
+                Read replicas will match the compute size of your primary database and will include
+                25% more disk size than the primary database to accommodate WAL files.
+              </p>
+              <p className="text-foreground-light text-sm">
+                The additional cost for the replica breaks down to:
+              </p>
+              <Table>
+                <TableHeader className="font-mono uppercase text-xs [&_th]:h-auto [&_th]:pb-2 [&_th]:pt-4">
+                  <TableRow>
+                    <TableHead className="w-[140px] pl-0">Item</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="text-right pr-0">Cost (/month)</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="[&_td]:py-0 [&_tr]:h-[50px] [&_tr]:border-dotted">
+                  <TableRow>
+                    <TableCell className="pl-0">Compute size</TableCell>
+                    <TableCell>{compute.label}</TableCell>
+                    <TableCell className="text-right font-mono pr-0" translate="no">
+                      {compute.cost}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell className="pl-0">Disk size</TableCell>
+                    <TableCell>{disk.label}</TableCell>
+                    <TableCell className="text-right font-mono pr-0" translate="no">
+                      {disk.cost}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell className="pl-0">IOPS</TableCell>
+                    <TableCell>{iops.label}</TableCell>
+                    <TableCell className="text-right font-mono pr-0" translate="no">
+                      {iops.cost}
+                    </TableCell>
+                  </TableRow>
+                  {disk.type === 'gp3' && (
+                    <TableRow>
+                      <TableCell className="pl-0">Throughput</TableCell>
+                      <TableCell>{throughput.label}</TableCell>
+                      <TableCell className="text-right font-mono pr-0">{throughput.cost}</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </>
+          ) : (
+            <p className="text-foreground-light text-sm">
+              Read replicas will be on the same compute size as your primary database. Deploying a
+              read replica on the <span className="text-foreground">{compute.label}</span> size
+              incurs additional{' '}
+              <span className="text-foreground" translate="no">
+                {compute?.priceDescription}
+              </span>
+              .
+            </p>
+          )}
+        </DialogSection>
+
+        <DialogFooter>
+          <DocsButton href={`${DOCS_URL}/guides/platform/manage-your-usage/read-replicas`} />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaPricingDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaPricingDialog.tsx
@@ -29,10 +29,10 @@ export const ReadReplicaPricingDialog = () => {
 
   return (
     <Dialog>
-      <DialogTrigger>
-        <p className={cn(InlineLinkClassName, 'text-sm text-foreground-light cursor-pointer')}>
+      <DialogTrigger asChild>
+        <button className={cn(InlineLinkClassName, 'text-sm text-foreground-light')}>
           Learn more
-        </p>
+        </button>
       </DialogTrigger>
       <DialogContent
         size={showNewDiskManagementUI ? 'medium' : 'small'}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
@@ -89,7 +89,7 @@ export const ReadReplicaForm = ({ onSuccess, onClose }: ReadReplicaFormProps) =>
             disabled={!canDeployReplica}
           >
             <SelectTrigger_Shadcn_>
-              <SelectValue_Shadcn_ placeholder="Select primary email" />
+              <SelectValue_Shadcn_ placeholder="Select a region" />
             </SelectTrigger_Shadcn_>
             <SelectContent_Shadcn_>
               {availableRegions.map((region) => (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { useParams } from 'common'
+import { AVAILABLE_REPLICA_REGIONS } from 'components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
+import { Region, useReadReplicaSetUpMutation } from 'data/read-replicas/replica-setup-mutation'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { AWS_REGIONS_DEFAULT, BASE_PATH } from 'lib/constants'
+import { AWS_REGIONS, AWS_REGIONS_KEYS } from 'shared-data'
+import {
+  Button,
+  InfoIcon,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+  SheetFooter,
+  SheetSection,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { ReadReplicaEligibilityWarnings } from './ReadReplicaEligibilityWarnings'
+import { ReadReplicaPricingDialog } from './ReadReplicaPricingDialog'
+import { useCheckEligibilityDeployReplica } from './useCheckEligibilityDeployReplica'
+import { useGetReplicaCost } from './useGetReplicaCost'
+
+interface ReadReplicaFormProps {
+  // [Joshen] Need to refetch replicas on the parent since they're created async
+  onSuccess?: () => void
+  onClose: () => void
+}
+
+export const ReadReplicaForm = ({ onSuccess, onClose }: ReadReplicaFormProps) => {
+  const { ref: projectRef } = useParams()
+  const { data } = useReadReplicasQuery({ projectRef })
+
+  const [defaultRegion] = Object.entries(AWS_REGIONS).find(
+    ([_, name]) => name === AWS_REGIONS_DEFAULT
+  ) ?? ['ap-southeast-1']
+  const { totalCost } = useGetReplicaCost()
+  const { can: canDeployReplica } = useCheckEligibilityDeployReplica()
+
+  const [selectedRegion, setSelectedRegion] = useState<string>(defaultRegion)
+
+  const { mutate: setUpReplica, isPending: isSettingUp } = useReadReplicaSetUpMutation({
+    onSuccess: () => {
+      const region = AVAILABLE_REPLICA_REGIONS.find((r) => r.key === selectedRegion)?.name
+      toast.success(`Spinning up new replica in ${region ?? ' Unknown'}...`)
+      onSuccess?.()
+      onClose()
+    },
+  })
+
+  const availableRegions =
+    process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+      ? AVAILABLE_REPLICA_REGIONS.filter((x) =>
+          ['SOUTHEAST_ASIA', 'CENTRAL_EU', 'EAST_US'].includes(x.key)
+        )
+      : AVAILABLE_REPLICA_REGIONS
+
+  const onSubmit = async () => {
+    const regionKey = AWS_REGIONS[selectedRegion as AWS_REGIONS_KEYS].code
+    if (!projectRef) return console.error('Project is required')
+    if (!regionKey) return toast.error('Unable to deploy replica: Unsupported region selected')
+
+    const primary = data?.find((db) => db.identifier === projectRef)
+    setUpReplica({ projectRef, region: regionKey as Region, size: primary?.size ?? 't4g.small' })
+  }
+
+  return (
+    <>
+      {!canDeployReplica && (
+        <SheetSection>
+          <ReadReplicaEligibilityWarnings />
+        </SheetSection>
+      )}
+
+      <SheetSection className="flex-grow overflow-auto px-0 py-0">
+        <FormItemLayout
+          isReactForm={false}
+          layout="horizontal"
+          className="p-5 [&>div]:gap-y-1 [&>div>span]:text-foreground-lighter"
+          label="Region"
+          labelOptional="Select a region to deploy your replica in"
+        >
+          <Select_Shadcn_
+            value={selectedRegion}
+            onValueChange={setSelectedRegion}
+            disabled={!canDeployReplica}
+          >
+            <SelectTrigger_Shadcn_>
+              <SelectValue_Shadcn_ placeholder="Select primary email" />
+            </SelectTrigger_Shadcn_>
+            <SelectContent_Shadcn_>
+              {availableRegions.map((region) => (
+                <SelectItem_Shadcn_ key={region.key} value={region.key}>
+                  <div className="flex gap-x-3 items-center">
+                    <img
+                      alt="region icon"
+                      className="w-5 rounded-sm"
+                      src={`${BASE_PATH}/img/regions/${region.region}.svg`}
+                    />
+                    <p className="flex items-center gap-x-2">
+                      <span>{region.name}</span>
+                      <span className="text-xs text-foreground-lighter font-mono">
+                        {region.region}
+                      </span>
+                    </p>
+                  </div>
+                </SelectItem_Shadcn_>
+              ))}
+            </SelectContent_Shadcn_>
+          </Select_Shadcn_>
+        </FormItemLayout>
+      </SheetSection>
+      <SheetFooter className="!justify-between">
+        <div className="flex items-center gap-x-4">
+          <InfoIcon className="h-5 w-5" />
+          <p className="text-sm">
+            New replica will cost an additional <span translate="no">{totalCost}/month</span>
+          </p>
+          <ReadReplicaPricingDialog />
+        </div>
+
+        <div className="flex items-center gap-x-2">
+          <Button disabled={isSettingUp} type="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={!canDeployReplica} loading={isSettingUp} onClick={onSubmit}>
+            Deploy replica
+          </Button>
+        </div>
+      </SheetFooter>
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica.ts
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+
+import { useParams } from 'common'
+import { useOverdueInvoicesQuery } from 'data/invoices/invoices-overdue-query'
+import {
+  MAX_REPLICAS_ABOVE_XL,
+  MAX_REPLICAS_BELOW_XL,
+  useReadReplicasQuery,
+} from 'data/read-replicas/replicas-query'
+import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useIsAwsK8sCloudProvider, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+
+export const useCheckEligibilityDeployReplica = () => {
+  const { ref: projectRef } = useParams()
+  const isAwsK8s = useIsAwsK8sCloudProvider()
+  const { data: project } = useSelectedProjectQuery()
+  const { data: org } = useSelectedOrganizationQuery()
+
+  const isFreePlan = org?.plan.id === 'free'
+  const isAWSProvider = project?.cloud_provider === 'AWS'
+  const isWalgEnabled = project?.is_physical_backups_enabled
+  const isNotOnHigherPlan = useMemo(
+    () => !['team', 'enterprise', 'platform'].includes(org?.plan.id ?? ''),
+    [org]
+  )
+  const isProWithSpendCapEnabled = org?.plan.id === 'pro' && !org.usage_billing_enabled
+
+  const { data: allOverdueInvoices } = useOverdueInvoicesQuery({
+    enabled: isNotOnHigherPlan,
+  })
+  const overdueInvoices = (allOverdueInvoices ?? []).filter(
+    (x) => x.organization_id === project?.organization_id
+  )
+  const hasOverdueInvoices = overdueInvoices.length > 0 && isNotOnHigherPlan
+
+  const { data: databases = [] } = useReadReplicasQuery({ projectRef })
+
+  const { data: addons } = useProjectAddonsQuery({ projectRef })
+  // Will be following the primary's compute size for the time being
+  const currentComputeAddon = addons?.selected_addons.find(
+    (addon) => addon.type === 'compute_instance'
+  )?.variant.identifier
+  const isMinimallyOnSmallCompute =
+    currentComputeAddon !== undefined && currentComputeAddon !== 'ci_micro'
+
+  const maxNumberOfReplicas = ['ci_micro', 'ci_small', 'ci_medium', 'ci_large'].includes(
+    currentComputeAddon ?? 'ci_micro'
+  )
+    ? MAX_REPLICAS_BELOW_XL
+    : MAX_REPLICAS_ABOVE_XL
+  const isReachedMaxReplicas =
+    (databases ?? []).filter((db) => db.identifier !== projectRef).length >= maxNumberOfReplicas
+
+  const currentPgVersion = Number(
+    (project?.dbVersion ?? '').split('supabase-postgres-')[1]?.split('.')[0]
+  )
+
+  const canDeployReplica =
+    !isReachedMaxReplicas &&
+    currentPgVersion >= 15 &&
+    isAWSProvider &&
+    !isFreePlan &&
+    isWalgEnabled &&
+    currentComputeAddon !== undefined &&
+    !hasOverdueInvoices &&
+    !isAwsK8s &&
+    !isProWithSpendCapEnabled &&
+    isMinimallyOnSmallCompute
+
+  return {
+    can: canDeployReplica,
+    hasOverdueInvoices,
+    isAWSProvider,
+    isAwsK8s,
+    isPgVersionBelow15: currentPgVersion < 15,
+    isBelowSmallCompute: !isMinimallyOnSmallCompute,
+    isWalgNotEnabled: !isWalgEnabled,
+    isProWithSpendCapEnabled,
+    isReachedMaxReplicas,
+    maxNumberOfReplicas,
+  }
+}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useGetReplicaCost.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useGetReplicaCost.ts
@@ -1,0 +1,79 @@
+import { useParams } from 'common'
+import {
+  calculateIOPSPrice,
+  calculateThroughputPrice,
+} from 'components/interfaces/DiskManagement/DiskManagement.utils'
+import {
+  DISK_PRICING,
+  DiskType,
+} from 'components/interfaces/DiskManagement/ui/DiskManagement.constants'
+import { useDiskAttributesQuery } from 'data/config/disk-attributes-query'
+import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
+import { formatCurrency } from 'lib/helpers'
+
+export const useGetReplicaCost = () => {
+  const { ref: projectRef } = useParams()
+  const { data: addons } = useProjectAddonsQuery({ projectRef })
+  const { data: diskConfiguration } = useDiskAttributesQuery({ projectRef })
+
+  const currentComputeAddon = addons?.selected_addons.find(
+    (addon) => addon.type === 'compute_instance'
+  )?.variant.identifier
+  const computeAddons =
+    addons?.available_addons.find((addon) => addon.type === 'compute_instance')?.variants ?? []
+  const selectedComputeMeta = computeAddons.find(
+    (addon) => addon.identifier === currentComputeAddon
+  )
+  const estComputeMonthlyCost = Math.floor((selectedComputeMeta?.price ?? 0) * 730) // 730 hours in a month
+
+  // @ts-ignore API types issue
+  const { size_gb, type, throughput_mbps, iops } = diskConfiguration?.attributes ?? {}
+  const readReplicaDiskSizes = (size_gb ?? 0) * 1.25
+  const additionalCostDiskSize =
+    readReplicaDiskSizes * (DISK_PRICING[type as DiskType]?.storage ?? 0)
+  const additionalCostIOPS = calculateIOPSPrice({
+    oldStorageType: type as DiskType,
+    newStorageType: type as DiskType,
+    oldProvisionedIOPS: 0,
+    newProvisionedIOPS: iops ?? 0,
+    numReplicas: 0,
+  }).newPrice
+  const additionalCostThroughput =
+    type === 'gp3'
+      ? calculateThroughputPrice({
+          storageType: type as DiskType,
+          newThroughput: throughput_mbps ?? 0,
+          oldThroughput: 0,
+          numReplicas: 0,
+        }).newPrice
+      : 0
+
+  const totalCost = formatCurrency(
+    estComputeMonthlyCost +
+      additionalCostDiskSize +
+      Number(additionalCostIOPS) +
+      Number(additionalCostThroughput)
+  )
+
+  return {
+    totalCost,
+    compute: {
+      label: selectedComputeMeta?.name,
+      cost: formatCurrency(estComputeMonthlyCost),
+      priceDescription: selectedComputeMeta?.price_description,
+    },
+    disk: {
+      type,
+      label: `${((size_gb ?? 0) * 1.25).toLocaleString()} GB (${type})`,
+      cost: formatCurrency(additionalCostDiskSize),
+    },
+    iops: {
+      label: `${iops?.toLocaleString()} IOPS`,
+      cost: formatCurrency(+additionalCostIOPS),
+    },
+    throughput: {
+      label: `${throughput_mbps?.toLocaleString()} MB/s`,
+      cost: formatCurrency(+additionalCostThroughput),
+    },
+  }
+}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -89,7 +89,8 @@ const InfrastructureInfo = () => {
     <>
       <ScaffoldDivider />
       {project?.cloud_provider !== 'FLY' &&
-        (unifiedReplication ? (
+        // [Joshen TODO] switch this back to unifiedReplication
+        (false ? (
           <ScaffoldContainer>
             <ScaffoldSection isFullWidth>
               <NoticeBar

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -89,8 +89,7 @@ const InfrastructureInfo = () => {
     <>
       <ScaffoldDivider />
       {project?.cloud_provider !== 'FLY' &&
-        // [Joshen TODO] switch this back to unifiedReplication
-        (false ? (
+        (unifiedReplication ? (
           <ScaffoldContainer>
             <ScaffoldSection isFullWidth>
               <NoticeBar

--- a/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
+++ b/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
@@ -47,6 +47,7 @@ interface RequestUpgradeToBillingOwnersProps {
   addon?: 'pitr' | 'customDomain' | 'spendCap' | 'computeSize'
   /** Used in the default message template, e.g: "Upgrade to ..." */
   featureProposition?: string
+  className?: string
 }
 
 export const RequestUpgradeToBillingOwners = ({
@@ -55,6 +56,7 @@ export const RequestUpgradeToBillingOwners = ({
   addon,
   featureProposition,
   children,
+  className,
 }: PropsWithChildren<RequestUpgradeToBillingOwnersProps>) => {
   const [open, setOpen] = useState(false)
   const track = useTrack()
@@ -154,7 +156,7 @@ export const RequestUpgradeToBillingOwners = ({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button block={block} type="primary">
+        <Button block={block} type="primary" className={className}>
           {buttonText}
         </Button>
       </DialogTrigger>

--- a/apps/studio/components/ui/UpgradePlanButton.tsx
+++ b/apps/studio/components/ui/UpgradePlanButton.tsx
@@ -23,6 +23,7 @@ interface UpgradePlanButtonProps {
   /** Used in the default message template for request upgrade dialog, e.g: "Upgrade to ..." */
   featureProposition?: string
   disabled?: boolean
+  className?: string
 }
 
 /**
@@ -38,6 +39,7 @@ export const UpgradePlanButton = ({
   featureProposition,
   disabled,
   children,
+  className,
 }: PropsWithChildren<UpgradePlanButtonProps>) => {
   const { ref } = useParams()
   const { data: organization } = useSelectedOrganizationQuery()
@@ -62,7 +64,9 @@ export const UpgradePlanButton = ({
   const href = isRequestingToDisableSpendCap
     ? `/org/${slug ?? '_'}/billing?panel=costControl&source=${source}`
     : isOnPaidPlanAndRequestingToPurchaseAddon
-      ? `/project/${ref ?? '_'}/settings/addons?panel=${addon}&source=${source}`
+      ? addon === 'computeSize'
+        ? `/project/${ref ?? '_'}/settings/compute-and-disk`
+        : `/project/${ref ?? '_'}/settings/addons?panel=${addon}&source=${source}`
       : `/org/${slug ?? '_'}/billing?panel=subscriptionPlan&source=${source}`
 
   const linkChildren = children || (!!addon ? 'Enable add-on' : `Upgrade to ${plan}`)
@@ -80,6 +84,7 @@ export const UpgradePlanButton = ({
         plan={plan}
         addon={addon}
         featureProposition={featureProposition}
+        className={className}
       >
         {children}
       </RequestUpgradeToBillingOwners>
@@ -91,6 +96,7 @@ export const UpgradePlanButton = ({
       <ButtonTooltip
         disabled
         type="primary"
+        className={className}
         tooltip={{
           content: {
             side: 'bottom',
@@ -104,7 +110,7 @@ export const UpgradePlanButton = ({
   }
 
   return (
-    <Button asChild type={type} disabled={disabled}>
+    <Button asChild type={type} disabled={disabled} className={className}>
       {link}
     </Button>
   )


### PR DESCRIPTION
## Context

Related project: https://linear.app/supabase/project/unify-read-replicas-with-replication-page-f0feb52cf161/overview

Implements creation of read replicas from the replication UI page of the Database Section
It's the same thing as per what was on the project settings -> infrastructure page, also has all the relevant warnings.

<img width="859" height="958" alt="image" src="https://github.com/user-attachments/assets/66bc4fd4-5cd3-4dac-98cb-700ba8f61be0" />

<img width="556" height="499" alt="image" src="https://github.com/user-attachments/assets/d376cd8c-a84a-44b1-a4cd-7a6755724ebc" />


## To test
Note that the changes here only supports creating read replicas, but not showing replicas in the replication UI yet, so I reckon it might be better to test locally

Firstly - you'll want to change `unifiedReplication` to `false` in `InfrastructureInfo` so that you can verify that the replicas are getting deployed. I won't go too much into detail on how to ensure that you project is eligible to deploy read replicas as I'd also like to verify that all the necessary warnings / CTAs are in place to guide the users to land in an eligible state, so let me know if anything's missing 🙏 

- [x] Verify that you can deploy a read replica from the replication UI
  - There'll be nothing shown in the replication UI atm, so verify that the replica is deployed from the project settings -> infrastructure page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read replica deployment flow: region selector, deploy action, and in-app pricing dialog with detailed cost breakdown.

* **UX / Warnings**
  * Comprehensive eligibility guidance with actionable prompts (billing, backups, compute, version limits, max replicas) and contextual next steps.

* **UI Improvements**
  * Styling hook (className) added to upgrade/billing buttons for easier customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->