### PR TITLE
Docs: Fix grammar typo in CLI Reference docs

### DIFF
--- a/apps/docs/spec/cli_v1_commands.yaml
+++ b/apps/docs/spec/cli_v1_commands.yaml
@@ -1640,7 +1640,7 @@ commands:
 
       Creates a new migration file locally.
 
-      A `supabase/migrations` directory will be created if it does not already exists in your current `workdir`. All schema migration files must be created in this directory following the pattern `<timestamp>_<name>.sql`.
+      A `supabase/migrations` directory will be created if it does not already exist in your current `workdir`. All schema migration files must be created in this directory following the pattern `<timestamp>_<name>.sql`.
 
       Outputs from other commands like `db diff` may be piped to `migration new <name>` via stdin.
     examples:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

The CLI Reference documentation contains a small grammatical typo:

> "does not already exists"

## What is the new behavior?

The typo is corrected to proper verb agreement:

> "does not already exist"

## Additional context

Minor documentation-only change. No functional impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor grammar corrections in CLI specification documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->