### PR TITLE
docs: add migration down command to cli docs

### DIFF
--- a/apps/docs/spec/common-cli-sections.json
+++ b/apps/docs/spec/common-cli-sections.json
@@ -211,7 +211,7 @@
       },
       {
         "id": "supabase-migration-down",
-        "title": "Rollback applied migration files",
+        "title": "Reset migrations to a prior version",
         "slug": "supabase-migration-down",
         "type": "cli-command"
       }

--- a/apps/docs/spec/common-cli-sections.json
+++ b/apps/docs/spec/common-cli-sections.json
@@ -208,6 +208,12 @@
         "title": "Apply pending migration files",
         "slug": "supabase-migration-up",
         "type": "cli-command"
+      },
+      {
+        "id": "supabase-migration-down",
+        "title": "Rollback applied migration files",
+        "slug": "supabase-migration-down",
+        "type": "cli-command"
       }
     ]
   },

--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -1927,7 +1927,7 @@ Absolutely. The SQL Editor includes syntax highlighting to improve code readabil
 
 ### Is the editor accessible via the Supabase CLI?
 
-While the editor is primarily a web-based tool within Supabase Studio, you can execute SQL queries using the [Supabase CLI](/features/cli) by utilizing the supabase db query command. This allows for integration into scripts and automation workflows.
+Yes, the editor is available locally through [Supabase CLI](/features/cli).
 `,
     icon: FileCode2,
     products: [ADDITIONAL_PRODUCTS.STUDIO],


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Adds missing command and removes hallucinated command.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new CLI migration rollback command to the docs, enabling users to reference rollback steps.
  * Clarified the SQL Editor feature description to state it is available locally via the Supabase CLI as well as in the web Studio.
  * Updates applied to docs and feature pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->