### PR TITLE
Fix/privatelink support

### DIFF
--- a/apps/docs/content/guides/platform/privatelink.mdx
+++ b/apps/docs/content/guides/platform/privatelink.mdx
@@ -178,3 +178,9 @@ The PrivateLink endpoint is a layer 3 solution so behaves like a standard Postgr
 Ready to enhance your database security with PrivateLink? [Contact our Enterprise team](/contact/enterprise) to discuss your requirements and begin the setup process.
 
 Our support team will guide you through the configuration and ensure your private database connectivity meets your security and performance requirements.
+
+## Regional availability
+
+PrivateLink is not currently available in the following regions:
+
+- **eu-central-2 (Zurich)** - Expected availability: April 2026

--- a/apps/studio/components/interfaces/Settings/Integrations/IntegrationsSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/IntegrationsSettings.tsx
@@ -32,7 +32,8 @@ const IntegrationSettings = () => {
   const showAWSPrivateLinkConfigCat = useFlag('awsPrivateLinkIntegration')
   // PrivateLink is not available in eu-central-2 (Zurich) until Feb 2026
   const isPrivateLinkUnsupportedRegion = project?.region === 'eu-central-2'
-  const showAWSPrivateLink = showAWSPrivateLinkFeature && showAWSPrivateLinkConfigCat && !isPrivateLinkUnsupportedRegion
+  const showAWSPrivateLink =
+    showAWSPrivateLinkFeature && showAWSPrivateLinkConfigCat && !isPrivateLinkUnsupportedRegion
 
   return (
     <>

--- a/apps/studio/components/interfaces/Settings/Integrations/IntegrationsSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/IntegrationsSettings.tsx
@@ -30,7 +30,9 @@ const IntegrationSettings = () => {
   const showVercelIntegration = useIsFeatureEnabled('integrations:vercel')
   const showAWSPrivateLinkFeature = useIsFeatureEnabled('integrations:aws_private_link')
   const showAWSPrivateLinkConfigCat = useFlag('awsPrivateLinkIntegration')
-  const showAWSPrivateLink = showAWSPrivateLinkFeature && showAWSPrivateLinkConfigCat
+  // PrivateLink is not available in eu-central-2 (Zurich) until Feb 2026
+  const isPrivateLinkUnsupportedRegion = project?.region === 'eu-central-2'
+  const showAWSPrivateLink = showAWSPrivateLinkFeature && showAWSPrivateLinkConfigCat && !isPrivateLinkUnsupportedRegion
 
   return (
     <>


### PR DESCRIPTION
Quick hotfix to address VPC Lattice being unavailable in eu-central-2 currently.
AWS are saying Feb availability, but giving an extra two months for flexibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added regional availability note for PrivateLink, clarifying it’s not yet available in Zurich (expected April 2026).

* **New Features**
  * Added region-based visibility controls to hide AWS PrivateLink where the service is unsupported (prevents exposure in Zurich until availability).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->