### PR TITLE
Docs/real time chat example

### DIFF
--- a/apps/ui-library/config/docs.ts
+++ b/apps/ui-library/config/docs.ts
@@ -104,7 +104,7 @@ export const componentPages: SidebarNavGroup = {
     },
     {
       title: 'Realtime Chat',
-      supportedFrameworks: ['nextjs', 'react-router', 'tanstack', 'react'],
+      supportedFrameworks: ['nextjs', 'react-router', 'expo','tanstack', 'react'],
       href: '/docs/nextjs/realtime-chat',
       items: [],
       commandItemLabel: 'Realtime Chat',
@@ -141,6 +141,7 @@ export const frameworkTitles: Record<string, string> = {
   'react-router': 'React Router',
   tanstack: 'TanStack Start',
   react: 'React SPA',
+  expo: 'Expo',
   vue: 'Vue',
   nuxtjs: 'Nuxt.js',
 }

--- a/apps/ui-library/content/docs/expo/realtime-chat.mdx
+++ b/apps/ui-library/content/docs/expo/realtime-chat.mdx
@@ -1,0 +1,189 @@
+---
+title: Realtime Chat
+description: Real-time chat component for Expo and React Native applications
+---
+
+## Introduction
+
+The Realtime Chat example shows how to build a low-latency chat experience in **Expo and React Native** using Supabase Realtime.
+
+Unlike web-based chat, mobile apps must handle **app backgrounding**, **re-subscription**, and **presence cleanup** explicitly. This guide focuses on those mobile-specific considerations.
+
+---
+
+## How it works under the hood
+
+This example combines multiple Supabase Realtime features:
+
+- **Broadcast** for delivering chat messages
+- **Presence** for tracking online users and typing indicators
+- **Postgres Changes** (optional) for persisted message delivery
+
+Each chat room maps to a single Realtime channel, for example:
+
+```ts
+supabase.channel(`chat:${roomId}`)
+```
+
+---
+
+## Setup
+
+This guide assumes:
+
+- An Expo project using the managed workflow
+- `@supabase/supabase-js` installed
+- A Supabase client configured with `AsyncStorage`
+
+See the [Expo User Management guide](/docs/guides/getting-started/tutorials/with-expo-react-native) for initial setup.
+
+---
+
+## Subscribing to a chat room
+
+In React Native, channel references should be **stored and cleaned up explicitly** to avoid duplicate subscriptions.
+
+```ts
+const channelRef = useRef<RealtimeChannel | null>(null)
+
+useEffect(() => {
+  const channel = supabase.channel(`chat:${roomId}`)
+  channelRef.current = channel
+
+  channel.subscribe((status) => {
+    if (status === 'SUBSCRIBED') {
+      channel.track({
+        userId,
+        typing: false,
+        onlineAt: new Date().toISOString(),
+      })
+    }
+  })
+
+  return () => {
+    supabase.removeChannel(channel)
+  }
+}, [roomId])
+```
+
+---
+
+## Sending messages (Broadcast)
+
+Messages are sent using Broadcast, which provides very low latency but does not persist messages.
+
+```ts
+channel.send({
+  type: 'broadcast',
+  event: 'message',
+  payload: {
+    text,
+    userId,
+    createdAt: new Date().toISOString(),
+  },
+})
+```
+
+If you need message history, persist messages separately using Postgres and load them on mount.
+
+---
+
+## Tracking presence and typing indicators
+
+Presence is used to track:
+
+- Online status
+- Typing state
+
+```ts
+channel.track({
+  userId,
+  typing: true,
+})
+```
+
+A short timeout is typically used to reset typing state after inactivity.
+
+```ts
+setTimeout(() => {
+  channel.track({ userId, typing: false })
+}, 1500)
+```
+
+---
+
+## Reading presence state
+
+Presence state is synchronized across all connected clients and can be queried locally:
+
+```ts
+const state = channel.presenceState()
+```
+
+Use this to determine:
+
+- Whether another user is online
+- Whether they are currently typing
+
+---
+
+## Handling app backgrounding
+
+Mobile apps frequently transition between foreground and background. You should re-sync presence when the app becomes active.
+
+```ts
+import { AppState } from 'react-native'
+
+AppState.addEventListener('change', (state) => {
+  if (state === 'active') {
+    channel.track({ userId, typing: false })
+  }
+})
+```
+
+Failing to do this can result in ghost users or stale presence state.
+
+---
+
+## Cleaning up subscriptions
+
+Always remove channels when a screen unmounts or a room changes:
+
+```ts
+supabase.removeChannel(channel)
+```
+
+This prevents duplicate listeners and incorrect presence counts.
+
+---
+
+## When to use Postgres Changes
+
+Use Postgres Changes if you need:
+
+- Guaranteed message delivery
+- Message persistence
+- Multi-device sync after reconnect
+
+Broadcast and Presence should be treated as ephemeral signals, not durable storage.
+
+---
+
+## Summary
+
+This Expo Realtime Chat example demonstrates:
+
+- Low-latency messaging with Broadcast
+- Online and typing indicators with Presence
+- Safe subscription lifecycle management in React Native
+- Mobile-specific pitfalls and cleanup patterns
+
+For framework-agnostic concepts, see the core [Realtime documentation](https://supabase.com/docs/guides/realtime).
+
+---
+
+## Further reading
+
+- [Realtime Broadcast](https://supabase.com/docs/guides/realtime/broadcast)
+- [Realtime Presence](https://supabase.com/docs/guides/realtime/presence)
+- [Realtime authorization](https://supabase.com/docs/guides/realtime/authorization)

--- a/apps/ui-library/public/llms.txt
+++ b/apps/ui-library/public/llms.txt
@@ -67,6 +67,8 @@ Library of components for your project. The components integrate with Supabase a
     - Avatar stack in realtime
 - [Realtime Chat](https://supabase.com/ui/docs/react/realtime-chat)
     - Real-time chat component for collaborative applications
+- [Realtime Chat](https://supabase.com/ui/docs/expo/realtime-chat)
+    - Real-time chat component for Expo and React Native applications
 - [Realtime Cursor](https://supabase.com/ui/docs/react/realtime-cursor)
     - Real-time cursor sharing for collaborative applications
 - [Social Authentication](https://supabase.com/ui/docs/react/social-auth)

--- a/apps/ui-library/types/nav.ts
+++ b/apps/ui-library/types/nav.ts
@@ -1,4 +1,4 @@
-type supportedFrameworks = 'nextjs' | 'react-router' | 'tanstack' | 'react' | 'vue' | 'nuxtjs'
+type supportedFrameworks = 'nextjs' | 'react-router' | 'tanstack' | 'expo' | 'react' | 'vue' | 'nuxtjs'
 export interface NavItem {
   title: string
   href?: string


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Realtime Chat example is available for web frameworks, but there is no Expo / React Native variant that documents mobile-specific Realtime patterns such as app backgrounding, explicit channel cleanup, or presence re-sync.

## What is the new behavior?

Adds an Expo / React Native variant of the Realtime Chat example to the UI Library docs.

The new page covers:

- Realtime Broadcast for low-latency messaging
- Presence for online status and typing indicators
- Explicit channel lifecycle management in React Native
- Mobile-specific considerations such as app backgrounding and cleanup

## Additional context

This change complements the existing Realtime Chat examples by addressing mobile-specific constraints and does not alter any existing behavior.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Expo and React Native support for the Realtime Chat component

* **Documentation**
  * Added comprehensive guide for building low-latency real-time chat in Expo and React Native, covering mobile-specific considerations, channel management, presence tracking, and lifecycle handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->