### PR TITLE
feature: add explain w/ AI on pretty-explain tab

### DIFF
--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
@@ -23,7 +23,6 @@ export function ExplainHeader({
   onExplainWithAI,
 }: ExplainHeaderProps) {
   const isVisual = mode === 'visual'
-  const showExplainWithAiInSQLEditor = useFlag('ShowExplainWithAiInQueryPerformance')
 
   const hasSummaryStats =
     isVisual && summary && (summary.totalTime > 0 || (summary.hasSeqScan && !summary.hasIndexScan))
@@ -50,7 +49,7 @@ export function ExplainHeader({
           )}
         </div>
         <div className="flex items-center gap-2">
-          {showExplainWithAiInSQLEditor && onExplainWithAI && (
+          {onExplainWithAI && (
             <Button
               type="default"
               size="tiny"

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp } from 'lucide-react'
+import { ArrowUp, Eye, Code } from 'lucide-react'
 
 import { useFlag } from 'common'
 import { AiIconAnimation, Button } from 'ui'
@@ -60,16 +60,14 @@ export function ExplainHeader({
               Explain with AI
             </Button>
           )}
-          <button
-            type="button"
+          <Button
+            type="default"
+            size="tiny"
+            icon={isVisual ? <Code size={14} /> : <Eye size={14} />}
             onClick={onToggleMode}
-            className="font-mono text-xs text-foreground-lighter hover:text-foreground transition-colors"
-            aria-label={
-              isVisual ? 'Switch to raw explain output' : 'Switch to visual explain output'
-            }
           >
-            {isVisual ? '[VISUAL]' : '[RAW]'}
-          </button>
+            {isVisual ? 'Raw' : 'Visual'}
+          </Button>
         </div>
       </div>
 

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
@@ -1,5 +1,7 @@
-import { Activity, ArrowUp, Clock, Database, GitMerge, Hash, Zap } from 'lucide-react'
-import { Badge } from 'ui'
+import { ArrowUp } from 'lucide-react'
+
+import { useFlag } from 'common'
+import { AiIconAnimation, Button } from 'ui'
 
 export interface ExplainSummary {
   totalTime: number
@@ -11,10 +13,17 @@ export interface ExplainHeaderProps {
   mode: 'visual' | 'raw'
   onToggleMode: () => void
   summary?: ExplainSummary
+  onExplainWithAI?: () => void
 }
 
-export function ExplainHeader({ mode, onToggleMode, summary }: ExplainHeaderProps) {
+export function ExplainHeader({
+  mode,
+  onToggleMode,
+  summary,
+  onExplainWithAI,
+}: ExplainHeaderProps) {
   const isVisual = mode === 'visual'
+  const showExplainWithAiInSQLEditor = useFlag('ShowExplainWithAiInQueryPerformance')
 
   const hasSummaryStats =
     isVisual && summary && (summary.totalTime > 0 || (summary.hasSeqScan && !summary.hasIndexScan))
@@ -22,30 +31,46 @@ export function ExplainHeader({ mode, onToggleMode, summary }: ExplainHeaderProp
   return (
     <div className="bg-surface-100 border-b px-4 py-3 flex flex-col gap-3 text-xs">
       {/* Title row */}
-      <div className="flex items-center gap-2 text-sm">
-        <h3 className="font-medium text-foreground">Query Execution Plan</h3>
-        {/* Summary stats - only show in visual mode when we have the data */}
-        {hasSummaryStats && (
-          <div className="flex items-center gap-4 flex-wrap">
-            {summary.totalTime > 0 && (
-              <div className="flex items-center gap-1.5">
-                <span className="text-foreground-light">/</span>
-                <span className="text-foreground-light">Total time</span>
-                <span className="font-mono font-medium text-foreground">
-                  {summary.totalTime.toFixed(2)}ms
-                </span>
-              </div>
-            )}
-          </div>
-        )}
-        <button
-          type="button"
-          onClick={onToggleMode}
-          className="font-mono text-xs text-foreground-lighter hover:text-foreground transition-colors"
-          aria-label={isVisual ? 'Switch to raw explain output' : 'Switch to visual explain output'}
-        >
-          {isVisual ? '[VISUAL]' : '[RAW]'}
-        </button>
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center gap-2">
+          <h3 className="font-medium text-foreground">Query Execution Plan</h3>
+          {/* Summary stats - only show in visual mode when we have the data */}
+          {hasSummaryStats && (
+            <div className="flex items-center gap-4 flex-wrap">
+              {summary.totalTime > 0 && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-foreground-light">/</span>
+                  <span className="text-foreground-light">Total time</span>
+                  <span className="font-mono font-medium text-foreground">
+                    {summary.totalTime.toFixed(2)}ms
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {showExplainWithAiInSQLEditor && onExplainWithAI && (
+            <Button
+              type="default"
+              size="tiny"
+              icon={<AiIconAnimation size={14} />}
+              onClick={onExplainWithAI}
+            >
+              Explain with AI
+            </Button>
+          )}
+          <button
+            type="button"
+            onClick={onToggleMode}
+            className="font-mono text-xs text-foreground-lighter hover:text-foreground transition-colors"
+            aria-label={
+              isVisual ? 'Switch to raw explain output' : 'Switch to visual explain output'
+            }
+          >
+            {isVisual ? '[VISUAL]' : '[RAW]'}
+          </button>
+        </div>
       </div>
 
       {/* How to read */}

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.ai.ts
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.ai.ts
@@ -16,24 +16,27 @@ export function buildExplainPrompt({
 }: ExplainPromptInput): ExplainPromptOutput {
   const explainPlan = explainPlanRows.map((row) => row['QUERY PLAN']).join('\n')
 
-  const prompt = `Analyze this SQL query and its execution plan:
+  const prompt = `Explain this PostgreSQL EXPLAIN ANALYZE output in simple terms:
 
-**SQL Query:**
 \`\`\`sql
 ${sql}
 \`\`\`
 
-**Execution Plan (EXPLAIN ANALYZE):**
 \`\`\`
 ${explainPlan}
 \`\`\`
 
-Provide a concise explanation covering:
-1. What the query does (1-2 sentences)
-2. Performance assessment based on the execution plan (good/concerning, 2-3 sentences)
-3. Actionable optimization suggestions based on any bottlenecks identified (if any, 2-3 sentences)
+Format your response with:
 
-Keep your response concise and focused on actionable insights.`
+**What it does** - 1-2 sentences.
+
+**How it runs** - Briefly explain the plan from bottom to top in plain English. Mention key operations (scans, joins, sorts) and why PostgreSQL chose them.
+
+**Issues** - Identify bottlenecks: slowest steps, sequential scans on large tables, inefficient joins, missing indexes. Be specific with timings from the plan.
+
+**Fixes** - 2-3 specific suggestions with CREATE INDEX statements if applicable.
+
+Keep it concise. Focus on actionable insights.`
 
   return {
     query: sql,

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.ai.ts
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.ai.ts
@@ -1,0 +1,42 @@
+import type { QueryPlanRow } from './ExplainVisualizer.types'
+
+export interface ExplainPromptInput {
+  sql: string
+  explainPlanRows: QueryPlanRow[]
+}
+
+export interface ExplainPromptOutput {
+  query: string
+  prompt: string
+}
+
+export function buildExplainPrompt({
+  sql,
+  explainPlanRows,
+}: ExplainPromptInput): ExplainPromptOutput {
+  const explainPlan = explainPlanRows.map((row) => row['QUERY PLAN']).join('\n')
+
+  const prompt = `Analyze this SQL query and its execution plan:
+
+**SQL Query:**
+\`\`\`sql
+${sql}
+\`\`\`
+
+**Execution Plan (EXPLAIN ANALYZE):**
+\`\`\`
+${explainPlan}
+\`\`\`
+
+Provide a concise explanation covering:
+1. What the query does (1-2 sentences)
+2. Performance assessment based on the execution plan (good/concerning, 2-3 sentences)
+3. Actionable optimization suggestions based on any bottlenecks identified (if any, 2-3 sentences)
+
+Keep your response concise and focused on actionable insights.`
+
+  return {
+    query: sql,
+    prompt,
+  }
+}

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
@@ -7,10 +7,10 @@ import type { QueryPlanRow } from './ExplainVisualizer.types'
 export interface ExplainVisualizerProps {
   rows: readonly QueryPlanRow[]
   onShowRaw?: () => void
-  onExplainWithAI?: () => void
+  id?: string
 }
 
-export function ExplainVisualizer({ rows, onShowRaw, onExplainWithAI }: ExplainVisualizerProps) {
+export function ExplainVisualizer({ rows, onShowRaw, id }: ExplainVisualizerProps) {
   const parsedTree = useMemo(() => createNodeTree(rows), [rows])
   const maxDuration = useMemo(() => calculateMaxDuration(parsedTree), [parsedTree])
   const summary = useMemo(() => calculateSummary(parsedTree), [parsedTree])
@@ -32,7 +32,8 @@ export function ExplainVisualizer({ rows, onShowRaw, onExplainWithAI }: ExplainV
           mode="visual"
           onToggleMode={onShowRaw}
           summary={summary}
-          onExplainWithAI={onExplainWithAI}
+          id={id}
+          rows={rows}
         />
       )}
 

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
@@ -7,9 +7,10 @@ import type { QueryPlanRow } from './ExplainVisualizer.types'
 export interface ExplainVisualizerProps {
   rows: readonly QueryPlanRow[]
   onShowRaw?: () => void
+  onExplainWithAI?: () => void
 }
 
-export function ExplainVisualizer({ rows, onShowRaw }: ExplainVisualizerProps) {
+export function ExplainVisualizer({ rows, onShowRaw, onExplainWithAI }: ExplainVisualizerProps) {
   const parsedTree = useMemo(() => createNodeTree(rows), [rows])
   const maxDuration = useMemo(() => calculateMaxDuration(parsedTree), [parsedTree])
   const summary = useMemo(() => calculateSummary(parsedTree), [parsedTree])
@@ -26,7 +27,14 @@ export function ExplainVisualizer({ rows, onShowRaw }: ExplainVisualizerProps) {
 
   return (
     <div className="bg-studio border-t h-full flex flex-col min-h-0">
-      {onShowRaw && <ExplainHeader mode="visual" onToggleMode={onShowRaw} summary={summary} />}
+      {onShowRaw && (
+        <ExplainHeader
+          mode="visual"
+          onToggleMode={onShowRaw}
+          summary={summary}
+          onExplainWithAI={onExplainWithAI}
+        />
+      )}
 
       {/* Plan nodes */}
       <div className="flex-1 overflow-auto min-h-0">

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
@@ -5,14 +5,9 @@ import CopyButton from 'components/ui/CopyButton'
 import { ExplainVisualizer } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer'
 import { ExplainHeader } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.Header'
 import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
-import { buildExplainPrompt } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.ai'
-import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
-import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
-import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import Results from './Results'
-import { QueryPlanRow } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.types'
 
 export type UtilityTabExplainProps = {
   id: string
@@ -23,30 +18,6 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
   const snapV2 = useSqlEditorV2StateSnapshot()
   const explainResult = snapV2.explainResults[id]
   const [mode, setMode] = useState<'visual' | 'raw'>('visual')
-
-  const { openSidebar } = useSidebarManagerSnapshot()
-  const aiSnap = useAiAssistantStateSnapshot()
-
-  const handleExplainWithAI = () => {
-    const snippet = snapV2.snippets[id]?.snippet
-    if (!snippet?.content?.sql) return
-
-    const { query, prompt } = buildExplainPrompt({
-      sql: snippet.content.sql,
-      explainPlanRows: (explainResult?.rows as QueryPlanRow[]) ?? [],
-    })
-
-    openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
-    aiSnap.newChat({
-      sqlSnippets: [
-        {
-          label: 'Query',
-          content: query,
-        },
-      ],
-      initialMessage: prompt,
-    })
-  }
 
   if (isExecuting) {
     return (
@@ -123,14 +94,10 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
   return (
     <div className="h-full flex flex-col">
       {mode === 'visual' ? (
-        <ExplainVisualizer
-          rows={explainResult.rows}
-          onShowRaw={toggleMode}
-          onExplainWithAI={handleExplainWithAI}
-        />
+        <ExplainVisualizer rows={explainResult.rows} onShowRaw={toggleMode} id={id} />
       ) : (
         <>
-          <ExplainHeader mode="raw" onToggleMode={toggleMode} />
+          <ExplainHeader mode="raw" onToggleMode={toggleMode} id={id} rows={explainResult.rows} />
           <Results rows={explainResult.rows} />
         </>
       )}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
@@ -12,6 +12,7 @@ import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import Results from './Results'
+import { QueryPlanRow } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.types'
 
 export type UtilityTabExplainProps = {
   id: string
@@ -32,7 +33,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
 
     const { query, prompt } = buildExplainPrompt({
       sql: snippet.content.sql,
-      explainPlanRows: [...explainResult.rows] as any,
+      explainPlanRows: (explainResult?.rows as QueryPlanRow[]) ?? [],
     })
 
     openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
@@ -1,11 +1,15 @@
 import { Loader2 } from 'lucide-react'
-import { forwardRef, useState } from 'react'
+import { useState } from 'react'
 
 import CopyButton from 'components/ui/CopyButton'
 import { ExplainVisualizer } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer'
 import { ExplainHeader } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.Header'
 import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
+import { buildExplainPrompt } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.ai'
+import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
+import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import Results from './Results'
 
@@ -18,6 +22,30 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
   const snapV2 = useSqlEditorV2StateSnapshot()
   const explainResult = snapV2.explainResults[id]
   const [mode, setMode] = useState<'visual' | 'raw'>('visual')
+
+  const { openSidebar } = useSidebarManagerSnapshot()
+  const aiSnap = useAiAssistantStateSnapshot()
+
+  const handleExplainWithAI = () => {
+    const snippet = snapV2.snippets[id]?.snippet
+    if (!snippet?.content?.sql) return
+
+    const { query, prompt } = buildExplainPrompt({
+      sql: snippet.content.sql,
+      explainPlanRows: [...explainResult.rows] as any,
+    })
+
+    openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+    aiSnap.newChat({
+      sqlSnippets: [
+        {
+          label: 'Query',
+          content: query,
+        },
+      ],
+      initialMessage: prompt,
+    })
+  }
 
   if (isExecuting) {
     return (
@@ -94,7 +122,11 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
   return (
     <div className="h-full flex flex-col">
       {mode === 'visual' ? (
-        <ExplainVisualizer rows={explainResult.rows} onShowRaw={toggleMode} />
+        <ExplainVisualizer
+          rows={explainResult.rows}
+          onShowRaw={toggleMode}
+          onExplainWithAI={handleExplainWithAI}
+        />
       ) : (
         <>
           <ExplainHeader mode="raw" onToggleMode={toggleMode} />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Add AI explain to new pretty-explain view
- Update raw/visual button to match designs

## Demo
<img width="626" height="1340" alt="Screenshot 2025-12-24 at 8 11 05 AM" src="https://github.com/user-attachments/assets/a3f008a5-496c-4519-b5a3-9ed90104246d" />
<img width="1826" height="596" alt="Screenshot 2025-12-24 at 8 10 59 AM" src="https://github.com/user-attachments/assets/3ae5bff1-482d-419f-b450-3818d0c8acd4" />
