### PR TITLE
fix: X/Twitter logo for users authenticated via the X provider

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -82,6 +82,7 @@ const providers = {
     { notion: 'notion-icon' },
     { twitch: 'twitch-icon' },
     { twitter: 'twitter-icon' },
+    { x: 'x-icon-light' },
     { slack_oidc: 'slack-icon' },
     { slack: 'slack-icon' },
     { spotify: 'spotify-icon' },
@@ -373,7 +374,9 @@ export const formatUserColumns = ({
                           width={16}
                           src={icon}
                           alt={`${provider} auth icon`}
-                          className={cn(provider === 'github' && 'dark:invert')}
+                          className={cn(
+                            (provider === 'github' || provider === 'x') && 'dark:invert'
+                          )}
                         />
                       </div>
                     )


### PR DESCRIPTION
Show the X provider logo in the Users table.

<img width="441" height="113" alt="Screenshot 2026-01-05 at 19 12 40" src="https://github.com/user-attachments/assets/54dfbfa6-4504-4e6a-bbe4-96b09cf8ac73" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for X as a social authentication provider.

* **Bug Fixes**
  * Improved dark-mode icon rendering for social authentication providers, ensuring correct display for X and GitHub.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->