### PR TITLE
Removed provider reassignment phrase from the saml sso docs

### DIFF
--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -346,7 +346,6 @@ supabase sso remove <provider-id> --project-ref <your-project>
 
 If successful, the details of the removed identity provider will be shown. All user accounts from that identity provider will be immediately logged out. User information will remain in the system, but it will no longer be possible for any of those accounts to be accessed in the future, even if you add the connection again.
 
-If you need to reassign those user accounts to another identity provider, [open a support ticket](/dashboard/support/new).
 A [list of all](/docs/reference/cli/supabase-sso-list) registered identity providers can be displayed by running:
 
 ```bash


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

SAML docs says

> If you need to reassign those user accounts to another identity provider, contact support

and this information is incorrect.

## What is the new behavior?

Removed the text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise SSO SAML setup guide by removing outdated guidance regarding account reassignment procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->