### PR TITLE
docs: fix broken Wasm example

### DIFF
--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -88,7 +88,8 @@ Follow this [guide on writing Wasm modules in Rust](https://developer.mozilla.or
         wasm-pack build --target deno
         ```
 
-        This will produce a Wasm binary file inside `add-wasm/pkg` directory.
+        This will produce a Wasm binary file (for example `add_wasm_bg.wasm`)
+        inside the `add-wasm/pkg` directory.
 
 
       </StepHikeCompact.Details>
@@ -99,6 +100,16 @@ Follow this [guide on writing Wasm modules in Rust](https://developer.mozilla.or
 ---
 
 ## Calling the Wasm module from the Edge Function
+
+<Admonition type="note">
+
+When using `wasm-pack --target deno`, the generated JavaScript wrapper
+must be imported, which internally loads the `.wasm` binary. Directly
+importing `.wasm` files is not supported in Supabase Edge Functions
+(Deno 1.46) without additional boilerplate.
+
+</Admonition>
+
 
 Update your Edge Function to call the add function from the Wasm module:
 
@@ -129,7 +140,9 @@ Before deploying, ensure the Wasm module is bundled with your function by defini
 
 ```toml
 [functions.wasm-add]
-static_files = [ "./functions/wasm-add/add-wasm/pkg/*"]
+static_files = [
+  "./functions/wasm-add/add-wasm/pkg/add_wasm_bg.wasm"
+]
 ```
 
 Deploy the function by running:

--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -88,7 +88,7 @@ Follow this [guide on writing Wasm modules in Rust](https://developer.mozilla.or
         wasm-pack build --target deno
         ```
 
-        This will produce a Wasm binary file (for example `add_wasm_bg.wasm`)
+        This produces a Wasm binary file (for example, `add_wasm_bg.wasm`)
         inside the `add-wasm/pkg` directory.
 
 


### PR DESCRIPTION
Fixes the Wasm modules documentation by clarifying how wasm-pack output
is loaded in Deno 1.46 Edge Functions and by making the static_files
configuration explicit.

This ensures the example works as written and avoids confusion around
Wasm imports and bundling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified where WebAssembly build outputs are placed and how they are named for Edge Functions.
  * Added guidance that the generated JavaScript wrapper must be imported when targeting Deno; direct .wasm imports aren’t supported without extra setup.
  * Updated configuration examples to reference the Wasm binary explicitly for correct deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/41676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->