### PR TITLE
Update FDW type for server_options to be nullable and fix TS issues

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -21,7 +21,7 @@ import {
 import { INTEGRATIONS } from '../Landing/Integrations.constants'
 import DeleteWrapperModal from './DeleteWrapperModal'
 import { EditWrapperSheet } from './EditWrapperSheet'
-import { formatWrapperTables } from './Wrappers.utils'
+import { convertKVStringArrayToJson, formatWrapperTables } from './Wrappers.utils'
 
 interface WrapperRowProps {
   wrapper: FDW
@@ -55,9 +55,7 @@ export const WrapperRow = ({
     return <p className="text-foreground-lighter text-sm">A wrapper with this ID does not exist</p>
   }
 
-  const serverOptions = Object.fromEntries(
-    wrapper.server_options.map((option) => option.split('='))
-  )
+  const serverOptions = convertKVStringArrayToJson(wrapper.server_options ?? [])
   const [encryptedMetadata, visibleMetadata] = partition(
     integration?.meta?.server.options.filter((option) => !option.hidden),
     'secureEntry'

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorTableSheet.tsx
@@ -111,7 +111,7 @@ export const CreateVectorTableSheet = ({ bucketName }: CreateVectorTableSheetPro
   const { can: canCreateBuckets } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   const { data: wrapperInstance } = useS3VectorsWrapperInstance({ bucketId: bucketName })
-  const schema = wrapperInstance?.server_options
+  const schema = (wrapperInstance?.server_options ?? [])
     .find((x) => x.startsWith('supabase_target_schema'))
     ?.split('supabase_target_schema=')[1]
 

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/index.tsx
@@ -104,7 +104,7 @@ export const VectorBucketDetails = () => {
   } = useS3VectorsWrapperInstance({ bucketId })
 
   const isLoading = isLoadingIndexes || isLoadingWrapper
-  const hasSetUpForeignSchema = wrapperInstance?.server_options.find((x) =>
+  const hasSetUpForeignSchema = (wrapperInstance?.server_options ?? []).find((x) =>
     x.startsWith('supabase_target_schema')
   )
 

--- a/apps/studio/data/fdw/fdws-query.ts
+++ b/apps/studio/data/fdw/fdws-query.ts
@@ -60,7 +60,7 @@ export type FDW = {
   name: string
   handler: string
   server_name: string
-  server_options: string[]
+  server_options: string[] | null
   tables: FDWTable[]
 }
 

--- a/apps/studio/hooks/useProtectedSchemas.ts
+++ b/apps/studio/hooks/useProtectedSchemas.ts
@@ -64,7 +64,7 @@ const useFdwSchemasQuery = () => {
 
     const fdwSchemas = icebergFDWs.map((fdw) => {
       const schemaOption =
-        convertKVStringArrayToJson(fdw.server_options)['supabase_target_schema'] ?? ''
+        convertKVStringArrayToJson(fdw.server_options ?? [])['supabase_target_schema'] ?? ''
 
       const schemas = uniq(schemaOption.split(',').filter(Boolean))
 


### PR DESCRIPTION
## Context

For FDWs, the `svroptions` column on `pg_catalog.pg_foreign_server` (which is used in the query to retrieve wrappers ([ref](https://github.com/supabase/supabase/blob/master/apps/studio/data/fdw/fdws-query.ts#L12)) is actually nullable.

As such, am updating the `FDW` type in the dashboard to reflect that + fix all the follow up TS issues subsequently which should mitigate errors of `Cannot read properties of null (reading 'map')` from `convertKVStringArrayToJson` which is primarily used for wrappers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding defensive null-checks to prevent runtime errors when configuration data is missing or undefined.

* **Refactor**
  * Enhanced type safety for configuration field handling across multiple components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->