### PR TITLE
Clarify MCP request handling and add reference link

### DIFF
--- a/apps/docs/content/guides/getting-started/byo-mcp.mdx
+++ b/apps/docs/content/guides/getting-started/byo-mcp.mdx
@@ -92,8 +92,9 @@ server.registerTool(
   })
 )
 
-// Handle MCP requests at the root path
-app.all('/', async (c) => {
+// Handle MCP requests at the root path of the edge function.
+// Due to how edge functions work, the edge function name should be always provided. 
+app.all('/mcp', async (c) => {
   const transport = new StreamableHTTPTransport()
   await server.connect(transport)
   return transport.handleRequest(c)
@@ -170,3 +171,4 @@ You can find ready-to-use MCP server implementations here:
 - [MCP Authentication](/docs/guides/auth/oauth-server/mcp-authentication)
 - [MCP server examples on GitHub](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp)
 - [Building MCP servers with mcp-lite](/docs/guides/functions/examples/mcp-server-mcp-lite) - Alternative lightweight framework
+- [Why to use Hono function name for edge function](https://github.com/supabase/supabase/issues/12629) 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Using the current behaviour does not work and just does not call the function.

## What is the new behavior?


Updated the MCP request handling to specify the edge function name and added a new reference link.

## Additional context

related issue: 

https://github.com/supabase/supabase/issues/12629

Docs path: https://supabase.com/docs/guides/getting-started/byo-mcp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP request routing documentation with clarification on path handling.
  * Added explanatory notes on edge function naming conventions and behavior.
  * Included additional guidance for implementing custom edge functions with Hono.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->