### PR TITLE
fix(studio): invalidate table editor menu on assistant mutations

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -1,9 +1,12 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/router'
-import { type DragEvent, type PropsWithChildren, useRef, useState } from 'react'
+import { useRef, useState, type DragEvent, type PropsWithChildren } from 'react'
 
 import { useParams } from 'common'
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
+import { entityTypeKeys } from 'data/entity-types/keys'
+import { lintKeys } from 'data/lint/keys'
 import { usePrimaryDatabase } from 'data/read-replicas/replicas-query'
 import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -51,6 +54,8 @@ export const DisplayBlockRenderer = ({
   onChartConfigChange,
   onQueryRun,
 }: PropsWithChildren<DisplayBlockRendererProps>) => {
+  const queryClient = useQueryClient()
+
   const savedInitialArgs = useRef(initialArgs)
   const savedInitialResults = useRef(initialResults)
   const savedInitialConfig = useRef<ChartConfig>({
@@ -167,6 +172,10 @@ export const DisplayBlockRenderer = ({
             messageId,
             results: Array.isArray(data.result) ? data.result : undefined,
           })
+          if (queryType === 'mutation') {
+            queryClient.invalidateQueries({ queryKey: lintKeys.lint(ref) })
+            queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(ref) })
+          }
         },
         onError: (error) => {
           const lowerMessage = error.message.toLowerCase()


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The queries used for the Table Editor menu aren't invalidated when the Assistant executes SQL, so newly created views/tables and fresh lints aren't shown.

## What is the new behavior?

Now adds invalidations whenever a write query is run from the Assistant interface.

## Additional context

https://github.com/user-attachments/assets/af36e0bd-8c6e-4664-a263-ab195f92d8fb

Resolves FE-2370


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data refresh mechanisms to improve consistency and performance when running operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->