### PR TITLE
fix(studio): PageSectionSummary alignment

### DIFF
--- a/apps/design-system/README.md
+++ b/apps/design-system/README.md
@@ -60,9 +60,9 @@ With that out of the way, there are several parts of this design system that nee
 - `config/docs.ts`: list of components in the sidebar
 - `content/docs`: the actual component documentation
 - `registry/examples.ts`: list of example components
-- `registry/default/example`: the actual example components
-- `registry/charts.ts`: chart components
-- `registry/fragments.ts`: fragment components
+- `registry/fragments.ts`: list of fragment components
+- `registry/charts.ts`: list of chart components
+- `registry/default/example/*`: the actual example components
 
 You will probably need to rebuild the design system’s registry after making new additions. You can do that via:
 

--- a/apps/design-system/__registry__/default/block/chart-composed-basic.tsx
+++ b/apps/design-system/__registry__/default/block/chart-composed-basic.tsx
@@ -28,15 +28,37 @@ export default function ComposedChartBasic() {
     },
   ]
 
-  const data = Array.from({ length: 46 }, (_, i) => {
+  const data = Array.from({ length: 40 }, (_, i) => {
     const date = new Date()
-    date.setMinutes(date.getMinutes() - i * 5) // Each point 5 minutes apart
+    date.setMinutes(date.getMinutes() - i * 3) // Each point 3 minutes apart
+
+    const progress = i / 40
+    const standard_score = Math.floor(55 + progress * 55 + (Math.random() - 0.5) * 12)
+    const performance = Math.floor(35 + progress * 35 + (Math.random() - 0.5) * 10)
+    const efficiency = Math.floor(25 + progress * 25 + (Math.random() - 0.5) * 12)
 
     return {
       timestamp: date.toISOString(),
-      standard_score: Math.floor(Math.random() * 100),
+      standard_score: Math.max(0, Math.min(100, standard_score)),
+      performance: Math.max(0, Math.min(100, performance)),
+      efficiency: Math.max(0, Math.min(100, efficiency)),
     }
   }).reverse()
+
+  const chartConfig = {
+    standard_score: {
+      label: 'Standard Score',
+      color: 'hsl(var(--brand-default))',
+    },
+    performance: {
+      label: 'Performance',
+      color: 'hsl(var(--chart-2))',
+    },
+    efficiency: {
+      label: 'Efficiency',
+      color: 'hsl(var(--chart-5))',
+    },
+  }
 
   useEffect(() => {
     setTimeout(() => {
@@ -50,10 +72,8 @@ export default function ComposedChartBasic() {
         <ChartCard>
           <ChartHeader>
             <ChartTitle tooltip="This is a tooltip">Standard Bar Chart</ChartTitle>
-
             <ChartActions actions={actions} />
           </ChartHeader>
-
           <ChartContent
             isEmpty={data.length === 0}
             emptyState={
@@ -86,10 +106,8 @@ export default function ComposedChartBasic() {
         <ChartCard>
           <ChartHeader>
             <ChartTitle tooltip="This is a tooltip">Standard Line Chart</ChartTitle>
-
             <ChartActions actions={actions} />
           </ChartHeader>
-
           <ChartContent
             isEmpty={data.length === 0}
             emptyState={
@@ -105,6 +123,8 @@ export default function ComposedChartBasic() {
               <ChartLine
                 data={data}
                 dataKey="standard_score"
+                dataKeys={['standard_score', 'performance', 'efficiency']}
+                config={chartConfig}
                 showGrid={true}
                 showYAxis={true}
                 YAxisProps={{

--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -159,17 +159,6 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
-    "aspect-ratio-demo": {
-      name: "aspect-ratio-demo",
-      type: "components:example",
-      registryDependencies: ["aspect-ratio"],
-      component: React.lazy(() => import("@/registry/default/example/aspect-ratio-demo")),
-      source: "",
-      files: ["registry/default/example/aspect-ratio-demo.tsx"],
-      category: "undefined",
-      subcategory: "undefined",
-      chunks: []
-    },
     "alert-dialog-destructive": {
       name: "alert-dialog-destructive",
       type: "components:example",
@@ -188,6 +177,17 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/alert-dialog-warning")),
       source: "",
       files: ["registry/default/example/alert-dialog-warning.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "aspect-ratio-demo": {
+      name: "aspect-ratio-demo",
+      type: "components:example",
+      registryDependencies: ["aspect-ratio"],
+      component: React.lazy(() => import("@/registry/default/example/aspect-ratio-demo")),
+      source: "",
+      files: ["registry/default/example/aspect-ratio-demo.tsx"],
       category: "undefined",
       subcategory: "undefined",
       chunks: []
@@ -2234,6 +2234,17 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/page-section-horizontal")),
       source: "",
       files: ["registry/default/example/page-section-horizontal.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "page-section-title-only": {
+      name: "page-section-title-only",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/page-section-title-only")),
+      source: "",
+      files: ["registry/default/example/page-section-title-only.tsx"],
       category: "undefined",
       subcategory: "undefined",
       chunks: []

--- a/apps/design-system/content/docs/fragments/page-section.mdx
+++ b/apps/design-system/content/docs/fragments/page-section.mdx
@@ -14,11 +14,11 @@ fragment: true
 ## Sub-components
 
 - `PageSection` - Root container with orientation variants (`horizontal` or `vertical`)
-- `PageSectionMeta` - Meta wrapper for summary and aside (groups summary and aside together)
-- `PageSectionSummary` - Container for section title and description (should be inside PageSectionMeta, has `flex-1`)
+- `PageSectionMeta` - Meta wrapper for `PageSectionSummary` and optional `PageSectionAside`
+- `PageSectionSummary` - Container for section title and description (should be inside `PageSectionMeta`, has `flex-1`)
 - `PageSectionTitle` - Section heading (h2)
 - `PageSectionDescription` - Supporting text below section title
-- `PageSectionAside` - Container for section-level actions (should be inside PageSectionMeta, has `shrink-0`)
+- `PageSectionAside` - Container for section-level actions (should be inside `PageSectionMeta`, has `shrink-0`)
 - `PageSectionContent` - Container for the main section content
 
 ## Orientation Variants
@@ -54,3 +54,5 @@ fragment: true
   peekCode
   wide
 />
+
+`PageSectionSummary` should be wrapped in a `PageSectionMeta` irrespective of `PageSectionAside` presence. 

--- a/apps/design-system/content/docs/fragments/page-section.mdx
+++ b/apps/design-system/content/docs/fragments/page-section.mdx
@@ -55,4 +55,3 @@ fragment: true
   wide
 />
 
-`PageSectionSummary` should be wrapped in a `PageSectionMeta` irrespective of `PageSectionAside` presence. 

--- a/apps/design-system/content/docs/fragments/page-section.mdx
+++ b/apps/design-system/content/docs/fragments/page-section.mdx
@@ -45,3 +45,12 @@ fragment: true
   peekCode
   wide
 />
+
+### Without Aside
+
+<ComponentPreview
+  name="page-section-title-only"
+  description="PageSection with title only"
+  peekCode
+  wide
+/>

--- a/apps/design-system/content/docs/fragments/page-section.mdx
+++ b/apps/design-system/content/docs/fragments/page-section.mdx
@@ -54,4 +54,3 @@ fragment: true
   peekCode
   wide
 />
-

--- a/apps/design-system/registry/default/example/page-section-title-only.tsx
+++ b/apps/design-system/registry/default/example/page-section-title-only.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent } from 'ui'
+import {
+  PageSection,
+  PageSectionContent,
+  PageSectionMeta,
+  PageSectionSummary,
+  PageSectionTitle,
+} from 'ui-patterns/PageSection'
+
+export default function PageSectionTitleOnly() {
+  return (
+    <div className="w-full">
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Section Title</PageSectionTitle>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent>
+          <Card>
+            <CardContent className="p-6">
+              <p className="text-sm text-foreground-light">
+                Note how the PageSectionSummary is aligned center, not to the bottom.
+              </p>
+            </CardContent>
+          </Card>
+        </PageSectionContent>
+      </PageSection>
+    </div>
+  )
+}

--- a/apps/design-system/registry/default/example/page-section-title-only.tsx
+++ b/apps/design-system/registry/default/example/page-section-title-only.tsx
@@ -20,7 +20,8 @@ export default function PageSectionTitleOnly() {
           <Card>
             <CardContent className="p-6">
               <p className="text-sm text-foreground-light">
-              PageSectionSummary should still be wrapped in PageSectionMeta, as the latter is a flex container that will allow the former to span its full width.
+                PageSectionSummary should still be wrapped in PageSectionMeta, as the latter is a
+                flex container that will allow the former to span its full width.
               </p>
             </CardContent>
           </Card>

--- a/apps/design-system/registry/default/example/page-section-title-only.tsx
+++ b/apps/design-system/registry/default/example/page-section-title-only.tsx
@@ -20,7 +20,7 @@ export default function PageSectionTitleOnly() {
           <Card>
             <CardContent className="p-6">
               <p className="text-sm text-foreground-light">
-                Note how the PageSectionSummary is aligned center, not to the bottom.
+              PageSectionSummary should still be wrapped in PageSectionMeta, as the latter is a flex container that will allow the former to span its full width.
               </p>
             </CardContent>
           </Card>

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -1264,6 +1264,11 @@ export const examples: Registry = [
     files: ['example/page-section-horizontal.tsx'],
   },
   {
+    name: 'page-section-title-only',
+    type: 'components:example',
+    files: ['example/page-section-title-only.tsx'],
+  },
+  {
     name: 'page-section-with-aside',
     type: 'components:example',
     files: ['example/page-section-with-aside.tsx'],

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -50,6 +50,7 @@ import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageSection,
   PageSectionContent,
+  PageSectionMeta,
   PageSectionSummary,
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
@@ -244,9 +245,11 @@ export const EdgeFunctionDetails = () => {
         </PageSectionSummary>
         <PageSectionContent>
           <PageSection className="pt-0">
+          <PageSectionMeta>
             <PageSectionSummary>
-              <PageSectionTitle>Function Configuration</PageSectionTitle>
+              <PageSectionTitle>Function configuration</PageSectionTitle>
             </PageSectionSummary>
+            </PageSectionMeta>
             <PageSectionContent>
               <Form_Shadcn_ {...form}>
                 <form onSubmit={form.handleSubmit(onUpdateFunction)}>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -176,7 +176,7 @@ export const EdgeFunctionDetails = () => {
           <PageSectionTitle>Details</PageSectionTitle>
           {isLoading && <GenericSkeletonLoader />}
           {isError && (
-            <AlertError error={error} subject="Failed to retrieve edge function details" />
+            <AlertError error={error} subject="Failed to retrieve edge function details" layout="vertical" />
           )}
           {isSuccess && (
             <dl className="grid grid-cols-1 @xl:grid-cols-[auto_1fr] gap-y-2 [&>dd]:mb-3 @xl:[&>dd]:mb-0 @xl:gap-y-4 gap-x-10">

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -329,9 +329,11 @@ export const EdgeFunctionDetails = () => {
           </PageSection>
 
           <PageSection>
+            <PageSectionMeta>
             <PageSectionSummary>
-              <PageSectionTitle>Invoke function</PageSectionTitle>
-            </PageSectionSummary>
+                <PageSectionTitle>Invoke function</PageSectionTitle>
+              </PageSectionSummary>
+            </PageSectionMeta>
             <PageSectionContent>
               <Card>
                 <CardContent className="px-0">
@@ -397,9 +399,11 @@ export const EdgeFunctionDetails = () => {
           </PageSection>
 
           <PageSection>
-            <PageSectionSummary>
-              <PageSectionTitle>Develop locally</PageSectionTitle>
-            </PageSectionSummary>
+            <PageSectionMeta>
+              <PageSectionSummary>
+                <PageSectionTitle>Develop locally</PageSectionTitle>
+              </PageSectionSummary>
+            </PageSectionMeta>
             <PageSectionContent>
               <div className="rounded border bg-surface-100 px-6 py-4 drop-shadow-sm">
                 <div className="space-y-6">
@@ -425,9 +429,11 @@ export const EdgeFunctionDetails = () => {
             </PageSectionContent>
           </PageSection>
           <PageSection>
+            <PageSectionMeta>
             <PageSectionSummary>
-              <PageSectionTitle>Delete function</PageSectionTitle>
-            </PageSectionSummary>
+                <PageSectionTitle>Delete function</PageSectionTitle>
+              </PageSectionSummary>
+            </PageSectionMeta>
             <PageSectionContent>
               <Alert_Shadcn_ variant="destructive">
                 <CriticalIcon />

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -176,7 +176,11 @@ export const EdgeFunctionDetails = () => {
           <PageSectionTitle>Details</PageSectionTitle>
           {isLoading && <GenericSkeletonLoader />}
           {isError && (
-            <AlertError error={error} subject="Failed to retrieve edge function details" layout="vertical" />
+            <AlertError
+              error={error}
+              subject="Failed to retrieve edge function details"
+              layout="vertical"
+            />
           )}
           {isSuccess && (
             <dl className="grid grid-cols-1 @xl:grid-cols-[auto_1fr] gap-y-2 [&>dd]:mb-3 @xl:[&>dd]:mb-0 @xl:gap-y-4 gap-x-10">
@@ -245,10 +249,10 @@ export const EdgeFunctionDetails = () => {
         </PageSectionSummary>
         <PageSectionContent>
           <PageSection className="pt-0">
-          <PageSectionMeta>
-            <PageSectionSummary>
-              <PageSectionTitle>Function configuration</PageSectionTitle>
-            </PageSectionSummary>
+            <PageSectionMeta>
+              <PageSectionSummary>
+                <PageSectionTitle>Function configuration</PageSectionTitle>
+              </PageSectionSummary>
             </PageSectionMeta>
             <PageSectionContent>
               <Form_Shadcn_ {...form}>
@@ -330,7 +334,7 @@ export const EdgeFunctionDetails = () => {
 
           <PageSection>
             <PageSectionMeta>
-            <PageSectionSummary>
+              <PageSectionSummary>
                 <PageSectionTitle>Invoke function</PageSectionTitle>
               </PageSectionSummary>
             </PageSectionMeta>
@@ -430,7 +434,7 @@ export const EdgeFunctionDetails = () => {
           </PageSection>
           <PageSection>
             <PageSectionMeta>
-            <PageSectionSummary>
+              <PageSectionSummary>
                 <PageSectionTitle>Delete function</PageSectionTitle>
               </PageSectionSummary>
             </PageSectionMeta>

--- a/packages/ui-patterns/src/PageSection/index.tsx
+++ b/packages/ui-patterns/src/PageSection/index.tsx
@@ -66,12 +66,7 @@ const PageSectionSummary = ({ className, children, ...props }: PageSectionSummar
   return (
     <div
       data-slot="page-section-summary"
-      className={cn(
-        'flex flex-col gap-1',
-        // Center alignment with PageSectionAside in case no PageSectionDescription present
-        '@xl:self-center',
-        className
-      )}
+      className={cn('flex flex-col gap-1', className)}
       {...props}
     >
       {children}
@@ -176,6 +171,8 @@ const PageSectionMeta = ({ className, children, ...props }: PageSectionMetaProps
         className={cn(
           'flex flex-col @xl:flex-row @xl:justify-between @xl:items-center gap-4',
           '[&>[data-slot="page-section-summary"]]:flex-1',
+          // Center alignment with PageSectionAside in case no PageSectionDescription present
+          '[&>[data-slot="page-section-summary"]]:@xl:self-center',
           '[&>[data-slot="page-section-aside"]]:shrink-0',
           className
         )}

--- a/packages/ui-patterns/src/PageSection/index.tsx
+++ b/packages/ui-patterns/src/PageSection/index.tsx
@@ -68,7 +68,7 @@ const PageSectionSummary = ({ className, children, ...props }: PageSectionSummar
       data-slot="page-section-summary"
       className={cn(
         'flex flex-col gap-1',
-        // Center alignment with PageSection Aside in case no PageSectionDescription present
+        // Center alignment with PageSectionAside in case no PageSectionDescription present
         '@xl:self-center',
         className
       )}
@@ -220,5 +220,6 @@ export {
   PageSectionDescription,
   PageSectionMeta,
   PageSectionSummary,
-  PageSectionTitle,
+  PageSectionTitle
 }
+

--- a/packages/ui-patterns/src/PageSection/index.tsx
+++ b/packages/ui-patterns/src/PageSection/index.tsx
@@ -217,6 +217,5 @@ export {
   PageSectionDescription,
   PageSectionMeta,
   PageSectionSummary,
-  PageSectionTitle
+  PageSectionTitle,
 }
-


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`PageSectionSummary` components that are:

- Not wrapped in a `PageSectionMeta`
- Do not contain `PageSectionAside`

...inherit the `grid` layout from the parent `PageSection` instead of the expected `flex` and therefore align wrongly on `xl`, due to a `self-center` utility class on the `PageSectionTitle`.

There seems to be just one case of this: `EdgeFunctionDetails`.

## What is the new behavior?

- Wrap each `PageSectionSummary` within `EdgeFunctionDetails` inside of a `PageSectionMeta`
- Better design documentation
- Smarter styles on component to prevent future footguns when `PageSectionMeta` is inevitably left out

| Before | After |
| --- | --- |
| <img width="1584" height="909" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/0df2a78d-bafa-4550-b2d0-87d485e14c03" /> | <img width="1584" height="909" alt="Edge Functions  Supabase" src="https://github.com/user-attachments/assets/c4403b6c-8ee1-413d-8366-72fc537fe7b3" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new example components: aspect-ratio demo and page-section title–only.

* **Improvements**
  * Charts now include multiple metrics (standard_score, performance, efficiency) with configurable styling; data sampling reduced and intervals tightened for smoother visualization.
  * PageSection layout refined: meta wrapper controls summary/aside alignment and alert layout improved.

* **Documentation**
  * Clarified PageSection subcomponent descriptions and added a "Without Aside" (title-only) example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->