### PR TITLE
docs: specify lack of support for S3 versioning

### DIFF
--- a/apps/docs/content/guides/storage/s3/compatibility.mdx
+++ b/apps/docs/content/guides/storage/s3/compatibility.mdx
@@ -22,7 +22,7 @@ The S3 protocol is currently in Public Alpha. If you encounter any issues or hav
 
 The most commonly used endpoints are implemented, and more will be added. Implemented S3 endpoints are marked with ✅ in the following tables.
 
-## Object Versioning
+## Object versioning
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/storage/s3/compatibility.mdx
+++ b/apps/docs/content/guides/storage/s3/compatibility.mdx
@@ -18,17 +18,15 @@ The S3 protocol is currently in Public Alpha. If you encounter any issues or hav
 
 </Admonition>
 
-## Implemented endpoints
-
-The most commonly used endpoints are implemented, and more will be added. Implemented S3 endpoints are marked with ✅ in the following tables.
-
-## Object versioning
-
 <Admonition type="caution">
 
 **S3 versioning is not supported.** Supabase Storage does not enable S3's versioning capabilities for buckets. Deleted objects are permanently removed and cannot be restored.
 
 </Admonition>
+
+## Implemented endpoints
+
+The most commonly used endpoints are implemented, and more will be added. Implemented S3 endpoints are marked with ✅ in the following tables.
 
 ### Bucket operations
 

--- a/apps/docs/content/guides/storage/s3/compatibility.mdx
+++ b/apps/docs/content/guides/storage/s3/compatibility.mdx
@@ -22,6 +22,14 @@ The S3 protocol is currently in Public Alpha. If you encounter any issues or hav
 
 The most commonly used endpoints are implemented, and more will be added. Implemented S3 endpoints are marked with ✅ in the following tables.
 
+## Object Versioning
+
+<Admonition type="caution">
+
+**S3 versioning is not supported.** Supabase Storage does not enable S3's versioning capabilities for buckets. Deleted objects are permanently removed and cannot be restored.
+
+</Admonition>
+
 ### Bucket operations
 
 {/* supa-mdx-lint-disable Rule003Spelling */}


### PR DESCRIPTION
Adds a specific mention of the lack of [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html) support in Supabase Storage, which has caused confusion in our Assistant about whether recovery of deleted objects is possible.

Ref: AI-332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a caution to the S3 compatibility guide clarifying that object versioning is not supported for buckets. Deleted objects are permanently removed and cannot be restored. The note is placed prior to the "Bucket operations" section for visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->