### PR TITLE
fix: handle errors better in index advisor

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
@@ -1,10 +1,11 @@
-import { Check, Table2, Lightbulb, X } from 'lucide-react'
+import { Check, Table2, Lightbulb } from 'lucide-react'
 import { useState, useEffect } from 'react'
 
 import { AccordionTrigger } from '@ui/components/shadcn/ui/accordion'
 import { useIndexAdvisorStatus } from 'components/interfaces/QueryPerformance/hooks/useIsIndexAdvisorStatus'
 import AlertError from 'components/ui/AlertError'
 import { DocsButton } from 'components/ui/DocsButton'
+import { Admonition } from 'ui-patterns'
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import { useGetIndexAdvisorResult } from 'data/database/retrieve-index-advisor-result-query'
 import { useGetIndexesFromSelectQuery } from 'data/database/retrieve-index-from-select-query'
@@ -256,7 +257,9 @@ export const QueryIndexes = ({
       </QueryPanelSection>
       <QueryPanelSection className="flex flex-col gap-y-6 py-6 border-t">
         <div className="flex flex-col gap-y-1">
-          <h4 className="mb-2">New index recommendations</h4>
+          {(!isSuccessIndexAdvisorResult || indexAdvisorResult !== null) && (
+            <h4 className="mb-2">New index recommendations</h4>
+          )}
           {isLoadingExtensions ? (
             <GenericSkeletonLoader />
           ) : !isIndexAdvisorEnabled ? (
@@ -274,15 +277,12 @@ export const QueryIndexes = ({
               {isSuccessIndexAdvisorResult && (
                 <>
                   {indexAdvisorResult === null ? (
-                    <Alert_Shadcn_ className="[&>svg]:rounded-full">
-                      <X />
-                      <AlertTitle_Shadcn_>Index recommendations not available</AlertTitle_Shadcn_>
-                      <AlertDescription_Shadcn_>
-                        Index advisor could not analyze this query. This can happen if the query
-                        references tables, functions, or extensions that no longer exist or were
-                        deleted.
-                      </AlertDescription_Shadcn_>
-                    </Alert_Shadcn_>
+                    <Admonition
+                      type="default"
+                      showIcon={true}
+                      title="Index recommendations not available"
+                      description="Index advisor could not analyze this query. This can happen if the query references tables, functions, or extensions that no longer exist or were deleted."
+                    />
                   ) : (index_statements ?? []).length === 0 ? (
                     <Alert_Shadcn_ className="[&>svg]:rounded-full">
                       <Check />

--- a/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
@@ -1,4 +1,4 @@
-import { Check, Table2, Lightbulb } from 'lucide-react'
+import { Check, Table2, Lightbulb, X } from 'lucide-react'
 import { useState, useEffect } from 'react'
 
 import { AccordionTrigger } from '@ui/components/shadcn/ui/accordion'
@@ -273,7 +273,17 @@ export const QueryIndexes = ({
               )}
               {isSuccessIndexAdvisorResult && (
                 <>
-                  {(index_statements ?? []).length === 0 ? (
+                  {indexAdvisorResult === null ? (
+                    <Alert_Shadcn_ className="[&>svg]:rounded-full">
+                      <X />
+                      <AlertTitle_Shadcn_>Index recommendations not available</AlertTitle_Shadcn_>
+                      <AlertDescription_Shadcn_>
+                        Index advisor could not analyze this query. This can happen if the query
+                        references tables, functions, or extensions that no longer exist or were
+                        deleted.
+                      </AlertDescription_Shadcn_>
+                    </Alert_Shadcn_>
+                  ) : (index_statements ?? []).length === 0 ? (
                     <Alert_Shadcn_ className="[&>svg]:rounded-full">
                       <Check />
                       <AlertTitle_Shadcn_>This query is optimized</AlertTitle_Shadcn_>

--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -39,16 +39,18 @@ export async function getIndexAdvisorResult({
   })
 
   if (!results || results.length === 0) {
-    throw new Error('Index advisor returned no results')
+    console.error('[index_advisor > getIndexAdvisorResult] No results from index_advisor')
+    return null
   }
 
   const parsed = IndexAdvisorResultSchema.safeParse(results[0])
   if (!parsed.success) {
     const firstError = parsed.error.errors[0]
     const errorPath = firstError.path.length > 0 ? ` at path: ${firstError.path.join('.')}` : ''
-    throw new Error(
+    console.error(
       `Invalid index advisor response${errorPath}: ${firstError.message}. Received: ${JSON.stringify(results[0])}`
     )
+    return null
   }
 
   return filterProtectedSchemaIndexAdvisorResult(parsed.data)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix: index advisor would show a unhelpful error when analyzing queries that referenced deleted entries. This should handle that case and show a more helpful error message

## How to test

- Create a table with zero indexes
- Use a column and run SQL statements 
- See if the query showes up in query performance (better to search)
- Delete the table
- Check index advisor for this error

## Demo
<img width="678" height="387" alt="Screenshot 2026-01-21 at 10 38 21 AM" src="https://github.com/user-attachments/assets/1277fce8-fc79-402b-a0c6-21fcc2966bb7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented abrupt errors when index recommendations are missing; the system now logs issues and returns a safe state so the app remains responsive.
* **UI/UX**
  * Shows a clear "Index recommendations not available" notice when advisor data is absent, while preserving existing empty/result flows and messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->