### PR TITLE
ci(studio): ensure E2E failures always fail the job

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -77,7 +77,7 @@ jobs:
           comment-title: '🎭 Playwright Test Results'
 
       - name: Fail job if tests failed
-        if: steps.filter.outputs.studio == 'true' && (steps.playwright.outcome != 'success' || steps.summarize.outputs.flaky_count > 0)
+        if: always() && steps.filter.outputs.studio == 'true' && steps.playwright.outcome != 'success'
         run: |
           echo "E2E tests failed" >&2
           exit 1


### PR DESCRIPTION
Ensure Studio E2E jobs fail when Playwright tests fail by running the failure check unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration test failure detection to more reliably identify and report failures in end-to-end testing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->