### PR TITLE
fix: Change the `authorize-vercel-builds` to be triggered by another action

### DIFF
--- a/.github/workflows/authorize-vercel-deploys.yml
+++ b/.github/workflows/authorize-vercel-deploys.yml
@@ -1,13 +1,14 @@
 name: Authorize Vercel Deploys
 
 on:
-  pull_request:
-    branches:
-      - 'master'
+  # only run this workflow when the validate-pr workflow completes (successfully or not)
+  workflow_run:
+    workflows: ['validate-pr']
+    types: [completed]
 
-# Cancel old builds on new commit for same workflow + branch/PR
+# Cancel old builds on new commit for same workflow + branch/PR.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -18,9 +19,11 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
+      # Checkout the master branch from the supabase repo and run that script to authorize Vercel deploys
       - name: Check out repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          ref: master
           # fetch only the root files and scripts folder
           sparse-checkout: |
             scripts


### PR DESCRIPTION
The `authorize-vercel-builds` needs to access GH secrets which is not possible if the PR is coming from a fork. There's two ways to do it:
- using `pull_request_target` which runs the GH action in context off the main `supabase` repo. This can be very dangerous (secrets can be leaked) but it can be done safely by checking out the `master` branch. The main issue with this approach is that it always runs, doesn't wait for the "Approve workflows to run" click on PRs from forks. 
- using `workflow_run` which makes the GH action run in context off the main repo but as a followup to another (unsafe) GH action. This PR implements this, it's also made extra safe by running the script from the `master` branch. It's run as a followup to `validate-pr` action (which is lightweight and fast).