### PR TITLE
fix(studio): StorageExplorer overflow on PreviewPane

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -145,7 +145,10 @@ export const PreviewPane = () => {
       leaveFrom="transform opacity-100"
       leaveTo="transform opacity-0"
     >
-      <div className="h-full border-l border-overlay bg-surface-100 p-4" style={{ width }}>
+      <div
+        className="h-full border-l border-overlay bg-surface-100 p-4 overflow-y-auto"
+        style={{ width }}
+      >
         {/* Preview Header */}
         <div className="flex w-full justify-end text-foreground-lighter transition-colors hover:text-foreground">
           <X


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bug fix
- Resolves DEPR-330

## What is the current behavior?

- Contents in `PreviewPane` that are taller than the container visibly overflow

## What is the new behavior?

- Contents in `PreviewPane` that are taller than the container scroll internally

| Before | After |
| --- | --- |
| <img width="1728" height="498" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/3115183e-27a7-49ba-97e9-fe71b30f963f" /> | <img width="1728" height="498" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/426180c9-cad7-426f-a833-52f329a3a496" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced vertical scrolling functionality in the Storage preview pane to improve content navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->