### PR TITLE
fix(studio): Twitter (Deprecated) oauth provider enabled status

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/index.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/index.tsx
@@ -107,6 +107,8 @@ export const AuthProvidersForm = () => {
                     isActive = authConfig && (authConfig as any)['EXTERNAL_WEB3_SOLANA_ENABLED']
                   } else if (providerSchema.title.includes('X / Twitter (OAuth 2.0)')) {
                     isActive = authConfig && (authConfig as any)['EXTERNAL_X_ENABLED']
+                  } else if (providerSchema.title === 'Twitter (Deprecated)') {
+                    isActive = authConfig && (authConfig as any)['EXTERNAL_TWITTER_ENABLED']
                   } else {
                     isActive =
                       authConfig &&


### PR DESCRIPTION
Previously this status would never show as enabled:

<img width="1231" height="185" alt="Screenshot 2026-01-12 at 11 50 13" src="https://github.com/user-attachments/assets/9fc6ee6e-0f9d-412a-96e3-78181d21d7b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of the deprecated Twitter provider in authentication configuration to properly respect the associated configuration setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->