### PR TITLE
docs(auth): fix verifyOtp type for magic link flows

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-passwordless.mdx
+++ b/apps/docs/content/guides/auth/auth-email-passwordless.mdx
@@ -147,7 +147,7 @@ If you're using PKCE flow, edit the Magic Link [email template](/docs/guides/aut
 <h2>Magic Link</h2>
 
 <p>Follow this link to login:</p>
-<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email">Log In</a></p>
+<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink">Log In</a></p>
 ```
 
 At the `/auth/confirm` endpoint, exchange the hash for the session:
@@ -159,9 +159,12 @@ const supabase = createClient('url', 'anonKey')
 // ---cut---
 const { error } = await supabase.auth.verifyOtp({
   token_hash: 'hash',
-  type: 'email',
+  type: 'magiclink',
 })
 ```
+
+> [!NOTE]
+> Use `type: 'magiclink'` when verifying magic links sent via `signInWithOtp`. Use `type: 'email'` only for numeric OTP codes. For most magic link flows, manual `verifyOtp` calls are unnecessary as Supabase automatically verifies the link and creates a session upon redirect.
 
 ## With OTP
 

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -123,9 +123,10 @@ hideToc: true
 
               if (token_hash) {
                   // Verify the OTP token
+                  // Use "magiclink" for magic link flows, "email" for numeric OTP codes
                   supabase.auth.verifyOtp({
                       token_hash,
-                      type: type || "email",
+                      type: type || "magiclink",
                   }).then(({ error }) => {
                       if (error) {
                           setAuthError(error.message);
@@ -262,7 +263,7 @@ hideToc: true
 
     - Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard.
     - Select the Confirm sign up template.
-    - Change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}?token_hash={{ .TokenHash }}&type=email`.
+    - Change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}?token_hash={{ .TokenHash }}&type=magiclink`.
     - Change your [Site URL](/dashboard/project/_/auth/url-configuration) to `https://localhost:5173`
 
     </StepHikeCompact.Details>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix to clarify `verifyOtp` type values for magic link authentication.

## What is the current behavior?

The React quickstart and passwordless auth docs show `type: 'email'` for magic link verification, which causes the error:

> "Email link is invalid or has expired"

even when the magic link is valid.

## What is the new behavior?

- Changed default type to `'magiclink'` for magic link flows
- Added clarifying comments explaining when to use each type
- Updated email template examples to use `type=magiclink`
- Added a NOTE in passwordless docs explaining the difference between types

### Files changed:
- `apps/docs/content/guides/auth/quickstarts/react.mdx`
- `apps/docs/content/guides/auth/auth-email-passwordless.mdx`

## Type values clarification:
| Type | When to Use |
|------|-------------|
| `magiclink` | Magic link flows (clicking a link in email) |
| `email` | Numeric OTP codes (6-digit code typed manually) |

Fixes #41672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guides to clarify magic link verification, specifying when to use `magiclink` versus `email` types
  * Documented that most magic link flows don't require manual verification calls due to automatic redirect verification
  * Updated OTP verification examples to reflect current best practices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->