### PR TITLE
docs(branching): add the list of all valid secrets fields

### DIFF
--- a/apps/docs/content/guides/deployment/branching/configuration.mdx
+++ b/apps/docs/content/guides/deployment/branching/configuration.mdx
@@ -154,7 +154,78 @@ secret = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET)"
 
 <Admonition type="note" label="Secret fields">
 
-The `encrypted:` syntax only works for designated "secret" fields in the configuration (like `secret` in auth providers). Using encrypted values in other fields will not be automatically decrypted and may cause issues. For non-secret fields, use environment variables with the `env()` syntax instead.
+The `encrypted:` syntax only works for designated "secret" fields in the configuration. Using encrypted values in other fields will not be automatically decrypted and may cause issues. For non-secret fields, use environment variables with the `env()` syntax instead.
+
+The following fields support the `encrypted:` syntax:
+
+**Studio**
+
+- `studio.openai_api_key`
+
+**Database**
+
+- `db.root_key`
+- `db.vault.*` (any key in the vault map)
+
+**Auth - Core Keys**
+
+- `auth.publishable_key`
+- `auth.secret_key`
+- `auth.jwt_secret`
+- `auth.anon_key`
+- `auth.service_role_key`
+
+**Auth - Email (SMTP)**
+
+- `auth.email.smtp.pass`
+
+**Auth - Captcha**
+
+- `auth.captcha.secret`
+
+**Auth - Hooks**
+
+- `auth.hook.mfa_verification_attempt.secrets`
+- `auth.hook.password_verification_attempt.secrets`
+- `auth.hook.custom_access_token.secrets`
+- `auth.hook.send_sms.secrets`
+- `auth.hook.send_email.secrets`
+- `auth.hook.before_user_created.secrets`
+
+**Auth - SMS Providers**
+
+- `auth.sms.twilio.auth_token`
+- `auth.sms.twilio_verify.auth_token`
+- `auth.sms.messagebird.access_key`
+- `auth.sms.textlocal.api_key`
+- `auth.sms.vonage.api_secret`
+
+**Auth - External OAuth Providers**
+
+- `auth.external.apple.secret`
+- `auth.external.azure.secret`
+- `auth.external.bitbucket.secret`
+- `auth.external.discord.secret`
+- `auth.external.facebook.secret`
+- `auth.external.figma.secret`
+- `auth.external.github.secret`
+- `auth.external.gitlab.secret`
+- `auth.external.google.secret`
+- `auth.external.kakao.secret`
+- `auth.external.keycloak.secret`
+- `auth.external.linkedin_oidc.secret`
+- `auth.external.notion.secret`
+- `auth.external.slack_oidc.secret`
+- `auth.external.spotify.secret`
+- `auth.external.twitch.secret`
+- `auth.external.twitter.secret`
+- `auth.external.x.secret`
+- `auth.external.workos.secret`
+- `auth.external.zoom.secret`
+
+**Edge Runtime**
+
+- `edge_runtime.secrets.*` (any key in the secrets map)
 
 </Admonition>
 

--- a/apps/docs/content/guides/deployment/branching/configuration.mdx
+++ b/apps/docs/content/guides/deployment/branching/configuration.mdx
@@ -202,26 +202,7 @@ The following fields support the `encrypted:` syntax:
 
 **Auth - External OAuth Providers**
 
-- `auth.external.apple.secret`
-- `auth.external.azure.secret`
-- `auth.external.bitbucket.secret`
-- `auth.external.discord.secret`
-- `auth.external.facebook.secret`
-- `auth.external.figma.secret`
-- `auth.external.github.secret`
-- `auth.external.gitlab.secret`
-- `auth.external.google.secret`
-- `auth.external.kakao.secret`
-- `auth.external.keycloak.secret`
-- `auth.external.linkedin_oidc.secret`
-- `auth.external.notion.secret`
-- `auth.external.slack_oidc.secret`
-- `auth.external.spotify.secret`
-- `auth.external.twitch.secret`
-- `auth.external.twitter.secret`
-- `auth.external.x.secret`
-- `auth.external.workos.secret`
-- `auth.external.zoom.secret`
+- `auth.external.*.secret`
 
 **Edge Runtime**
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -358,6 +358,7 @@ allow_list = [
     "gte-small",
     "halfvec",
     "hCaptcha",
+    "Captcha",
     "https?:\\/\\/\\S+",
     "i.e.",
     "imgproxy",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The documentation mentions that the `encrypted:` syntax only works for designated "secret" fields, but doesn't specify which fields are valid. Users had to guess or discover through trial and error which configuration fields support encrypted values.

## What is the new behavior?

Added a comprehensive list of all valid secret fields that support the `encrypted:` syntax, organized by category:

- Studio fields (e.g., `studio.openai_api_key`)
- Database fields (e.g., `db.root_key`, `db.vault.*`)
- Auth core keys (e.g., `auth.secret_key`, `auth.jwt_secret`)
- Auth email/SMTP fields
- Auth captcha fields
- Auth hook secrets
- Auth SMS provider secrets
- Auth external OAuth provider secrets (all providers)
- Edge runtime secrets

This makes it clear which fields can use encrypted values and helps prevent users from attempting to use `encrypted:` syntax on unsupported fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the configuration guide to explicitly enumerate all fields and sections that accept the encrypted: syntax (Studio, Database, Auth core keys, Email SMTP, Captcha, Hooks, SMS providers, External OAuth providers, Edge runtime).
* **Style**
  * Added "Captcha" to the spelling allow list so the capitalized form is accepted in linting/config docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->