### PR TITLE
fix(studio): align permissions hook exports

### DIFF
--- a/apps/studio/hooks/misc/useCheckPermissions.ts
+++ b/apps/studio/hooks/misc/useCheckPermissions.ts
@@ -188,3 +188,5 @@ export function useAsyncCheckPermissions(
 
   return { isLoading, isSuccess, can }
 }
+
+export { useAsyncCheckPermissions as useCheckPermissions }


### PR DESCRIPTION
Adds a compatibility export to align the permissions hook API and prevent
import mismatches in Studio. No behavior changes.
