### PR TITLE
fix: Fix a bug in Edit FDW sheet

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
@@ -198,8 +198,14 @@ export const EditWrapperSheet = ({
               )
 
               if (encryptedIdsToFetch.length > 0) {
+                console.log(encryptedIdsToFetch)
                 fetchEncryptedValues(encryptedIdsToFetch)
               }
+              /**
+               * [Joshen] We're deliberately not adding values and initialValues to the dependency array here
+               * as we only want to fetch the encrypted values once on load + values and initialValues will be updated
+               * as a result of that
+               */
               // eslint-disable-next-line react-hooks/exhaustive-deps
             }, [project?.ref, project?.connectionString])
 

--- a/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
@@ -159,26 +159,31 @@ export const EditWrapperSheet = ({
             // eslint-disable-next-line react-hooks/rules-of-hooks
             useEffect(() => {
               const fetchEncryptedValues = async (ids: string[]) => {
-                setLoadingSecrets(true)
-                // If the secrets haven't loaded, escape and run the effect again when they're loaded
-                const decryptedValues = await getDecryptedValues({
-                  projectRef: project?.ref,
-                  connectionString: project?.connectionString,
-                  ids: ids,
-                })
-
-                // replace all values which are in the decryptedValues object with the decrypted value
-                const transformValues = (values: Record<string, string>) => {
-                  return mapValues(values, (value) => {
-                    return decryptedValues[value] ?? value
+                try {
+                  setLoadingSecrets(true)
+                  // If the secrets haven't loaded, escape and run the effect again when they're loaded
+                  const decryptedValues = await getDecryptedValues({
+                    projectRef: project?.ref,
+                    connectionString: project?.connectionString,
+                    ids: ids,
                   })
-                }
 
-                resetForm({
-                  values: transformValues(values),
-                  initialValues: transformValues(initialValues),
-                })
-                setLoadingSecrets(false)
+                  // replace all values which are in the decryptedValues object with the decrypted value
+                  const transformValues = (values: Record<string, string>) => {
+                    return mapValues(values, (value) => {
+                      return decryptedValues[value] ?? value
+                    })
+                  }
+
+                  resetForm({
+                    values: transformValues(values),
+                    initialValues: transformValues(initialValues),
+                  })
+                } catch (error) {
+                  toast.error('Failed to fetch encrypted values')
+                } finally {
+                  setLoadingSecrets(false)
+                }
               }
 
               const encryptedOptions = wrapperMeta.server.options.filter(

--- a/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
@@ -197,7 +197,7 @@ export const EditWrapperSheet = ({
                   return value ?? null
                 })
               ).filter((x) => UUID_REGEX.test(x))
-              // [Joshen] ^ Validate UUID to filter out already encrypted values
+              // [Joshen] ^ Validate UUID to filter out already decrypted values
 
               if (encryptedIdsToFetch.length > 0) {
                 fetchEncryptedValues(encryptedIdsToFetch)

--- a/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
@@ -193,17 +193,14 @@ export const EditWrapperSheet = ({
               const encryptedIdsToFetch = compact(
                 encryptedOptions.map((option) => {
                   const value = initialValues[option.name]
-                  if (value) {
-                    return value as string
-                  }
-                  return null
+                  return value ?? null
                 })
               )
 
               if (encryptedIdsToFetch.length > 0) {
                 fetchEncryptedValues(encryptedIdsToFetch)
               }
-            }, [])
+            }, [project?.ref, project?.connectionString])
 
             return (
               <>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
@@ -69,7 +69,7 @@ export const EditWrapperSheet = ({
     ...convertKVStringArrayToJson(wrapper?.server_options ?? []),
   }
 
-  const onUpdateTable = (values: any) => {
+  const onUpdateTable = (values: FormattedWrapperTable) => {
     setWrapperTables((prev) => {
       // if the new values have tableIndex, we are editing an existing table
       if (values.tableIndex !== undefined) {
@@ -85,9 +85,9 @@ export const EditWrapperSheet = ({
     setSelectedTableToEdit(undefined)
   }
 
-  const onSubmit = async (values: any) => {
+  const onSubmit = async (values: Record<string, string>) => {
     const validate = makeValidateRequired(wrapperMeta.server.options)
-    const errors: any = validate(values)
+    const errors = validate(values)
 
     const { wrapper_name } = values
     if (wrapper_name.length === 0) errors.name = 'Please provide a name for your wrapper'
@@ -138,7 +138,7 @@ export const EditWrapperSheet = ({
           }: {
             values: Record<string, string>
             initialValues: Record<string, string>
-            resetForm: any
+            resetForm: (value: Record<string, Record<string, string>>) => void
           }) => {
             // [Alaister] although this "technically" is breaking the rules of React hooks
             // it won't error because the hooks are always rendered in the same order
@@ -200,6 +200,7 @@ export const EditWrapperSheet = ({
               if (encryptedIdsToFetch.length > 0) {
                 fetchEncryptedValues(encryptedIdsToFetch)
               }
+              // eslint-disable-next-line react-hooks/exhaustive-deps
             }, [project?.ref, project?.connectionString])
 
             return (
@@ -284,8 +285,7 @@ export const EditWrapperSheet = ({
                                     Target: {target}
                                   </p>
                                   <p className="text-sm text-foreground-light">
-                                    Columns:{' '}
-                                    {table.columns.map((column: any) => column.name).join(', ')}
+                                    Columns: {table.columns.map((column) => column.name).join(', ')}
                                   </p>
                                 </div>
                                 <div className="flex items-center space-x-2">

--- a/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/EditWrapperSheet.tsx
@@ -4,6 +4,7 @@ import { Edit, Trash } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import { UUID_REGEX } from '@/lib/constants'
 import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms/FormSection'
 import { invalidateSchemasQuery } from 'data/database/schemas-query'
 import { useFDWUpdateMutation } from 'data/fdw/fdw-update-mutation'
@@ -195,10 +196,10 @@ export const EditWrapperSheet = ({
                   const value = initialValues[option.name]
                   return value ?? null
                 })
-              )
+              ).filter((x) => UUID_REGEX.test(x))
+              // [Joshen] ^ Validate UUID to filter out already encrypted values
 
               if (encryptedIdsToFetch.length > 0) {
-                console.log(encryptedIdsToFetch)
                 fetchEncryptedValues(encryptedIdsToFetch)
               }
               /**

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -25,7 +25,6 @@ import { formatWrapperTables } from './Wrappers.utils'
 
 interface WrapperRowProps {
   wrapper: FDW
-  wrappers: FDW[]
   selectedWrapperToEdit?: FDW
   selectedWrapperToDelete?: FDW
   setSelectedWrapperToEdit: (value: string | null) => void
@@ -33,9 +32,8 @@ interface WrapperRowProps {
   deletingWrapperIdRef: MutableRefObject<string | null>
 }
 
-const WrapperRow = ({
+export const WrapperRow = ({
   wrapper,
-  wrappers,
   selectedWrapperToEdit,
   selectedWrapperToDelete,
   setSelectedWrapperToEdit,
@@ -88,17 +86,20 @@ const WrapperRow = ({
 
         <TableCell className="space-y-2 !p-4">
           {_tables?.map((table) => {
-            const target = table.table ?? table.object
+            const target = table.table ?? table.object ?? table.src_key
 
             return (
-              <div key={table.id} className="flex items-center -space-x-3">
-                <Badge className="bg-surface-300 bg-opacity-100 pr-1 gap-2 font-mono text-[0.75rem] h-6 text-foreground">
+              <div key={table.id} className="flex items-center">
+                <Badge className="bg-surface-300 bg-opacity-100 gap-2 font-mono text-[0.75rem] h-6 text-foreground rounded-r-none">
                   <div className="relative w-3 h-3 flex items-center justify-center">
                     {integration.icon({ className: 'p-0' })}
                   </div>
                   <Tooltip>
                     <TooltipTrigger className="truncate max-w-28">{target}</TooltipTrigger>
-                    <TooltipContent className="max-w-64 whitespace-pre-wrap break-words">
+                    <TooltipContent
+                      side="bottom"
+                      className="max-w-64 whitespace-pre-wrap break-words"
+                    >
                       {target}
                     </TooltipContent>
                   </Tooltip>
@@ -110,13 +111,16 @@ const WrapperRow = ({
                 </Badge>
 
                 <Link href={`/project/${ref}/editor/${table.id}`}>
-                  <Badge className="transition hover:bg-surface-300 pl-5 rounded-l-none gap-2 h-6 font-mono text-[0.75rem] border-l-0">
+                  <Badge className="transition hover:bg-surface-300 px-2 rounded-l-none gap-1.5 h-6 font-mono text-[0.75rem] border-l-0">
                     <Table2 size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
                     <Tooltip>
                       <TooltipTrigger className="truncate max-w-28">
                         {table.schema}.{table.table_name}
                       </TooltipTrigger>
-                      <TooltipContent className="max-w-64 whitespace-pre-wrap break-words">
+                      <TooltipContent
+                        side="bottom"
+                        className="max-w-64 whitespace-pre-wrap break-words"
+                      >
                         {table.schema}.{table.table_name}
                       </TooltipContent>
                     </Tooltip>
@@ -129,7 +133,6 @@ const WrapperRow = ({
         <TableCell>
           {encryptedMetadata.map((metadata) => (
             <div key={metadata.name} className="flex items-center space-x-2 text-sm">
-              {/* <p className="text-foreground-light">{metadata.label}:</p> */}
               <Link
                 href={`/project/${ref}/settings/vault/secrets?search=${wrapper.name}_${metadata.name}`}
                 className="transition text-foreground-light hover:text-foreground flex items-center space-x-2 max-w-28"
@@ -212,5 +215,3 @@ const WrapperRow = ({
     </>
   )
 }
-
-export default WrapperRow

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
@@ -17,7 +17,7 @@ import {
   TableRow,
 } from 'ui'
 import { INTEGRATIONS } from '../Landing/Integrations.constants'
-import WrapperRow from './WrapperRow'
+import { WrapperRow } from './WrapperRow'
 import { wrapperMetaComparator } from './Wrappers.utils'
 
 interface WrapperTableProps {
@@ -91,7 +91,6 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
               <WrapperRow
                 key={x.id}
                 wrapper={x}
-                wrappers={wrappers}
                 selectedWrapperToEdit={selectedWrapperToEdit}
                 selectedWrapperToDelete={selectedWrapperToDelete}
                 setSelectedWrapperToEdit={setSelectedWrapperToEdit}

--- a/apps/studio/data/auth/user-query.ts
+++ b/apps/studio/data/auth/user-query.ts
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 
+import { UUID_REGEX } from '@/lib/constants'
 import { executeSql, type ExecuteSqlError } from 'data/sql/execute-sql-query'
 import { getUserSQL } from 'data/sql/queries/get-user'
 import { UseCustomQueryOptions } from 'types'
 import { authKeys } from './keys'
 import { User } from './users-infinite-query'
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 type UserVariables = {
   projectRef?: string

--- a/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
+++ b/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
@@ -87,5 +87,5 @@ export const getDecryptedValues = async (
   const { result } = await executeSql({ projectRef, connectionString, sql }, signal)
   return result.reduce((a: any, b: any) => {
     return { ...a, [b.id]: b.decrypted_secret }
-  }, {})
+  }, {}) as { [key: string]: string }
 }

--- a/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
+++ b/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
@@ -84,8 +84,14 @@ export const getDecryptedValues = async (
   signal?: AbortSignal
 ) => {
   const sql = vaultSecretDecryptedValuesQuery(ids)
-  const { result } = await executeSql({ projectRef, connectionString, sql }, signal)
-  return result.reduce((a: any, b: any) => {
-    return { ...a, [b.id]: b.decrypted_secret }
-  }, {}) as { [key: string]: string }
+  const { result } = await executeSql<{ id: string; decrypted_secret: string }[]>(
+    { projectRef, connectionString, sql },
+    signal
+  )
+  return result.reduce(
+    (a, b) => {
+      return { ...a, [b.id]: b.decrypted_secret }
+    },
+    {} as Record<string, string>
+  )
 }

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -56,3 +56,5 @@ export const OPT_IN_TAGS = {
 export const GB = 1024 * 1024 * 1024
 export const MB = 1024 * 1024
 export const KB = 1024
+
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i


### PR DESCRIPTION
This PR fixes a bug where the secret value is empty if the user created the FDW via the SQL editor. Previously, it required the secret name to follow a specific convention but it wasn't needed because the secret id is stored in the option value so it can be derived from it.


Fixes https://linear.app/supabase/issue/FE-2324/redis-fdw-created-via-sql-editor-cannot-be-modified-via-dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes secret handling in the Edit FDW sheet by deriving and batch-fetching decrypted values from option IDs, then applying them to form state.
> 
> - Replaces `useVaultSecretsQuery` + per-secret `getDecryptedValue` with `getDecryptedValues(ids)` and transforms form `values/initialValues` via decrypted map
> - Derives encrypted secret IDs from `initialValues` for encrypted options; shows error toast on failure; maintains loading state
> - Adds explicit types for `Form` render props and `executeSql` generic; `getDecryptedValues` now returns `Record<string,string>`
> - Minor: imports `compact/mapValues`, adjusts effect deps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96c3c94b6ae624f519508f6be1e4b69cf4ba7780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated encrypted-field handling into a single bulk fetch and mapping step; decrypted values now populate both current and initial form state on load.

* **Bug Fixes**
  * Added user-facing error toasts on fetch failures and ensured loading indicators clear properly.

* **Style/Types**
  * Improved type safety around decrypted-value results and form render typings.

* **UI**
  * Minor layout, spacing and badge styling adjustments in the integrations/wrappers list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->