### PR TITLE
papercut: add units to api charts

### DIFF
--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -123,11 +123,7 @@ const BarChart = ({
         title={title}
         format={format}
         customDateFormat={customDateFormat}
-        highlightedValue={
-          typeof resolvedHighlightedValue === 'number'
-            ? numberFormatter(resolvedHighlightedValue, valuePrecision)
-            : resolvedHighlightedValue
-        }
+        highlightedValue={resolvedHighlightedValue}
         highlightedLabel={resolvedHighlightedLabel}
         minimalHeader={minimalHeader}
         syncId={syncId}

--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -102,7 +102,13 @@ export const ChartHeader = ({
       return formatBytes(bytesValue, valuePrecision)
     }
 
-    return numberFormatter(value, valuePrecision)
+    const formattedValue = numberFormatter(value, valuePrecision)
+    
+    if (typeof format === 'string' && format) {
+      return `${formattedValue}${format}`
+    }
+
+    return formattedValue
   }
 
   useEffect(() => {

--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -103,7 +103,7 @@ export const ChartHeader = ({
     }
 
     const formattedValue = numberFormatter(value, valuePrecision)
-    
+
     if (typeof format === 'string' && format) {
       return `${formattedValue}${format}`
     }


### PR DESCRIPTION
## BEFORE
<img width="2306" height="1524" alt="CleanShot 2026-01-22 at 11 58 45@2x" src="https://github.com/user-attachments/assets/439d601a-1609-43b5-b4ee-d51f01829253" />


## AFTER
<img width="2282" height="1520" alt="CleanShot 2026-01-22 at 11 58 30@2x" src="https://github.com/user-attachments/assets/c68920b0-6789-4939-8cfe-3581288ec3f5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced chart header value formatting and display for more accurate highlighted value presentation.
  - Added support for optional numeric value suffixes in chart headers to improve data clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->