### PR TITLE
fix: add a note about special chars in dashboard password

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -205,11 +205,11 @@ Access to Studio dashboard and internal API is protected with **HTTP basic authe
 
 </Admonition>
 
+The password must include at least one letter: do not use numbers only and do not use any special characters.
+
 Change the password in the `.env` file:
 
 - `DASHBOARD_PASSWORD`: password for Studio / dashboard
-
-The password must include at least one letter (do not use numbers only).
 
 Optionally change the user:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a note about Studio (dashboard) password requirements. A follow-up to https://github.com/supabase/supabase/pull/42028.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified password requirements for self-hosted Studio/dashboard installations. Passwords must include at least one letter and cannot consist of numbers only or contain special characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->