### PR TITLE
feat(studio): add cached egress quota violation label

### DIFF
--- a/apps/studio/data/usage/constants.ts
+++ b/apps/studio/data/usage/constants.ts
@@ -1,6 +1,7 @@
 export const VIOLATION_TYPE_LABELS: Record<string, string> = {
   exceed_db_size_quota: 'DB Size Exceeded',
   exceed_egress_quota: 'Egress Exceeded',
+  exceed_cached_egress_quota: 'Cached Egress Exceeded',
   exceed_edge_functions_count_quota: 'Edge Functions Count Exceeded',
   exceed_edge_functions_invocations_quota: 'Edge Functions Invocations Exceeded',
   exceed_monthly_active_users_quota: 'Monthly Active Users Exceeded',


### PR DESCRIPTION
## Summary

Adds a human-readable label for the new `exceed_cached_egress_quota` violation type. Without this, users who exceed their cached egress quota would see the raw key string in billing alerts instead of "Cached Egress Exceeded".

## Changes

- Add `exceed_cached_egress_quota: 'Cached Egress Exceeded'` to `VIOLATION_TYPE_LABELS` in `apps/studio/data/usage/constants.ts`

## Testing

**Quick test:**
1. Trigger a cached egress quota violation (or mock `org.restriction_data.violations` to include `exceed_cached_egress_quota`)
2. Verify the billing restriction alerts show "Cached Egress Exceeded" instead of the raw key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added proper display label for "Cached Egress Exceeded" violation alerts in usage monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->