### PR TITLE
Add pause indicator to ProjectDropdown

### DIFF
--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -11,7 +11,7 @@ import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from 'lib/constants'
-import { Button, CommandGroup_Shadcn_, CommandItem_Shadcn_, cn } from 'ui'
+import { Badge, Button, CommandGroup_Shadcn_, CommandItem_Shadcn_, cn } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 export const sanitizeRoute = (route: string, routerQueries: ParsedUrlQuery) => {
@@ -87,11 +87,13 @@ export const ProjectDropdown = () => {
           const sanitizedRoute = sanitizeRoute(router.route, router.query)
           const href = sanitizedRoute?.replace('[ref]', project.ref) ?? `/project/${project.ref}`
           const isSelected = project.ref === ref
+          const isPaused = project.status === 'INACTIVE'
 
           return (
             <Link href={href} className="w-full flex items-center justify-between">
               <span className={cn('truncate', isSelected ? 'max-w-60' : 'max-w-64')}>
                 {project.name}
+                {isPaused && <Badge className="ml-2">Paused</Badge>}
               </span>
               {isSelected && <Check size={16} />}
             </Link>


### PR DESCRIPTION
## Context

Adds a pause indicator if the project is paused in the project dropdown for easier reference

<img width="430" height="202" alt="image" src="https://github.com/user-attachments/assets/20ef4637-dd43-4ff2-98fe-b7621fdec397" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The project dropdown list now displays a visual "Paused" badge next to any projects with inactive status. This enhancement provides immediate clarity on project availability at a glance and allows you to quickly distinguish between active and paused projects without requiring additional navigation or status checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->