### PR TITLE
chore(studio): hide pg stat monitor from extensions list

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
@@ -14,6 +14,7 @@ export const HIDDEN_EXTENSIONS = [
   'intagg',
   'xml2',
   'pg_tle',
+  'pg_stat_monitor',
 ]
 
 export const SEARCH_TERMS: Record<string, string[]> = {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

As the extension doesn't currently work as expected, hiding it for the timebeing.

cc @soedirgo 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `pg_stat_monitor` extension is now hidden from the database extensions list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->