### PR TITLE
fix(docs): resolve 404 on /docs/guides/auth/server-side

### DIFF
--- a/apps/docs/content/guides/auth/server-side.mdx
+++ b/apps/docs/content/guides/auth/server-side.mdx
@@ -17,10 +17,6 @@ Make sure to use the PKCE flow instructions where those differ from the implicit
 
 We have developed an [`@supabase/ssr`](https://www.npmjs.com/package/@supabase/ssr) package to make setting up the Supabase client as simple as possible. This package is currently in beta. Adoption is recommended but be aware that the API is still unstable and may have breaking changes in the future.
 
-<$Partial
-path="auth_helpers.mdx"
-/>
-
 ## Framework quickstarts
 
 <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-6 mb-6 not-prose">


### PR DESCRIPTION
Removes broken partial reference to non-existent `auth_helpers.mdx` file that was causing the server-side auth docs page to return 404.

<details>
<summary><strong>Before</strong></summary>

<img width="1011" height="689" alt="image" src="https://github.com/user-attachments/assets/4965d1a9-0a6b-4449-bb3f-7b236aef0df3" />

</details>

<details>
<summary><strong>After fix</strong></summary>

<img width="1207" height="846" alt="image" src="https://github.com/user-attachments/assets/52dfc0f6-bc65-4791-b880-bac318e9edd7" />

</details>

closes https://github.com/supabase/supabase/issues/41598