### PR TITLE
docs: Add 'pgjwt' to spelling rule list

### DIFF
--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -268,6 +268,7 @@ allow_list = [
     "PGAudit",
     "PGroonga",
     "PgBouncer",
+	"pgjwt",
     "PHI",
     "Pico",
     "PingIdentity",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES