### PR TITLE
docs: Remove the instruction to use the management API within quickstarts

### DIFF
--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -12,7 +12,6 @@ Alternatively, you can run the following snippet in your project's [SQL Editor](
 
 </StepHikeCompact.Details>
 
-
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -2,33 +2,7 @@
 
 Go to [database.new](https://database.new) and create a new Supabase project.
 
-Alternatively, you can create a project using the Management API:
-
 </StepHikeCompact.Details>
-
-<StepHikeCompact.Code>
-
-```bash
-# First, get your access token from https://supabase.com/dashboard/account/tokens
-export SUPABASE_ACCESS_TOKEN="your-access-token"
-
-# List your organizations to get the organization ID
-curl -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
-  https://api.supabase.com/v1/organizations
-
-# Create a new project (replace <org-id> with your organization ID)
-curl -X POST https://api.supabase.com/v1/projects \
-  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "organization_id": "<org-id>",
-    "name": "My Project",
-    "region": "us-east-1",
-    "db_pass": "<your-secure-password>"
-  }'
-```
-
-</StepHikeCompact.Code>
 
 <StepHikeCompact.Details>
 
@@ -37,6 +11,7 @@ When your project is up and running, go to the [Table Editor](/dashboard/project
 Alternatively, you can run the following snippet in your project's [SQL Editor](/dashboard/project/_/sql/new). This will create an `instruments` table with some sample data.
 
 </StepHikeCompact.Details>
+
 
 <StepHikeCompact.Code>
 

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -6,12 +6,10 @@ Go to [database.new](https://database.new) and create a new Supabase project.
 
 <StepHikeCompact.Code>
 
-```markdown
-1. Go to https://database.new
-2. Enter a name for your project
-3. Select a strong password for the database
-4. Choose a region closest to you
-5. Click "Create new project"
+```bash
+# After project creation, you will find:
+# - Project URL (available in Project Settings > Data API)
+# - API Keys (available in Project Settings > API Keys)
 ```
 
 </StepHikeCompact.Code>

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -4,6 +4,18 @@ Go to [database.new](https://database.new) and create a new Supabase project.
 
 </StepHikeCompact.Details>
 
+<StepHikeCompact.Code>
+
+```markdown
+1. Go to https://database.new
+2. Enter a name for your project
+3. Select a strong password for the database
+4. Choose a region closest to you
+5. Click "Create new project"
+```
+
+</StepHikeCompact.Code>
+
 <StepHikeCompact.Details>
 
 When your project is up and running, go to the [Table Editor](/dashboard/project/_/editor), create a new table and insert some data.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes the alternative instruction to use the management API to create a Supabase project. 

IMO, these quickstarts are meant to be the quickest way to get started with Supabase, and fewer options are better. Also, realistically speaking, it is hard to image that anyone would go through creating a personal access token and calling the management API when you can just head to database.new to create a project.

I do understand that removing the code block at the top does make the whole section look slightly uglier, but I thought it was better than making it look very complex. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quickstart database setup guide to streamline project initialization instructions and clarify where to find Project URL and API Keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->