### PR TITLE
Update managing-environments.mdx | updated section on permission errors

### DIFF
--- a/apps/docs/content/guides/deployment/managing-environments.mdx
+++ b/apps/docs/content/guides/deployment/managing-environments.mdx
@@ -380,21 +380,11 @@ grant all on all sequences in schema graphql to postgres, anon, authenticated, s
 
 ### Permission denied on `db push`
 
-If you created a table through Supabase dashboard, and your new migration script contains `ALTER TABLE` statements, you might run into permission error when applying them on staging or production databases.
-
-```bash
-ERROR: must be owner of table employees (SQLSTATE 42501); while executing migration <timestamp>
-```
-
-This is because tables created through Supabase dashboard are owned by `supabase_admin` role while the migration scripts executed through CLI are under `postgres` role.
-
-One way to solve this is to reassign the owner of those tables to `postgres` role. For example, if your table is named `users` in the public schema, you can run the following command to reassign owner.
+If you create a table using a custom database role, the default postgres user may lack permission to modify it. This can cause `42501` privilege errors during migrations. To resolve this, grant the postgres user ownership of the custom role.
 
 ```sql
-ALTER TABLE users OWNER TO postgres;
+grant "custom_role" to "postgres";
 ```
-
-Apart from tables, you also need to reassign owner of other entities using their respective commands, including [types](https://www.postgresql.org/docs/current/sql-altertype.html), [functions](https://www.postgresql.org/docs/current/sql-alterroutine.html), and [schemas](https://www.postgresql.org/docs/current/sql-alterschema.html).
 
 ### Rebasing new migrations
 

--- a/apps/docs/content/guides/deployment/managing-environments.mdx
+++ b/apps/docs/content/guides/deployment/managing-environments.mdx
@@ -380,7 +380,7 @@ grant all on all sequences in schema graphql to postgres, anon, authenticated, s
 
 ### Permission denied on `db push`
 
-If you create a table using a custom database role, the default `postgres` user may lack permission to modify it. This can cause `42501` privilege errors during migrations. To resolve this, grant the postgres user ownership of the custom role.
+If you create a table using a custom database role, the default `postgres` user may lack permission to modify it. This can cause `42501` privilege errors during migrations. To resolve this, grant the 'postgres` user ownership of the custom role.
 
 ```sql
 grant "custom_role" to "postgres";

--- a/apps/docs/content/guides/deployment/managing-environments.mdx
+++ b/apps/docs/content/guides/deployment/managing-environments.mdx
@@ -380,7 +380,7 @@ grant all on all sequences in schema graphql to postgres, anon, authenticated, s
 
 ### Permission denied on `db push`
 
-If you create a table using a custom database role, the default postgres user may lack permission to modify it. This can cause `42501` privilege errors during migrations. To resolve this, grant the postgres user ownership of the custom role.
+If you create a table using a custom database role, the default `postgres` user may lack permission to modify it. This can cause `42501` privilege errors during migrations. To resolve this, grant the postgres user ownership of the custom role.
 
 ```sql
 grant "custom_role" to "postgres";


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Tells users that the Dashboard uses the supabase_admin role and the CLI uses the postgres role. Although this was true in past versions of Supabase, both now use the postgres role.

## What is the new behavior?

Updated the docs to state that permission errors are caused by custom roles owning objects outside of Postgres's scope. Added instructions on how to grant Postgres permission over custom roles.

## Additional context

A [user wrote in](https://supabase.frontapp.com/open/msg_2zs0owke?key=FcbzQsGBYHDuXUVJG4h5-paMqGmSu0nx) expressing confusion when both dashboard and CLI generated objects were both owned by the postgres role. Updated the docs to avoid future confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Generalized guidance for fixing permission errors with custom DB roles by granting privileges to the postgres user instead of reassigning ownership.
  * Removed instructions about reassigning ownership for types, functions, and schemas.
  * Clarified migration rebasing: prefer renaming the old migration (new timestamp) and rerunning, with a fallback for manual conflict resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->