### PR TITLE
new homepage: gate new usage section behind flag

### DIFF
--- a/apps/studio/components/interfaces/HomeNew/Home.tsx
+++ b/apps/studio/components/interfaces/HomeNew/Home.tsx
@@ -46,9 +46,7 @@ export const HomeV2 = () => {
     'empty'
   )
 
-  const UsageSection = showHomepageUsageV2
-    ? ProjectUsageSectionV2
-    : ProjectUsageSectionV1
+  const UsageSection = showHomepageUsageV2 ? ProjectUsageSectionV2 : ProjectUsageSectionV1
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
 

--- a/apps/studio/components/interfaces/HomeNew/Home.tsx
+++ b/apps/studio/components/interfaces/HomeNew/Home.tsx
@@ -3,7 +3,8 @@ import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-ki
 import dayjs from 'dayjs'
 import { useEffect, useRef } from 'react'
 
-import { IS_PLATFORM, useParams } from 'common'
+import { IS_PLATFORM, useFlag, useParams } from 'common'
+import { ProjectUsageSection as ProjectUsageSectionV1 } from 'components/interfaces/Home/ProjectUsageSection'
 import { SortableSection } from 'components/interfaces/HomeNew/SortableSection'
 import { TopSection } from 'components/interfaces/HomeNew/TopSection'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
@@ -18,7 +19,7 @@ import { AdvisorSection } from './AdvisorSection'
 import { CustomReportSection } from './CustomReportSection'
 import { type GettingStartedState } from './GettingStarted/GettingStarted.types'
 import { GettingStartedSection } from './GettingStarted/GettingStartedSection'
-import { ProjectUsageSection } from './ProjectUsageSection'
+import { ProjectUsageSection as ProjectUsageSectionV2 } from './ProjectUsageSection'
 
 export const HomeV2 = () => {
   const { enableBranching } = useParams()
@@ -26,6 +27,9 @@ export const HomeV2 = () => {
   const { data: project } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
   const { mutate: sendEvent } = useSendEventMutation()
+
+  const isNewHomepageMetricsV2Enabled = useFlag('newHomepageMetricsV2')
+  const shouldShowNewHomepageMetrics = isNewHomepageMetricsV2Enabled === true
 
   const isMatureProject = dayjs(project?.inserted_at).isBefore(dayjs().subtract(10, 'day'))
 
@@ -42,6 +46,10 @@ export const HomeV2 = () => {
     `home-getting-started-${project?.ref || 'default'}`,
     'empty'
   )
+
+  const UsageSection = shouldShowNewHomepageMetrics
+    ? ProjectUsageSectionV2
+    : ProjectUsageSectionV1
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
 
@@ -104,7 +112,7 @@ export const HomeV2 = () => {
                     return (
                       <div key={id} className={cn(isComingUp && 'opacity-60 pointer-events-none')}>
                         <SortableSection id={id}>
-                          <ProjectUsageSection />
+                          <UsageSection />
                         </SortableSection>
                       </div>
                     )

--- a/apps/studio/components/interfaces/HomeNew/Home.tsx
+++ b/apps/studio/components/interfaces/HomeNew/Home.tsx
@@ -28,8 +28,7 @@ export const HomeV2 = () => {
   const { data: organization } = useSelectedOrganizationQuery()
   const { mutate: sendEvent } = useSendEventMutation()
 
-  const isNewHomepageMetricsV2Enabled = useFlag('newHomepageMetricsV2')
-  const shouldShowNewHomepageMetrics = isNewHomepageMetricsV2Enabled === true
+  const showHomepageUsageV2 = useFlag('newHomepageUsageV2')
 
   const isMatureProject = dayjs(project?.inserted_at).isBefore(dayjs().subtract(10, 'day'))
 
@@ -47,7 +46,7 @@ export const HomeV2 = () => {
     'empty'
   )
 
-  const UsageSection = shouldShowNewHomepageMetrics
+  const UsageSection = showHomepageUsageV2
     ? ProjectUsageSectionV2
     : ProjectUsageSectionV1
 


### PR DESCRIPTION
- shows old usage section unless flag for new usage section is on
- this is to launch the new homepage early without waiting for clickhouse support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homepage usage section now supports dynamic variant selection via a feature flag, allowing controlled rollout of an updated usage display and seamless fallback to the existing version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->