### PR TITLE
Fix Auth OAuth apps request error if oauth server has not been configured

### DIFF
--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -71,12 +71,7 @@ export const OAuthAppsList = () => {
   const [filteredClientTypes, setFilteredClientTypes] = useState<string[]>([])
   const deletingOAuthAppIdRef = useRef<string | null>(null)
 
-  const {
-    data,
-    isPending: isLoading,
-    isError,
-    error,
-  } = useOAuthServerAppsQuery({ projectRef }, { enabled: isOAuthServerEnabled })
+  const { data, isPending: isLoading, isError, error } = useOAuthServerAppsQuery({ projectRef })
 
   const { mutateAsync: regenerateSecret, isPending: isRegenerating } =
     useOAuthServerAppRegenerateSecretMutation({
@@ -89,7 +84,7 @@ export const OAuthAppsList = () => {
 
   const { data: endpointData } = useProjectEndpointQuery({ projectRef })
 
-  const oAuthApps = data?.clients || []
+  const oAuthApps = useMemo(() => data?.clients || [], [data])
 
   const [showCreateSheet, setShowCreateSheet] = useQueryState(
     'new',

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
@@ -78,7 +78,6 @@ export const OAuthServerSettingsForm = () => {
     isPending: isAuthConfigLoading,
     isSuccess,
   } = useAuthConfigQuery({ projectRef })
-  const isOAuthServerEnabled = !!authConfig?.OAUTH_SERVER_ENABLED
 
   const { mutate: updateAuthConfig, isPending } = useAuthConfigUpdateMutation({
     onSuccess: () => {

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
@@ -72,11 +72,14 @@ interface OAuthServerSettings {
 
 export const OAuthServerSettingsForm = () => {
   const { ref: projectRef } = useParams()
+
   const {
     data: authConfig,
     isPending: isAuthConfigLoading,
     isSuccess,
   } = useAuthConfigQuery({ projectRef })
+  const isOAuthServerEnabled = !!authConfig?.OAUTH_SERVER_ENABLED
+
   const { mutate: updateAuthConfig, isPending } = useAuthConfigUpdateMutation({
     onSuccess: () => {
       toast.success('OAuth server settings updated successfully')


### PR DESCRIPTION
## Context

Addresses the `Failed to retrieve OAuth Server apps` `Unexpected non-whitespace character after JSON` errors

The following error shows up on the Auth OAuth Apps page if you were to 
- Land on `/oauth-apps`
- Navigate to `/oauth-server`
- Then head back to `/oauth-apps`

<img width="735" height="299" alt="image" src="https://github.com/user-attachments/assets/b714ecef-0747-4e34-a992-1a9282ddc7a1" />

For context 
- `useOAuthServerAppsQuery` is being called on both OAuth Apps and OAuth server pages
  - However the request will return a `text/plain` 404 if the OAuth server has yet to be configured
- On the OAuth Apps page, there's an `enabled` check that validates if the OAuth server has been configured before firing a request to fetch the OAuth apps, but the `enabled` check is missing on the OAuth server page
- Hence why the odd repro steps

## Changes involved
- Shift checking of auth config into `useOAuthServerAppsQuery`

## To test
- [ ] Verify that the error no longer shows up when reproducing the steps above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of OAuth server availability to avoid unnecessary requests and ensure OAuth apps load only when the server is enabled.
  * Fixed conditional data loading so OAuth apps are fetched only when all required config and endpoints are present.
* **Refactor**
  * Optimized OAuth apps list access using a memoized selector for more efficient dependency tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->