### PR TITLE
docs: update msg_id to message_id for rpc delete queue

### DIFF
--- a/apps/docs/content/guides/queues/consuming-messages-with-edge-functions.mdx
+++ b/apps/docs/content/guides/queues/consuming-messages-with-edge-functions.mdx
@@ -39,7 +39,7 @@ async function processMessage(message: QueueMessage) {
   // Delete the message from the queue
   const { error: deleteError } = await supabase.schema('pgmq_public').rpc('delete', {
     queue_name: queueName,
-    msg_id: message.msg_id,
+    message_id: message.msg_id,
   })
 
   if (deleteError) {


### PR DESCRIPTION
msg_id to message_id for rpc delete queue

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

I followed the example, and receive this error while deleting the queue.
<img width="1897" height="759" alt="Screenshot 2025-12-21 at 8 21 37 PM" src="https://github.com/user-attachments/assets/f3bbb041-c63f-4dc5-b1cf-bc9c9db38a0b" />

## What is the new behavior?

No new behaviour change. 

## Additional context

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected parameter naming in the edge functions guide to reflect accurate field names for message deletion operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->