### PR TITLE
fix(studio): make CreateNewAPIKeysButton catch block type-safe

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/CreateNewAPIKeysButton.tsx
+++ b/apps/studio/components/interfaces/APIKeys/CreateNewAPIKeysButton.tsx
@@ -36,7 +36,7 @@ export const CreateNewAPIKeysButton = () => {
 
       setCreateKeysDialogOpen(false)
       toast.success('Successfully created a new set of API keys!')
-    } catch (error) {
+    } catch (error:unknown) {
       console.error('Failed to create API keys:', error)
     } finally {
       setIsCreatingKeys(false)


### PR DESCRIPTION
Types the catch parameter as `unknown` to improve type safety in the
API Keys creation flow without changing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in error handling within the API keys interface.

---

**Note:** This release contains no user-facing changes. The updates are internal code quality improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->