### PR TITLE
fix(studio): clear storage file list when switching buckets

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -162,6 +162,7 @@ function createStorageExplorerState({
     selectedBucket: {} as Bucket,
     setSelectedBucket: (bucket: Bucket) => {
       state.selectedBucket = bucket
+      state.columns = []
       state.setSelectedFilePreview(undefined)
       state.clearOpenedFolders()
       state.clearSelectedItems()


### PR DESCRIPTION
### Summary
Fixes cached/stale file list showing when navigating between storage buckets in the Dashboard.

### Problem
When switching from one bucket to another, the UI briefly displayed the previous bucket's files instead of showing a loading state. This happened because setSelectedBucket() cleared openedFolders and selectedItems but not the columns array that holds the file list data.

### Solution
Clear the columns array in setSelectedBucket() so the UI shows a loading state while fetching the new bucket's contents.

### Related
- Closes https://github.com/supabase/supabase/issues/41884


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where column settings from a previously selected bucket would persist when switching to a new bucket in the storage explorer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->