### PR TITLE
feat(metrics-api)update-docs-secrets

### DIFF
--- a/apps/docs/content/_partials/metrics_access.mdx
+++ b/apps/docs/content/_partials/metrics_access.mdx
@@ -23,9 +23,9 @@ className="rounded-lg border border-foreground/10 bg-surface-100 text-foreground
     3. Authenticate with HTTP Basic Auth:
 
     - **Username**: `service_role`
-    - **Password**: a service role secret (JWT) from [**Project Settings > JWT**](/dashboard/project/_/settings/jwt) or any other Secret API key from [**Project Settings > API keys** (opens in a new tab)](/dashboard/project/_/settings/api-keys)
+    - **Password**: a **Secret API key** (`sb_secret_...`). You can create/copy it in [**Project Settings → API Keys**](/dashboard/project/_/settings/api-keys). For more context, see [Understanding API keys](/docs/guides/api/api-keys).
 
-    Testing locally is as simple as running `curl` with your service role secret:
+    Testing locally is as simple as running `curl` with your Secret API key:
 
     ```bash
     curl <project-url>/customer/v1/privileged/metrics \
@@ -35,7 +35,7 @@ className="rounded-lg border border-foreground/10 bg-surface-100 text-foreground
     You can provision long-lived automation tokens in two ways:
 
     - Create an account access token once at [**Account Settings > Access Tokens**](/dashboard/account/tokens) and reuse it wherever you configure observability tooling.
-    - **Optional**: programmatically exchange an access token for project API keys via the [Management API ](/docs/reference/api/management-projects-api-keys-retrieve').
+    - **Optional**: programmatically exchange an access token for project API keys via the [Management API](/docs/reference/api/management-projects-api-keys-retrieve).
 
     ```bash
     # (Optional) Exchange an account access token for project API keys

