### PR TITLE
fix(studio): remove bucket list query for useSelectedBucket

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/useSelectedBucket.ts
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/useSelectedBucket.ts
@@ -1,15 +1,18 @@
 import { useParams } from 'common'
-import { useBucketsQuery } from 'data/storage/buckets-query'
+import { useBucketQuery } from 'data/storage/buckets-query'
 
 export const useSelectedBucket = () => {
   const { ref, bucketId } = useParams()
 
-  return useBucketsQuery(
-    { projectRef: ref },
+  const query = useBucketQuery(
     {
-      select(data) {
-        return data.find((b) => b.id === bucketId)
-      },
+      projectRef: ref,
+      bucketId,
+    },
+    {
+      enabled: !!bucketId,
     }
   )
+
+  return query
 }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
@@ -14,6 +14,7 @@ export interface FileExplorerProps {
   columns: StorageColumn[]
   selectedItems: StorageItemWithColumn[]
   itemSearchString: string
+  isLoading?: boolean
   onFilesUpload: (event: any, index: number) => void
   onSelectAllItemsInColumn: (index: number) => void
   onSelectColumnEmptySpace: (index: number) => void
@@ -24,6 +25,7 @@ export const FileExplorer = ({
   columns = [],
   selectedItems = [],
   itemSearchString,
+  isLoading = false,
   onFilesUpload = noop,
   onSelectAllItemsInColumn = noop,
   onSelectColumnEmptySpace = noop,
@@ -31,9 +33,6 @@ export const FileExplorer = ({
 }: FileExplorerProps) => {
   const fileExplorerRef = useRef<any>(null)
   const snap = useStorageExplorerStateSnapshot()
-
-  // [Joshen] StorageExplorer will always have at least 1 column once data is loaded
-  const hasLoaded = columns.length > 0
 
   useEffect(() => {
     if (fileExplorerRef) {
@@ -56,7 +55,7 @@ export const FileExplorer = ({
       <ItemContextMenu id={CONTEXT_MENU_KEYS.STORAGE_ITEM} />
       <FolderContextMenu id={CONTEXT_MENU_KEYS.STORAGE_FOLDER} />
 
-      {!hasLoaded ? (
+      {isLoading ? (
         <FileExplorerColumn
           column={{ id: '', name: '', items: [], status: STORAGE_ROW_STATUS.LOADING }}
         />

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -20,7 +20,7 @@ import { MoveItemsModal } from './MoveItemsModal'
 import { PreviewPane } from './PreviewPane'
 
 export const StorageExplorer = () => {
-  const { ref } = useParams()
+  const { ref, bucketId } = useParams()
   const storageExplorerRef = useRef(null)
   const {
     projectRef,
@@ -49,7 +49,11 @@ export const StorageExplorer = () => {
   } = useStorageExplorerStateSnapshot()
 
   useProjectStorageConfigQuery({ projectRef: ref }, { enabled: IS_PLATFORM })
-  const { data: bucket } = useSelectedBucket()
+  const { data: bucket, isLoading: isBucketQueryLoading } = useSelectedBucket()
+
+  // Detect when transitioning between buckets to avoid showing stale content from the previous bucket.
+  // This happens because the bucket query and effects that update the store run after the first render.
+  const isLoading = isBucketQueryLoading || (!!bucketId && bucketId !== selectedBucket.id)
 
   // This state exists outside of the header because FileExplorerColumn needs to listen to these as well
   // Things like showing results from a search filter is "temporary", hence we use react state to manage
@@ -186,6 +190,7 @@ export const StorageExplorer = () => {
           columns={columns}
           selectedItems={selectedItems}
           itemSearchString={itemSearchString}
+          isLoading={isLoading}
           onFilesUpload={onFilesUpload}
           onSelectAllItemsInColumn={onSelectAllItemsInColumn}
           onSelectColumnEmptySpace={onSelectColumnEmptySpace}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -1,6 +1,7 @@
 import { compact, get, isEmpty, uniqBy } from 'lodash'
 import { useEffect, useRef, useState } from 'react'
 
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 import { useDebounce } from '@uidotdev/usehooks'
 import { useParams } from 'common'
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
@@ -55,57 +56,44 @@ export const StorageExplorer = () => {
   const [itemSearchString, setItemSearchString] = useState('')
   const debouncedSearchString = useDebounce(itemSearchString, 500)
 
-  const fetchFoldersByPathRef = useLatest(fetchFoldersByPath)
-  const fetchFolderContentsRef = useLatest(fetchFolderContents)
-  const viewRef = useLatest(view)
-  const openedFoldersRef = useLatest(openedFolders)
-  useEffect(() => {
-    const fetchContents = async (bucket: Bucket) => {
-      if (viewRef.current === STORAGE_VIEWS.LIST) {
-        const currentFolderIdx = openedFoldersRef.current.length - 1
-        const currentFolder = openedFoldersRef.current[currentFolderIdx]
+  const fetchContents = useStaticEffectEvent(async (bucket: Bucket) => {
+    if (view === STORAGE_VIEWS.LIST) {
+      const currentFolderIdx = openedFolders.length - 1
+      const currentFolder = openedFolders[currentFolderIdx]
 
-        const folderId = !currentFolder ? bucket.id : currentFolder.id
-        const folderName = !currentFolder ? bucket.name : currentFolder.name
-        const index = !currentFolder ? -1 : currentFolderIdx
+      const folderId = !currentFolder ? bucket.id : currentFolder.id
+      const folderName = !currentFolder ? bucket.name : currentFolder.name
+      const index = !currentFolder ? -1 : currentFolderIdx
 
-        await fetchFolderContentsRef.current({
+      await fetchFolderContents({
+        bucketId: bucket.id,
+        folderId,
+        folderName,
+        index,
+        searchString: debouncedSearchString,
+      })
+    } else if (view === STORAGE_VIEWS.COLUMNS) {
+      if (openedFolders.length > 0) {
+        const paths = openedFolders.map((folder) => folder.name)
+        fetchFoldersByPath({
+          paths,
+          searchString: debouncedSearchString,
+          showLoading: true,
+        })
+      } else {
+        await fetchFolderContents({
           bucketId: bucket.id,
-          folderId,
-          folderName,
-          index,
+          folderId: bucket.id,
+          folderName: bucket.name,
+          index: -1,
           searchString: debouncedSearchString,
         })
-      } else if (viewRef.current === STORAGE_VIEWS.COLUMNS) {
-        if (openedFoldersRef.current.length > 0) {
-          const paths = openedFoldersRef.current.map((folder) => folder.name)
-          fetchFoldersByPathRef.current({
-            paths,
-            searchString: debouncedSearchString,
-            showLoading: true,
-          })
-        } else {
-          await fetchFolderContentsRef.current({
-            bucketId: bucket.id,
-            folderId: bucket.id,
-            folderName: bucket.name,
-            index: -1,
-            searchString: debouncedSearchString,
-          })
-        }
       }
     }
-
-    if (bucket && !!projectRef) fetchContents(bucket)
-  }, [
-    bucket,
-    projectRef,
-    debouncedSearchString,
-    viewRef,
-    openedFoldersRef,
-    fetchFolderContentsRef,
-    fetchFoldersByPathRef,
-  ])
+  })
+  useEffect(() => {
+    if (bucket && projectRef) fetchContents(bucket)
+  }, [bucket, projectRef, debouncedSearchString, fetchContents])
 
   const openBucketRef = useLatest(openBucket)
   useEffect(() => {

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/index.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/index.tsx
@@ -73,11 +73,7 @@ export const VectorBucketDetails = () => {
     { enabled: isSuccess && !!_bucket }
   )
 
-  const {
-    data,
-    isPending: isLoadingIndexes,
-    isSuccess: isSuccessIndexes,
-  } = useVectorBucketsIndexesQuery({
+  const { data, isPending: isLoadingIndexes } = useVectorBucketsIndexesQuery({
     projectRef,
     vectorBucketName: bucket?.vectorBucketName,
   })

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -117,7 +117,7 @@ export type BucketsData = Awaited<ReturnType<typeof getBuckets>>
 export type BucketsWithPaginationData = Awaited<ReturnType<typeof getBucketsPaginated>>
 export type BucketsError = ResponseError
 
-const useBucketQuery = <TData = BucketData>(
+export const useBucketQuery = <TData = BucketData>(
   { projectRef, bucketId }: GetBucketParams,
   { enabled = true, ...options }: UseCustomQueryOptions<BucketData, BucketsError, TData>
 ) => {
@@ -133,6 +133,9 @@ const useBucketQuery = <TData = BucketData>(
   })
 }
 
+/**
+ * @deprecated - use usePaginatedBucketsQuery instead for better performance
+ */
 export const useBucketsQuery = <TData = BucketsData>(
   { projectRef }: BucketsVariables,
   { enabled = true, ...options }: UseCustomQueryOptions<BucketsData, BucketsError, TData> = {}

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/index.ts
@@ -10,14 +10,27 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { method } = req
 
   switch (method) {
+    case 'GET':
+      return handleGet(req, res)
     case 'PATCH':
       return handlePatch(req, res)
     case 'DELETE':
       return handleDelete(req, res)
     default:
-      res.setHeader('Allow', ['PATCH', 'DELETE'])
+      res.setHeader('Allow', ['GET', 'PATCH', 'DELETE'])
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
   }
+}
+
+const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { id } = req.query
+
+  const { data, error } = await supabase.storage.getBucket(id as string)
+  if (error) {
+    return res.status(400).json({ error: { message: error.message } })
+  }
+
+  return res.status(200).json(data)
 }
 
 const handlePatch = async (req: NextApiRequest, res: NextApiResponse) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / refactor

## What is the current behavior?

`useSelectedBucket` hook uses the non-paginated buckets list query.

## What is the new behavior?

`useSelectedBucket` doesn't actually need a list query, we can directly fetch the desired bucket

## Additional context

Towards FE-2118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET endpoint for retrieving a single bucket.

* **Performance Improvements**
  * Refactored storage browsing to centralize fetch logic and improve folder-listing responsiveness.
  * Recommended paginated bucket queries for better bulk performance.

* **Refactor**
  * Improved loading state handling during bucket transitions and simplified fetch flow.

* **Chores**
  * Marked the legacy bulk-buckets query as deprecated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->