### PR TITLE
fix(studio): functions egress not showing in daily breakdown chart

### DIFF
--- a/apps/studio/data/analytics/org-daily-stats-query.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.ts
@@ -10,7 +10,7 @@ export enum EgressType {
   AUTH = 'egress_auth',
   STORAGE = 'egress_storage',
   REALTIME = 'egress_realtime',
-  FUNCTIONS = 'egress_functions',
+  FUNCTIONS = 'egress_function',
   SUPAVISOR = 'egress_supavisor',
   LOGDRAIN = 'egress_logdrain',
 }


### PR DESCRIPTION
The daily breakdown chart doesn't show functions egress because the key we're looking for doesn't match the key being sent by API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected analytics data categorization for function egress metrics to ensure accurate reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->