--- a/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
@@ -14,7 +14,7 @@ Grafana maintains a [Supabase integration guide](https://grafana.com/docs/grafan
 
 ## Prerequisites
 
-- A Supabase project with access to the Metrics API (service role key or another secret key).
+- A Supabase project with access to the Metrics API (Secret API key `sb_secret_...`).
 - A Grafana Cloud account with Prometheus metrics enabled (Free or Pro tier).
 - A Grafana API token with the `metrics:write` and `metrics:read` scopes if you plan to push data manually.
 
@@ -31,7 +31,7 @@ Grafana maintains a [Supabase integration guide](https://grafana.com/docs/grafan
 2. Provide:
    - Your Supabase project ref (e.g. `abcd1234`).
    - The Metrics API endpoint: `https://<project-ref>.supabase.co/customer/v1/privileged/metrics`.
-   - HTTP Basic Auth credentials (`service_role` / `service_role key`).
+   - HTTP Basic Auth credentials (`service_role` / `sb_secret_...`).
 3. Choose the scrape interval (1 minute recommended) and test the connection. Grafana Cloud will deploy an agent in the background that scrapes the Metrics API and forwards the data to Prometheus.
 
 If you prefer to reuse an existing Grafana Agent deployment, configure an [integration pipeline](https://grafana.com/docs/grafana-cloud/send-data/agent/integrations/integration-reference/integration-supabase/) with the same URL and credentials.
@@ -56,6 +56,6 @@ The [`docs/example-alerts.md`](https://github.com/supabase/supabase-grafana/blob
 
 ## 5. Troubleshooting
 
-- Metrics missing? Ensure the Grafana Cloud agent can reach `https://<project-ref>.supabase.co` and that the selected service role key is still valid.
-- 401 errors? Rotate the service role key from the [API settings page](/dashboard/project/_/settings/api-keys) and update the Grafana Cloud credentials.
+- Metrics missing? Ensure the Grafana Cloud agent can reach `https://<project-ref>.supabase.co` and that the selected Secret API key is still valid.
+- 401 errors? Create/rotate a Secret API key in [Project Settings → API Keys](/dashboard/project/_/settings/api-keys) and update the Grafana Cloud credentials.
 - Long scrape durations? Reduce label cardinality in your Grafana queries or lower the time range to focus on recent data.

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -32,7 +32,7 @@ scrape_configs:
     scheme: https
     basic_auth:
       username: service_role
-      password: '<service-role key or JWT>'
+      password: '<secret API key (sb_secret_...)>'
     static_configs:
       - targets:
           - '<project-ref>.supabase.co:443'
@@ -44,7 +44,7 @@ scrape_configs:
 
 - Keep the scrape interval at 60 seconds to match Supabase’s refresh cadence.
 - If you run Prometheus behind a proxy, make sure it can establish outbound HTTPS connections to `*.supabase.co`.
-- Store secrets (service role key) with your secret manager or inject them via environment variables.
+- Store secrets (Secret API key) with your secret manager or inject them via environment variables.
 
 </Admonition>
 
@@ -79,4 +79,4 @@ You now have over 200 production-ready panels covering CPU, IO, WAL, replication
 
 - **Multiple projects:** add one scrape job per project ref so you can separate metrics and labels cleanly.
 - **Right-sizing guidance:** pair the dashboards with Supabase’s [Query Performance report](/dashboard/project/_/observability/query-performance) and [Advisors](/dashboard/project/_/observability/database) to decide when to optimize vs upgrade.
-- **Security:** rotate the service role key on a regular cadence and update the Prometheus config accordingly.
+- **Security:** rotate Secret API keys on a regular cadence and update the Prometheus config accordingly.

--- a/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
@@ -25,7 +25,7 @@ No matter which collector you use, you need to hit the Metrics API once per minu
   scheme: https
   basic_auth:
     username: service_role
-    password: '<service-role key or JWT>'
+    password: '<secret API key (sb_secret_...)>'
   static_configs:
     - targets:
         - '<project-ref>.supabase.co:443'
@@ -41,9 +41,9 @@ No matter which collector you use, you need to hit the Metrics API once per minu
 
 ## 2. Secure the credentials
 
-- Store the service role key in your secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, etc.).
-- Rotate the key periodically via [Project Settings → API keys](/dashboard/project/_/settings/api-keys) and update your collector.
-- If you need to give observability vendors access without exposing the service role key broadly, create a dedicated service key for metrics-only automation.
+- Store the Secret API key in your secret manager (AWS Secrets Manager, GCP Secret Manager, Vault, etc.).
+- Rotate the key periodically via [Project Settings → API Keys](/dashboard/project/_/settings/api-keys) and update your collector.
+- If you need to give observability vendors access without exposing a broadly-scoped key, create a dedicated Secret API key for metrics-only automation.
 
 ## 3. Downstream dashboards
 

--- a/apps/docs/content/troubleshooting/grafana-not-displaying-data-sXJrMj.mdx
+++ b/apps/docs/content/troubleshooting/grafana-not-displaying-data-sXJrMj.mdx
@@ -14,7 +14,7 @@ This guide is for identifying configuration mistakes in [self-hosted Supabase Gr
 Use the below cURL command to make sure your metrics endpoint returns data:
 
 ```sh
-curl https://<YOUR_PROJECT_REF>.supabase.co/customer/v1/privileged/metrics --user 'service_role:<SERVICE_ROLE_KEY>'
+curl https://<YOUR_PROJECT_REF>.supabase.co/customer/v1/privileged/metrics --user 'service_role:<SECRET_API_KEY>'
 ```
 
 ## Step 2: Set your Grafana Dashboard to auto-refresh in the top right corner


### PR DESCRIPTION
Pretty simple change, we are still referencing legacy service role API keys in the docs. This only updates to reference the current preferred solution with secret API keys

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

docs direct users to use the old service_role and not the preferred secret API keys

## What is the new behavior?

Direct to use secret API keys

## Additional context

Add any other context or screenshots.

<img width="844" height="378" alt="image" src="https://github.com/user-attachments/assets/fae9c0bc-317a-45bf-a6da-b5ccf8062ab4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance across metrics documentation to use Secret API keys instead of service role keys for improved clarity
  * Clarified instructions on obtaining and managing Secret API keys via Project Settings
  * Updated all example commands and configuration snippets to reflect correct authentication parameters

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->