### PR TITLE
feat(telemetry): set gotrue_id as person property in frontend identify

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -426,7 +426,7 @@ export function useTelemetryIdentify(API_URL: string) {
         ...(anonymousId && { anonymous_id: anonymousId }),
       })
 
-      posthogClient.identify(user.id)
+      posthogClient.identify(user.id, { gotrue_id: user.id })
     }
   }, [API_URL, user?.id])
 }


### PR DESCRIPTION
## Problem

We currently call `PostHog.identify()` in two places when a user logs in:
- Frontend (`telemetry.tsx`) - just passes the user ID
- Backend (`identify.controller.ts`) - passes user ID + sets `gotrue_id` as a person property

This creates potential race conditions and violates PostHog's recommendation that the frontend should be the authoritative source for user identification.

The backend identify also sets a `gotrue_id` person property that's used in feature flag evaluation. We need to preserve this property, but it should be set from the frontend instead.

## Changes

Updated the frontend `identify()` call to include the `gotrue_id` property:

```typescript
// Before
posthogClient.identify(user.id)

// After  
posthogClient.identify(user.id, { gotrue_id: user.id })
```

This is a one-line change that ensures the `gotrue_id` property is set from the frontend (the right place), which allows us to remove the duplicate backend `identify()` call in a follow-up PR.

## Testing

The behavior should be identical - PostHog user profiles will still have the `gotrue_id` property, it's just set from a different place now. Feature flag evaluation will continue to work as before.

GROWTH-565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved telemetry data collection to enhance analytics accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->