### PR TITLE
fix(docs): add missing `await` to JavaScript RPC examples

### DIFF
--- a/apps/docs/content/guides/database/extensions/plv8.mdx
+++ b/apps/docs/content/guides/database/extensions/plv8.mdx
@@ -86,7 +86,7 @@ select function_name();
 <TabPanel id="js" label="JavaScript">
 
 ```js
-const { data, error } = supabase.rpc('function_name')
+const { data, error } = await supabase.rpc('function_name')
 ```
 
 </TabPanel>

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -240,7 +240,7 @@ where id = 1;
 <TabPanel id="js" label="JavaScript">
 
 ```js
-const { data, error } = supabase.rpc('get_planets').eq('id', 1)
+const { data, error } = await supabase.rpc('get_planets').eq('id', 1)
 ```
 
 </TabPanel>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation bug fix - adds missing `await` keyword to two JavaScript code examples.

## What is the current behavior?

Two JavaScript examples for `supabase.rpc()` are missing the `await` keyword:

**1. `apps/docs/content/guides/database/extensions/plv8.mdx` (line 89):**
```js
const { data, error } = supabase.rpc('function_name')
```

**2. `apps/docs/content/guides/database/functions.mdx` (line 243):**
```js
const { data, error } = supabase.rpc('get_planets').eq('id', 1)
```

## What is the new behavior?

Both examples now include `await`:

```js
const { data, error } = await supabase.rpc('function_name')
```

```js
const { data, error } = await supabase.rpc('get_planets').eq('id', 1)
```

## Why this matters

### The Problem
Without `await`, these code snippets fail silently when copied by developers:

1. `supabase.rpc()` returns a **Promise**, not the actual data
2. Destructuring `{ data, error }` from a Promise yields `undefined` for both
3. No error is thrown - the code "works" but `data` is always `undefined`
4. Developers waste hours debugging, often blaming their database setup, RLS policies, or network issues

### The Impact
This is particularly problematic because:

- **Documentation is trusted** - developers copy examples expecting them to work
- **Silent failures are the worst kind** - no error message points to the real issue
- **Beginners are hit hardest** - experienced devs might spot the missing `await`, but newcomers to async JavaScript won't
- **It generates support burden** - users file issues or ask in Discord when the real problem is the documentation

### Evidence of Correct Pattern
The [official JavaScript reference for `rpc()`](https://supabase.com/docs/reference/javascript/rpc) correctly shows:
```js
const { data, error } = await supabase.rpc('hello_world')
```

Additionally, in `functions.mdx`, the Dart and Swift examples in the same code block correctly use `await`:
```dart
final data = await supabase.rpc('get_planets').eq('id', 1);
```

## Additional context

Related: #26733 (similar missing `await` issue in SvelteKit docs)

Found while systematically reviewing JavaScript code examples in the documentation for async correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JavaScript code examples in PLV8 extension and database functions guides to correctly demonstrate async/await syntax for RPC database function calls
  * Ensured all code samples properly await promises when executing asynchronous database operations, helping developers avoid potential runtime errors from missing await statements in their applications

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->