### PR TITLE
fix(studio): cron job form incorrectly parses functions without schema prefix

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -41,6 +41,16 @@ describe('parseCronJobCommand', () => {
     })
   })
 
+  it('should default to public schema when function has no schema prefix', () => {
+    const command = 'SELECT truncate_uploaded_images()'
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      type: 'sql_function',
+      schema: 'public',
+      functionName: 'truncate_uploaded_images',
+      snippet: command,
+    })
+  })
+
   it('should return a sql snippet command when the command is SELECT public.test_fn(1, 2)', () => {
     const command = 'SELECT public.test_fn(1, 2)'
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -129,17 +129,19 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
 
   const regexDBFunction = /select\s+[a-zA-Z-_]*\.?[a-zA-Z-_]*\s*\(\)/g
   if (command.toLocaleLowerCase().match(regexDBFunction)) {
-    const [schemaName, functionName] = command
+    const parts = command
       .replace('SELECT ', '')
       .replace(/\(.*\);*/, '')
-
       .trim()
       .split('.')
 
+    const [schema, functionName] =
+      parts.length > 1 ? [parts[0], parts[1]] : ['public', parts[0]]
+
     return {
       type: 'sql_function',
-      schema: schemaName,
-      functionName: functionName,
+      schema,
+      functionName,
       snippet: originalCommand,
     }
   }
@@ -230,7 +232,7 @@ export const formatCronJobColumns = ({
   onSelectDelete: (job: CronJob) => void
 }) => {
   return CRON_TABLE_COLUMNS.map((col) => {
-    const res: Column<any> = {
+    const res: Column<unknown> = {
       key: col.id,
       name: col.name,
       minWidth: col.minWidth ?? 100,


### PR DESCRIPTION
Editing a cron job with `SELECT my_function()` was putting the function name in the Schema dropdown and leaving Function name empty.

Now it correctly defaults to `public` schema when no schema prefix is provided.

closes https://github.com/supabase/supabase/issues/41508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of cron job SQL functions to correctly handle functions referenced without explicit schema prefixes, now defaulting to the public schema.

* **Tests**
  * Added test coverage for cron job SQL function parsing with implicit public schema handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->