### PR TITLE
types(studio): replace any with SyntheticEvent in Storage explorer

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -5,6 +5,7 @@ import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { STORAGE_ROW_STATUS, STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
 import { StorageItem } from '../Storage.types'
 import { RowIcon } from './FileExplorerRow'
+import type React from 'react'
 
 export interface FileExplorerRowEditingProps {
   item: StorageItem
@@ -25,7 +26,7 @@ export const FileExplorerRowEditing = ({
   const inputRef = useRef<any>(null)
   const [itemName, setItemName] = useState(item.name)
 
-  const onSaveItemName = async (name: string, event?: any) => {
+  const onSaveItemName = async (name: string, event?: React.SyntheticEvent) => {
     if (event) {
       event.preventDefault()
       event.stopPropagation()


### PR DESCRIPTION
Replaces a generic `any` event type with `React.SyntheticEvent` in the
Storage explorer UI to improve type safety without changing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for event handling in the storage file explorer component.

**Note:** This release contains internal code quality improvements with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->