### PR TITLE
add notification on db reboot when enabling ssl enforcement

### DIFF
--- a/apps/docs/content/guides/platform/ssl-enforcement.mdx
+++ b/apps/docs/content/guides/platform/ssl-enforcement.mdx
@@ -17,6 +17,12 @@ Projects need to be at least on Postgres 13.3.0 to enable SSL enforcement. You c
 
 SSL enforcement can be configured via the "Enforce SSL on incoming connections" setting under the SSL Configuration section in [Database Settings page](/dashboard/project/_/database/settings) of the dashboard.
 
+<Admonition type="note">
+
+Updating SSL enforcement requires a brief database reboot. This restarts only the database and involves a few minutes of downtime.
+
+</Admonition>
+
 ## Manage SSL enforcement via the Management API
 
 You can also manage SSL enforcement using the Management API:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## Additional context

Related to:
Linear https://linear.app/supabase/issue/FE-2356/ssl-enforcement-triggered-full-shutdown
PR: https://github.com/supabase/supabase/pull/41887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added advisory note to SSL enforcement guide clarifying that updates require a brief database reboot with a few minutes of downtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->