### PR TITLE
fix: wrap table creation in transaction to prevent partial creation on error

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.createTable.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.createTable.test.ts
@@ -1,8 +1,10 @@
+import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField } from './SidePanelEditor.types'
+// Import after mocks are set up
+import { createTable } from './SidePanelEditor.utils'
 
 // Define mock functions at module level
 const mockExecuteSql = vi.fn()
@@ -50,9 +52,6 @@ vi.mock('sonner', () => ({
 vi.mock('components/ui/SparkBar', () => ({
   default: () => null,
 }))
-
-// Import after mocks are set up
-import { createTable } from './SidePanelEditor.utils'
 
 // Helper to create a column field with defaults
 const createColumnField = (overrides: Partial<ColumnField> = {}): ColumnField => ({

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.createTable.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.createTable.test.ts
@@ -522,4 +522,64 @@ describe('createTable', () => {
       }),
     })
   })
+
+  it('should wrap table creation in a transaction for atomicity', async () => {
+    const columns: ColumnField[] = [
+      createColumnField({
+        id: 'col-1',
+        name: 'id',
+        format: 'int8',
+        isNullable: false,
+        isIdentity: true,
+        isPrimaryKey: true,
+      }),
+    ]
+
+    await createTable({
+      projectRef,
+      connectionString,
+      toastId,
+      payload: basePayload,
+      columns,
+      foreignKeyRelations: [],
+      isRLSEnabled: false,
+    })
+
+    const sqlCall = mockExecuteSql.mock.calls[0][0]
+    expect(sqlCall.sql).toMatch(/^BEGIN;/)
+    expect(sqlCall.sql).toMatch(/COMMIT;$/)
+    expect((sqlCall.sql.match(/\bBEGIN;/g) ?? []).length).toBe(1)
+    expect((sqlCall.sql.match(/\bCOMMIT;/g) ?? []).length).toBe(1)
+  })
+
+  it('should rollback entire table creation if any statement fails', async () => {
+    mockExecuteSql.mockRejectedValue(new Error('Column constraint violation'))
+
+    const columns: ColumnField[] = [
+      createColumnField({
+        id: 'col-1',
+        name: 'invalid_column',
+        format: 'int8',
+        defaultValue: "'not_a_number'",
+      }),
+    ]
+
+    await expect(
+      createTable({
+        projectRef,
+        connectionString,
+        toastId,
+        payload: basePayload,
+        columns,
+        foreignKeyRelations: [],
+        isRLSEnabled: false,
+      })
+    ).rejects.toThrow('Column constraint violation')
+
+    const sqlCall = mockExecuteSql.mock.calls[0][0]
+    expect(sqlCall.sql).toMatch(/^BEGIN;/)
+    expect(sqlCall.sql).toMatch(/COMMIT;$/)
+    expect((sqlCall.sql.match(/\bBEGIN;/g) ?? []).length).toBe(1)
+    expect((sqlCall.sql.match(/\bCOMMIT;/g) ?? []).length).toBe(1)
+  })
 })

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -1,10 +1,6 @@
 import pgMeta from '@supabase/pg-meta'
-import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
-import { chunk, find, isEmpty, isEqual } from 'lodash'
-import Papa from 'papaparse'
-import { toast } from 'sonner'
-
 import { Query } from '@supabase/pg-meta/src/query'
