### PR TITLE
chore(telemetry): standardize event naming conventions

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/DeleteCronJob.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/DeleteCronJob.tsx
@@ -26,7 +26,7 @@ export const DeleteCronJob = ({ cronJob, visible, onClose, onDeleteStart }: Dele
   const { mutate: deleteDatabaseCronJob, isPending } = useDatabaseCronJobDeleteMutation({
     onSuccess: () => {
       sendEvent({
-        action: 'cron_job_deleted',
+        action: 'cron_job_removed',
         groups: { project: project?.ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
       })
       toast.success(`Successfully removed cron job ${cronJob.jobname}`)

--- a/apps/studio/data/database-integrations/stripe/stripe-sync-install-mutation.ts
+++ b/apps/studio/data/database-integrations/stripe/stripe-sync-install-mutation.ts
@@ -63,7 +63,7 @@ export const useStripeSyncInstallMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      track('integration_install_started', {
+      track('integration_install_submitted', {
         integrationName: 'stripe_sync_engine',
       })
 

--- a/apps/studio/data/database-integrations/stripe/stripe-sync-uninstall-mutation.ts
+++ b/apps/studio/data/database-integrations/stripe/stripe-sync-uninstall-mutation.ts
@@ -60,7 +60,7 @@ export const useStripeSyncUninstallMutation = ({
     async onSuccess(data, variables, context) {
       const { projectRef } = variables
 
-      track('integration_uninstall_started', {
+      track('integration_uninstall_submitted', {
         integrationName: 'stripe_sync_engine',
       })
 

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -224,7 +224,7 @@ const MergePage: NextPageWithLayout = () => {
 
         // Track successful merge
         sendEvent({
-          action: 'branch_merge_succeeded',
+          action: 'branch_merge_completed',
           properties: {
             branchType: currentBranch?.persistent ? 'persistent' : 'preview',
           },

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -167,14 +167,14 @@ export interface CronJobUpdatedEvent {
 }
 
 /**
- * Cron job deleted.
+ * Cron job removed.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/integrations/cron/jobs
  */
-export interface CronJobDeletedEvent {
-  action: 'cron_job_deleted'
+export interface CronJobRemovedEvent {
+  action: 'cron_job_removed'
   groups: TelemetryGroups
 }
 
@@ -2737,7 +2737,7 @@ export type TelemetryEvent =
   | ApiDocsCodeCopyButtonClickedEvent
   | CronJobCreatedEvent
   | CronJobUpdatedEvent
-  | CronJobDeletedEvent
+  | CronJobRemovedEvent
   | CronJobCreateClickedEvent
   | CronJobUpdateClickedEvent
   | CronJobDeleteClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3,8 +3,10 @@
  *
  * Note that events are not emitted for users that have opted out of telemetry.
  *
- * Original definitions located at:
- * https://github.com/supabase/supabase/blob/master/packages/common/telemetry-constants.ts
+ * ## Naming conventions
+ * Event names and actions should use standardized past-tense verbs for data quality and consistency.
+ * Only use verbs already established in this file or in https://github.com/supabase/platform/blob/develop/shared/src/telemetry.ts
+ * Adding new verbs requires @growth-eng review to prevent data pollution.
  *
  * @module telemetry-frontend
  */

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1541,14 +1541,14 @@ export interface BranchMergeSubmittedEvent {
 }
 
 /**
- * Triggered when a branch merge is successful.
+ * Triggered when a branch merge completes successfully.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/merge
  */
-export interface BranchMergeSucceededEvent {
-  action: 'branch_merge_succeeded'
+export interface BranchMergeCompletedEvent {
+  action: 'branch_merge_completed'
   properties: {
     /**
      * The type of branch being merged, e.g. preview, persistent
@@ -2824,7 +2824,7 @@ export type TelemetryEvent =
   | BranchCreateMergeRequestButtonClickedEvent
   | BranchCloseMergeRequestButtonClickedEvent
   | BranchMergeSubmittedEvent
-  | BranchMergeSucceededEvent
+  | BranchMergeCompletedEvent
   | BranchMergeFailedEvent
   | BranchUpdatedEvent
   | BranchReviewWithAssistantClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -670,7 +670,7 @@ export interface AssistantEditInSqlEditorClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/reports/{id}
  */
-export interface CustomReportAddSQLBlockClicked {
+export interface CustomReportAddSQLBlockClickedEvent {
   action: 'custom_report_add_sql_block_clicked'
   groups: TelemetryGroups
 }
@@ -1409,7 +1409,7 @@ export interface SupabaseUiCommandCopyButtonClickedEvent {
  * @source studio
  * @page /dashboard/org/{slug}/security
  */
-export interface OrganizationMfaEnforcementUpdated {
+export interface OrganizationMfaEnforcementUpdatedEvent {
   action: 'organization_mfa_enforcement_updated'
   properties: {
     mfaEnforced: boolean
@@ -2779,7 +2779,7 @@ export type TelemetryEvent =
   | HomepageDiscordButtonClickedEvent
   | HomepageCustomerStoryCardClickedEvent
   | HomepageProjectTemplateCardClickedEvent
-  | CustomReportAddSQLBlockClicked
+  | CustomReportAddSQLBlockClickedEvent
   | CustomReportAssistantSQLBlockAddedEvent
   | OpenSourceRepoCardClickedEvent
   | StartProjectButtonClickedEvent
@@ -2816,7 +2816,7 @@ export type TelemetryEvent =
   | SupabaseUiCommandCopyButtonClickedEvent
   | SupportTicketSubmittedEvent
   | AiAssistantInSupportFormClickedEvent
-  | OrganizationMfaEnforcementUpdated
+  | OrganizationMfaEnforcementUpdatedEvent
   | ForeignDataWrapperCreatedEvent
   | StorageBucketCreatedEvent
   | BranchCreateButtonClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -167,7 +167,7 @@ export interface CronJobUpdatedEvent {
 }
 
 /**
- * Cron job removed.
+ * Cron job removed. Previously: cron_job_deleted
  *
  * @group Events
  * @source studio
@@ -1541,7 +1541,7 @@ export interface BranchMergeSubmittedEvent {
 }
 
 /**
- * Triggered when a branch merge completes successfully.
+ * Triggered when a branch merge completes successfully. Previously: branch_merge_succeeded
  *
  * @group Events
  * @source studio
@@ -2623,7 +2623,7 @@ export interface DashboardErrorCreatedEvent {
 
 /**
  * User successfully completed installing an integration via the integrations marketplace in the dashboard.
- * Note: This excludes Wrappers and Postgres Extensions.
+ * Note: This excludes Wrappers and Postgres Extensions. Previously: integration_installed
  *
  * @group Events
  * @source studio
@@ -2641,7 +2641,7 @@ export interface IntegrationInstallCompletedEvent {
 }
 
 /**
- * User submitted an integration install via the integrations marketplace.
+ * User submitted an integration install via the integrations marketplace. Previously: integration_install_started
  *
  * @group Events
  * @source studio
@@ -2659,7 +2659,7 @@ export interface IntegrationInstallSubmittedEvent {
 }
 
 /**
- * User submitted an integration uninstall via the integrations marketplace.
+ * User submitted an integration uninstall via the integrations marketplace. Previously: integration_uninstall_started
  *
  * @group Events
  * @source studio
@@ -2696,7 +2696,7 @@ export interface IntegrationInstallFailedEvent {
 
 /**
  * User successfully completed uninstalling an integration via the integrations marketplace in the dashboard.
- * Note: This excludes Wrappers and Postgres Extensions.
+ * Note: This excludes Wrappers and Postgres Extensions. Previously: integration_uninstalled
  *
  * @group Events
  * @source studio

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2622,15 +2622,15 @@ export interface DashboardErrorCreatedEvent {
 }
 
 /**
- * User successfully installed an integration via the integrations marketplace in the dashboard.
+ * User successfully completed installing an integration via the integrations marketplace in the dashboard.
  * Note: This excludes Wrappers and Postgres Extensions.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/integrations/{integration_slug}
  */
-export interface IntegrationInstalledEvent {
-  action: 'integration_installed'
+export interface IntegrationInstallCompletedEvent {
+  action: 'integration_install_completed'
   properties: {
     /**
      * The name of the integration installed
@@ -2641,14 +2641,14 @@ export interface IntegrationInstalledEvent {
 }
 
 /**
- * User started installing an integration via the integrations marketplace.
+ * User submitted an integration install via the integrations marketplace.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/integrations/{integration_slug}
  */
-export interface IntegrationInstallStartedEvent {
-  action: 'integration_install_started'
+export interface IntegrationInstallSubmittedEvent {
+  action: 'integration_install_submitted'
   properties: {
     /**
      * The name of the integration being installed
@@ -2659,14 +2659,14 @@ export interface IntegrationInstallStartedEvent {
 }
 
 /**
- * User started uninstalling an integration via the integrations marketplace.
+ * User submitted an integration uninstall via the integrations marketplace.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/integrations/{integration_slug}
  */
-export interface IntegrationUninstallStartedEvent {
-  action: 'integration_uninstall_started'
+export interface IntegrationUninstallSubmittedEvent {
+  action: 'integration_uninstall_submitted'
   properties: {
     /**
      * The name of the integration being uninstalled
@@ -2695,15 +2695,15 @@ export interface IntegrationInstallFailedEvent {
 }
 
 /**
- * User uninstalled an integration via the integrations marketplace in the dashboard.
+ * User successfully completed uninstalling an integration via the integrations marketplace in the dashboard.
  * Note: This excludes Wrappers and Postgres Extensions.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/integrations/{integration_slug}
  */
-export interface IntegrationUninstalledEvent {
-  action: 'integration_uninstalled'
+export interface IntegrationUninstallCompletedEvent {
+  action: 'integration_uninstall_completed'
   properties: {
     /**
      * The name of the integration installed
@@ -2871,9 +2871,9 @@ export type TelemetryEvent =
   | RequestUpgradeModalOpenedEvent
   | RequestUpgradeSubmittedEvent
   | DashboardErrorCreatedEvent
-  | IntegrationInstalledEvent
-  | IntegrationInstallStartedEvent
-  | IntegrationUninstallStartedEvent
+  | IntegrationInstallCompletedEvent
+  | IntegrationInstallSubmittedEvent
+  | IntegrationUninstallSubmittedEvent
   | IntegrationInstallFailedEvent
-  | IntegrationUninstalledEvent
+  | IntegrationUninstallCompletedEvent
   | RlsEventTriggerBannerCreateButtonClickedEvent


### PR DESCRIPTION
## Summary

Standardizes telemetry event naming conventions for better data quality and consistency. Adds documentation about verb standardization and renames several events to follow consistent patterns: `_clicked` for button clicks, `_submitted` for process initiation, `_completed` for successful completion, and `_removed` instead of `_deleted`.

## Changes

- Add naming conventions documentation to telemetry-constants.ts header
- Fix missing `Event` suffix on interface names (`OrganizationMfaEnforcementUpdated`, `CustomReportAddSQLBlockClicked`)
- Rename `branch_merge_succeeded` → `branch_merge_completed`
- Rename `cron_job_deleted` → `cron_job_removed`
- Rename integration events: `_started` → `_submitted`, `_installed/_uninstalled` → `_install_completed/_uninstall_completed`
- Update all usages in studio app to use new event names
- Add "Previously:" comments for renamed events to aid data migration

## Testing

**Quick test:**
1. Verify TypeScript compiles without errors
2. Check that telemetry events in studio still fire correctly after the renames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal event naming conventions across cron jobs, integrations, and branch merge operations for improved consistency and clarity in backend tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->