### PR TITLE
fix: disable logs viewer for initial workflow run

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/WorkflowLogs.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/WorkflowLogs.tsx
@@ -108,6 +108,7 @@ export const WorkflowLogs = ({ projectRef, status }: WorkflowLogsProps) => {
                       <li key={workflowRun.id} className="py-3">
                         <button
                           type="button"
+                          disabled={workflowRun.id === projectRef}
                           onClick={() => setSelectedWorkflowRun(workflowRun)}
                           className="flex items-center gap-2 w-full justify-between"
                         >

--- a/apps/studio/components/interfaces/BranchManagement/WorkflowLogs.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/WorkflowLogs.tsx
@@ -122,7 +122,7 @@ export const WorkflowLogs = ({ projectRef, status }: WorkflowLogsProps) => {
                               {dayjs(workflowRun.created_at).format('DD MMM, YYYY HH:mm')}
                             </span>
                           </div>
-                          <ArrowRight size={16} />
+                          {workflowRun.id !== projectRef && <ArrowRight size={16} />}
                         </button>
                       </li>
                     ))}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Since logs are not available for git-less branch creation request, we disable the logs button for the first run id.

Subsequent run logs are still accessible.

## Additional context

<img width="813" height="170" alt="Screenshot 2025-12-23 at 4 30 54 PM" src="https://github.com/user-attachments/assets/7bbf6ff3-bf26-4b3b-a5d7-35e4fe1eb411" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Prevented users from selecting the current project's workflow run. The action indicator is now hidden for the current project to clarify that it cannot be interacted with.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->