### PR TITLE
docs: fix typos and formatting in troubleshooting guides

### DIFF
--- a/apps/docs/content/troubleshooting/discovering-and-interpreting-api-errors-in-the-logs-7xREI9.mdx
+++ b/apps/docs/content/troubleshooting/discovering-and-interpreting-api-errors-in-the-logs-7xREI9.mdx
@@ -11,7 +11,7 @@ database_id = "188986c9-019d-4f26-baaf-6f58cec8fa7a"
 
 # Navigating the API logs:
 
-The Database API is powered by a [ PostgREST web-server](https://postgrest.org/en/v12/), recording every request to the API Edge Network logs. To precisely navigate them, use the [Log Explorer](/dashboard/project/_/logs/explorer). These logs are managed through [Logflare](/blog/supabase-logs-self-hosted) and can be queried with a subset of BigQuery SQL syntax.
+The Database API is powered by a [PostgREST web-server](https://postgrest.org/en/v12/), recording every request to the API Edge Network logs. To precisely navigate them, use the [Log Explorer](/dashboard/project/_/logs/explorer). These logs are managed through [Logflare](/blog/supabase-logs-self-hosted) and can be queried with a subset of BigQuery SQL syntax.
 
 The log table that contains API requests is `edge_logs`.
 
@@ -71,12 +71,12 @@ select
   city
 from
   edge_logs
--- Unpack 'metadata' field
-cross join unnest(metadata) AS metadata
--- unpack 'request' from 'metadata'
-cross join unnest(request) AS request;
--- unpack 'cf' from 'request'
-cross join unnest(cf) AS cf;
+  -- Unpack 'metadata' field
+  cross join unnest(metadata) as metadata
+  -- unpack 'request' from 'metadata'
+  cross join unnest(request) as request
+  -- unpack 'cf' from 'request'
+  cross join unnest(cf) as cf;
 ```
 
 ### IP and browser/environment data:
@@ -99,12 +99,12 @@ select
   cf_connecting_ip
 from
   edge_logs
--- Unpack 'metadata' field
-cross join unnest(metadata) AS metadata
--- unpack 'request' from 'metadata'
-cross join unnest(request) AS request;
--- unpack 'headers' from 'request'
-cross join unnest(headers) AS headers;
+  -- Unpack 'metadata' field
+  cross join unnest(metadata) as metadata
+  -- unpack 'request' from 'metadata'
+  cross join unnest(request) as request
+  -- unpack 'headers' from 'request'
+  cross join unnest(headers) as headers;
 ```
 
 ### Query type and formatting data:
@@ -129,12 +129,12 @@ select
   auth_users
 from
   edge_logs
--- Unpack 'metadata' field
-cross join unnest(metadata) AS metadata
--- unpack 'request' from 'metadata'
-cross join unnest(request) AS request;
--- unpack 'sb' from 'request'
-cross join unnest(sb) AS sb;
+  -- Unpack 'metadata' field
+  cross join unnest(metadata) as metadata
+  -- unpack 'request' from 'metadata'
+  cross join unnest(request) as request
+  -- unpack 'sb' from 'request'
+  cross join unnest(sb) as sb;
 ```
 
 ## Response object
@@ -203,7 +203,7 @@ where
   -- find all errors
   status_code >= 400
     and
-  -- find queries featuring the a specific <table_name> and <column_name>
+  -- find queries featuring a specific <table_name> and <column_name>
   (
     regexp_contains(url, '<table_name>')
     and
@@ -250,7 +250,7 @@ Like PostgREST, Postgres has a [reference table](https://www.postgresql.org/docs
 
 ## PostgREST server and Cloudflare errors
 
-In some cases, errors may emerge because of Cloudflare or PostgREST server errors. For 500 and above errors, you may want to check your [PostgREST](/dashboard/project/_/logs/postgrest-logs) logs and the [Cloudflare docs.](https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/#error-502-bad-gateway-or-error-504-gateway-timeout))
+In some cases, errors may emerge because of Cloudflare or PostgREST server errors. For 500 and above errors, you may want to check your [PostgREST](/dashboard/project/_/logs/postgrest-logs) logs and the [Cloudflare docs.](https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/#error-502-bad-gateway-or-error-504-gateway-timeout)
 
 # Practical examples:
 
@@ -335,7 +335,7 @@ order by ip_count;
 
 ```sql
 select
-  -- only available for front-end clients
+  -- only available for frontend clients
   auth_users,
   path,
   count(auth_users) as ip_count

--- a/apps/docs/content/troubleshooting/how-to-interpret-and-explore-the-postgres-logs-OuCIOj.mdx
+++ b/apps/docs/content/troubleshooting/how-to-interpret-and-explore-the-postgres-logs-OuCIOj.mdx
@@ -122,7 +122,7 @@ cross join unnest(parsed) AS parsed;
 - Filter connections by IP
 - Identify connections to specific databases
 - Filter connections by sessions for debugging
-- identify extension events
+- Identify extension events
 
 ## Filtering logs
 
@@ -136,7 +136,7 @@ When exploring the logs for atypical behavior, it's often strategic to filter ou
 ...query
 where
   -- Excluding routine events related to cron, PgBouncer, checkpoints, and successful connections
-  not regexp_contains(event_message, '^cron|PgBouncer|checkpoint|connection received|authenticated|authorized';
+  not regexp_contains(event_message, '^cron|PgBouncer|checkpoint|connection received|authenticated|authorized')
 ```
 
 ### By timeframe
@@ -187,7 +187,7 @@ Queries can use complex syntax, so it is often helpful to isolate by referenced 
 - `^`: look for values at start of string
 - `|`: or operator
 
-## By APIs/roles
+### By APIs/roles
 
 All failed queries, including those from PostgREST, Auth, and external libraries (e.g., Prisma) are logged with helpful error messages for debugging.
 
@@ -217,7 +217,7 @@ where
 ...
 ```
 
-## By Dashboard queries
+### By Dashboard queries
 
 Queries from the Supabase Dashboard are executed under the `postgres` role and include the comment `-- source: dashboard`. To isolate or exclude Dashboard requests during debugging, you can filter by this comment.
 
@@ -228,7 +228,7 @@ where
   regexp_contains(parsed.query, '-- source: dashboard')
 ```
 
-## Full example for finding errors
+### Full example for finding errors
 
 ```sql
 select
@@ -319,7 +319,7 @@ The settings that affect logs are categorized under:
 | Category | Description |
 |----------|-------------|
 | `Reporting and Logging / What to Log` | Specifies system events worth logging.|
-| `Reporting and Logging / When to Log` | Specifies certain conditions or rules for logging
+| `Reporting and Logging / When to Log` | Specifies certain conditions or rules for logging.
 | `Customized Options` | Configures extensions and loaded modules, including those enhancing logging like auto_explain and pg_audit. |
 
 To view all log settings for your database, you can execute the following SQL:

--- a/apps/docs/content/troubleshooting/supavisor-faq-YyP5tI.mdx
+++ b/apps/docs/content/troubleshooting/supavisor-faq-YyP5tI.mdx
@@ -23,7 +23,7 @@ A pooler is ultimately a load balancer for database connections. It maintains se
 
 All database connection libraries, such as Prisma, SQLAlchemy, and Postgres.js have built-in poolers. These are known as application-side poolers and they are fundamental for sustainable connection management. Most libraries have default pool sizes that may need to be changed for specific workloads. As an example, most edge/serverless functions are called to service a single user's request. They usually require significantly fewer connections (often 1 is optimal) than a dedicated application server.
 
-Note, that like databases, servers can only maintain a certain amount of connections themselves. If you were to increase the number aggressively, the server may not be able gracefully orchestrate them. For instance, Prisma's [default pool size](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#connection-pool-size) is automatically set to one more than twice the server's CPU count (1 + 2 \* num_of_CPUs). The Prisma Team chose this value because it is generally performant with ORM's internal architecture.
+Note, that like databases, servers can only maintain a certain amount of connections themselves. If you were to increase the number aggressively, the server may not be able to gracefully orchestrate them. For instance, Prisma's [default pool size](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#connection-pool-size) is automatically set to one more than twice the server's CPU count (1 + 2 \* num_of_CPUs). The Prisma Team chose this value because it is generally performant with ORM's internal architecture.
 
 When deploying to static architecture, such as long-standing containers or VMs, application-side poolers are satisfactory on their own.
 
@@ -43,7 +43,7 @@ Supabase provides 3 database connection strings that can be used simultaneously 
 
 #### Direct connections:
 
-> "Note uses an IPv6 address by default. [Check here to see if your network is IPv6 compatible](https://github.com/orgs/supabase/discussions/27034)"
+> "Note: This uses an IPv6 address by default. [Check here to see if your network is IPv6 compatible](https://github.com/orgs/supabase/discussions/27034)"
 
 ```sh
 # Example connection string
@@ -80,7 +80,7 @@ When clients connect to either Postgres or Supavisor, they do so with the Postgr
 
 ### What are "client connections"?
 
-In summary, they have nothing to do with front-end clients. They are the amount of backend-server connections that can connect to a serverside pooler.
+In summary, they have nothing to do with frontend clients. They are the amount of backend-server connections that can connect to a serverside pooler.
 Imagine a chess tournament with 60 boards. Each board represents a connection in a database. When a player sits down at a board, it's like a client connecting to the database. They can take their time with their moves or just sit there, not making any.
 
 But when the tournament fills up and all the boards are taken, new players are turned away, and told to check back at a later time to see if a table becomes available.
@@ -103,7 +103,7 @@ CREATE DATABASE another_database;
 Similarly, a database can have many database users, but most people just rely on the default user `postgres`.
 
 ```sql
-CREATE USER postgres WITH PASSWORD 'super-secret-password;
+CREATE USER postgres WITH PASSWORD 'super-secret-password';
 CREATE USER some_new_user WITH PASSWORD 'password';
 ```
 
@@ -123,7 +123,7 @@ No, it doesn't. Let's break it down:
 
 - In transaction mode, the pooler will only add connections if there are not enough connections to service all pending queries simultaneously. If 10 clients connect, but a single direct connection can comfortably accommodate them all, the pooler will not create more.
 - If necessary, it can create as many connections to prevent queries from pending up to the limit specified by the "Pool Size".
-- In session mode, it will immediately create a new a direct connection for a new client unless the "Pool Size" is reached
+- In session mode, it will immediately create a new direct connection for a new client unless the "Pool Size" is reached
 - In transaction mode, once a direct connection is established, the pooler will keep it available for reuse for another client. However, if the connection remains unused for 5 minutes, the pooler will close it to free up database resources. In session mode, the connection will be immediately closed.
 - If a client is connected to the pooler, then at least 1 hot connection will be sustained, even if no client needs it.
 


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Documentation improvements - fixes typos, formatting, and syntax errors in troubleshooting guides.

## What is the current behavior?

Troubleshooting documentation contains typos, broken links, SQL syntax errors, and inconsistent formatting.

## What is the new behavior?

**Fixes across 3 troubleshooting guides:**
- Typos: "front-end" → "frontend", article duplications ("the a" → "a")
- Links: Fixed orphaned parenthesis in Cloudflare docs link
- SQL: Fixed premature semicolons, missing quotes/parenthesis
- Markdown: Corrected header levels and table punctuation
- Formatting: Applied Prettier for consistent indentation and SQL casing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved troubleshooting guides with standardized formatting, corrected code examples, and enhanced readability
  * Enhanced FAQ documentation with grammar fixes, clearer explanations, and corrected SQL syntax
  * Reorganized documentation structure for better navigation and accessibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->