### PR TITLE
Clarify OAuth link in Next Steps authentication docs

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -747,5 +747,5 @@ language="typescript"
 ## Next steps
 
 - Implement [Authentication using Email and Password](/docs/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr)
-- Implement [Authentication using OAuth](/docs/guides/auth/server-side/oauth-with-pkce-flow-for-ssr)
+- Alternatively, implement [Authentication using OAuth](/docs/guides/auth/server-side/oauth-with-pkce-flow-for-ssr)
 - [Learn more about SSR](/docs/guides/auth/server-side-rendering)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The “Implement Authentication using OAuth” link appears in the Next Steps section of a password-based authentication guide, which can be confusing for readers. The context does not clearly indicate that OAuth is an alternative authentication method.

## What is the new behavior?

The documentation has been updated to clearly present OAuth authentication as an alternative option, improving clarity and reducing confusion for readers following the authentication setup guide.

## Additional context

This is a small documentation improvement aimed at enhancing readability and developer experience. No functional or breaking changes are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the server-side authentication guide's Next steps section to present OAuth implementation as an alternative approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->