### PR TITLE
fix(telemetry): decouple initial pageview from feature flag loading

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -280,7 +280,6 @@ export const PageTelemetry = ({
     if (
       (router?.isReady ?? true) &&
       hasAcceptedConsent &&
-      featureFlags.hasLoaded &&
       !hasSentInitialPageTelemetryRef.current
     ) {
       const cookies = document.cookie.split(';')
@@ -316,7 +315,7 @@ export const PageTelemetry = ({
 
       hasSentInitialPageTelemetryRef.current = true
     }
-  }, [router?.isReady, hasAcceptedConsent, featureFlags.hasLoaded, slug, ref])
+  }, [router?.isReady, hasAcceptedConsent, slug, ref])
 
   useEffect(() => {
     // For pages router


### PR DESCRIPTION
## Problem

The initial pageview event is gated on `featureFlags.hasLoaded`, which means if feature flags get blocked by an ad blocker or are slow to load, we never send that first pageview. More importantly, the first-touch attribution cookie (`supabase-telemetry-data`) is consumed in the same gated block, so it sticks around longer than it should and can get applied to the wrong event later.

This undermines the first-touch attribution work from GROWTH-573 and makes our telemetry data less reliable.

## What happened

Back when we added feature flags to pageview events, we gated the entire initial pageview on `featureFlags.hasLoaded` so we could include the `$feature/*` properties. The problem is this creates a hard dependency where the most important event (first pageview with referrer data) can be blocked by the least critical part (feature flags).

In practice, feature flag loading fails often enough (ad blockers, network issues) that this is causing real data loss.

## Changes

Removed the `featureFlags.hasLoaded` gate from the initial pageview. Now it fires as soon as the router is ready and consent is accepted. Feature flags are still included in the event if they've loaded - we just don't wait for them.

- Deleted `featureFlags.hasLoaded &&` condition from the useEffect
- Removed it from the dependency array

The trade-off is the initial pageview might lack `$feature/*` properties if flags haven't loaded yet, but all subsequent pageviews will have them. You can still segment users by feature flags using any event after the first one, which is fine for analysis.

## Testing

Test with an ad blocker enabled - the initial pageview should still fire and the first-touch cookie should be consumed immediately. Subsequent pageviews will include feature flags as normal.

Resolves GROWTH-575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry delivery timing to capture analytics data faster after user interactions and consent acceptance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->