+import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
 import { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import SparkBar from 'components/ui/SparkBar'
 import { createDatabaseColumn } from 'data/database-columns/database-column-create-mutation'
@@ -26,10 +22,10 @@ import { tableRowKeys } from 'data/table-rows/keys'
 import { executeWithRetry } from 'data/table-rows/table-rows-query'
 import { tableKeys } from 'data/tables/keys'
 import {
+  RetrieveTableResult,
+  RetrievedTableColumn,
   getTable,
   getTableQuery,
-  RetrievedTableColumn,
-  RetrieveTableResult,
 } from 'data/tables/table-retrieve-query'
 import {
   UpdateTableBody,
@@ -38,6 +34,10 @@ import {
 import { getTables } from 'data/tables/tables-query'
 import { sendEvent } from 'data/telemetry/send-event-mutation'
 import { timeout, tryParseJson } from 'lib/helpers'
+import { chunk, find, isEmpty, isEqual } from 'lodash'
+import Papa from 'papaparse'
+import { toast } from 'sonner'
+
 import {
   generateCreateColumnPayload,
   generateUpdateColumnPayload,
@@ -51,7 +51,10 @@ const BATCH_SIZE = 1000
 const CHUNK_SIZE = 1024 * 1024 * 0.1 // 0.1MB
 
 const unwrapTransaction = (sql: string) =>
-  sql.replace(/^\s*BEGIN;?\s*/i, '').replace(/\s*COMMIT;?\s*$/i, '').trim()
+  sql
+    .replace(/^\s*BEGIN;?\s*/i, '')
+    .replace(/\s*COMMIT;?\s*$/i, '')
+    .trim()
 
 /**
  * The functions below are basically just queries but may be supported directly

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -50,6 +50,9 @@ import type { ImportContent } from './TableEditor/TableEditor.types'
 const BATCH_SIZE = 1000
 const CHUNK_SIZE = 1024 * 1024 * 0.1 // 0.1MB
 
+const unwrapTransaction = (sql: string) =>
+  sql.replace(/^\s*BEGIN;?\s*/i, '').replace(/\s*COMMIT;?\s*$/i, '').trim()
+
 /**
  * The functions below are basically just queries but may be supported directly
  * from the pg-meta library in the future
@@ -72,9 +75,13 @@ const addPrimaryKey = async (
   connectionString: string | undefined | null,
   schema: string,
   table: string,
-  columns: string[]
+  columns: string[],
+  noTransaction = false
 ) => {
   const query = getAddPrimaryKeySQL({ schema, table, columns })
+  if (noTransaction) {
+    return query
+  }
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -88,9 +95,13 @@ const dropConstraint = async (
   connectionString: string | undefined | null,
   schema: string,
   table: string,
-  name: string
+  name: string,
+  noTransaction = false
 ) => {
   const query = `ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${name}"`
+  if (noTransaction) {
+    return query
+  }
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -147,13 +158,18 @@ const addForeignKey = async ({
   connectionString,
   table,
   foreignKeys,
+  noTransaction = false,
 }: {
   projectRef: string
   connectionString?: string | null
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
+  noTransaction?: boolean
 }) => {
   const query = getAddForeignKeySQL({ table, foreignKeys })
+  if (noTransaction) {
+    return query
+  }
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -188,13 +204,18 @@ const removeForeignKey = async ({
   connectionString,
   table,
   foreignKeys,
+  noTransaction = false,
 }: {
   projectRef: string
   connectionString?: string | null
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
+  noTransaction?: boolean
 }) => {
   const query = getRemoveForeignKeySQL({ table, foreignKeys })
+  if (noTransaction) {
+    return query
+  }
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -208,11 +229,13 @@ const updateForeignKey = async ({
   connectionString,
   table,
   foreignKeys,
+  noTransaction = false,
 }: {
   projectRef: string
   connectionString?: string | null
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
+  noTransaction?: boolean
 }) => {
   const query = `
   ${getRemoveForeignKeySQL({ table, foreignKeys })}
@@ -220,6 +243,9 @@ const updateForeignKey = async ({
   `
     .replace(/\s+/g, ' ')
     .trim()
+  if (noTransaction) {
+    return query
+  }
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -525,7 +551,7 @@ export const createTable = async ({
 
   // 1. Create table SQL
   const { sql: createTableSql } = pgMeta.tables.create(payload)
-  sqlStatements.push(createTableSql)
+  sqlStatements.push(unwrapTransaction(createTableSql))
 
   // 2. Enable RLS if configured
   if (isRLSEnabled) {
@@ -553,7 +579,7 @@ export const createTable = async ({
       comment: columnPayload.comment,
       check: columnPayload.check,
     })
-    sqlStatements.push(columnSQL)
+    sqlStatements.push(unwrapTransaction(columnSQL))
   }
 
   // 4. Add primary key constraint (supports composite keys)
@@ -561,20 +587,26 @@ export const createTable = async ({
     .filter((column) => column.isPrimaryKey)
     .map((column) => column.name)
   if (primaryKeyColumns.length > 0) {
-    const primaryKeySQL = getAddPrimaryKeySQL({
-      schema: payload.schema,
-      table: payload.name,
-      columns: primaryKeyColumns,
-    })
+    const primaryKeySQL = (await addPrimaryKey(
+      projectRef,
+      connectionString,
+      payload.schema,
+      payload.name,
+      primaryKeyColumns,
+      true
+    )) as string
     sqlStatements.push(primaryKeySQL)
   }
 
   // 5. Add foreign key constraints
   if (foreignKeyRelations.length > 0) {
-    const fkSql = getAddForeignKeySQL({
+    const fkSql = (await addForeignKey({
+      projectRef,
+      connectionString,
       table: { schema: payload.schema, name: payload.name },
       foreignKeys: foreignKeyRelations,
-    })
+      noTransaction: true,
+    })) as string
     // Remove trailing semicolon since we join with semicolons
     sqlStatements.push(fkSql.replace(/;+$/, ''))
   }
@@ -585,7 +617,7 @@ export const createTable = async ({
   await executeSql({
     projectRef,
     connectionString,
-    sql: sqlStatements.join(';\n'),
+    sql: `BEGIN;\n${sqlStatements.join(';\n')};\nCOMMIT;`,
     queryKey: ['table', 'create-with-columns'],
   })
 


### PR DESCRIPTION
### Summary

Fixes table creation atomicity in the Dashboard Table Editor by wrapping all SQL statements in a transaction block.

### Problem

When creating a table with invalid column configurations (e.g., invalid default value, broken foreign key), the table is partially created in the database despite the error. 
This causes a `42P07: relation already exists` error when users retry after fixing the issue.

### Solution

Wrapped all table creation SQL statements in a `BEGIN...COMMIT` transaction block.
 PostgreSQL automatically rolls back the entire transaction if any statement fails, 
ensuring no partial table creation.

### Related

- Closes #42089