### PR TITLE
fix(studio): add backward-compatible alias for async permissions hook

### DIFF
--- a/apps/studio/hooks/misc/useCheckPermissions.ts
+++ b/apps/studio/hooks/misc/useCheckPermissions.ts
@@ -188,3 +188,6 @@ export function useAsyncCheckPermissions(
 
   return { isLoading, isSuccess, can }
 }
+
+// Backward-compatible export alias for SSR builds
+export const useAsyncCheckProjectPermissions = useAsyncCheckPermissions


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Supabase Studio production SSR builds fail because the hook
`useAsyncCheckProjectPermissions` is imported but not exported from
`apps/studio/hooks/misc/useCheckPermissions.ts`, resulting in a static
export resolution error during SSR.

Related issue: #41582

## What is the new behavior?

SSR builds succeed because a backward-compatible export alias ensures
both `useAsyncCheckPermissions` and `useAsyncCheckProjectPermissions`
resolve correctly without changing runtime behavior.

## Additional context

The hook was previously renamed, and this alias restores compatibility
for SSR and production builds while keeping the change minimal and safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a backward-compatible export alias for improved cross-environment compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->