### PR TITLE
fix: use heading id for TOC anchors instead of querying anchor tags

### DIFF
--- a/apps/docs/features/docs/GuidesMdx.client.tsx
+++ b/apps/docs/features/docs/GuidesMdx.client.tsx
@@ -36,8 +36,7 @@ const TocAnchorsProvider = ({ children }: PropsWithChildren) => {
         .filter((heading) => heading.id)
         .map((heading) => {
           const text = heading.textContent?.replace('#', '') || ''
-          const link = heading.querySelector('a')?.getAttribute('href')
-          if (!link) return null
+          const link = heading.id ? `#${heading.id}` : null
 
           const level = heading.tagName === 'H2' ? 2 : 3
 


### PR DESCRIPTION


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Fixes TOC anchor generation for headings that contain markdown links. The old logic queried the first <a> inside a heading and could pick an external link instead of the heading fragment, breaking TOC anchors.

Observed only on two pages:
https://supabase.com/docs/guides/auth/debugging/error-codes#403-forbidden
https://supabase.com/docs/guides/telemetry/advanced-log-filtering#filtering-with-regular-expressions

<details>
  <summary><strong>BEFORE</strong></summary>

  ![CleanShot 2026-01-04 at 22 01 35](https://github.com/user-attachments/assets/bc837402-223f-4794-a93b-5696e7d0cfc3)

</details>

<details>
  <summary><strong>AFTER</strong></summary>

  ![CleanShot 2026-01-04 at 22 03 29](https://github.com/user-attachments/assets/98b15b33-f2f3-4a90-a5a0-43477a8d61dd)

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated table of contents link generation to use heading IDs instead of DOM anchor traversal, improving the reliability of how TOC links are constructed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->