### PR TITLE
Fix OAuth Link in docs

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -747,5 +747,5 @@ language="typescript"
 ## Next steps
 
 - Implement [Authentication using Email and Password](/docs/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr)
-- Implement [Authentication using OAuth](/docs/guides/auth/server-side/oauth-with-pkce-flow-for-ssr)
+- Implement [Authentication using OAuth](https://supabase.com/docs/guides/auth/social-login)
 - [Learn more about SSR](/docs/guides/auth/server-side-rendering)

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -747,5 +747,5 @@ language="typescript"
 ## Next steps
 
 - Implement [Authentication using Email and Password](/docs/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr)
-- Implement [Authentication using OAuth](https://supabase.com/docs/guides/auth/social-login)
+- Implement [Authentication using OAuth](/docs/guides/auth/social-login)
 - [Learn more about SSR](/docs/guides/auth/server-side-rendering)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Edited link for signing in with OAuth.

## What is the current behavior?

Previously, it would take the user to the email and [password login page](https://supabase.com/docs/guides/auth/passwords). The link to this page of the documentation is [here](https://supabase.com/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=nextjs) when selecting "Implement Authentication Using OAuth".

## What is the new behavior?

Now the link takes the user to the [OAuth Overview](https://supabase.com/docs/guides/auth/social-login). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference links within authentication guides for improved navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->