### PR TITLE
Remove the resource that links to the page the user is already on.

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -534,6 +534,5 @@ This prevents the policy `( (select auth.uid()) = user_id )` from running for an
 ## More resources
 
 - [Testing your database](/docs/guides/database/testing)
-- [Row Level Security and Supabase Auth](/docs/guides/database/postgres/row-level-security)
 - [RLS Guide and Best Practices](https://github.com/orgs/supabase/discussions/14576)
 - Community repo on testing RLS using [pgTAP and dbdev](https://github.com/usebasejump/supabase-test-helpers/tree/main)


### PR DESCRIPTION
Removed duplicate link to Row Level Security and Supabase Auth.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Simple bug fix

## What is the current behavior?

The link leads to the page the user is already on.

## What is the new behavior?

The link has been removed.

## Additional context

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Row Level Security and Supabase Auth resource link from the guides' "More resources" section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->