### PR TITLE
docs(auth): clarify local OAuth callback URLs for Azure, Google, and LinkedIn

### DIFF
--- a/apps/docs/content/_partials/social_provider_setup.mdx
+++ b/apps/docs/content/_partials/social_provider_setup.mdx
@@ -7,6 +7,17 @@ The next step requires a callback URL, which looks like this: `https://<project-
 
 <Admonition type="note">
 
+#### Local development
+
+When testing OAuth locally with the Supabase CLI, ensure your OAuth provider
+is configured with the local Supabase Auth callback URL:
+
+http://localhost:54321/auth/v1/callback
+
+If this callback URL is missing or misconfigured, OAuth sign-in may fail or not redirect correctly during local development.
+
+See the [local development docs](/docs/guides/local-development) for more details.
+
 For testing OAuth locally with the Supabase CLI see the [local development docs](/docs/guides/local-development).
 
 </Admonition>

--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -31,6 +31,19 @@ Setting up OAuth with Azure consists of four broad steps:
 
 ## Obtain a client ID and secret
 
+### Local development with Azure OAuth
+
+Azure does not allow `127.0.0.1` as a redirect URI hostname and requires
+the use of `localhost`.
+
+To enable Azure OAuth during local Supabase development, configure the
+Supabase API external URL in your `config.toml`:
+
+```toml
+[api]
+external_url = "http://localhost:54321"
+```
+
 - Once your app has been registered, the client ID can be found under the [list of app registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps) under the column titled _Application (client) ID_.
 - You can also find it in the app overview screen.
 - Place the Client ID in the Azure configuration screen in the Supabase Auth dashboard.

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -67,7 +67,7 @@ Regardless of whether you use application code or Google's pre-built solutions t
    - Add `http://localhost:<port>` while developing locally. Remember to remove this when your application [goes into production](/docs/guides/deployment/going-into-prod).
 1. Under **Authorized redirect URIs** add your Supabase project's callback URL.
    - Access it from the [Google provider page on the Dashboard](/dashboard/project/_/auth/providers?provider=Google).
-   - For local development, use `http://localhost:3000/auth/v1/callback`.
+   - For local development, use `http://127.0.0.1:54321/auth/v1/callback`.
 1. Click `Create` and make sure you save the Client ID and Client Secret.
    - Add these values to the [Google provider page on the Dashboard](/dashboard/project/_/auth/providers?provider=Google).
 

--- a/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
@@ -23,6 +23,9 @@ Setting up LinkedIn logins for your application consists of 3 parts:
 
 ## Find your callback URL
 
+For local OAuth testing, ensure your provider is configured with the correct
+Supabase Auth callback URL as shown above.
+
 <$Partial path="social_provider_setup.mdx" variables={{ "provider": "LinkedIn" }} />
 
 ## Create a LinkedIn OAuth app

--- a/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
@@ -23,9 +23,6 @@ Setting up LinkedIn logins for your application consists of 3 parts:
 
 ## Find your callback URL
 
-For local OAuth testing, ensure your provider is configured with the correct
-Supabase Auth callback URL as shown above.
-
 <$Partial path="social_provider_setup.mdx" variables={{ "provider": "LinkedIn" }} />
 
 ## Create a LinkedIn OAuth app


### PR DESCRIPTION
### Summary
This PR clarifies local OAuth callback URL configuration across Azure, Google,
and LinkedIn authentication docs.

### Changes
- Documented the required `external_url` config for Azure OAuth local development
  due to Azure not allowing `127.0.0.1` as a redirect URI.
- Corrected the Google local redirect URI to match Supabase CLI defaults.
- Clarified LinkedIn local OAuth callback expectations.

### Why
These mismatches currently cause OAuth failures during local development and
are a common source of confusion when setting up social login with Supabase CLI.

fixes #41883 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Azure OAuth local development setup with configuration guidance.
  * Updated Google OAuth local development redirect URI specifications.
  * Improved social login local testing documentation with callback URL details and configuration warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->