### PR TITLE
feat: add homeNew flag helper for boolean to string migration

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -12,6 +12,7 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { withAuth } from 'hooks/misc/withAuth'
 import { usePHFlag } from 'hooks/ui/useFlag'
+import { isHomeNewVariant, type HomeNewFlagValue } from 'lib/featureFlags/homeNew'
 import { PROJECT_STATUS } from 'lib/constants'
 import { useAppStateSnapshot } from 'state/app-state'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
@@ -276,7 +277,8 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
   const { ref } = useParams()
   const state = useDatabaseSelectorStateSnapshot()
   const { data: selectedProject } = useSelectedProjectQuery()
-  const isHomeNewFlag = usePHFlag('homeNew')
+  const homeNewVariant = usePHFlag<HomeNewFlagValue>('homeNew')
+  const isHomeNewFlag = isHomeNewVariant(homeNewVariant)
 
   const isBranchesPage = router.pathname.includes('/project/[ref]/branches')
   const isSettingsPages = router.pathname.includes('/project/[ref]/settings')

--- a/apps/studio/lib/featureFlags/homeNew.ts
+++ b/apps/studio/lib/featureFlags/homeNew.ts
@@ -1,4 +1,26 @@
-// Temporary helper for the homeNew experiment rollout.
+/**
+ * Temporary helper for the homeNew experiment rollout.
+ *
+ * PostHog requires string variants for A/B test analysis, but we initially implemented
+ * this flag as a boolean. This helper supports both formats during the migration period
+ * to avoid disrupting existing users.
+ *
+ * Once migration is complete, we'll use only string values ('control'/'new-home') and
+ * this helper can be removed.
+ */
 export type HomeNewFlagValue = 'control' | 'new-home' | boolean | undefined
 
-export const isHomeNewVariant = (value: HomeNewFlagValue) => value === true || value === 'new-home'
+/**
+ * Checks if the homeNew flag value indicates the new home experience should be shown.
+ *
+ * @param value - The PostHog flag value (boolean, string variant, or undefined)
+ * @returns true if user should see the new home (true or 'new-home')
+ *
+ * @example
+ * const variant = usePHFlag<HomeNewFlagValue>('homeNew')
+ * const shouldShowNewHome = isHomeNewVariant(variant)
+ * // Returns true for: true or 'new-home'
+ * // Returns false for: false, 'control', or undefined
+ */
+export const isHomeNewVariant = (value: HomeNewFlagValue): boolean =>
+  value === true || value === 'new-home'

--- a/apps/studio/lib/featureFlags/homeNew.ts
+++ b/apps/studio/lib/featureFlags/homeNew.ts
@@ -1,0 +1,4 @@
+// Temporary helper for the homeNew experiment rollout.
+export type HomeNewFlagValue = 'control' | 'new-home' | boolean | undefined
+
+export const isHomeNewVariant = (value: HomeNewFlagValue) => value === true || value === 'new-home'

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -53,6 +53,7 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { withAuth } from 'hooks/misc/withAuth'
 import { usePHFlag } from 'hooks/ui/useFlag'
 import { DOCS_URL, PROJECT_STATUS, PROVIDERS, useDefaultProvider } from 'lib/constants'
+import { isHomeNewVariant, type HomeNewFlagValue } from 'lib/featureFlags/homeNew'
 import { useTrack } from 'lib/telemetry/track'
 import { AWS_REGIONS, type CloudProvider } from 'shared-data'
 import type { NextPageWithLayout } from 'types'
@@ -83,7 +84,8 @@ const Wizard: NextPageWithLayout = () => {
   const projectCreationDisabled = useFlag('disableProjectCreationAndUpdate')
   const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
   const cloudProviderEnabled = useFlag('enableFlyCloudProvider')
-  const isHomeNew = usePHFlag('homeNew')
+  const homeNewVariant = usePHFlag<HomeNewFlagValue>('homeNew')
+  const isHomeNew = isHomeNewVariant(homeNewVariant)
 
   const showNonProdFields = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod'
   const isNotOnHigherPlan = !['team', 'enterprise', 'platform'].includes(currentOrg?.plan.id ?? '')

--- a/apps/studio/pages/project/[ref]/index.tsx
+++ b/apps/studio/pages/project/[ref]/index.tsx
@@ -3,10 +3,12 @@ import { HomeV2 } from 'components/interfaces/HomeNew/Home'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ProjectLayoutWithAuth } from 'components/layouts/ProjectLayout'
 import { usePHFlag } from 'hooks/ui/useFlag'
+import { isHomeNewVariant, type HomeNewFlagValue } from 'lib/featureFlags/homeNew'
 import type { NextPageWithLayout } from 'types'
 
 const HomePage: NextPageWithLayout = () => {
-  const isHomeNewPH = usePHFlag('homeNew')
+  const homeNewVariant = usePHFlag<HomeNewFlagValue>('homeNew')
+  const isHomeNewPH = isHomeNewVariant(homeNewVariant)
 
   if (isHomeNewPH) {
     return <HomeV2 />


### PR DESCRIPTION
PostHog requires string variants for proper A/B test analysis, but we originally implemented homeNew as a boolean flag. This means we can't get meaningful experiment data.

## Changes
- Created a small helper that accepts both boolean and string variants during migration
- Applied it to project home, new project flow, and layout gating logic
- Added docs explaining why this exists and that it's temporary

Once everyone's migrated to string variants, we can remove this helper and use only 'control'/'new-home'.

## Testing
- Ran tsc --noEmit and prettier checks
- Verified flag works with both boolean (true/false) and string ('control'/'new-home') values

Resolves GROWTH-582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced type-safety and consistency for feature flag handling related to home interface variations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->