### PR TITLE
fix(studio): TSV file upload

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -180,7 +180,7 @@ export const Grid = memo(
                           isValidFileDraggedOver ? (
                             'Drop your CSV file here'
                           ) : (
-                            <span className="text-destructive">Only CSV files are accepted</span>
+                            <span className="text-destructive">Only CSV and TSV files are accepted</span>
                           )
                         ) : (
                           'This table is empty'

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -180,7 +180,9 @@ export const Grid = memo(
                           isValidFileDraggedOver ? (
                             'Drop your CSV file here'
                           ) : (
-                            <span className="text-destructive">Only CSV and TSV files are accepted</span>
+                            <span className="text-destructive">
+                              Only CSV and TSV files are accepted
+                            </span>
                           )
                         ) : (
                           'This table is empty'

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -46,6 +46,7 @@ import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePanelEditor.types'
 import { checkIfRelationChanged } from './TableEditor/ForeignKeysManagement/ForeignKeysManagement.utils'
 import type { ImportContent } from './TableEditor/TableEditor.types'
+import { isTsvFile } from './SpreadsheetImport/SpreadsheetImport.utils'
 
 const BATCH_SIZE = 1000
 const CHUNK_SIZE = 1024 * 1024 * 0.1 // 0.1MB
@@ -1027,7 +1028,7 @@ export const insertRowsViaSpreadsheet = async (
       dynamicTyping: false,
       skipEmptyLines: true,
       chunkSize: CHUNK_SIZE,
-      quoteChar: file.type === 'text/tab-separated-values' ? '' : '"',
+      quoteChar: isTsvFile(file) ? '' : '"',
       chunk: async (results: any, parser: any) => {
         parser.pause()
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetTextInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetTextInput.tsx
@@ -1,32 +1,46 @@
+import { ChangeEvent, KeyboardEvent } from 'react'
 import { Input } from 'ui'
 
 interface SpreadSheetTextInputProps {
   input: string
-  onInputChange: (event: any) => void
+  onInputChange: (value: string) => void
 }
 
-const SpreadSheetTextInput = ({ input, onInputChange }: SpreadSheetTextInputProps) => (
-  <div className="space-y-10">
-    <div>
-      <p className="mb-2 text-sm text-foreground-light">
-        Copy a table from a spreadsheet program such as Google Sheets or Excel and paste it in the
-        field below. The first row should be the headers of the table, and your headers should not
-        include any special characters other than hyphens (<code>-</code>) or underscores (
-        <code>_</code>).
-      </p>
-      <p className="text-sm text-foreground-lighter">
-        Tip: Datetime columns should be formatted as YYYY-MM-DD HH:mm:ss
-      </p>
+const SpreadSheetTextInput = ({ input, onInputChange }: SpreadSheetTextInputProps) => {
+  const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onInputChange(event.target.value)
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Tab") {
+      event.preventDefault()
+      onInputChange(input + "\t")
+    }
+  }
+  return (
+    <div className="space-y-10">
+      <div>
+        <p className="mb-2 text-sm text-foreground-light">
+          Copy a table from a spreadsheet program such as Google Sheets or Excel and paste it in the
+          field below. The first row should be the headers of the table, and your headers should not
+          include any special characters other than hyphens (<code>-</code>) or underscores (
+          <code>_</code>).
+        </p>
+        <p className="text-sm text-foreground-lighter">
+          Tip: Datetime columns should be formatted as YYYY-MM-DD HH:mm:ss
+        </p>
+      </div>
+      <Input.TextArea
+        size="tiny"
+        className="font-mono"
+        rows={15}
+        style={{ resize: 'none' }}
+        value={input}
+        onKeyDown={handleKeyDown}
+        onChange={handleInputChange}
+      />
     </div>
-    <Input.TextArea
-      size="tiny"
-      className="font-mono"
-      rows={15}
-      style={{ resize: 'none' }}
-      value={input}
-      onChange={onInputChange}
-    />
-  </div>
-)
+  )
+}
 
 export default SpreadSheetTextInput

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetTextInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetTextInput.tsx
@@ -12,10 +12,10 @@ const SpreadSheetTextInput = ({ input, onInputChange }: SpreadSheetTextInputProp
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Tab" && !event.shiftKey) {
-      if (!input.endsWith("\t")) {
+    if (event.key === 'Tab' && !event.shiftKey) {
+      if (!input.endsWith('\t')) {
         event.preventDefault()
-        onInputChange(input + "\t")
+        onInputChange(input + '\t')
       }
     }
   }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetTextInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetTextInput.tsx
@@ -12,9 +12,11 @@ const SpreadSheetTextInput = ({ input, onInputChange }: SpreadSheetTextInputProp
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Tab") {
-      event.preventDefault()
-      onInputChange(input + "\t")
+    if (event.key === "Tab" && !event.shiftKey) {
+      if (!input.endsWith("\t")) {
+        event.preventDefault()
+        onInputChange(input + "\t")
+      }
     }
   }
   return (
@@ -27,7 +29,10 @@ const SpreadSheetTextInput = ({ input, onInputChange }: SpreadSheetTextInputProp
           <code>_</code>).
         </p>
         <p className="text-sm text-foreground-lighter">
-          Tip: Datetime columns should be formatted as YYYY-MM-DD HH:mm:ss
+          Tip 1: Datetime columns should be formatted as YYYY-MM-DD HH:mm:ss
+        </p>
+        <p className="text-sm text-foreground-lighter">
+          Tip 2: Press <kbd>Tab</kbd> 2 times to move focus to the next element
         </p>
       </div>
       <Input.TextArea

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -140,9 +140,9 @@ export const SpreadsheetImport = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handler = useCallback(debounce(readSpreadsheetText, debounceDuration), [])
-  const onInputChange = (event: any) => {
-    setInput(event.target.value)
-    handler(event.target.value)
+  const onInputChange = (value: string) => {
+    setInput(value)
+    handler(value)
   }
 
   const onToggleHeader = (header: string) => {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -167,9 +167,9 @@ export const inferColumnType = (column: string, rows: object[]) => {
   return 'text'
 }
 
-export const acceptedFileExtension = (file: any) => {
-  const ext = file?.name.split('.').pop().toLowerCase()
-  return UPLOAD_FILE_EXTENSIONS.includes(ext)
+export const acceptedFileExtension = (file: File) => {
+  const ext = file.name.split('.').pop()?.toLowerCase()
+  return ext !== undefined && UPLOAD_FILE_EXTENSIONS.includes(ext)
 }
 
 /**

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -205,7 +205,7 @@ export function flagInvalidFileImport(file: File): boolean {
   } else if (file.size > MAX_TABLE_EDITOR_IMPORT_CSV_SIZE) {
     toast.error(
       <div className="space-y-1">
-        <p>The dashboard currently only supports importing of CSVs below 100MB.</p>
+        <p>The dashboard currently only supports importing of files below 100MB.</p>
         <p>For bulk data loading, we recommend doing so directly through the database.</p>
         <Button asChild type="default" icon={<ExternalLink />} className="!mt-2">
           <Link

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -68,7 +68,7 @@ export const parseSpreadsheet = (
       dynamicTyping: false,
       skipEmptyLines: true,
       worker: true,
-      quoteChar: file.type === 'text/tab-separated-values' ? '' : '"',
+      quoteChar: isTsvFile(file) ? '' : '"',
       chunkSize: CHUNK_SIZE,
       chunk: (results) => {
         headers = results.meta.fields as string[]
@@ -167,6 +167,11 @@ export const inferColumnType = (column: string, rows: object[]) => {
   return 'text'
 }
 
+export const isTsvFile = (file: File) => {
+  const ext = file.name.split('.').pop()?.toLowerCase()
+  return (file.type.length === 0 || file.type === 'text/tab-separated-values') && ext === 'tsv'
+}
+
 export const acceptedFileExtension = (file: File) => {
   const ext = file.name.split('.').pop()?.toLowerCase()
   return ext !== undefined && UPLOAD_FILE_EXTENSIONS.includes(ext)
@@ -175,10 +180,10 @@ export const acceptedFileExtension = (file: File) => {
 /**
  * Checks file mime type. Returns `true` if the mime type is among the accepted file types
  * or is an empty string.
- * 
+ *
  * The reason for that is that browsers derive the uploaded mime type from the local machine's
  * registry, and sets it to `''` if the machine doesn't have a spot for the type in the machine.
- * 
+ *
  * @param {File} file the file to check the mime type of
  * @returns {boolean} indicates the validity of the mime type, or `true` if it's an empty string
  */

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -172,9 +172,23 @@ export const acceptedFileExtension = (file: any) => {
   return UPLOAD_FILE_EXTENSIONS.includes(ext)
 }
 
+/**
+ * Checks file mime type. Returns `true` if the mime type is among the accepted file types
+ * or is an empty string.
+ * 
+ * The reason for that is that browsers derive the uploaded mime type from the local machine's
+ * registry, and sets it to `''` if the machine doesn't have a spot for the type in the machine.
+ * 
+ * @param {File} file the file to check the mime type of
+ * @returns {boolean} indicates the validity of the mime type, or `true` if it's an empty string
+ */
+export const acceptedFileType = (file: File): boolean => {
+  return file.type.length === 0 || UPLOAD_FILE_TYPES.includes(file.type)
+}
+
 export function flagInvalidFileImport(file: File): boolean {
-  if (!file || !UPLOAD_FILE_TYPES.includes(file.type) || !acceptedFileExtension(file)) {
-    toast.error("Couldn't import file: only CSV files are accepted")
+  if (!file || !acceptedFileType(file) || !acceptedFileExtension(file)) {
+    toast.error("Couldn't import file: only CSV and TSV files are accepted")
     return true
   } else if (file.size > MAX_TABLE_EDITOR_IMPORT_CSV_SIZE) {
     toast.error(

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -186,9 +186,16 @@ export const acceptedFileType = (file: File): boolean => {
   return file.type.length === 0 || UPLOAD_FILE_TYPES.includes(file.type)
 }
 
+export const isFileEmpty = (file: File): boolean => {
+  return file.size === 0
+}
+
 export function flagInvalidFileImport(file: File): boolean {
   if (!file || !acceptedFileType(file) || !acceptedFileExtension(file)) {
     toast.error("Couldn't import file: only CSV and TSV files are accepted")
+    return true
+  } else if (isFileEmpty(file)) {
+    toast.error("Couldn't import file because it is empty")
     return true
   } else if (file.size > MAX_TABLE_EDITOR_IMPORT_CSV_SIZE) {
     toast.error(

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -2,6 +2,7 @@ import { type DragEvent, useCallback, useState } from 'react'
 
 import { type ImportDataFileDroppedEvent } from 'common/telemetry-constants'
 import { flagInvalidFileImport } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
+import { UPLOAD_FILE_TYPES } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.constants'
 
 interface UseCsvFileDropOptions {
   enabled: boolean
@@ -35,7 +36,10 @@ export function useCsvFileDrop({
 
       if (event.type === 'dragover' && !isDraggedOver) {
         setIsDraggedOver(true)
-        setIsValidFile(item.type === 'text/csv')
+        // Can't check extension because browsers don't expose the files while being dragged
+        // for security reasons. Only their metadata (mime type) is available to us before the drop
+        // event
+        setIsValidFile(item.type.length === 0 || UPLOAD_FILE_TYPES.includes(item.type))
       } else if (event.type === 'dragleave' || event.type === 'drop') {
         setIsDraggedOver(false)
         setIsValidFile(false)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Resolves #41493 

- TSV files are fully supported now.
- Users can insert tabs inside "Paste text" section, or press Tab 2 times to focus on next element.
- Upload file error messaging includes TSV.

## Additional context

4 things I want to mention:

**First**: The issue can only be replicated on some machines due to the nature of the bug. The browser gets the mime type from the local machine's registry, which doesn't have a match for `text/tab-separated-values` in my case. The result is that `file.type` is an empty string. I checked it myself:

<img width="872" height="485" alt="mime" src="https://github.com/user-attachments/assets/5cdd1e96-1eff-4f04-833d-b6275c7cab39" />

This is confirmed by [this Stackoverflow thread](https://stackoverflow.com/questions/51724649/mime-type-of-file-returning-empty-in-javascript-on-some-machines). The conclusion is that `file.type` is not a safe mechanism to determine the whether the file is a true CSV or TSV file, extensions are more robust.

**Second**: when a table is empty and users drag a file before dropping it, a red text appears that says "Only CSV files are accepted" if the file is invalid. I tried to include the new context into account, but turns out browsers don't expose file information like file name and content before drop.

So, while the file is being drag, the only information we are allowed to obtain from it is it's mime type, which is, as I said earlier, not reliable enough. That's why I included the empty `file.type` string as a valid case among `UPLOAD_FILE_TYPES`

**Third**: I noticed that the textarea in "Paste text" section doesn't support tab insertion (tabs can be pasted though), so I fixed, and added a note saying that users should press tab 2 times to focus out of the textarea.

**Fourth**: empty files' upload are not handled. If an empty file has been uploaded, a toast popup with a generic error message appears, but no details are shown under the textarea. I just care of the issue by changing the toast message to "Couldn't import file because it is empty".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept TSV files in addition to CSV.
  * Auto-insert a Tab character when pressing Tab in the spreadsheet text input.

* **Bug Fixes**
  * Improved file validation for missing MIME metadata and zero-byte files.
  * Updated drag-and-drop and import messages to list CSV and TSV.

* **Improvements**
  * Converted spreadsheet input to a controlled field and clarified usage tips.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->