### PR TITLE
docs: clarify bundling requirement for Wasm binariesnow what 

### DIFF
--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -114,6 +114,16 @@ Supabase Edge Functions currently use Deno 1.46. From [Deno 2.1, importing Wasm 
 
 </Admonition>
 
+<Admonition type="warning">
+
+Although the Wasm module is imported in `index.ts`, the generated `.wasm` binary still
+needs to be explicitly bundled with the Edge Function.  
+If the `.wasm` file is not included (for example via `static_files`), it may be removed
+during deployment and lead to runtime errors.
+
+</Admonition>
+
+
 ---
 
 ## Bundle and deploy
@@ -126,6 +136,8 @@ Before deploying, ensure the Wasm module is bundled with your function by defini
 - Static files cannot be deployed using the `--use-api` API flag. You need to build them with [Docker on the CLI](/docs/guides/functions/quickstart#step-6-deploy-to-production).
 
 </Admonition>
+
+
 
 ```toml
 [functions.wasm-add]

--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -121,6 +121,7 @@ needs to be explicitly bundled with the Edge Function.
 If the `.wasm` file is not included (for example via `static_files`), it may be removed
 during deployment and lead to runtime errors.
 
+
 </Admonition>
 
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
The documentation does not clearly explain that the generated `.wasm` binary may be
removed during deployment unless it is explicitly bundled, which can cause the example
to fail at runtime.

## What is the new behavior?
The documentation now clarifies that even when a Wasm module is imported in `index.ts`,
the `.wasm` binary must be explicitly bundled (for example via `static_files`) to ensure
it is preserved during deployment.

## Additional context
Fixes #41568.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warning about the importance of explicitly bundling .wasm binary files with Edge Functions to prevent removal during deployment and runtime errors.
  * Included a static_files configuration example demonstrating proper WASM artifact bundling practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->