### PR TITLE
Prevent supabase role deletion and creation of roles by users without permission

### DIFF
--- a/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -21,6 +21,7 @@ import { ROLE_PERMISSIONS } from './Roles.constants'
 
 interface CreateRolePanelProps {
   visible: boolean
+  disabled: boolean
   onClose: () => void
 }
 
@@ -44,7 +45,7 @@ const initialValues = {
   canBypassRls: false,
 }
 
-export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
+export const CreateRolePanel = ({ visible, disabled, onClose }: CreateRolePanelProps) => {
   const formId = 'create-new-role'
 
   const { data: project } = useSelectedProjectQuery()
@@ -86,6 +87,7 @@ export const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
         <div className="flex w-full justify-end space-x-3 border-t border-default px-3 py-4">
           <FormActions
             form={formId}
+            disabled={disabled}
             isSubmitting={isCreating}
             hasChanges={form.formState.isDirty}
             handleReset={handleClose}

--- a/apps/studio/components/interfaces/Database/Roles/DeleteRoleModal.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/DeleteRoleModal.tsx
@@ -1,4 +1,4 @@
-import type { PostgresRole } from '@supabase/postgres-meta'
+import { PgRole } from 'data/database-roles/database-roles-query'
 import { toast } from 'sonner'
 
 import { useDatabaseRoleDeleteMutation } from 'data/database-roles/database-role-delete-mutation'
@@ -6,7 +6,7 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Modal } from 'ui'
 
 interface DeleteRoleModalProps {
-  role: PostgresRole
+  role: PgRole
   visible: boolean
   onClose: () => void
   onDelete?: () => void

--- a/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -24,7 +24,7 @@ import { ROLE_PERMISSIONS } from './Roles.constants'
 interface RoleRowProps {
   role: PgRole
   disabled?: boolean
-  onSelectDelete: (role: string) => void
+  onSelectDelete: (role: number) => void
 }
 
 export const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
@@ -141,7 +141,7 @@ export const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps
                           className="space-x-2"
                           onClick={(event) => {
                             event.stopPropagation()
-                            onSelectDelete(role.id.toString())
+                            onSelectDelete(role.id)
                           }}
                         >
                           <Trash className="text-red-800" size="14" strokeWidth={2} />

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -45,19 +45,6 @@ export const RolesList = () => {
     connectionString: project?.connectionString,
   })
 
