### PR TITLE
fix(studio): convert tableCreateGeneratePolicies flag to multivariate for PostHog experimentation

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -26,6 +26,7 @@ import { RetrieveTableResult } from 'data/tables/table-retrieve-query'
 import { getTables } from 'data/tables/tables-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { isValidExperimentVariant } from 'hooks/misc/useTableCreateGeneratePolicies'
 import { useConfirmOnClose, type ConfirmOnCloseModalProps } from 'hooks/ui/useConfirmOnClose'
 import { usePHFlag } from 'hooks/ui/useFlag'
 import { useUrlState } from 'hooks/ui/useUrlState'
@@ -140,7 +141,7 @@ export const SidePanelEditor = ({
   const { data: project } = useSelectedProjectQuery()
   const { data: org } = useSelectedOrganizationQuery()
   const getImpersonatedRoleState = useGetImpersonatedRoleState()
-  const generatePoliciesFlag = usePHFlag<boolean>('tableCreateGeneratePolicies')
+  const generatePoliciesFlag = usePHFlag<string>('tableCreateGeneratePolicies')
 
   const [isEdited, setIsEdited] = useState<boolean>(false)
 
@@ -551,10 +552,10 @@ export const SidePanelEditor = ({
         }
 
         // Track experiment conversion if user is in the experiment
-        if (generatePoliciesFlag !== undefined) {
+        if (isValidExperimentVariant(generatePoliciesFlag)) {
           track('table_create_generate_policies_experiment_converted', {
             experiment_id: 'tableCreateGeneratePolicies',
-            variant: generatePoliciesFlag ? 'treatment' : 'control',
+            variant: generatePoliciesFlag,
             has_rls_enabled: isRLSEnabled,
             has_rls_policies: generatedPolicies.length > 0,
             has_generated_policies: generatedPolicies.length > 0,

--- a/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
+++ b/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
@@ -8,6 +8,16 @@ import { useTrack } from 'lib/telemetry/track'
 
 dayjs.extend(utc)
 
+export type TableCreateGeneratePoliciesVariant = 'control' | 'variation'
+
+const VALID_VARIANTS: TableCreateGeneratePoliciesVariant[] = ['control', 'variation']
+
+export function isValidExperimentVariant(
+  value: unknown
+): value is TableCreateGeneratePoliciesVariant {
+  return typeof value === 'string' && VALID_VARIANTS.includes(value as TableCreateGeneratePoliciesVariant)
+}
+
 interface UseTableCreateGeneratePoliciesOptions {
   /**
    * Whether this is a new table being created
@@ -38,12 +48,12 @@ export function useTableCreateGeneratePolicies({
   projectInsertedAt,
 }: UseTableCreateGeneratePoliciesOptions): UseTableCreateGeneratePoliciesResult {
   const track = useTrack()
-  const tableCreateGeneratePoliciesFlag = usePHFlag<boolean>('tableCreateGeneratePolicies')
+  const tableCreateGeneratePoliciesFlag = usePHFlag<string>('tableCreateGeneratePolicies')
   const hasTrackedExposure = useRef(false)
 
   const enabled = useMemo(() => {
     if (!IS_PLATFORM) return false
-    if (!tableCreateGeneratePoliciesFlag) return false
+    if (tableCreateGeneratePoliciesFlag !== 'variation') return false
     return true
   }, [tableCreateGeneratePoliciesFlag])
 
@@ -51,7 +61,7 @@ export function useTableCreateGeneratePolicies({
     if (!IS_PLATFORM) return
     if (hasTrackedExposure.current) return
     if (!isNewRecord) return
-    if (tableCreateGeneratePoliciesFlag === undefined) return
+    if (!isValidExperimentVariant(tableCreateGeneratePoliciesFlag)) return
     if (!projectInsertedAt) return
 
     try {
@@ -61,7 +71,7 @@ export function useTableCreateGeneratePolicies({
       const daysSinceCreation = dayjs.utc().diff(insertedDate, 'day')
       track('table_create_generate_policies_experiment_exposed', {
         experiment_id: 'tableCreateGeneratePolicies',
-        variant: tableCreateGeneratePoliciesFlag ? 'treatment' : 'control',
+        variant: tableCreateGeneratePoliciesFlag,
         days_since_project_creation: daysSinceCreation,
       })
       hasTrackedExposure.current = true

--- a/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
+++ b/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
@@ -15,7 +15,10 @@ const VALID_VARIANTS: TableCreateGeneratePoliciesVariant[] = ['control', 'variat
 export function isValidExperimentVariant(
   value: unknown
 ): value is TableCreateGeneratePoliciesVariant {
-  return typeof value === 'string' && VALID_VARIANTS.includes(value as TableCreateGeneratePoliciesVariant)
+  return (
+    typeof value === 'string' &&
+    VALID_VARIANTS.includes(value as TableCreateGeneratePoliciesVariant)
+  )
 }
 
 interface UseTableCreateGeneratePoliciesOptions {

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2046,9 +2046,9 @@ export interface TableCreateGeneratePoliciesExperimentConvertedEvent {
      */
     experiment_id: 'tableCreateGeneratePolicies'
     /**
-     * Experiment variant: 'control' (feature disabled) or 'treatment' (feature enabled)
+     * Experiment variant: 'control' (feature disabled) or 'variation' (feature enabled)
      */
-    variant: 'control' | 'treatment'
+    variant: 'control' | 'variation'
     /**
      * Whether RLS was enabled on the table
      */
@@ -2058,7 +2058,7 @@ export interface TableCreateGeneratePoliciesExperimentConvertedEvent {
      */
     has_rls_policies: boolean
     /**
-     * Whether AI-generated policies were used (only possible in treatment)
+     * Whether AI-generated policies were used (only possible in variation)
      */
     has_generated_policies: boolean
   }
@@ -2080,9 +2080,9 @@ export interface TableCreateGeneratePoliciesExperimentExposedEvent {
      */
     experiment_id: 'tableCreateGeneratePolicies'
     /**
-     * Experiment variant: 'control' (feature disabled) or 'treatment' (feature enabled)
+     * Experiment variant: 'control' (feature disabled) or 'variation' (feature enabled)
      */
-    variant: 'control' | 'treatment'
+    variant: 'control' | 'variation'
     /**
      * Days since project creation (to segment by new user cohorts)
      */


### PR DESCRIPTION
## Problem

Turns out PostHog only supports running experiments on multivariate feature flags, not boolean ones. We originally implemented `tableCreateGeneratePolicies` as a simple true/false flag, which means we can't actually get proper experiment results from it.

This is blocking us from getting data we need to make business decisions around the generate policies feature, so we need to fix this ASAP.

## Changes

Updated the flag from boolean to multivariate (`"control"` / `"variation"`):

- **useTableCreateGeneratePolicies.ts** - Changed flag type to string, added a `isValidExperimentVariant()` type guard, updated logic to check for `'variation'` instead of truthy
- **SidePanelEditor.tsx** - Updated conversion event to use the type guard
- **telemetry-constants.ts** - Updated variant types from `'control' | 'treatment'` to `'control' | 'variation'`

Also made the exposure/conversion events only fire when the flag returns a valid experiment value (`"control"` or `"variation"`). If PostHog returns undefined/null/false for whatever reason, we skip tracking since those users aren't actually in the experiment.

## Testing

- Verified TypeScript compiles without errors
- The flag has already been updated in PostHog to return the new multivariate values

---

Fixes GROWTH-580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled experiment variant handling and validation to use explicit variant strings.
  * Changed the feature flag type from boolean to string for clearer semantics.
  * Exposure and conversion gating now validate variant values before tracking.
  * Telemetry reports the raw variant label and updated variant naming (treatment → variation) for experiment events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->