### PR TITLE
[FE-2227] chore: Refactor the Deno libraries to be bundled loaded as dynamic ES modules

### DIFF
--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -38,7 +38,7 @@ interface AIEditorProps {
 // Can we try to de-dupe accordingly? Perhaps the SQL Editor could use this AIEditor
 // We have a tendency to create multiple versions of the monaco editor like RLSCodeEditor
 // so hoping to prevent that from snowballing
-const AIEditor = ({
+export const AIEditor = ({
   language = 'javascript',
   value,
   defaultValue = '',
@@ -456,5 +456,3 @@ const AIEditor = ({
     </div>
   )
 }
-
-export default AIEditor

--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -203,12 +203,20 @@ export const AIEditor = ({
     if (language === 'javascript' || language === 'typescript') {
       // The Deno libs are loaded as a raw text via raw-loader in next.config.js. They're passed as raw text to the
       // Monaco editor.
-      import('public/deno/edge-runtime.d.ts' as string).then((module) => {
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(module.default)
-      })
-      import('public/deno/lib.deno.d.ts' as string).then((module) => {
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(module.default)
-      })
+      import('public/deno/edge-runtime.d.ts' as string)
+        .then((module) => {
+          monaco.languages.typescript.typescriptDefaults.addExtraLib(module.default)
+        })
+        .catch((error) => {
+          console.error('Failed to load Deno edge-runtime typings:', error)
+        })
+      import('public/deno/lib.deno.d.ts' as string)
+        .then((module) => {
+          monaco.languages.typescript.typescriptDefaults.addExtraLib(module.default)
+        })
+        .catch((error) => {
+          console.error('Failed to load Deno lib typings:', error)
+        })
     }
 
     if (!!executeQueryRef.current) {

--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -200,18 +200,16 @@ const AIEditor = ({
       diagnosticCodesToIgnore: [2792],
     })
 
-    fetch(`${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/deno/lib.deno.d.ts`)
-      .then((response) => response.text())
-      .then((code) => {
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(code)
+    if (language === 'javascript' || language === 'typescript') {
+      // The Deno libs are loaded as a raw text via raw-loader in next.config.js. They're passed as raw text to the
+      // Monaco editor.
+      import('public/deno/edge-runtime.d.ts' as string).then((module) => {
+        monaco.languages.typescript.typescriptDefaults.addExtraLib(module.default)
       })
-
-    // Add edge runtime types to the TS language service
-    fetch(`${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/deno/edge-runtime.d.ts`)
-      .then((response) => response.text())
-      .then((code) => {
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(code)
+      import('public/deno/lib.deno.d.ts' as string).then((module) => {
+        monaco.languages.typescript.typescriptDefaults.addExtraLib(module.default)
       })
+    }
 
     if (!!executeQueryRef.current) {
       editor.addAction({

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
+import { generateSnippetTitle } from 'components/interfaces/SQLEditor/SQLEditor.constants'
 import {
   createSqlSnippetSkeletonV2,
   suffixWithLimit,
@@ -40,11 +42,9 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { containsUnknownFunction, isReadOnlySelect } from '../AIAssistantPanel/AIAssistant.utils'
-import AIEditor from '../AIEditor'
+import { AIEditor } from '../AIEditor'
 import { ButtonTooltip } from '../ButtonTooltip'
 import { SqlWarningAdmonition } from '../SqlWarningAdmonition'
-import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
-import { generateSnippetTitle } from 'components/interfaces/SQLEditor/SQLEditor.constants'
 
 export const EditorPanel = () => {
   const {

--- a/apps/studio/components/ui/FileExplorerAndEditor/index.tsx
+++ b/apps/studio/components/ui/FileExplorerAndEditor/index.tsx
@@ -1,9 +1,9 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { Edit, File, Plus, Trash } from 'lucide-react'
 import { useEffect, useState } from 'react'
-
-import AIEditor from 'components/ui/AIEditor'
 import { toast } from 'sonner'
+
+import { AIEditor } from 'components/ui/AIEditor'
 import {
   Button,
   ContextMenu_Shadcn_,

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -566,6 +566,15 @@ const nextConfig = {
         loaders: ['raw-loader'],
         as: '*.js',
       },
+      // special case for Deno libs to be loaded as a raw text. They're passed as raw text to the Monaco editor.
+      'edge-runtime.d.ts': {
+        loaders: ['raw-loader'],
+        as: '*.js',
+      },
+      'lib.deno.d.ts': {
+        loaders: ['raw-loader'],
+        as: '*.js',
+      },
     },
   },
   onDemandEntries: {


### PR DESCRIPTION
This PR refactors the loading of the Deno libs to be loaded as raw strings and passed on to the Monaco instance.

The Deno libraries are needed in the Edge functions Code Editor. Without them, the editor will mark all Deno types as invalid.

This also fixes the loading of the Deno libs through the CDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured AI Editor component module exports to improve code organization and consistency
  * Enhanced type definition loading for JavaScript and TypeScript editing with improved error handling to gracefully manage unavailable type files
  * Updated module import patterns across editor components for improved consistency

* **Chores**
  * Updated build configuration to properly process Deno type declaration files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->