-  const [isCreatingRole, setIsCreatingRole] = useQueryState(
-    'new',
-    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
-  )
-
-  const { setValue: setSelectedRoleIdToDelete, value: roleToDelete } = useQueryStateWithSelect({
-    urlKey: 'delete',
-    select: (id: string) => (id ? data?.find((role) => role.id.toString() === id) : undefined),
-    enabled: !!data,
-    onError: (_error, selectedId) =>
-      handleErrorOnDelete(deletingRoleIdRef, selectedId, `Database Role not found`),
-  })
-
   const roles = sortBy(data ?? [], (r) => r.name.toLocaleLowerCase())
 
   const filteredRoles = (
@@ -75,6 +62,19 @@ export const RolesList = () => {
     roles.filter((role) => role.activeConnections > 0),
     (r) => -r.activeConnections
   )
+
+  const [isCreatingRole, setIsCreatingRole] = useQueryState(
+    'new',
+    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
+  )
+
+  const { setValue: setSelectedRoleIdToDelete, value: roleToDelete } = useQueryStateWithSelect({
+    urlKey: 'delete',
+    select: (id: string) => (id ? otherRoles?.find((role) => role.id.toString() === id) : undefined),
+    enabled: !!otherRoles,
+    onError: (_error, selectedId) =>
+      handleErrorOnDelete(deletingRoleIdRef, selectedId, `Database Role not found`),
+  })
 
   return (
     <>

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -92,7 +92,7 @@ export const RolesList = () => {
 
       setRoleToDeleteId(null)
     }
-  }, [isLoading, roleToDeleteId, roleToDelete, deletingRoleIdRef.current])
+  }, [isLoading, roleToDeleteId, roleToDelete])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -75,6 +75,7 @@ export const RolesList = () => {
 
   const roleToDelete = otherRoles.find((role) => role.id === roleToDeleteId)
 
+  // In case user tries to bypass restrictions by manually typing role id in the URL
   useEffect(() => {
     if (
       !isLoading &&

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -70,17 +70,22 @@ export const RolesList = () => {
 
   const { setValue: setSelectedRoleIdToDelete, value: roleToDelete } = useQueryStateWithSelect({
     urlKey: 'delete',
-    select: (id: string) => (id ? otherRoles?.find((role) => role.id.toString() === id) : undefined),
+    select: (id: string) =>
+      id ? otherRoles?.find((role) => role.id.toString() === id) : undefined,
     enabled: !!otherRoles,
     onError: (_error, selectedId) => {
-      const isSupabaseRole = supabaseRoles.find((role) => role.id === Number(selectedId)) !== undefined
+      const isSupabaseRole =
+        supabaseRoles.find((role) => role.id === Number(selectedId)) !== undefined
       if (isSupabaseRole) {
-        handleErrorOnDelete(deletingRoleIdRef, selectedId, `Cannot delete role as it is a Supabase role`)
+        handleErrorOnDelete(
+          deletingRoleIdRef,
+          selectedId,
+          `Cannot delete role as it is a Supabase role`
+        )
       } else {
         handleErrorOnDelete(deletingRoleIdRef, selectedId, `Database Role not found`)
       }
-    }
-
+    },
   })
 
   return (
@@ -232,7 +237,11 @@ export const RolesList = () => {
         <NoSearchResults searchString={filterString} onResetFilter={() => setFilterString('')} />
       )}
 
-      <CreateRolePanel visible={isCreatingRole} disabled={!canUpdateRoles} onClose={() => setIsCreatingRole(false)} />
+      <CreateRolePanel
+        visible={isCreatingRole}
+        disabled={!canUpdateRoles}
+        onClose={() => setIsCreatingRole(false)}
+      />
 
       <DeleteRoleModal
         role={roleToDelete as unknown as PostgresRole}

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -232,7 +232,7 @@ export const RolesList = () => {
         <NoSearchResults searchString={filterString} onResetFilter={() => setFilterString('')} />
       )}
 
-      <CreateRolePanel visible={isCreatingRole} onClose={() => setIsCreatingRole(false)} />
+      <CreateRolePanel visible={isCreatingRole} disabled={!canUpdateRoles} onClose={() => setIsCreatingRole(false)} />
 
       <DeleteRoleModal
         role={roleToDelete as unknown as PostgresRole}

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -72,8 +72,15 @@ export const RolesList = () => {
     urlKey: 'delete',
     select: (id: string) => (id ? otherRoles?.find((role) => role.id.toString() === id) : undefined),
     enabled: !!otherRoles,
-    onError: (_error, selectedId) =>
-      handleErrorOnDelete(deletingRoleIdRef, selectedId, `Database Role not found`),
+    onError: (_error, selectedId) => {
+      const isSupabaseRole = supabaseRoles.find((role) => role.id === Number(selectedId)) !== undefined
+      if (isSupabaseRole) {
+        handleErrorOnDelete(deletingRoleIdRef, selectedId, `Cannot delete role as it is a Supabase role`)
+      } else {
+        handleErrorOnDelete(deletingRoleIdRef, selectedId, `Database Role not found`)
+      }
+    }
+
   })
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, resolves #41599 

## What is the new behavior?

1. if the user manually adds `delete=${roleId}` query param to the url, and `roleId` is the role id of a Supabase role, the confirmation dialog won't appear. Instead, the user will get a toast message saying "Cannot delete role as it is a Supabase role".

2. if the user manually adds `new=true` query param to the url, and he/she isn't allowed to create roles, the action buttons of the side panel ("cancel", "save") are disabled, whether the form values change or not.

Edit: removed `useQueryStateWithSelect`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creation panel now respects permissions and shows a disabled state when role creation is not allowed.
  * Delete action selection updated to use explicit role selection, improving deletion flow clarity.

* **Bug Fixes**
  * Deletion modal only appears for a valid selected role; invalid delete requests show contextual toasts and reset the selection.
  * Delete actions more reliably target the intended role, reducing accidental deletes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->