### PR TITLE
chore: move cached egress under storage on pricing page

### DIFF
--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -38,8 +38,8 @@ export const pricingTooltips: PricingTooltips = {
   'database.egress': {
     main: 'Billing is based on the total sum of all outgoing traffic (includes Database, Storage, Realtime, Auth, API, Edge Functions, Supavisor, Log Drains) in GB throughout your billing period. Excludes cache hits.',
   },
-  'database.cachedEgress': {
-    main: 'Billing is based on the total sum of any outgoing traffic (includes Database, Storage, API, Edge Functions) in GB throughout your billing period that is served from our CDN cache.',
+  'storage.cachedEgress': {
+    main: 'Billing is based on the total sum of outgoing Storage traffic in GB throughout your billing period that is served from our CDN cache.',
   },
   'auth.totalUsers': {
     main: 'The maximum number of users your project can have',

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -37,7 +37,6 @@ export type FeatureKey =
   | 'database.pausing'
   | 'database.branching'
   | 'database.egress'
-  | 'database.cachedEgress'
   | 'auth.totalUsers'
   | 'auth.maus'
   | 'auth.userDataOwnership'
@@ -58,6 +57,7 @@ export type FeatureKey =
   | 'storage.size'
   | 'storage.customAccessControls'
   | 'storage.maxFileSize'
+  | 'storage.cachedEgress'
   | 'storage.cdn'
   | 'storage.transformations'
   | 'storage.byoc'
@@ -190,17 +190,6 @@ export const pricing: Pricing = {
           free: '5 GB included',
           pro: ['250 GB included', 'then $0.09 per GB'],
           team: ['250 GB included', 'then $0.09 per GB'],
-          enterprise: 'Custom',
-        },
-        usage_based: true,
-      },
-      {
-        key: 'database.cachedEgress',
-        title: 'Cached Egress',
-        plans: {
-          free: '5 GB included',
-          pro: ['250 GB included', 'then $0.03 per GB'],
-          team: ['250 GB included', 'then $0.03 per GB'],
           enterprise: 'Custom',
         },
         usage_based: true,
@@ -414,6 +403,17 @@ export const pricing: Pricing = {
           free: '1 GB included',
           pro: ['100 GB included', 'then $0.021 per GB'],
           team: ['100 GB included', 'then $0.021 per GB'],
+          enterprise: 'Custom',
+        },
+        usage_based: true,
+      },
+      {
+        key: 'storage.cachedEgress',
+        title: 'Cached Egress',
+        plans: {
+          free: '5 GB included',
+          pro: ['250 GB included', 'then $0.03 per GB'],
+          team: ['250 GB included', 'then $0.03 per GB'],
           enterprise: 'Custom',
         },
         usage_based: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pricing classification by moving the Cached Egress billing feature from Database to Storage pricing tier. Updated pricing descriptions to clarify that billing is based on the total sum of outgoing Storage traffic in GB throughout your billing period that is served from the CDN cache.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->