### PR TITLE
feat(studio): Replication UI to also show rows for read replicas

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -649,7 +649,7 @@ export const DestinationForm = ({
               <p className="text-foreground-light text-sm">
                 {isValidating
                   ? 'Validating destination configuration...'
-                  : 'Creating destination...'}
+                  : `${editMode ? 'Updating' : 'Creating'} destination...`}
               </p>
             </motion.div>
           ) : (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -26,6 +26,7 @@ interface DestinationPanelProps {
     statusName?: string
   }
   onClose: () => void
+  onSuccessCreateReadReplica?: () => void
 }
 
 export const DestinationPanel = ({
@@ -33,6 +34,7 @@ export const DestinationPanel = ({
   type,
   existingDestination,
   onClose,
+  onSuccessCreateReadReplica,
 }: DestinationPanelProps) => {
   const unifiedReplication = useFlag('unifiedReplication')
 
@@ -69,7 +71,7 @@ export const DestinationPanel = ({
             <DialogSectionSeparator />
 
             {selectedType === 'Read Replica' ? (
-              <ReadReplicaForm onClose={onClose} />
+              <ReadReplicaForm onClose={onClose} onSuccess={() => onSuccessCreateReadReplica?.()} />
             ) : (
               <DestinationForm
                 visible={visible}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/index.tsx
@@ -25,8 +25,7 @@ import { useCheckEligibilityDeployReplica } from './useCheckEligibilityDeployRep
 import { useGetReplicaCost } from './useGetReplicaCost'
 
 interface ReadReplicaFormProps {
-  // [Joshen] Need to refetch replicas on the parent since they're created async
-  onSuccess?: () => void
+  onSuccess: () => void
   onClose: () => void
 }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
-import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
 import { useDeleteDestinationPipelineMutation } from 'data/replication/delete-destination-pipeline-mutation'
 import { useReplicationPipelineReplicationStatusQuery } from 'data/replication/pipeline-replication-status-query'
@@ -16,7 +15,15 @@ import {
   usePipelineRequestStatus,
 } from 'state/replication-pipeline-request-status'
 import type { ResponseError } from 'types'
-import { Button, Tooltip, TooltipContent, TooltipTrigger, WarningIcon } from 'ui'
+import {
+  Button,
+  TableCell,
+  TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  WarningIcon,
+} from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { DeleteDestination } from './DeleteDestination'
 import { DestinationPanel } from './DestinationPanel/DestinationPanel'
@@ -137,8 +144,8 @@ export const DestinationRow = ({
         <AlertError error={pipelineError} subject={PIPELINE_ERROR_MESSAGES.RETRIEVE_PIPELINE} />
       )}
       {isPipelineSuccess && (
-        <Table.tr>
-          <Table.td>
+        <TableRow>
+          <TableCell>
             {isPipelineLoading ? (
               <ShimmeringLoader />
             ) : pipeline?.id ? (
@@ -151,9 +158,9 @@ export const DestinationRow = ({
             ) : (
               destinationName
             )}
-          </Table.td>
-          <Table.td>{isPipelineLoading ? <ShimmeringLoader /> : type}</Table.td>
-          <Table.td>
+          </TableCell>
+          <TableCell>{isPipelineLoading ? <ShimmeringLoader /> : type}</TableCell>
+          <TableCell>
             {isPipelineLoading || !pipeline ? (
               <ShimmeringLoader />
             ) : (
@@ -167,15 +174,15 @@ export const DestinationRow = ({
                 pipelineId={pipeline?.id}
               />
             )}
-          </Table.td>
-          <Table.td>
+          </TableCell>
+          <TableCell>
             {isPipelineLoading || !pipeline ? (
               <ShimmeringLoader />
             ) : (
               pipeline.config.publication_name
             )}
-          </Table.td>
-          <Table.td>
+          </TableCell>
+          <TableCell>
             <div className="flex items-center justify-end gap-x-2">
               {hasTableErrors && (
                 <Tooltip>
@@ -204,8 +211,8 @@ export const DestinationRow = ({
                 onUpdateClick={() => setShowUpdateVersionModal(true)}
               />
             </div>
-          </Table.td>
-        </Table.tr>
+          </TableCell>
+        </TableRow>
       )}
 
       <DeleteDestination

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -3,13 +3,15 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
-import AlertError from 'components/ui/AlertError'
+import { AlertError } from 'components/ui/AlertError'
 import { useDeleteDestinationPipelineMutation } from 'data/replication/delete-destination-pipeline-mutation'
 import { useReplicationPipelineReplicationStatusQuery } from 'data/replication/pipeline-replication-status-query'
 import { useReplicationPipelineStatusQuery } from 'data/replication/pipeline-status-query'
 import { useReplicationPipelineVersionQuery } from 'data/replication/pipeline-version-query'
 import { Pipeline } from 'data/replication/pipelines-query'
 import { useStopPipelineMutation } from 'data/replication/stop-pipeline-mutation'
+import { AnalyticsBucket, BigQuery, Database } from 'icons'
+import { Minus } from 'lucide-react'
 import {
   PipelineStatusRequestStatus,
   usePipelineRequestStatus,
@@ -146,20 +148,30 @@ export const DestinationRow = ({
       {isPipelineSuccess && (
         <TableRow>
           <TableCell>
-            {isPipelineLoading ? (
-              <ShimmeringLoader />
-            ) : pipeline?.id ? (
-              <Tooltip>
-                <TooltipTrigger>
-                  <span className="cursor-default">{destinationName}</span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Pipeline ID: {pipeline.id}</TooltipContent>
-              </Tooltip>
+            {type === 'BigQuery' ? (
+              <BigQuery size={18} className="text-foreground-light" />
+            ) : type === 'Analytics Bucket' ? (
+              <AnalyticsBucket size={18} className="text-foreground-light" />
             ) : (
-              destinationName
+              <Database size={18} className="text-foreground-light" />
             )}
           </TableCell>
-          <TableCell>{isPipelineLoading ? <ShimmeringLoader /> : type}</TableCell>
+
+          <TableCell className="max-w-[180px]">
+            {isPipelineLoading ? (
+              <ShimmeringLoader />
+            ) : (
+              <div>
+                <p title={destinationName} className="truncate">
+                  {destinationName}
+                </p>
+                <p className="text-foreground-lighter">
+                  {type} (ID: {pipeline?.id})
+                </p>
+              </div>
+            )}
+          </TableCell>
+
           <TableCell>
             {isPipelineLoading || !pipeline ? (
               <ShimmeringLoader />
@@ -175,6 +187,11 @@ export const DestinationRow = ({
               />
             )}
           </TableCell>
+
+          <TableCell>
+            <Minus size={18} className="text-foreground-lighter" />
+          </TableCell>
+
           <TableCell>
             {isPipelineLoading || !pipeline ? (
               <ShimmeringLoader />
@@ -182,6 +199,7 @@ export const DestinationRow = ({
               pipeline.config.publication_name
             )}
           </TableCell>
+
           <TableCell>
             <div className="flex items-center justify-end gap-x-2">
               {hasTableErrors && (

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -57,11 +57,13 @@ export const Destinations = () => {
     error: databasesError,
     isPending: isDatabasesLoading,
     isError: isDatabasesError,
+    isSuccess: isDatabasesSuccess,
     refetch: refetchDatabases,
   } = useReadReplicasQuery({
     projectRef,
   })
   const readReplicas = databases.filter((x) => x.identifier !== projectRef)
+  const hasReplicas = isDatabasesSuccess && readReplicas.length > 0
   const filteredReplicas =
     filterString.length === 0
       ? readReplicas
@@ -152,10 +154,14 @@ export const Destinations = () => {
       const hasTransientStatus = replicasInTransition.length > 0
 
       // If any replica's status has changed, refetch databases
-      if (statuses.length !== databases.length) await refetchDatabases()
+      if (statuses.length !== databases.length) {
+        await refetchDatabases()
+      }
 
       // If all replicas are active healthy, stop fetching statuses
-      if (!hasTransientStatus) setStatusRefetchInterval(false)
+      if (!hasTransientStatus && statuses.length === databases.length) {
+        setStatusRefetchInterval(false)
+      }
     }
 
     pollReplicas()
@@ -228,7 +234,7 @@ export const Destinations = () => {
               <DocsButton href={`${DOCS_URL}/guides/database/replication#replication`} />
             </div>
           </div>
-        ) : hasDestinations ? (
+        ) : (unifiedReplication && hasReplicas) || hasDestinations ? (
           <Card>
             <CardContent className="p-0">
               <Table>

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -140,7 +140,7 @@ export const Destinations = () => {
     if (!isSuccessReplicasStatuses) return
 
     const pollReplicas = async () => {
-      const fixedStatues = [
+      const fixedStatuses = [
         REPLICA_STATUS.ACTIVE_HEALTHY,
         REPLICA_STATUS.ACTIVE_UNHEALTHY,
         REPLICA_STATUS.INIT_READ_REPLICA_FAILED,
@@ -148,7 +148,7 @@ export const Destinations = () => {
       const replicasInTransition = statuses.filter((db) => {
         const { status } = db.replicaInitializationStatus || {}
         return (
-          !fixedStatues.includes(db.status) || status === ReplicaInitializationStatus.InProgress
+          !fixedStatuses.includes(db.status) || status === ReplicaInitializationStatus.InProgress
         )
       })
       const hasTransientStatus = replicasInTransition.length > 0
@@ -299,7 +299,7 @@ export const Destinations = () => {
                   {!isLoading &&
                     filteredDestinations.length === 0 &&
                     filteredReplicas.length === 0 &&
-                    hasDestinations && (
+                    ((unifiedReplication && hasReplicas) || hasDestinations) && (
                       <TableRow>
                         <TableCell colSpan={5}>
                           <p>No results found</p>

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -1,8 +1,13 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { Plus, Search } from 'lucide-react'
+import { Plus, Search, X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
-import { useParams } from 'common'
+import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
+import {
+  ReplicaInitializationStatus,
+  useReadReplicasStatusesQuery,
+} from '@/data/read-replicas/replicas-status-query'
+import { useFlag, useParams } from 'common'
 import { AlertError } from 'components/ui/AlertError'
 import { DocsButton } from 'components/ui/DocsButton'
 import { UpgradePlanButton } from 'components/ui/UpgradePlanButton'
@@ -20,16 +25,19 @@ import {
   cn,
   Table,
   TableBody,
+  TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
+import { REPLICA_STATUS } from '../../Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { DestinationPanel } from './DestinationPanel/DestinationPanel'
 import { DestinationRow } from './DestinationRow'
 import { EnableReplicationModal } from './EnableReplicationModal'
 import { PIPELINE_ERROR_MESSAGES } from './Pipeline.utils'
+import { ReadReplicaRow } from './ReadReplicas/ReadReplicaRow'
 
 export const Destinations = () => {
   const queryClient = useQueryClient()
@@ -37,9 +45,30 @@ export const Destinations = () => {
   const { data: organization } = useSelectedOrganizationQuery()
   const isPaidPlan = organization?.plan.id !== 'free'
 
+  const unifiedReplication = useFlag('unifiedReplication')
+
   const prefetchedRef = useRef(false)
   const [filterString, setFilterString] = useState<string>('')
   const [showNewDestinationPanel, setShowNewDestinationPanel] = useState(false)
+  const [statusRefetchInterval, setStatusRefetchInterval] = useState<number | false>(5000)
+
+  const {
+    data: databases = [],
+    error: databasesError,
+    isPending: isDatabasesLoading,
+    isError: isDatabasesError,
+    refetch: refetchDatabases,
+  } = useReadReplicasQuery({
+    projectRef,
+  })
+  const readReplicas = databases.filter((x) => x.identifier !== projectRef)
+  const filteredReplicas =
+    filterString.length === 0
+      ? readReplicas
+      : readReplicas.filter((replica) => replica.identifier.includes(filterString.toLowerCase()))
+
+  const { data: statuses = [], isSuccess: isSuccessReplicasStatuses } =
+    useReadReplicasStatusesQuery({ projectRef }, { refetchInterval: statusRefetchInterval })
 
   const {
     data: sourcesData,
@@ -62,6 +91,14 @@ export const Destinations = () => {
   } = useReplicationDestinationsQuery({
     projectRef,
   })
+  const destinations = destinationsData?.destinations ?? []
+  const hasDestinations = isDestinationsSuccess && destinationsData.destinations.length > 0
+  const filteredDestinations =
+    filterString.length === 0
+      ? destinations ?? []
+      : (destinations ?? []).filter((destination) =>
+          destination.name.toLowerCase().includes(filterString.toLowerCase())
+        )
 
   const {
     data: pipelinesData,
@@ -72,13 +109,9 @@ export const Destinations = () => {
   } = useReplicationPipelinesQuery({
     projectRef,
   })
-  const hasDestinations = isDestinationsSuccess && destinationsData.destinations.length > 0
-  const filteredDestinations =
-    filterString.length === 0
-      ? destinationsData?.destinations ?? []
-      : (destinationsData?.destinations ?? []).filter((destination) =>
-          destination.name.toLowerCase().includes(filterString.toLowerCase())
-        )
+
+  const isLoading = isSourcesLoading || isDestinationsLoading || isDatabasesLoading
+  const hasErrorsFetchingData = isSourcesError || isDestinationsError || isDatabasesError
 
   useEffect(() => {
     if (
@@ -101,6 +134,33 @@ export const Destinations = () => {
     }
   }, [projectRef, pipelinesData?.pipelines, isPipelinesSuccess, queryClient])
 
+  useEffect(() => {
+    if (!isSuccessReplicasStatuses) return
+
+    const pollReplicas = async () => {
+      const fixedStatues = [
+        REPLICA_STATUS.ACTIVE_HEALTHY,
+        REPLICA_STATUS.ACTIVE_UNHEALTHY,
+        REPLICA_STATUS.INIT_READ_REPLICA_FAILED,
+      ]
+      const replicasInTransition = statuses.filter((db) => {
+        const { status } = db.replicaInitializationStatus || {}
+        return (
+          !fixedStatues.includes(db.status) || status === ReplicaInitializationStatus.InProgress
+        )
+      })
+      const hasTransientStatus = replicasInTransition.length > 0
+
+      // If any replica's status has changed, refetch databases
+      if (statuses.length !== databases.length) await refetchDatabases()
+
+      // If all replicas are active healthy, stop fetching statuses
+      if (!hasTransientStatus) setStatusRefetchInterval(false)
+    }
+
+    pollReplicas()
+  }, [databases.length, isSuccessReplicasStatuses, refetchDatabases, statuses])
+
   return (
     <>
       <div className="mb-4">
@@ -113,6 +173,16 @@ export const Destinations = () => {
               value={filterString}
               className="w-full lg:w-52"
               onChange={(e) => setFilterString(e.target.value)}
+              actions={
+                filterString.length > 0 && (
+                  <Button
+                    type="text"
+                    icon={<X />}
+                    className="p-0 h-5 w-5"
+                    onClick={() => setFilterString('')}
+                  />
+                )
+              }
             />
           </div>
           <div className="flex items-center gap-x-2">
@@ -131,14 +201,14 @@ export const Destinations = () => {
       </div>
 
       <div className="w-full overflow-hidden overflow-x-auto">
-        {(isSourcesError || isDestinationsError) && (
+        {hasErrorsFetchingData && (
           <AlertError
-            error={sourcesError || destinationsError}
+            error={sourcesError || destinationsError || databasesError}
             subject={PIPELINE_ERROR_MESSAGES.RETRIEVE_DESTINATIONS}
           />
         )}
 
-        {isSourcesLoading || isDestinationsLoading ? (
+        {isLoading ? (
           <GenericSkeletonLoader />
         ) : replicationNotEnabled ? (
           <div className="border rounded-md p-4 md:p-12 flex flex-col gap-y-4">
@@ -164,14 +234,34 @@ export const Destinations = () => {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead key="name">Name</TableHead>
-                    <TableHead key="type">Type</TableHead>
-                    <TableHead key="status">Status</TableHead>
+                    <TableHead key="type" className="w-[20px]" />
+                    <TableHead key="name" className="w-[250px]">
+                      Name
+                    </TableHead>
+                    <TableHead key="status" className="w-[150px]">
+                      Status
+                    </TableHead>
+                    <TableHead key="lag" className="w-[80px]">
+                      Lag
+                    </TableHead>
                     <TableHead key="publication">Publication</TableHead>
                     <TableHead key="actions" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
+                  {unifiedReplication &&
+                    filteredReplicas.map((replica) => {
+                      const status = statuses.find((x) => x.identifier === replica.identifier)
+                      return (
+                        <ReadReplicaRow
+                          key={replica.identifier}
+                          replica={replica}
+                          replicaStatus={status}
+                          onUpdateReplica={() => setStatusRefetchInterval(5000)}
+                        />
+                      )
+                    })}
+
                   {filteredDestinations.map((destination) => {
                     const pipeline = pipelinesData?.pipelines.find(
                       (p) => p.destination_id === destination.id
@@ -199,15 +289,27 @@ export const Destinations = () => {
                       />
                     )
                   })}
+
+                  {!isLoading &&
+                    filteredDestinations.length === 0 &&
+                    filteredReplicas.length === 0 &&
+                    hasDestinations && (
+                      <TableRow>
+                        <TableCell colSpan={5}>
+                          <p>No results found</p>
+                          <p className="text-foreground-light">
+                            Your search for "{filterString}" did not return any results
+                          </p>
+                        </TableCell>
+                      </TableRow>
+                    )}
                 </TableBody>
               </Table>
             </CardContent>
           </Card>
         ) : (
-          !isSourcesLoading &&
-          !isDestinationsLoading &&
-          !isSourcesError &&
-          !isDestinationsError && (
+          !isLoading &&
+          !hasErrorsFetchingData && (
             <div
               className={cn(
                 'w-full',
@@ -233,18 +335,10 @@ export const Destinations = () => {
         )}
       </div>
 
-      {!isSourcesLoading &&
-        !isDestinationsLoading &&
-        filteredDestinations.length === 0 &&
-        hasDestinations && (
-          <div className="text-center py-8 text-foreground-light">
-            <p>No destinations match "{filterString}"</p>
-          </div>
-        )}
-
       <DestinationPanel
         visible={showNewDestinationPanel}
         onClose={() => setShowNewDestinationPanel(false)}
+        onSuccessCreateReadReplica={() => setStatusRefetchInterval(5000)}
       />
     </>
   )

--- a/apps/studio/components/interfaces/Database/Replication/PipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/PipelineStatus.tsx
@@ -1,12 +1,11 @@
-import { AlertTriangle, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 
 import { useParams } from 'common'
-import { DotPing } from 'components/ui/DotPing'
 import { InlineLink } from 'components/ui/InlineLink'
 import { ReplicationPipelineStatusData } from 'data/replication/pipeline-status-query'
 import { PipelineStatusRequestStatus } from 'state/replication-pipeline-request-status'
 import type { ResponseError } from 'types'
-import { cn, Tooltip, TooltipContent, TooltipTrigger, WarningIcon } from 'ui'
+import { Badge, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { getPipelineStateMessages } from './Pipeline.utils'
 import { PipelineStatusName } from './Replication.constants'
@@ -33,7 +32,11 @@ export const PipelineStatus = ({
   const { ref } = useParams()
 
   // Map backend statuses to UX-friendly display
-  const getStatusConfig = () => {
+  const getStatusConfig = (): {
+    label: string
+    type?: 'failure' | 'warning' | 'loading' | 'success' | 'idle'
+    tooltip: string
+  } => {
     const statusName =
       pipelineStatus && typeof pipelineStatus === 'object' && 'name' in pipelineStatus
         ? pipelineStatus.name
@@ -43,95 +46,41 @@ export const PipelineStatus = ({
     const stateMessages = getPipelineStateMessages(requestStatus, statusName)
 
     // Show optimistic request state while backend still reports steady states
-    if (requestStatus === PipelineStatusRequestStatus.RestartRequested) {
-      return {
-        label: 'Restarting',
-        dot: <Loader2 className="animate-spin w-3 h-3 text-warning" />,
-        color: 'text-warning',
-        tooltip: stateMessages.message,
-      }
-    }
-    if (requestStatus === PipelineStatusRequestStatus.StartRequested) {
-      return {
-        label: 'Starting',
-        dot: <Loader2 className="animate-spin w-3 h-3 text-warning" />,
-        color: 'text-warning',
-        tooltip: stateMessages.message,
-      }
-    }
-    if (requestStatus === PipelineStatusRequestStatus.StopRequested) {
-      return {
-        label: 'Stopping',
-        dot: <Loader2 className="animate-spin w-3 h-3 text-warning" />,
-        color: 'text-warning',
-        tooltip: stateMessages.message,
-      }
+    switch (requestStatus) {
+      case PipelineStatusRequestStatus.RestartRequested:
+        return { label: 'Restarting', type: 'loading', tooltip: stateMessages.message }
+      case PipelineStatusRequestStatus.StartRequested:
+        return { label: 'Starting', type: 'loading', tooltip: stateMessages.message }
+      case PipelineStatusRequestStatus.StopRequested:
+        return { label: 'Stopping', type: 'loading', tooltip: stateMessages.message }
     }
 
     if (pipelineStatus && typeof pipelineStatus === 'object' && 'name' in pipelineStatus) {
       switch (pipelineStatus.name) {
         case PipelineStatusName.FAILED:
-          return {
-            label: 'Failed',
-            dot: <AlertTriangle className="w-3 h-3 text-destructive-600" />,
-            color: 'text-destructive-600',
-            tooltip: stateMessages.message,
-          }
+          return { label: 'Failed', type: 'failure', tooltip: stateMessages.message }
         case PipelineStatusName.STARTING:
-          return {
-            label: 'Starting',
-            dot: <Loader2 className="animate-spin w-3 h-3 text-warning" />,
-            color: 'text-warning',
-            tooltip: stateMessages.message,
-          }
+          return { label: 'Starting', type: 'loading', tooltip: stateMessages.message }
         case PipelineStatusName.STARTED:
-          return {
-            label: 'Running',
-            dot: <DotPing animate={true} variant="primary" />,
-            color: 'text-brand-600',
-            tooltip: stateMessages.message,
-          }
+          return { label: 'Running', type: 'success', tooltip: stateMessages.message }
         case PipelineStatusName.STOPPED:
-          return {
-            label: 'Stopped',
-            dot: <div className="w-2 h-2 bg-foreground-lighter rounded-full" />,
-            color: 'text-foreground-light',
-            tooltip: stateMessages.message,
-          }
+          return { label: 'Stopped', type: 'idle', tooltip: stateMessages.message }
         case PipelineStatusName.STOPPING:
-          return {
-            label: 'Stopping',
-            dot: <Loader2 className="animate-spin w-3 h-3 text-warning" />,
-            color: 'text-warning',
-            tooltip: stateMessages.message,
-          }
-        case PipelineStatusName.UNKNOWN:
-          return {
-            label: 'Unknown',
-            dot: <div className="w-2 h-2 bg-warning-600 rounded-full" />,
-            color: 'text-warning',
-            tooltip: stateMessages.message,
-          }
+          return { label: 'Stopping', type: 'loading', tooltip: stateMessages.message }
         default:
-          return {
-            label: 'Unknown',
-            dot: <div className="w-2 h-2 bg-destructive-600 rounded-full" />,
-            color: 'text-destructive-600',
-            tooltip: stateMessages.message,
-          }
+          return { label: 'Unknown', type: 'idle', tooltip: stateMessages.message }
       }
     }
 
     // Fallback for undefined or invalid status
     return {
       label: 'Unknown',
-      dot: <div className="w-2 h-2 bg-destructive-600 rounded-full" />,
-      color: 'text-destructive-600',
+      type: 'idle',
       tooltip: 'Pipeline status is unclear - check logs for details',
     }
   }
 
-  const statusConfig = getStatusConfig()
+  const { type, tooltip, label } = getStatusConfig()
 
   const pipelineLogsUrl = pipelineId
     ? `/project/${ref}/logs/replication-logs?f=${encodeURIComponent(
@@ -142,29 +91,42 @@ export const PipelineStatus = ({
   return (
     <>
       {isLoading && <ShimmeringLoader />}
+
       {isError && (
         <Tooltip>
           <TooltipTrigger>
-            <WarningIcon />
+            <Badge variant="default">Unknown</Badge>
           </TooltipTrigger>
           <TooltipContent side="bottom" className="w-64 text-center">
             Unable to retrieve status: {error?.message}
           </TooltipContent>
         </Tooltip>
       )}
+
       {isSuccess && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className={cn('flex items-center gap-2 text-sm w-min', statusConfig.color)}>
-              {statusConfig.dot}
-              <span>{statusConfig.label}</span>
+            <div className="flex items-center gap-x-2">
+              <Badge
+                variant={
+                  type === 'failure'
+                    ? 'destructive'
+                    : type === 'warning'
+                      ? 'warning'
+                      : type === 'success'
+                        ? 'success'
+                        : 'default'
+                }
+              >
+                {label}
+              </Badge>
+              {type === 'loading' && <Loader2 className="animate-spin w-3 h-3" />}
             </div>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            {statusConfig.tooltip}
+            {tooltip}{' '}
             {['unknown', 'failed'].includes(pipelineStatus?.name ?? '') && (
               <>
-                {' '}
                 Check the <InlineLink href={pipelineLogsUrl}>logs</InlineLink> for more information.
               </>
             )}

--- a/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
@@ -97,6 +97,8 @@ export const ReadReplicaRow = ({ replica, replicaStatus, onUpdateReplica }: Read
         return 'Restarting'
       case REPLICA_STATUS.RESIZING:
         return 'Resizing'
+      case REPLICA_STATUS.RESTORING:
+        return 'Restoring'
       case REPLICA_STATUS.ACTIVE_HEALTHY:
         return 'Healthy'
       default:

--- a/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
@@ -35,8 +35,10 @@ interface ReadReplicaRow {
 
 export const ReadReplicaRow = ({ replica, replicaStatus, onUpdateReplica }: ReadReplicaRow) => {
   const { ref } = useParams()
-  const { identifier, region } = replica
-  const { status, replicaInitializationStatus } = replicaStatus || { status: 'UNKNOWN' }
+  const { identifier, region, status: baseStatus } = replica
+
+  const status = replicaStatus?.status ?? baseStatus
+  const replicaInitializationStatus = replicaStatus?.replicaInitializationStatus
   const formattedId = formatDatabaseID(identifier ?? '')
 
   const {
@@ -134,10 +136,10 @@ export const ReadReplicaRow = ({ replica, replicaStatus, onUpdateReplica }: Read
         </TableCell>
 
         <TableCell>
-          {isLoadingLag ? (
-            <ShimmeringLoader />
-          ) : isErrorLag ? (
+          {isErrorLag || status !== REPLICA_STATUS.ACTIVE_HEALTHY ? (
             <Minus size={18} className="text-foreground-lighter" />
+          ) : isLoadingLag ? (
+            <ShimmeringLoader />
           ) : (
             <p>{lagDuration}s</p>
           )}

--- a/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
@@ -1,0 +1,189 @@
+import { Loader2, Minus, MoreVertical, RotateCcw, Trash } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import DropReplicaConfirmationModal from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal'
+import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
+import { RestartReplicaConfirmationModal } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/RestartReplicaConfirmationModal'
+import { useReplicationLagQuery } from '@/data/read-replicas/replica-lag-query'
+import { type Database } from '@/data/read-replicas/replicas-query'
+import {
+  DatabaseStatus,
+  ReplicaInitializationStatus,
+} from '@/data/read-replicas/replicas-status-query'
+import { formatDatabaseID } from '@/data/read-replicas/replicas.utils'
+import { useParams } from 'common'
+import { Database as DatabaseIcon } from 'icons'
+import { AWS_REGIONS } from 'shared-data'
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  TableCell,
+  TableRow,
+} from 'ui'
+import { ShimmeringLoader } from 'ui-patterns'
+
+interface ReadReplicaRow {
+  replica: Database
+  replicaStatus?: DatabaseStatus
+  onUpdateReplica: () => void
+}
+
+export const ReadReplicaRow = ({ replica, replicaStatus, onUpdateReplica }: ReadReplicaRow) => {
+  const { ref } = useParams()
+  const { identifier, region } = replica
+  const { status, replicaInitializationStatus } = replicaStatus || { status: 'UNKNOWN' }
+  const formattedId = formatDatabaseID(identifier ?? '')
+
+  const {
+    data: lagDuration,
+    isPending: isLoadingLag,
+    isError: isErrorLag,
+  } = useReplicationLagQuery(
+    {
+      id: identifier,
+      projectRef: ref,
+      connectionString: replica.connectionString,
+    },
+    { enabled: status === REPLICA_STATUS.ACTIVE_HEALTHY }
+  )
+
+  const [showConfirmRestart, setShowConfirmRestart] = useState(false)
+  const [showConfirmDrop, setShowConfirmDrop] = useState(false)
+
+  const initStatus = replicaInitializationStatus?.status
+  const regionLabel = Object.values(AWS_REGIONS).find((x) => x.code === region)?.displayName
+
+  const isInTransition =
+    (
+      [
+        REPLICA_STATUS.UNKNOWN,
+        REPLICA_STATUS.COMING_UP,
+        REPLICA_STATUS.GOING_DOWN,
+        REPLICA_STATUS.RESTORING,
+        REPLICA_STATUS.RESTARTING,
+        REPLICA_STATUS.RESIZING,
+        REPLICA_STATUS.INIT_READ_REPLICA,
+      ] as string[]
+    ).includes(status) || initStatus === ReplicaInitializationStatus.InProgress
+
+  const statusLabel = useMemo(() => {
+    if (
+      initStatus === ReplicaInitializationStatus.InProgress ||
+      status === REPLICA_STATUS.COMING_UP ||
+      status === REPLICA_STATUS.UNKNOWN ||
+      status === REPLICA_STATUS.INIT_READ_REPLICA
+    ) {
+      return 'Coming up'
+    }
+
+    if (
+      initStatus === ReplicaInitializationStatus.Failed ||
+      status === REPLICA_STATUS.INIT_READ_REPLICA_FAILED
+    ) {
+      return 'Failed'
+    }
+
+    switch (status) {
+      case REPLICA_STATUS.GOING_DOWN:
+        return 'Going down'
+      case REPLICA_STATUS.RESTARTING:
+        return 'Restarting'
+      case REPLICA_STATUS.RESIZING:
+        return 'Resizing'
+      case REPLICA_STATUS.ACTIVE_HEALTHY:
+        return 'Healthy'
+      default:
+        return 'Unhealthy'
+    }
+  }, [initStatus, status])
+
+  return (
+    <>
+      <TableRow>
+        <TableCell>
+          <DatabaseIcon size={18} className="text-foreground-light" />
+        </TableCell>
+
+        <TableCell>
+          <div>
+            <p>{regionLabel}</p>
+            <p className="text-foreground-lighter">Read Replica (ID: {formattedId})</p>
+          </div>
+        </TableCell>
+
+        <TableCell>
+          <div className="flex items-center gap-x-2">
+            <Badge
+              variant={
+                statusLabel === 'Healthy'
+                  ? 'success'
+                  : statusLabel === 'Failed'
+                    ? 'destructive'
+                    : 'default'
+              }
+            >
+              {statusLabel}
+            </Badge>
+            {isInTransition && <Loader2 className="animate-spin w-3 h-3" />}
+          </div>
+        </TableCell>
+
+        <TableCell>
+          {isLoadingLag ? (
+            <ShimmeringLoader />
+          ) : isErrorLag ? (
+            <Minus size={18} className="text-foreground-lighter" />
+          ) : (
+            <p>{lagDuration}s</p>
+          )}
+        </TableCell>
+
+        <TableCell>
+          <Minus size={18} className="text-foreground-lighter" />
+        </TableCell>
+
+        <TableCell>
+          <div className="flex items-center justify-end gap-x-2">
+            {/* [Joshen] Temporarily hidden - will work on the replica detail page in another PR */}
+            {/* <Button asChild type="default" className="relative">
+              <Link href={`/project/${ref}/database/replication`}>View replication</Link>
+            </Button> */}
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <Button type="default" icon={<MoreVertical />} className="w-7" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <DropdownMenuItem className="gap-x-2" onClick={() => setShowConfirmRestart(true)}>
+                  <RotateCcw size={14} />
+                  <span>Restart replica</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="gap-x-2" onClick={() => setShowConfirmDrop(true)}>
+                  <Trash size={14} />
+                  <span>Drop replica</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </TableCell>
+      </TableRow>
+
+      <DropReplicaConfirmationModal
+        selectedReplica={showConfirmDrop ? replica : undefined}
+        onSuccess={() => onUpdateReplica()}
+        onCancel={() => setShowConfirmDrop(false)}
+      />
+
+      <RestartReplicaConfirmationModal
+        selectedReplica={showConfirmRestart ? replica : undefined}
+        onSuccess={() => onUpdateReplica()}
+        onCancel={() => setShowConfirmRestart(false)}
+      />
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/Replication.constants.ts
+++ b/apps/studio/components/interfaces/Database/Replication/Replication.constants.ts
@@ -1,4 +1,4 @@
-export const STATUS_REFRESH_FREQUENCY_MS: number = 5000
+export const STATUS_REFRESH_FREQUENCY_MS: number = 10000 // 10 seconds
 
 export enum PipelineStatusName {
   FAILED = 'failed',

--- a/apps/studio/components/interfaces/Database/Replication/RowMenu.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/RowMenu.tsx
@@ -181,7 +181,7 @@ export const RowMenu = ({
             <p>Edit destination</p>
           </DropdownMenuItem>
           <DropdownMenuItem className="space-x-2" onClick={onDeleteClick}>
-            <Trash stroke="red" size={14} />
+            <Trash size={14} />
             <p>Delete destination</p>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal.tsx
@@ -1,10 +1,13 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { replicaKeys } from '@/data/read-replicas/keys'
 import { useParams } from 'common'
 import { useReadReplicaRemoveMutation } from 'data/read-replicas/replica-remove-mutation'
 import type { Database } from 'data/read-replicas/replicas-query'
 import { formatDatabaseID } from 'data/read-replicas/replicas.utils'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { REPLICA_STATUS } from './InstanceConfiguration.constants'
 
 interface DropReplicaConfirmationModalProps {
   selectedReplica?: Database
@@ -18,10 +21,24 @@ const DropReplicaConfirmationModal = ({
   onCancel,
 }: DropReplicaConfirmationModalProps) => {
   const { ref: projectRef } = useParams()
+  const queryClient = useQueryClient()
   const formattedId = formatDatabaseID(selectedReplica?.identifier ?? '')
   const { mutate: removeReadReplica, isPending: isRemoving } = useReadReplicaRemoveMutation({
     onSuccess: () => {
       toast.success(`Tearing down read replica (ID: ${formattedId})`)
+
+      // [Joshen] Temporarily optimistic rendering until API supports immediate status update
+      queryClient.setQueriesData({ queryKey: replicaKeys.list(projectRef) }, (old: Database[]) => {
+        const updatedReplicas = old.map((x) => {
+          if (x.identifier === selectedReplica?.identifier) {
+            return { ...x, status: REPLICA_STATUS.GOING_DOWN }
+          } else {
+            return x
+          }
+        })
+        return updatedReplicas
+      })
+
       onSuccess()
       onCancel()
     },

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal.tsx
@@ -28,16 +28,18 @@ const DropReplicaConfirmationModal = ({
       toast.success(`Tearing down read replica (ID: ${formattedId})`)
 
       // [Joshen] Temporarily optimistic rendering until API supports immediate status update
-      queryClient.setQueriesData({ queryKey: replicaKeys.list(projectRef) }, (old: Database[]) => {
-        const updatedReplicas = old.map((x) => {
-          if (x.identifier === selectedReplica?.identifier) {
-            return { ...x, status: REPLICA_STATUS.GOING_DOWN }
-          } else {
+      queryClient.setQueriesData(
+        { queryKey: replicaKeys.list(projectRef) },
+        (old: Database[] | undefined) => {
+          const updatedReplicas = old?.map((x) => {
+            if (x.identifier === selectedReplica?.identifier) {
+              return { ...x, status: REPLICA_STATUS.GOING_DOWN }
+            }
             return x
-          }
-        })
-        return updatedReplicas
-      })
+          })
+          return updatedReplicas
+        }
+      )
 
       onSuccess()
       onCancel()

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -386,9 +386,6 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
             >
               Restart replica
             </DropdownMenuItem>
-            {/* <DropdownMenuItem className="gap-x-2" onClick={() => onSelectResizeReplica()}>
-                Resize replica
-              </DropdownMenuItem> */}
             <DropdownMenuItemTooltip
               className="gap-x-2 !pointer-events-auto"
               disabled={!canManageReplicas}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/RestartReplicaConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/RestartReplicaConfirmationModal.tsx
@@ -29,7 +29,18 @@ export const RestartReplicaConfirmationModal = ({
       toast.success(`Restarting read replica (ID: ${formattedId})`)
 
       // [Joshen] Temporarily optimistic rendering until API supports immediate status update
-      queryClient.setQueriesData<any>({ queryKey: replicaKeys.list(ref) }, (old: Database[]) => {
+      queryClient.setQueriesData({ queryKey: replicaKeys.list(ref) }, (old: Database[]) => {
+        const updatedReplicas = old.map((x) => {
+          if (x.identifier === selectedReplica?.identifier) {
+            return { ...x, status: REPLICA_STATUS.RESTARTING }
+          } else {
+            return x
+          }
+        })
+        return updatedReplicas
+      })
+
+      queryClient.setQueriesData({ queryKey: replicaKeys.statuses(ref) }, (old: Database[]) => {
         const updatedReplicas = old.map((x) => {
           if (x.identifier === selectedReplica?.identifier) {
             return { ...x, status: REPLICA_STATUS.RESTARTING }
@@ -57,6 +68,7 @@ export const RestartReplicaConfirmationModal = ({
   return (
     <ConfirmationModal
       size="medium"
+      variant="warning"
       loading={isRestartingProject}
       visible={selectedReplica !== undefined}
       title={`Confirm to restart selected replica? (ID: ${formattedId})`}

--- a/apps/studio/data/read-replicas/replica-remove-mutation.ts
+++ b/apps/studio/data/read-replicas/replica-remove-mutation.ts
@@ -43,7 +43,6 @@ export const useReadReplicaRemoveMutation = ({
       if (invalidateReplicaQueries) {
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: replicaKeys.list(projectRef) }),
-          queryClient.invalidateQueries({ queryKey: replicaKeys.statuses(projectRef) }),
           queryClient.invalidateQueries({ queryKey: replicaKeys.loadBalancers(projectRef) }),
         ])
       }

--- a/apps/studio/data/read-replicas/replica-remove-mutation.ts
+++ b/apps/studio/data/read-replicas/replica-remove-mutation.ts
@@ -43,6 +43,7 @@ export const useReadReplicaRemoveMutation = ({
       if (invalidateReplicaQueries) {
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: replicaKeys.list(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: replicaKeys.statuses(projectRef) }),
           queryClient.invalidateQueries({ queryKey: replicaKeys.loadBalancers(projectRef) }),
         ])
       }


### PR DESCRIPTION
## Context

Part of unifying read replicas into database/replication page, changes in this PR include
- Render read replicas into destinations UI (Behind feature flag)
- Support restart / drop replicas from this UI (status long polling logic is in place as well)
- Use new Table component for destinations UI
- Adjust row component for destinations UI

<img width="1144" height="710" alt="image" src="https://github.com/user-attachments/assets/ddc94e0b-b8a7-48dd-b874-ca0dc4f76ff7" />

## To test
- [ ] Verify that you can create a read replica from the database/replications page, and long polling logic for status works
- [ ] Verify that you can restart / drop a read replica from the database/replications page, and long polling logic for status works
- [ ] Verify that you can only cannot see read replicas in database/replications page if feature flag is off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified replication view now includes read replica rows, per-replica search/clear, and a new ReadReplica row component; added a callback to resume polling after replica creation; loading text now reflects "Creating" vs "Updating".

* **Refactor**
  * Badge-based status UI and reworked row/table/card layout (incl. new minus/action column); increased status polling to 10s.

* **Bug Fixes**
  * Added optimistic UI updates for replica restart and drop.

* **Style**
  * Adjusted trash icon styling; removed "Resize replica" option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->