### PR TITLE
chore(studio): update upgrade to pro admonition button variants

### DIFF
--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -506,7 +506,7 @@ export const MfaAuthSettingsForm = () => {
                     source="authSmsMfa"
                     featureProposition="configure settings for SMS MFA"
                     primaryText="SMS MFA is only available on the Pro Plan and above"
-                    secondaryText="Upgrade to the Pro plan to configure settings for SMS MFA"
+                    secondaryText="Upgrade to the Pro plan to configure settings for SMS MFA."
                   />
                 )}
 

--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -1,17 +1,17 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import { boolean, number, object, string } from 'yup'
 import { useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
 import NoPermission from 'components/ui/NoPermission'
 import { UpgradeToPro } from 'components/ui/UpgradeToPro'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { IS_PLATFORM } from 'lib/constants'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
@@ -42,7 +42,7 @@ import {
   PageSectionSummary,
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
-import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
+import { boolean, number, object, string } from 'yup'
 
 function determineMFAStatus(verifyEnabled: boolean, enrollEnabled: boolean) {
   return verifyEnabled ? (enrollEnabled ? 'Enabled' : 'Verify Enabled') : 'Disabled'
@@ -517,7 +517,7 @@ export const MfaAuthSettingsForm = () => {
                     </Button>
                   )}
                   <Button
-                    type="primary"
+                    type={promptProPlanUpgrade ? 'default' : 'primary'}
                     htmlType="submit"
                     disabled={
                       !canUpdateConfig ||

--- a/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.tsx
@@ -196,8 +196,8 @@ export const PerformanceSettingsForm = () => {
           <UpgradeToPro
             source="authPerformance"
             featureProposition="configure advanced Auth server settings"
-            primaryText="Configuring Auth server performance is only available on the Pro plan and above"
-            secondaryText="Upgrade to the Pro plan to configure settings for your Auth server"
+            primaryText="Only available on the Pro Plan and above"
+            secondaryText="Upgrade to the Pro Plan to configure Auth server performance settings."
           />
         )}
       </ScaffoldSection>

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -368,7 +368,7 @@ export const SessionsAuthSettingsForm = () => {
                     source="authSessions"
                     featureProposition="configure user sessions"
                     primaryText="Configuring user sessions is only available on the Pro Plan and above"
-                    secondaryText="Upgrade to the Pro plan to configure settings for user sessions"
+                    secondaryText="Upgrade to Pro Plan to configure settings for user sessions."
                   />
                 )}
 
@@ -379,7 +379,7 @@ export const SessionsAuthSettingsForm = () => {
                     </Button>
                   )}
                   <Button
-                    type="primary"
+                    type={promptProPlanUpgrade ? 'default' : 'primary'}
                     htmlType="submit"
                     disabled={
                       !canUpdateConfig ||

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -273,7 +273,8 @@ export const CreateBranchModal = () => {
                 source="create-branch"
                 featureProposition="enable branching"
                 primaryText="Upgrade to unlock branching"
-                secondaryText="Create and test schema changes, functions, and more in a separate, temporary instance without affecting production"
+                secondaryText="Create and test schema changes, functions, and more in a separate, temporary instance without affecting production."
+                className="pb-5"
               />
             )}
 

--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -10,13 +10,13 @@ import { UpgradeToPro } from 'components/ui/UpgradeToPro'
 import { useBackupRestoreMutation } from 'data/database/backup-restore-mutation'
 import { DatabaseBackup, useBackupsQuery } from 'data/database/backups-query'
 import { useSetProjectStatus } from 'data/projects/project-detail-query'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { BackupItem } from './BackupItem'
 import { BackupsEmpty } from './BackupsEmpty'
 import { BackupsStorageAlert } from './BackupsStorageAlert'
