### PR TITLE
update api keys section in connect dialog

### DIFF
--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -13,7 +13,7 @@ import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { PROJECT_STATUS } from 'lib/constants'
+import { BASE_PATH, PROJECT_STATUS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import {
   Button,
@@ -493,7 +493,7 @@ export const Connect = () => {
                       <>
                         <p>
                           View your publishable and secret API keys from the project{' '}
-                          <Link href={`/project/${projectRef}/settings/api-keys`}>
+                          <Link href={`${BASE_PATH}/project/${projectRef}/settings/api-keys`}>
                             API settings page
                           </Link>
                         </p>
@@ -509,7 +509,7 @@ export const Connect = () => {
                         </p>
                       </>
                     }
-                    href={`/project/${projectRef}/settings/api-keys`}
+                    href={`${BASE_PATH}/project/${projectRef}/settings/api-keys`}
                     buttonText="View API keys"
                   />
                 )}

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { ExternalLink, Plug } from 'lucide-react'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
@@ -484,33 +484,35 @@ export const Connect = () => {
                   selectedFrameworkOrTool={selectedFrameworkOrTool}
                   className="rounded-b-none"
                 />
-                <Panel.Notice
-                  className="border border-t-0 rounded-lg rounded-t-none"
-                  badgeLabel="Changelog"
-                  title="New publishable and secret API keys"
-                  description={
-                    <>
-                      <p>
-                        View your publishable and secret API keys from the project{' '}
-                        <Link href={`/project/${projectRef}/settings/api-keys`}>
-                          API settings page
-                        </Link>
-                      </p>
-                      <p>
-                        To learn more about the new API keys, read the{' '}
-                        <a
-                          href="https://supabase.com/docs/guides/api/api-keys"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          documentation
-                        </a>
-                      </p>
-                    </>
-                  }
-                  href={`/project/${projectRef}/settings/api-keys`}
-                  buttonText="View API keys"
-                />
+                {IS_PLATFORM && (
+                  <Panel.Notice
+                    className="border border-t-0 rounded-lg rounded-t-none"
+                    badgeLabel="Changelog"
+                    title="New publishable and secret API keys"
+                    description={
+                      <>
+                        <p>
+                          View your publishable and secret API keys from the project{' '}
+                          <Link href={`/project/${projectRef}/settings/api-keys`}>
+                            API settings page
+                          </Link>
+                        </p>
+                        <p>
+                          To learn more about the new API keys, read the{' '}
+                          <a
+                            href="https://supabase.com/docs/guides/api/api-keys"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            documentation
+                          </a>
+                        </p>
+                      </>
+                    }
+                    href={`/project/${projectRef}/settings/api-keys`}
+                    buttonText="View API keys"
+                  />
+                )}
               </TabsContent_Shadcn_>
             )
           })}

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -36,6 +36,7 @@ import { CONNECTION_TYPES, ConnectionType, FRAMEWORKS, MOBILES, ORMS } from './C
 import { getContentFilePath, inferConnectTabFromParentKey } from './Connect.utils'
 import { ConnectDropdown } from './ConnectDropdown'
 import { ConnectTabContent } from './ConnectTabContent'
+import Link from 'next/link'
 
 export const Connect = () => {
   const router = useRouter()
@@ -485,12 +486,30 @@ export const Connect = () => {
                 />
                 <Panel.Notice
                   className="border border-t-0 rounded-lg rounded-t-none"
-                  title="New API keys coming 2025"
-                  description={`
-\`anon\` and \`service_role\` API keys will be changing to \`publishable\` and \`secret\` API keys.
-`}
-                  href="https://github.com/orgs/supabase/discussions/29260"
-                  buttonText="Read the announcement"
+                  badgeLabel="Changelog"
+                  title="New publishable and secret API keys"
+                  description={
+                    <>
+                      <p>
+                        View your publishable and secret API keys from the project{' '}
+                        <Link href={`/project/${projectRef}/settings/api-keys`}>
+                          API settings page
+                        </Link>
+                      </p>
+                      <p>
+                        To learn more about the new API keys, read the{' '}
+                        <a
+                          href="https://supabase.com/docs/guides/api/api-keys"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          documentation
+                        </a>
+                      </p>
+                    </>
+                  }
+                  href={`/project/${projectRef}/settings/api-keys`}
+                  buttonText="View API keys"
                 />
               </TabsContent_Shadcn_>
             )

--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -70,7 +70,7 @@ const PanelNotice = forwardRef<
   {
     className?: string | false
     title?: string
-    description?: string
+    description?: ReactNode
     href?: string
     buttonText?: string
     layout?: 'horizontal' | 'vertical'


### PR DESCRIPTION
## BEFORE
<img width="2128" height="550" alt="CleanShot 2025-12-29 at 14 08 05@2x" src="https://github.com/user-attachments/assets/0ff5052d-4f28-4b96-b8ff-208555ac1ef8" />


## AFTER
<img width="2016" height="352" alt="CleanShot 2025-12-29 at 13 53 39@2x" src="https://github.com/user-attachments/assets/6c3f66da-e882-40ac-a694-4028245a6dd0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated API keys notification with direct links to project API keys settings and documentation.
  * Added a "View API keys" button for quick navigation to API key management.
  * Notification now appears only on the platform where it’s applicable.

* **Style**
  * Refreshed notification badge and messaging to emphasize new publishable and secret API keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->