### PR TITLE
fix: sanitize file paths with parent directory references in edge function downloads

### DIFF
--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
@@ -133,13 +133,58 @@ const EdgeFunctionDetailsLayout = ({
 
     const zipFileWriter = new BlobWriter('application/zip')
     const zipWriter = new ZipWriter(zipFileWriter, { bufferedWrite: true })
+
+    // Extract file paths relative to function slug
+    const filePaths = functionBody.files.map((file) => {
+      const nameSections = file.name.split('/')
+      const slugIndex = nameSections.indexOf(functionSlug ?? '')
+      return nameSections.slice(slugIndex + 1).join('/')
+    })
+
+    // Find the deepest relative path (count leading ../ segments)
+    let maxDepth = 0
+    filePaths.forEach((path) => {
+      const segments = path.split('/')
+      let depth = 0
+      for (const segment of segments) {
+        if (segment === '..') {
+          depth++
+        } else {
+          break
+        }
+      }
+      maxDepth = Math.max(maxDepth, depth)
+    })
+
+    // Add files to zip with normalized paths
     functionBody.files.forEach((file) => {
       const nameSections = file.name.split('/')
       const slugIndex = nameSections.indexOf(functionSlug ?? '')
       const fileName = nameSections.slice(slugIndex + 1).join('/')
 
+      // Count and remove leading ../ segments
+      const segments = fileName.split('/')
+      let parentDirCount = 0
+      while (segments.length > 0 && segments[0] === '..') {
+        segments.shift()
+        parentDirCount++
+      }
+
+      // Calculate safe path:
+      // - Files without ../ go into the full base path
+      // - Files with ../ go into a shallower path based on how many levels up they go
+      const depthFromBase = maxDepth - parentDirCount
+      const safePath =
+        depthFromBase > 0
+          ? Array.from({ length: depthFromBase }, (_, i) => (i === 0 ? 'src' : `src${i}`)).join(
+              '/'
+            ) +
+            '/' +
+            segments.join('/')
+          : segments.join('/')
+
       const fileBlob = new Blob([file.content])
-      zipWriter.add(fileName, new BlobReader(fileBlob))
+      zipWriter.add(safePath, new BlobReader(fileBlob))
     })
 
     const blobURL = URL.createObjectURL(await zipWriter.close())


### PR DESCRIPTION
Refactored downloadFunction to safely handle files with ../ in their paths by detecting the deepest relative path and creating a normalized directory structure. This prevents path traversal vulnerabilities and ensures all files are safely contained within the zip archive.

Fixes https://linear.app/supabase/issue/FUNC-400/fix-frontend-zip-generation-for-parent-relative-paths



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved edge function ZIP downloads: archive contents are normalized to remove unsafe parent-directory references and organized into a consistent src-based structure.
  * Depth-aware path handling ensures files are placed predictably inside the ZIP, making downloaded packages easier to integrate and less error-prone.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->