### PR TITLE
fix(studio): remove mobile sidebar toggle in table editor

### DIFF
--- a/apps/studio/components/layouts/Tabs/CollapseButton.tsx
+++ b/apps/studio/components/layouts/Tabs/CollapseButton.tsx
@@ -11,7 +11,7 @@ export function CollapseButton({ hideTabs }: { hideTabs: boolean }) {
       <TooltipTrigger asChild>
         <button
           className={cn(
-            'flex items-center justify-center w-10 h-10 hover:bg-surface-100 shrink-0',
+            'hidden md:flex items-center justify-center w-10 h-10 hover:bg-surface-100 shrink-0',
             !hideTabs && 'border-b border-b-default'
           )}
           onClick={() => setShowSidebar(!showSidebar)}


### PR DESCRIPTION
On mobile viewports, the "Collapse sidebar" toggle in the table editor tabs heading doesn't have any effect as it's controlled by a different button.

<img width="137" height="139" alt="Screenshot 2026-01-15 at 12 22 11" src="https://github.com/user-attachments/assets/b508a3be-90af-4021-bd67-8cc09ee1efd0" />

The solution in this PR is to hide the redundant collapse/expand toggle in the table editor tabs row and keep the above submenu button toggle, which is the standard mobile navigation pattern for contextual submenus in other dashboard sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the collapse button's visibility behavior across different screen sizes. The button is now hidden on small screens and displayed on medium and larger screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->