### PR TITLE
ci(studio): use app token for ratchet decrease workflow

### DIFF
--- a/.github/workflows/studio-lint-ratchet-decrease.yml
+++ b/.github/workflows/studio-lint-ratchet-decrease.yml
@@ -35,9 +35,16 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+
       - name: Decrease ESLint ratchet baselines and open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -eo pipefail


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

CI improvement

## What is the current behavior?

We're using the default GITHUB_TOKEN to create the ratchet baseline decrease PR. By default, this does not auto-run the PR checks to prevent infinite loops.

## What is the new behavior?

Switching to a GitHub App token instead so the PR checks will auto-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow authentication to generate and use a GitHub App token for actions that push or interact with pull requests, replacing the previous token usage to improve security and maintain existing automation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->