### PR TITLE
fix: update MCP to use function name

### DIFF
--- a/examples/edge-functions/supabase/functions/mcp/simple-mcp-server/index.ts
+++ b/examples/edge-functions/supabase/functions/mcp/simple-mcp-server/index.ts
@@ -9,6 +9,9 @@ import { z } from "zod";
 // Create Hono app
 const app = new Hono();
 
+// Your function name, change it based on your project.
+const functionName = "simplge-mcp-server";
+
 // Create your MCP server
 const server = new McpServer({
   name: "mcp",
@@ -25,7 +28,7 @@ server.registerTool("add", {
 }));
 
 // Handle MCP requests at the root path
-app.all("/", async (c) => {
+app.all("/" + functionName , async (c) => {
   const transport = new StreamableHTTPTransport();
   await server.connect(transport);
   return transport.handleRequest(c);


### PR DESCRIPTION


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Using the simple MCP server does not work out of the box.

## What is the new behavior?

The project seems to show and explain the correct implementation of the MCP server.

## Additional context
Since the simple MCP server is using hono, it would not work if the function name was not provided to the app. 

related issue: 

https://github.com/supabase/supabase/issues/12629#issuecomment-1442842459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced MCP server configuration with dynamic endpoint path customization.
  * Added version tracking to the MCP server setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->