### PR TITLE
fix(studio): small font size fix on access tokens table

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenList.tsx
@@ -245,23 +245,29 @@ export const AccessTokenList = ({ searchString = '', onDeleteSuccess }: AccessTo
                   <TimestampInfo
                     utcTimestamp={x.last_used_at}
                     label={dayjs(x.last_used_at).fromNow()}
+                    className="text-sm"
                   />
                 ) : (
-                  'Never used'
+                  <p className="text-foreground-light text-sm">Never used</p>
                 )}
               </TableCell>
               <TableCell className="min-w-28 text-foreground-light">
                 {x.expires_at ? (
                   dayjs(x.expires_at).isBefore(dayjs()) ? (
-                    <TimestampInfo utcTimestamp={x.expires_at} label="Expired" />
+                    <TimestampInfo
+                      utcTimestamp={x.expires_at}
+                      label="Expired"
+                      className="text-sm"
+                    />
                   ) : (
                     <TimestampInfo
                       utcTimestamp={x.expires_at}
                       label={dayjs(x.expires_at).format('DD MMM YYYY')}
+                      className="text-sm"
                     />
                   )
                 ) : (
-                  <p className="text-foreground-light">Never</p>
+                  <p className="text-foreground-light text-sm">Never</p>
                 )}
               </TableCell>
               <TableCell>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Empty state vs. date on `used_at` and `expiry` columns font size was a little off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency by applying uniform small-text styling to all timestamps in the Access Tokens interface, including last-used and expiration information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->