### PR TITLE
feat(studio): show SQL snippet description

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -251,6 +251,7 @@ export const SQLEditorTreeViewItem = ({
             }}
             {...props}
             name={element.name}
+            nameForTitle={props.nameForTitle}
             description={element.metadata?.description || undefined}
             xPadding={16}
           />

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -251,6 +251,7 @@ export const SQLEditorTreeViewItem = ({
             }}
             {...props}
             name={element.name}
+            description={element.metadata?.description || undefined}
             xPadding={16}
           />
         </ContextMenuTrigger_Shadcn_>

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -115,13 +115,9 @@ export const SearchList = ({ search }: SearchListProps) => {
                     ...element,
                     name: (
                       <span className="flex flex-col py-0.5">
-                        <span className="truncate">
-                          {element.name}
-                        </span>
+                        <span className="truncate">{element.name}</span>
                         {!!visibility && (
-                          <span className="text-foreground-lighter text-xs">
-                            {visibility}
-                          </span>
+                          <span className="text-foreground-lighter text-xs">{visibility}</span>
                         )}
                       </span>
                     ),

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -115,17 +115,18 @@ export const SearchList = ({ search }: SearchListProps) => {
                     ...element,
                     name: (
                       <span className="flex flex-col py-0.5">
-                        <span title={element.name} className="truncate">
+                        <span className="truncate">
                           {element.name}
                         </span>
                         {!!visibility && (
-                          <span title={visibility} className="text-foreground-lighter text-xs">
+                          <span className="text-foreground-lighter text-xs">
                             {visibility}
                           </span>
                         )}
                       </span>
                     ),
                   }}
+                  nameForTitle={element.name}
                   isBranch={false}
                   isOpened={isOpened && !isPreview}
                   isSelected={isActive}

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -63,9 +63,11 @@ const TreeViewItem = forwardRef<
     /** The horizontal padding of the item */
     xPadding?: number
     /** name of entity */
-    name: string
+    name: string | ReactNode
     /** Optional description of entity */
     description?: string
+    /** String name to use for title attribute when name is a ReactNode */
+    nameForTitle?: string
     /** icon of entity */
     icon?: ReactNode
     /** Specifies if the item is being edited, shows an input */
@@ -93,6 +95,7 @@ const TreeViewItem = forwardRef<
       xPadding = 16,
       name = '',
       description,
+      nameForTitle,
       icon,
       isEditing = false,
       onEditSubmit,
@@ -102,7 +105,8 @@ const TreeViewItem = forwardRef<
     },
     ref
   ) => {
-    const [localValueState, setLocalValueState] = useState(name)
+    const nameString = nameForTitle ?? (typeof name === 'string' ? name : '')
+    const [localValueState, setLocalValueState] = useState(nameString)
     const inputRef = useRef<HTMLInputElement>(null)
     const timeRef = useRef<number>(0)
 
@@ -143,15 +147,15 @@ const TreeViewItem = forwardRef<
           }
         }, 200)
       } else {
-        setLocalValueState(name)
+        setLocalValueState(nameString)
       }
-    }, [isEditing])
+    }, [isEditing, nameString])
 
     useEffect(() => {
       if (!isLoading) {
-        setLocalValueState(name)
+        setLocalValueState(nameString)
       }
-    }, [isLoading])
+    }, [isLoading, nameString])
 
     const handleBlur = (e: FocusEvent<HTMLInputElement, Element>) => {
       const timestamp = Number(new Date())
@@ -181,10 +185,12 @@ const TreeViewItem = forwardRef<
       ...divProps
     } = props as any
 
+    const titleText = `${nameString}${description && typeof description === 'string' && description.trim() ? `: ${description.trim()}` : ''}`
+
     return (
       <div
         ref={ref}
-        title={description && typeof description === 'string' && description.trim() ? description : undefined}
+        title={titleText}
         {...divProps}
         aria-selected={isSelected}
         aria-expanded={!isEditing && isExpanded}
@@ -258,7 +264,7 @@ const TreeViewItem = forwardRef<
               />
             )
           )}
