### PR TITLE
Fix incorrect msg_id parameter name in docs (should be `message_id`)

### DIFF
--- a/apps/docs/content/guides/queues/consuming-messages-with-edge-functions.mdx
+++ b/apps/docs/content/guides/queues/consuming-messages-with-edge-functions.mdx
@@ -39,7 +39,7 @@ async function processMessage(message: QueueMessage) {
   // Delete the message from the queue
   const { error: deleteError } = await supabase.schema('pgmq_public').rpc('delete', {
     queue_name: queueName,
-    msg_id: message.msg_id,
+    message_id: message.msg_id,
   })
 
   if (deleteError) {


### PR DESCRIPTION
This PR fixes an error in the documentation where an incorrect parameter name (`msg_id`) is used.

While following the docs and executing the example as-is, an error occurs because the actual RPC parameter name is `message_id`. Updating the documentation ensures the example works correctly and prevents confusion for users.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The documentation uses `msg_id` as a parameter name in the RPC example.
Running the example results in an error because `msg_id` is not a valid parameter.

## What is the new behavior?

The documentation now uses the correct parameter name, `message_id`, matching the actual RPC definition.
The example works correctly when executed.

## Additional context

This issue was discovered while following the documentation step by step and running the provided example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the consuming messages with edge functions guide to reflect parameter naming changes in queue operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->