### PR TITLE
fix(stripe-sync-interation): Add notes to clarify common instalation hiccups

### DIFF
--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/InstallationOverview.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/InstallationOverview.tsx
@@ -316,6 +316,22 @@ export const StripeSyncInstallationPage = () => {
               </SheetHeader>
               <SheetSection className="flex-1">
                 <StripeSyncChangesCard />
+                <Admonition type="warning" className="mt-6">
+                  <p>
+                    This integration currently requires{' '}
+                    <Link
+                      href="https://supabase.com/docs/guides/platform/ssl-enforcement"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      SSL Enforcement
+                    </Link>{' '}
+                    to be disabled during initial setup. Support for SSL Enforcement will be added
+                    in a future update. Once installed, all webhook and sync operations use
+                    HTTPS/SSL.
+                  </p>
+                </Admonition>
                 <h3 className="heading-default mb-4 mt-6">Configuration</h3>
                 {installError && (
                   <Admonition type="destructive" className="mb-4">
@@ -336,7 +352,7 @@ export const StripeSyncInstallationPage = () => {
                     <FormItemLayout
                       layout="flex-row-reverse"
                       label="Stripe API key"
-                      description="Used to fetch your Stripe configuration and set up syncing."
+                      description="Your Stripe secret key. Requires write access to Webhook Endpoints and read-only access to all other categories."
                     >
                       <FormControl_Shadcn_ className="col-span-8">
                         <Input


### PR DESCRIPTION
Small notices to remedy common issues when installing the Stripe Sync Engine integration.

1. Note about SSL enforcement needing to be disabled
2. Note clarifying that a Stripe _secret_ key is required with specific permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SSL Enforcement guidance for Stripe integration setup, clarifying that SSL must be disabled initially with planned future support
  * Enhanced Stripe API key field description with detailed permission requirements
  * Clarified that webhook and sync operations use HTTPS/SSL encryption after installation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->