### PR TITLE
fix storage.download() returns stale/cached data after file updates

### DIFF
--- a/apps/docs/content/guides/storage/quickstart.mdx
+++ b/apps/docs/content/guides/storage/quickstart.mdx
@@ -204,11 +204,12 @@ To ensure you get the latest version, create a signed URL and fetch it with `cac
 ```js
 const { data } = await supabase.storage
   .from('avatars')
-  .createSignedUrl('public/avatar1.png', 60)
+  .createSignedUrl('public/avatar1.png', 60) // URL valid for 60 seconds
 
 if (data) {
   const response = await fetch(data.signedUrl, { cache: 'no-store' })
   const blob = await response.blob()
+  // Use blob as needed (e.g., create object URL, read as text, etc.)
 }
 ```
 

--- a/apps/docs/content/guides/storage/quickstart.mdx
+++ b/apps/docs/content/guides/storage/quickstart.mdx
@@ -196,6 +196,24 @@ const { data, error } = await supabase.storage.from('avatars').download('public/
 
 [Reference.](/docs/reference/javascript/storage-from-download)
 
+<Admonition type="note">
+
+The `download` method may return stale data if the file was recently updated, due to caching.
+To ensure you get the latest version, create a signed URL and fetch it with `cache: 'no-store'`:
+
+```js
+const { data } = await supabase.storage
+  .from('avatars')
+  .createSignedUrl('public/avatar1.png', 60)
+
+if (data) {
+  const response = await fetch(data.signedUrl, { cache: 'no-store' })
+  const blob = await response.blob()
+}
+```
+
+</Admonition>
+
 </TabPanel>
 <$Show if="sdk:dart">
 <TabPanel id="dart" label="Dart">


### PR DESCRIPTION
Issue
storage.download() returns stale data because it uses the default fetch behavior which may cache responses, and the method currently provides no way to pass Cache-Control headers or options to opt-out of this caching (e.g. no-store). This is particularly problematic in environments like Supabase Edge Functions (Deno).

Solution
Updated the documentation in 
apps/docs/content/guides/storage/quickstart.mdx
 to provide a verified workaround. The guide now includes an example of using createSignedUrl combined with fetch(..., { cache: 'no-store' }) to ensure fresh data retrieval.

Includes inline comments to clarify URL validity and blob usage, incorporating review feedback for better developer experience.

closes:#41841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Storage Quickstart (JavaScript) download section with an admonition about cached/stale downloads. Adds guidance on obtaining the freshest file by using signed download links and fetching with cache control to bypass caches, and includes a code example demonstrating the approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->