### PR TITLE
fix: various issues with create index side panel

### DIFF
--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -38,6 +38,7 @@ import { MultiSelectV2 } from 'ui-patterns/MultiSelectDeprecated/MultiSelectV2'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { INDEX_TYPES } from './Indexes.constants'
+import { useProtectedSchemas } from 'hooks/useProtectedSchemas'
 
 interface CreateIndexSidePanelProps {
   visible: boolean
@@ -48,6 +49,8 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
   const { data: project } = useSelectedProjectQuery()
   const isOrioleDb = useIsOrioleDb()
 
+  const { data: protectedSchemas } = useProtectedSchemas()
+
   const [selectedSchema, setSelectedSchema] = useState('public')
   const [selectedEntity, setSelectedEntity] = useState<string | undefined>(undefined)
   const [selectedColumns, setSelectedColumns] = useState<string[]>([])
@@ -56,10 +59,13 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
   const [tableDropdownOpen, setTableDropdownOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
 
-  const { data: schemas } = useSchemasQuery({
+  const { data: AllSchemas } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+  const schemas = (AllSchemas ?? []).filter(
+    (schema) => !protectedSchemas.some((_schema) => _schema.name === schema.name)
+  )
   const { data: entities, isPending: isLoadingEntities } = useEntityTypesQuery({
     schemas: [selectedSchema],
     sort: 'alphabetical',
@@ -187,9 +193,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                 sameWidthAsTrigger
               >
                 <Command_Shadcn_>
-                  <CommandInput_Shadcn_
-                    placeholder="Find table..."
-                  />
+                  <CommandInput_Shadcn_ placeholder="Find table..." />
                   <CommandList_Shadcn_>
                     <CommandEmpty_Shadcn_>No schemas found</CommandEmpty_Shadcn_>
                     <CommandGroup_Shadcn_>

--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -146,7 +146,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
     setSelectedIndexType(INDEX_TYPES[0].value)
   }, [selectedEntity])
 
-  const isSelectEntityDisabled = entityTypes.length === 0
+  const isSelectEntityDisabled = entityTypes.length === 0 && searchTerm.length === 0
 
   return (
     <SidePanel

--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -189,8 +189,6 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                 <Command_Shadcn_>
                   <CommandInput_Shadcn_
                     placeholder="Find table..."
-                    value={searchTerm}
-                    onValueChange={handleSearchChange}
                   />
                   <CommandList_Shadcn_>
                     <CommandEmpty_Shadcn_>No schemas found</CommandEmpty_Shadcn_>

--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -208,7 +208,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                             }}
                           >
                             <span>{schema.name}</span>
-                            {selectedEntity === schema.name && (
+                            {selectedSchema === schema.name && (
                               <Check className="text-brand" strokeWidth={2} size={16} />
                             )}
                           </CommandItem_Shadcn_>

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -74,10 +74,13 @@ const Indexes = () => {
     parseAsString.withOptions({ history: 'push', clearOnDefault: true })
   )
 
-  const indexToDelete =
-    allIndexes !== undefined
-      ? allIndexes.find((index) => index.name === indexNameToDelete)
-      : undefined
+  const indexToDelete = useMemo(
+    () =>
+      allIndexes !== undefined
+        ? allIndexes.find((index) => index.name === indexNameToDelete)
+        : undefined,
+    [indexNameToDelete, allIndexes]
+  )
 
   const {
     data: schemas,

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -168,7 +168,7 @@ const Indexes = () => {
           {isLoadingIndexes && <GenericSkeletonLoader />}
 
           {isErrorIndexes && (
-            <AlertError error={indexesError as any} subject="Failed to retrieve database indexes" />
+            <AlertError error={indexesError} subject="Failed to retrieve database indexes" />
           )}
 
           {isSuccessIndexes && (

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -147,7 +147,7 @@ const Indexes = () => {
         setIndexNameToDelete(null)
       }
     }
-  }, [isLoadingIndexes, indexNameToDelete, setIndexNameToDelete, isSchemaLocked])
+  }, [isLoadingIndexes, indexNameToDelete, setIndexNameToDelete, isSchemaLocked, indexToDelete])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -137,6 +137,18 @@ const Indexes = () => {
     }
   }, [isLoadingIndexes, selectedIndexName, setSelectedIndexName, selectedIndex])
 
+  useEffect(() => {
+    if (!isLoadingIndexes && indexNameToDelete !== null) {
+      if (isSchemaLocked) {
+        toast.error("Can't delete index because it is applied on a protected schema")
+        setIndexNameToDelete(null)
+      } else if (indexToDelete === undefined) {
+        toast.error('Index not found')
+        setIndexNameToDelete(null)
+      }
+    }
+  }, [isLoadingIndexes, indexNameToDelete, setIndexNameToDelete, isSchemaLocked])
+
   return (
     <>
       <div className="pb-8">
@@ -290,7 +302,7 @@ const Indexes = () => {
         variant="warning"
         size="medium"
         loading={isExecuting}
-        visible={indexToDelete !== undefined}
+        visible={!isSchemaLocked && indexToDelete !== undefined}
         title={
           <>
             Confirm to delete index <code className="text-sm">{indexToDelete?.name}</code>

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -69,7 +69,10 @@ const Indexes = () => {
     parseAsString.withOptions({ history: 'push', clearOnDefault: true })
   )
 
-  const indexToDelete = allIndexes !== undefined ? allIndexes.find((index) => index.name === indexNameToDelete) : undefined
+  const indexToDelete =
+    allIndexes !== undefined
+      ? allIndexes.find((index) => index.name === indexNameToDelete)
+      : undefined
 
   const {
     data: schemas,
@@ -280,9 +283,7 @@ const Indexes = () => {
         }
         confirmLabel="Confirm delete"
         confirmLabelLoading="Deleting..."
-        onConfirm={() =>
-          indexToDelete !== undefined ? onConfirmDeleteIndex(indexToDelete) : {}
-        }
+        onConfirm={() => (indexToDelete !== undefined ? onConfirmDeleteIndex(indexToDelete) : {})}
         onCancel={() => setIndexNameToDelete(null)}
         alert={{
           title: 'This action cannot be undone',

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -1,4 +1,4 @@
-import { ident, literal } from '@supabase/pg-meta/src/pg-format'
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -26,7 +26,7 @@ export async function createDatabaseIndex({
 
   const sql = `
   CREATE INDEX ON ${ident(schema)}.${ident(entity)} USING ${ident(type)} (${columns
-    .map((column) => `${literal(column)}`)
+    .map((column) => `${ident(column)}`)
     .join(', ')});
   `.trim()
 

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -1,3 +1,4 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -24,8 +25,8 @@ export async function createDatabaseIndex({
   const { schema, entity, type, columns } = payload
 
   const sql = `
-  CREATE INDEX ON "${schema}"."${entity}" USING ${type} (${columns
-    .map((column) => `"${column}"`)
+  CREATE INDEX ON ${ident(schema)}.${ident(entity)} USING ${ident(type)} (${columns
+    .map((column) => `${literal(column)}`)
     .join(', ')});
   `.trim()
 

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -1,3 +1,4 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -18,7 +19,7 @@ export async function deleteDatabaseIndex({
   name,
   schema,
 }: DatabaseIndexDeleteVariables) {
-  const sql = `drop index if exists "${schema}"."${name}"`
+  const sql = `drop index if exists "${ident(schema)}"."${ident(name)}"`
 
   const { result } = await executeSql({
     projectRef,

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -19,7 +19,7 @@ export async function deleteDatabaseIndex({
   name,
   schema,
 }: DatabaseIndexDeleteVariables) {
-  const sql = `drop index if exists "${ident(schema)}"."${ident(name)}"`
+  const sql = `drop index if exists ${ident(schema)}.${ident(name)}`
 
   const { result } = await executeSql({
     projectRef,


### PR DESCRIPTION
## 1. Escape identifiers in SQL statements for index creation and deletion
## 2. Separate search for schemas and entities

When opening the dropdown menu for schemas and typing to search for a schema, the search input applies to entities as well.

## 3. Enable entities search on empty result after search

The dropdown menu for the entities search is disabled if there are no entities in the selected schema, but it is also disabled when the search doesn't yield any results

## 4. Show a green check icon next to the selected schema in the dropdown menu

## 5. Remove `any`

## 6. Only list non protected schemas in create index side panel

Users aren't allowed to create indexes on non-public schemas, but when they switch to a public schema, like "public", they can click on "Create index" button, the side panel for index creation will open up.

Inside the panel, thre is a dropdown for schemas for the user to choose. This dropdown lists all schemas, including protected ones. I tried creating an index on "supabase_functions", which is a protected schema, and it worked. This behaviour shouldn't be possible.

My solution was to only show public schemas in the dropdown. This also closes a vulnerability where users can bypass this restriction by adding "new=true" to the url and opening the side panel on a protected schema.

## 7. Remove `useQueryStateFromSelect`

## 8. Prevent unwanted index deletion through the URL

Even if users aren't allowed to delete indexes on protected schemas, they can still add `delete=${index_name}` to the url and the delete confirmation modal will appear, even on a protected schema.

I fixed this behaviour by showing an error message instead if the user attempts to delete an index directly through the url. Either "Can't delete index because it is applied on a protected schema" if the index belongs to a protected schema, or "Index not found", if index doesn't exist on current schema, otherwise the modal will show up perfectly.

2 and 3 fix #41537 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of database identifiers for index create/delete to prevent misquoting.
  * Improved validation and clearer "Index not found" handling during selection and deletion; deletion state is reliably cleared after success.

* **UI/UX Changes**
  * Schema list now excludes protected schemas and checkmark reflects the selected schema.
  * Table selection disables only when truly empty; schema dropdown search input is now static (no live binding).
  * Side panel and confirmation modal visibility reflect actual selection/protection state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->