### PR TITLE
fix(studio): table editor sidebar toggle on mobile

### DIFF
--- a/apps/studio/components/layouts/Tabs/CollapseButton.tsx
+++ b/apps/studio/components/layouts/Tabs/CollapseButton.tsx
@@ -2,9 +2,19 @@ import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 
 import { useAppStateSnapshot } from 'state/app-state'
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { useBreakpoint } from 'common'
 
 export function CollapseButton({ hideTabs }: { hideTabs: boolean }) {
-  const { showSidebar, setShowSidebar } = useAppStateSnapshot()
+  const { showSidebar, setShowSidebar, mobileMenuOpen, setMobileMenuOpen } = useAppStateSnapshot()
+  const isMobile = useBreakpoint('md')
+
+  const handleToggle = () => {
+    if (isMobile) {
+      setMobileMenuOpen(!mobileMenuOpen)
+    } else {
+      setShowSidebar(!showSidebar)
+    }
+  }
 
   return (
     <Tooltip>
@@ -14,7 +24,7 @@ export function CollapseButton({ hideTabs }: { hideTabs: boolean }) {
             'flex items-center justify-center w-10 h-10 hover:bg-surface-100 shrink-0',
             !hideTabs && 'border-b border-b-default'
           )}
-          onClick={() => setShowSidebar(!showSidebar)}
+          onClick={handleToggle}
         >
           {showSidebar ? (
             <PanelLeftClose


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

In smaller viewports, our collapse button for the Table Editor sidebar wasn't working. This patches it to open on smaller viewports as well. Original report of this came from user feedback, should be fixed now 🙏 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced collapse button with responsive design that properly adapts functionality across mobile and desktop devices, improving user interaction on all screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->