### PR TITLE
fix: added portal prop for weird popover placement

### DIFF
--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
@@ -221,7 +221,7 @@ const EdgeFunctionDetailsLayout = ({
                       Download
                     </Button>
                   </PopoverTrigger_Shadcn_>
-                  <PopoverContent_Shadcn_ align="end" className="p-0">
+                  <PopoverContent_Shadcn_ align="end" portal className="p-0">
                     <div className="p-3 flex flex-col gap-y-2">
                       <p className="text-xs text-foreground-light">Download via CLI</p>
                       <Input


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: Portal for download was WAYYY OUT THERE. Now its in the right place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced popover rendering behavior in the Edge Functions details section. Optimizations to the rendering mechanism improve visual presentation, positioning accuracy, and overall display consistency. Layout properties including alignment and padding configuration remain unchanged, ensuring the interface maintains visual stability and consistency while benefiting from the improved rendering approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->