### PR TITLE
chore(studio): add URL state management to database tables page

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { parseAsString, useQueryState } from 'nuqs'
 import { useState } from 'react'
 
 import { useParams } from 'common'
@@ -45,7 +46,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Input,
   Label_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
@@ -60,6 +60,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
 import { formatAllEntities } from './Tables.utils'
@@ -85,7 +86,7 @@ export const TableList = ({
 
   const { selectedSchema, setSelectedSchema } = useQuerySchemaState()
 
-  const [filterString, setFilterString] = useState<string>('')
+  const [filterString, setFilterString] = useQueryState('search', parseAsString.withDefault(''))
   const [visibleTypes, setVisibleTypes] = useState<string[]>(Object.values(ENTITY_TYPE))
 
   const { can: canUpdateTables } = useAsyncCheckPermissions(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor improvement.

## What is the current behavior?

Using the text input to search for a specific database table (`/database/tables`) does not add a URL query parameter. Similar pages like `/database/indexes` does this.

This is useful for when linking to this page and wanting to target a specific table. E.g. https://github.com/supabase/supabase/pull/41527/

## What is the new behavior?

- Replace deprecated `Input` with one from `DataInputs/Input`
- Add URL state management
- Syncs the search value with the URL query parameter

## To test

- [ ] Make sure search on `/database/tables` works as it did before
- [ ] See if the URL param updates as this input value is added, changed, and removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search filter now persists in the URL, enabling users to share filtered search states and maintain their search term when returning to the page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->