### PR TITLE
feat(studio): add api keys to connect modal

### DIFF
--- a/apps/studio/components/interfaces/Connect/ApiKeysTabContent.tsx
+++ b/apps/studio/components/interfaces/Connect/ApiKeysTabContent.tsx
@@ -1,0 +1,77 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useParams } from 'common'
+import { AlertCircle, ExternalLink, Loader2 } from 'lucide-react'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { Button } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
+import type { projectKeys } from './Connect.types'
+
+function KeyRow({ label, value }: { label: ReactNode; value: string }) {
+  return (
+    <div className="flex flex-col gap-5 lg:grid lg:grid-cols-12">
+      <div className="col-span-4">
+        <h3 className="text-sm text-foreground">{label}</h3>
+      </div>
+      <div className="col-span-8">
+        <Input readOnly copy className="font-mono" value={value} />
+      </div>
+    </div>
+  )
+}
+
+export function ApiKeysTabContent({ projectKeys }: { projectKeys: projectKeys }) {
+  const { ref: projectRef } = useParams()
+
+  const { isLoading: isLoadingPermissions, can: canReadAPIKeys } = useAsyncCheckPermissions(
+    PermissionAction.SECRETS_READ,
+    '*'
+  )
+
+  if (isLoadingPermissions) {
+    return (
+      <div className="flex items-center justify-center py-8 space-x-2">
+        <Loader2 className="animate-spin" size={16} strokeWidth={1.5} />
+        <p className="text-sm text-foreground-light">Retrieving API keys</p>
+      </div>
+    )
+  }
+
+  if (!canReadAPIKeys) {
+    return (
+      <div className="flex items-center py-8 space-x-2">
+        <AlertCircle size={16} strokeWidth={1.5} />
+        <p className="text-sm text-foreground-light">You don't have permission to view API keys.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <KeyRow label="Project URL" value={projectKeys.apiUrl ?? ''} />
+
+      <KeyRow label="Publishable Key" value={projectKeys.publishableKey ?? ''} />
+
+      <KeyRow
+        label={
+          <>
+            Anon Key <span className="text-foreground-lighter font-normal">(Legacy)</span>
+          </>
+        }
+        value={projectKeys.anonKey ?? ''}
+      />
+
+      {/* Footer */}
+      <div className="gap-5 lg:grid lg:grid-cols-12">
+        <div className="col-start-5 col-span-8 pl-2 flex items-center justify-between">
+          <p className="text-xs text-foreground-lighter">For secret keys, see API settings.</p>
+          <Button asChild type="default" icon={<ExternalLink size={14} />}>
+            <Link href={`/project/${projectRef}/settings/api-keys`}>API settings</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Connect/Connect.constants.ts
+++ b/apps/studio/components/interfaces/Connect/Connect.constants.ts
@@ -378,6 +378,7 @@ export const CONNECTION_TYPES = [
   { key: 'frameworks', label: 'App Frameworks', obj: FRAMEWORKS },
   { key: 'mobiles', label: 'Mobile Frameworks', obj: MOBILES },
   { key: 'orms', label: 'ORMs', obj: ORMS },
+  { key: 'api-keys', label: 'API Keys', obj: [] },
   { key: 'mcp', label: 'MCP', obj: [] },
 ]
 

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, Plug } from 'lucide-react'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
 
+import { ApiKeysTabContent } from 'components/interfaces/Connect/ApiKeysTabContent'
 import { DatabaseConnectionString } from 'components/interfaces/Connect/DatabaseConnectionString'
 import { McpTabContent } from 'components/interfaces/Connect/McpTabContent'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
@@ -408,6 +409,18 @@ export const Connect = () => {
                   className={cn(DIALOG_PADDING_X, DIALOG_PADDING_Y, '!mt-0')}
                 >
                   <McpTabContent projectKeys={projectKeys} />
+                </TabsContent_Shadcn_>
+              )
+            }
+
+            if (type.key === 'api-keys') {
+              return (
+                <TabsContent_Shadcn_
+                  key="api-keys"
+                  value="api-keys"
+                  className={cn(DIALOG_PADDING_X, DIALOG_PADDING_Y, '!mt-0')}
+                >
+                  <ApiKeysTabContent projectKeys={projectKeys} />
                 </TabsContent_Shadcn_>
               )
             }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The Connect Modal does not display API URL and API keys information.

## What is the new behavior?

Add a new tab to Connect Modal to display API URL and public (publishable) API keys directly.

## Additional context

<img width="1071" height="447" alt="CleanShot 2026-01-23 at 12 57 36" src="https://github.com/user-attachments/assets/3705df47-c8c2-4a94-b78a-017bd1e74f34" />

Resolves FE-2398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API Keys tab in the Connect interface for convenient access to project credentials
  * View your Project URL, Publishable Key, and Anon Key in a secure, read-only format
  * Permission-based access controls ensure only authorized users can view sensitive API keys
  * Quick navigation to API key settings for additional configuration options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->