### PR TITLE
feat(studio): swap area chart fills for gradients

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -442,6 +442,23 @@ export function ComposedChart({
             key={xAxisKey}
           />
 
+          {/* Add gradient definitions */}
+          <defs>
+            {visibleAttributes.map((attribute) => (
+              <linearGradient
+                key={`gradient-${attribute.name}`}
+                id={`gradient-${attribute.name}`}
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop offset="3%" stopColor={attribute.color} stopOpacity={0.2} />
+                <stop offset="90%" stopColor="#131313" stopOpacity={0} />
+              </linearGradient>
+            ))}
+          </defs>
+
           {chartStyle === 'bar'
             ? visibleAttributes.map((attribute) => (
                 <Bar
@@ -461,10 +478,10 @@ export function ComposedChart({
             : visibleAttributes.map((attribute, i) => (
                 <Area
                   key={attribute.name}
-                  type="step"
+                  type="linear"
                   dataKey={attribute.name}
                   stackId="1"
-                  fill={attribute.fill}
+                  fill={`url(#gradient-${attribute.name})`}
                   fillOpacity={1}
                   stroke={attribute.color}
                   radius={20}
@@ -480,7 +497,7 @@ export function ComposedChart({
           {maxAttribute && _showMaxValue && (
             <Line
               key={maxAttribute.attribute}
-              type="step"
+              type="linear"
               dataKey={maxAttribute.attribute}
               stroke={CHART_COLORS.REFERENCE_LINE}
               strokeWidth={2}

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -442,7 +442,6 @@ export function ComposedChart({
             key={xAxisKey}
           />
 
-          {/* Add gradient definitions */}
           <defs>
             {visibleAttributes.map((attribute) => (
               <linearGradient
@@ -453,8 +452,8 @@ export function ComposedChart({
                 x2="0"
                 y2="1"
               >
-                <stop offset="3%" stopColor={attribute.color} stopOpacity={0.2} />
-                <stop offset="90%" stopColor="#131313" stopOpacity={0} />
+                <stop offset="5%" stopColor={attribute.color} stopOpacity={0.15} />
+                <stop offset="95%" stopColor="#131313" stopOpacity={0} />
               </linearGradient>
             ))}
           </defs>

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -453,7 +453,7 @@ export function ComposedChart({
                 y2="1"
               >
                 <stop offset="5%" stopColor={attribute.color} stopOpacity={0.15} />
-                <stop offset="95%" stopColor="#131313" stopOpacity={0} />
+                <stop offset="95%" stopColor={isDarkMode ? '#131313' : '#FFFFFF'} stopOpacity={0} />
               </linearGradient>
             ))}
           </defs>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Further improving upon our area charts in `<ComposedChart />` as the fill can still be a little bit jarring. Switching to gradients instead.

| Before | After |
|--------|--------|
| <img width="889" height="348" alt="Screenshot 2026-01-22 at 11 28 20" src="https://github.com/user-attachments/assets/54a65650-23aa-444f-b379-49939bfb19e6" /> | <img width="901" height="349" alt="Screenshot 2026-01-22 at 11 28 27" src="https://github.com/user-attachments/assets/8d1cc8f3-aced-43ca-8f27-f727d0feed28" /> |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced chart visualization with gradient fills for visible attributes to improve aesthetics.
  * Improved area chart smoothness by switching interpolation from stepped to linear.
  * Aligned maximum/reference line rendering to linear interpolation for consistent visuals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->