### PR TITLE
ci: use github app generated token

### DIFF
--- a/.github/workflows/docs-js-libs-update.yml
+++ b/.github/workflows/docs-js-libs-update.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
         with:
           app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
           private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}

--- a/.github/workflows/docs-js-libs-update.yml
+++ b/.github/workflows/docs-js-libs-update.yml
@@ -54,14 +54,21 @@ jobs:
           echo "Generating new typespec snapshot for review..."
           npx vitest run --update ./features/docs/Reference.typeSpec.test.ts
 
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'docs: update js client libraries (${{ github.event.inputs.version }})'
-          title: 'docs: update js client libraries (${{ github.event.inputs.version }})'
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: 'docs: update js sdk docs (${{ github.event.inputs.version }})'
+          title: 'docs: update js sdk docs (${{ github.event.inputs.version }})'
           body: |
-            Updates JS client libraries documentation following stable release. 
+            Updates JS sdk documentation following stable release. 
             Ran `make` in apps/docs/spec to regenerate tsdoc files.
 
             **Details:**
@@ -69,6 +76,6 @@ jobs:
             - **Source:** `${{ github.event.inputs.source }}`
             - **Changes:** Regenerated tsdoc files from latest spec files
 
-            🤖 Auto-generated from supabase-js-libs stable release.
-          branch: 'gha/update-js-libs-docs-${{ github.run_number }}'
+            🤖 Auto-generated from @supabase/supabase-js stable release.
+          branch: 'gha/update-js-sdk-docs-${{ github.run_number }}'
           base: 'master'

--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -39,10 +39,17 @@ jobs:
         working-directory: apps/docs/spec
         run: make download.api.v1 dereference.api.v1 generate.sections.api.v1 format
 
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'feat: update mgmt api docs'
           title: 'feat: update mgmt api docs'
           body: 'This PR updates mgmt api docs automatically.'

--- a/.github/workflows/fix-typos.yml
+++ b/.github/workflows/fix-typos.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
           private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}

--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -56,11 +56,18 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
-
+      
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+      
       - name: Create pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'feat: update @supabase/*-js libraries to v${{ github.event.inputs.version }}'
           title: 'feat: update @supabase/*-js libraries to v${{ github.event.inputs.version }}'
           body: |

--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -59,7 +59,7 @@ jobs:
       
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
           private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}


### PR DESCRIPTION
Use GitHub App generated token, to re-enable PR creation from workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved authentication for automated docs updates by switching to a generated app token for PR creation, increasing security and reliability.
  * Standardized automated PR titles, branch names, and body copy to use "JS SDK" terminology.
  * Pinned action version in workflows to reduce unexpected changes and improve stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->