### PR TITLE
fix(studio): function form reset only after open or change

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -139,17 +139,7 @@ export const CreateFunction = ({
   }
 
   useEffect(() => {
-    if (!visible) {
-      // Reset tracking when panel closes
-      lastInitializedFuncIdRef.current = undefined
-      return
-    }
-
-    const funcId = func?.id
-    const shouldReset =
-      lastInitializedFuncIdRef.current === undefined || funcId !== lastInitializedFuncIdRef.current
-
-    if (shouldReset) {
+    if (visible) {
       setFocusedEditor(false)
       form.reset({
         name: func?.name ?? '',
@@ -162,7 +152,6 @@ export const CreateFunction = ({
         security_definer: func?.security_definer ?? false,
         config_params: convertConfigParams(func?.config_params).value,
       })
-      lastInitializedFuncIdRef.current = funcId
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, func?.id])

--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { isEmpty, isNull, keyBy, mapValues, partition } from 'lodash'
 import { Plus, Trash } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import z from 'zod'
@@ -79,6 +79,8 @@ export const CreateFunction = ({
   const { data: project } = useSelectedProjectQuery()
   const [advancedSettingsShown, setAdvancedSettingsShown] = useState(false)
   const [focusedEditor, setFocusedEditor] = useState(false)
+  const lastInitializedFuncIdRef = useRef<number | undefined>(undefined)
+  const wasVisibleRef = useRef(false)
 
   const isEditing = !isDuplicating && !!func?.id
 
@@ -138,21 +140,35 @@ export const CreateFunction = ({
   }
 
   useEffect(() => {
+    const funcId = func?.id
+    const isOpening = visible && !wasVisibleRef.current
+    const funcChanged = funcId !== lastInitializedFuncIdRef.current
+
     if (visible) {
-      setFocusedEditor(false)
-      form.reset({
-        name: func?.name ?? '',
-        schema: func?.schema ?? 'public',
-        args: convertArgumentTypes(func?.argument_types || '').value,
-        behavior: func?.behavior ?? 'VOLATILE',
-        definition: func?.definition ?? '',
-        language: func?.language ?? 'plpgsql',
-        return_type: func?.return_type ?? 'void',
-        security_definer: func?.security_definer ?? false,
-        config_params: convertConfigParams(func?.config_params).value,
-      })
+      // Only reset if panel is opening or function ID actually changed
+      if (isOpening || funcChanged) {
+        setFocusedEditor(false)
+        form.reset({
+          name: func?.name ?? '',
+          schema: func?.schema ?? 'public',
+          args: convertArgumentTypes(func?.argument_types || '').value,
+          behavior: func?.behavior ?? 'VOLATILE',
+          definition: func?.definition ?? '',
+          language: func?.language ?? 'plpgsql',
+          return_type: func?.return_type ?? 'void',
+          security_definer: func?.security_definer ?? false,
+          config_params: convertConfigParams(func?.config_params).value,
+        })
+        lastInitializedFuncIdRef.current = funcId
+      }
+      wasVisibleRef.current = true
+    } else {
+      // Reset tracking when panel closes
+      wasVisibleRef.current = false
+      lastInitializedFuncIdRef.current = undefined
     }
-  }, [visible, func])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, func?.id])
 
   const { data: protectedSchemas } = useProtectedSchemas()
 

--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -80,7 +80,6 @@ export const CreateFunction = ({
   const [advancedSettingsShown, setAdvancedSettingsShown] = useState(false)
   const [focusedEditor, setFocusedEditor] = useState(false)
   const lastInitializedFuncIdRef = useRef<number | undefined>(undefined)
-  const wasVisibleRef = useRef(false)
 
   const isEditing = !isDuplicating && !!func?.id
 
@@ -140,32 +139,30 @@ export const CreateFunction = ({
   }
 
   useEffect(() => {
-    const funcId = func?.id
-    const isOpening = visible && !wasVisibleRef.current
-    const funcChanged = funcId !== lastInitializedFuncIdRef.current
-
-    if (visible) {
-      // Only reset if panel is opening or function ID actually changed
-      if (isOpening || funcChanged) {
-        setFocusedEditor(false)
-        form.reset({
-          name: func?.name ?? '',
-          schema: func?.schema ?? 'public',
-          args: convertArgumentTypes(func?.argument_types || '').value,
-          behavior: func?.behavior ?? 'VOLATILE',
-          definition: func?.definition ?? '',
-          language: func?.language ?? 'plpgsql',
-          return_type: func?.return_type ?? 'void',
-          security_definer: func?.security_definer ?? false,
-          config_params: convertConfigParams(func?.config_params).value,
-        })
-        lastInitializedFuncIdRef.current = funcId
-      }
-      wasVisibleRef.current = true
-    } else {
+    if (!visible) {
       // Reset tracking when panel closes
-      wasVisibleRef.current = false
       lastInitializedFuncIdRef.current = undefined
+      return
+    }
+
+    const funcId = func?.id
+    const shouldReset =
+      lastInitializedFuncIdRef.current === undefined || funcId !== lastInitializedFuncIdRef.current
+
+    if (shouldReset) {
+      setFocusedEditor(false)
+      form.reset({
+        name: func?.name ?? '',
+        schema: func?.schema ?? 'public',
+        args: convertArgumentTypes(func?.argument_types || '').value,
+        behavior: func?.behavior ?? 'VOLATILE',
+        definition: func?.definition ?? '',
+        language: func?.language ?? 'plpgsql',
+        return_type: func?.return_type ?? 'void',
+        security_definer: func?.security_definer ?? false,
+        config_params: convertConfigParams(func?.config_params).value,
+      })
+      lastInitializedFuncIdRef.current = funcId
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, func?.id])

--- a/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/CreateFunction/index.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { isEmpty, isNull, keyBy, mapValues, partition } from 'lodash'
 import { Plus, Trash } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import z from 'zod'
@@ -79,7 +79,6 @@ export const CreateFunction = ({
   const { data: project } = useSelectedProjectQuery()
   const [advancedSettingsShown, setAdvancedSettingsShown] = useState(false)
   const [focusedEditor, setFocusedEditor] = useState(false)
-  const lastInitializedFuncIdRef = useRef<number | undefined>(undefined)
 
   const isEditing = !isDuplicating && !!func?.id
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix
- Resolves DEPR-323

## What is the current behavior?

1. Navigate to [Database Functions](http://localhost:8082/project/_/database/functions)
2. Duplicate an existing function, which should open a sheet
3. Add 1+ new arguments, leave the sheet open
4. Blur focus (open a new tab, different window, wait a minute)
5. Come back and notice how the new, unsaved, arguments disappear

This bug exists because the `useEffect` depends on the entire `func` object, which changes often and therefore resets the form.

## What is the new behavior?

- Changed the dependency array from `[visible, func]` to `[visible, func?.id]` to track the function ID instead of the object reference
- Only resets the form when:
	- The panel opens (first time), or
	- The function ID changes (switching to a different function)

## To test

Please run through steps 1–5 on both `master` (or prod) vs this branch to see the difference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form state management in the database function creation panel: the form now reliably resets when the panel opens/closes and correctly repopulates when switching between different functions, preventing stale or incorrect values from appearing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->