### PR TITLE
Cli reference doc updates | added examples to the storage section

### DIFF
--- a/apps/docs/spec/cli_v1_commands.yaml
+++ b/apps/docs/spec/cli_v1_commands.yaml
@@ -349,6 +349,35 @@ commands:
   - id: supabase-storage-cp
     title: supabase storage cp
     summary: Copy objects from src to dst path
+    description: |
+      Relies on standard uploads to move files between local and remote storage. [Not suitable for moving files over 6MB in size](https://supabase.com/docs/guides/storage/uploads/standard-uploads?queryGroups=language&language=js#uploading).
+    examples:
+      - id: upload-file-to-bucket
+        name: Upload file to bucket
+        code: supabase storage cp -r path/to/file ss:///bucket_name --experimental
+        response: |
+          Uploading: /path/to/file/example.txt => /bucket_name/example.txt
+      - id: Upload-file-to-folder
+        name: Upload file to folder
+        code: supabase storage cp -r path/to/local/file ss:///bucket_name/path/to/folder --experimental
+        response: |
+          Uploading: /path/to/file/example.txt => /bucket_name/path/to/folder/example.txt
+      - id: upload-entire-folder-to-bucket
+        name: Upload folder to bucket
+        code: supabase storage cp -r path/to/local/folder ss:///bucket_name --experimental
+        response: |
+          Uploading: /path/to/folder/example1.txt => /bucket_name/folder/example1.txt
+          Uploading: /path/to/folder/example2.txt => /bucket_name/folder/example2.txt
+          Uploading: /path/to/folder/example3.txt => /bucket_name/folder/example3.txt
+          ...
+      - id: download-entire-bucket
+        name: Download bucket
+        code: supabase storage cp -r ss://bucket_name path/to/local/folder --experimental
+        response: |
+          Downloading: bucket_name/example1.txt => path/to/local/folder/bucket_name/example1.txt
+          Downloading: bucket_name/example2.txt => path/to/local/folder/bucket_name/example2.txt
+          Downloading: bucket_name/example3.txt => path/to/local/folder/bucket_name/example3.txt
+          ...
     tags: []
     links: []
     usage: supabase storage cp <src> <dst> [flags]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

CLI `storage cp` command lacks examples

## What is the new behavior?

Added examples and warning about upload size limitations
<img width="2314" height="1076" alt="CleanShot 2026-01-05 at 19 10 12@2x" src="https://github.com/user-attachments/assets/9a43c0f9-5489-41c4-8147-654b9a373f52" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced command documentation with detailed descriptions clarifying storage copy functionality, behavior, and operational boundaries.
  * Added comprehensive usage examples demonstrating practical scenarios: uploading files to buckets, uploading to folders, synchronizing folder structures, and downloading bucket contents.
  * Included important considerations for handling large files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->