### PR TITLE
fix(studio): legal page buttons

### DIFF
--- a/apps/studio/components/interfaces/Organization/Documents/CustomDocument.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/CustomDocument.tsx
@@ -15,17 +15,21 @@ interface CustomDocumentProps {
 export const CustomDocument = ({ doc }: CustomDocumentProps) => {
   return (
     <ScaffoldContainer id={doc.id}>
-      <ScaffoldSection>
-        <ScaffoldSectionDetail className="sticky top-12 flex flex-col gap-y-8">
+      <ScaffoldSection className="py-12">
+        <ScaffoldSectionDetail>
           <p className="text-base m-0">{doc.name}</p>
-          <p className="text-sm text-foreground-light m-0">{doc.description}</p>
+          <div className="space-y-2 text-sm text-foreground-light [&_p]:m-0">
+            <p>{doc.description}</p>
+          </div>
         </ScaffoldSectionDetail>
-        <ScaffoldSectionContent className="flex items-center justify-center h-full">
-          <Button asChild type="default" iconRight={<ExternalLink />}>
-            <a download href={doc.action.url} target="_blank" rel="noreferrer noopener">
-              {doc.action.text}
-            </a>
-          </Button>
+        <ScaffoldSectionContent>
+          <div className="@lg:flex items-center justify-center h-full">
+            <Button asChild type="default" iconRight={<ExternalLink />}>
+              <a download href={doc.action.url} target="_blank" rel="noreferrer noopener">
+                {doc.action.text}
+              </a>
+            </Button>
+          </div>
         </ScaffoldSectionContent>
       </ScaffoldSection>
     </ScaffoldContainer>

--- a/apps/studio/components/interfaces/Organization/Documents/DPA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/DPA.tsx
@@ -38,9 +38,9 @@ export const DPA = () => {
   return (
     <>
       <ScaffoldSection>
-        <ScaffoldSectionDetail className="sticky space-y-6 top-12">
-          <p className="text-base m-0">Data Processing Addendum (DPA)</p>
-          <div className="space-y-2 text-sm text-foreground-light m-0">
+        <ScaffoldSectionDetail>
+          <p className="text-base">Data Processing Addendum (DPA)</p>
+          <div className="space-y-2 text-sm text-foreground-light">
             <p>
               All organizations can sign our Data Processing Addendum ("DPA") as part of their GDPR
               compliance.
@@ -62,18 +62,20 @@ export const DPA = () => {
             </p>
           </div>
         </ScaffoldSectionDetail>
-        <ScaffoldSectionContent className="flex items-center justify-center h-full">
-          <Button
-            onClick={() => {
-              setIsOpen(true)
-              sendEvent({
-                action: 'dpa_request_button_clicked',
-              })
-            }}
-            type="default"
-          >
-            Request DPA
-          </Button>
+        <ScaffoldSectionContent>
+          <div className="@lg:flex items-center justify-center h-full">
+            <Button
+              onClick={() => {
+                setIsOpen(true)
+                sendEvent({
+                  action: 'dpa_request_button_clicked',
+                })
+              }}
+              type="default"
+            >
+              Request DPA
+            </Button>
+          </div>
         </ScaffoldSectionContent>
       </ScaffoldSection>
 

--- a/apps/studio/components/interfaces/Organization/Documents/DPA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/DPA.tsx
@@ -37,10 +37,10 @@ export const DPA = () => {
 
   return (
     <>
-      <ScaffoldSection>
+      <ScaffoldSection className="py-12">
         <ScaffoldSectionDetail>
-          <p className="text-base">Data Processing Addendum (DPA)</p>
-          <div className="space-y-2 text-sm text-foreground-light">
+          <h4 className="mb-5">Data Processing Addendum (DPA)</h4>
+          <div className="space-y-2 text-sm text-foreground-light [&_p]:m-0">
             <p>
               All organizations can sign our Data Processing Addendum ("DPA") as part of their GDPR
               compliance.

--- a/apps/studio/components/interfaces/Organization/Documents/Documents.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/Documents.tsx
@@ -58,7 +58,7 @@ export const Documents = () => {
 
       <ScaffoldContainer>
         <ScaffoldSection>
-          <p className="sticky space-y-6 top-12 text-sm text-foreground-light m-0 whitespace-nowrap">
+          <p className="text-sm text-foreground-light m-0">
             <SupportLink className={InlineLinkClassName}>Submit a support request</SupportLink> if
             you require additional documents for financial or tax reasons, such as a W-9 form.
           </p>

--- a/apps/studio/components/interfaces/Organization/Documents/Documents.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/Documents.tsx
@@ -1,5 +1,10 @@
 import { SupportLink } from 'components/interfaces/Support/SupportLink'
-import { ScaffoldContainer, ScaffoldDivider, ScaffoldSection } from 'components/layouts/Scaffold'
+import {
+  ScaffoldContainer,
+  ScaffoldDivider,
+  ScaffoldSection,
+  ScaffoldSectionDetail,
+} from 'components/layouts/Scaffold'
 import { InlineLinkClassName } from 'components/ui/InlineLink'
 import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { Fragment } from 'react'
@@ -57,11 +62,13 @@ export const Documents = () => {
       <ScaffoldDivider />
 
       <ScaffoldContainer>
-        <ScaffoldSection>
-          <p className="text-sm text-foreground-light m-0">
-            <SupportLink className={InlineLinkClassName}>Submit a support request</SupportLink> if
-            you require additional documents for financial or tax reasons, such as a W-9 form.
-          </p>
+        <ScaffoldSection className="py-12">
+          <ScaffoldSectionDetail className="col-span-full">
+            <p className="text-sm text-foreground-light m-0">
+              <SupportLink className={InlineLinkClassName}>Submit a support request</SupportLink> if
+              you require additional documents for financial or tax reasons, such as a W-9 form.
+            </p>
+          </ScaffoldSectionDetail>
         </ScaffoldSection>
       </ScaffoldContainer>
     </>

--- a/apps/studio/components/interfaces/Organization/Documents/HIPAA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/HIPAA.tsx
@@ -16,9 +16,9 @@ export const HIPAA = () => {
   return (
     <>
       <ScaffoldSection>
-        <ScaffoldSectionDetail className="sticky space-y-6 top-12">
+        <ScaffoldSectionDetail>
           <p className="text-base m-0">HIPAA</p>
-          <div className="space-y-2 text-sm text-foreground-light m-0">
+          <div className="space-y-2 text-sm text-foreground-light">
             <p>
               This is only for HIPAA requests. Please ignore this if you already have HIPAA enabled.
             </p>
@@ -34,7 +34,7 @@ export const HIPAA = () => {
           </div>
         </ScaffoldSectionDetail>
         <ScaffoldSectionContent>
-          <div className="flex items-center justify-center h-full">
+          <div className="@lg:flex items-center justify-center h-full">
             <Button asChild type="default" iconRight={<ExternalLink />}>
               <a
                 href="https://forms.supabase.com/hipaa2"

--- a/apps/studio/components/interfaces/Organization/Documents/HIPAA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/HIPAA.tsx
@@ -14,45 +14,43 @@ export const HIPAA = () => {
   const { mutate: sendEvent } = useSendEventMutation()
 
   return (
-    <>
-      <ScaffoldSection>
-        <ScaffoldSectionDetail>
-          <p className="text-base m-0">HIPAA</p>
-          <div className="space-y-2 text-sm text-foreground-light">
-            <p>
-              This is only for HIPAA requests. Please ignore this if you already have HIPAA enabled.
-            </p>
-            <p>
-              Organizations on the Team Plan or above are eligible for a paid HIPAA compliance
-              add-on. You can submit a request here and we will get back to you on the pricing and
-              process for your use case.
-            </p>
-            <p>
-              Organizations on the Free or Pro Plan can also submit a request for HIPAA. Note that
-              you are still required to upgrade to the Team Plan after your request is approved.
-            </p>
-          </div>
-        </ScaffoldSectionDetail>
-        <ScaffoldSectionContent>
-          <div className="@lg:flex items-center justify-center h-full">
-            <Button asChild type="default" iconRight={<ExternalLink />}>
-              <a
-                href="https://forms.supabase.com/hipaa2"
-                target="_blank"
-                rel="noreferrer noopener"
-                onClick={() =>
-                  sendEvent({
-                    action: 'hipaa_request_button_clicked',
-                    groups: { organization: organization?.slug ?? 'Unknown' },
-                  })
-                }
-              >
-                Request HIPAA
-              </a>
-            </Button>
-          </div>
-        </ScaffoldSectionContent>
-      </ScaffoldSection>
-    </>
+    <ScaffoldSection className="py-12">
+      <ScaffoldSectionDetail>
+        <h4 className="mb-5">HIPAA</h4>
+        <div className="space-y-2 text-sm text-foreground-light [&_p]:m-0">
+          <p>
+            This is only for HIPAA requests. Please ignore this if you already have HIPAA enabled.
+          </p>
+          <p>
+            Organizations on the Team Plan or above are eligible for a paid HIPAA compliance add-on.
+            You can submit a request here and we will get back to you on the pricing and process for
+            your use case.
+          </p>
+          <p>
+            Organizations on the Free or Pro Plan can also submit a request for HIPAA. Note that you
+            are still required to upgrade to the Team Plan after your request is approved.
+          </p>
+        </div>
+      </ScaffoldSectionDetail>
+      <ScaffoldSectionContent>
+        <div className="@lg:flex items-center justify-center h-full">
+          <Button asChild type="default" iconRight={<ExternalLink />}>
+            <a
+              href="https://forms.supabase.com/hipaa2"
+              target="_blank"
+              rel="noreferrer noopener"
+              onClick={() =>
+                sendEvent({
+                  action: 'hipaa_request_button_clicked',
+                  groups: { organization: organization?.slug ?? 'Unknown' },
+                })
+              }
+            >
+              Request HIPAA
+            </a>
+          </Button>
+        </div>
+      </ScaffoldSectionContent>
+    </ScaffoldSection>
   )
 }

--- a/apps/studio/components/interfaces/Organization/Documents/SOC2.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SOC2.tsx
@@ -74,9 +74,11 @@ export const SOC2 = () => {
           <NoPermission resourceText="access our SOC2 Type 2 report" />
         ) : !hasAccessToSoc2Report ? (
           <div className="@lg:flex items-center justify-center h-full">
-            <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=soc2`}>
-              <Button type="default">Upgrade to Team</Button>
-            </Link>
+            <Button asChild type="default">
+              <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=soc2`}>
+                Upgrade to Team
+              </Link>
+            </Button>
           </div>
         ) : (
           <div className="@lg:flex items-center justify-center h-full">

--- a/apps/studio/components/interfaces/Organization/Documents/SOC2.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SOC2.tsx
@@ -57,7 +57,7 @@ export const SOC2 = () => {
 
   return (
     <ScaffoldSection>
-      <ScaffoldSectionDetail className="sticky space-y-6 top-12">
+      <ScaffoldSectionDetail>
         <p className="text-base m-0">SOC2 Type 2</p>
         <div className="space-y-2 text-sm text-foreground-light m-0">
           <p>
@@ -67,19 +67,19 @@ export const SOC2 = () => {
       </ScaffoldSectionDetail>
       <ScaffoldSectionContent>
         {isLoadingPermissions || isLoadingEntitlement ? (
-          <div className="flex items-center justify-center h-full">
+          <div className="@lg:flex items-center justify-center h-full">
             <ShimmeringLoader className="w-24" />
           </div>
         ) : !canReadSubscriptions ? (
           <NoPermission resourceText="access our SOC2 Type 2 report" />
         ) : !hasAccessToSoc2Report ? (
-          <div className="flex items-center justify-center h-full">
+          <div className="@lg:flex items-center justify-center h-full">
             <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=soc2`}>
               <Button type="default">Upgrade to Team</Button>
             </Link>
           </div>
         ) : (
-          <div className="flex items-center justify-center h-full">
+          <div className="@lg:flex items-center justify-center h-full">
             <Button
               type="default"
               icon={<Download />}

--- a/apps/studio/components/interfaces/Organization/Documents/SOC2.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SOC2.tsx
@@ -56,10 +56,10 @@ export const SOC2 = () => {
   }
 
   return (
-    <ScaffoldSection>
+    <ScaffoldSection className="py-12">
       <ScaffoldSectionDetail>
-        <p className="text-base m-0">SOC2 Type 2</p>
-        <div className="space-y-2 text-sm text-foreground-light m-0">
+        <h4 className="mb-5">SOC2 Type 2</h4>
+        <div className="space-y-2 text-sm text-foreground-light [&_p]:m-0">
           <p>
             Organizations on Team Plan or above have access to our most recent SOC2 Type 2 report.
           </p>

--- a/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
@@ -54,46 +54,43 @@ export const SecurityQuestionnaire = () => {
   }
 
   return (
-    <>
-      <ScaffoldSection>
-        <ScaffoldSectionDetail>
-          <p className="text-base m-0">Standard Security Questionnaire</p>
-          <div className="space-y-2 text-sm text-foreground-light m-0">
-            <p>
-              Organizations on Team Plan or above have access to our standard security
-              questionnaire.
-            </p>
+    <ScaffoldSection className="py-12">
+      <ScaffoldSectionDetail>
+        <h4 className="mb-5">Standard Security Questionnaire</h4>
+        <div className="space-y-2 text-sm text-foreground-light [&_p]:m-0">
+          <p>
+            Organizations on Team Plan or above have access to our standard security questionnaire.
+          </p>
+        </div>
+      </ScaffoldSectionDetail>
+      <ScaffoldSectionContent>
+        {isLoadingPermissions || isLoadingEntitlement ? (
+          <div className="@lg:flex items-center justify-center h-full">
+            <ShimmeringLoader className="w-24" />
           </div>
-        </ScaffoldSectionDetail>
-        <ScaffoldSectionContent>
-          {isLoadingPermissions || isLoadingEntitlement ? (
-            <div className="@lg:flex items-center justify-center h-full">
-              <ShimmeringLoader className="w-24" />
-            </div>
-          ) : !canReadSubscriptions ? (
-            <NoPermission resourceText="access our security questionnaire" />
-          ) : !hasAccessToQuestionnaire ? (
-            <div className="@lg:flex items-center justify-center h-full">
-              <Link
-                href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}
-              >
-                <Button type="default">Upgrade to Team</Button>
-              </Link>
-            </div>
-          ) : (
-            <div className="@lg:flex items-center justify-center h-full">
-              <Button
-                type="default"
-                icon={<Download />}
-                onClick={handleDownloadClick}
-                disabled={!slug}
-              >
-                Download Questionnaire
-              </Button>
-            </div>
-          )}
-        </ScaffoldSectionContent>
-      </ScaffoldSection>
-    </>
+        ) : !canReadSubscriptions ? (
+          <NoPermission resourceText="access our security questionnaire" />
+        ) : !hasAccessToQuestionnaire ? (
+          <div className="@lg:flex items-center justify-center h-full">
+            <Link
+              href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}
+            >
+              <Button type="default">Upgrade to Team</Button>
+            </Link>
+          </div>
+        ) : (
+          <div className="@lg:flex items-center justify-center h-full">
+            <Button
+              type="default"
+              icon={<Download />}
+              onClick={handleDownloadClick}
+              disabled={!slug}
+            >
+              Download Questionnaire
+            </Button>
+          </div>
+        )}
+      </ScaffoldSectionContent>
+    </ScaffoldSection>
   )
 }

--- a/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
@@ -72,9 +72,11 @@ export const SecurityQuestionnaire = () => {
           <NoPermission resourceText="access our security questionnaire" />
         ) : !hasAccessToQuestionnaire ? (
           <div className="@lg:flex items-center justify-center h-full">
-            <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}>
-              <Button type="default">Upgrade to Team</Button>
-            </Link>
+            <Button asChild type="default">
+              <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}>
+                Upgrade to Team
+              </Link>
+            </Button>
           </div>
         ) : (
           <div className="@lg:flex items-center justify-center h-full">

--- a/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
@@ -72,9 +72,7 @@ export const SecurityQuestionnaire = () => {
           <NoPermission resourceText="access our security questionnaire" />
         ) : !hasAccessToQuestionnaire ? (
           <div className="@lg:flex items-center justify-center h-full">
-            <Link
-              href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}
-            >
+            <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}>
               <Button type="default">Upgrade to Team</Button>
             </Link>
           </div>

--- a/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
@@ -56,7 +56,7 @@ export const SecurityQuestionnaire = () => {
   return (
     <>
       <ScaffoldSection>
-        <ScaffoldSectionDetail className="sticky space-y-6 top-12">
+        <ScaffoldSectionDetail>
           <p className="text-base m-0">Standard Security Questionnaire</p>
           <div className="space-y-2 text-sm text-foreground-light m-0">
             <p>
@@ -67,13 +67,13 @@ export const SecurityQuestionnaire = () => {
         </ScaffoldSectionDetail>
         <ScaffoldSectionContent>
           {isLoadingPermissions || isLoadingEntitlement ? (
-            <div className="flex items-center justify-center h-full">
+            <div className="@lg:flex items-center justify-center h-full">
               <ShimmeringLoader className="w-24" />
             </div>
           ) : !canReadSubscriptions ? (
             <NoPermission resourceText="access our security questionnaire" />
           ) : !hasAccessToQuestionnaire ? (
-            <div className="flex items-center justify-center h-full">
+            <div className="@lg:flex items-center justify-center h-full">
               <Link
                 href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}
               >
@@ -81,7 +81,7 @@ export const SecurityQuestionnaire = () => {
               </Link>
             </div>
           ) : (
-            <div className="flex items-center justify-center h-full">
+            <div className="@lg:flex items-center justify-center h-full">
               <Button
                 type="default"
                 icon={<Download />}

--- a/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/SecurityQuestionnaire.tsx
@@ -73,7 +73,9 @@ export const SecurityQuestionnaire = () => {
         ) : !hasAccessToQuestionnaire ? (
           <div className="@lg:flex items-center justify-center h-full">
             <Button asChild type="default">
-              <Link href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}>
+              <Link
+                href={`/org/${slug}/billing?panel=subscriptionPlan&source=securityQuestionnaire`}
+              >
                 Upgrade to Team
               </Link>
             </Button>

--- a/apps/studio/components/interfaces/Organization/Documents/TIA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/TIA.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react'
+import { Download } from 'lucide-react'
 
 import {
   ScaffoldSection,
@@ -15,7 +15,7 @@ export const TIA = () => {
 
   return (
     <ScaffoldSection>
-      <ScaffoldSectionDetail className="sticky space-y-6 top-12">
+      <ScaffoldSectionDetail>
         <p className="text-base m-0">Transfer Impact Assessment (TIA)</p>
         <div className="space-y-2 text-sm text-foreground-light m-0">
           <p>
@@ -24,24 +24,26 @@ export const TIA = () => {
           </p>
         </div>
       </ScaffoldSectionDetail>
-      <ScaffoldSectionContent className="flex items-center justify-center h-full">
-        <Button asChild type="default" iconRight={<ExternalLink />}>
-          <a
-            href="https://supabase.com/downloads/docs/Supabase+TIA+250314.pdf"
-            target="_blank"
-            rel="noreferrer noopener"
-            download={true}
-            onClick={() =>
-              sendEvent({
-                action: 'document_view_button_clicked',
-                properties: { documentName: 'TIA' },
-                groups: { organization: organization?.slug ?? 'Unknown' },
-              })
-            }
-          >
-            View TIA
-          </a>
-        </Button>
+      <ScaffoldSectionContent>
+        <div className="@lg:flex items-center justify-center h-full">
+          <Button asChild type="default" iconRight={<Download />}>
+            <a
+              href="https://supabase.com/downloads/docs/Supabase+TIA+250314.pdf"
+              target="_blank"
+              rel="noreferrer noopener"
+              download={true}
+              onClick={() =>
+                sendEvent({
+                  action: 'document_view_button_clicked',
+                  properties: { documentName: 'TIA' },
+                  groups: { organization: organization?.slug ?? 'Unknown' },
+                })
+              }
+            >
+              Download TIA
+            </a>
+          </Button>
+        </div>
       </ScaffoldSectionContent>
     </ScaffoldSection>
   )

--- a/apps/studio/components/interfaces/Organization/Documents/TIA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/TIA.tsx
@@ -14,10 +14,10 @@ export const TIA = () => {
   const { mutate: sendEvent } = useSendEventMutation()
 
   return (
-    <ScaffoldSection>
+    <ScaffoldSection className="py-12">
       <ScaffoldSectionDetail>
-        <p className="text-base m-0">Transfer Impact Assessment (TIA)</p>
-        <div className="space-y-2 text-sm text-foreground-light m-0">
+        <h4 className="mb-5">Transfer Impact Assessment (TIA)</h4>
+        <div className="space-y-2 text-sm text-foreground-light [&_p]:m-0">
           <p>
             All organizations can access and use our TIA as part of their GDPR-compliant data
             transfer process.


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bug fix
- Resolves DEPR-335

## What is the current behavior?

The `/org/_/documents` page behaves strangely on small breakpoints. The buttons are slightly sticky and collide with text.

## What is the new behavior?

- Fixes the unnecessarily-sticky button issue
- Removes redundant markup

| Before | After |
| --- | --- |
| <img width="390" height="850" alt="Supabase" src="https://github.com/user-attachments/assets/5a7f7d15-9e28-4c11-a4cf-fd0a5df481c8" /> | <img width="390" height="850" alt="Supabase" src="https://github.com/user-attachments/assets/232e35af-a2f7-4449-8d4b-a9f2288eba32" /> |

## Additional context

This whole page is due for a redesign. So this PR takes more of a “fix it in its current form” type approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified and standardized layout, spacing, and typography across document panels for a cleaner, more consistent appearance.
  * Streamlined loading and content flows in the security questionnaire panel for clearer states.
* **UX**
  * Renamed "View TIA" to "Download TIA" and updated its icon to reflect the download action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->