### PR TITLE
fix: updated explain to not crash on non text formats

### DIFF
--- a/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.utils.ts
+++ b/apps/studio/components/interfaces/ExplainVisualizer/ExplainVisualizer.utils.ts
@@ -133,6 +133,12 @@ export function isExplainQuery(rows: readonly unknown[]): boolean {
   return 'QUERY PLAN' in firstRow && Object.keys(firstRow).length === 1
 }
 
+export function isTextFormatExplain(rows: readonly unknown[]): boolean {
+  if (!isExplainQuery(rows)) return false
+  const firstRow = rows[0] as Record<string, unknown>
+  return typeof firstRow['QUERY PLAN'] === 'string'
+}
+
 export function isExplainSql(sql: string): boolean {
   return /^\s*explain\b/i.test(sql)
 }

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react'
 import CopyButton from 'components/ui/CopyButton'
 import { ExplainVisualizer } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer'
 import { ExplainHeader } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.Header'
-import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
+import {
+  isExplainQuery,
+  isTextFormatExplain,
+} from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import Results from './Results'
@@ -78,6 +81,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
   }
 
   const isValidExplain = isExplainQuery(explainResult.rows)
+  const isTextFormat = isTextFormatExplain(explainResult.rows)
 
   if (!isValidExplain) {
     return (
@@ -85,6 +89,20 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
         <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
           Unable to parse explain results. Please try running the query again.
         </p>
+      </div>
+    )
+  }
+
+  // Handle non-TEXT formats (JSON, YAML, XML) - show raw output only
+  if (!isTextFormat) {
+    return (
+      <div className="h-full flex flex-col pb-9">
+        <div className="px-4 py-3 bg-surface-100 border-b border-default flex items-center gap-2">
+          <span className="text-sm text-foreground-light">
+            Visual execution plan is only available for TEXT format. Showing raw output.
+          </span>
+        </div>
+        <Results rows={explainResult.rows} />
       </div>
     )
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix: SQL editor would crash on JSON/YAML formats of explain. Fixed it to not handle for now, will change in the future to use JSON as default rather than parsing text 🙈 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of EXPLAIN queries in non-text formats (JSON, YAML). The system now displays raw output with an informative message instead of attempting to render an incompatible visual plan.

* **Tests**
  * Added test coverage for EXPLAIN query format detection across text, JSON, and YAML formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->