### PR TITLE
fix: updated snippet values so they store the generated name in the side bar

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -231,7 +231,8 @@ export const SQLEditor = () => {
     async (id: string, sql: string) => {
       try {
         const { title: name } = await generateSqlTitle({ sql })
-        snapV2.renameSnippet({ id, name })
+        snapV2.updateSnippet({ id, snippet: { name } })
+        snapV2.addNeedsSaving(id)
         const tabId = createTabId('sql', { id })
         tabs.updateTab(tabId, { label: name })
       } catch (error) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

When AI generated a title for a SQL snippet, setAiTitle() called snapV2.renameSnippet() which only updated local state without triggering a database save. When the auto-save debounced function ran, it used the original snippet object (before rename), saving "Untitled query" to the database.

The original save indicator was removed here: https://github.com/supabase/supabase/commit/f3af2c3d3c#diff-9ba6336ab608965d624e3119ddd79ceb41e5311e495e37f9f6865580b26c3b6eL148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL snippet rename functionality to correctly mark changes as needing to be saved.

* **Refactor**
  * Streamlined the snippet update mechanism for improved internal consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->