### PR TITLE
fix redirect after unsaved changes in reports

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -24,6 +24,7 @@ import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { BASE_PATH } from 'lib/constants'
 import { Metric, TIME_PERIODS_REPORTS } from 'lib/constants/metrics'
 import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
@@ -548,8 +549,12 @@ const Reports = () => {
         confirmLabel="Confirm"
         onConfirm={() => {
           setConfirmNavigate(true)
+          let urlToNavigate = navigateUrl ?? '/'
+          if (BASE_PATH && urlToNavigate.startsWith(BASE_PATH)) {
+            urlToNavigate = urlToNavigate.replace(BASE_PATH, '')
+          }
           setNavigateUrl(undefined)
-          router.push(navigateUrl ?? '/')
+          router.push(urlToNavigate)
         }}
         onCancel={() => setNavigateUrl(undefined)}
       >

--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -551,8 +551,9 @@ const Reports = () => {
           setConfirmNavigate(true)
           let urlToNavigate = navigateUrl ?? '/'
           if (BASE_PATH && urlToNavigate.startsWith(BASE_PATH)) {
-            urlToNavigate = urlToNavigate.replace(BASE_PATH, '')
+            urlToNavigate = urlToNavigate.slice(BASE_PATH.length) || '/'
           }
+          if (!urlToNavigate.startsWith('/')) urlToNavigate = `/${urlToNavigate}`
           setNavigateUrl(undefined)
           router.push(urlToNavigate)
         }}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Redirect fix

## What is the current behavior?

- add a block in the custom report
- open another section/page
- confirm unsaved changes will be lost
- redirect link includes 2 "dashboard"

## What is the new behavior?

Fixed redirect

## Additional context

![CleanShot 2026-01-24 at 10 06 30](https://github.com/user-attachments/assets/503d2e3d-5461-4733-8887-4e715c3ca677)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation in the Reports interface when confirming actions with unsaved changes so users are routed to the correct destination.
  * Normalized destination paths before navigation (handling prefixed paths and ensuring a proper leading slash) to prevent routing errors and improve post-confirmation consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->