### PR TITLE
Validate against empty name in FileExplorerRowEditing.tsx

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -17,7 +17,6 @@ import {
 import { useContextMenu } from 'react-contexify'
 import SVG from 'react-inlinesvg'
 
-import { useParams } from 'common'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { BASE_PATH } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
@@ -115,8 +114,6 @@ export const FileExplorerRow = ({
   selectedItems = [],
   style,
 }: FileExplorerRowProps) => {
-  const { bucketId } = useParams()
-
   const {
     selectedBucket,
     selectedFilePreview,

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -1,5 +1,6 @@
 import { has } from 'lodash'
 import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import { toast } from 'sonner'
 
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { STORAGE_ROW_STATUS, STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
@@ -29,6 +30,11 @@ export const FileExplorerRowEditing = ({
     if (event) {
       event.preventDefault()
       event.stopPropagation()
+    }
+
+    if (name.length === 0) {
+      inputRef.current.focus()
+      return toast.error('Name cannot be empty')
     }
 
     if (item.type === STORAGE_ROW_TYPES.FILE) {

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -1,6 +1,5 @@
 import { has } from 'lodash'
 import { useEffect, useRef, useState, type CSSProperties } from 'react'
-import { toast } from 'sonner'
 
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { STORAGE_ROW_STATUS, STORAGE_ROW_TYPES, STORAGE_VIEWS } from '../Storage.constants'
@@ -30,11 +29,6 @@ export const FileExplorerRowEditing = ({
     if (event) {
       event.preventDefault()
       event.stopPropagation()
-    }
-
-    if (name.length === 0) {
-      inputRef.current.focus()
-      return toast.error('Name cannot be empty')
     }
 
     if (item.type === STORAGE_ROW_TYPES.FILE) {
@@ -107,7 +101,7 @@ export const FileExplorerRowEditing = ({
             mimeType={item.metadata?.mimetype}
           />
         </div>
-        <form className="h-9" onSubmit={(event) => onSaveItemName(itemName, event)}>
+        <form className="h-9" onSubmit={(event) => onSaveItemName(itemName || item.name, event)}>
           <input
             autoFocus
             ref={inputRef}
@@ -115,12 +109,12 @@ export const FileExplorerRowEditing = ({
             type="text"
             value={itemName}
             onChange={(event) => setItemName(event.target.value)}
-            onBlur={(event) => onSaveItemName(itemName, event)}
+            onBlur={(event) => onSaveItemName(itemName || item.name, event)}
           />
           <button
             className="hidden"
             type="submit"
-            onClick={(event) => onSaveItemName(itemName, event)}
+            onClick={(event) => onSaveItemName(itemName || item.name, event)}
           />
         </form>
       </div>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -101,7 +101,10 @@ export const FileExplorerRowEditing = ({
             mimeType={item.metadata?.mimetype}
           />
         </div>
-        <form className="h-9" onSubmit={(event) => onSaveItemName(itemName || item.name, event)}>
+        <form
+          className="h-9"
+          onSubmit={(event) => onSaveItemName(itemName.trim() || item.name, event)}
+        >
           <input
             autoFocus
             ref={inputRef}
@@ -109,12 +112,12 @@ export const FileExplorerRowEditing = ({
             type="text"
             value={itemName}
             onChange={(event) => setItemName(event.target.value)}
-            onBlur={(event) => onSaveItemName(itemName || item.name, event)}
+            onBlur={(event) => onSaveItemName(itemName.trim() || item.name, event)}
           />
           <button
             className="hidden"
             type="submit"
-            onClick={(event) => onSaveItemName(itemName || item.name, event)}
+            onClick={(event) => onSaveItemName(itemName.trim() || item.name, event)}
           />
         </form>
       </div>

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -716,7 +716,7 @@ function createStorageExplorerState({
           })
         }
 
-        if (state.openedFolders[columnIndex].name === folder.name) {
+        if (state.openedFolders[columnIndex]?.name === folder.name) {
           state.setSelectedFilePreview(undefined)
           state.popOpenedFoldersAtIndex(columnIndex - 1)
         }

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -209,6 +209,71 @@ test.describe.serial('Storage', () => {
     await renameItem(page, folderName, newFolderName)
   })
 
+  test('resets folder name when renaming with empty string', async ({ page, ref }) => {
+    const bucketName = `${bucketNamePrefix}_rename_folder_empty`
+    const folderName = 'folder_to_rename'
+
+    // Create a bucket, navigate to it, and create a folder
+    await createBucket(page, ref, bucketName, false)
+    await navigateToBucket(page, ref, bucketName)
+    await createFolder(page, folderName)
+
+    // Right-click on the folder to open context menu
+    const folder = page.getByTitle(folderName)
+    await expect(folder, `Folder ${folderName} should be visible`).toBeVisible()
+    await folder.click({ button: 'right' })
+
+    // Click rename option from context menu
+    await page.getByRole('menuitem', { name: 'Rename' }).click()
+
+    // Clear the input and press Enter with empty name
+    const nameInput = page.getByRole('textbox')
+    await expect(nameInput, 'Rename input should be visible').toBeVisible()
+    await nameInput.clear()
+    await nameInput.press('Enter')
+
+    // Verify the input disappears (edit mode exits)
+    await expect(nameInput, 'Input should disappear after pressing Enter').not.toBeVisible()
+
+    // Verify the folder name is reset to original
+    await expect(
+      page.getByTitle(folderName),
+      'Folder should retain its original name'
+    ).toBeVisible()
+  })
+
+  test('resets folder name when clicking outside with empty string', async ({ page, ref }) => {
+    const bucketName = `${bucketNamePrefix}_rename_folder_blur`
+    const folderName = 'folder_to_blur'
+
+    // Create a bucket, navigate to it, and create a folder
+    await createBucket(page, ref, bucketName, false)
+    await navigateToBucket(page, ref, bucketName)
+    await createFolder(page, folderName)
+
+    // Right-click on the folder to open context menu
+    const folder = page.getByTitle(folderName)
+    await expect(folder, `Folder ${folderName} should be visible`).toBeVisible()
+    await folder.click({ button: 'right' })
+
+    // Click rename option from context menu
+    await page.getByRole('menuitem', { name: 'Rename' }).click()
+
+    // Clear the input and click outside to blur
+    const nameInput = page.getByRole('textbox')
+    await expect(nameInput, 'Rename input should be visible').toBeVisible()
+    await nameInput.clear()
+
+    // Click outside the input to trigger blur
+    await page.getByRole('button', { name: 'Edit bucket' }).click()
+
+    // Verify the folder name is reset to original
+    await expect(
+      page.getByTitle(folderName),
+      'Folder should retain its original name after blur'
+    ).toBeVisible()
+  })
+
   test('can delete a file', async ({ page, ref }) => {
     const bucketName = `${bucketNamePrefix}_delete_file`
     const fileName = 'test-file.txt'

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from '@playwright/test'
 import path from 'path'
 import { env } from '../env.config.js'
-import { dismissToastsIfAny } from '../utils/dismiss-toast.js'
+import { test } from '../utils/test.js'
+import { waitForApiResponse } from '../utils/wait-for-response.js'
 import {
   createBucket,
   createFolder,
@@ -13,8 +14,7 @@ import {
   renameItem,
   uploadFile,
 } from '../utils/storage-helpers.js'
-import { test } from '../utils/test.js'
-import { waitForApiResponse } from '../utils/wait-for-response.js'
+import { dismissToastsIfAny } from '../utils/dismiss-toast.js'
 
 const bucketNamePrefix = 'pw_bucket'
 

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -267,37 +267,6 @@ test.describe.serial('Storage', () => {
     ).not.toBeVisible()
   })
 
-  test('cancels folder creation when name is empty', async ({ page, ref }) => {
-    const bucketName = `${bucketNamePrefix}_folder_empty_name`
-
-    // Create a bucket and navigate to it
-    await createBucket(page, ref, bucketName, false)
-    await navigateToBucket(page, ref, bucketName)
-
-    // Click create folder button
-    const createFolderBtn = page.getByRole('button', { name: 'Create folder' })
-    await expect(createFolderBtn, 'Create folder button should be visible').toBeVisible()
-    await createFolderBtn.click()
-
-    // Clear the input and press Enter with empty name
-    const nameInput = page.getByRole('textbox')
-    await expect(nameInput, 'Folder name input should be visible').toBeVisible()
-    await nameInput.clear()
-    await nameInput.press('Enter')
-
-    // Verify the input disappears (folder creation cancelled)
-    await expect(
-      nameInput,
-      'Input should disappear when folder creation is cancelled'
-    ).not.toBeVisible({ timeout: 3000 })
-
-    // Verify no folder was created (no items in the explorer besides the empty state)
-    await expect(
-      page.getByTitle('Untitled folder'),
-      'No folder should be created with empty name'
-    ).not.toBeVisible()
-  })
-
   test('can download a file', async ({ page, ref }) => {
     const bucketName = `${bucketNamePrefix}_download`
     const fileName = 'test-file.txt'

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -1,8 +1,7 @@
 import { expect } from '@playwright/test'
 import path from 'path'
 import { env } from '../env.config.js'
-import { test } from '../utils/test.js'
-import { waitForApiResponse } from '../utils/wait-for-response.js'
+import { dismissToastsIfAny } from '../utils/dismiss-toast.js'
 import {
   createBucket,
   createFolder,
@@ -14,7 +13,8 @@ import {
   renameItem,
   uploadFile,
 } from '../utils/storage-helpers.js'
-import { dismissToastsIfAny } from '../utils/dismiss-toast.js'
+import { test } from '../utils/test.js'
+import { waitForApiResponse } from '../utils/wait-for-response.js'
 
 const bucketNamePrefix = 'pw_bucket'
 
@@ -265,34 +265,6 @@ test.describe.serial('Storage', () => {
       page.getByTitle('test#folder'),
       'Folder with invalid character should not be created'
     ).not.toBeVisible()
-  })
-
-  test('cannot create a folder with duplicate name', async ({ page, ref }) => {
-    const bucketName = `${bucketNamePrefix}_folder_duplicate`
-    const folderName = 'duplicate_folder'
-
-    // Create a bucket, navigate to it, and create a folder
-    await createBucket(page, ref, bucketName, false)
-    await navigateToBucket(page, ref, bucketName)
-    await createFolder(page, folderName)
-
-    // Dismiss any toasts from previous action
-    await dismissToastsIfAny(page)
-
-    // Try to create another folder with the same name
-    const createFolderBtn = page.getByRole('button', { name: 'Create folder' })
-    await createFolderBtn.click()
-
-    const nameInput = page.getByRole('textbox')
-    await expect(nameInput, 'Folder name input should be visible').toBeVisible()
-    await nameInput.fill(folderName)
-    await nameInput.press('Enter')
-
-    // Verify error toast appears for duplicate name
-    await expect(
-      page.getByText(`The name ${folderName} already exists in the current directory`),
-      'Error message for duplicate name should appear'
-    ).toBeVisible()
   })
 
   test('cancels folder creation when name is empty', async ({ page, ref }) => {

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -237,36 +237,6 @@ test.describe.serial('Storage', () => {
     await deleteItem(page, folderName)
   })
 
-  test('cannot create a folder with special characters', async ({ page, ref }) => {
-    const bucketName = `${bucketNamePrefix}_folder_special_chars`
-
-    // Create a bucket and navigate to it
-    await createBucket(page, ref, bucketName, false)
-    await navigateToBucket(page, ref, bucketName)
-
-    // Try to create a folder with invalid character '#'
-    const createFolderBtn = page.getByRole('button', { name: 'Create folder' })
-    await expect(createFolderBtn, 'Create folder button should be visible').toBeVisible()
-    await createFolderBtn.click()
-
-    const nameInput = page.getByRole('textbox')
-    await expect(nameInput, 'Folder name input should be visible').toBeVisible()
-    await nameInput.fill('test#folder')
-    await nameInput.press('Enter')
-
-    // Verify error toast appears
-    await expect(
-      page.getByText('Folder name cannot contain the "#" character'),
-      'Error message for invalid character should appear'
-    ).toBeVisible()
-
-    // Verify folder was not created (input should still be visible since creation failed)
-    await expect(
-      page.getByTitle('test#folder'),
-      'Folder with invalid character should not be created'
-    ).not.toBeVisible()
-  })
-
   test('can download a file', async ({ page, ref }) => {
     const bucketName = `${bucketNamePrefix}_download`
     const fileName = 'test-file.txt'


### PR DESCRIPTION
## Context

Patches a dashboard bug whereby:
- Users can rename a folder to an empty string, should not be allowed
- Renaming a folder throws a toast error (2nd level onwards, not at the root)

## Changes involved
- Am using MacOS finder as a prior art - setting the folder name to an empty string and saving (either by hitting enter or clicking out of the input) will just reset the name to its original name

## To test
- [ ] Verify that you cannot set a folder name (or item name) to an empty string
- [ ] Verify that you can rename folders (at the root, or nested folders)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saving empty names when renaming items/folders; trimming now falls back to the original name.
  * Improved folder-rename guard to avoid runtime errors and related UI issues.
* **Tests**
  * Added end-to-end tests ensuring empty-name renames are canceled and the rename UI closes appropriately.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->