### PR TITLE
Fix API keys copy button for safari

### DIFF
--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -48,21 +48,13 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
       <Button
         ref={ref}
         onClick={(e) => {
-          // [Joshen] Don't await asyncText - pass the promise directly to copyToClipboard
-          // so Safari can create the ClipboardItem synchronously in the user gesture context
           const textToCopy = asyncText ? asyncText() : text
           setShowCopied(true)
           copyToClipboard(textToCopy)
           onClick?.(e)
         }}
         {...props}
-        className={cn(
-          {
-            'px-1': iconOnly,
-            // '!pointer-events-auto': props.disabled,
-          },
-          props.className
-        )}
+        className={cn({ 'px-1': iconOnly }, props.className)}
         icon={
           showCopied ? <Check strokeWidth={2} className="text-brand" /> : props.icon ?? <Copy />
         }

--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -47,8 +47,10 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     return (
       <Button
         ref={ref}
-        onClick={async (e) => {
-          const textToCopy = asyncText ? await asyncText() : text
+        onClick={(e) => {
+          // [Joshen] Don't await asyncText - pass the promise directly to copyToClipboard
+          // so Safari can create the ClipboardItem synchronously in the user gesture context
+          const textToCopy = asyncText ? asyncText() : text
           setShowCopied(true)
           copyToClipboard(textToCopy)
           onClick?.(e)


### PR DESCRIPTION
## Context

Copy button for API keys isn't working on Safari - this PR fixes it

## To test
- [ ] Verify that you can copy the values from the copy button on the API keys page on Safari and on Chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal implementation of the copy button component's event handling and styling logic for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->