### PR TITLE
docs: Switch Expo quickstart to local storage

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
@@ -45,7 +45,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npx expo install @supabase/supabase-js react-native-url-polyfill
+      cd my-app && npx expo install @supabase/supabase-js react-native-url-polyfill expo-sqlite
       ```
 
     </StepHikeCompact.Code>

--- a/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
@@ -82,7 +82,7 @@ hideToc: true
 
     Create a helper file at `lib/supabase.ts` to initialize the Supabase client using the environment variables.
 
-    The code below uses Expo's default local storage and then syncs the data to Supabase.
+    The code below uses Expo's localStorage polyfill to persist authentication sessions.
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
@@ -45,7 +45,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      cd my-app && npx expo install @supabase/supabase-js @react-native-async-storage/async-storage react-native-url-polyfill
+      cd my-app && npx expo install @supabase/supabase-js react-native-url-polyfill
       ```
 
     </StepHikeCompact.Code>
@@ -82,7 +82,7 @@ hideToc: true
 
     Create a helper file at `lib/supabase.ts` to initialize the Supabase client using the environment variables.
 
-    The code below uses [AsyncStorage](https://www.npmjs.com/package/@react-native-async-storage/async-storage) to persist the user session in your app.
+    The code below uses Expo's default local storage and then syncs the data to Supabase.
 
     </StepHikeCompact.Details>
 
@@ -91,14 +91,14 @@ hideToc: true
       ```ts name=lib/supabase.ts
       import 'react-native-url-polyfill/auto'
       import { createClient } from '@supabase/supabase-js'
-      import AsyncStorage from '@react-native-async-storage/async-storage'
+      import 'expo-sqlite/localStorage/install';
 
       const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL
       const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 
       export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
         auth: {
-          storage: AsyncStorage,
+          storage: localStorage,
           autoRefreshToken: true,
           persistSession: true,
           detectSessionInUrl: false,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

Based on this PR: https://github.com/supabase/supabase/pull/40435, this PR also switches the Expo quickstart to use local storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Expo React Native quickstart with simplified setup and examples.
  * Switched guidance to use Expo’s built-in localStorage for persisting authentication sessions instead of an external AsyncStorage package.
  * Updated code snippets and instructions to reflect the new storage configuration and reduced dependency requirements for Expo projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->