### PR TITLE
fix(studio): use paginated buckets endpoint for command menu

### DIFF
--- a/apps/studio/data/storage/buckets-max-size-limit-query.ts
+++ b/apps/studio/data/storage/buckets-max-size-limit-query.ts
@@ -14,15 +14,14 @@ import {
 
 export const THRESHOLD_FOR_AUTO_QUERYING_BUCKET_LIMITS = 10_000
 
-const getBucketNumberEstimateKey = (projectRef: string | undefined) =>
+export const getBucketNumberEstimateKey = (projectRef: string | undefined) =>
   getLiveTupleEstimateKey(projectRef, 'buckets', 'storage')
 
-const getBucketNumberEstimate = async ({
+export const getBucketNumberEstimate = async ({
   projectRef,
   connectionString,
 }: ConnectionVars): Promise<number | undefined> => {
   if (!projectRef) throw new Error('Project reference is required')
-  if (!connectionString) throw new Error('Connection string is required')
 
   const queryKey = getBucketNumberEstimateKey(projectRef)
 

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -17,6 +17,7 @@ import {
   type UseCustomInfiniteQueryOptions,
   type UseCustomQueryOptions,
 } from 'types'
+import { getBucketNumberEstimate, getBucketNumberEstimateKey } from './buckets-max-size-limit-query'
 import { storageKeys } from './keys'
 
 export type BucketsVariables = { projectRef?: string }
@@ -145,6 +146,27 @@ export const useBucketsQuery = <TData = BucketsData>(
     enabled: enabled && typeof projectRef !== 'undefined' && isActive,
     ...options,
     retry: shouldRetryBucketsQuery,
+  })
+}
+
+export const useBucketNumberEstimateQuery = (
+  { projectRef }: BucketsVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<number | undefined, ResponseError> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const connectionString = project?.connectionString
+
+  return useQuery<number | undefined, ResponseError>({
+    // Query remains functionally the same even if connectionString changes
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: getBucketNumberEstimateKey(projectRef),
+    queryFn: () =>
+      getBucketNumberEstimate({
+        projectRef,
+        connectionString,
+      }),
+    enabled: enabled && !!projectRef,
+    ...options,
   })
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The command menu search uses the unpaginated buckets endpoint, which times out or causes jankiness when users have tens of thousands of buckets.

## What is the new behavior?

Uses the paginated buckets endpoint. Only the first 10 results are shown, and users need a more specific search query to find other buckets (same UX as before, but with better performance).

## Additional context

Towards FE-2118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Debounced search queries to reduce API calls during storage searches
  * Paginated fetching for bucket lists and server-side filtering for file buckets

* **New Features**
  * Display estimated total bucket count with an “(estimate)” indicator in results
  * Improved empty-state and footer behavior to align with the debounced search flow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->