### PR TITLE
Fix incorrect project access callout for project scoped roles

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -60,6 +60,7 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
   const { data: allRoles, isSuccess: isSuccessRoles } = useOrganizationRolesV2Query({ slug })
 
   const { data: projectsData } = useOrgProjectsInfiniteQuery({ slug })
+  const totalNumOrgProjects = projectsData?.pages[0].pagination.count ?? 0
   const orgProjects =
     useMemo(() => projectsData?.pages.flatMap((page) => page.projects), [projectsData?.pages]) || []
 
@@ -97,7 +98,6 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
     return !projectsRoleConfiguration.some((p) => p.ref === project.ref)
   })
   const numberOfProjectsWithAccess = orgProjects.length - noAccessProjects.length
-  const numberOfAccessHasChanges = originalConfiguration.length !== noAccessProjects.length
   const hasNoChanges = isEqual(projectsRoleConfiguration, originalConfiguration)
 
   const onSelectProject = (project: OrgProject) => {
@@ -206,7 +206,7 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
 
               {!isApplyingRoleToAllProjects &&
                 projectsRoleConfiguration.length > 0 &&
-                projectsRoleConfiguration.length !== orgProjects.length && (
+                projectsRoleConfiguration.length < totalNumOrgProjects && (
                   <Collapsible_Shadcn_ className="bg-alternative border rounded-lg py-4 group">
                     <CollapsibleTrigger_Shadcn_ className="w-full text-left px-4 flex items-center justify-between">
                       <span className="text-sm">


### PR DESCRIPTION
## Context

The "Member only has access" callout in the Update Member Role panel incorrectly shows up if the organization has more than 96 projects, and the user has access to more than 96 projects. (e.g Org has 1000 projects, user has access to 800 projects)

<img width="424" height="244" alt="image" src="https://github.com/user-attachments/assets/d74f3beb-1f30-4e88-b79d-c1fb74edd818" />

This is due to a part of the UI that we missed to update after swapping the GET projects query to use the new paginated endpoint, such that we were using the length of array returned from the endpoint response as the number of projects in the org.

Main fix is to use the `pagination.count` data from the GET projects query as the accurate indicator of number of projects in the org

## To test

A little tricky to test on staging unless you've got > 96 projects, so I'd recommend testing locally and manually changing the page limit to something smaller like 10.

- [ ] Ensure that you've got an org on team plan and above to have access to project scoped roles
- [ ] Ensure that your org has > 10 projects (n being the page limit that you've manually set)
- [ ] Ensure that you've got one member in the org on an org role
  - Flip that role to project scoped role, and ensure the user has a role for each project in the org and save
- [ ] Now change the page limit in `org-projects-infinite-query` to something smaller like 5
- [ ] Open the update role panel once more -> on staging there should be the callout incorrectly, on this branch there shouldn't be this callout