### PR TITLE
fix(studio): prevent github repo name overflow in project card

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -79,11 +79,13 @@ export const ProjectCard = ({
                 </div>
               )}
               {isGithubIntegrated && (
-                <div className="bg-surface-100 flex items-center gap-x-0.5 h-5 pr-1 border border-strong rounded-md">
-                  <div className="w-5 h-5 p-1 flex items-center justify-center">
+                <div className="bg-surface-100 flex items-center gap-x-0.5 h-5 pr-1 border border-strong rounded-md overflow-hidden">
+                  <div className="w-5 h-5 p-1 flex items-center justify-center flex-shrink-0">
                     <Github size={12} strokeWidth={1.5} />
                   </div>
-                  <p className="text-xs text-foreground-light truncate">{githubRepository}</p>
+                  <p className="text-xs text-foreground-light truncate flex-1 min-w-0">
+                    {githubRepository}
+                  </p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
On the Projects dashboard, when a project has GitHub integration enabled and the repository name is long, the repo name can overflow outside the project card rather than truncating within

## What is the new behavior?
Long GitHub repository names are constrained within the badge and truncate correctly
Adds overflow-hidden on the badge container, prevents the GitHub icon from shrinking, and applies min-w-0 within the flex layout so truncation works as intended

Before:

<img width="592" height="360" alt="Screenshot 2026-01-18 211449" src="https://github.com/user-attachments/assets/c97937e7-47c2-403f-ad6f-46de97a867ff" />

After: 

<img width="526" height="361" alt="image" src="https://github.com/user-attachments/assets/8b52c56c-4a6d-4bef-a567-040984b5d867" />

## Additional context
Tested with a GitHub-synced project using a long organisation and repository name
No functional changes, styling only




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display and truncation of long repository names in GitHub integration badges, ensuring consistent layout and preventing visual overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->