### PR TITLE
fix: Refactor deploy commit API route

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
+++ b/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
@@ -33,7 +33,7 @@ export const formatMessage = ({
   message: string
   attachments?: string[]
   error: string | null | undefined
-  commit: { commitSha: string; commitTime: string } | undefined
+  commit: { time: string; sha: string } | undefined
   dashboardLogUrl?: string
 }) => {
   const errorString = error != null ? `\n\nError: ${error}` : ''
@@ -41,7 +41,7 @@ export const formatMessage = ({
     attachments.length > 0 ? `\n\nAttachments:\n${attachments.join('\n')}` : ''
   const commitString =
     commit != undefined
-      ? `\n\n---\nSupabase Studio version: SHA ${commit.commitSha} deployed at ${commit.commitTime === 'unknown' ? 'unknown time' : dayjs(commit.commitTime).format('YYYY-MM-DD HH:mm:ss Z')}`
+      ? `\n\n---\nSupabase Studio version: SHA ${commit.sha} deployed at ${commit.time === 'unknown' ? 'unknown time' : dayjs(commit.time).format('YYYY-MM-DD HH:mm:ss Z')}`
       : ''
   const logString = dashboardLogUrl ? `\nDashboard logs: ${dashboardLogUrl}` : ''
   return `${message}${errorString}${attachmentsString}${commitString}${logString}`

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -82,7 +82,8 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
 
   const sanitizedLogSnapshot = useConstant(getSanitizedBreadcrumbs)
 
-  const { data: commit } = useDeploymentCommitQuery()
+  const { data } = useDeploymentCommitQuery()
+  const commit = data?.deploymentCommit
 
   const { mutate: submitSupportTicket } = useSendSupportTicketMutation({
     onSuccess: (_, variables) => {

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -82,9 +82,7 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
 
   const sanitizedLogSnapshot = useConstant(getSanitizedBreadcrumbs)
 
-  const { data: commit } = useDeploymentCommitQuery({
-    staleTime: 1000 * 60 * 10, // 10 minutes
-  })
+  const { data: commit } = useDeploymentCommitQuery()
 
   const { mutate: submitSupportTicket } = useSendSupportTicketMutation({
     onSuccess: (_, variables) => {

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -75,8 +75,8 @@ const { mockCommitSha, mockCommitTime, mockUseDeploymentCommitQuery } = vi.hoist
   const commitTime = '2024-01-01T00:00:00Z'
 
   const createCommitResponse = () => ({
-    commitSha: sha,
-    commitTime,
+    deploymentCommit: { time: commitTime, sha },
+    latestCommit: { time: commitTime, sha },
   })
 
   return {

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -300,7 +300,10 @@ describe('SupportFormPage', () => {
 
   beforeEach(async () => {
     mockUseDeploymentCommitQuery.mockReturnValue({
-      data: { commitSha: mockCommitSha, commitTime: mockCommitTime },
+      data: {
+        deploymentCommit: { time: mockCommitTime, sha: mockCommitSha },
+        latestCommit: { time: mockCommitTime, sha: mockCommitSha },
+      },
     })
     const { createSupportStorageClient } = await import('../support-storage-client')
     createSupportStorageClientMock = vi.mocked(createSupportStorageClient)

--- a/apps/studio/data/utils/deployment-commit-query.ts
+++ b/apps/studio/data/utils/deployment-commit-query.ts
@@ -21,6 +21,6 @@ export const useDeploymentCommitQuery = <TData = DeploymentCommitData>({
     queryKey: ['deployment-commit'],
     queryFn: ({ signal }) => getDeploymentCommit(signal),
     enabled: IS_PLATFORM && enabled,
-    staleTime: 1000 * 60 * 10, // 10 minutes
+    staleTime: 1000 * 60 * 60, // 1 hour
     ...options,
   })

--- a/apps/studio/data/utils/deployment-commit-query.ts
+++ b/apps/studio/data/utils/deployment-commit-query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchHandler } from 'data/fetchers'
-import { BASE_PATH } from 'lib/constants'
+import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 
 export async function getDeploymentCommit(signal?: AbortSignal) {
@@ -17,5 +17,7 @@ export const useDeploymentCommitQuery = <TData = DeploymentCommitData>({
   useQuery<DeploymentCommitData, ResponseError, TData>({
     queryKey: ['deployment-commit'],
     queryFn: ({ signal }) => getDeploymentCommit(signal),
+    enabled: IS_PLATFORM && enabled,
+    staleTime: 1000 * 60 * 10, // 10 minutes
     ...options,
   })

--- a/apps/studio/data/utils/deployment-commit-query.ts
+++ b/apps/studio/data/utils/deployment-commit-query.ts
@@ -4,8 +4,11 @@ import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 
 export async function getDeploymentCommit(signal?: AbortSignal) {
-  const response = await fetchHandler(`${BASE_PATH}/api/get-deployment-commit`)
-  return (await response.json()) as { commitSha: string; commitTime: string }
+  const response = await fetchHandler(`${BASE_PATH}/api/get-deployment-commit`, { signal })
+  return (await response.json()) as {
+    deploymentCommit: { time: string; sha: string }
+    latestCommit: { time: string; sha: string }
+  }
 }
 
 export type DeploymentCommitData = Awaited<ReturnType<typeof getDeploymentCommit>>

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -36,35 +36,34 @@ export function useCheckLatestDeploy() {
   const [currentCommitTime, setCurrentCommitTime] = useState('')
   const [isToastShown, setIsToastShown] = useState(false)
 
-  const { data: commit } = useDeploymentCommitQuery()
+  const { data } = useDeploymentCommitQuery()
+  const commit = data?.deploymentCommit
 
   const commitLoggedRef = useRef(false)
   useEffect(() => {
     if (commit && !commitLoggedRef.current) {
       const commitTime =
-        commit.commitTime === 'unknown'
+        commit.time === 'unknown'
           ? 'unknown time'
-          : dayjs(commit.commitTime).format('YYYY-MM-DD HH:mm:ss Z')
-      console.log(
-        `Supabase Studio is running commit ${commit.commitSha} deployed at ${commitTime}.`
-      )
+          : dayjs(commit.time).format('YYYY-MM-DD HH:mm:ss Z')
+      console.log(`Supabase Studio is running commit ${commit.sha} deployed at ${commitTime}.`)
       commitLoggedRef.current = true
     }
   }, [commit])
 
   useEffect(() => {
-    if (!commit || commit.commitTime === 'unknown') {
+    if (!commit || commit.time === 'unknown') {
       return
     }
 
     // set the current commit on first load
     if (!currentCommitTime) {
-      setCurrentCommitTime(commit.commitTime)
+      setCurrentCommitTime(commit.time)
       return
     }
 
     // if the current commit is the same as the fetched commit, do nothing
-    if (currentCommitTime === commit.commitTime) {
+    if (currentCommitTime === commit.time) {
       return
     }
 
@@ -74,7 +73,7 @@ export function useCheckLatestDeploy() {
     }
 
     // check if the time difference between commits is more than 24 hours
-    const hourDiff = dayjs(commit.commitTime).diff(dayjs(currentCommitTime), 'hour')
+    const hourDiff = dayjs(commit.time).diff(dayjs(currentCommitTime), 'hour')
     if (hourDiff < 24) {
       return
     }

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -3,9 +3,9 @@ import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
-import { IS_PLATFORM, useFlag } from 'common'
 import { useDeploymentCommitQuery } from 'data/utils/deployment-commit-query'
 import { Button, StatusIcon } from 'ui'
+import { useFlag } from 'common'
 
 const DeployCheckToast = ({ id }: { id: string | number }) => {
   const router = useRouter()
@@ -39,10 +39,7 @@ export function useCheckLatestDeploy() {
   const [currentCommitTime, setCurrentCommitTime] = useState('')
   const [isToastShown, setIsToastShown] = useState(false)
 
-  const { data: commit } = useDeploymentCommitQuery({
-    enabled: IS_PLATFORM,
-    staleTime: 1000 * 60 * 10, // 10 minutes
-  })
+  const { data: commit } = useDeploymentCommitQuery()
 
   const commitLoggedRef = useRef(false)
   useEffect(() => {

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -33,11 +33,11 @@ const DeployCheckToast = ({ id }: { id: string | number }) => {
 // there's a new version of Studio is available, and the user has been on the old dashboard (based on commit) for more than 24 hours.
 // [Joshen] K-Dog has a suggestion here to bring down the time period here by checking commits
 export function useCheckLatestDeploy() {
-  const [currentCommitTime, setCurrentCommitTime] = useState('')
   const [isToastShown, setIsToastShown] = useState(false)
 
   const { data } = useDeploymentCommitQuery()
   const commit = data?.deploymentCommit
+  const latestCommit = data?.latestCommit
 
   const commitLoggedRef = useRef(false)
   useEffect(() => {
@@ -52,18 +52,12 @@ export function useCheckLatestDeploy() {
   }, [commit])
 
   useEffect(() => {
-    if (!commit || commit.time === 'unknown') {
-      return
-    }
-
-    // set the current commit on first load
-    if (!currentCommitTime) {
-      setCurrentCommitTime(commit.time)
-      return
-    }
-
-    // if the current commit is the same as the fetched commit, do nothing
-    if (currentCommitTime === commit.time) {
+    if (
+      !commit?.time ||
+      commit.time === 'unknown' ||
+      !latestCommit?.time ||
+      latestCommit.time === 'unknown'
+    ) {
       return
     }
 
@@ -73,7 +67,7 @@ export function useCheckLatestDeploy() {
     }
 
     // check if the time difference between commits is more than 24 hours
-    const hourDiff = dayjs(commit.time).diff(dayjs(currentCommitTime), 'hour')
+    const hourDiff = dayjs(latestCommit.time).diff(dayjs(commit.time), 'hour')
     if (hourDiff < 24) {
       return
     }
@@ -84,5 +78,5 @@ export function useCheckLatestDeploy() {
       position: 'bottom-right',
     })
     setIsToastShown(true)
-  }, [commit, isToastShown, currentCommitTime])
+  }, [commit?.time, latestCommit?.time, isToastShown])
 }

--- a/apps/studio/hooks/use-check-latest-deploy.tsx
+++ b/apps/studio/hooks/use-check-latest-deploy.tsx
@@ -5,7 +5,6 @@ import { toast } from 'sonner'
 
 import { useDeploymentCommitQuery } from 'data/utils/deployment-commit-query'
 import { Button, StatusIcon } from 'ui'
-import { useFlag } from 'common'
 
 const DeployCheckToast = ({ id }: { id: string | number }) => {
   const router = useRouter()
@@ -34,8 +33,6 @@ const DeployCheckToast = ({ id }: { id: string | number }) => {
 // there's a new version of Studio is available, and the user has been on the old dashboard (based on commit) for more than 24 hours.
 // [Joshen] K-Dog has a suggestion here to bring down the time period here by checking commits
 export function useCheckLatestDeploy() {
-  const showRefreshToast = useFlag('showRefreshToast')
-
   const [currentCommitTime, setCurrentCommitTime] = useState('')
   const [isToastShown, setIsToastShown] = useState(false)
 
@@ -56,7 +53,7 @@ export function useCheckLatestDeploy() {
   }, [commit])
 
   useEffect(() => {
-    if (!showRefreshToast || !commit || commit.commitTime === 'unknown') {
+    if (!commit || commit.commitTime === 'unknown') {
       return
     }
 
@@ -88,5 +85,5 @@ export function useCheckLatestDeploy() {
       position: 'bottom-right',
     })
     setIsToastShown(true)
-  }, [commit, showRefreshToast, isToastShown, currentCommitTime])
+  }, [commit, isToastShown, currentCommitTime])
 }

--- a/apps/studio/pages/api/get-deployment-commit.ts
+++ b/apps/studio/pages/api/get-deployment-commit.ts
@@ -1,28 +1,32 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-async function getCommitTime(commitSha: string) {
+async function getCommit(commitSha: string) {
   try {
     const response = await fetch(`https://github.com/supabase/supabase/commit/${commitSha}.json`, {
-      headers: {
-        Accept: 'application/json',
-      },
+      headers: { Accept: 'application/json' },
     })
 
     if (!response.ok) {
-      throw new Error('Failed to fetch commit details')
+      throw new Error('Failed to fetch deployment commit details')
     }
 
     const data = await response.json()
-    return new Date(data.payload.commit.committedDate).toISOString()
+    return {
+      time: new Date(data.payload.commit.committedDate).toISOString(),
+      sha: data.payload.commit.oid as string,
+    }
   } catch (error) {
-    console.error('Error fetching commit time:', error)
-    return 'unknown'
+    console.error('Error while fetching deployment commit details:', error)
+    return { time: 'unknown', sha: 'unknown' }
   }
 }
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ commitSha: string; commitTime: string }>
+  res: NextApiResponse<{
+    deploymentCommit: { time: string; sha: string }
+    latestCommit: { time: string; sha: string }
+  }>
 ) {
   // Set cache control headers for 10 minutes so that we don't get banned by GitHub API
   res.setHeader('Cache-Control', 's-maxage=600')
@@ -31,10 +35,18 @@ export default async function handler(
   const commitSha = process.env.VERCEL_GIT_COMMIT_SHA || 'development'
 
   // Only fetch commit time if we have a valid SHA
-  const commitTime = commitSha !== 'development' ? await getCommitTime(commitSha) : 'unknown'
+  const deploymentCommitPromise =
+    commitSha !== 'development'
+      ? getCommit(commitSha)
+      : Promise.resolve({ time: 'unknown', sha: 'unknown' })
+  const latestCommitPromise = getCommit('master')
 
+  const [deploymentCommit, latestCommit] = await Promise.all([
+    deploymentCommitPromise,
+    latestCommitPromise,
+  ])
   res.status(200).json({
-    commitSha,
-    commitTime,
+    deploymentCommit,
+    latestCommit,
   })
 }


### PR DESCRIPTION
This PR changes the logic for the deployment commit API which is used to power the "your Studio is outdated, please refresh" feature.

The changes are:
- The API now returns both deployment and latest commit info. The info is used on FE to see if there has been new commits since the rendering of Studio. If there were new commits and more than 24 hours have passed, the toast is shown.
- The default `staleTime` for the query is set to 1 hour which means Studio will check every hour if it's outdated. It was 10 minutes before.

To test, check out the branch and set an older commit from the master branch as `commitSha` var in `apps/studio/pages/api/get-deployment-commit.ts`. You'll be able to see the toast, depending on how old the commit is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined how deployment commit information is obtained and represented across the app.

* **Bug Fixes**
  * Support form now displays deployment commit details consistently.

* **Performance**
  * Deployment data is cached for one hour to reduce network requests and improve responsiveness.

* **UX**
  * Improved detection of newer deployments and tighter refresh notifications so users receive more accurate update prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->