### PR TITLE
docs: add OAuth redirect example for SvelteKit SSR

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -303,6 +303,35 @@ language="typescript"
 />
 </$CodeTabs>
 
+### Using OAuth with SvelteKit SSR
+
+When using OAuth providers (such as GitHub or Google) in a SvelteKit app with SSR, the `signInWithOAuth` method returns a URL that the user must be redirected to in order to complete the authentication flow.
+
+In SvelteKit, this redirect must be handled on the server using the `redirect` helper.
+
+For example, using a server action:
+
+```ts
+import { redirect } from '@sveltejs/kit'
+
+export const actions = {
+  signInWithOAuth: async ({ locals }) => {
+    const { data, error } = await locals.supabase.auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'http://localhost:5173/auth/callback',
+      },
+    })
+
+    if (error) {
+      console.error(error)
+      throw redirect(303, '/auth/error')
+    }
+
+    throw redirect(303, data.url)
+  },
+}
+```
 ## Congratulations
 
 You're done! To recap, you've successfully:

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -332,6 +332,7 @@ export const actions = {
   },
 }
 ```
+
 ## Congratulations
 
 You're done! To recap, you've successfully:


### PR DESCRIPTION
## Problem
The SvelteKit SSR guide did not include an example for handling OAuth redirects.
When using `signInWithOAuth`, the returned `data.url` must be redirected to, which was unclear.

## Solution
Added a concise SvelteKit SSR example showing how to handle OAuth redirects using
`redirect(303, data.url)` inside a server action.

## Related issue
Closes #23618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for OAuth integration with SvelteKit server-side rendering that explains handling OAuth redirects on the server.
  * Includes server-side examples demonstrating success and error redirect flows to help implement sign-in via OAuth in SSR apps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->