### PR TITLE
fix: added portal property for date and time editor 

### DIFF
--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -76,7 +76,7 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
           {value === null ? 'NULL' : value}
         </div>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ align="start" className="p-0 rounded-none w-64">
+      <PopoverContent_Shadcn_ portal align="start" className="p-0 rounded-none w-64">
         <BlockKeys
           ignoreOutsideClicks
           value={inputValue}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: update portal property so that when a timestamp column is frozen it does not render behind the column.

## Test
- Create a timestamp column
- Add some data
- Freeze the column
- Try to edit a single cell, it should not appear behind the column 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date/time picker popover rendering to prevent display and stacking issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->