### PR TITLE
fix: add error handling for undefined items in storage context menus

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FolderContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FolderContextMenu.tsx
@@ -1,7 +1,8 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Copy, Download, Edit, Trash2 } from 'lucide-react'
-import { Item, Menu, Separator } from 'react-contexify'
+import { Item, ItemParams, Menu, Separator } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
+import { toast } from 'sonner'
 
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
@@ -16,25 +17,61 @@ export const FolderContextMenu = ({ id = '' }: FolderContextMenuProps) => {
     useStorageExplorerStateSnapshot()
   const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
+  const handleRename = (args: ItemParams) => {
+    if (!args.props?.item) {
+      toast.error('Unable to rename folder. Please try again.')
+      console.error('FolderContextMenu: Rename failed - missing item in props', args.props)
+      return
+    }
+    setSelectedItemToRename(args.props.item)
+  }
+
+  const handleDownload = (args: ItemParams) => {
+    if (!args.props?.item) {
+      toast.error('Unable to download folder. Please try again.')
+      console.error('FolderContextMenu: Download failed - missing item in props', args.props)
+      return
+    }
+    downloadFolder(args.props.item)
+  }
+
+  const handleCopyPath = (args: ItemParams) => {
+    if (!args.props?.item) {
+      toast.error('Unable to copy path. Please try again.')
+      console.error('FolderContextMenu: Copy path failed - missing item in props', args.props)
+      return
+    }
+    copyPathToFolder(openedFolders, args.props.item)
+  }
+
+  const handleDelete = (args: ItemParams) => {
+    if (!args.props?.item) {
+      toast.error('Unable to delete folder. Please try again.')
+      console.error('FolderContextMenu: Delete failed - missing item in props', args.props)
+      return
+    }
+    setSelectedItemsToDelete([args.props.item])
+  }
+
   return (
     <Menu id={id} animation="fade">
       {canUpdateFiles && (
-        <Item onClick={({ props }) => setSelectedItemToRename(props.item)}>
+        <Item onClick={handleRename}>
           <Edit size={12} />
           <span className="ml-2 text-xs">Rename</span>
         </Item>
       )}
-      <Item onClick={({ props }) => downloadFolder(props.item)}>
+      <Item onClick={handleDownload}>
         <Download size={12} />
         <span className="ml-2 text-xs">Download</span>
       </Item>
-      <Item onClick={({ props }) => copyPathToFolder(openedFolders, props.item)}>
+      <Item onClick={handleCopyPath}>
         <Copy size={12} />
         <span className="ml-2 text-xs">Copy path to folder</span>
       </Item>
       {canUpdateFiles && [
         <Separator key="separator" />,
-        <Item key="delete" onClick={({ props }) => setSelectedItemsToDelete([props.item])}>
+        <Item key="delete" onClick={handleDelete}>
           <Trash2 size={12} />
           <span className="ml-2 text-xs">Delete</span>
         </Item>,

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
@@ -1,7 +1,8 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ChevronRight, Copy, Download, Edit, Move, Trash2 } from 'lucide-react'
-import { Item, Menu, Separator, Submenu } from 'react-contexify'
+import { Item, ItemParams, Menu, Separator, Submenu } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
+import { toast } from 'sonner'
 
 import { useParams } from 'common'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -30,6 +31,11 @@ export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
   const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   const onHandleClick = async (event: any, item: StorageItemWithColumn, expiresIn?: number) => {
+    if (!item) {
+      toast.error('Unable to perform action. Please try again.')
+      console.error('ItemContextMenu: Action failed - missing item', { event, expiresIn })
+      return
+    }
     if (item.isCorrupted) return
     switch (event) {
       case 'copy':
@@ -46,10 +52,19 @@ export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
     }
   }
 
+  const handleDelete = (args: ItemParams) => {
+    if (!args.props?.item) {
+      toast.error('Unable to delete file. Please try again.')
+      console.error('ItemContextMenu: Delete failed - missing item in props', args.props)
+      return
+    }
+    setSelectedItemsToDelete([args.props.item])
+  }
+
   return (
     <Menu id={id} animation="fade">
       {isPublic ? (
-        <Item onClick={({ props }) => onHandleClick('copy', props.item)}>
+        <Item onClick={({ props }) => onHandleClick('copy', props?.item)}>
           <Copy size={14} />
           <span className="ml-2 text-xs">Get URL</span>
         </Item>
@@ -64,40 +79,40 @@ export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
           arrow={<ChevronRight size={14} />}
         >
           <Item
-            onClick={({ props }) => onHandleClick('copy', props.item, URL_EXPIRY_DURATION.WEEK)}
+            onClick={({ props }) => onHandleClick('copy', props?.item, URL_EXPIRY_DURATION.WEEK)}
           >
             <span className="ml-2 text-xs">Expire in 1 week</span>
           </Item>
           <Item
-            onClick={({ props }) => onHandleClick('copy', props.item, URL_EXPIRY_DURATION.MONTH)}
+            onClick={({ props }) => onHandleClick('copy', props?.item, URL_EXPIRY_DURATION.MONTH)}
           >
             <span className="ml-2 text-xs">Expire in 1 month</span>
           </Item>
           <Item
-            onClick={({ props }) => onHandleClick('copy', props.item, URL_EXPIRY_DURATION.YEAR)}
+            onClick={({ props }) => onHandleClick('copy', props?.item, URL_EXPIRY_DURATION.YEAR)}
           >
             <span className="ml-2 text-xs">Expire in 1 year</span>
           </Item>
-          <Item onClick={({ props }) => onHandleClick('copy', props.item, -1)}>
+          <Item onClick={({ props }) => onHandleClick('copy', props?.item, -1)}>
             <span className="ml-2 text-xs">Custom expiry</span>
           </Item>
         </Submenu>
       )}
       {canUpdateFiles && [
-        <Item key="rename-file" onClick={({ props }) => onHandleClick('rename', props.item)}>
+        <Item key="rename-file" onClick={({ props }) => onHandleClick('rename', props?.item)}>
           <Edit size={14} strokeWidth={1} />
           <span className="ml-2 text-xs">Rename</span>
         </Item>,
-        <Item key="move-file" onClick={({ props }) => onHandleClick('move', props.item)}>
+        <Item key="move-file" onClick={({ props }) => onHandleClick('move', props?.item)}>
           <Move size={14} strokeWidth={1} />
           <span className="ml-2 text-xs">Move</span>
         </Item>,
-        <Item key="download-file" onClick={({ props }) => onHandleClick('download', props.item)}>
+        <Item key="download-file" onClick={({ props }) => onHandleClick('download', props?.item)}>
           <Download size={14} strokeWidth={1} />
           <span className="ml-2 text-xs">Download</span>
         </Item>,
         <Separator key="file-separator" />,
-        <Item key="delete-file" onClick={({ props }) => setSelectedItemsToDelete([props.item])}>
+        <Item key="delete-file" onClick={handleDelete}>
           <Trash2 size={14} strokeWidth={1} stroke="red" />
           <span className="ml-2 text-xs">Delete</span>
         </Item>,


### PR DESCRIPTION
## Problem
Context menu actions in Storage Explorer crash with `Cannot read properties of undefined (reading 'name')` when `props.item` is undefined.

## Solution
- Added null checks with user-friendly toast notifications
- Extracted inline handlers into dedicated functions for better error handling
- Added console logging for debugging
- Applied consistent pattern across FolderContextMenu and ItemContextMenu

## Changes
- **FolderContextMenu.tsx**: Created `handleRename`, `handleDownload`, `handleCopyPath`, `handleDelete` with validation
- **ItemContextMenu.tsx**: Added validation to `onHandleClick` and `handleDelete`
- Added `ItemParams` type import for type safety
- Added `toast` from `sonner` for user feedback

Fixes #41704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage context menu actions (rename, download, copy path, delete) now include validation with user-friendly error messages.
  * Enhanced error handling prevents silent failures and improves overall stability of folder and item operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->