### PR TITLE
fix: remove git branches from merge requests dropdown

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchSelector.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchSelector.tsx
@@ -34,9 +34,9 @@ export const BranchSelector = ({
   const [open, setOpen] = useState(false)
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null)
 
-  // Filter out branches that are already ready for review and the main branch
+  // Filter out branches that are already ready for review or linked to a github branch
   const availableBranches = branches.filter(
-    (branch) => !branch.is_default && !branch.review_requested_at
+    (branch) => !branch.is_default && !branch.review_requested_at && !branch.git_branch
   )
 
   const handleBranchSelect = (branch: Branch) => {

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -369,7 +369,11 @@ const MergePage: NextPageWithLayout = () => {
   }
 
   const isMergeDisabled =
-    !combinedHasChanges || isCombinedDiffLoading || isBranchOutOfDateOverall || isWorkflowRunning
+    !combinedHasChanges ||
+    isCombinedDiffLoading ||
+    isBranchOutOfDateOverall ||
+    isWorkflowRunning ||
+    Boolean(mainBranch?.git_branch)
 
   const primaryActions = (
     <div className="flex items-end gap-2">
@@ -388,7 +392,9 @@ const MergePage: NextPageWithLayout = () => {
                 ? 'No changes to merge'
                 : isWorkflowRunning
                   ? 'Workflow is currently running'
-                  : 'Unable to merge at this time',
+                  : Boolean(mainBranch?.git_branch)
+                    ? 'Base branch is tracked in git'
+                    : 'Unable to merge at this time',
             },
           }}
           type="primary"
@@ -404,7 +410,6 @@ const MergePage: NextPageWithLayout = () => {
           type="primary"
           loading={isMerging || isSubmitting}
           onClick={() => setShowConfirmDialog(true)}
-          disabled={isBranchOutOfDateOverall}
           icon={<GitMerge size={16} strokeWidth={1.5} className="text-brand" />}
         >
           Merge branch

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -393,7 +393,7 @@ const MergePage: NextPageWithLayout = () => {
                 : isWorkflowRunning
                   ? 'Workflow is currently running'
                   : Boolean(mainBranch?.git_branch)
-                    ? 'Base branch is tracked in git'
+                    ? 'Deploy to production from GitHub is enabled'
                     : 'Unable to merge at this time',
             },
           }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

If user enabled `Deploy to production` under github integration, we should enforce that only code pushes from github repo will trigger a prod deploy.

<img width="692" height="203" alt="Screenshot 2026-01-09 at 5 24 33 PM" src="https://github.com/user-attachments/assets/710616fb-1739-4a70-9275-65611b4470de" />

User may disable this toggle to merge git-less branches.

## Additional context

Verified that
- [x] all my git connected branches are hidden from dropdown

<img width="472" height="278" alt="Screenshot 2026-01-09 at 4 16 32 PM" src="https://github.com/user-attachments/assets/f485ee36-c53e-428b-ac87-b9b067298a0d" />

- [x] merge is disabled when deploy to production from git

<img width="287" height="238" alt="Screenshot 2026-01-09 at 5 16 41 PM" src="https://github.com/user-attachments/assets/54831431-9f05-4d92-8b99-d50c262b011e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge workflow now recognizes when the main branch is tracked in GitHub.

* **Bug Fixes**
  * Branches with active GitHub connections are now excluded from available branch selections.
  * Improved merge button behavior and messaging when the main branch is GitHub-tracked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->