### PR TITLE
Remove check for sourceId for rendering add destination button

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -190,7 +190,7 @@ export const Destinations = () => {
             />
           </div>
           <div className="flex items-center gap-x-2">
-            {(unifiedReplication || (!unifiedReplication && !!sourceId)) && (
+            {(unifiedReplication || !!sourceId) && (
               <Button
                 type="default"
                 icon={<Plus />}

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -42,7 +42,6 @@ export const Destinations = () => {
   const queryClient = useQueryClient()
   const { ref: projectRef } = useParams()
   const { data: organization } = useSelectedOrganizationQuery()
-  const isPaidPlan = organization?.plan.id !== 'free'
 
   const unifiedReplication = useFlag('unifiedReplication')
 
@@ -191,9 +190,15 @@ export const Destinations = () => {
             />
           </div>
           <div className="flex items-center gap-x-2">
-            <Button type="default" icon={<Plus />} onClick={() => setShowNewDestinationPanel(true)}>
-              Add destination
-            </Button>
+            {(unifiedReplication || (!unifiedReplication && !!sourceId)) && (
+              <Button
+                type="default"
+                icon={<Plus />}
+                onClick={() => setShowNewDestinationPanel(true)}
+              >
+                Add destination
+              </Button>
+            )}
             <DocsButton href={`${DOCS_URL}/guides/database/replication`} />
           </div>
         </div>

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -191,15 +191,9 @@ export const Destinations = () => {
             />
           </div>
           <div className="flex items-center gap-x-2">
-            {!!sourceId && (
-              <Button
-                type="default"
-                icon={<Plus />}
-                onClick={() => setShowNewDestinationPanel(true)}
-              >
-                Add destination
-              </Button>
-            )}
+            <Button type="default" icon={<Plus />} onClick={() => setShowNewDestinationPanel(true)}>
+              Add destination
+            </Button>
             <DocsButton href={`${DOCS_URL}/guides/database/replication`} />
           </div>
         </div>


### PR DESCRIPTION
## Context

The "Add destination" button should no longer require a check for `sourceId` if `unifiedReplication` is on, since `sourceId` is ETL specific, while destinations will now include Read Replicas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The "Add destination" button in Database Replication now appears when unified replication is active as well as under previous conditions (e.g., when a source is present). This makes it easier to configure replication destinations across more scenarios and streamlines the replication setup experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->