### PR TITLE
fix: SQL injection vulnerability in parameter processing

### DIFF
--- a/apps/studio/lib/sql-parameters.test.ts
+++ b/apps/studio/lib/sql-parameters.test.ts
@@ -75,3 +75,75 @@ describe('processParameterizedSql', () => {
     expect(result).not.toContain('@set')
   })
 })
+
+describe('SQL Injection Protection', () => {
+  it('prevents SQL injection via single quote escape', () => {
+    const sql = "@set name = John\nSELECT * FROM users WHERE name = : name"
+    const result = processParameterizedSql(sql, { name: "'; DROP TABLE users; --" })
+    
+    // Should escape the single quotes and treat as literal string
+    expect(result).toContain("''; DROP TABLE users; --'")
+    expect(result).not.toContain("DROP TABLE users")
+  })
+
+  it('prevents SQL injection via UNION attack', () => {
+    const sql = "@set userId: int = 1\nSELECT * FROM users WHERE id = :userId"
+    const result = processParameterizedSql(sql, { 
+      userId: "1 UNION SELECT password FROM admin_users" 
+    })
+    
+    // Should treat entire input as a literal string
+    expect(result).toContain("'1 UNION SELECT password FROM admin_users'")
+  })
+
+  it('prevents SQL injection via OR 1=1', () => {
+    const sql = "@set email = user@example.com\nSELECT * FROM users WHERE email = :email"
+    const result = processParameterizedSql(sql, { 
+      email: "' OR '1'='1" 
+    })
+    
+    // Should escape and quote properly
+    expect(result).toContain("''' OR ''1''=''1'")
+  })
+
+  it('prevents SQL injection via comment injection', () => {
+    const sql = "@set status = active\nUPDATE users SET status = : status WHERE id = 1"
+    const result = processParameterizedSql(sql, { 
+      status: "active'; DELETE FROM users; --" 
+    })
+    
+    // Should escape the entire malicious payload
+    expect(result).toContain("''")
+    expect(result).not.toMatch(/DELETE FROM users; --$/)
+  })
+
+  it('prevents SQL injection via semicolon statement termination', () => {
+    const sql = "@set name = test\nINSERT INTO logs (name) VALUES (:name)"
+    const result = processParameterizedSql(sql, { 
+      name: "test'); DROP TABLE logs; --" 
+    })
+    
+    // Should properly escape the value
+    expect(result).toContain("'test''); DROP TABLE logs; --'")
+  })
+
+  it('handles numeric SQL injection attempts', () => {
+    const sql = "@set id: int = 1\nSELECT * FROM users WHERE id = :id"
+    const result = processParameterizedSql(sql, { 
+      id: "1 OR 1=1" 
+    })
+    
+    // Should treat as string literal
+    expect(result).toContain("'1 OR 1=1'")
+  })
+
+  it('prevents batch statement injection', () => {
+    const sql = "@set query = test\nSELECT * FROM items WHERE name = :query"
+    const result = processParameterizedSql(sql, { 
+      query: "test'; GRANT ALL ON DATABASE mydb TO attacker; --" 
+    })
+    
+    // Should escape properly
+    expect(result).not.toContain("GRANT ALL")
+  })
+})


### PR DESCRIPTION
This pull request introduces important security improvements to the SQL parameterization logic, specifically to prevent SQL injection attacks. The main change is the use of a proper SQL literal escaping function when substituting parameters, and a comprehensive set of tests has been added to verify protection against various SQL injection techniques.

Security enhancements:

* Updated `processParameterizedSql` in `sql-parameters.ts` to use the `literal()` function from `@supabase/pg-meta/src/pg-format`, ensuring all parameter values are safely escaped and quoted to prevent SQL injection. [[1]](diffhunk://#diff-bab72f5896c222a2880990ae0979308d4c78bfd591dc9e49a60e94b94c249512R1-R2) [[2]](diffhunk://#diff-bab72f5896c222a2880990ae0979308d4c78bfd591dc9e49a60e94b94c249512L103-R115)

Testing improvements:

* Added a new test suite to `sql-parameters.test.ts` covering multiple SQL injection scenarios (single quote escape, UNION attacks, OR 1=1, comment injection, semicolon termination, numeric injection, and batch statement injection) to confirm that the escaping logic effectively neutralizes malicious input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL parameter security with enhanced escaping to prevent SQL injection attacks.

* **Tests**
  * Added comprehensive test suite for SQL injection protection, validating defense mechanisms against multiple attack vectors including quote escaping, UNION-based injections, and command injections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->