### PR TITLE
chore: add Auth team as code owners for SQL queries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 /packages/shared-data/pricing.ts @roryw10 @supabase/billing
 /packages/shared-data/plans.ts @roryw10 @supabase/billing
 /packages/common/telemetry-constants.ts @supabase/growth-eng
-/packages/pg-meta @supabase/postgres @avallete
+/packages/pg-meta @supabase/postgres @supabase/auth @avallete
 
 /apps/studio/ @supabase/Dashboard
 
@@ -19,4 +19,4 @@
 /apps/studio/components/interfaces/Organization/Documents/          @supabase/security
 /apps/studio/pages/new/index.tsx                                    @supabase/security
 
-/apps/studio/data/sql/queries/                                      @supabase/postgres @avallete
+/apps/studio/data/sql/queries/                                      @supabase/postgres @supabase/auth @avallete


### PR DESCRIPTION
Adds `@supabase/auth` as code owners for SQL queries and `pg-meta`.

Eventually, we might want to consider segmenting the queries into separate directories by function to reduce the ownership surface area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for internal review processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->