### PR TITLE
fix: introduction pages in docs categories

### DIFF
--- a/apps/design-system/config/docs.ts
+++ b/apps/design-system/config/docs.ts
@@ -61,7 +61,7 @@ export const docsConfig: DocsConfig = {
       items: [
         {
           title: 'Introduction',
-          href: '/docs/ui-patterns/ui-patterns',
+          href: '/docs/ui-patterns/introduction',
           items: [],
           priority: true,
         },
@@ -108,7 +108,7 @@ export const docsConfig: DocsConfig = {
       items: [
         {
           title: 'Introduction',
-          href: '/docs/fragments/fragment-components',
+          href: '/docs/fragments/introduction',
           items: [],
           priority: true,
         },
@@ -210,7 +210,7 @@ export const docsConfig: DocsConfig = {
       items: [
         {
           title: 'Introduction',
-          href: '/docs/components/atom-components',
+          href: '/docs/components/introduction',
           items: [],
           priority: true,
         },


### PR DESCRIPTION
was linked incorrectly

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

3 pages like this is linked incorrectly. changed last part to "introduction"
https://supabase-design-system.vercel.app/design-system/docs/ui-patterns/ui-patterns
fix
https://supabase-design-system.vercel.app/design-system/docs/ui-patterns/introduction

## What is the new behavior?

Page made available


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Reorganized documentation navigation: Updated sidebar links for UI Patterns, Fragment Components, and Atom Components to point to their dedicated introduction pages, improving access to design system component documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->