### PR TITLE
2 free projects troubleshooting guide

### DIFF
--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -5,7 +5,7 @@ topics = [ "platform" ]
 keywords = [ "free tier", "pro plan", "billing", "organizations", "project transfer" ]
 ---
 
-**Can you keep your 2 free projects after upgrading to Pro?**
+## Can you keep your 2 free projects after upgrading to Pro?
 
 Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
 

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -18,7 +18,7 @@ To keep both your free projects and Pro organization:
 
 - Go to your [dashboard](/dashboard)
 - Click on your organization dropdown
-- Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
+- Select "New organization" (or visit [https://supabase.com/dashboard/new](/dashboard/new))
 - Create a new organization on the default Free Plan
 
 **Additional resources**

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -5,7 +5,7 @@ topics = [ "platform" ]
 keywords = [ "free tier", "pro plan", "billing", "organizations", "project transfer" ]
 ---
 
-**Can I keep 2 free projects after upgrading to Pro?**
+**Can keep 2 free projects after upgrading to Pro?**
 
 Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
 

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -21,7 +21,7 @@ Create a new Free Plan organization (or use an existing free organization if you
 - Select "New organization" (or visit [https://supabase.com/dashboard/new](/dashboard/new))
 - Create a new organization on the default Free Plan
 
-**Additional resources**
+## Additional resources
 
 - [Organization-based billing](/docs/guides/platform/billing-on-supabase#organization-based-billing)
 - [Project transfer guide](/docs/guides/platform/project-transfer)

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -15,10 +15,11 @@ Because billing is managed at the organization level, not the project level. We 
 
 To keep both your free projects and Pro organization:
 **Create a new Free Plan organization** (or use an existing free organization if you have one)
-   - Go to your [dashboard](/dashboard)
-   - Click on your organization dropdown
-   - Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
-   - Create a new organization on the default Free Plan
+
+- Go to your [dashboard](/dashboard)
+- Click on your organization dropdown
+- Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
+- Create a new organization on the default Free Plan
 
 **Additional resources**
 

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -18,7 +18,7 @@ To keep both free projects and Pro organization:
 
 - Go to your [dashboard](/dashboard)
 - Click on your organization dropdown
-- Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
+- Select "New organization" (or visit [https://supabase.com/dashboard/new](/dashboard/new))
 - Create a new organization on the default Free Plan
 
 **Additional resources**

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -5,20 +5,20 @@ topics = [ "platform" ]
 keywords = [ "free tier", "pro plan", "billing", "organizations", "project transfer" ]
 ---
 
-**Can I keep my 2 free projects after I upgrade to Pro?**
+**Can I keep 2 free projects after upgrading to Pro?**
 
 Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
 
-**Why do my free projects need to be in a separate organization?**
+**Why do free projects need to be in a separate organization?**
 
 Because billing is managed at the organization level, not the project level. We need to keep your free tier usage separate from your Pro tier usage for accurate billing and cost transparency.
 
-To keep both your free projects and Pro organization:
+To keep both free projects and Pro organization:
 **Create a new Free Plan organization** (or use an existing free organization if you have one)
 
 - Go to your [dashboard](/dashboard)
 - Click on your organization dropdown
-- Select "New organization" (or visit [https://supabase.com/dashboard/new](/dashboard/new))
+- Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
 - Create a new organization on the default Free Plan
 
 **Additional resources**

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -1,0 +1,27 @@
+---
+title = "Keeping your 2 Free projects after upgrading to Pro"
+date_created = "2026-01-23T00:00:00+00:00"
+topics = [ "platform" ]
+keywords = [ "free tier", "pro plan", "billing", "organizations", "project transfer" ]
+---
+
+**Can I keep my 2 free projects after I upgrade to Pro?**
+
+Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
+
+**Why do my free projects need to be in a separate organization?**
+
+Because billing is managed at the organization level, not the project level. We need to keep your free tier usage separate from your Pro tier usage for accurate billing and cost transparency.
+
+To keep both your free projects and Pro organization:
+**Create a new Free Plan organization** (or use an existing free organization if you have one)
+   - Go to your [dashboard](/dashboard)
+   - Click on your organization dropdown
+   - Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
+   - Create a new organization on the default Free Plan
+
+**Additional resources**
+
+- [Organization-based billing](/docs/guides/platform/billing-on-supabase#organization-based-billing)
+- [Project transfer guide](/docs/guides/platform/project-transfer)
+- [Billing FAQ](/docs/guides/platform/billing-faq)

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -9,7 +9,7 @@ keywords = [ "free tier", "pro plan", "billing", "organizations", "project trans
 
 Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
 
-**Why do free projects need to be in a separate organization?**
+## Why do free projects need to be in a separate organization?
 
 Because billing is managed at the organization level, not the project level. We need to keep Free tier usage separate from Pro tier usage for accurate billing and cost transparency.
 

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -18,7 +18,7 @@ Create a new Free Plan organization (or use an existing free organization if you
 
 - Go to the [Dashboard](/dashboard)
 - Click on the organization dropdown
-- Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
+- Select "New organization" (or visit [https://supabase.com/dashboard/new](/dashboard/new))
 - Create a new organization on the default Free Plan
 
 **Additional resources**

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -5,7 +5,7 @@ topics = [ "platform" ]
 keywords = [ "free tier", "pro plan", "billing", "organizations", "project transfer" ]
 ---
 
-**Can keep 2 free projects after upgrading to Pro?**
+**Can you keep your 2 free projects after upgrading to Pro?**
 
 Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
 

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -11,14 +11,14 @@ Yes! You still get 2 free projects after you upgrade to Pro. They just need to b
 
 **Why do free projects need to be in a separate organization?**
 
-Because billing is managed at the organization level, not the project level. We need to keep your free tier usage separate from your Pro tier usage for accurate billing and cost transparency.
+Because billing is managed at the organization level, not the project level. We need to keep Free tier usage separate from Pro tier usage for accurate billing and cost transparency.
 
 To keep both free projects and Pro organization:
-**Create a new Free Plan organization** (or use an existing free organization if you have one)
+Create a new Free Plan organization (or use an existing free organization if you have one)
 
-- Go to your [dashboard](/dashboard)
-- Click on your organization dropdown
-- Select "New organization" (or visit [https://supabase.com/dashboard/new](/dashboard/new))
+- Go to the [Dashboard](/dashboard)
+- Click on the organization dropdown
+- Select "New organization" (or visit [https://supabase.com/dashboard/new](https://supabase.com/dashboard/new))
 - Create a new organization on the default Free Plan
 
 **Additional resources**

--- a/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
+++ b/apps/docs/content/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2.mdx
@@ -5,7 +5,7 @@ topics = [ "platform" ]
 keywords = [ "free tier", "pro plan", "billing", "organizations", "project transfer" ]
 ---
 
-## Can you keep your 2 free projects after upgrading to Pro?
+## Can you keep your 2 free projects after upgrading to pro?
 
 Yes! You still get 2 free projects after you upgrade to Pro. They just need to be in a **separate** Free Plan organization.
 


### PR DESCRIPTION

https://docs-git-chore-2-free-projects-troubleshooting-supabase.vercel.app/docs/guides/troubleshooting/keeping-free-projects-after-pro-upgrade-Kf9Xm2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide describing how to keep two Free Plan projects usable after upgrading to Pro by placing them in a separate Free Plan organization. Provides step‑by‑step dashboard instructions, clarifies organization‑level billing behavior, and links to related resources on organization billing, project transfer, and billing FAQs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->