### PR TITLE
Update NoticeBanner content for scheduled maintenance

### DIFF
--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { useAppBannerContext } from 'components/interfaces/App/AppBannerWrapperContext'
 import { HeaderBanner } from 'components/interfaces/Organization/HeaderBanner'
 import { InlineLink } from 'components/ui/InlineLink'
+import { TimestampInfo } from 'ui-patterns'
 
 /**
  * Used to display urgent notices that apply for all users, such as maintenance windows.
@@ -20,16 +21,21 @@ export const NoticeBanner = () => {
   return (
     <HeaderBanner
       variant="warning"
-      title="Urgent dashboard and management API maintenance"
+      title="Upcoming Dashboard and Management API maintenance"
       description={
         <>
-          23:00 UTC Nov 21–23, 2025.{' '}
-          <InlineLink href="https://status.supabase.com/incidents/z0l2157y33xk">
+          <TimestampInfo
+            className="text-sm"
+            utcTimestamp={1768530600000}
+            label="02:30 UTC on Jan 16, 2026"
+          />
+          .{' '}
+          <InlineLink href="https://status.supabase.com/incidents/lg4j8mcn50zb">
             Learn more
           </InlineLink>
         </>
       }
-      onDismiss={() => onUpdateAcknowledged('maintenance-window-banner-2025-11-21')}
+      onDismiss={() => onUpdateAcknowledged('maintenance-window-banner-2026-01-16')}
     />
   )
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -68,7 +68,7 @@ export const LOCAL_STORAGE_KEYS = {
   // Notice banner keys
   FLY_POSTGRES_DEPRECATION_WARNING: 'fly-postgres-deprecation-warning-dismissed',
   API_KEYS_FEEDBACK_DISMISSED: (ref: string) => `supabase-api-keys-feedback-dismissed-${ref}`,
-  MAINTENANCE_WINDOW_BANNER: 'maintenance-window-banner-2025-11-21',
+  MAINTENANCE_WINDOW_BANNER: 'maintenance-window-banner-2026-01-16',
   REPORT_DATERANGE: 'supabase-report-daterange',
 
   // api keys view switcher for new and legacy api keys


### PR DESCRIPTION
## Context

We've got a scheduled dashboard and API maintenance on Friday as per our [status page](https://status.supabase.com/incidents/lg4j8mcn50zb)

Changes here just updates the banner to show that - we'll also need to toggle the notice banner once this changes goes live

<img width="1946" height="294" alt="image" src="https://github.com/user-attachments/assets/78c6452f-3a9c-4ae1-b098-70eafc823237" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated maintenance notification with new scheduled date and improved timestamp display.
  * Changed banner messaging from "Urgent" to "Upcoming" to better reflect the maintenance status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->