### PR TITLE
fix(auth-config): invalidate lint cache on update to dismiss stale Pe…

### DIFF
--- a/apps/studio/data/auth/auth-config-update-mutation.ts
+++ b/apps/studio/data/auth/auth-config-update-mutation.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import type { components } from 'data/api'
 import { handleError, patch } from 'data/fetchers'
+import { lintKeys } from 'data/lint/keys'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { authKeys } from './keys'
 
@@ -42,6 +43,7 @@ export const useAuthConfigUpdateMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
       await queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) })
+      await queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/auth/auth-config-update-mutation.ts
+++ b/apps/studio/data/auth/auth-config-update-mutation.ts
@@ -42,8 +42,10 @@ export const useAuthConfigUpdateMutation = ({
     mutationFn: (vars) => updateAuthConfig(vars),
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
-      await queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) })
-      await queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) }),
+        queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) })
+      ])
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/auth/auth-config-update-mutation.ts
+++ b/apps/studio/data/auth/auth-config-update-mutation.ts
@@ -44,7 +44,7 @@ export const useAuthConfigUpdateMutation = ({
       const { projectRef } = variables
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) }),
-        queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) })
+        queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) }),
       ])
       await onSuccess?.(data, variables, context)
     },


### PR DESCRIPTION
Issue:
Performance Advisor warning "Auth Absolute Connection Management Strategy" doesn't dismiss after switching to percentage-based allocation.
Root Cause:
Lint query cache wasn't invalidated when Auth config was updated, so the Performance Advisor showed stale warnings.
Fix:
Added lint query cache invalidation in auth-config-update-mutation.ts so the Performance Advisor refreshes when Auth config changes.
File Changed:
apps/studio/data/auth/auth-config-update-mutation.ts
Changes:
Import lintKeys
Invalidate lint cache in mutation onSuccess callback
close:#41619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auth configuration and lint project results now refresh together immediately after updates.
  * Changes make UI updates more consistent and reduce stale or mismatched data following configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures UI reflects latest auth changes by refreshing related lint data.
> 
> - `useAuthConfigUpdateMutation` now invalidates both `authKeys.authConfig` and `lintKeys.lint` via `Promise.all` in `onSuccess`
> - Imports `lintKeys` to support lint cache invalidation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d84d9ded1b94d329592f75e75ca893b552634fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->