### PR TITLE
docs(swift): improve iOS quickstart guide

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
@@ -27,9 +27,11 @@ hideToc: true
 
     <StepHikeCompact.Details title="Install the Supabase client library">
 
-      Install Supabase package dependency using Xcode by following Apple's [tutorial](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app).
+      Add the [supabase-swift](https://github.com/supabase/supabase-swift) package to your app using the Swift Package Manager.
 
-      Make sure to add `Supabase` product package as dependency to the application.
+      In Xcode, navigate to `File > Add Package Dependencies...` and enter the repository URL `https://github.com/supabase/supabase-swift` in the search bar. For detailed instructions, see Apple's [tutorial on adding package dependencies](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app).
+
+      Make sure to add `Supabase` product package as a dependency to your application target.
 
     </StepHikeCompact.Details>
 
@@ -76,7 +78,7 @@ hideToc: true
 
     <StepHikeCompact.Code>
 
-      ```swift name=Supabase.swift
+      ```swift name=Instrument.swift
       struct Instrument: Decodable, Identifiable {
         let id: Int
         let name: String
@@ -100,6 +102,8 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```swift name=ContentView.swift
+      import SwiftUI
+
       struct ContentView: View {
 
         @State var instruments: [Instrument] = []
@@ -138,3 +142,12 @@ hideToc: true
   </StepHikeCompact.Step>
 
 </StepHikeCompact>
+
+## Setting up deep links
+
+If you want to implement authentication features like magic links or OAuth, you need to set up deep links to redirect users back to your app. For instructions on configuring custom URL schemes for your iOS app, see the [deep linking guide](/docs/guides/auth/native-mobile-deep-linking?platform=swift).
+
+## Next steps
+
+- Learn how to build a complete user management app with authentication in the [Swift tutorial](/docs/guides/getting-started/tutorials/with-swift)
+- Explore the [supabase-swift](https://github.com/supabase/supabase-swift) library on GitHub

--- a/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
@@ -29,7 +29,7 @@ hideToc: true
 
       Add the [supabase-swift](https://github.com/supabase/supabase-swift) package to your app using the Swift Package Manager.
 
-      In Xcode, navigate to `File > Add Package Dependencies...` and enter the repository URL `https://github.com/supabase/supabase-swift` in the search bar. For detailed instructions, see Apple's [tutorial on adding package dependencies](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app).
+      In Xcode, navigate to **File > Add Package Dependencies...** and enter the repository URL `https://github.com/supabase/supabase-swift` in the search bar. For detailed instructions, see Apple's [tutorial on adding package dependencies](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app).
 
       Make sure to add `Supabase` product package as a dependency to your application target.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The iOS SwiftUI quickstart guide had several issues: incorrect code block filename, missing import statement, and unclear package installation instructions. It lacked guidance on deep links and next steps for users wanting to implement authentication.

## What is the new behavior?

Fixed code block filename bug (Instrument.swift), added missing SwiftUI import, provided clearer installation instructions with the supabase-swift GitHub repository URL, and added sections for deep links setup and next steps to guide users toward authentication and comprehensive tutorials.

## Additional context

Aligned the iOS quickstart with similar guides (Flutter, Kotlin) by including deep linking guidance and directing users to the comprehensive tutorial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated iOS SwiftUI quickstart with step-by-step Swift Package Manager instructions for adding the client library.
  * Clarified how to add the package to the app target and improved code examples with explicit imports.
  * Added “Setting up deep links” and “Next steps” sections linking to deep-linking and Swift/client library resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->