### PR TITLE
Allow disabling GH integration on project if org is on a free plan

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -448,7 +448,7 @@ const GitHubIntegrationConnectionForm = ({
                           <Button
                             type="default"
                             className="justify-start h-[34px] w-full"
-                            disabled={isLoadingGitHubRepos}
+                            disabled={disabled || isLoadingGitHubRepos}
                             loading={isLoadingGitHubRepos}
                             icon={
                               <div className="bg-black shadow rounded p-1 w-6 h-6 flex justify-center items-center">
@@ -704,7 +704,7 @@ const GitHubIntegrationConnectionForm = ({
                   <Button
                     type="outline"
                     onClick={handleRemoveIntegration}
-                    disabled={disabled || isDeletingConnection}
+                    disabled={isDeletingConnection}
                     loading={isDeletingConnection}
                   >
                     Disable integration

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
@@ -14,7 +14,6 @@ import { useGitHubConnectionsQuery } from 'data/integrations/github-connections-
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-import { cn } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
 import GitHubIntegrationConnectionForm from './GitHubIntegrationConnectionForm'
 
@@ -71,20 +70,21 @@ export const GitHubSection = () => {
                   branch, keep your production branch in sync, and automatically create preview
                   branches for every pull request.
                 </p>
-                {promptProPlanUpgrade ? (
+
+                {promptProPlanUpgrade && (
                   <div className="mb-6">
                     <UpgradeToPro
                       source="github-integration"
                       featureProposition="use GitHub integrations"
-                      primaryText="Upgrade to unlock GitHub integration"
+                      primaryText={`Upgrade to ${!!existingConnection ? 'manage' : 'unlock'} GitHub integration`}
                       secondaryText="Connect your GitHub repository to automatically sync preview branches and deploy changes."
                     />
                   </div>
-                ) : (
-                  <div className={cn(promptProPlanUpgrade && 'opacity-25 pointer-events-none')}>
-                    <GitHubIntegrationConnectionForm connection={existingConnection} />
-                  </div>
                 )}
+                <GitHubIntegrationConnectionForm
+                  disabled={promptProPlanUpgrade}
+                  connection={existingConnection}
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Context

Currently GH integrations for projects is only available for set up while on a paid plan.

However, because we hide the GH connection form behind the plan, if the user downgraded to a free plan, the existing GH connection cannot be removed from the project's settings page (current workaround is to do so via the organization integrations page)

## Changes involved

- Opting to show the GH connection form irregardless of plan (Similar UX to private link)
<img width="946" height="685" alt="image" src="https://github.com/user-attachments/assets/399efb1c-c35c-4e47-a0f2-3058bc063813" />

- Disable field inputs of the connection form if not on a paid plan except the disable integration button
<img width="941" height="679" alt="image" src="https://github.com/user-attachments/assets/c0f2ab43-7e27-4a95-a916-8c0a84785bed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub repository selection button now properly disables when loading repos or when externally disabled.
  * Delete integration button now disables only during deletion operations.

* **User Experience**
  * GitHub integration form displays context-aware upgrade messaging based on connection status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->