### PR TITLE
Update programmatically generated policies to use authenticated role

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/Policies.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.utils.test.ts
@@ -214,7 +214,7 @@ describe('Policies.utils - Policy Generation', () => {
         expect(selectPolicy?.sql).toContain('CREATE POLICY')
         expect(selectPolicy?.sql).toContain('public.posts')
         expect(selectPolicy?.sql).toContain('AS PERMISSIVE FOR SELECT')
-        expect(selectPolicy?.sql).toContain('TO public')
+        expect(selectPolicy?.sql).toContain('TO authenticated')
         expect(selectPolicy?.sql).toContain('USING')
         expect(selectPolicy?.sql).toContain('auth.uid()')
       })

--- a/apps/studio/components/interfaces/Auth/Policies/Policies.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.utils.test.ts
@@ -156,7 +156,7 @@ describe('Policies.utils - Policy Generation', () => {
           expect(policy).toHaveProperty('schema', 'public')
           expect(policy).toHaveProperty('action', 'PERMISSIVE')
           expect(policy).toHaveProperty('roles')
-          expect(policy.roles).toContain('public')
+          expect(policy.roles).toContain('authenticated')
         }
       })
 

--- a/apps/studio/components/interfaces/Auth/Policies/Policies.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.utils.ts
@@ -316,7 +316,7 @@ const buildPoliciesForPath = (
 
   return (['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const).map((command) => {
     const name = `Enable ${command.toLowerCase()} access for users based on ${ident(targetCol)}`
-    const base = `CREATE POLICY "${name}" ON ${ident(table.schema)}.${ident(table.name)} AS PERMISSIVE FOR ${command} TO public`
+    const base = `CREATE POLICY "${name}" ON ${ident(table.schema)}.${ident(table.name)} AS PERMISSIVE FOR ${command} TO authenticated`
 
     const sql =
       command === 'INSERT'
@@ -338,7 +338,7 @@ const buildPoliciesForPath = (
       definition,
       check,
       action: 'PERMISSIVE' as const,
-      roles: ['public'],
+      roles: ['authenticated'],
     }
   })
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -319,9 +319,10 @@ export const ApiAccessToggle = ({
             <p className="text-sm text-foreground flex items-center gap-1.5">
               Data API Access
               <InfoTooltip side="top" className="max-w-80">
-                This controls which operations the <code className="text-xs">anon</code> and{' '}
-                <code className="text-xs">authenticated</code> roles can perform on this table via
-                the Data API. Unselected privileges are revoked from these roles.
+                This controls which operations the <code className="text-code-inline">anon</code>{' '}
+                and <code className="text-code-inline whitespace-nowrap">authenticated</code> roles
+                can perform on this table via the Data API. Unselected privileges are revoked from
+                these roles.
               </InfoTooltip>
             </p>
             <p className="text-sm text-foreground-lighter">


### PR DESCRIPTION
## Context

Part of secure by default project - updates the programatically generated RLS policies to use the `authenticated` role instead of the `public` role.

Also updated the Data API Access tooltip in the table side panel editor to use `text-code-inline` for better code element stying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default access policies now require authenticated users instead of allowing public access, tightening data access controls and aligning generated policies with expected role behavior.

* **Style**
  * Improved styling of Data API access role indicators and inline code formatting in the editor for clearer, more consistent display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->