### PR TITLE
fix(docs)bad-links

### DIFF
--- a/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
@@ -60,4 +60,3 @@ The [`docs/example-alerts.md`](https://github.com/supabase/supabase-grafana/blob
 - 401 errors? Rotate the service role key from the [API settings page](/dashboard/project/_/settings/api-keys) and update the Grafana Cloud credentials.
 - Long scrape durations? Reduce label cardinality in your Grafana queries or lower the time range to focus on recent data.
 
-[← Back to the Metrics API landing](/guides/telemetry/metrics)

--- a/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
@@ -59,4 +59,3 @@ The [`docs/example-alerts.md`](https://github.com/supabase/supabase-grafana/blob
 - Metrics missing? Ensure the Grafana Cloud agent can reach `https://<project-ref>.supabase.co` and that the selected service role key is still valid.
 - 401 errors? Rotate the service role key from the [API settings page](/dashboard/project/_/settings/api-keys) and update the Grafana Cloud credentials.
 - Long scrape durations? Reduce label cardinality in your Grafana queries or lower the time range to focus on recent data.
-

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -80,4 +80,3 @@ You now have over 200 production-ready panels covering CPU, IO, WAL, replication
 - **Multiple projects:** add one scrape job per project ref so you can separate metrics and labels cleanly.
 - **Right-sizing guidance:** pair the dashboards with Supabase’s [Query Performance report](/dashboard/project/_/observability/query-performance) and [Advisors](/dashboard/project/_/observability/database) to decide when to optimize vs upgrade.
 - **Security:** rotate the service role key on a regular cadence and update the Prometheus config accordingly.
-

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -81,4 +81,3 @@ You now have over 200 production-ready panels covering CPU, IO, WAL, replication
 - **Right-sizing guidance:** pair the dashboards with Supabase’s [Query Performance report](/dashboard/project/_/observability/query-performance) and [Advisors](/dashboard/project/_/observability/database) to decide when to optimize vs upgrade.
 - **Security:** rotate the service role key on a regular cadence and update the Prometheus config accordingly.
 
-[← Back to the Metrics API landing](/guides/telemetry/metrics)

--- a/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
@@ -68,4 +68,3 @@ No matter which collector you use, you need to hit the Metrics API once per minu
 - Create one scrape job per project ref so you can control sampling individually.
 - If you run many projects, consider templating the scrape jobs via Helm, Terraform, or the Grafana Agent Operator.
 - Use label joins (`project`, `instance_class`, `org`) to aggregate across tenants or environments.
-

--- a/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
@@ -69,4 +69,3 @@ No matter which collector you use, you need to hit the Metrics API once per minu
 - If you run many projects, consider templating the scrape jobs via Helm, Terraform, or the Grafana Agent Operator.
 - Use label joins (`project`, `instance_class`, `org`) to aggregate across tenants or environments.
 
-[← Back to the Metrics API landing](/guides/telemetry/metrics)


### PR DESCRIPTION
These links are not routing correctly. It was also discussed that such a UI feature in docs should be discussed an implemented in way that could be scaled out more anyway.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix docs

## What is the current behavior?

404

## What is the new behavior?

no 404, no links

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed trailing "Back to the Metrics API landing" navigation links from the Grafana Cloud, Grafana self‑hosted, and vendor‑agnostic metrics guides. This simplifies end-of-guide navigation and removes the duplicate back-link at the bottom of those pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->