### PR TITLE
feat(billing): use entitlements for read replica access

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica.ts
@@ -8,6 +8,7 @@ import {
   useReadReplicasQuery,
 } from 'data/read-replicas/replicas-query'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useIsAwsK8sCloudProvider, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 
@@ -16,8 +17,7 @@ export const useCheckEligibilityDeployReplica = () => {
   const isAwsK8s = useIsAwsK8sCloudProvider()
   const { data: project } = useSelectedProjectQuery()
   const { data: org } = useSelectedOrganizationQuery()
-
-  const isFreePlan = org?.plan.id === 'free'
+  const { hasAccess: hasReadReplicaAccess } = useCheckEntitlements('instances.read_replicas')
   const isAWSProvider = project?.cloud_provider === 'AWS'
   const isWalgEnabled = project?.is_physical_backups_enabled
   const isNotOnHigherPlan = useMemo(
@@ -60,7 +60,7 @@ export const useCheckEligibilityDeployReplica = () => {
     !isReachedMaxReplicas &&
     currentPgVersion >= 15 &&
     isAWSProvider &&
-    !isFreePlan &&
+    hasReadReplicaAccess &&
     isWalgEnabled &&
     currentComputeAddon !== undefined &&
     !hasOverdueInvoices &&


### PR DESCRIPTION
### Summary

This PR updates the Read Replicas UI to use the entitlements API instead of hardcoded plan checks.

### Test Plan

### Initial Setup

Apply this patch to test locally (since we can't fetch replication sources/destinations in local dev):

```diff
diff --git a/apps/studio/data/replication/destinations-query.ts b/apps/studio/data/replication/destinations-query.ts
index 961c49ebc7..f729c418c0 100644
--- a/apps/studio/data/replication/destinations-query.ts
+++ b/apps/studio/data/replication/destinations-query.ts
@@ -13,6 +13,9 @@ async function fetchReplicationDestinations(
 ) {
   if (!projectRef) throw new Error('projectRef is required')

+  return { destinations: [] }
+
   const { data, error } = await get('/platform/replication/{ref}/destinations', {
     params: { path: { ref: projectRef } },
     signal,
diff --git a/apps/studio/data/replication/sources-query.ts b/apps/studio/data/replication/sources-query.ts
index 54e5a94298..b9550b388f 100644
--- a/apps/studio/data/replication/sources-query.ts
+++ b/apps/studio/data/replication/sources-query.ts
@@ -13,6 +13,9 @@ async function fetchReplicationSources(
 ) {
   if (!projectRef) throw new Error('projectRef is required')

+  return { sources: [] }
+
   const { data, error } = await get('/platform/replication/{ref}/sources', {
     params: { path: { ref: projectRef } },
     signal,
```

#### Test Scenario 1: Database > Replication (Unified UI)

1. `unifiedReplication` feature flag must be enabled in ConfigCat
1. Navigate to Database > Replication
2. Click "Add destination" button
3. Select "Read Replica" from type selector

Expected behavior:

- Free org: Deploy button disabled, shows warning about compute size being too small
- Pro org: Can select region and deploy
- Pro with spend cap enabled: Shows "Spend cap needs to be disabled" warning

#### Test Scenario 2: Settings > Infrastructure (Legacy UI)

1. `unifiedReplication` feature flag must be disabled in ConfigCat
2. Navigate to Settings > Infrastructure
3. Scroll to Read Replicas section
 4. Click "Deploy a new read replica" button

Expected behavior:

- Free org: Shows compute size warning with "Upgrade to Pro" button
- Pro org: Shows region/compute selectors, can deploy
- Pro with spend cap enabled: Shows "Disable spend cap" warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated read replica deployment access control to use entitlement-based gating instead of legacy plan-based checks.
  * Refined eligibility criteria and deployment workflows for read replica management.
  * Enhanced user-facing messaging and navigation for users without read replica access, directing them to upgrade options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->