### PR TITLE
fix(docs): close feedback modal on button press

### DIFF
--- a/apps/docs/components/Feedback/FeedbackModal.tsx
+++ b/apps/docs/components/Feedback/FeedbackModal.tsx
@@ -15,7 +15,13 @@ type FeedbackModalProps = {
 
 function FeedbackModal({ visible, page, onCancel, onSubmit }: FeedbackModalProps) {
   return (
-    <Modal hideFooter header="Leave a comment" visible={visible} onEscapeKeyDown={onCancel}>
+    <Modal
+      hideFooter
+      header="Leave a comment"
+      visible={visible}
+      onCancel={onCancel}
+      onEscapeKeyDown={onCancel}
+    >
       <Form
         initialValues={{ page, comment: '' }}
         validateOnBlur


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The close button on the top right of the feedback modal was not properly closing on button press because the `onCancel` wasn't being passed through.

## What is the new behavior?

The close button now works.

https://github.com/user-attachments/assets/a5f9a9db-7af9-4e3e-85de-6c887ff8ada8

## Additional context

Resolves FE-2335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feedback modal to properly handle cancel actions, ensuring the modal correctly responds when dismissed via the escape key or cancel button.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->