### PR TITLE
Mark useQueryStateWithSelect as deprecated

### DIFF
--- a/apps/studio/hooks/misc/useQueryStateWithSelect.ts
+++ b/apps/studio/hooks/misc/useQueryStateWithSelect.ts
@@ -16,6 +16,7 @@ import { toast } from 'sonner'
  *
  * @deprecated Avoid using this hook, and use nuqs directly
  * Refer to this PR for more information: https://github.com/supabase/supabase/pull/41380
+ * as well as context on how to refactor to remove usage of this hook
  */
 export function useQueryStateWithSelect<T>({
   enabled,

--- a/apps/studio/hooks/misc/useQueryStateWithSelect.ts
+++ b/apps/studio/hooks/misc/useQueryStateWithSelect.ts
@@ -13,6 +13,9 @@ import { toast } from 'sonner'
  * @returns Object with:
  *   - value: The result of select(selectedId) or undefined
  *   - setValue: Function to set/clear the selected ID in the URL
+ *
+ * @deprecated Avoid using this hook, and use nuqs directly
+ * Refer to this PR for more information: https://github.com/supabase/supabase/pull/41380
  */
 export function useQueryStateWithSelect<T>({
   enabled,


### PR DESCRIPTION
## Context

Just marks the `useQueryStateWithSelect` hook as deprecated - more information from a previous PR [here](https://github.com/supabase/supabase/pull/41380)