### PR TITLE
docs: desired instance size and platform blog post links

### DIFF
--- a/apps/docs/content/guides/integrations/supabase-for-platforms.mdx
+++ b/apps/docs/content/guides/integrations/supabase-for-platforms.mdx
@@ -28,6 +28,7 @@ We recommend:
 - **a _very_ secure password for each database**. Do not reuse the same password across databases.
 - **storing the encrypted version of the password**. Once you set the password during project creation, there is no way to programmatically change the password but you can do so manually in the Supabase Dashboard.
 - **using smart region selection to ensure there's enough capacity**. The available smart region codes are `americas`, `emea`, and `apac` and you can make a request to [`GET /v1/projects/available-regions`](https://api.supabase.com/api/v1#tag/projects/get/v1/projects/available-regions) for region details.
+- **using an appropriate instance size**. Scale to zero pricing only applies to `pico` instances, make sure to not pass in a `desired_instance_size` when creating a project. >= Micro instances are not able to scale to zero.
 - **make sure that the services are `ACTIVE_HEALTHY` after project creation**. After creating project, confirm the service that you want to make a request to has a status of `ACTIVE_HEALTHY` by polling [`GET /v1/projects/{ref}/health`](https://api.supabase.com/api/v1#tag/projects/get/v1/projects/{ref}/health). For example, before making a request to set an Auth configuration confirm that the Auth service has a status of `ACTIVE_HEALTHY`.
 
 ```sh

--- a/apps/www/_blog/2025-12-05-introducing-supabase-for-platforms.mdx
+++ b/apps/www/_blog/2025-12-05-introducing-supabase-for-platforms.mdx
@@ -26,7 +26,7 @@ And while AI builders are leading the way, **Supabase for Platforms** is built f
 
 # What is Supabase for Platforms?
 
-**Supabase for Platforms** lets you white-label Supabase and provision backends for your users—all managed through our [Management API](https://supabase.com/docs/reference/api/introduction) or [remote MCP Server](https://supabase.com/docs/guides/getting-started/mcp).
+**Supabase for Platforms** lets you white-label Supabase and provision backends for your users—all managed through our [Management API](/docs/reference/api/introduction) or [remote MCP Server](/docs/guides/getting-started/mcp).
 
 Your users get the full Supabase stack:
 
@@ -56,7 +56,7 @@ This model works well when your users don't know or care about infrastructure. Y
 
 <Admonition title='Want users to bring their own Supabase accounts instead?'>
 
-With [OAuth integrations](https://supabase.com/docs/guides/integrations/build-a-supabase-integration), users connect their existing Supabase org to your tool. They own and manage their projects directly, and you get API access to help them build.
+With [OAuth integrations](/docs/guides/integrations/build-a-supabase-integration), users connect their existing Supabase org to your tool. They own and manage their projects directly, and you get API access to help them build.
 
 This model works well when your users are developers who already use Supabase or want more control from the start.
 
@@ -66,37 +66,37 @@ This model works well when your users are developers who already use Supabase or
 
 # Features available today
 
-These features are available through the [Management API](https://supabase.com/docs/reference/api/introduction) or [remote MCP Server](https://supabase.com/docs/guides/getting-started/mcp) right now.
+These features are available through the [Management API](/docs/reference/api/introduction) or [remote MCP Server](/docs/guides/getting-started/mcp) right now.
 
 ## Launch projects
 
 Create projects programmatically. We highly recommend using smart region selection to ensure capacity.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#launching-projects)
+[Docs](/docs/guides/integrations/supabase-for-platforms#launching-projects)
 
 ## Manage configuration
 
 Update settings for Auth, Data API (PostgREST), Edge Functions, Storage, and Realtime through the Management API. Every setting in the Supabase Dashboard is available for configuration programmatically.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#configuration-changes)
+[Docs](/docs/guides/integrations/supabase-for-platforms#configuration-changes)
 
 ## Deploy Edge Functions
 
 Deploy functions directly through the API. No CLI required.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#deploying-edge-functions)
+[Docs](/docs/guides/integrations/supabase-for-platforms#deploying-edge-functions)
 
 ## Change compute sizes
 
 Upgrade or downgrade compute as your users' needs change.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#changing-compute-sizes)
+[Docs](/docs/guides/integrations/supabase-for-platforms#changing-compute-sizes)
 
 ## Run security checks
 
 Use the security advisor API to check projects before deploying to production. Catch issues before your users, and their users, do.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#security-checks-for-production)
+[Docs](/docs/guides/integrations/supabase-for-platforms#security-checks-for-production)
 
 ## API keys
 
@@ -104,13 +104,13 @@ Get and manage API keys for each project. We recommend using the `publishable` a
 
 For more information, read the announcement [here](https://github.com/orgs/supabase/discussions/29260).
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#recommended-api-keys)
+[Docs](/docs/guides/integrations/supabase-for-platforms#recommended-api-keys)
 
 ## Development Environments
 
 Create ephemeral development environments for each project using branching. Your users can make changes safely on a branch, then merge to production. If something goes wrong, destroy the branch and start fresh based off production.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#creating-a-dev-branch)
+[Docs](/docs/guides/integrations/supabase-for-platforms#creating-a-dev-branch)
 
 ## Platform Kit
 
@@ -140,19 +140,19 @@ These features are available to a subset of our AI Builder customers. [Contact u
 
 We offer Pico instances that scale to zero when not in use. This is ideal for platforms with many projects that have variable usage. You only pay for what your users actually use.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#pico-compute-instance)
+[Docs](/docs/guides/integrations/supabase-for-platforms#pico-compute-instance)
 
 ## Restore points
 
 Once you have development environments, create restore points after every backend change. Roll back if something goes wrong. This gives your users confidence as they’re developing.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#create-a-restore-point)
+[Docs](/docs/guides/integrations/supabase-for-platforms#create-a-restore-point)
 
 ## Database migrations
 
 Run schema migrations through the API. Changes are tracked automatically. If a migration fails, it rolls back.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#make-database-changes)
+[Docs](/docs/guides/integrations/supabase-for-platforms#make-database-changes)
 
 ## Claim flow
 
@@ -160,15 +160,15 @@ Let users transfer projects from your organization to their own. You retain API 
 
 This is useful when users want to eventually manage their own infrastructure and billing.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#claim-flow)
+[Docs](/docs/guides/integrations/supabase-for-platforms#claim-flow)
 
 # Recommended development flow
 
-Supabase stores data. You cannot simply roll back production changes without risking data loss. Check out the [docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#development-workflow) for our recommended dev/production workflow.
+Supabase stores data. You cannot simply roll back production changes without risking data loss. Check out the [docs](/docs/guides/integrations/supabase-for-platforms#development-workflow) for our recommended dev/production workflow.
 
-[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#development-workflow)
+[Docs](/docs/guides/integrations/supabase-for-platforms#development-workflow)
 
 ## Get started
 
-- [Read the documentation](https://supabase.com/docs/guides/integrations/supabase-for-platforms)
+- [Read the documentation](/docs/guides/integrations/supabase-for-platforms)
 - [Contact us](/solutions/ai-builders#talk-to-partnerships-team) if you're building an AI platform or coding tool

--- a/apps/www/_blog/2025-12-05-introducing-supabase-for-platforms.mdx
+++ b/apps/www/_blog/2025-12-05-introducing-supabase-for-platforms.mdx
@@ -26,7 +26,7 @@ And while AI builders are leading the way, **Supabase for Platforms** is built f
 
 # What is Supabase for Platforms?
 
-**Supabase for Platforms** lets you white-label Supabase and provision backends for your users—all managed through our [Management API](/docs/reference/api/introduction) or [remote MCP Server](/docs/guides/getting-started/mcp).
+**Supabase for Platforms** lets you white-label Supabase and provision backends for your users—all managed through our [Management API](https://supabase.com/docs/reference/api/introduction) or [remote MCP Server](https://supabase.com/docs/guides/getting-started/mcp).
 
 Your users get the full Supabase stack:
 
@@ -56,7 +56,7 @@ This model works well when your users don't know or care about infrastructure. Y
 
 <Admonition title='Want users to bring their own Supabase accounts instead?'>
 
-With [OAuth integrations](/docs/guides/integrations/build-a-supabase-integration), users connect their existing Supabase org to your tool. They own and manage their projects directly, and you get API access to help them build.
+With [OAuth integrations](https://supabase.com/docs/guides/integrations/build-a-supabase-integration), users connect their existing Supabase org to your tool. They own and manage their projects directly, and you get API access to help them build.
 
 This model works well when your users are developers who already use Supabase or want more control from the start.
 
@@ -66,37 +66,37 @@ This model works well when your users are developers who already use Supabase or
 
 # Features available today
 
-These features are available through the [Management API](/docs/reference/api/introduction) or [remote MCP Server](/docs/guides/getting-started/mcp) right now.
+These features are available through the [Management API](https://supabase.com/docs/reference/api/introduction) or [remote MCP Server](https://supabase.com/docs/guides/getting-started/mcp) right now.
 
 ## Launch projects
 
 Create projects programmatically. We highly recommend using smart region selection to ensure capacity.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#launching-projects)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#launching-projects)
 
 ## Manage configuration
 
 Update settings for Auth, Data API (PostgREST), Edge Functions, Storage, and Realtime through the Management API. Every setting in the Supabase Dashboard is available for configuration programmatically.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#configuration-changes)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#configuration-changes)
 
 ## Deploy Edge Functions
 
 Deploy functions directly through the API. No CLI required.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#deploying-edge-functions)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#deploying-edge-functions)
 
 ## Change compute sizes
 
 Upgrade or downgrade compute as your users' needs change.
 
-[Docs](docs/guides/integrations/supabase-for-platforms#changing-compute-sizes)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#changing-compute-sizes)
 
 ## Run security checks
 
 Use the security advisor API to check projects before deploying to production. Catch issues before your users, and their users, do.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#security-checks-for-production)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#security-checks-for-production)
 
 ## API keys
 
@@ -104,13 +104,13 @@ Get and manage API keys for each project. We recommend using the `publishable` a
 
 For more information, read the announcement [here](https://github.com/orgs/supabase/discussions/29260).
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#recommended-api-keys)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#recommended-api-keys)
 
 ## Development Environments
 
 Create ephemeral development environments for each project using branching. Your users can make changes safely on a branch, then merge to production. If something goes wrong, destroy the branch and start fresh based off production.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#creating-a-dev-branch)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#creating-a-dev-branch)
 
 ## Platform Kit
 
@@ -140,19 +140,19 @@ These features are available to a subset of our AI Builder customers. [Contact u
 
 We offer Pico instances that scale to zero when not in use. This is ideal for platforms with many projects that have variable usage. You only pay for what your users actually use.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#pico-compute-instance)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#pico-compute-instance)
 
 ## Restore points
 
 Once you have development environments, create restore points after every backend change. Roll back if something goes wrong. This gives your users confidence as they’re developing.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#create-a-restore-point)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#create-a-restore-point)
 
 ## Database migrations
 
 Run schema migrations through the API. Changes are tracked automatically. If a migration fails, it rolls back.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#make-database-changes)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#make-database-changes)
 
 ## Claim flow
 
@@ -160,15 +160,15 @@ Let users transfer projects from your organization to their own. You retain API 
 
 This is useful when users want to eventually manage their own infrastructure and billing.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#claim-flow)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#claim-flow)
 
 # Recommended development flow
 
-Supabase stores data. You cannot simply roll back production changes without risking data loss. Check out the [docs](/docs/guides/integrations/supabase-for-platforms#development-workflow) for our recommended dev/production workflow.
+Supabase stores data. You cannot simply roll back production changes without risking data loss. Check out the [docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#development-workflow) for our recommended dev/production workflow.
 
-[Docs](/docs/guides/integrations/supabase-for-platforms#development-workflow)
+[Docs](https://supabase.com/docs/guides/integrations/supabase-for-platforms#development-workflow)
 
 ## Get started
 
-- [Read the documentation](/docs/guides/integrations/supabase-for-platforms)
+- [Read the documentation](https://supabase.com/docs/guides/integrations/supabase-for-platforms)
 - [Contact us](/solutions/ai-builders#talk-to-partnerships-team) if you're building an AI platform or coding tool


### PR DESCRIPTION
- Some doc links led to 404 on blog post
- Note on omitting `desired_instance_size`