### PR TITLE
chore(www): remove announcement banner

### DIFF
--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import { Button } from 'ui'
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
-import AnnouncementBadge from '../Announcement/Badge'
 
 const Hero = () => {
   const sendTelemetryEvent = useSendTelemetryEvent()
@@ -15,11 +14,6 @@ const Hero = () => {
           <div className="mx-auto">
             <div className="mx-auto max-w-2xl lg:col-span-6 lg:flex lg:items-center justify-center text-center">
               <div className="relative z-10 lg:h-auto pt-[90px] lg:pt-[90px] lg:min-h-[300px] flex flex-col items-center justify-center sm:mx-auto md:w-3/4 lg:mx-0 lg:w-full gap-4 lg:gap-8">
-                <AnnouncementBadge
-                  url="/wrapped"
-                  announcement="Supabase Wrapped 2025: The year in review"
-                  announcementMobile="Supabase Wrapped 2025"
-                />
                 <div className="flex flex-col items-center">
                   <h1 className="text-foreground text-4xl sm:text-5xl sm:leading-none lg:text-7xl">
                     <span className="block text-foreground">Build in a weekend</span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor UI update

## What is the current behavior?

We show an `AnnouncementBanner` on the homepage to promote our Supabase Wrapped for 2025. Since it’s now late January 2026, the announcement feels a bit stale.

## What is the new behavior?

We no longer show this banner (but the page itself [remains](https://supabase.com/wrapped)).

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/2a94e2a8-1a3c-4d85-8a80-b3dbbd3fa97f" /> | <img width="1024" height="759" alt="Supabase  The Postgres Development Platform" src="https://github.com/user-attachments/assets/d8a98eed-4d7f-4679-b359-ef83b3355f0f" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the announcement badge from the hero section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->