### PR TITLE
fix Log Explorer run query inconsistency

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,7 +1,6 @@
-import dayjs from 'dayjs'
 import { BookOpen, Check, ChevronDown, Copy, ExternalLink, X } from 'lucide-react'
 import Link from 'next/link'
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 
 import { IS_PLATFORM } from 'common'
 import Table from 'components/to-be-cleaned/Table'
@@ -32,8 +31,7 @@ import { LogsWarning, LogTemplate } from './Logs.types'
 
 export interface LogsQueryPanelProps {
   templates?: LogTemplate[]
-  defaultFrom: string
-  defaultTo: string
+  value: DatePickerValue
   warnings: LogsWarning[]
   onSelectTemplate: (template: LogTemplate) => void
   onSelectSource: (source: string) => void
@@ -51,8 +49,7 @@ function DropdownMenuItemContent({ name, desc }: { name: ReactNode; desc?: strin
 
 const LogsQueryPanel = ({
   templates = [],
-  defaultFrom,
-  defaultTo,
+  value,
   warnings,
   onSelectTemplate,
   onSelectSource,
@@ -77,26 +74,11 @@ const LogsQueryPanel = ({
     })
     .map(([, value]) => value)
 
-  function getDefaultDatePickerValue() {
-    if (defaultFrom && defaultTo) {
-      return {
-        to: defaultTo,
-        from: defaultFrom,
-        text: `${dayjs(defaultFrom).format('DD MMM, HH:mm')} - ${dayjs(defaultTo).format('DD MMM, HH:mm')}`,
-        isHelper: false,
-      }
-    }
-    return {
-      to: EXPLORER_DATEPICKER_HELPERS[0].calcTo(),
-      from: EXPLORER_DATEPICKER_HELPERS[0].calcFrom(),
-      text: EXPLORER_DATEPICKER_HELPERS[0].text,
-      isHelper: true,
-    }
-  }
+  const [selectedDatePickerValue, setSelectedDatePickerValue] = useState<DatePickerValue>(value)
 
-  const [selectedDatePickerValue, setSelectedDatePickerValue] = useState<DatePickerValue>(
-    getDefaultDatePickerValue()
-  )
+  useEffect(() => {
+    setSelectedDatePickerValue(value)
+  }, [value.from, value.to, value.text, value.isHelper])
 
   return (
     <div className="border-b bg-surface-100">

--- a/apps/studio/components/interfaces/Settings/Logs/logsDateRange.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/logsDateRange.ts
@@ -1,0 +1,56 @@
+import dayjs from 'dayjs'
+
+import { EXPLORER_DATEPICKER_HELPERS, getDefaultHelper } from './Logs.constants'
+import type { DatePickerValue } from './Logs.DatePickers'
+import type { DatetimeHelper } from './Logs.types'
+
+export interface ResolvedLogDateRange {
+  from: string
+  to: string
+}
+
+export interface ResolvedLogParams extends ResolvedLogDateRange {
+  sql: string
+}
+
+const findHelper = (value: DatePickerValue, helpers: DatetimeHelper[]) => {
+  if (!value.text) return undefined
+  return helpers.find((helper) => helper.text === value.text)
+}
+
+const ensureEnd = (candidate: string | undefined, now: dayjs.Dayjs) => {
+  if (candidate && candidate.length > 0) return candidate
+  return now.toISOString()
+}
+
+export const resolveLogDateRange = (
+  value: DatePickerValue,
+  helpers: DatetimeHelper[] = EXPLORER_DATEPICKER_HELPERS
+): ResolvedLogDateRange => {
+  const now = dayjs()
+  if (value.isHelper) {
+    const matchedHelper = findHelper(value, helpers) ?? getDefaultHelper(helpers)
+    const from = matchedHelper?.calcFrom() ?? value.from ?? ''
+    const to = ensureEnd(matchedHelper?.calcTo() ?? value.to, now)
+    return { from, to }
+  }
+
+  const defaultHelper = getDefaultHelper(helpers)
+  const from = value.from || defaultHelper.calcFrom()
+  const to = ensureEnd(value.to, now)
+  return { from, to }
+}
+
+export const buildLogQueryParams = (
+  value: DatePickerValue,
+  sql: string,
+  helpers: DatetimeHelper[] = EXPLORER_DATEPICKER_HELPERS
+): ResolvedLogParams => {
+  const range = resolveLogDateRange(value, helpers)
+  return {
+    sql,
+    from: range.from,
+    to: range.to,
+  }
+}
+

--- a/apps/studio/components/interfaces/Settings/Logs/logsDateRange.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/logsDateRange.ts
@@ -53,4 +53,3 @@ export const buildLogQueryParams = (
     to: range.to,
   }
 }
-

--- a/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
+++ b/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
@@ -72,6 +72,11 @@ const CodeEditor = ({
     ...actions,
   }
 
+  const runQueryCallbackRef = useRef(runQuery.callback)
+  useEffect(() => {
+    runQueryCallbackRef.current = runQuery.callback
+  }, [runQuery.callback])
+
   const showPlaceholderDefault = placeholder !== undefined && (value ?? '').trim().length === 0
   const [showPlaceholder, setShowPlaceholder] = useState(showPlaceholderDefault)
 
@@ -134,7 +139,7 @@ const CodeEditor = ({
           const selectedValue = (editorRef?.current as any)
             .getModel()
             .getValueInRange((editorRef?.current as any)?.getSelection())
-          runQuery.callback(selectedValue || (editorRef?.current as any)?.getValue())
+          runQueryCallbackRef.current(selectedValue || (editorRef?.current as any)?.getValue())
         },
       })
     }

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -9,14 +9,13 @@ import { toast } from 'sonner'
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS, useParams } from 'common'
 
 import {
+  EXPLORER_DATEPICKER_HELPERS,
   LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD,
   TEMPLATES,
+  getDefaultHelper,
 } from 'components/interfaces/Settings/Logs/Logs.constants'
-import {
-  DatePickerToFrom,
-  LogTemplate,
-  LogsWarning,
-} from 'components/interfaces/Settings/Logs/Logs.types'
+import { LogData, LogTemplate, LogsWarning } from 'components/interfaces/Settings/Logs/Logs.types'
+import { DatePickerValue } from 'components/interfaces/Settings/Logs/Logs.DatePickers'
 import {
   maybeShowUpgradePromptIfNotEntitled,
   useEditorHints,
@@ -43,6 +42,10 @@ import { useUpgradePrompt } from 'hooks/misc/useUpgradePrompt'
 import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
 import type { LogSqlSnippets, NextPageWithLayout } from 'types'
+import {
+  buildLogQueryParams,
+  resolveLogDateRange,
+} from 'components/interfaces/Settings/Logs/logsDateRange'
 import {
   Button,
   Form,
@@ -76,6 +79,22 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const editorRef = useRef<editor.IStandaloneCodeEditor>()
   const [editorId] = useState<string>(uuidv4())
   const { timestampStart, timestampEnd, setTimeRange } = useLogsUrlState()
+  const defaultHelper = useMemo(() => getDefaultHelper(EXPLORER_DATEPICKER_HELPERS), [])
+  const initialDatePickerValue = useMemo<DatePickerValue>(() => {
+    if (timestampStart && timestampEnd) {
+      return { from: timestampStart, to: timestampEnd, isHelper: false }
+    }
+    if (timestampStart) {
+      return { from: timestampStart, to: timestampEnd || '', isHelper: false }
+    }
+    return {
+      from: defaultHelper.calcFrom(),
+      to: defaultHelper.calcTo(),
+      isHelper: true,
+      text: defaultHelper.text,
+    }
+  }, [timestampStart, timestampEnd, defaultHelper])
+  const [datePickerValue, setDatePickerValue] = useState<DatePickerValue>(initialDatePickerValue)
 
   const { logsDefaultQuery } = useCustomContent(['logs:default_query'])
   const PLACEHOLDER_QUERY = IS_PLATFORM
@@ -85,7 +104,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const [editorValue, setEditorValue] = useState<string>(PLACEHOLDER_QUERY)
   const [saveModalOpen, setSaveModalOpen] = useState<boolean>(false)
   const [warnings, setWarnings] = useState<LogsWarning[]>([])
-  const [selectedLog, setSelectedLog] = useState<any>(null)
+  const [selectedLog, setSelectedLog] = useState<LogData | null>(null)
 
   const [recentLogs, setRecentLogs] = useLocalStorage<LogSqlSnippets.Content[]>(
     `project-content-${projectRef}-recent-log-sql`,
@@ -100,18 +119,28 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
     type: 'log_sql',
   })
   const query = content?.content.find((x) => x.id === queryId)
+
+  const resolvedRange = useMemo(() => {
+    if (datePickerValue.isHelper) {
+      return resolveLogDateRange(datePickerValue)
+    }
+    if (timestampStart && timestampEnd) {
+      return { from: timestampStart, to: timestampEnd }
+    }
+    return resolveLogDateRange(datePickerValue)
+  }, [timestampStart, timestampEnd, datePickerValue])
+
   const {
     params,
     logData,
     error,
     isLoading: logsLoading,
-    changeQuery,
-    runQuery,
+    setParams,
   } = useLogsQuery(
     projectRef,
     {
-      iso_timestamp_start: timestampStart,
-      iso_timestamp_end: timestampEnd,
+      iso_timestamp_start: resolvedRange.from,
+      iso_timestamp_end: resolvedRange.to,
     },
     true
   )
@@ -173,12 +202,27 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
 
   const handleRun = (value?: string | React.MouseEvent<HTMLButtonElement>) => {
     const query = typeof value === 'string' ? value || editorValue : editorValue
+    const resolvedParams = buildLogQueryParams(datePickerValue, query)
 
-    changeQuery(query)
-    runQuery()
+    setParams((prev) => ({
+      ...prev,
+      sql: resolvedParams.sql,
+      iso_timestamp_start: resolvedParams.from,
+      iso_timestamp_end: resolvedParams.to,
+    }))
+    if (!datePickerValue.isHelper) {
+      setTimeRange(resolvedParams.from, resolvedParams.to)
+    } else {
+      setTimeRange('', '')
+    }
+    const queryParams: Record<string, string | string[] | undefined> = { ...router.query, q: query }
+    if (datePickerValue.isHelper) {
+      delete queryParams.its
+      delete queryParams.ite
+    }
     router.push({
       pathname: router.pathname,
-      query: { ...router.query, q: query },
+      query: queryParams,
     })
     addRecentLogSqlSnippet({ sql: query })
   }
@@ -206,7 +250,12 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
     }
   }
 
-  const handleCreateQuery = async (values: any, { setSubmitting }: any) => {
+  type SaveQueryFormValues = { name: string; description?: string }
+
+  const handleCreateQuery = async (
+    values: SaveQueryFormValues,
+    { setSubmitting }: { setSubmitting: (value: boolean) => void }
+  ) => {
     if (!projectRef) return console.error('Project ref is required')
     if (!profile) return console.error('Profile is required')
     setSubmitting(true)
@@ -253,17 +302,29 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
     setSaveModalOpen(!saveModalOpen)
   }
 
-  const handleDateChange = ({ to, from }: DatePickerToFrom) => {
+  const handleDateChange = (value: DatePickerValue) => {
+    setDatePickerValue(value)
+    const resolvedRange = resolveLogDateRange(value)
     const shouldShowUpgradePrompt = maybeShowUpgradePromptIfNotEntitled(
-      from,
+      resolvedRange.from,
       entitledToAuditLogDays
     )
 
     if (shouldShowUpgradePrompt) {
-      setShowUpgradePrompt(!showUpgradePrompt)
-    } else {
-      setTimeRange(from || '', to || '')
+      setShowUpgradePrompt(true)
+      return
     }
+
+    if (value.isHelper) {
+      setTimeRange('', '')
+    } else {
+      setTimeRange(resolvedRange.from || '', resolvedRange.to || '')
+    }
+    setParams((prev) => ({
+      ...prev,
+      iso_timestamp_start: resolvedRange.from,
+      iso_timestamp_end: resolvedRange.to,
+    }))
   }
 
   useEffect(() => {
@@ -271,6 +332,10 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
       setEditorValue(q)
     }
   }, [q])
+
+  useEffect(() => {
+    setDatePickerValue(initialDatePickerValue)
+  }, [initialDatePickerValue])
 
   useEffect(() => {
     let newWarnings = []
@@ -297,10 +362,10 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         entitledToAuditLogDays
       )
       if (shouldShowUpgradePrompt) {
-        setShowUpgradePrompt(!showUpgradePrompt)
+        setShowUpgradePrompt(true)
       }
     }
-  }, [timestampStart, entitledToAuditLogDays])
+  }, [timestampStart, entitledToAuditLogDays, setShowUpgradePrompt])
 
   return (
     <div className="w-full h-full mx-auto">
@@ -311,8 +376,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
       >
         <ResizablePanel collapsible minSize={5}>
           <LogsQueryPanel
-            defaultFrom={timestampStart || ''}
-            defaultTo={timestampEnd || ''}
+            value={datePickerValue}
             onDateChange={handleDateChange}
             onSelectSource={handleInsertSource}
             templates={allTemplates.filter((template) => template.mode === 'custom')}
@@ -342,7 +406,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
               error={error}
               projectRef={projectRef}
               onSelectedLogChange={setSelectedLog}
-              selectedLog={selectedLog}
+              selectedLog={selectedLog || undefined}
             />
 
             <div className="flex flex-row justify-end mt-2">

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -426,7 +426,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         <Form
           initialValues={{
             name: '',
-            desdcription: '',
+            description: '',
           }}
           onSubmit={handleCreateQuery}
         >

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -334,7 +334,12 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   }, [q])
 
   useEffect(() => {
-    setDatePickerValue(initialDatePickerValue)
+    // prevents overwriting when the user selects a helper.
+    // without this, if the user selects "last 3 days" it would overwrite it with "last hour"
+    // its the simplest solution I could come up with - jordi
+    if (!initialDatePickerValue.isHelper) {
+      setDatePickerValue(initialDatePickerValue)
+    }
   }, [initialDatePickerValue])
 
   useEffect(() => {

--- a/apps/studio/tests/features/logs/LogsQueryPanel.test.tsx
+++ b/apps/studio/tests/features/logs/LogsQueryPanel.test.tsx
@@ -7,8 +7,7 @@ import { render } from 'tests/helpers'
 test('run and clear', async () => {
   render(
     <LogsQueryPanel
-      defaultFrom=""
-      defaultTo=""
+      value={{ from: '', to: '', isHelper: false }}
       onDateChange={() => {}}
       onSelectSource={() => {}}
       onSelectTemplate={() => {}}

--- a/apps/studio/tests/unit/logs/logsDateRange.test.ts
+++ b/apps/studio/tests/unit/logs/logsDateRange.test.ts
@@ -84,4 +84,3 @@ describe('buildLogQueryParams', () => {
     vi.useRealTimers()
   })
 })
-

--- a/apps/studio/tests/unit/logs/logsDateRange.test.ts
+++ b/apps/studio/tests/unit/logs/logsDateRange.test.ts
@@ -1,0 +1,87 @@
+import dayjs from 'dayjs'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  EXPLORER_DATEPICKER_HELPERS,
+  getDefaultHelper,
+} from 'components/interfaces/Settings/Logs/Logs.constants'
+import {
+  buildLogQueryParams,
+  resolveLogDateRange,
+} from 'components/interfaces/Settings/Logs/logsDateRange'
+
+const lastHourHelper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
+
+describe('resolveLogDateRange', () => {
+  it('recomputes helper ranges up to current time', () => {
+    vi.useFakeTimers()
+    const firstNow = new Date('2025-01-01T12:00:00.000Z')
+    vi.setSystemTime(firstNow)
+
+    const first = resolveLogDateRange({
+      from: '',
+      to: '',
+      isHelper: true,
+      text: lastHourHelper.text,
+    })
+
+    expect(first.to).toBe(dayjs(firstNow).toISOString())
+    expect(first.from).toBe(dayjs(firstNow).subtract(1, 'hour').toISOString())
+
+    const later = new Date('2025-01-01T13:10:00.000Z')
+    vi.setSystemTime(later)
+
+    const second = resolveLogDateRange({
+      from: '',
+      to: '',
+      isHelper: true,
+      text: lastHourHelper.text,
+    })
+
+    expect(second.to).toBe(dayjs(later).toISOString())
+    expect(second.from).toBe(dayjs(later).subtract(1, 'hour').toISOString())
+    expect(second.from).not.toBe(first.from)
+
+    vi.useRealTimers()
+  })
+
+  it('uses provided range when not a helper', () => {
+    const range = resolveLogDateRange({
+      from: '2025-01-01T10:00:00.000Z',
+      to: '2025-01-01T11:00:00.000Z',
+      isHelper: false,
+    })
+
+    expect(range.from).toBe('2025-01-01T10:00:00.000Z')
+    expect(range.to).toBe('2025-01-01T11:00:00.000Z')
+  })
+})
+
+describe('buildLogQueryParams', () => {
+  it('returns sql with recomputed helper range for repeated runs', () => {
+    vi.useFakeTimers()
+    const now = new Date('2025-01-02T08:00:00.000Z')
+    vi.setSystemTime(now)
+
+    const first = buildLogQueryParams(
+      { from: '', to: '', isHelper: true, text: lastHourHelper.text },
+      'select 1'
+    )
+
+    const later = new Date('2025-01-02T09:30:00.000Z')
+    vi.setSystemTime(later)
+
+    const second = buildLogQueryParams(
+      { from: '', to: '', isHelper: true, text: lastHourHelper.text },
+      'select 1'
+    )
+
+    expect(first.sql).toBe('select 1')
+    expect(second.sql).toBe('select 1')
+    expect(first.from).not.toBe(second.from)
+    expect(second.to).toBe(dayjs(later).toISOString())
+
+    vi.useRealTimers()
+  })
+})
+


### PR DESCRIPTION
- Fixes Logs Explorer so “Last hour/3 days/...” helpers always recompute on every run (button or Cmd+Enter) and don’t get frozen into static timestamps.
- Ensures keyboard shortcut and Run button use the same run logic.

- Made date-picker state explicit: page owns datePickerValue and passes it to LogsQueryPanel, keeping helper vs custom ranges in sync.
- Helper ranges stay dynamic: on run, we recompute timestamps; we clear URL timestamps and avoid persisting them when a helper is active.
- Custom ranges stay static: we persist their timestamps to URL state on selection/run.
- Both Run button and Cmd+Enter now share the same run handler (CodeEditor uses a ref to the latest callback), so behavior is consistent.
- Added pure date-range helpers and tests to ensure helper ranges recalc relative to “now” while custom ranges remain fixed.

## To test

- go to log explorer
- with Last hour selected → click run query a few times → always fetches latest results
- with last hour selected → press ⌘ + Enter a few times → always fetches latest results
- with a date range selected → Click run a few times → shows the same results all the time (does nothing basically)
- with a date range selected → press ⌘ Enter a few times → shows the same results all the time (does nothing basically)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date picker now uses a single controlled value and supports helper-based ranges for log queries.

* **Refactor**
  * Centralized date-range resolution and reactive synchronization of date picker state.
  * Run Query action updated to always invoke the latest callback.
  * Selected-log handling in the logs table improved for more consistent selection behavior.

* **Tests**
  * Added/updated tests covering date-range resolution and query parameter construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->