### PR TITLE
docs: remove Adding Tools section from byo-mcp guide

### DIFF
--- a/apps/docs/content/guides/getting-started/byo-mcp.mdx
+++ b/apps/docs/content/guides/getting-started/byo-mcp.mdx
@@ -155,46 +155,6 @@ https://<your-project-ref>.supabase.co/functions/v1/mcp
 
 Update your MCP client configuration to use the production URL.
 
-## Adding more tools
-
-Extend your MCP server by registering additional tools. Here's an example that queries your Supabase database:
-
-```ts
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-// Create Supabase client
-const supabase = createClient(
-  Deno.env.get('SUPABASE_URL')!,
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-)
-
-server.registerTool(
-  'list_users',
-  {
-    title: 'List Users',
-    description: 'Get a list of users from the database',
-    inputSchema: { limit: z.number().optional().default(10) },
-  },
-  async ({ limit }) => {
-    const { data, error } = await supabase
-      .from('users')
-      .select('id, email, created_at')
-      .limit(limit)
-
-    if (error) {
-      return {
-        content: [{ type: 'text', text: `Error: ${error.message}` }],
-        isError: true,
-      }
-    }
-
-    return {
-      content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
-    }
-  }
-)
-```
-
 ## Examples
 
 You can find ready-to-use MCP server implementations here:


### PR DESCRIPTION
Removed the "Adding more tools" section from the byo-mcp docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the getting-started guide by removing the "Adding more tools" example section, including related code examples and setup instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->