### PR TITLE
fix: remove message from api contact allowing users to flll helpful context

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/ApiKeysIllustrations.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeysIllustrations.tsx
@@ -153,8 +153,6 @@ export const ApiKeysFeedbackBanner = () => {
             queryParams={{
               category: SupportCategories.PROBLEM,
               subject: 'Help with API keys',
-              message:
-                "I'm experiencing problems with the new API keys feature. Please describe your specific issue here.",
             }}
           >
             Contact support


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Support has been experiencing issues where the message is not very useful. By removing the message we ask users to fill something more details when submitting a support ticket 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed pre-filled message from API Keys support link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->