### PR TITLE
fix(studio): mouse wheel scroll in column type selector

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -186,18 +186,18 @@ const ColumnType = ({
           </Button>
         </PopoverTrigger_Shadcn_>
         <PopoverContent_Shadcn_ className="w-[460px] p-0" side="bottom" align="center">
-          <ScrollArea className="h-[335px]">
-            <Command_Shadcn_>
-              <CommandInput_Shadcn_
-                placeholder="Search types..."
-                // [Joshen] Addresses style issues when this component is being used in the old Form component
-                // Specifically in WrapperDynamicColumns - can be cleaned up once we're no longer using that
-                className="!bg-transparent focus:!shadow-none focus:!ring-0"
-              />
-              <CommandEmpty_Shadcn_>Type not found.</CommandEmpty_Shadcn_>
+          <Command_Shadcn_>
+            <CommandInput_Shadcn_
+              placeholder="Search types..."
+              // [Joshen] Addresses style issues when this component is being used in the old Form component
+              // Specifically in WrapperDynamicColumns - can be cleaned up once we're no longer using that
+              className="!bg-transparent focus:!shadow-none focus:!ring-0"
+            />
 
-              <CommandList_Shadcn_>
-                <CommandGroup_Shadcn_>
+            <CommandList_Shadcn_>
+              <CommandEmpty_Shadcn_>Type not found.</CommandEmpty_Shadcn_>
+              <CommandGroup_Shadcn_>
+                <ScrollArea className={POSTGRES_DATA_TYPE_OPTIONS.length > 7 ? 'h-[250px]' : ''}>
                   {POSTGRES_DATA_TYPE_OPTIONS.map((option: PostgresDataTypeOption) => (
                     <CommandItem_Shadcn_
                       key={option.name}
@@ -218,11 +218,13 @@ const ColumnType = ({
                       </span>
                     </CommandItem_Shadcn_>
                   ))}
-                </CommandGroup_Shadcn_>
-                {enumTypes.length > 0 && (
-                  <>
-                    <CommandItem_Shadcn_>Other types</CommandItem_Shadcn_>
-                    <CommandGroup_Shadcn_>
+                </ScrollArea>
+              </CommandGroup_Shadcn_>
+              {enumTypes.length > 0 && (
+                <>
+                  <CommandItem_Shadcn_>Other types</CommandItem_Shadcn_>
+                  <CommandGroup_Shadcn_>
+                    <ScrollArea className={enumTypes.length > 7 ? 'h-[210px]' : ''}>
                       {enumTypes.map((option) => (
                         <CommandItem_Shadcn_
                           key={option.id}
@@ -263,12 +265,12 @@ const ColumnType = ({
                           </div>
                         </CommandItem_Shadcn_>
                       ))}
-                    </CommandGroup_Shadcn_>
-                  </>
-                )}
-              </CommandList_Shadcn_>
-            </Command_Shadcn_>
-          </ScrollArea>
+                    </ScrollArea>
+                  </CommandGroup_Shadcn_>
+                </>
+              )}
+            </CommandList_Shadcn_>
+          </Command_Shadcn_>
         </PopoverContent_Shadcn_>
       </Popover_Shadcn_>
 


### PR DESCRIPTION
## Problem
Mouse wheel scrolling does not work in the column type selector dropdown when creating or editing table columns.

## Solution
Restructured the scroll container hierarchy to match the pattern used in other similar components (SchemaComboBox, DatabaseSelector, FunctionSelector):
- Moved `ScrollArea` inside `CommandGroup` instead of wrapping the entire `Command` component
- Set ScrollArea height to `h-[250px]` (smaller than CommandList's default `max-h-[300px]`)
- This ensures a single scroll container, allowing mouse wheel events to work properly

## Related
- Closes https://github.com/supabase/supabase/issues/42125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned column type selector with improved scrolling for long lists, a dedicated area for enum/custom types, and an "Other types" header for clearer organization.
  * Consistent visual selection indicators across primary and enum options, with normalized display of type names and preserved selection behavior.
  * Repositioned "type not found" message for clearer feedback when a type isn't available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->