### PR TITLE
feat: Add GH workflow for authorizing Vercel deploys

### DIFF
--- a/.github/workflows/authorize-vercel-deploys.yml
+++ b/.github/workflows/authorize-vercel-deploys.yml
@@ -1,0 +1,41 @@
+name: Authorize Vercel Deploys
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+
+# Cancel old builds on new commit for same workflow + branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  authorize-vercel-deploys:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          sparse-checkout: scripts
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        name: Install pnpm
+        with:
+          run_install: false
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - name: Download dependencies
+        run: |
+          pnpm install --frozen-lockfile
+      - name: Authorize Vercel Deploys
+        run: |-
+          pnpm run authorize-vercel-deploys
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/authorize-vercel-deploys.yml
+++ b/.github/workflows/authorize-vercel-deploys.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          sparse-checkout: scripts
+          # fetch only the root files and scripts folder
+          sparse-checkout: |
+            scripts
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm
         with:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "setup:cli": "supabase start -x studio && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
     "generate:types": "supabase gen types typescript --local > ./supabase/functions/common/database-types.ts",
     "api:codegen": "cd packages/api-types && pnpm run codegen",
-    "knip": "pnpx knip@~5.50.0"
+    "knip": "pnpx knip@~5.50.0",
+    "authorize-vercel-deploys": "tsx scripts/authorizeVercelDeploys.ts"
   },
   "devDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.823.0",
@@ -52,6 +53,7 @@
     "supabase": "^2.65.6",
     "supports-color": "^8.0.0",
     "tailwindcss": "catalog:",
+    "tsx": "catalog:",
     "turbo": "2.3.3",
     "typescript": "catalog:"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "tailwindcss": "catalog:",
     "tsx": "catalog:",
     "turbo": "2.3.3",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "zod": "catalog:"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       tailwindcss:
         specifier: 'catalog:'
         version: 3.4.1(ts-node@10.9.2(@types/node@22.13.14)(typescript@5.9.2))
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.3
       turbo:
         specifier: 2.3.3
         version: 2.3.3
@@ -541,7 +544,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^1.19.1
-        version: 1.19.1(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
+        version: 1.19.1(next@15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
       openai:
         specifier: ^4.75.1
         version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
@@ -19603,6 +19606,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -36755,7 +36759,7 @@ snapshots:
 
   number-flow@0.3.7: {}
 
-  nuqs@1.19.1(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)):
+  nuqs@1.19.1(next@15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)):
     dependencies:
       mitt: 3.0.1
       next: 15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
 
   apps/cms:
     dependencies:
