### PR TITLE
Chore/allow users to access edge functions while project is paused

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -358,7 +358,7 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
     return <RestoringState />
   }
 
-  if (isProjectRestoreFailed && !isBackupsPage) {
+  if (isProjectRestoreFailed && !isBackupsPage && !isEdgeFunctionPages) {
     return <RestoreFailedState />
   }
 

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -107,11 +107,14 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
       ? selectedProject.status === PROJECT_STATUS.ACTIVE_HEALTHY ||
         (selectedProject.status === PROJECT_STATUS.COMING_UP &&
           router.pathname.includes('/project/[ref]/settings')) ||
-        router.pathname.includes('/project/[ref]/branches')
+        router.pathname.includes('/project/[ref]/branches') ||
+        router.pathname.includes('/project/[ref]/functions')
       : true
 
     const ignorePausedState =
-      router.pathname === '/project/[ref]' || router.pathname.includes('/project/[ref]/settings')
+      router.pathname === '/project/[ref]' ||
+      router.pathname.includes('/project/[ref]/settings') ||
+      router.pathname.includes('/project/[ref]/functions')
     const showPausedState = isPaused && !ignorePausedState
 
     const sidebarMinSizePercentage = 1
@@ -280,12 +283,16 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
 
   const isBranchesPage = router.pathname.includes('/project/[ref]/branches')
   const isSettingsPages = router.pathname.includes('/project/[ref]/settings')
+  const isEdgeFunctionPages = router.pathname.includes('/project/[ref]/functions')
   const isVaultPage = router.pathname === '/project/[ref]/settings/vault'
   const isBackupsPage = router.pathname.includes('/project/[ref]/database/backups')
   const isHomePage = router.pathname === '/project/[ref]'
 
   const requiresDbConnection: boolean =
-    (!isSettingsPages && !routesToIgnoreDBConnection.includes(router.pathname)) || isVaultPage
+    (!isEdgeFunctionPages &&
+      !isSettingsPages &&
+      !routesToIgnoreDBConnection.includes(router.pathname)) ||
+    isVaultPage
   const requiresPostgrestConnection = !routesToIgnorePostgrestConnection.includes(router.pathname)
   const requiresProjectDetails = !routesToIgnoreProjectDetailsRequest.includes(router.pathname)
 


### PR DESCRIPTION
## Context

Resolves FE-2376

Allows edge function pages to be accessible while project is restoring or paused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for edge function pages within project layouts, ensuring proper menu visibility and state management.

* **Bug Fixes**
  * Improved handling of edge function routes to correctly manage paused states, building states, and restore failure conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->