### PR TITLE
fix: prisma to-schema-datamodel option is removed and replaced by to-schema

### DIFF
--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -280,7 +280,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             ```bash
               npx prisma migrate diff \
               --from-empty \
-              --to-schema-datamodel prisma/schema.prisma \
+              --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="tip" label="conflict management">
@@ -308,7 +308,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             ```bash
               pnpx prisma migrate diff \
               --from-empty \
-              --to-schema-datamodel prisma/schema.prisma \
+              --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="note" label="conflict management">
@@ -336,7 +336,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             ```bash
               npx prisma migrate diff \
               --from-empty \
-              --to-schema-datamodel prisma/schema.prisma \
+              --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="note" label="conflict management">
@@ -364,7 +364,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             ```bash
               bunx prisma migrate diff \
               --from-empty \
-              --to-schema-datamodel prisma/schema.prisma \
+              --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
             <Admonition type="note" label="conflict management">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?
prisma fails with error:
```
Error:
`--to-schema-datamodel` was removed. Please use `--[from/to]-schema` instead.
```

## What is the new behavior?
prisma command runs successfully

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database guide with current Prisma migration command syntax for improved accuracy and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->