### PR TITLE
fix(studio): allow newlines in SMS OTP template

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -29,6 +29,9 @@ const FormField = ({
   disabled = false,
   setFieldValue,
 }: FormFieldProps) => {
+  const isSmsTemplate = name === 'SMS_TEMPLATE'
+
+  
   const [hidden, setHidden] = useState(!!properties.isSecret)
   const [dateAsText, setDateAsText] = useState(
     formValues[name] ? formatDate(new Date(formValues[name])) : ''
@@ -100,6 +103,35 @@ const FormField = ({
       )
 
     case 'string':
+      if (isSmsTemplate) {
+        return (
+          <Input.TextArea
+            size="small"
+            layout="vertical"
+            id={name}
+            name={name}
+            disabled={disabled}
+            label={properties.title}
+            labelOptional={
+              properties.descriptionOptional ? (
+                <Markdown
+                  content={properties.descriptionOptional}
+                  className="text-foreground-lighter"
+                />
+              ) : null
+            }
+            descriptionText={
+              properties.description ? (
+                <Markdown
+                  content={properties.description}
+                  className="text-foreground-lighter"
+                />
+              ) : null
+            }
+          />
+        )
+      }
+
       return (
         <Input
           size="small"
@@ -119,7 +151,10 @@ const FormField = ({
           }
           descriptionText={
             properties.description ? (
-              <Markdown content={properties.description} className="text-foreground-lighter" />
+              <Markdown
+                content={properties.description}
+                className="text-foreground-lighter"
+              />
             ) : null
           }
           actions={
@@ -141,7 +176,7 @@ const FormField = ({
           }
         />
       )
-
+  
     case 'multiline-string':
       return (
         <Input.TextArea


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file
YES

## What kind of change does this PR introduce?
Bug fix (Studio UI)

## What is the current behavior?
The SMS OTP template field (`SMS_TEMPLATE`) is rendered as a single-line input in Supabase Studio.
This strips newline characters, preventing compliance with the WebOTP API, which requires at least one newline.

Related issue: #6435

## What is the new behavior?
The SMS OTP template is rendered as a multiline textarea, preserving newline characters.
This allows SMS OTP messages to work correctly with WebOTP.

## Additional context
This change only affects Supabase Studio UI.
No backend or GoTrue changes are required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS template field rendering to use text area input instead of single-line text, providing better support for multi-line content.
  * Enhanced description display formatting for SMS template configuration fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->