### PR TITLE
Bump @tanstack/eslint-plugin-query and migrate the config.

### DIFF
--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -3,7 +3,6 @@ const js = require('@eslint/js')
 const { FlatCompat } = require('@eslint/eslintrc')
 const prettierConfig = require('eslint-config-prettier/flat')
 const { default: turboConfig } = require('eslint-config-turbo/flat')
-const { fixupPluginRules } = require('@eslint/compat')
 const tanstackQuery = require('@tanstack/eslint-plugin-query')
 const tseslint = require('@typescript-eslint/eslint-plugin')
 const tsparser = require('@typescript-eslint/parser')
@@ -13,19 +12,6 @@ const compat = new FlatCompat({
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 })
-
-// Tanstack Query config is meant for the old non-flat esling configs. This adapts it to work with flat configs. v5 of
-// the plugin supports flat configs natively.
-const tanstackQueryConfig = {
-  name: '@tanstack/query',
-  plugins: { '@tanstack/query': fixupPluginRules(tanstackQuery) },
-  rules: {
-    '@tanstack/query/exhaustive-deps': 'warn',
-    '@tanstack/query/no-deprecated-options': 'error',
-    '@tanstack/query/prefer-query-object-syntax': 'warn',
-    '@tanstack/query/stable-query-client': 'warn',
-  },
-}
 
 // TypeScript ESLint config for TypeScript files
 const typescriptConfig = {
@@ -48,10 +34,15 @@ const typescriptConfig = {
 
 module.exports = defineConfig([
   // Global ignore for the .next folder
-  { ignores: ['.next', 'public'] },
+  { ignores: ['.next', 'public', '.contentlayer'] },
   turboConfig,
   prettierConfig,
-  tanstackQueryConfig,
+  {
+    extends: tanstackQuery.configs['flat/recommended'],
+    rules: {
+      '@tanstack/query/exhaustive-deps': 'warn',
+    },
+  },
   typescriptConfig,
   {
     extends: compat.extends('next/core-web-vitals'),

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -37,8 +37,8 @@ module.exports = defineConfig([
   { ignores: ['.next', 'public', '.contentlayer'] },
   turboConfig,
   prettierConfig,
+  tanstackQuery.configs['flat/recommended'],
   {
-    extends: tanstackQuery.configs['flat/recommended'],
     rules: {
       '@tanstack/query/exhaustive-deps': 'warn',
     },

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -56,7 +56,7 @@ module.exports = defineConfig([
   },
   {
     // check for default exports in all files except app and pages folders.
-    ignores: ['pages/**.tsx', 'app/**.tsx'],
+    ignores: ['pages/**/*.ts', 'app/**/*.ts', 'pages/**/*.tsx', 'app/**/*.tsx'],
     rules: {
       'no-restricted-exports': [
         'warn',

--- a/packages/eslint-config-supabase/package.json
+++ b/packages/eslint-config-supabase/package.json
@@ -8,10 +8,9 @@
     "clean": "rimraf node_modules"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.4.0",
     "@eslint/eslintrc": "^3.0.0",
     "@eslint/js": "^9.0.0",
-    "@tanstack/eslint-plugin-query": "^4.0.0",
+    "@tanstack/eslint-plugin-query": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^8.48.0",
     "@typescript-eslint/parser": "^8.48.0",
     "eslint-config-next": "^15.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,7 +541,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^1.19.1
-        version: 1.19.1(next@15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
+        version: 1.19.1(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
       openai:
         specifier: ^4.75.1
         version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
@@ -2132,9 +2132,6 @@ importers:
 
   packages/eslint-config-supabase:
     devDependencies:
-      '@eslint/compat':
-        specifier: ^1.4.0
-        version: 1.4.0(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))
       '@eslint/eslintrc':
         specifier: ^3.0.0
         version: 3.3.1(supports-color@8.1.1)
@@ -2142,8 +2139,8 @@ importers:
         specifier: ^9.0.0
         version: 9.37.0
       '@tanstack/eslint-plugin-query':
-        specifier: ^4.0.0
-        version: 4.39.1(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))
+        specifier: ^5.0.0
+        version: 5.91.2(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.48.0
         version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
@@ -3717,15 +3714,6 @@ packages:
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/compat@1.4.0':
-    resolution: {integrity: sha512-DEzm5dKeDBPm3r08Ixli/0cmxr8LkRdwxMRUIJBlSCpAwSrvFEJpVBzV+66JhDxiaqKxnRzCXhtiMiczF7Hglg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.40 || 9
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/config-array@0.21.0':
     resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
@@ -9054,10 +9042,10 @@ packages:
     resolution: {integrity: sha512-eXjzg2T7eiEruKXtu1XQ2bHV1oO8muGWs+TuDWH3tIFPwH1hIzahWpcTwz5lc7jW5xqud3gru2tK6wTk2JlIrw==}
     engines: {node: '>=12'}
 
-  '@tanstack/eslint-plugin-query@4.39.1':
-    resolution: {integrity: sha512-5YDX4mdRC0hllHKp531CnScFWZU7aFrJ1aTyyuaB6+z0/i0JfcKuckSTYaji3vUk82GALM90eWwHFVRAch+7tQ==}
+  '@tanstack/eslint-plugin-query@5.91.2':
+    resolution: {integrity: sha512-UPeWKl/Acu1IuuHJlsN+eITUHqAaa9/04geHHPedY8siVarSaWprY0SVMKrkpKfk5ehRT7+/MZ5QwWuEtkWrFw==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0
 
   '@tanstack/history@1.114.22':
     resolution: {integrity: sha512-CNwKraj/Xa8H7DUyzrFBQC3wL96JzIxT4i9CW0hxqFNNmLDyUcMJr8264iqqfxC0u1lFSG96URad08T2Qhadpw==}
@@ -21793,12 +21781,6 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.4.0(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))':
-    dependencies:
-      '@eslint/core': 0.16.0
-    optionalDependencies:
-      eslint: 9.37.0(jiti@2.5.1)(supports-color@8.1.1)
-
   '@eslint/config-array@0.21.0(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.6
@@ -28203,9 +28185,13 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/eslint-plugin-query@4.39.1(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))':
+  '@tanstack/eslint-plugin-query@5.91.2(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
+      '@typescript-eslint/utils': 8.48.0(eslint@9.37.0(jiti@2.5.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       eslint: 9.37.0(jiti@2.5.1)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@tanstack/history@1.114.22': {}
 
@@ -36769,7 +36755,7 @@ snapshots:
 
   number-flow@0.3.7: {}
 
-  nuqs@1.19.1(next@15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)):
+  nuqs@1.19.1(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)):
     dependencies:
       mitt: 3.0.1
       next: 15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ESLint config to use TanStack Query plugin v5, improving query-related linting and rules.
  * Removed a deprecated linting utility and consolidated its settings into an inline configuration.
  * Expanded global lint ignore patterns to include an additional build/content directory.
  * Broadened file-specific lint ignores to cover both .ts and .tsx files in pages and app areas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->