### PR TITLE
Add alert dialog when toggling SSL enforcement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -165,11 +165,11 @@ const SSLConfiguration = () => {
                 <AlertDialogContent size="medium">
                   <AlertDialogHeader>
                     <AlertDialogTitle>
-                      Updating SSL enforcement requires a brief database reboot
+                      Updating SSL enforcement involves a brief downtime
                     </AlertDialogTitle>
                     <AlertDialogDescription>
-                      This restarts only the database and involves a few minutes of downtime. Would
-                      you like to proceed now?
+                      A database restart is required for SSL enforcement changes to take place, and
+                      this involves a few minutes of downtime. Confirm to proceed now?
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -18,6 +18,15 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
 import {
   Alert,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
   Button,
   Card,
   CardContent,
@@ -28,10 +37,10 @@ import {
 } from 'ui'
 import {
   PageSection,
+  PageSectionContent,
   PageSectionMeta,
   PageSectionSummary,
   PageSectionTitle,
-  PageSectionContent,
 } from 'ui-patterns'
 import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 
@@ -117,40 +126,64 @@ const SSLConfiguration = () => {
               label="Enforce SSL on incoming connections"
               description="Reject non-SSL connections to your database"
             >
-              <div className="flex items-center justify-end mt-2.5 space-x-2">
-                {(isLoading || isSubmitting) && (
-                  <Loader2 className="animate-spin" strokeWidth={1.5} size={16} />
-                )}
-                {isSuccess && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
-                      <div>
-                        <Switch
-                          size="large"
-                          checked={isEnforced}
-                          disabled={
-                            isLoading ||
-                            isSubmitting ||
-                            !canUpdateSSLEnforcement ||
-                            !hasAccessToSSLEnforcement
-                          }
-                          onCheckedChange={toggleSSLEnforcement}
-                        />
-                      </div>
-                    </TooltipTrigger>
-                    {(!canUpdateSSLEnforcement || !hasAccessToSSLEnforcement) && (
-                      <TooltipContent side="bottom" className="w-64 text-center">
-                        {!canUpdateSSLEnforcement
-                          ? 'You need additional permissions to update SSL enforcement for your project'
-                          : !hasAccessToSSLEnforcement
-                            ? 'Your project does not have access to SSL enforcement'
-                            : undefined}
-                      </TooltipContent>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <div className="flex items-center justify-end mt-2.5 space-x-2">
+                    {(isLoading || isSubmitting) && (
+                      <Loader2 className="animate-spin" strokeWidth={1.5} size={16} />
                     )}
-                  </Tooltip>
-                )}
-              </div>
+                    {isSuccess && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
+                          <div>
+                            <Switch
+                              size="large"
+                              checked={isEnforced}
+                              disabled={
+                                isLoading ||
+                                isSubmitting ||
+                                !canUpdateSSLEnforcement ||
+                                !hasAccessToSSLEnforcement
+                              }
+                            />
+                          </div>
+                        </TooltipTrigger>
+                        {(!canUpdateSSLEnforcement || !hasAccessToSSLEnforcement) && (
+                          <TooltipContent side="bottom" className="w-64 text-center">
+                            {!canUpdateSSLEnforcement
+                              ? 'You need additional permissions to update SSL enforcement for your project'
+                              : !hasAccessToSSLEnforcement
+                                ? 'Your project does not have access to SSL enforcement'
+                                : undefined}
+                          </TooltipContent>
+                        )}
+                      </Tooltip>
+                    )}
+                  </div>
+                </AlertDialogTrigger>
+                <AlertDialogContent size="medium">
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      Updating SSL enforcement requires a brief database reboot
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This restarts only the database and involves a few minutes of downtime. Would
+                      you like to proceed now?
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      variant="warning"
+                      disabled={isSubmitting}
+                      onClick={toggleSSLEnforcement}
+                    >
+                      {!isEnforced ? 'Enable SSL' : 'Disable SSL'}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </FormLayout>
             {isSuccess && !sslEnforcementConfiguration?.appliedSuccessfully && (
               <Alert


### PR DESCRIPTION
Resolves FE-2356

## Context

Updating SSL enforcement within the database settings triggers a fast database reboot, but there's no warning or indication in the dashboard to inform the users of that.

## Changes involved

Makes toggling SSL enforcement into a 2 step UX with AlertDialog (Applies for both enabling and disabling SSL)

<img width="600" height="247" alt="image" src="https://github.com/user-attachments/assets/419e154f-662b-4cde-a024-02c8e7dfa3c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSL configuration now requires confirmation via a modal dialog before enabling or disabling SSL, including clear header, description, and confirm/cancel actions.
  * Loading and success states preserved; tooltip and disabled/permission messaging remain visible when applicable.

* **Refactor**
  * Interactive toggle flow reorganized to present the confirmation dialog first, improving safety and clarity of SSL changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->