### PR TITLE
chore: update Stripe Subscriptions Starter to point to Supabase Community maintained repo

### DIFF
--- a/apps/www/data/Examples.ts
+++ b/apps/www/data/Examples.ts
@@ -25,13 +25,13 @@ const Examples: Example[] = [
     title: 'Stripe Subscriptions Starter',
     description:
       'The all-in-one subscription starter kit for high-performance SaaS applications, powered by Stripe, Supabase, and Vercel.',
-    author: 'Vercel',
-    author_url: 'https://github.com/vercel',
-    author_img: 'https://avatars.githubusercontent.com/u/14985020',
-    repo_name: 'vercel/nextjs-subscription-payments',
-    repo_url: 'https://github.com/vercel/nextjs-subscription-payments',
+    author: 'Supabase Community',
+    author_url: 'https://github.com/supabase-community',
+    author_img: 'https://avatars.githubusercontent.com/u/54469796',
+    repo_name: 'supabase-community/nextjs-subscription-payments',
+    repo_url: 'https://github.com/supabase-community/nextjs-subscription-payments',
     vercel_deploy_url:
-      'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnextjs-subscription-payments&env=NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,STRIPE_SECRET_KEY&envDescription=Enter%20your%20Stripe%20API%20keys.&envLink=https%3A%2F%2Fdashboard.stripe.com%2Fapikeys&project-name=nextjs-subscription-payments&repository-name=nextjs-subscription-payments&integration-ids=oac_VqOgBHqhEoFTPzGkPd7L0iH6&external-id=https%3A%2F%2Fgithub.com%2Fvercel%2Fnextjs-subscription-payments%2Ftree%2Fmain',
+      'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fsupabase-community%2Fnextjs-subscription-payments&env=NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,STRIPE_SECRET_KEY&envDescription=Enter%20your%20Stripe%20API%20keys.&envLink=https%3A%2F%2Fdashboard.stripe.com%2Fapikeys&project-name=nextjs-subscription-payments&repository-name=nextjs-subscription-payments&integration-ids=oac_VqOgBHqhEoFTPzGkPd7L0iH6&external-id=https%3A%2F%2Fgithub.com%2Fsupabase-community%2Fnextjs-subscription-payments%2Ftree%2Fmain',
     demo_url: 'https://subscription-payments.vercel.app/',
   },
   {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update 'Next.js Subscription and Auth' starter kit reference to point to the actively maintained supabase-community/nextjs-subscription-payments repository

Updates repo URL, Vercel deploy URL, author attribution, and demo link

## What is the current behavior?

The starter kit currently references vercel/nextjs-subscription-payments, which has been archived and is no longer maintained

Users deploying from the homepage are directed to an outdated version of the starter kit

## What is the new behavior?

The starter kit now references supabase-community/nextjs-subscription-payments, which is actively maintained with modern dependencies and best practices

All deployment flows and documentation links direct users to the current, supported version

## Additional context

This is the first PR updating the starter kit. This change ensures users have access to the most up-to-date version with the latest Supabase features and security updates.

Additional references in documentation will be updated pending Vercel's response on whether they would like to integrate and maintain the modernized version in their official examples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example attribution and metadata to reference Supabase Community resources and repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->