### PR TITLE
add free project info to project creation

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -226,6 +226,8 @@ const Wizard: NextPageWithLayout = () => {
     { enabled: currentOrg !== null }
   )
 
+  const shouldShowFreeProjectInfo = !!currentOrg && !isFreePlan
+
   const {
     mutate: createProject,
     isPending: isCreatingNewProject,
@@ -442,6 +444,23 @@ const Wizard: NextPageWithLayout = () => {
                     {showAdvancedConfig && !!availableOrioleVersion && (
                       <AdvancedConfiguration form={form} />
                     )}
+
+                    {shouldShowFreeProjectInfo ? (
+                      <Admonition
+                        className="rounded-none border-0"
+                        type="note"
+                        title="Need a free project?"
+                        description={
+                          <p>
+                            Supabase billing is organization-based. Get 2 free projects by{' '}
+                            <Link className="underline text-foreground" href="/new">
+                              creating a free organization
+                            </Link>
+                            .
+                          </p>
+                        }
+                      />
+                    ) : null}
                   </>
                 )}
 


### PR DESCRIPTION
<img width="1582" height="736" alt="CleanShot 2026-01-18 at 19 56 39@2x" src="https://github.com/user-attachments/assets/7daff978-d8ef-4d9b-a353-d9835933c02a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational messaging about free project availability in the project creation flow for users on non-free plans with an organization, including a link to free organization creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->