### PR TITLE
(chore) studIo: Refactor use query state with select part 01

### DIFF
--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/index.tsx
@@ -2,8 +2,7 @@ import { MoreVertical, Search, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
-import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
+import { useState } from 'react'
 
 import { useParams } from 'common'
 import {
@@ -59,7 +58,7 @@ export const VectorBucketDetails = () => {
     'delete',
     parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
   )
-  const [selectedTableIdToDelete, setSelectedTableIdToDelete] = useQueryState(
+  const [_, setSelectedTableIdToDelete] = useQueryState(
     'deleteTable',
     parseAsString.withOptions({ history: 'push', clearOnDefault: true })
   )
@@ -83,9 +82,6 @@ export const VectorBucketDetails = () => {
     vectorBucketName: bucket?.vectorBucketName,
   })
   const allIndexes = data?.indexes ?? []
-  const selectedTableToDelete = allIndexes.find(
-    (index) => index.indexName === selectedTableIdToDelete
-  )
 
   const filteredList =
     filterString.length === 0
@@ -114,13 +110,6 @@ export const VectorBucketDetails = () => {
         ? 'added'
         : 'missing'
       : extensionState
-
-  useEffect(() => {
-    if (!!selectedTableIdToDelete && isSuccessIndexes && !selectedTableToDelete) {
-      toast(`Table ${selectedTableIdToDelete} cannot be found in your bucket`)
-      setSelectedTableIdToDelete(null)
-    }
-  }, [isSuccessIndexes, selectedTableIdToDelete, selectedTableToDelete, setSelectedTableIdToDelete])
 
   return (
     <>
@@ -332,11 +321,7 @@ export const VectorBucketDetails = () => {
         </ScaffoldContainer>
       )}
 
-      <DeleteVectorTableModal
-        visible={!!selectedTableToDelete}
-        table={selectedTableToDelete}
-        onClose={() => setSelectedTableIdToDelete(null)}
-      />
+      <DeleteVectorTableModal />
 
       <DeleteVectorBucketModal
         visible={showDeleteModal}

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -38,7 +38,7 @@ interface SchemaSelectorProps {
   align?: 'start' | 'end'
 }
 
-const SchemaSelector = ({
+export const SchemaSelector = ({
   className,
   disabled = false,
   size = 'tiny',


### PR DESCRIPTION
## Context

Removes the usage of `useQueryStateWithSelect` in 3 parts of the dashboard
- Auth -> Policies (Edit)
- Storage -> Vector buckets (Delete table)
- Edge Function -> Secrets (Edit + Delete secrets)

Ensures that the appropriate behaviours are in place too
- Toast should show when landing on a page with an invalid ID param that entity doesn't exist
- Toast should not show when deleting the param (which `useQueryStateWithSelect` was using `useRef` as a workaround prior)

## To test
- [x] Auth
  - URL updates when editing policy
  - Refresh the page, panel should open with the correct policy
  - Update the ID query param to something invalid, show see a toast
- [x] Storage
  - URL updates when deleting a table/index
  - Refresh the page, dialog should open with the correct table/index
  - Update the ID query param to something invalid, show see a toast
  - Deleting the table/index should show a success toast from the deletion, and no "Not found" toast
- [x] Edge functions
  - URL updates when editing / deleting a secret
  - Refresh the page, dialog should open with the correct secret
  - Update the ID query param to something invalid, show see a toast
  - Deleting the secret should show a success toast from the deletion, and no "Not found" toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for edge function secrets, vector bucket tables, and policy editors by consolidating internal tracking mechanisms.
  * Enhanced error handling with improved user notifications for deleted or unavailable items.
  * Simplified component architecture for better maintainability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->