### PR TITLE
docs(studio): clarify free project limit message

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -452,11 +452,11 @@ const Wizard: NextPageWithLayout = () => {
                         title="Need a free project?"
                         description={
                           <p>
-                            Supabase billing is organization-based. Get 2 free projects by{' '}
+                            You can have up to 2 free projects across all organizations.{' '}
                             <Link className="underline text-foreground" href="/new">
-                              creating a free organization
-                            </Link>
-                            .
+                              Create a free organization
+                            </Link>{' '}
+                            to use them.
                           </p>
                         }
                       />


### PR DESCRIPTION
## Summary
Updates the informational text shown to users on paid organizations when creating a new project. The previous message was confusing about how free projects work. The new message clearly explains that users can have up to 2 free projects across all organizations and directs them to create a free organization to use them.

## Changes
- Updated description text from "Supabase billing is organization-based. Get 2 free projects by creating a free organization" to "You can have up to 2 free projects across all organizations. Create a free organization to use them"

## Testing
**Quick test:**
1. Log in to a paid organization and go to create a new project
2. Verify the admonition shows the updated text: "You can have up to 2 free projects across all organizations. Create a free organization to use them."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding messaging to clarify free project limits across organizations
  * Improved language for creating free organizations in setup instructions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->