### PR TITLE
fix(flags): set org/project context before flag fetch

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -31,7 +31,7 @@ import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 import Head from 'next/head'
 import { NuqsAdapter } from 'nuqs/adapters/next/pages'
-import { ErrorInfo, useCallback } from 'react'
+import { type ComponentProps, ErrorInfo, useCallback } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import {
@@ -53,6 +53,7 @@ import { GlobalErrorBoundaryState } from 'components/ui/ErrorBoundary/GlobalErro
 import { useRootQueryClient } from 'data/query-client'
 import { customFont, sourceCodePro } from 'fonts'
 import { useCustomContent } from 'hooks/custom-content/useCustomContent'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { AuthProvider } from 'lib/auth'
 import { API_URL, BASE_PATH, IS_PLATFORM, useDefaultProvider } from 'lib/constants'
 import { ProfileProvider } from 'lib/profile'
@@ -66,6 +67,19 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
+
+const FeatureFlagProviderWithOrgContext = ({
+  children,
+  ...props
+}: ComponentProps<typeof FeatureFlagProvider>) => {
+  const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
+
+  return (
+    <FeatureFlagProvider {...props} organizationSlug={selectedOrganization?.slug ?? undefined}>
+      {children}
+    </FeatureFlagProvider>
+  )
+}
 
 loader.config({
   // [Joshen] Attempt for offline support/bypass ISP issues is to store the assets required for monaco
@@ -124,7 +138,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
         <NuqsAdapter>
           <HydrationBoundary state={pageProps.dehydratedState}>
             <AuthProvider>
-              <FeatureFlagProvider
+              <FeatureFlagProviderWithOrgContext
                 API_URL={API_URL}
                 enabled={IS_PLATFORM}
                 getConfigCatFlags={getConfigCatFlags}
@@ -180,7 +194,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                     <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
                   )}
                 </ProfileProvider>
-              </FeatureFlagProvider>
+              </FeatureFlagProviderWithOrgContext>
             </AuthProvider>
           </HydrationBoundary>
         </NuqsAdapter>

--- a/packages/common/feature-flags.tsx
+++ b/packages/common/feature-flags.tsx
@@ -14,9 +14,22 @@ import { useParams } from './hooks'
 type TrackFeatureFlagVariables = components['schemas']['TelemetryFeatureFlagBody']
 export type CallFeatureFlagsResponse = components['schemas']['TelemetryCallFeatureFlagsResponse']
 
-export async function getFeatureFlags(API_URL: string) {
+export async function getFeatureFlags(
+  API_URL: string,
+  options: { organizationSlug?: string; projectRef?: string } = {}
+) {
   try {
-    const data = await get(`${ensurePlatformSuffix(API_URL)}/telemetry/feature-flags`)
+    const url = new URL(`${ensurePlatformSuffix(API_URL)}/telemetry/feature-flags`)
+
+    if (options.organizationSlug) {
+      url.searchParams.set('organization_slug', options.organizationSlug)
+    }
+
+    if (options.projectRef) {
+      url.searchParams.set('project_ref', options.projectRef)
+    }
+
+    const data = await get(url.toString())
     return data as CallFeatureFlagsResponse
   } catch (error: any) {
     if (error.message.includes('Failed to fetch')) {
@@ -137,7 +150,10 @@ export const FeatureFlagProvider = ({
         loadPHFlags
           ? (async () => {
               await ensureGroupContext()
-              return getFeatureFlags(API_URL)
+              return getFeatureFlags(API_URL, {
+                organizationSlug: resolvedOrganizationSlug,
+                projectRef: resolvedProjectRef,
+              })
             })()
           : Promise.resolve({}),
         loadCCFlags

--- a/packages/common/feature-flags.tsx
+++ b/packages/common/feature-flags.tsx
@@ -207,6 +207,7 @@ export const FeatureFlagProvider = ({
     session?.user?.id,
     resolvedOrganizationSlug,
     resolvedProjectRef,
+    getConfigCatFlags,
   ])
 
   return (


### PR DESCRIPTION
PostHog flags targeted at orgs/projects were returning `false` on staging even at 100% rollout. 

**Root cause:** Cross-site cookie restrictions (SameSite=Lax) prevent org/project cookies from being sent to the platform API on staging, so the backend couldn't evaluate flags with the correct group context.

**Fix:**
- Pass `organization_slug` and `project_ref` as query params to `/telemetry/feature-flags`
- Add `organizationSlug` and `projectRef` props to `FeatureFlagProvider` (resolved from URL params if not provided)
- Wrap Studio's `FeatureFlagProvider` with org context from `useSelectedOrganizationQuery`
- Ensure group context is identified before fetching flags (with deduplication via ref)
- Flag evaluation no longer depends on cookies being present

**Unblocked by:** https://github.com/supabase/platform/pull/29104

GROWTH-593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature flags now respect organization and project context so users see flags scoped to the current org/project.

* **Improvements**
  * Telemetry identification is throttled and tied to resolved org/project context to avoid duplicate identification requests.
  * App initialization now supplies organization context to the feature-flag system for more accurate flag evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->