### PR TITLE
fix: storage folder rename crash when openedFolders index is undefined

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -40,14 +40,14 @@ export const FileExplorerRowEditing = ({
         newName: name,
         columnIndex,
         onError: () => {
-          if (event.type === 'blur') {
+          if (event?.type === 'blur') {
             updateRowStatus({
               name: itemWithColumnIndex.name,
               status: STORAGE_ROW_STATUS.READY,
               columnIndex,
             })
           } else {
-            inputRef.current.select()
+            inputRef.current?.select()
           }
         },
       })
@@ -56,10 +56,10 @@ export const FileExplorerRowEditing = ({
         folderName: name,
         columnIndex,
         onError: () => {
-          if (event.type === 'blur') {
+          if (event?.type === 'blur') {
             addNewFolder({ folderName: '', columnIndex })
           } else {
-            inputRef.current.select()
+            inputRef.current?.select()
           }
         },
       })

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -716,7 +716,7 @@ function createStorageExplorerState({
           })
         }
 
-        if (state.openedFolders[columnIndex].name === folder.name) {
+        if (state.openedFolders[columnIndex]?.name === folder.name) {
           state.setSelectedFilePreview(undefined)
           state.popOpenedFoldersAtIndex(columnIndex - 1)
         }

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1667,7 +1667,7 @@ function createStorageExplorerState({
     // ======== UI Helper functions ========
 
     selectRangeItems: (columnIndex: number, toItemIndex: number) => {
-      const columnItems = state.columns[columnIndex].items
+      const columnItems = state.columns[columnIndex]?.items
       const toItem = columnItems[toItemIndex]
       const selectedItemIds = state.selectedItems.map((item) => item.id)
       const lastSelectedItemId = selectedItemIds[selectedItemIds.length - 1]
@@ -1711,7 +1711,7 @@ function createStorageExplorerState({
     }) => {
       const columnIndex_ = columnIndex !== undefined ? columnIndex : state.getLatestColumnIndex()
       const currentColumn = state.columns[columnIndex_]
-      const currentColumnItems = currentColumn.items.filter(
+      const currentColumnItems = currentColumn?.items?.filter(
         (item) => item.status !== STORAGE_ROW_STATUS.EDITING
       )
       // [Joshen] JFYI storage does support folders of the same name with different casing

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1668,6 +1668,7 @@ function createStorageExplorerState({
 
     selectRangeItems: (columnIndex: number, toItemIndex: number) => {
       const columnItems = state.columns[columnIndex]?.items
+      if (!columnItems) return
       const toItem = columnItems[toItemIndex]
       const selectedItemIds = state.selectedItems.map((item) => item.id)
       const lastSelectedItemId = selectedItemIds[selectedItemIds.length - 1]
@@ -1714,6 +1715,7 @@ function createStorageExplorerState({
       const currentColumnItems = currentColumn?.items?.filter(
         (item) => item.status !== STORAGE_ROW_STATUS.EDITING
       )
+      if (!currentColumnItems) return name
       // [Joshen] JFYI storage does support folders of the same name with different casing
       // but its an issue with the List V1 endpoint that's causing an issue with fetching contents
       // for folders of the same name with different casing


### PR DESCRIPTION
## summary

adds optional chaining to prevent crash when renaming storage folders.

## problem

renaming a folder throws `Cannot read properties of undefined (reading 'name')` when `openedFolders[columnIndex]` is undefined.

## solution

added optional chaining following the same pattern used in commit b04e54b3.

## related

- closes #41704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added defensive null-safety checks across the storage explorer UI and state flows to avoid runtime errors when data or event references may be missing.
  * No public API changes and no alterations to user-visible behavior or workflows; stability and runtime safety improved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->