### PR TITLE
fix(studio): maintain focus on input for assistant

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -557,12 +557,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             )}
             loading={isChatLoading}
             isEditing={!!editingMessageId}
-            disabled={
-              !isApiKeySet ||
-              disablePrompts ||
-              isLoadingOrganization ||
-              (isChatLoading && !editingMessageId)
-            }
+            disabled={!isApiKeySet || disablePrompts || isLoadingOrganization}
             placeholder={
               hasMessages
                 ? 'Ask a follow up question...'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

While Assistant responses are streaming, the text input box is disabled. This is an odd UX since it sends focus all over the place.

## What is the new behavior?

Now, the text input box is still usable while streaming, though you still have to wait until streaming is done to actually submit. Allows the user to prepare next messages and also keeps focus consistent.

## Additional context

https://github.com/user-attachments/assets/aaf2cc59-1a32-4994-9dbd-68854ac04cfc

Resolves FE-2368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The AI Assistant form now remains enabled when editing messages while chat is processing, providing a smoother editing experience during message loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->