### PR TITLE
query perf improvements FE-2223

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
@@ -8,6 +8,7 @@ import {
   ReportsNumericFilter,
 } from 'components/interfaces/Reports/v2/ReportsNumericFilter'
 import { FilterInput } from './components/FilterInput'
+import { FilterPill } from './components/FilterPill'
 import { IndexAdvisorFilter } from './components/IndexAdvisorFilter'
 import { RolesFilterDropdown } from './components/RolesFilterDropdown'
 import { SortIndicator } from './components/SortIndicator'
@@ -83,40 +84,83 @@ export const QueryPerformanceFilterBar = ({
     setFilters({ roles: [] })
   }
 
+  const getCallsFilterDisplay = () => {
+    if (!callsFilter) return null
+    return `${callsFilter.operator} ${callsFilter.value}`
+  }
+
+  const getTotalTimeFilterDisplay = () => {
+    if (!totalTimeFilter) return null
+    return `${totalTimeFilter.operator} ${totalTimeFilter.value}`
+  }
+
   return (
     <div className="px-4 py-1.5 bg-surface-200 border-t -mt-px flex justify-between items-center overflow-x-auto overflow-y-hidden w-full flex-shrink-0">
       <div className="flex items-center gap-x-4">
         <div className="flex items-center gap-x-2">
           <FilterInput value={inputValue} onChange={setInputValue} />
 
-          <ReportsNumericFilter
-            label="Calls"
-            value={callsFilter}
-            onChange={(value) => setSearchParams({ callsFilter: value })}
-            operators={['=', '>=', '<=', '>', '<', '!=']}
-            defaultOperator=">="
-            placeholder="e.g. 100"
-            min={0}
-            className="w-auto"
-          />
-
-          <ReportsNumericFilter
-            label="Total Time"
-            value={totalTimeFilter}
-            onChange={(value) => setSearchParams({ totalTimeFilter: value })}
-            operators={['=', '>=', '<=', '>', '<', '!=']}
-            defaultOperator=">"
-            placeholder="e.g. 1000"
-            min={0}
-            className="w-auto"
-          />
-
-          {showRolesFilter && (
-            <RolesFilterDropdown
-              activeOptions={filters.roles}
-              onSaveFilters={onFilterRolesChange}
+          {callsFilter ? (
+            <FilterPill
+              label="Calls"
+              value={getCallsFilterDisplay() || ''}
+              onClear={(e) => {
+                e.stopPropagation()
+                setSearchParams({ callsFilter: null })
+              }}
+            />
+          ) : (
+            <ReportsNumericFilter
+              label="Calls"
+              value={callsFilter}
+              onChange={(value) => setSearchParams({ callsFilter: value })}
+              operators={['=', '>=', '<=', '>', '<', '!=']}
+              defaultOperator=">="
+              placeholder="e.g. 100"
+              min={0}
+              className="w-auto"
             />
           )}
+
+          {totalTimeFilter ? (
+            <FilterPill
+              label="Total Time"
+              value={getTotalTimeFilterDisplay() || ''}
+              onClear={(e) => {
+                e.stopPropagation()
+                setSearchParams({ totalTimeFilter: null })
+              }}
+            />
+          ) : (
+            <ReportsNumericFilter
+              label="Total Time"
+              value={totalTimeFilter}
+              onChange={(value) => setSearchParams({ totalTimeFilter: value })}
+              operators={['=', '>=', '<=', '>', '<', '!=']}
+              defaultOperator=">"
+              placeholder="e.g. 1000"
+              min={0}
+              className="w-auto"
+            />
+          )}
+
+          {showRolesFilter &&
+            (filters.roles && filters.roles.length > 0 ? (
+              <FilterPill
+                label="Roles"
+                value={filters.roles.join(', ')}
+                onClear={(e) => {
+                  e.stopPropagation()
+                  setFilters({ roles: [] })
+                  setSearchParams({ roles: [] })
+                }}
+              />
+            ) : (
+              <RolesFilterDropdown
+                activeOptions={filters.roles}
+                onSaveFilters={onFilterRolesChange}
+              />
+            ))}
 
           {isIndexAdvisorEnabled && (
             <IndexAdvisorFilter
@@ -124,8 +168,6 @@ export const QueryPerformanceFilterBar = ({
               onToggle={onIndexAdvisorToggle}
             />
           )}
-
-          {sort && <SortIndicator sort={sort} onClearSort={clearSort} />}
 
           {hasActiveFilters && (
             <ButtonTooltip
@@ -142,6 +184,8 @@ export const QueryPerformanceFilterBar = ({
               }}
             />
           )}
+
+          {sort && <SortIndicator sort={sort} onClearSort={clearSort} />}
         </div>
       </div>
       <div className="flex gap-2 items-center pl-2">{actions}</div>

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
@@ -1,8 +1,5 @@
 import { parseAsArrayOf, parseAsJson, parseAsString, useQueryStates } from 'nuqs'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
-import { X } from 'lucide-react'
-
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { ReactNode, useEffect, useState } from 'react'
 import {
   NumericFilter,
   ReportsNumericFilter,
@@ -75,27 +72,6 @@ export const QueryPerformanceFilterBar = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedInputValue])
 
-  const hasActiveFilters = useMemo(() => {
-    return (
-      (searchQuery && searchQuery.length > 0) ||
-      (defaultFilterRoles && defaultFilterRoles.length > 0) ||
-      callsFilter !== null ||
-      totalTimeFilter !== null ||
-      indexAdvisor === 'true'
-    )
-  }, [searchQuery, defaultFilterRoles, callsFilter, totalTimeFilter, indexAdvisor])
-
-  const handleClearAllFilters = () => {
-    setSearchParams({
-      search: '',
-      roles: [],
-      callsFilter: null,
-      totalTimeFilter: null,
-      indexAdvisor: 'false',
-    })
-    setInputValue('')
-    setFilters({ roles: [] })
-  }
 
   const getCallsFilterDisplay = () => {
     if (!callsFilter) return null
@@ -179,22 +155,6 @@ export const QueryPerformanceFilterBar = ({
             <IndexAdvisorFilter
               isActive={indexAdvisor === 'true'}
               onToggle={onIndexAdvisorToggle}
-            />
-          )}
-
-          {hasActiveFilters && (
-            <ButtonTooltip
-              type="text"
-              size="tiny"
-              icon={<X />}
-              onClick={handleClearAllFilters}
-              className="px-1"
-              tooltip={{
-                content: {
-                  side: 'top',
-                  text: 'Clear all filters',
-                },
-              }}
             />
           )}
 

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
@@ -27,15 +27,28 @@ export const QueryPerformanceFilterBar = ({
   const { isIndexAdvisorEnabled } = useIndexAdvisorStatus()
 
   const [
-    { search: searchQuery, roles: defaultFilterRoles, callsFilter, totalTimeFilter, indexAdvisor },
+    {
+      search: searchQuery,
+      roles: defaultFilterRoles,
+      callsFilter: callsFilterRaw,
+      totalTimeFilter: totalTimeFilterRaw,
+      indexAdvisor,
+    },
     setSearchParams,
   ] = useQueryStates({
     search: parseAsString.withDefault(''),
     roles: parseAsArrayOf(parseAsString).withDefault([]),
-    callsFilter: parseAsJson((value) => value as NumericFilter | null).withDefault(null),
-    totalTimeFilter: parseAsJson((value) => value as NumericFilter | null).withDefault(null),
+    callsFilter: parseAsJson<NumericFilter | null>((value) =>
+      value === null || value === undefined ? null : (value as NumericFilter)
+    ),
+    totalTimeFilter: parseAsJson<NumericFilter | null>((value) =>
+      value === null || value === undefined ? null : (value as NumericFilter)
+    ),
     indexAdvisor: parseAsString.withDefault('false'),
   })
+
+  const callsFilter = callsFilterRaw ?? null
+  const totalTimeFilter = totalTimeFilterRaw ?? null
 
   const [filters, setFilters] = useState<{ roles: string[] }>({
     roles: defaultFilterRoles,

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceFilterBar.tsx
@@ -72,7 +72,6 @@ export const QueryPerformanceFilterBar = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedInputValue])
 
-
   const getCallsFilterDisplay = () => {
     if (!callsFilter) return null
     return `${callsFilter.operator} ${callsFilter.value}`

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
@@ -54,12 +54,9 @@ export const QueryPerformanceMetrics = () => {
       {stats.map((card, i) => (
         <React.Fragment key={i}>
           <div
-            className={cn(
-              'flex items-baseline gap-2 heading-subSection text-foreground-light',
-              {
-                'cursor-pointer hover:text-foreground transition-colors': card.onClick,
-              }
-            )}
+            className={cn('flex items-baseline gap-2 heading-subSection text-foreground-light', {
+              'cursor-pointer hover:text-foreground transition-colors': card.onClick,
+            })}
             onClick={card.onClick}
           >
             {isLoading ? (

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
@@ -37,10 +37,14 @@ export const QueryPerformanceMetrics = () => {
       {
         title: 'Cache Hit Rate',
         value: queryMetrics?.[0]?.cache_hit_rate || '0%',
+        tooltip:
+          'Percentage of data read from cache vs disk. Higher is better - it means faster queries and less database load.',
       },
       {
         title: 'Avg. Rows Per Call',
         value: queryMetrics?.[0]?.avg_rows_per_call || '0',
+        tooltip:
+          'Average number of rows returned per query execution. Helps identify queries that return too much or too little data.',
       },
     ]
   }, [queryMetrics, setSearchParams])
@@ -65,7 +69,7 @@ export const QueryPerformanceMetrics = () => {
                 <span className="text-foreground">{card.value}</span>
                 <span className="flex items-center gap-1">
                   {card.title}
-                  {card.title === 'Slow Queries' || card.title === 'Slow Query' ? (
+                  {(card.title === 'Slow Queries' || card.title === 'Slow Query') && (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button
@@ -84,7 +88,26 @@ export const QueryPerformanceMetrics = () => {
                         time) greater than 1000ms.
                       </TooltipContent>
                     </Tooltip>
-                  ) : null}
+                  )}
+                  {card.tooltip && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={`What is ${card.title}?`}
+                          className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-surface-200 text-foreground-lighter transition-colors hover:bg-surface-300 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-foreground-lighter"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                          }}
+                        >
+                          <Info size={12} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" align="start" className="max-w-xs text-xs">
+                        {card.tooltip}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
                 </span>
               </>
             )}

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
@@ -1,18 +1,38 @@
 import React, { useMemo } from 'react'
+import { parseAsJson, useQueryStates } from 'nuqs'
+import { Info } from 'lucide-react'
 
-import { Skeleton } from 'ui'
+import { Skeleton, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { useQueryPerformanceQuery } from '../Reports/Reports.queries'
+import { NumericFilter } from 'components/interfaces/Reports/v2/ReportsNumericFilter'
 
 export const QueryPerformanceMetrics = () => {
   const { data: queryMetrics, isLoading } = useQueryPerformanceQuery({
     preset: 'queryMetrics',
   })
 
+  const [, setSearchParams] = useQueryStates({
+    totalTimeFilter: parseAsJson<NumericFilter | null>(
+      (value) => value as NumericFilter | null
+    ).withDefault(null),
+  })
+
   const stats = useMemo(() => {
+    const slowQueriesTitle = queryMetrics?.[0]?.slow_queries === 1 ? 'Slow Query' : 'Slow Queries'
+    const slowQueriesValue = queryMetrics?.[0]?.slow_queries || '0'
+
     return [
       {
-        title: queryMetrics?.[0]?.slow_queries === 1 ? 'Slow Query' : 'Slow Queries',
-        value: queryMetrics?.[0]?.slow_queries || '0',
+        title: slowQueriesTitle,
+        value: slowQueriesValue,
+        onClick: () => {
+          setSearchParams({
+            totalTimeFilter: {
+              operator: '>',
+              value: 1000,
+            } as NumericFilter,
+          })
+        },
       },
       {
         title: 'Cache Hit Rate',
@@ -23,19 +43,49 @@ export const QueryPerformanceMetrics = () => {
         value: queryMetrics?.[0]?.avg_rows_per_call || '0',
       },
     ]
-  }, [queryMetrics])
+  }, [queryMetrics, setSearchParams])
 
   return (
     <section className="px-6 pt-2 pb-4 flex flex-wrap gap-x-6 gap-y-2 w-full">
       {stats.map((card, i) => (
         <React.Fragment key={i}>
-          <div className="flex items-baseline gap-2 heading-subSection text-foreground-light">
+          <div
+            className={cn(
+              'flex items-baseline gap-2 heading-subSection text-foreground-light',
+              {
+                'cursor-pointer hover:text-foreground transition-colors': card.onClick,
+              }
+            )}
+            onClick={card.onClick}
+          >
             {isLoading ? (
               <Skeleton className="h-5 w-24" />
             ) : (
               <>
                 <span className="text-foreground">{card.value}</span>
-                <span>{card.title}</span>
+                <span className="flex items-center gap-1">
+                  {card.title}
+                  {card.title === 'Slow Queries' || card.title === 'Slow Query' ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="How are slow queries calculated?"
+                          className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-surface-200 text-foreground-lighter transition-colors hover:bg-surface-300 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-foreground-lighter"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                          }}
+                        >
+                          <Info size={12} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" align="start" className="max-w-xs text-xs">
+                        Slow queries are those with total execution time (execution time + planning
+                        time) greater than 1000ms.
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : null}
+                </span>
               </>
             )}
           </div>

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceMetrics.tsx
@@ -12,9 +12,9 @@ export const QueryPerformanceMetrics = () => {
   })
 
   const [, setSearchParams] = useQueryStates({
-    totalTimeFilter: parseAsJson<NumericFilter | null>(
-      (value) => value as NumericFilter | null
-    ).withDefault(null),
+    totalTimeFilter: parseAsJson<NumericFilter | null>((value) =>
+      value === null || value === undefined ? null : (value as NumericFilter)
+    ),
   })
 
   const stats = useMemo(() => {

--- a/apps/studio/components/interfaces/QueryPerformance/components/FilterPill.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/components/FilterPill.tsx
@@ -1,0 +1,30 @@
+import { X } from 'lucide-react'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
+interface FilterPillProps {
+  label: string
+  value: string
+  onClear: (e: React.MouseEvent) => void
+}
+
+export const FilterPill = ({ label, value, onClear }: FilterPillProps) => {
+  return (
+    <div className="text-xs border rounded-md px-1.5 md:px-2.5 py-1 h-[26px] flex items-center gap-x-2">
+      <p className="md:inline-flex gap-x-1 hidden truncate">
+        {label}: <span className="text-foreground-lighter">{value}</span>
+      </p>
+      <Tooltip>
+        <TooltipTrigger
+          onClick={(e) => {
+            e.stopPropagation()
+            onClear(e)
+          }}
+        >
+          <X size={14} className="text-foreground-light hover:text-foreground" />
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Clear {label.toLowerCase()} filter</TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Reports/Reports.queries.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.queries.ts
@@ -30,6 +30,7 @@ export type QueryPerformanceQueryOpts = {
   roles?: string[]
   runIndexAdvisor?: boolean
   minCalls?: number
+  minTotalTime?: number
   filterIndexAdvisor?: boolean
 }
 
@@ -40,6 +41,7 @@ export const useQueryPerformanceQuery = ({
   roles,
   runIndexAdvisor = false,
   minCalls,
+  minTotalTime,
   filterIndexAdvisor = false,
 }: QueryPerformanceQueryOpts) => {
   const queryPerfQueries = PRESET_CONFIG[Presets.QUERY_PERFORMANCE]
@@ -51,6 +53,9 @@ export const useQueryPerformanceQuery = ({
       : '',
     searchQuery.length > 0 ? `statements.query ~* '${searchQuery}'` : '',
     typeof minCalls === 'number' && minCalls > 0 ? `statements.calls >= ${minCalls}` : '',
+    typeof minTotalTime === 'number' && minTotalTime > 0
+      ? `(statements.total_exec_time + statements.total_plan_time) >= ${minTotalTime}`
+      : '',
   ]
     .filter((x) => x.length > 0)
     .join(' AND ')

--- a/apps/studio/pages/project/[ref]/observability/query-performance.tsx
+++ b/apps/studio/pages/project/[ref]/observability/query-performance.tsx
@@ -37,17 +37,21 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
     handleDatePickerChange,
   } = useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
 
-  const [{ search: searchQuery, roles, minCalls, totalTimeFilter, indexAdvisor }] = useQueryStates({
+  const [
+    { search: searchQuery, roles, minCalls, totalTimeFilter: totalTimeFilterRaw, indexAdvisor },
+  ] = useQueryStates({
     sort: parseAsString,
     order: parseAsString,
     search: parseAsString.withDefault(''),
     roles: parseAsArrayOf(parseAsString).withDefault([]),
     minCalls: parseAsInteger,
-    totalTimeFilter: parseAsJson<NumericFilter | null>(
-      (value) => value as NumericFilter | null
-    ).withDefault(null),
+    totalTimeFilter: parseAsJson<NumericFilter | null>((value) =>
+      value === null || value === undefined ? null : (value as NumericFilter)
+    ),
     indexAdvisor: parseAsString.withDefault('false'),
   })
+
+  const totalTimeFilter = totalTimeFilterRaw ?? null
 
   const config = PRESET_CONFIG[Presets.QUERY_PERFORMANCE]
   const hooks = queriesFactory(config.queries, ref ?? 'default')


### PR DESCRIPTION
## Changes
- Made "Slow Queries" metric clickable — filters to queries with total time > 1000ms
- Added tooltip to "Slow Queries" explaining calculation (total execution time + planning time > 1000ms)
- Fixed Calls filter default — shows dashed border when unset (default changed from >= 0 to null)
- Added "Clear all filters" button — X icon appears when any filter is active, with tooltip
- Updated filter state management to track active filters and enable bulk clearing
- Added button to clear filter without having to open it
- Minor UI stuff (dashed border)

## To test
- Go to query performance
- Click Slow queries → should filter by slow queries
- Click clear all filters → should do that
- Click button to remove just 1 filter → should remove that filter
- Hover tooltips in metrics → should show quick description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Total Time filter to Query Performance, enabling results to be limited by query execution time.
  * Slow Queries metric card is clickable to auto-filter queries >1000ms.
  * Added informational tooltips explaining slow-query calculations.

* **UI Improvements**
  * Introduced compact filter pills with clear actions for Calls, Total Time, and Roles.
  * Filters now toggle between pill display and editable numeric/dropdown controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->