### PR TITLE
fix(studio): explain tab scroll area and small improvements

### DIFF
--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
@@ -65,10 +65,10 @@ export function ExplainHeader({ mode, onToggleMode, summary, id, rows }: Explain
           {hasSummaryStats && (
             <div className="flex items-center gap-4 flex-wrap">
               {summary.totalTime > 0 && (
-                <div className="flex items-center gap-1.5">
-                  <span className="text-foreground-light">/</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-foreground-muted">/</span>
                   <span className="text-foreground-light">Total time</span>
-                  <span className="font-mono font-medium text-foreground">
+                  <span className="font-medium text-foreground">
                     {summary.totalTime.toFixed(2)}ms
                   </span>
                 </div>

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
@@ -76,18 +76,21 @@ export function ExplainHeader({ mode, onToggleMode, summary, id, rows }: Explain
                 Start at the bottom where data is read from tables, then follow upward as each step
                 processes the results.
               </p>
-              <h3 className="text-xs font-medium mt-4 mb-2">Key</h3>
+
               {isVisual && (
-                <div className="flex flex-col gap-1 text-foreground-light">
-                  <div className="flex items-center gap-1.5">
-                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-warning" />
-                    <span>Seq Scan (slow)</span>
+                <>
+                  <h3 className="text-xs font-medium mt-4 mb-2">Key</h3>
+                  <div className="flex flex-col gap-1 text-foreground-light">
+                    <div className="flex items-center gap-1.5">
+                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-warning" />
+                      <span>Seq Scan (slow)</span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-brand" />
+                      <span>Index Scan (fast)</span>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-1.5">
-                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-brand" />
-                    <span>Index Scan (fast)</span>
-                  </div>
-                </div>
+                </>
               )}
             </TooltipContent>
           </Tooltip>

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.Header.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Eye, Code } from 'lucide-react'
+import { ArrowUp, Eye, Code, HelpCircle } from 'lucide-react'
 
 import { useFlag } from 'common'
 import { AiIconAnimation, Button } from 'ui'
@@ -8,6 +8,7 @@ import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { buildExplainPrompt } from './ExplainVisualizer.ai'
 import type { QueryPlanRow } from './ExplainVisualizer.types'
+import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 export interface ExplainSummary {
   totalTime: number
@@ -61,6 +62,35 @@ export function ExplainHeader({ mode, onToggleMode, summary, id, rows }: Explain
       <div className="flex items-center justify-between text-sm">
         <div className="flex items-center gap-2">
           <h3 className="font-medium text-foreground">Query Execution Plan</h3>
+          <Tooltip>
+            <TooltipTrigger>
+              <HelpCircle
+                size="14"
+                strokeWidth={2}
+                className="text-foreground-lighter hover:text-foreground-light transition-colors cursor-help"
+              />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs p-4">
+              <h3 className="text-xs font-medium mb-2">How to read</h3>
+              <p className="text-foreground-light text-xs">
+                Start at the bottom where data is read from tables, then follow upward as each step
+                processes the results.
+              </p>
+              <h3 className="text-xs font-medium mt-4 mb-2">Key</h3>
+              {isVisual && (
+                <div className="flex flex-col gap-1 text-foreground-light">
+                  <div className="flex items-center gap-1.5">
+                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-warning" />
+                    <span>Seq Scan (slow)</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-brand" />
+                    <span>Index Scan (fast)</span>
+                  </div>
+                </div>
+              )}
+            </TooltipContent>
+          </Tooltip>
           {/* Summary stats - only show in visual mode when we have the data */}
           {hasSummaryStats && (
             <div className="flex items-center gap-4 flex-wrap">
@@ -97,30 +127,6 @@ export function ExplainHeader({ mode, onToggleMode, summary, id, rows }: Explain
           </Button>
         </div>
       </div>
-
-      {/* How to read */}
-      <div className="flex items-center gap-2 text-foreground-lighter">
-        <ArrowUp size={12} className="text-foreground-light" />
-        <span className="font-medium text-foreground-light">How to read:</span>
-        <span>
-          Start at the bottom where data is read from tables, then follow upward as each step
-          processes the results.
-        </span>
-      </div>
-
-      {/* Icon legend - only relevant in visual mode */}
-      {isVisual && (
-        <div className="flex items-center gap-4 flex-wrap text-foreground-lighter">
-          <div className="flex items-center gap-1.5">
-            <span className="inline-block w-2 h-2 rounded-full bg-warning" />
-            <span>Seq Scan (slow)</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <span className="inline-block w-2 h-2 rounded-full bg-brand" />
-            <span>Index Scan (fast)</span>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.NodeRow.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.NodeRow.tsx
@@ -36,7 +36,7 @@ export function ExplainNodeRow({ node, depth, maxDuration }: ExplainNodeRowProps
         {/* Main row */}
         <div
           className={cn(
-            'flex items-stretch border-b-border-muted border-b border-l-4 transition-colors bg-studio group-hover:bg-surface-100/50',
+            'flex items-stretch border-l-4 transition-colors bg-studio group-hover:bg-surface-100/50',
             borderColorClass
           )}
         >
@@ -117,12 +117,12 @@ export function ExplainNodeRow({ node, depth, maxDuration }: ExplainNodeRowProps
         {isExpanded && detailLines.length > 0 && (
           <div
             className={cn(
-              'border-b-border-muted border-b border-l-4 bg-studio group-hover:bg-surface-100/50',
+              'border-t-border-muted border-t border-l-4 bg-studio group-hover:bg-surface-100/50',
               borderColorClass
             )}
             style={{ paddingLeft: `${16 + indentPx + 32}px` }}
           >
-            <div className="px-4 py-3 space-y-2 font-mono text-xs">
+            <div className="px-0 py-3 space-y-2 font-mono text-xs">
               {detailLines.map((line, idx) => (
                 <div key={idx} className="flex items-start gap-1">
                   {line.label && <span className="text-foreground-muted">{line.label}</span>}

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
@@ -39,7 +39,7 @@ export function ExplainVisualizer({ rows, onShowRaw, id }: ExplainVisualizerProp
 
       {/* Plan nodes */}
       <div className="flex-1 overflow-auto min-h-0">
-        <div className="flex flex-col min-w-max pb-4">
+        <div className="flex flex-col min-w-max pb-1 divide-y divide-border-muted">
           {parsedTree.map((node, idx) => (
             <ExplainNodeRow key={idx} node={node} depth={0} maxDuration={maxDuration} />
           ))}

--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.tsx
@@ -17,7 +17,7 @@ export function ExplainVisualizer({ rows, onShowRaw, id }: ExplainVisualizerProp
 
   if (parsedTree.length === 0) {
     return (
-      <div className="bg-studio border-t">
+      <div className="bg-studio">
         <p className="m-0 border-0 px-4 py-3 font-mono text-sm text-foreground-light">
           No execution plan data available
         </p>
@@ -26,7 +26,7 @@ export function ExplainVisualizer({ rows, onShowRaw, id }: ExplainVisualizerProp
   }
 
   return (
-    <div className="bg-studio border-t h-full flex flex-col min-h-0">
+    <div className="bg-studio h-full flex flex-col min-h-0">
       {onShowRaw && (
         <ExplainHeader
           mode="visual"

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
@@ -35,7 +35,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
 
     return (
       <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
-        <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
+        <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4 pb-9">
           <div className="flex flex-col gap-y-1">
             {formattedError.length > 0 ? (
               formattedError.map((x: string, i: number) => (
@@ -92,7 +92,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
   const toggleMode = () => setMode(mode === 'visual' ? 'raw' : 'visual')
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col pb-9">
       {mode === 'visual' ? (
         <ExplainVisualizer rows={explainResult.rows} onShowRaw={toggleMode} id={id} />
       ) : (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

A small bug where the list wasn't scrolling to the bottom of the area, so added some slack below. I've also removed an extra border top that appears on the Visualiser code that was causing a double up of the border below the editor.

**List of small improvements:**
- Added appropriate padding to bottom of scroll area so it doesn't get stuck below the bottom bar now.
- Removed border top from the visual editor as it doubled up borders with the editor causing a layout shift.
- Swapped border bottom on each row for Tailwind's divide utility, nice clean last item.
- Tidied "How to read" and key into a tooltip to gain some space on the header of the visualiser. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltip-based help information to the query explain visualizer header.

* **Style**
  * Refined visual styling and spacing throughout the explain visualizer interface.
  * Improved visual separation between query plan nodes with updated borders and dividers.
  * Adjusted padding and layout for better content organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->