### PR TITLE
Remove isOpened from table editor

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -178,7 +178,6 @@ export const EntityListItem = ({
       className={cn(
         TreeViewItemVariant({
           isSelected: isActive && !isPreview,
-          isOpened: isOpened && !isPreview,
           isPreview,
         }),
         'pl-4 pr-1'


### PR DESCRIPTION
Removes a background class when table is open as a tab within the table editor. We've received feedback this is visually confusing and unnecessary given the tabs are visible

**Before**
<img width="957" height="683" alt="image" src="https://github.com/user-attachments/assets/635fa754-69ca-431f-90e3-8a6813c98886" />

**After**
<img width="942" height="692" alt="image" src="https://github.com/user-attachments/assets/a64bb3d8-ca48-4caa-93b7-398a035498c8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display behavior of tree view item states in the table editor, ensuring proper visual representation when items are expanded or collapsed outside of preview mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->