### PR TITLE
docs: fix typo in Google SMTP troubleshooting guide

### DIFF
--- a/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
+++ b/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
@@ -7,12 +7,12 @@ keywords = [ "smtp", "google", "workspace", "2FA", "TLS", "encryption", "port" ]
 database_id = "4d5390a0-445d-4e0a-ae7e-9b713b7cc4f6"
 ---
 
-Hey everyone, i've been hearing feedback about how challenging it can be to get google SMTP working properly with Supabase. I've tried setting this up with a trial Google Workspace account and this is what i've discovered.
+Hey everyone, I've been hearing feedback about how challenging it can be to get Google SMTP working properly with Supabase. I've tried setting this up with a trial Google Workspace account and this is what I've discovered.
 
 1. The sender email and SMTP username has to be your Google Workspace admin email.
 2. The SMTP password used has to be an app password. Google Workspace doesn't make it easy to figure out how to create this. You need to **enable 2FA** on your workspace account first (not inside the admin console but in https://myaccount.google.com/)
-3. If you want to use `smtp-relay.gmail.com` only port 465 works. If you want to use `smtp.gmail.com`, you can use port 465 or 587.
-   The following screenshots show what those steps look like:
+3. For `smtp-relay.gmail.com`, only port 465 works. For `smtp.gmail.com`, you can use port 465 or 587.
+   The following screenshots show these configuration steps:
 
 ## For `smtp-relay.gmail.com`
 

--- a/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
+++ b/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
@@ -7,10 +7,10 @@ keywords = [ "smtp", "google", "workspace", "2FA", "TLS", "encryption", "port" ]
 database_id = "4d5390a0-445d-4e0a-ae7e-9b713b7cc4f6"
 ---
 
-Hey everyone, i've been hearing feedback about how challenging it can be to get google SMTP working properly with Supabase. I've tried setting this up with a trial google workspace account and this is what i've discovered.
+Hey everyone, i've been hearing feedback about how challenging it can be to get google SMTP working properly with Supabase. I've tried setting this up with a trial Google Workspace account and this is what i've discovered.
 
-1. The sender email and SMTP username has to be your google workspace admin email.
-2. The SMTP password used has to be an app password. Google workspace doesn't make it easy to figure out how to create this. You need to **enable 2FA** on your workspace account first (not inside the admin console but in https://myaccount.google.com/)
+1. The sender email and SMTP username has to be your Google Workspace admin email.
+2. The SMTP password used has to be an app password. Google Workspace doesn't make it easy to figure out how to create this. You need to **enable 2FA** on your workspace account first (not inside the admin console but in https://myaccount.google.com/)
 3. If you want to use `smtp-relay.gmail.com` only port 465 works. If you want to use `smtp.gmail.com`, you can use port 465 or 587.
    The following screenshots show what those steps look like:
 

--- a/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
+++ b/apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx
@@ -10,7 +10,7 @@ database_id = "4d5390a0-445d-4e0a-ae7e-9b713b7cc4f6"
 Hey everyone, i've been hearing feedback about how challenging it can be to get google SMTP working properly with Supabase. I've tried setting this up with a trial google workspace account and this is what i've discovered.
 
 1. The sender email and SMTP username has to be your google workspace admin email.
-2. The SMTP password used has to be an app password. Google workspace doesn't make it easy to to figure out how to create this. You need to **enable 2FA** on your workspace account first (not inside the admin console but in https://myaccount.google.com/)
+2. The SMTP password used has to be an app password. Google workspace doesn't make it easy to figure out how to create this. You need to **enable 2FA** on your workspace account first (not inside the admin console but in https://myaccount.google.com/)
 3. If you want to use `smtp-relay.gmail.com` only port 465 works. If you want to use `smtp.gmail.com`, you can use port 465 or 587.
    The following screenshots show what those steps look like:
 


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Documentation fixes (typos and grammar)

## What is the current behavior?

The Google SMTP troubleshooting guide contains typos and inconsistent capitalization:
- Duplicate word "to to"
- Lowercase brand names and sentence starts
- Repetitive phrasing

## What is the new behavior?

Fixed typos, grammar, and improved clarity:
- Removed duplicate "to"
- Capitalized "Google Workspace" and "Google SMTP"
- Capitalized "I've" at sentence starts
- Simplified repetitive port instructions

File: `apps/docs/content/troubleshooting/using-google-smtp-with-supabase-custom-smtp-ZZzU4Y.mdx`