### PR TITLE
fix(studio): update projectRef handling in useCreateCommandsConfig function

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.utils.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.utils.tsx
@@ -79,8 +79,11 @@ export function getIntegrationCommandName(integration: IntegrationDefinition): s
 }
 
 export function useCreateCommandsConfig() {
-  let { ref } = useParams()
-  ref ||= '_'
+  const { ref: urlRef } = useParams()
+
+  // Use '_' as fallback for route building, but keep undefined for API queries
+  const ref = urlRef ?? '_'
+
   const setPage = useSetPage()
   const { openSidebar } = useSidebarManagerSnapshot()
   const snap = useAiAssistantStateSnapshot()
@@ -104,7 +107,7 @@ export function useCreateCommandsConfig() {
     data: authConfig,
     isError: isAuthConfigError,
     isPending: isAuthConfigLoading,
-  } = useAuthConfigQuery({ projectRef: ref })
+  } = useAuthConfigQuery({ projectRef: urlRef })
 
   const { getEntitlementSetValues: getEntitledHookSet } = useCheckEntitlements('auth.hooks')
   const entitledHookSet = getEntitledHookSet()
@@ -152,8 +155,8 @@ export function useCreateCommandsConfig() {
   // Storage
   const { data: organization } = useSelectedOrganizationQuery()
   const isFreePlan = organization?.plan.id === 'free'
-  const isVectorBucketsEnabled = useIsVectorBucketsEnabled({ projectRef: ref })
-  const isAnalyticsBucketsEnabled = useIsAnalyticsBucketsEnabled({ projectRef: ref })
+  const isVectorBucketsEnabled = useIsVectorBucketsEnabled({ projectRef: urlRef })
+  const isAnalyticsBucketsEnabled = useIsAnalyticsBucketsEnabled({ projectRef: urlRef })
 
   // Integrations
   const { installedIntegrations } = useInstalledIntegrations()


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When visiting `/organizations` pages in the Studio app, two API calls return 404 errors:
- `GET /platform/auth/_/config`
- `GET /platform/projects/_/config/storage`

This happens because `useCreateCommandsConfig` in `CreateCommands.utils.tsx` sets `ref ||= '_'` as a fallback when no project ref is available. This `'_'` string is then passed to `useAuthConfigQuery`, `useIsVectorBucketsEnabled`, and `useIsAnalyticsBucketsEnabled`. Since `'_'` is a string (not `undefined`), the query guards (`typeof projectRef !== 'undefined'`) don't prevent these queries from firing.

## What is the new behavior?

The URL param is now separated from the fallback value:
- `urlRef` - The raw URL param (undefined on organization page) - passed to API queries
- `ref` - Has `'_'` fallback - used only for building route strings in command menu

API queries now receive `undefined` when there's no project ref, which triggers their existing guards and prevents the invalid 404 requests.

## Additional context

The `'_'` fallback is still needed for building command menu routes (e.g., `/project/${ref}/editor`), but it should never be used for actual API calls.

Fixes #41736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved parameter handling in the command menu creation utilities to better manage URL reference values for API queries and feature flag checks, while maintaining route-building compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->