### PR TITLE
fix(studio): update Prisma Connect snippets for Prisma 7.2+ (use DIRECT_URL for migrations)

### DIFF
--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -168,12 +168,25 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
                     postgres://prisma.[PROJECT-REF]...
                     ```
 
-                    In your schema.prisma file, edit your `datasource db` configs to reference your DIRECT_URL
+                    In your `prisma.config.ts` file, add the following configuration to ensure Prisma CLI uses your `DIRECT_URL` for migrations.
+
+                    ```ts prisma.config.ts
+                    import 'dotenv/config'
+                    import { defineConfig, env } from 'prisma/config'
+
+                    export default defineConfig({
+                      schema: 'prisma/schema.prisma',
+                      datasource: {
+                        url: env('DIRECT_URL'),
+                      },
+                    })
+                    ```
+
+                    In your `schema.prisma` file, your `datasource db` should only specify the provider.
+
                     ```text schema.prisma
                     datasource db {
-                      provider  = "postgresql"
-                      url       = env("DATABASE_URL")
-                      directUrl = env("DIRECT_URL")
+                      provider = "postgresql"
                     }
                     ```
 

--- a/apps/docs/content/guides/database/prisma/prisma-troubleshooting.mdx
+++ b/apps/docs/content/guides/database/prisma/prisma-troubleshooting.mdx
@@ -151,11 +151,23 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
-  schemas   = ["public", "other_schema"] //list out relevant schemas
+  provider = "postgresql"
+  schemas  = ["public", "other_schema"] //list out relevant schemas
 }
+```
+
+Then, configure the datasource in `prisma.config.ts`:
+
+```ts prisma.config.ts
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DIRECT_URL'),
+  },
+})
 ```
 
 - Supabase managed schemas: Schemas managed by Supabase, such as `auth` and `storage`, may be changed to support new features. Referencing these schemas directly will cause schema drift in the future. It is best to remove references to these schemas from your migrations.

--- a/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
@@ -116,10 +116,20 @@ hideToc: true
     <StepHikeCompact.Code>
       ```prisma name=api/db/schema.prisma
       datasource db {
-        provider  = "postgresql"
-        url       = env("DATABASE_URL")
-        directUrl = env("DIRECT_URL")
+        provider = "postgresql"
       }
+      ```
+
+      ```ts name=prisma.config.ts
+      import 'dotenv/config'
+      import { defineConfig, env } from 'prisma/config'
+
+      export default defineConfig({
+        schema: 'api/db/schema.prisma',
+        datasource: {
+          url: env('DIRECT_URL'),
+        },
+      })
       ```
     </StepHikeCompact.Code>
 

--- a/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
@@ -15,6 +15,7 @@ const ContentFile = ({ connectionStringPooler }: ContentFileProps) => {
       <ConnectTabTriggers>
         <ConnectTabTrigger value=".env.local" />
         <ConnectTabTrigger value="prisma/schema.prisma" />
+        <ConnectTabTrigger value="prisma.config.ts" />
       </ConnectTabTriggers>
 
       <ConnectTabContent value=".env.local">
@@ -59,10 +60,25 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  provider = "postgresql"
 }
+        `}
+        </SimpleCodeBlock>
+      </ConnectTabContent>
+
+      <ConnectTabContent value="prisma.config.ts">
+        <SimpleCodeBlock className="ts" parentClassName="min-h-72">
+          {`
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    // Prisma CLI migrations should use DIRECT_URL (session/direct connection)
+    url: env('DIRECT_URL'),
+  },
+})
         `}
         </SimpleCodeBlock>
       </ConnectTabContent>

--- a/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
@@ -50,7 +50,6 @@ DATABASE_URL="${IS_PLATFORM ? `${connectionStringPooler.transactionShared}?pgbou
 DIRECT_URL="${IS_PLATFORM ? connectionStringPooler.sessionShared : connectionStringPooler.direct}"
 `}
         </SimpleCodeBlock>
-        
       </ConnectTabContent>
 
       <ConnectTabContent value="prisma/schema.prisma">

--- a/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
@@ -50,6 +50,7 @@ DATABASE_URL="${IS_PLATFORM ? `${connectionStringPooler.transactionShared}?pgbou
 DIRECT_URL="${IS_PLATFORM ? connectionStringPooler.sessionShared : connectionStringPooler.direct}"
 `}
         </SimpleCodeBlock>
+        
       </ConnectTabContent>
 
       <ConnectTabContent value="prisma/schema.prisma">

--- a/apps/www/_blog/2024-06-18-calcom-platform-starter-kit-nextjs-supabase.mdx
+++ b/apps/www/_blog/2024-06-18-calcom-platform-starter-kit-nextjs-supabase.mdx
@@ -32,15 +32,27 @@ Initially the application was built to be run on SQLite. However, once requireme
 
 When working with Prisma, your application will connect directly to your Postgres databases hosted on Supabase. To handle connection management efficiently, especially when working with serverless applications like Next.js, Supabase provides a connection pooler called [Supavisor](/blog/supavisor-1-million) to make sure your database runs efficiently with increasing traffic.
 
-The configuration is specified in the `schema.prisma` file where you provide the following connection strings:
+The configuration is specified in the `schema.prisma` file where you provide the datasource provider:
 
 ```ts schema.prisma
 datasource db {
-  provider  = "postgresql"
-  url       = env("POSTGRES_PRISMA_URL")
-  directUrl = env("POSTGRES_URL_NON_POOLING")
-  schemas   = ["prisma"] // see multi-schema support below
+  provider = "postgresql"
+  schemas  = ["prisma"] // see multi-schema support below
 }
