### PR TITLE
fix(studio): tab focus on generate password button

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ComputeSizeSelector.tsx
@@ -38,21 +38,11 @@ export const ComputeSizeSelector = ({ form }: ComputeSizeSelectorProps) => {
               <>
                 <p>
                   The size for your dedicated database. You can change this later. Learn more about{' '}
-                  <InlineLink
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-inherit hover:text-foreground transition-colors"
-                    href={`${DOCS_URL}/guides/platform/compute-add-ons`}
-                  >
+                  <InlineLink href={`${DOCS_URL}/guides/platform/compute-add-ons`}>
                     compute add-ons
                   </InlineLink>{' '}
                   and{' '}
-                  <InlineLink
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-inherit hover:text-foreground transition-colors"
-                    href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
-                  >
+                  <InlineLink href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}>
                     compute billing
                   </InlineLink>
                   .

--- a/apps/studio/components/ui/PasswordStrengthBar.tsx
+++ b/apps/studio/components/ui/PasswordStrengthBar.tsx
@@ -1,4 +1,5 @@
 import { PASSWORD_STRENGTH_COLOR, PASSWORD_STRENGTH_PERCENTAGE } from 'lib/constants'
+import { InlineLinkClassName } from './InlineLink'
 
 interface Props {
   passwordStrengthScore: number
@@ -39,12 +40,9 @@ const PasswordStrengthBar = ({
           ? passwordStrengthMessage
           : 'This is the password to your Postgres database, so it must be strong and hard to guess.') +
           ' '}
-        <span
-          className="text-inherit underline hover:text-foreground transition-colors cursor-pointer"
-          onClick={generateStrongPassword}
-        >
+        <button type="button" className={InlineLinkClassName} onClick={generateStrongPassword}>
           Generate a password
-        </span>
+        </button>
         .
       </p>
     </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bug fix

## What is the current behavior?

- The _Generate a password_ button (that looks like `InlineLink`) in the _New project_ form is not focusable by keyboard
- The other ones (`InlineLinks`) around it _are_ focusable by keyboard
- The _Generate a password_ button uses a `span` but a `button` would be more semantic and fix this issue

## What is the new behavior?

- The _Generate a password_ button now uses a `button` element, not a `span`
- Minor cleanup of redundant `className` elsewhere in form

## Additional context

No visual changes. Here’s the bit of UI in question:

| New Project |
| --- |
| <img width="1616" height="874" alt="25617" src="https://github.com/user-attachments/assets/c727212c-8566-47bf-a534-e29320e144af" /> |

Spotted by @jahrlin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated links in the compute size selector to open in the same tab with standard styling instead of launching external windows for a more seamless navigation experience.
  * Enhanced the password strength bar with improved semantic structure for better accessibility when generating strong passwords.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->