### PR TITLE
docs(auth): Add OAuth example to SvelteKit SSR guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -352,7 +352,9 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      return redirect(303, `/${next.slice(1)}`)
+      // Normalize redirect path - ensure it starts with /
+      const redirectTo = next.startsWith('/') ? next : `/${next}`
+      return redirect(303, redirectTo)
     }
   }
 

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -303,12 +303,77 @@ language="typescript"
 />
 </$CodeTabs>
 
+### Sign in with OAuth
+
+To sign in with an OAuth provider (like Google, GitHub, etc.), create a form action that calls `signInWithOAuth` and redirects to the provider's authentication page.
+
+```ts name=src/routes/login/+page.server.ts
+import { redirect } from '@sveltejs/kit'
+import type { Actions } from './$types'
+
+export const actions: Actions = {
+  signInWithOAuth: async ({ locals: { supabase }, url }) => {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'github', // or 'google', 'discord', etc.
+      options: {
+        redirectTo: `${url.origin}/auth/callback`
+      }
+    })
+
+    if (error) {
+      console.error(error)
+      return redirect(303, '/auth/error')
+    }
+
+    // Redirect to the OAuth provider
+    return redirect(303, data.url)
+  }
+}
+```
+
+Then create a form to trigger the action:
+
+```svelte name=src/routes/login/+page.svelte
+<form method="POST" action="?/signInWithOAuth">
+  <button type="submit">Sign in with GitHub</button>
+</form>
+```
+
+After the user authenticates with the OAuth provider, they'll be redirected back to your callback route. Create a callback route to handle the code exchange:
+
+```ts name=src/routes/auth/callback/+server.ts
+import { redirect } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+  const code = url.searchParams.get('code')
+  const next = url.searchParams.get('next') ?? '/'
+
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      return redirect(303, `/${next.slice(1)}`)
+    }
+  }
+
+  // Return the user to an error page with instructions
+  return redirect(303, '/auth/error')
+}
+```
+
+<Admonition type="tip">
+
+Make sure to add your callback URL (`http://localhost:5173/auth/callback` for local development) to your [redirect allow list](/docs/guides/auth/redirect-urls) in the Supabase dashboard.
+
+</Admonition>
+
 ## Congratulations
 
 You're done! To recap, you've successfully:
 
 - Set up server-side hooks to create a request-specific Supabase client and guard protected pages.
 - Created a Supabase client in your root layout to use on both the client and server.
+- Set up OAuth authentication with a callback route to exchange the auth code for a session.
 
 You can now use any Supabase features from your client or server code!
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement - adds OAuth example to SvelteKit SSR guide.

## What is the current behavior?

The SvelteKit SSR guide at `/guides/auth/server-side/creating-a-client` shows how to set up the Supabase client with server-side hooks and layout, but doesn't include an example of how to implement OAuth authentication.

Users found it difficult to figure out how to:
1. Call `signInWithOAuth` from a SvelteKit form action
2. Redirect to `data.url` to initiate the OAuth flow
3. Handle the callback to exchange the auth code

## What is the new behavior?

Adds a complete "Sign in with OAuth" section to the SvelteKit tab with:

1. **Form action** (`+page.server.ts`) - Shows how to call `signInWithOAuth` and redirect to the provider
2. **Form component** (`+page.svelte`) - Simple form to trigger the OAuth flow
3. **Callback route** (`auth/callback/+server.ts`) - Handles the code exchange
4. **Tip** - Reminder to add callback URL to redirect allow list

## Additional context

Fixes #23618

The example follows the same patterns used in the existing SvelteKit documentation and is consistent with how OAuth is documented for other frameworks (Next.js, Astro, Remix) in the codebase.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Sign in with OAuth" guide showing the full server-side OAuth sign-in flow, client trigger form, callback exchange, and redirect URL guidance.
  * Updated the Congratulations/finish sections to include OAuth setup guidance across the SvelteKit and server-side auth guides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->