### PR TITLE
Add aria-label to menu dropdown button for accessibility

### DIFF
--- a/apps/studio/components/ui/DropdownMenuItemTooltip.tsx
+++ b/apps/studio/components/ui/DropdownMenuItemTooltip.tsx
@@ -17,6 +17,7 @@ export const DropdownMenuItemTooltip = forwardRef<
         <DropdownMenuItem
           ref={ref}
           {...props}
+          aria-label={props.tooltip?.content?.text}
           className={cn(props.className, '!pointer-events-auto')}
           onClick={(e) => {
             if (!props.disabled && props.onClick) props.onClick(e)
@@ -25,6 +26,7 @@ export const DropdownMenuItemTooltip = forwardRef<
           {props.children}
         </DropdownMenuItem>
       </TooltipTrigger>
+
       {props.disabled && props.tooltip.content.text !== undefined && (
         <TooltipContent {...props.tooltip.content}>{props.tooltip.content.text}</TooltipContent>
       )}


### PR DESCRIPTION
### What does this PR do?
Adds an aria-label to the icon-only menu dropdown button.

### Why?
Icon-only buttons without aria-labels are not accessible to screen readers.
This improves accessibility without changing existing behavior.

### Checklist
- [x] No breaking changes
- [x] Improves accessibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility with improved screen reader support for dropdown menu items

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->