### PR TITLE
feat(studio): show incident banner automatically based on api

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from 'react'
 
+import { useIncidentStatusQuery } from '@/data/platform/incident-status-query'
 import { useFlag } from 'common'
 import { ClockSkewBanner } from 'components/layouts/AppLayout/ClockSkewBanner'
 import { IncidentBanner } from 'components/layouts/AppLayout/IncidentBanner'
@@ -7,8 +8,12 @@ import { NoticeBanner } from 'components/layouts/AppLayout/NoticeBanner'
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
+  const { data: incidents } = useIncidentStatusQuery()
+
   const ongoingIncident =
-    useFlag('ongoingIncident') || process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true'
+    useFlag('ongoingIncident') ||
+    process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true' ||
+    (incidents?.length ?? 0) > 0
   const showNoticeBanner = useFlag('showNoticeBanner')
   const clockSkewBanner = useFlag('clockSkewBanner')
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Incident banner must be manually toggled

## What is the new behavior?

Incident banner automatically displays if incidents are ongoing in status page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incident banner display to reflect actual incident status data, ensuring notifications appear when incidents are detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->