-          <span className={cn(isEditing && 'hidden', 'truncate text-sm')} title={name}>
+          <span className={cn(isEditing && 'hidden', 'truncate text-sm')}>
             {name}
           </span>
         </div>
@@ -279,8 +285,8 @@ const TreeViewItem = forwardRef<
               if (e.key === 'Enter') {
                 inputRef.current?.blur()
               } else if (e.key === 'Escape') {
-                setLocalValueState(name)
-                onEditSubmit?.(name)
+                setLocalValueState(nameString)
+                onEditSubmit?.(nameString)
               } else {
                 e.stopPropagation()
               }

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -185,7 +185,8 @@ const TreeViewItem = forwardRef<
       ...divProps
     } = props as any
 
-    const titleText = `${nameString}${description && typeof description === 'string' && description.trim() ? `: ${description.trim()}` : ''}`
+    const trimmedDescription = description?.trim()
+    const titleText = trimmedDescription ? `${nameString}: ${trimmedDescription}` : nameString
 
     return (
       <div

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -64,6 +64,8 @@ const TreeViewItem = forwardRef<
     xPadding?: number
     /** name of entity */
     name: string
+    /** Optional description of entity */
+    description?: string
     /** icon of entity */
     icon?: ReactNode
     /** Specifies if the item is being edited, shows an input */
@@ -90,6 +92,7 @@ const TreeViewItem = forwardRef<
       isLoading = false,
       xPadding = 16,
       name = '',
+      description,
       icon,
       isEditing = false,
       onEditSubmit,
@@ -181,6 +184,7 @@ const TreeViewItem = forwardRef<
     return (
       <div
         ref={ref}
+        title={description && typeof description === 'string' && description.trim() ? description : undefined}
         {...divProps}
         aria-selected={isSelected}
         aria-expanded={!isEditing && isExpanded}

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -186,7 +186,7 @@ const TreeViewItem = forwardRef<
     } = props as any
 
     const trimmedDescription = description?.trim()
-    const titleText = trimmedDescription ? `${nameString}: ${trimmedDescription}` : nameString
+    const titleText = trimmedDescription ? `${nameString}\n${trimmedDescription}` : nameString
 
     return (
       <div
@@ -265,9 +265,7 @@ const TreeViewItem = forwardRef<
               />
             )
           )}
-          <span className={cn(isEditing && 'hidden', 'truncate text-sm')}>
-            {name}
-          </span>
+          <span className={cn(isEditing && 'hidden', 'truncate text-sm')}>{name}</span>
         </div>
 
         {!isEditing && actions}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Feature
- Resolves DEPR-332

## What is the current behavior?

Some users add descriptions to their SQL snippets. We don’t show this description anywhere.

## What is the new behavior?

We show this optional description when hovering over the snippet’s name on the sidebar.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/e6115ed3-2398-46f9-a5f3-1e3ec2ba9402) | ![after3](https://github.com/user-attachments/assets/7b1f7c05-35d1-4f28-ad18-42aa9bd94368) |

## Additional context

- A cleaner approach might be to deprecate the description field but people are actively using it
	- It might come in handy later too, e.g. with improved sharing
- I chose to append the description to the snippet name as the `title` element already is in use for that
	- This `title` is needed because some (many of my) snippets are truncated
- Our built-in `Tooltip` component is a too heavy-handed for this
	- The HTML `title` element has the perfect weight, I think, for this type of affordance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tree view items in the SQL editor now show clearer titles and optional descriptions, improving readability.
  * Tooltips updated: item hover text now combines title and description when present; redundant per-element tooltips removed for a cleaner UI.
  * Names can display richer content (not limited to plain text), ensuring more flexible item rendering across navigation and search.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->