### PR TITLE
fix: updated to check fetch status if the user does not have permissions for audit logs

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -76,6 +76,7 @@ export const AuditLogs = () => {
     isSuccess,
     isError,
     isRefetching,
+    fetchStatus,
     refetch,
   } = useOrganizationAuditLogsQuery(
     {
@@ -256,7 +257,9 @@ export const AuditLogs = () => {
               </div>
             )}
 
-            {isLoading || isLoadingPermissions || isLoadingEntitlements ? (
+            {(isLoading && fetchStatus !== 'idle') ||
+            isLoadingPermissions ||
+            isLoadingEntitlements ? (
               <div className="space-y-2">
                 <ShimmeringLoader />
                 <ShimmeringLoader className="w-3/4" />

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -141,6 +141,9 @@ export const AuditLogs = () => {
       }
     })
 
+  const shouldShowLoadingState =
+    (isLoading && fetchStatus !== 'idle') || isLoadingPermissions || isLoadingEntitlements
+
   // This feature depends on the subscription tier of the user.
   // The API limits the logs to maximum of 62 days and 5 minutes so when the page is
   // viewed for more than 5 minutes, the call parameters needs to be updated. This also works with
@@ -257,9 +260,7 @@ export const AuditLogs = () => {
               </div>
             )}
 
-            {(isLoading && fetchStatus !== 'idle') ||
-            isLoadingPermissions ||
-            isLoadingEntitlements ? (
+            {shouldShowLoadingState ? (
               <div className="space-y-2">
                 <ShimmeringLoader />
                 <ShimmeringLoader className="w-3/4" />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

When `canReadAuditLogs` is false, the query is disabled but returns a loading state, causing the loading shimmer to display indefinitely. Fixed by checking `fetchStatus` to properly detect when the query is actually fetching data versus when it's disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit logs loading behavior: the loading shimmer now appears only when a backend fetch is actively in progress, while permission and entitlement checks remain responsive and independent. This reduces unnecessary loading states and gives a more accurate, snappier user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->