### PR TITLE
feat(billing): use entitlements for replication access

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import { useReplicationSourcesQuery } from '@/data/replication/sources-query'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useFlag, useParams } from 'common'
 import {
   cn,
@@ -41,6 +42,7 @@ export const DestinationPanel = ({
 }: DestinationPanelProps) => {
   const { ref: projectRef } = useParams()
   const unifiedReplication = useFlag('unifiedReplication')
+  const { hasAccess: hasReplicationAccess } = useCheckEntitlements('replication.etl')
 
   const [selectedType, setSelectedType] = useState<DestinationType>(
     type || (unifiedReplication ? 'Read Replica' : 'BigQuery')
@@ -84,7 +86,11 @@ export const DestinationPanel = ({
               <ReadReplicaForm onClose={onClose} onSuccess={() => onSuccessCreateReadReplica?.()} />
             ) : unifiedReplication && replicationNotEnabled ? (
               <SheetSection>
-                <EnableReplicationCallout className="!p-6" type={selectedType} />
+                <EnableReplicationCallout
+                  className="!p-6"
+                  type={selectedType}
+                  hasAccess={hasReplicationAccess}
+                />
               </SheetSection>
             ) : (
               <DestinationForm

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -42,7 +42,7 @@ export const DestinationPanel = ({
 }: DestinationPanelProps) => {
   const { ref: projectRef } = useParams()
   const unifiedReplication = useFlag('unifiedReplication')
-  const { hasAccess: hasReplicationAccess } = useCheckEntitlements('replication.etl')
+  const { hasAccess: hasETLReplicationAccess } = useCheckEntitlements('replication.etl')
 
   const [selectedType, setSelectedType] = useState<DestinationType>(
     type || (unifiedReplication ? 'Read Replica' : 'BigQuery')
@@ -89,7 +89,7 @@ export const DestinationPanel = ({
                 <EnableReplicationCallout
                   className="!p-6"
                   type={selectedType}
-                  hasAccess={hasReplicationAccess}
+                  hasAccess={hasETLReplicationAccess}
                 />
               </SheetSection>
             ) : (

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -41,7 +41,7 @@ import { ReadReplicaRow } from './ReadReplicas/ReadReplicaRow'
 export const Destinations = () => {
   const queryClient = useQueryClient()
   const { ref: projectRef } = useParams()
-  const { hasAccess: hasReplicationAccess, isLoading: isLoadingEntitlement } =
+  const { hasAccess: hasETLReplicationAccess, isLoading: isLoadingEntitlement } =
     useCheckEntitlements('replication.etl')
 
   const unifiedReplication = useFlag('unifiedReplication')
@@ -217,7 +217,7 @@ export const Destinations = () => {
         {isLoading ? (
           <GenericSkeletonLoader />
         ) : !unifiedReplication && replicationNotEnabled ? (
-          <EnableReplicationCallout hasAccess={hasReplicationAccess} />
+          <EnableReplicationCallout hasAccess={hasETLReplicationAccess} />
         ) : (unifiedReplication && hasReplicas) || hasDestinations ? (
           <Card>
             <CardContent className="p-0">

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -15,7 +15,7 @@ import { replicationKeys } from 'data/replication/keys'
 import { fetchReplicationPipelineVersion } from 'data/replication/pipeline-version-query'
 import { useReplicationPipelinesQuery } from 'data/replication/pipelines-query'
 import { useReplicationSourcesQuery } from 'data/replication/sources-query'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { DOCS_URL } from 'lib/constants'
 import {
   Button,
@@ -41,7 +41,8 @@ import { ReadReplicaRow } from './ReadReplicas/ReadReplicaRow'
 export const Destinations = () => {
   const queryClient = useQueryClient()
   const { ref: projectRef } = useParams()
-  const { data: organization } = useSelectedOrganizationQuery()
+  const { hasAccess: hasReplicationAccess, isLoading: isLoadingEntitlement } =
+    useCheckEntitlements('replication.etl')
 
   const unifiedReplication = useFlag('unifiedReplication')
 
@@ -110,7 +111,8 @@ export const Destinations = () => {
     projectRef,
   })
 
-  const isLoading = isSourcesLoading || isDestinationsLoading || isDatabasesLoading
+  const isLoading =
+    isSourcesLoading || isDestinationsLoading || isDatabasesLoading || isLoadingEntitlement
   const hasErrorsFetchingData = isSourcesError || isDestinationsError || isDatabasesError
 
   useEffect(() => {
@@ -215,7 +217,7 @@ export const Destinations = () => {
         {isLoading ? (
           <GenericSkeletonLoader />
         ) : !unifiedReplication && replicationNotEnabled ? (
-          <EnableReplicationCallout />
+          <EnableReplicationCallout hasAccess={hasReplicationAccess} />
         ) : (unifiedReplication && hasReplicas) || hasDestinations ? (
           <Card>
             <CardContent className="p-0">

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -93,7 +93,7 @@ export const Destinations = () => {
     projectRef,
   })
   const destinations = destinationsData?.destinations ?? []
-  const hasDestinations = isDestinationsSuccess && destinationsData.destinations.length > 0
+  const hasDestinations = isDestinationsSuccess && destinationsData?.destinations.length > 0
   const filteredDestinations =
     filterString.length === 0
       ? destinations ?? []

--- a/apps/studio/components/interfaces/Database/Replication/EnableReplicationCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/EnableReplicationCallout.tsx
@@ -3,7 +3,6 @@ import { toast } from 'sonner'
 
 import { DocsButton } from '@/components/ui/DocsButton'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
 import { useParams } from 'common'
 import { useCreateTenantSourceMutation } from 'data/replication/create-tenant-source-mutation'
@@ -85,24 +84,23 @@ const EnableReplicationModal = () => {
 export const EnableReplicationCallout = ({
   type,
   className,
+  hasAccess,
 }: {
   type?: string
   className?: string
+  hasAccess: boolean
 }) => {
-  const { data: organization, isSuccess } = useSelectedOrganizationQuery()
-  const isPaidPlan = isSuccess && organization?.plan.id !== 'free'
-
   return (
     <div className={cn('border rounded-md p-4 md:p-12 flex flex-col gap-y-4', className)}>
       <div className="flex flex-col gap-y-1">
         <h3>Replicate data to external destinations in real-time</h3>
         <p className="text-sm text-foreground-light">
-          {isPaidPlan ? 'Enable replication' : 'Upgrade to the Pro plan'} to start replicating your
+          {hasAccess ? 'Enable replication' : 'Upgrade to the Pro plan'} to start replicating your
           database changes to {type ?? 'data warehouses and analytics platforms'}
         </p>
       </div>
       <div className="flex gap-x-2">
-        {isPaidPlan ? (
+        {hasAccess ? (
           <EnableReplicationModal />
         ) : (
           <UpgradePlanButton source="replication" featureProposition="use replication" />


### PR DESCRIPTION
## Summary

This PR updates the Database Replication UI to use the `replication.etl` entitlement API instead of hardcoded plan checks.

## Test Plan

### Initial Setup

Apply this patch to test locally (since we can't fetch replication sources/destinations in local dev):

```diff
diff --git a/apps/studio/data/replication/destinations-query.ts b/apps/studio/data/replication/destinations-query.ts
index 961c49ebc7..f729c418c0 100644
--- a/apps/studio/data/replication/destinations-query.ts
+++ b/apps/studio/data/replication/destinations-query.ts
@@ -13,6 +13,9 @@ async function fetchReplicationDestinations(
 ) {
   if (!projectRef) throw new Error('projectRef is required')

+  return { destinations: [] }
+
   const { data, error } = await get('/platform/replication/{ref}/destinations', {
     params: { path: { ref: projectRef } },
     signal,
diff --git a/apps/studio/data/replication/sources-query.ts b/apps/studio/data/replication/sources-query.ts
index 54e5a94298..b9550b388f 100644
--- a/apps/studio/data/replication/sources-query.ts
+++ b/apps/studio/data/replication/sources-query.ts
@@ -13,6 +13,9 @@ async function fetchReplicationSources(
 ) {
   if (!projectRef) throw new Error('projectRef is required')

+  return { sources: [] }
+
   const { data, error } = await get('/platform/replication/{ref}/sources', {
     params: { path: { ref: projectRef } },
     signal,
```

### Test Scenarios

#### Scenario 1: Free Organization (Unified Replication Enabled)

1. Navigate to Database > Replication
2. "Add destination" button should be visible
3. Click "Add destination"
4. Panel should open up with "Read Replica" selected by default
5. Switch to "BigQuery" or "Analytics Bucket"
6. Should show "Upgrade to the Pro plan" callout in panel

#### Scenario 2: Pro/Team/Enterprise Organization (Unified Replication Enabled)

1. Navigate to Database > Replication
2. "Add destination" button should be visible
3. Click "Add destination"
4. Panel should open up with "Read Replica" selected by default
5. Switch to "BigQuery" or "Analytics Bucket"
6. Should show "Enable replication" callout in panel

#### Scenario 3: Free Organization (Unified Replication Disabled)

1. Disable the `unifiedReplication` frontend flag from ConfigCat for the local environment
2. Wait a couple of minutes for the changes to reflect
3. Navigate to Database > Replication in Studio
4. Should see "Upgrade to the Pro plan" callout on the main page
5. Clicking on the button should update the subscription upgrade panel

#### Scenario 4: Pro/Team/Enterprise Organization (Unified Replication Disabled)

1. Disable the `unifiedReplication` frontend flag from ConfigCat for the local environment
2. Wait a couple of minutes for the changes to reflect
3. Navigate to Database > Replication in Studio
4. Expected: Should see "Enable replication" callout on the main page
5. Clicking the button should open a modal allowing you to add a destination


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replication UI now validates user entitlements before allowing enablement.
* **User Experience**
  * Improved messaging for users without replication access, showing appropriate upgrade or enablement prompts.
  * Enable controls and modals now reflect actual access status.
* **Stability**
  * Loading behavior enhanced to include entitlement checks so UI state is consistent during load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->