### PR TITLE
docs: add OAuth example to SvelteKit SSR guide

### DIFF
--- a/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/+page.server.ts
+++ b/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/+page.server.ts
@@ -4,11 +4,14 @@ import type { Actions } from './$types'
 export const actions: Actions = {
   login: async ({ locals: { supabase }, url }) => {
     const next = url.searchParams.get('next') ?? '/dashboard'
+    // Validate next parameter to prevent open redirects (must be relative, not protocol-relative)
+    const isValidPath = next.startsWith('/') && !next.startsWith('//')
+    const safePath = isValidPath ? next : '/dashboard'
 
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${url.origin}/auth/callback?next=${encodeURIComponent(next)}`,
+        redirectTo: `${url.origin}/auth/callback?next=${encodeURIComponent(safePath)}`,
       },
     })
 
@@ -26,11 +29,13 @@ export const actions: Actions = {
 
   signup: async ({ locals: { supabase }, url }) => {
     const next = url.searchParams.get('next') ?? '/dashboard'
+    const isValidPath = next.startsWith('/') && !next.startsWith('//')
+    const safePath = isValidPath ? next : '/dashboard'
 
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${url.origin}/auth/callback?next=${encodeURIComponent(next)}`,
+        redirectTo: `${url.origin}/auth/callback?next=${encodeURIComponent(safePath)}`,
       },
     })
 

--- a/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/+page.server.ts
+++ b/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/+page.server.ts
@@ -1,0 +1,20 @@
+import { redirect } from '@sveltejs/kit'
+import type { Actions } from './$types'
+
+export const actions: Actions = {
+  login: async ({ locals: { supabase }, url }) => {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${url.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      console.error(error)
+      return redirect(303, '/auth/error')
+    }
+
+    return redirect(303, data.url)
+  },
+}

--- a/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/+page.server.ts
+++ b/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/+page.server.ts
@@ -3,18 +3,51 @@ import type { Actions } from './$types'
 
 export const actions: Actions = {
   login: async ({ locals: { supabase }, url }) => {
+    const next = url.searchParams.get('next') ?? '/dashboard'
+
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${url.origin}/auth/callback`,
+        redirectTo: `${url.origin}/auth/callback?next=${encodeURIComponent(next)}`,
       },
     })
 
     if (error) {
       console.error(error)
-      return redirect(303, '/auth/error')
+      redirect(303, '/auth/error')
     }
 
-    return redirect(303, data.url)
+    if (data.url) {
+      redirect(303, data.url)
+    }
+
+    redirect(303, '/auth/error')
+  },
+
+  signup: async ({ locals: { supabase }, url }) => {
+    const next = url.searchParams.get('next') ?? '/dashboard'
+
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${url.origin}/auth/callback?next=${encodeURIComponent(next)}`,
+      },
+    })
+
+    if (error) {
+      console.error(error)
+      redirect(303, '/auth/error')
+    }
+
+    if (data.url) {
+      redirect(303, data.url)
+    }
+
+    redirect(303, '/auth/error')
+  },
+
+  logout: async ({ locals: { supabase } }) => {
+    await supabase.auth.signOut()
+    redirect(303, '/')
   },
 }

--- a/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/callback/+server.ts
+++ b/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/callback/+server.ts
@@ -4,11 +4,13 @@ import type { RequestHandler } from './$types'
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
     const code = url.searchParams.get('code')
     const next = url.searchParams.get('next') ?? '/dashboard'
+    const isValidPath = next.startsWith('/') && !next.startsWith('//')
+    const safePath = isValidPath ? next : '/dashboard'
 
     if (code) {
         const { error } = await supabase.auth.exchangeCodeForSession(code)
         if (!error) {
-            redirect(303, `/${next.slice(1)}`)
+            redirect(303, safePath)
         }
     }
 

--- a/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/callback/+server.ts
+++ b/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/callback/+server.ts
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+    const code = url.searchParams.get('code')
+    const next = url.searchParams.get('next') ?? '/dashboard'
+
+    if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code)
+        if (!error) {
+            return redirect(303, `/${next.slice(1)}`)
+        }
+    }
+
+    // return the user to an error page with instructions
+    return redirect(303, '/auth/auth-code-error')
+}

--- a/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/callback/+server.ts
+++ b/apps/docs/content/code-samples/auth/sveltekit/src/routes/auth/callback/+server.ts
@@ -8,10 +8,10 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
     if (code) {
         const { error } = await supabase.auth.exchangeCodeForSession(code)
         if (!error) {
-            return redirect(303, `/${next.slice(1)}`)
+            redirect(303, `/${next.slice(1)}`)
         }
     }
 
     // return the user to an error page with instructions
-    return redirect(303, '/auth/auth-code-error')
+    redirect(303, '/auth/auth-code-error')
 }

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -312,6 +312,24 @@ You're done! To recap, you've successfully:
 
 You can now use any Supabase features from your client or server code!
 
+### OAuth Login
+
+To implement OAuth login (e.g., Google, GitHub), create a form action that initiates the OAuth flow and redirects to the provider:
+
+<$CodeTabs>
+<$CodeSample
+path="/auth/sveltekit/src/routes/auth/+page.server.ts"
+meta="name=src/routes/auth/+page.server.ts"
+language="typescript"
+/>
+
+<$CodeSample
+path="/auth/sveltekit/src/routes/auth/callback/+server.ts"
+meta="name=src/routes/auth/callback/+server.ts"
+language="typescript"
+/>
+</$CodeTabs>
+
 </TabPanel>
 <TabPanel id="astro" label="Astro">
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation - Adds OAuth login examples for SvelteKit SSR

## What is the current behavior?

The SvelteKit SSR documentation shows how to set up the Supabase client but doesn't include examples for OAuth provider logins.

Fixes #23618

## What is the new behavior?

Added a new "OAuth Login" section to the SvelteKit tab with:
- Form action to initiate OAuth sign-in 
- Callback route handler to exchange the code for a session
- Shows how to properly redirect to `data.url` from the OAuth response

## Additional context

This addresses the confusion noted in the issue where the user couldn't figure out how to handle OAuth redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google OAuth for SvelteKit: server-side sign-in (login/signup), sign-out, and callback handling to complete authentication and redirect users.

* **Documentation**
  * Added an OAuth login guide with server-side examples for SvelteKit and Next.js, demonstrating sign-in initiation and callback flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->