### PR TITLE
Move JWT Page

### DIFF
--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -340,7 +340,7 @@ const JWTSettings = () => {
                               icon={<ExternalLink className="size-4" />}
                               asChild
                             >
-                              <Link href={`/project/${projectRef}/settings/jwt/signing-keys`}>
+                              <Link href={`/project/${projectRef}/auth/jwt`}>
                                 Go to JWT Signing Keys
                               </Link>
                             </Button>

--- a/apps/studio/components/layouts/AuthLayout/Auth.Commands.tsx
+++ b/apps/studio/components/layouts/AuthLayout/Auth.Commands.tsx
@@ -120,6 +120,13 @@ export function useAuthGotoCommands(options?: CommandOptions) {
         route: `/project/${ref}/auth/url-configuration`,
         defaultHidden: true,
       },
+      {
+        id: 'nav-auth-jwt',
+        name: 'JWT',
+        value: 'Auth: JWT',
+        route: `/project/${ref}/auth/jwt`,
+        defaultHidden: true,
+      },
       ...(authenticationAttackProtection
         ? [
             {

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
@@ -103,6 +103,12 @@ export const generateAuthMenu = (
                 url: `/project/${ref}/auth/sessions`,
                 items: [],
               },
+              {
+                name: 'JWT Keys',
+                key: 'jwt',
+                url: `/project/${ref}/auth/jwt`,
+                items: [],
+              },
               ...(authenticationRateLimits
                 ? [
                     {

--- a/apps/studio/components/layouts/JWTKeys/JWTKeysLayout.tsx
+++ b/apps/studio/components/layouts/JWTKeys/JWTKeysLayout.tsx
@@ -10,12 +10,12 @@ const JWTKeysLayout = ({ children }: PropsWithChildren) => {
   const navigationItems = [
     {
       label: 'JWT Signing Keys',
-      href: `/project/${projectRef}/settings/jwt`,
+      href: `/project/${projectRef}/auth/jwt`,
       id: 'signing-keys',
     },
     {
       label: 'Legacy JWT Secret',
-      href: `/project/${projectRef}/settings/jwt/legacy`,
+      href: `/project/${projectRef}/auth/jwt/legacy`,
       id: 'legacy-jwt-keys',
     },
   ]

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsLayout.tsx
@@ -52,7 +52,6 @@ const SettingsLayout = ({ title, children }: PropsWithChildren<SettingsLayoutPro
     edgeFunctions: edgeFunctionsEnabled,
     storage: storageEnabled,
     invoices: invoicesEnabled,
-    legacyJwtKeys: legacyJWTKeysEnabled,
     logDrains: projectSettingsLogDrains,
     billing: billingAll,
   })

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -15,7 +15,6 @@ export const generateSettingsMenu = (
     edgeFunctions?: boolean
     storage?: boolean
     invoices?: boolean
-    legacyJwtKeys?: boolean
     logDrains?: boolean
     billing?: boolean
   }
@@ -42,7 +41,6 @@ export const generateSettingsMenu = (
   const authProvidersEnabled = features?.authProviders ?? true
   const edgeFunctionsEnabled = features?.edgeFunctions ?? true
   const storageEnabled = features?.storage ?? true
-  const legacyJwtKeysEnabled = features?.legacyJwtKeys ?? true
   const billingEnabled = features?.billing ?? true
 
   return [
@@ -87,15 +85,6 @@ export const generateSettingsMenu = (
           url: `/project/${ref}/settings/api-keys/new`,
           items: [],
         },
-        {
-          name: 'JWT Keys',
-          key: 'jwt',
-          url: legacyJwtKeysEnabled
-            ? `/project/${ref}/settings/jwt`
-            : `/project/${ref}/settings/jwt/signing-keys`,
-          items: [],
-        },
-
         {
           name: `Log Drains`,
           key: `log-drains`,

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -247,7 +247,17 @@ const nextConfig = {
       {
         permanent: true,
         source: '/project/:ref/settings/jwt/signing-keys',
-        destination: '/project/:ref/settings/jwt',
+        destination: '/project/:ref/auth/jwt',
+      },
+      {
+        permanent: true,
+        source: '/project/:ref/settings/jwt',
+        destination: '/project/:ref/auth/jwt',
+      },
+      {
+        permanent: true,
+        source: '/project/:ref/settings/jwt/legacy',
+        destination: '/project/:ref/auth/jwt/legacy',
       },
       {
         source: '/project/:ref/database/api-logs',

--- a/apps/studio/pages/project/[ref]/auth/jwt/index.tsx
+++ b/apps/studio/pages/project/[ref]/auth/jwt/index.tsx
@@ -2,8 +2,8 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 import { JWTSecretKeysTable } from 'components/interfaces/JwtSecrets/jwt-secret-keys-table'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import JWTKeysLayout from 'components/layouts/JWTKeys/JWTKeysLayout'
-import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import type { NextPageWithLayout } from 'types'
@@ -30,9 +30,9 @@ const JWTSigningKeysPage: NextPageWithLayout = () => {
 
 JWTSigningKeysPage.getLayout = (page) => (
   <DefaultLayout>
-    <SettingsLayout>
+    <AuthLayout>
       <JWTKeysLayout>{page}</JWTKeysLayout>
-    </SettingsLayout>
+    </AuthLayout>
   </DefaultLayout>
 )
 

--- a/apps/studio/pages/project/[ref]/auth/jwt/legacy.tsx
+++ b/apps/studio/pages/project/[ref]/auth/jwt/legacy.tsx
@@ -1,7 +1,7 @@
 import JWTSettings from 'components/interfaces/JwtSecrets/jwt-settings'
 import DefaultLayout from 'components/layouts/DefaultLayout'
+import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import JWTKeysLayout from 'components/layouts/JWTKeys/JWTKeysLayout'
-import SettingsLayout from 'components/layouts/ProjectSettingsLayout/SettingsLayout'
 import type { NextPageWithLayout } from 'types'
 
 import { JwtSecretUpdateError, JwtSecretUpdateStatus } from '@supabase/shared-types/out/events'
@@ -51,7 +51,7 @@ const JWTKeysLegacyPage: NextPageWithLayout = () => {
   }, [jwtSecretUpdateStatus])
 
   if (!projectSettingsLegacyJwtKeys) {
-    return <UnknownInterface urlBack={`/project/${projectRef}/settings/jwt/signing-keys`} />
+    return <UnknownInterface urlBack={`/project/${projectRef}/auth/jwt`} />
   }
 
   return (
@@ -63,7 +63,7 @@ const JWTKeysLegacyPage: NextPageWithLayout = () => {
 
 JWTKeysLegacyPage.getLayout = (page) => (
   <DefaultLayout>
-    <SettingsLayout>{page}</SettingsLayout>
+    <AuthLayout>{page}</AuthLayout>
   </DefaultLayout>
 )
 


### PR DESCRIPTION
<img width="1047" height="753" alt="image" src="https://github.com/user-attachments/assets/aedfdb38-68e2-4c00-a226-3d09ff004ddb" />

This moves the JWT Keys page out of project settings and into auth settings (auth/jwt) for a couple reasons:
- Creates greater separation from API Keys
- Auth is a more natural fit



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "JWT Keys" entry in the authentication configuration for easier access.

* **Improvements**
  * Moved JWT signing keys and legacy JWT keys into the authentication section and updated navigation paths.
  * Added permanent redirects from old JWT settings URLs to the new authentication URLs to preserve links.
  * Pages now use the authentication layout for JWT-related screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->