### PR TITLE
Disable self-hosted Studio features via server environment variable

### DIFF
--- a/apps/studio/data/profile/profile-query.ts
+++ b/apps/studio/data/profile/profile-query.ts
@@ -14,14 +14,7 @@ export async function getProfile(signal?: AbortSignal) {
 
   if (error) handleError(error)
 
-  if (!IS_PLATFORM) {
-    return {
-      ...data,
-      disabled_features: process.env.NEXT_PUBLIC_DISABLED_FEATURES?.split(',') ?? [],
-    } as Profile
-  } else {
-    return data as Profile
-  }
+  return data as Profile
 }
 
 export type ProfileData = Awaited<ReturnType<typeof getProfile>>

--- a/apps/studio/pages/api/platform/profile/index.ts
+++ b/apps/studio/pages/api/platform/profile/index.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import apiWrapper from 'lib/api/apiWrapper'
 import { DEFAULT_PROJECT } from 'lib/constants/api'
+import { IS_PLATFORM } from 'lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
@@ -35,5 +36,10 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
       },
     ],
   }
+
+  if (!IS_PLATFORM) {
+    response.disabled_features = process.env.DISABLED_FEATURES?.split(',') ?? []
+  }
+
   return res.status(200).json(response)
 }


### PR DESCRIPTION
closes #41500

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Disable features in Studio a la: #17553. To disable features, the `NEXT_PUBLIC_DISABLED_FEATURES` environment variable must be configured at Next.js build time.

## What is the new behavior?

Studio features are still disabled, but changing the server environment like so:

```envrc
# .env
DISABLED_FEATURES=project_edge_function:all,realtime:all
```

Will disable Edge Functions and Realtime in Studio like the following, without requiring a Next.js app re-build:

<img width="1910" height="1826" alt="localhost_8082_project_default_editor" src="https://github.com/user-attachments/assets/ededf268-67e0-40be-8dfc-cb6f15880087" />

## Additional context

[Related Discord thread
](https://discord.com/channels/839993398554656828/1451284005399035944)