### PR TITLE
docs: Add SvelteKit SSR OAuth authentication guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -1,0 +1,139 @@
+---
+
+title: SvelteKit SSR Authentication
+description: Use Supabase Auth with OAuth in SvelteKit using server-side rendering.
+-----------------------------------------------------------------------------------
+
+## Overview
+
+This guide shows how to use Supabase Auth with OAuth providers (such as GitHub or Google) in a SvelteKit application using server-side rendering (SSR).
+
+It covers:
+
+* Starting an OAuth sign-in flow
+* Handling the OAuth callback
+* Persisting the session using cookies
+* Accessing the authenticated user on the server
+
+This approach is recommended for SvelteKit apps that rely on SSR and need consistent authentication across server and client.
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+* A Supabase project
+* A SvelteKit app (`@sveltejs/kit`)
+* An OAuth provider configured in the Supabase dashboard
+* The `@supabase/ssr` package installed
+
+```bash
+npm install @supabase/ssr @supabase/supabase-js
+```
+
+## Creating a Supabase client for SSR
+
+Create a helper to initialize the Supabase client using cookies. This ensures the session is available during server-side rendering.
+
+```ts
+// src/lib/server/supabase.ts
+import { createServerClient } from '@supabase/ssr'
+import { env } from '$env/dynamic/private'
+import type { Cookies } from '@sveltejs/kit'
+
+export function createSupabaseServerClient(cookies: Cookies) {
+  return createServerClient(
+    env.PUBLIC_SUPABASE_URL,
+    env.PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookies.get(name)
+        },
+        set(name, value, options) {
+          cookies.set(name, value, options)
+        },
+        remove(name, options) {
+          cookies.delete(name, options)
+        },
+      },
+    }
+  )
+}
+```
+
+## Starting an OAuth sign-in
+
+Create a server action to start the OAuth flow.
+
+```ts
+// src/routes/login/+page.server.ts
+import { redirect } from '@sveltejs/kit'
+import { createSupabaseServerClient } from '$lib/server/supabase'
+
+export const actions = {
+  default: async ({ cookies }) => {
+    const supabase = createSupabaseServerClient(cookies)
+
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'http://localhost:5173/auth/callback',
+      },
+    })
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    throw redirect(303, data.url)
+  },
+}
+```
+
+## Handling the OAuth callback
+
+Supabase redirects back to your app after authentication. Handle this in a server route to exchange the code and persist the session.
+
+```ts
+// src/routes/auth/callback/+server.ts
+import { redirect } from '@sveltejs/kit'
+import { createSupabaseServerClient } from '$lib/server/supabase'
+
+export async function GET({ url, cookies }) {
+  const code = url.searchParams.get('code')
+
+  if (code) {
+    const supabase = createSupabaseServerClient(cookies)
+    await supabase.auth.exchangeCodeForSession(code)
+  }
+
+  throw redirect(303, '/')
+}
+```
+
+## Accessing the session on the server
+
+Once authenticated, you can access the current user during server-side rendering.
+
+```ts
+// src/routes/+layout.server.ts
+import { createSupabaseServerClient } from '$lib/server/supabase'
+
+export async function load({ cookies }) {
+  const supabase = createSupabaseServerClient(cookies)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  return {
+    user,
+  }
+}
+```
+
+## Notes and considerations
+
+* OAuth redirect URLs must match the callback URL configured in the Supabase dashboard.
+* Cookies are required for session persistence during SSR.
+* This setup avoids relying on client-only authentication helpers.
+* Error and metadata behavior may differ from controller-based frameworks.

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -77,7 +77,7 @@ export const actions = {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'github',
       options: {
-        redirectTo: 'http://localhost:5173/auth/callback',
+        redirectTo: `${process.env.PUBLIC_SITE_URL}/auth/callback`,
       },
     })
 
