### PR TITLE
fix: update to rollback and changes with insert,update or delete on pretty explain

### DIFF
--- a/apps/studio/data/sql/utils/transaction.ts
+++ b/apps/studio/data/sql/utils/transaction.ts
@@ -1,9 +1,19 @@
 export function wrapWithTransaction(sql: string) {
   return /* SQL */ `
     begin;
-
+ 
     ${sql}
     
     commit;
+  `
+}
+
+export function wrapWithRollback(sql: string) {
+  return /* SQL */ `
+    begin;
+ 
+    ${sql}
+    
+    rollback;
   `
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: we need to ensure that insert/update and delete statements are rolled back when the user switches to the pretty explain tab. This ensures that happens by wrapping it in a transaction and rollbacking 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic rollback protection to query analysis operations, ensuring data remains unmodified when exploring and analyzing query execution plans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->