### PR TITLE
Fix GH integrations authorize CTA

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useMemo } from 'react'
 
+import { useGitHubAuthorizationQuery } from '@/data/integrations/github-authorization-query'
 import { useParams } from 'common'
 import {
   ScaffoldContainer,
@@ -36,6 +37,8 @@ export const GitHubSection = () => {
 
   const isProPlanAndUp = organization?.plan?.id !== 'free'
   const promptProPlanUpgrade = IS_PLATFORM && !isProPlanAndUp
+
+  const { data: gitHubAuthorization } = useGitHubAuthorizationQuery()
 
   const { data: connections } = useGitHubConnectionsQuery(
     { organizationId: organization?.id },
@@ -81,10 +84,15 @@ export const GitHubSection = () => {
                     />
                   </div>
                 )}
-                <GitHubIntegrationConnectionForm
-                  disabled={promptProPlanUpgrade}
-                  connection={existingConnection}
-                />
+
+                {/* [Joshen] Show connection form if GH has already been authorized OR no GH authorization but on a paid plan */}
+                {/* So this shouldn't render if there's no GH authorization and on a free plan */}
+                {(!!gitHubAuthorization || (!gitHubAuthorization && !promptProPlanUpgrade)) && (
+                  <GitHubIntegrationConnectionForm
+                    disabled={promptProPlanUpgrade}
+                    connection={existingConnection}
+                  />
+                )}
               </div>
             </div>
           )}

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GithubSection.tsx
@@ -87,7 +87,7 @@ export const GitHubSection = () => {
 
                 {/* [Joshen] Show connection form if GH has already been authorized OR no GH authorization but on a paid plan */}
                 {/* So this shouldn't render if there's no GH authorization and on a free plan */}
-                {(!!gitHubAuthorization || (!gitHubAuthorization && !promptProPlanUpgrade)) && (
+                {(!!gitHubAuthorization || !promptProPlanUpgrade) && (
                   <GitHubIntegrationConnectionForm
                     disabled={promptProPlanUpgrade}
                     connection={existingConnection}


### PR DESCRIPTION
## Context

UI bug introduced from a previous PR of mine - the "Authorize" CTA for GH integrations in project settings should not show up if the user has yet to authorize GH + on a free plan org

Yet to authorize + On a free plan:
<img width="1170" height="353" alt="image" src="https://github.com/user-attachments/assets/754f92ba-85dd-4b21-b8d5-2fdc2701ec97" />

Yet to authorize + on a paid plan:
<img width="1162" height="382" alt="image" src="https://github.com/user-attachments/assets/80b32cef-4068-453b-b07d-91295ad7ab64" />

Authorized + on a free plan: (Form shows, all disabled - will also allow users to disable GH integration if they've set up one already, then downgraded)
This is already the current behaviour
<img width="1160" height="907" alt="image" src="https://github.com/user-attachments/assets/ec34c9ad-5075-482b-b6aa-ac58603a1177" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * GitHub integration settings now show the connection form only when GitHub is authorized or the user is on a paid plan.
  * For free-plan users without authorization, the form is disabled and a prompt to upgrade is preserved, reducing accidental access attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->