@@ -544,7 +547,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^1.19.1
-        version: 1.19.1(next@15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
+        version: 1.19.1(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
       openai:
         specifier: ^4.75.1
         version: 4.104.0(encoding@0.1.13)(ws@8.18.3)(zod@3.25.76)
@@ -36759,7 +36762,7 @@ snapshots:
 
   number-flow@0.3.7: {}
 
-  nuqs@1.19.1(next@15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)):
+  nuqs@1.19.1(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)):
     dependencies:
       mitt: 3.0.1
       next: 15.5.9(@babel/core@7.28.4(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)

--- a/scripts/authorizeVercelDeploys.ts
+++ b/scripts/authorizeVercelDeploys.ts
@@ -126,8 +126,8 @@ async function main() {
       console.log(`Target URL: ${status.target_url}`)
 
       // Extract job info from target URL
-      const jobInfo = await extractJobInfoFromTargetUrl(status.target_url)
-      console.log(jobInfo)
+      const jobInfo = extractJobInfoFromTargetUrl(status.target_url)
+
       // Authorize the job
       await authorizeVercelJob(jobInfo, vercelToken)
     } catch (error) {

--- a/scripts/authorizeVercelDeploys.ts
+++ b/scripts/authorizeVercelDeploys.ts
@@ -1,0 +1,135 @@
+/**
+ * Script to authorize Vercel deployments from PR information.
+ *
+ * Gets the current SHA from environment variable, fetches GitHub statuses,
+ * finds authorization-required statuses, and authorizes them via Vercel API.
+ */
+
+interface GitHubStatus {
+  url: string
+  avatar_url: string
+  id: number
+  node_id: string
+  state: 'success' | 'pending' | 'failure' | 'error'
+  description: string
+  target_url: string
+  context: string
+  created_at: string
+  updated_at: string
+}
+
+interface JobInfo {
+  job: {
+    headInfo: {
+      sha: string
+    }
+    org: string
+    prId: number
+    repo: string
+  }
+}
+
+async function fetchGitHubStatuses(sha: string): Promise<GitHubStatus[]> {
+  const url = `https://api.github.com/repos/supabase/supabase/statuses/${sha}`
+  console.log(`Fetching GitHub statuses for SHA: ${sha}`)
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch GitHub statuses: ${response.status} ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+function extractJobInfoFromTargetUrl(targetUrl: string): JobInfo {
+  const url = new URL(targetUrl)
+  const jobParam = url.searchParams.get('job')
+
+  if (!jobParam) {
+    throw new Error('No job parameter found in target URL')
+  }
+
+  try {
+    const jobData = JSON.parse(jobParam)
+    return { job: jobData }
+  } catch (e) {
+    throw new Error(`Failed to parse job parameter as JSON: ${e}`)
+  }
+}
+
+async function authorizeVercelJob(jobInfo: JobInfo, vercelToken: string): Promise<void> {
+  const url = 'https://vercel.com/api/v1/integrations/authorize-job'
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: '*/*',
+      'Content-Type': 'application/json; charset=utf-8',
+      Authorization: `Bearer ${vercelToken}`,
+    },
+    body: JSON.stringify(jobInfo),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(
+      `Failed to authorize Vercel job: ${response.status} ${response.statusText}\n${errorText}`
+    )
+  }
+
+  console.log('✓ Vercel job authorized successfully!')
+}
+
+async function main() {
+  const sha = process.env.GITHUB_SHA
+  if (!sha) {
+    throw new Error('GITHUB_SHA environment variable is required')
+  }
+
+  const vercelToken = process.env.VERCEL_TOKEN
+  if (!vercelToken) {
+    throw new Error('VERCEL_TOKEN environment variable is required')
+  }
+
+  console.log(`Starting authorization process for SHA: ${sha}`)
+
+  // Fetch GitHub statuses
+  const statuses = await fetchGitHubStatuses(sha)
+  console.log(`Found ${statuses.length} statuses`)
+
+  // Filter for authorization-required statuses
+  const authRequiredStatuses = statuses.filter(
+    (status) => status.description === 'Authorization required to deploy.'
+  )
+
+  if (authRequiredStatuses.length === 0) {
+    console.log('No authorization-required statuses found. Nothing to authorize.')
+    return
+  }
+
+  console.log(`Found ${authRequiredStatuses.length} authorization-required status(es)`)
+
+  // Process each authorization-required status
+  for (const status of authRequiredStatuses) {
+    try {
+      console.log(`\nProcessing status: ${status.context}`)
+      console.log(`Target URL: ${status.target_url}`)
+
+      // Extract job info from target URL
+      const jobInfo = await extractJobInfoFromTargetUrl(status.target_url)
+      console.log(jobInfo)
+      // Authorize the job
+      await authorizeVercelJob(jobInfo, vercelToken)
+    } catch (error) {
+      console.error(`Failed to process status ${status.context}:`, error)
+      // Continue with other statuses even if one fails
+    }
+  }
+
+  console.log('\n✓ Authorization process completed!')
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
This PR adds a GH action which will automatically approve all Vercel builds when it runs. This is to avoid manual work where a Supabase team member has to manually approve all deploys on each new commit.

The Vercel builds have Git Fork protection which means builds are not run automatically when the PR is coming from GH fork. This is done to protect the environment variables in Vercel (bad actor might console.log `OPENAI_API_KEY` and abuse it). Builds have to be manually approved by a person with Vercel account.

The GH action will only run once "Approve workflows to run" is clicked. 

<img width="948" height="155" alt="Screenshot 2026-01-05 at 16 24 00" src="https://github.com/user-attachments/assets/2c9540fd-cf61-40fb-9b1f-ae1928aa29cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to authorize Vercel deployments on pull requests to master, with concurrency cancellation for older runs and scoped runner execution.
  * Added a project script and supporting development dependencies to run the authorization task during CI.
  * Improved logging, validation, and error handling for the deployment authorization flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->