### PR TITLE
fix: add space between spans in sql row editor

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -109,7 +109,7 @@ export const InputField = ({
               <span className="text-sm text-foreground-lighter">{field.comment} </span>
             )}
             <span className="text-sm text-foreground-lighter">
-              {field.comment && '('}Has a foreign key relation to
+              {field.comment && '('}Has a foreign key relation to {" "}
             </span>
             <span className="text-code font-mono text-xs text-foreground-lighter">
               {field.foreignKey.target_table_schema}.{field.foreignKey.target_table_name}.

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -109,7 +109,7 @@ export const InputField = ({
               <span className="text-sm text-foreground-lighter">{field.comment} </span>
             )}
             <span className="text-sm text-foreground-lighter">
-              {field.comment && '('}Has a foreign key relation to {" "}
+              {field.comment && '('}Has a foreign key relation to{" "}
             </span>
             <span className="text-code font-mono text-xs text-foreground-lighter">
               {field.foreignKey.target_table_schema}.{field.foreignKey.target_table_name}.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Small visual bug fix.




## What is the current behavior?

<img width="1506" height="822" alt="image" src="https://github.com/user-attachments/assets/d902101f-a794-4fcc-a0ba-582674b1a98a" />

Can reproduce by going to the supabase row insert panel and then for any field which has a foreign key, the above issue shows up. It is simply because there are two spans next to eachother with no gap so this adds a space. 

## What is the new behavior?

<img width="678" height="170" alt="image" src="https://github.com/user-attachments/assets/9976b313-d504-428b-8e0a-73fa9a5d165b" />

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text formatting in foreign key relation descriptions for better clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->