### PR TITLE
fix(studio): toggle secret visibility independently in edge function secrets

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -57,7 +57,7 @@ const removeWrappingQuotes = (str: string): string => {
 
 const AddNewSecretForm = () => {
   const { ref: projectRef } = useParams()
-  const [visibleSecrets, setVisibleSecrets] = useState<Set<number>>(new Set())
+  const [visibleSecrets, setVisibleSecrets] = useState<Set<string>>(new Set())
   const [duplicateSecretName, setDuplicateSecretName] = useState<string>('')
   const [pendingSecrets, setPendingSecrets] = useState<z.infer<typeof FormSchema> | null>(null)
 
@@ -164,6 +164,46 @@ const AddNewSecretForm = () => {
     setPendingSecrets(null)
   }
 
+  const handleToggleSecretVisibility = (fieldId: string) => {
+    setVisibleSecrets((prev) => {
+      const visibleSet = new Set(prev)
+      if (visibleSet.has(fieldId)) {
+        visibleSet.delete(fieldId)
+      } else {
+        visibleSet.add(fieldId)
+      }
+      return visibleSet
+    })
+  }
+
+  const handleRemoveSecret = (fieldId: string, index: number) => {
+    if (fields.length > 1) {
+      setVisibleSecrets((prev) => {
+        const visibleSet = new Set(prev)
+        visibleSet.delete(fieldId)
+        return visibleSet
+      })
+      remove(index)
+    } else {
+      form.reset(defaultValues)
+      setVisibleSecrets(new Set())
+    }
+  }
+
+  const handleAddAnotherSecret = () => {
+    const formValues = form.getValues('secrets')
+    const isEmptyForm = formValues.every((field) => !field.name && !field.value)
+    if (isEmptyForm) {
+      fields.forEach((_, index) => remove(index))
+      append({ name: '', value: '' })
+      setVisibleSecrets(new Set())
+    } else {
+      append({ name: '', value: '' })
+    }
+  }
+
+  const isSecretVisible = (fieldId: string) => visibleSecrets.has(fieldId)
+
   return (
     <>
       <Form_Shadcn_ {...form}>
@@ -201,7 +241,7 @@ const AddNewSecretForm = () => {
                         <FormControl_Shadcn_>
                           <Input
                             {...field}
-                            type={visibleSecrets.has(index) ? 'text' : 'password'}
+                            type={isSecretVisible(fieldItem.id) ? 'text' : 'password'}
                             data-1p-ignore
                             data-lpignore="true"
                             data-form-type="other"
@@ -211,18 +251,8 @@ const AddNewSecretForm = () => {
                                 <Button
                                   type="text"
                                   className="px-1"
-                                  icon={visibleSecrets.has(index) ? <EyeOff /> : <Eye />}
-                                  onClick={() => {
-                                    setVisibleSecrets((prev) => {
-                                      const next = new Set(prev)
-                                      if (next.has(index)) {
-                                        next.delete(index)
-                                      } else {
-                                        next.add(index)
-                                      }
-                                      return next
-                                    })
-                                  }}
+                                  icon={isSecretVisible(fieldItem.id) ? <EyeOff /> : <Eye />}
+                                  onClick={() => handleToggleSecretVisibility(fieldItem.id)}
                                 />
                               </div>
                             }
@@ -238,44 +268,17 @@ const AddNewSecretForm = () => {
                     className="h-[34px] mt-6"
                     icon={<MinusCircle />}
                     disabled={fields.length <= 1}
-                    onClick={() => {
-                      if (fields.length > 1) {
-                        remove(index)
-                        setVisibleSecrets((prev) => {
-                          const next = new Set<number>()
-                          prev.forEach((i) => {
-                            if (i < index) next.add(i)
-                            else if (i > index) next.add(i - 1)
-                          })
-                          return next
-                        })
-                      } else {
-                        form.reset(defaultValues)
-                        setVisibleSecrets(new Set())
-                      }
-                    }}
+                    onClick={() => handleRemoveSecret(fieldItem.id, index)}
                   />
                 </div>
               ))}
 
-              <Button
-                type="default"
-                onClick={() => {
-                  const formValues = form.getValues('secrets')
-                  const isEmptyForm = formValues.every((field) => !field.name && !field.value)
-                  if (isEmptyForm) {
-                    fields.forEach((_, index) => remove(index))
-                    append({ name: '', value: '' })
-                  } else {
-                    append({ name: '', value: '' })
-                  }
-                }}
-              >
+              <Button type="default" onClick={handleAddAnotherSecret}>
                 Add another
               </Button>
             </CardContent>
             <CardFooter className="justify-between space-x-2">
-              <p className="text-sm text-foreground-lighter">
+              <p className="text-sm text-foreground-muted">
                 Insert or update multiple secrets at once by pasting key-value pairs
               </p>
 

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -191,15 +191,7 @@ const AddNewSecretForm = () => {
   }
 
   const handleAddAnotherSecret = () => {
-    const formValues = form.getValues('secrets')
-    const isEmptyForm = formValues.every((field) => !field.name && !field.value)
-    if (isEmptyForm) {
-      fields.forEach((_, index) => remove(index))
-      append({ name: '', value: '' })
-      setVisibleSecrets(new Set())
-    } else {
-      append({ name: '', value: '' })
-    }
+    append({ name: '', value: '' })
   }
 
   const isSecretVisible = (fieldId: string) => visibleSecrets.has(fieldId)


### PR DESCRIPTION
fixes an issue where clicking the eye icon to reveal one secret's value would reveal all secrets simultaneously.

changed from a single `boolean` to a `Set<number>` to track visibility per `secret index`, with proper index shifting when secrets are removed.

closes #41459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-secret visibility now toggles independently and icons reflect each field’s state.
  * Form resets and visibility are reliably cleared after successful creation.
  * Adding/removing multiple secrets preserves correct visibility state and behavior.
  * Minor UI text color update for descriptive text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->