### PR TITLE
remove studio observability reference from high swap troubleshooting

### DIFF
--- a/apps/docs/content/troubleshooting/exhaust-swap.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-swap.mdx
@@ -33,9 +33,7 @@ High Swap usage can affect your database performance. For example, you might see
 
 ## Monitor your swap
 
-You can check your Swap usage directly on the Supabase Platform. Navigate to the [**Database** page](/dashboard/project/_/observability/database) of the **Observability** section.
-
-You can also monitor your resources and set up alerts using Prometheus/Grafana. See the [metrics guide](/docs/guides/platform/metrics) for more information.
+You can monitor your resources and set up alerts using Prometheus/Grafana. See the [metrics guide](/docs/guides/platform/metrics) for more information.
 
 An [example repository](https://github.com/supabase/supabase-grafana) to ingest metrics and visualize them with Grafana is provided in the linked guide, where we maintain a [list of the exported metrics](https://github.com/supabase/supabase-grafana/blob/main/docs/metrics.md).
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## Additional context

Removed this: You can check your Swap usage directly on the Supabase Platform. Navigate to the Database page of the Observability section.

Slack discussion: https://supabase.slack.com/archives/C02BJ2239GA/p1765517708888249
Ticket: https://supabase.frontapp.com/open/cnv_1kze6a1q?key=FY3JbqFzj46NZQ7QQ21YU9KdPv_Yd6Cv

Since we removed the swap observability block, this created confusion for one of the clients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated swap troubleshooting documentation to streamline monitoring guidance and improve clarity. Refined instructions now prioritize Prometheus/Grafana metrics as the primary recommended approach for tracking swap usage and optimizing system performance. These changes consolidate best practices into clearer, more actionable guidance for effective monitoring and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->