@@ -134,6 +134,7 @@ export async function load({ cookies }) {
 ## Notes and considerations
 
 * OAuth redirect URLs must match the callback URL configured in the Supabase dashboard.
+* Use an environment variable (for example, `PUBLIC_SITE_URL`) for OAuth redirect URLs so they can differ between development and production.
 * Cookies are required for session persistence during SSR.
 * This setup avoids relying on client-only authentication helpers.
 * Error and metadata behavior may differ from controller-based frameworks.

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -1,7 +1,7 @@
 ---
 
-Title: SvelteKit SSR Authentication
-Description: Use Supabase Auth with OAuth in SvelteKit using server-side rendering.
+title: SvelteKit SSR Authentication
+description: Use Supabase Auth with OAuth in SvelteKit using server-side rendering.
 -----------------------------------------------------------------------------------
 
 ## Overview
@@ -25,6 +25,7 @@ Before you begin, make sure you have:
 * A SvelteKit app (`@sveltejs/kit`)
 * An OAuth provider configured in the Supabase dashboard
 * The `@supabase/ssr` package installed
+* Environment variables configured for your Supabase project (for example, `PUBLIC_SITE_URL`)
 
 ```bash
 npm install @supabase/ssr @supabase/supabase-js
@@ -143,6 +144,7 @@ export async function load({ cookies }) {
 * OAuth redirect URLs must match the callback URL configured in the Supabase dashboard.
 * Use an environment variable (for example, `PUBLIC_SITE_URL`) for OAuth redirect URLs so they can differ between development and production.
 * `PUBLIC_*` environment variables should be imported from `$env/dynamic/public` in SvelteKit.
+* Ensure `PUBLIC_SITE_URL` is set to your application’s base URL (for example, `http://localhost:5173` in development) and matches the OAuth redirect URLs configured in the Supabase dashboard.
 * Cookies are required for session persistence during SSR.
 * This setup avoids relying on client-only authentication helpers.
 * Error and metadata behavior may differ from controller-based frameworks.

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -1,7 +1,7 @@
 ---
 
-title: SvelteKit SSR Authentication
-description: Use Supabase Auth with OAuth in SvelteKit using server-side rendering.
+Title: SvelteKit SSR Authentication
+Description: Use Supabase Auth with OAuth in SvelteKit using server-side rendering.
 -----------------------------------------------------------------------------------
 
 ## Overview
@@ -37,7 +37,7 @@ Create a helper to initialize the Supabase client using cookies. This ensures th
 ```ts
 // src/lib/server/supabase.ts
 import { createServerClient } from '@supabase/ssr'
-import { env } from '$env/dynamic/private'
+import { env } from '$env/dynamic/public'
 import type { Cookies } from '@sveltejs/kit'
 
 export function createSupabaseServerClient(cookies: Cookies) {
@@ -68,6 +68,7 @@ Create a server action to start the OAuth flow.
 ```ts
 // src/routes/login/+page.server.ts
 import { redirect } from '@sveltejs/kit'
+import { env } from '$env/dynamic/public'
 import { createSupabaseServerClient } from '$lib/server/supabase'
 
 export const actions = {
@@ -77,7 +78,7 @@ export const actions = {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'github',
       options: {
-        redirectTo: `${process.env.PUBLIC_SITE_URL}/auth/callback`,
+        redirectTo: `${env.PUBLIC_SITE_URL}/auth/callback`,
       },
     })
 
@@ -96,15 +97,21 @@ Supabase redirects back to your app after authentication. Handle this in a serve
 
 ```ts
 // src/routes/auth/callback/+server.ts
-import { redirect } from '@sveltejs/kit'
+import { redirect, error as kitError } from '@sveltejs/kit'
 import { createSupabaseServerClient } from '$lib/server/supabase'
 
 export async function GET({ url, cookies }) {
   const code = url.searchParams.get('code')
 
-  if (code) {
-    const supabase = createSupabaseServerClient(cookies)
-    await supabase.auth.exchangeCodeForSession(code)
+  if (!code) {
+    throw kitError(400, 'Missing OAuth code')
+  }
+
+  const supabase = createSupabaseServerClient(cookies)
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    throw kitError(401, 'Authentication failed')
   }
 
   throw redirect(303, '/')
@@ -135,6 +142,7 @@ export async function load({ cookies }) {
 
 * OAuth redirect URLs must match the callback URL configured in the Supabase dashboard.
 * Use an environment variable (for example, `PUBLIC_SITE_URL`) for OAuth redirect URLs so they can differ between development and production.
+* `PUBLIC_*` environment variables should be imported from `$env/dynamic/public` in SvelteKit.
 * Cookies are required for session persistence during SSR.
 * This setup avoids relying on client-only authentication helpers.
 * Error and metadata behavior may differ from controller-based frameworks.


### PR DESCRIPTION
### Summary

Adds a new documentation page describing how to use Supabase Auth with OAuth providers in a SvelteKit application using server-side rendering (SSR).

### What this includes

- An end-to-end OAuth flow example for SvelteKit SSR
- Server-side Supabase client setup using cookies
- OAuth callback handling and session persistence
- Notes on SSR-specific considerations

### Why

SvelteKit SSR authentication with OAuth can be non-obvious, and this fills a gap in the existing server-side auth documentation by providing a clear, framework-specific example.

Closes #40388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New guide for server-side authentication in SvelteKit using OAuth: initiating the OAuth flow, handling callbacks and exchanging codes for sessions, persisting sessions via cookies for SSR, accessing the authenticated user on the server, prerequisites, practical server-side examples, and notes on redirects, cookie usage, and framework-specific considerations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->