+```
+
+Then, configure the datasource in `prisma.config.ts` to ensure Prisma CLI uses your non-pooling connection for migrations:
+
+```ts prisma.config.ts
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('POSTGRES_URL_NON_POOLING'),
+  },
+})
 ```
 
 This loads the relevant Supabase connections strings from your `.env` file

--- a/apps/www/_blog/2024-06-18-calcom-platform-starter-kit-nextjs-supabase.mdx
+++ b/apps/www/_blog/2024-06-18-calcom-platform-starter-kit-nextjs-supabase.mdx
@@ -50,7 +50,7 @@ import { defineConfig, env } from 'prisma/config'
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
-    url: env('POSTGRES_URL_NON_POOLING'),
+    url: env('DIRECT_URL'),
   },
 })
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -238,7 +238,7 @@ services:
     image: supabase/storage-api:v1.33.0
     restart: unless-stopped
     volumes:
-      - ./volumes/storage:/var/lib/storage:z
+      - storage_data:/var/lib/storage
     healthcheck:
       test:
         [
@@ -282,7 +282,7 @@ services:
     image: darthsim/imgproxy:v3.8.0
     restart: unless-stopped
     volumes:
-      - ./volumes/storage:/var/lib/storage:z
+      - storage_data:/var/lib/storage
     healthcheck:
       test:
         [
@@ -533,3 +533,4 @@ services:
 
 volumes:
   db-config:
+  storage_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -238,7 +238,7 @@ services:
     image: supabase/storage-api:v1.33.0
     restart: unless-stopped
     volumes:
-      - storage_data:/var/lib/storage
+      - ./volumes/storage:/var/lib/storage:z
     healthcheck:
       test:
         [
@@ -282,7 +282,7 @@ services:
     image: darthsim/imgproxy:v3.8.0
     restart: unless-stopped
     volumes:
-      - storage_data:/var/lib/storage
+      - ./volumes/storage:/var/lib/storage:z
     healthcheck:
       test:
         [
@@ -533,4 +533,3 @@ services:
 
 volumes:
   db-config:
-  storage_data:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix + docs/snippet update (fixes Prisma 7.2+ compatibility in Supabase Studio “Connect → Prisma” snippets)

##  What is the current behavior?

Prisma **7.2+** no longer supports defining `url` / `directUrl` inside `schema.prisma`.  
However, Supabase Studio’s **Connect → Prisma** snippet currently shows a `schema.prisma` example that includes:

- `url = env("DATABASE_URL")`
- `directUrl = env("DIRECT_URL")`

In Supabase setups, `DATABASE_URL` is commonly a **pooled/transaction** connection string, while migrations must use a **direct/session** connection (`DIRECT_URL`). This mismatch causes Prisma migrations to hang/fail unless users manually swap environment variables.

Related issue: https://github.com/supabase/supabase/issues/41621

## What is the new behavior?

Supabase Studio now provides Prisma 7.2+ compatible guidance:

- `prisma/schema.prisma` snippet shows **only** `provider = "postgresql"` (no `url` / `directUrl`)
- A new `prisma.config.ts` snippet/tab is added so Prisma CLI migrations can use:
  - `datasource.url = DIRECT_URL` (direct/session connection)

This makes the “two URL” Supabase workflow work again without manual env swapping:
- **Runtime** can keep using pooled `DATABASE_URL`
- **Migrations** use `DIRECT_URL`

## Additional context

I created the diagram below to summarize the root cause and fix:

```mermaid
flowchart TD
  A[Supabase docs or Studio snippet] --> B[User upgrades to Prisma 7.2+]
  B --> C[Prisma no longer allows url/directUrl in schema.prisma]
  C --> D[Prisma CLI migrations read prisma.config.ts instead]

  D --> E[Supabase has two DB URLs]
  E --> E1[DATABASE_URL = pooled runtime]
  E --> E2[DIRECT_URL = direct for migrations]

  F[Old Supabase guidance] --> G[Prisma CLI uses DATABASE_URL for migrations]
  G --> H[Migrations run over pooled connection]
  H --> I[Migrate hangs or fails on Supabase]

  J[Fix] --> K[Studio: schema.prisma shows provider only]
  J --> L[Studio: add prisma.config.ts tab]
  L --> M[prisma.config.ts uses DIRECT_URL for migrations]
  M --> O[Migrations succeed]
```
I have also updated docs and blog.

Files changed :
apps/studio/components/interfaces/Connect/content/prisma/content.tsx
apps/docs/content/guides/database/prisma.mdx
apps/docs/content/guides/database/prisma/prisma-troubleshooting.mdx
apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
apps/www/_blog/2024-06-18-calcom-platform-starter-kit-nextjs-supabase.mdx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma configuration guides to use an external config file for connection and migration settings.
  * Added troubleshooting content and alternative strategies (including managed-schema examples and SQL/trigger approaches) for schema and migration scenarios.

* **UI Updates**
  * Prisma setup UI now surfaces the new external configuration pattern and shows the updated guidance to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->