-import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 
 export const BackupsList = () => {
   const router = useRouter()
@@ -60,7 +60,7 @@ export const BackupsList = () => {
         addon="pitr"
         source="backups"
         featureProposition="have up to 7 days of scheduled backups"
-        icon={<Clock size={20} strokeWidth={1.5} />}
+        icon={<Clock size={20} />}
         primaryText="Free Plan does not include project backups."
         secondaryText="Upgrade to the Pro Plan for up to 7 days of scheduled backups."
         buttonText="Upgrade"

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
@@ -133,7 +133,7 @@ export const ReadReplicaEligibilityWarnings = () => {
         </p>
         <div className="flex items-center gap-x-2 mt-2">
           <UpgradePlanButton
-            type="default"
+            variant="default"
             plan="Pro"
             addon="computeSize"
             source="read-replicas"
@@ -206,7 +206,7 @@ export const ReadReplicaEligibilityWarnings = () => {
           the spend cap first to allow overages before launching a replica.
         </p>
         <UpgradePlanButton
-          type="default"
+          variant="default"
           source="read-replicas"
           addon="spendCap"
           className="mt-2"
@@ -230,7 +230,7 @@ export const ReadReplicaEligibilityWarnings = () => {
               project is on an XL compute or higher.
             </p>
             <UpgradePlanButton
-              type="default"
+              variant="default"
               plan="Pro"
               addon="computeSize"
               source="read-replicas"

--- a/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
+++ b/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
@@ -108,8 +108,8 @@ export const RestoreToNewProject = () => {
         buttonText="Upgrade"
         source="backupsRestoreToNewProject"
         featureProposition="enable restoring to new project"
-        primaryText="Restore to a new project requires a pro plan or above."
-        secondaryText="To restore to a new project, you need to upgrade to a Pro plan and have physical backups enabled."
+        primaryText="Restore to a new project requires Pro Plan and above"
+        secondaryText="To restore to a new project, you need to upgrade to a Pro Plan and have physical backups enabled."
       />
     )
   }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -331,8 +331,8 @@ export function DiskManagementForm() {
         {isEntitlementsLoaded && isPlanUpgradeRequired && (
           <UpgradeToPro
             featureProposition="configure compute and disk"
-            primaryText="Compute and Disk configuration is not available on the Free Plan"
-            secondaryText="You will need to upgrade to at least the Pro Plan to configure compute and disk"
+            primaryText="Only available on Pro Plan and above"
+            secondaryText="Upgrade to the Pro Plan to configure compute and disk settings."
           />
         )}
 

--- a/apps/studio/components/interfaces/Organization/SecuritySettings.tsx
+++ b/apps/studio/components/interfaces/Organization/SecuritySettings.tsx
@@ -110,7 +110,7 @@ export const SecuritySettings = () => {
         {!isPaidPlan ? (
           <UpgradeToPro
             source="organizationMfa"
-            primaryText="Organization MFA enforcement is not available on Free plan"
+            primaryText="Organization MFA enforcement is not available on Free Plan"
             secondaryText="Upgrade to Pro or above to enforce MFA requirements for your organization."
             featureProposition="enforce MFA requirements"
           />

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -275,7 +275,7 @@ const PITRSidePanel = () => {
                   className="mb-4"
                   addon="pitr"
                   primaryText="Changing your Point-In-Time-Recovery is only available on the Pro Plan"
-                  secondaryText="Upgrade your plan to change PITR for your project"
+                  secondaryText="Upgrade your plan to change PITR for your project."
                   featureProposition="enable PITR"
                 />
               ) : !hasSufficientCompute ? (
@@ -283,7 +283,7 @@ const PITRSidePanel = () => {
                   className="mb-4"
                   addon="computeSize"
                   primaryText="Project needs to be at least on a Small compute size to enable PITR"
-                  secondaryText="This ensures enough resources to execute PITR successfully"
+                  secondaryText="This ensures enough resources to execute PITR successfully."
                   featureProposition="enable PITR"
                 />
               ) : null}

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
@@ -81,7 +81,8 @@ export const AWSPrivateLinkSection = () => {
                 {promptPlanUpgrade && (
                   <div className="mb-6">
                     <UpgradeToPro
-                      primaryText="Upgrade to Team or Enterprise to use AWS PrivateLink"
+                    layout="vertical"
+                      primaryText="Only available on Team or Enterprise Plan and above"
                       secondaryText="Connect your AWS VPC privately to your Supabase project using AWS PrivateLink."
                       buttonText="Upgrade to Team"
                       source="aws-privatelink-integration"

--- a/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/AWSPrivateLink/AWSPrivateLinkSection.tsx
@@ -81,7 +81,7 @@ export const AWSPrivateLinkSection = () => {
                 {promptPlanUpgrade && (
                   <div className="mb-6">
                     <UpgradeToPro
-                    layout="vertical"
+                      layout="vertical"
                       primaryText="Only available on Team or Enterprise Plan and above"
                       secondaryText="Connect your AWS VPC privately to your Supabase project using AWS PrivateLink."
                       buttonText="Upgrade to Team"

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
@@ -74,6 +74,7 @@ export const GitHubSection = () => {
                 {promptProPlanUpgrade && (
                   <div className="mb-6">
                     <UpgradeToPro
+                    layout="vertical"
                       source="github-integration"
                       featureProposition="use GitHub integrations"
                       primaryText={`Upgrade to ${!!existingConnection ? 'manage' : 'unlock'} GitHub integration`}

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
@@ -74,7 +74,7 @@ export const GitHubSection = () => {
                 {promptProPlanUpgrade && (
                   <div className="mb-6">
                     <UpgradeToPro
-                    layout="vertical"
+                      layout="vertical"
                       source="github-integration"
                       featureProposition="use GitHub integrations"
                       primaryText={`Upgrade to ${!!existingConnection ? 'manage' : 'unlock'} GitHub integration`}

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -401,7 +401,7 @@ export const StorageSettings = () => {
                         {isFreeTier && (
                           <UpgradeToPro
                             fullWidth
-                            buttonVariant="primary"
+                            variant="primary"
                             source="storageSizeLimit"
                             featureProposition="configure upload file size limits in Storage"
                             primaryText="Free Plan has a fixed upload file size limit of 50 MB"
@@ -414,7 +414,7 @@ export const StorageSettings = () => {
                           <UpgradeToPro
                             fullWidth
                             addon="spendCap"
-                            buttonVariant="default"
+                            variant="default"
                             source="storageSizeLimit"
                             featureProposition="increase the file upload size limits in Storage"
                             buttonText="Disable spend cap"

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -404,7 +404,7 @@ export const StorageSettings = () => {
                             buttonVariant="default"
                             source="storageSizeLimit"
                             featureProposition="configure upload file size limits in Storage"
-                            primaryText="Free Plan has a fixed upload file size limit of 50 MB."
+                            primaryText="Free Plan has a fixed upload file size limit of 50 MB"
                             secondaryText={`Upgrade to Pro Plan for a configurable upload file size limit of ${formatBytes(
                               STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED
                             )} and unlock image transformations.`}

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -401,6 +401,7 @@ export const StorageSettings = () => {
                         {isFreeTier && (
                           <UpgradeToPro
                             fullWidth
+                            buttonVariant="default"
                             source="storageSizeLimit"
                             featureProposition="configure upload file size limits in Storage"
                             primaryText="Free Plan has a fixed upload file size limit of 50 MB."
@@ -413,11 +414,12 @@ export const StorageSettings = () => {
                           <UpgradeToPro
                             fullWidth
                             addon="spendCap"
+                            buttonVariant="default"
                             source="storageSizeLimit"
                             featureProposition="increase the file upload size limits in Storage"
-                            buttonText="Disable Spend Cap"
-                            primaryText="Reduced max upload file size limit due to Spend Cap"
-                            secondaryText={`Disable your Spend Cap to allow file uploads of up to ${formatBytes(
+                            buttonText="Disable spend cap"
+                            primaryText="Reduced max upload file size limit due to spend cap"
+                            secondaryText={`Disable your spend cap to allow file uploads of up to ${formatBytes(
                               STORAGE_FILE_SIZE_LIMIT_MAX_BYTES_UNCAPPED
                             )}.`}
                           />

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -401,7 +401,7 @@ export const StorageSettings = () => {
                         {isFreeTier && (
                           <UpgradeToPro
                             fullWidth
-                            buttonVariant="default"
+                            buttonVariant="primary"
                             source="storageSizeLimit"
                             featureProposition="configure upload file size limits in Storage"
                             primaryText="Free Plan has a fixed upload file size limit of 50 MB"
@@ -447,7 +447,7 @@ export const StorageSettings = () => {
                             </Button>
                           )}
                           <Button
-                            type="primary"
+                            type={isFreeTier ? 'default' : 'primary'}
                             htmlType="submit"
                             loading={isUpdating}
                             disabled={

--- a/apps/studio/components/ui/UpgradePlanButton.tsx
+++ b/apps/studio/components/ui/UpgradePlanButton.tsx
@@ -95,7 +95,7 @@ export const UpgradePlanButton = ({
     return (
       <ButtonTooltip
         disabled
-        type="primary"
+        type={variant}
         className={className}
         tooltip={{
           content: {

--- a/apps/studio/components/ui/UpgradePlanButton.tsx
+++ b/apps/studio/components/ui/UpgradePlanButton.tsx
@@ -17,7 +17,7 @@ export const PLAN_REQUEST_EMPTY_PLACEHOLDER =
 interface UpgradePlanButtonProps {
   /** Stick to camel case for consistency */
   source: string
-  type?: 'default' | 'primary'
+  variant?: 'default' | 'primary'
   plan?: 'Pro' | 'Team' | 'Enterprise'
   addon?: 'pitr' | 'customDomain' | 'spendCap' | 'computeSize'
   /** Used in the default message template for request upgrade dialog, e.g: "Upgrade to ..." */
@@ -33,7 +33,7 @@ interface UpgradePlanButtonProps {
  */
 export const UpgradePlanButton = ({
   source,
-  type = 'primary',
+  variant = 'primary',
   plan = 'Pro',
   addon,
   featureProposition,
@@ -110,7 +110,7 @@ export const UpgradePlanButton = ({
   }
 
   return (
-    <Button asChild type={type} disabled={disabled} className={className}>
+    <Button asChild type={variant} disabled={disabled} className={className}>
       {link}
     </Button>
   )

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -58,7 +58,7 @@ export const UpgradeToPro = ({
           source={source}
           featureProposition={featureProposition}
           disabled={disabled}
-          type={buttonVariant}
+          variant={buttonVariant}
         >
           {buttonText}
         </UpgradePlanButton>

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -48,7 +48,7 @@ export const UpgradeToPro = ({
       className={cn(
         'mb-0',
         fullWidth &&
-          'border-0 rounded-none border-b px-6 [&>svg]:left-6 [&>div>button]:w-min [&>div>button]:mt-3 [&>div>a]:w-min [&>div>a]:mt-3',
+          'border-0 rounded-none border-b',
         className
       )}
       actions={

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -45,12 +45,7 @@ export const UpgradeToPro = ({
       layout={layout}
       title={primaryText}
       description={secondaryText}
-      className={cn(
-        'mb-0',
-        fullWidth &&
-          'border-0 rounded-none border-b',
-        className
-      )}
+      className={cn(fullWidth && 'border-0 rounded-none border-b', className)}
       actions={
         <UpgradePlanButton
           plan={planToUpgrade}

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -19,7 +19,7 @@ interface UpgradeToProProps {
   disabled?: boolean
   fullWidth?: boolean
   layout?: 'vertical' | 'horizontal'
-  buttonVariant?: 'default' | 'primary'
+  variant?: 'default' | 'primary'
   className?: string
 }
 
@@ -35,7 +35,7 @@ export const UpgradeToPro = ({
   disabled = false,
   fullWidth = false,
   layout = 'horizontal',
-  buttonVariant = 'primary',
+  variant = 'primary',
   className,
 }: UpgradeToProProps) => {
   return (
@@ -53,7 +53,7 @@ export const UpgradeToPro = ({
           source={source}
           featureProposition={featureProposition}
           disabled={disabled}
-          variant={buttonVariant}
+          variant={variant}
         >
           {buttonText}
         </UpgradePlanButton>

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -18,8 +18,9 @@ interface UpgradeToProProps {
   source?: string
   disabled?: boolean
   fullWidth?: boolean
-  className?: string
   layout?: 'vertical' | 'horizontal'
+  buttonVariant?: 'default' | 'primary'
+  className?: string
 }
 
 export const UpgradeToPro = ({
@@ -34,6 +35,7 @@ export const UpgradeToPro = ({
   disabled = false,
   fullWidth = false,
   layout = 'horizontal',
+  buttonVariant = 'primary',
   className,
 }: UpgradeToProProps) => {
   return (
@@ -44,7 +46,7 @@ export const UpgradeToPro = ({
       title={primaryText}
       description={secondaryText}
       className={cn(
-        'bg-surface-100 mb-0',
+        'mb-0',
         fullWidth &&
           'border-0 rounded-none border-b px-6 [&>svg]:left-6 [&>div>button]:w-min [&>div>button]:mt-3 [&>div>a]:w-min [&>div>a]:mt-3',
         className
@@ -56,6 +58,7 @@ export const UpgradeToPro = ({
           source={source}
           featureProposition={featureProposition}
           disabled={disabled}
+          type={buttonVariant}
         >
           {buttonText}
         </UpgradePlanButton>

--- a/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -108,13 +108,13 @@ const PITR = () => {
         <>
           {!isEnabled ? (
             <UpgradeToPro
-              addon="pitr"
+              addon={plan === 'free' ? undefined : 'pitr'}
               source="pitr"
               featureProposition="enable Point in Time Recovery"
-              primaryText="Point in Time Recovery is a Pro Plan add-on."
+              primaryText="Point in Time Recovery (PITR) is a Pro Plan add-on"
               secondaryText={
                 plan === 'free'
-                  ? 'With PITR, you can roll back to a specific time (to the second!). PITR starts from $100/mo and is available for Pro Plan customers. Note that the Pro Plan already includes daily backups for no extra charge — PITR is an optional upgrade that starts at $100/month.'
+                  ? 'With PITR, you can roll back to a specific time (to the second!). PITR starts from $100/mo and is available for Pro Plan customers. Note that the Pro Plan already includes daily backups for no extra charge. PITR is an optional upgrade that starts at $100/month.'
                   : 'Please enable the add-on to enable point in time recovery for your project.'
               }
             />

--- a/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -111,10 +111,10 @@ const PITR = () => {
               addon={plan === 'free' ? undefined : 'pitr'}
               source="pitr"
               featureProposition="enable Point in Time Recovery"
-              primaryText="Point in Time Recovery (PITR) is a Pro Plan add-on"
+              primaryText="Point in Time Recovery is a Pro Plan add-on"
               secondaryText={
                 plan === 'free'
-                  ? 'With PITR, you can roll back to a specific time (to the second!). PITR starts from $100/mo and is available for Pro Plan customers. Note that the Pro Plan already includes daily backups for no extra charge. PITR is an optional upgrade that starts at $100/month.'
+                  ? 'Roll back your database to a specific second. Starts at $100/month. Pro Plan already includes daily backups at no extra cost.'
                   : 'Please enable the add-on to enable point in time recovery for your project.'
               }
             />

--- a/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -76,6 +76,7 @@ const PITR = () => {
   } = useBackupsQuery({ projectRef })
 
   const plan = organization?.plan?.id
+  const isFreePlan = plan === 'free'
   const isEnabled = backups?.pitr_enabled
   const isActiveHealthy = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
@@ -108,12 +109,12 @@ const PITR = () => {
         <>
           {!isEnabled ? (
             <UpgradeToPro
-              addon={plan === 'free' ? undefined : 'pitr'}
+              addon={isFreePlan ? undefined : 'pitr'}
               source="pitr"
               featureProposition="enable Point in Time Recovery"
               primaryText="Point in Time Recovery is a Pro Plan add-on"
               secondaryText={
-                plan === 'free'
+                isFreePlan
                   ? 'Roll back your database to a specific second. Starts at $100/month. Pro Plan already includes daily backups at no extra cost.'
                   : 'Please enable the add-on to enable point in time recovery for your project.'
               }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- UI improvement
- Resolves DEPR-117

## What is the current behavior?

- The file storage settings `UpgradeToPro` admonition uses the green primary button variant. This visually collides with the ‘Save’ button beneath it, which uses the same variant (but is disabled anyway since the user must be Pro plan to do anything on this form)
- Same problem with the SMS MFA `UpgradeToPro` admonition
- The file storage settings Spend cap admonition (also `UpgradeToPro` under the hood) clashes with the (enabled) ‘Save’ button beneath it
- Other minor stylistic and copywriting issues with the `UpgradeToPro` admonition instances

There should only be one primary button at any one time within a view to make it clear what the primary action is.

## What is the new behavior?

- File storage settings `UpgradeToPro` admonition uses the `primary` button variant. The Save button beneath becomes default (disabled)
- Spend cap admonition uses default button variant since the sibling Save button is always functional
- SMS MFA `UpgradeToPro` admonition continues to use the `primary` button variant. The Save button below it becomes (disabled) `default` whilst that admonition is shown to distinguish the two

Other updates:

- Updated the ‘spend cap’ language to be sentence case, as per our copywriting guidelines
- Reset the global `bg` override on the admonition so it is distinguished from the form contents.

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Storage  Supabase" src="https://github.com/user-attachments/assets/a8cdcf05-541c-41ba-85c9-9cd8d9e6f318" /> | <img width="1024" height="759" alt="Storage  Supabase" src="https://github.com/user-attachments/assets/12b4d3c8-f0b2-4feb-955e-882d20d86249" /> |
| <img width="1024" height="759" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/31a812e8-ec04-4538-a1f4-126c33eba299" /> | <img width="1024" height="759" alt="Authentication  Supabase" src="https://github.com/user-attachments/assets/a529e231-0f4f-42d3-9322-40acfa763ef1" /> |
| <img width="1024" height="759" alt="Storage  Supabase" src="https://github.com/user-attachments/assets/bce8960e-b87e-44ed-95e1-e33370f52870" /> | <img width="1024" height="759" alt="Storage  Supabase" src="https://github.com/user-attachments/assets/2a12dd4e-33c9-4e05-8c28-7123050608a9" /> |

## Additional context

The admonition is actually wrapped in an `UpgradeToPro` component. I don’t fully understand why. Leaving as-is since billing is related.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined upgrade prompt wording across many settings for clearer, more consistent messaging and punctuation.
  * Call-to-action buttons for upgrade prompts and save actions now adapt their visual style based on plan/entitlement, improving emphasis and guidance.
  * Backups view now displays the upgrade prompt when backup access is missing.
  * Minor spacing and layout tweaks to upgrade panels for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->