### PR TITLE
feat(telemetry): track security settings on project creation

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -236,6 +236,9 @@ const Wizard: NextPageWithLayout = () => {
         'project_creation_simple_version_submitted',
         {
           instanceSize: form.getValues('instanceSize'),
+          dataApiEnabled: form.getValues('dataApi'),
+          useApiSchema: form.getValues('useApiSchema'),
+          useOrioleDb: form.getValues('useOrioleDb'),
         },
         {
           project: res.ref,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -257,6 +257,9 @@ const Wizard: NextPageWithLayout = () => {
     if (additionalMonthlySpend > 0 && (hasOAuthApps || launchingLargerInstance)) {
       track('project_creation_simple_version_confirm_modal_opened', {
         instanceSize: values.instanceSize,
+        dataApiEnabled: values.dataApi,
+        useApiSchema: values.useApiSchema,
+        useOrioleDb: values.useOrioleDb,
       })
       setIsComputeCostsConfirmationModalVisible(true)
     } else {

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -257,9 +257,6 @@ const Wizard: NextPageWithLayout = () => {
     if (additionalMonthlySpend > 0 && (hasOAuthApps || launchingLargerInstance)) {
       track('project_creation_simple_version_confirm_modal_opened', {
         instanceSize: values.instanceSize,
-        dataApiEnabled: values.dataApi,
-        useApiSchema: values.useApiSchema,
-        useOrioleDb: values.useOrioleDb,
       })
       setIsComputeCostsConfirmationModalVisible(true)
     } else {

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -278,6 +278,24 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
    */
   properties: {
     instanceSize?: string
+    /**
+     * Whether Data API is enabled.
+     * true = "Data API + Connection String" (default)
+     * false = "Only Connection String"
+     */
+    dataApiEnabled?: boolean
+    /**
+     * Data API schema configuration. Only relevant when dataApiEnabled is true.
+     * true = "Use dedicated API schema for Data API"
+     * false = "Use public schema for Data API" (default)
+     */
+    useApiSchema?: boolean
+    /**
+     * Postgres engine type selection.
+     * true = "Postgres with OrioleDB" (alpha)
+     * false = "Postgres" (default)
+     */
+    useOrioleDb?: boolean
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -314,24 +314,6 @@ export interface ProjectCreationSimpleVersionConfirmModalOpenedEvent {
    */
   properties: {
     instanceSize?: string
-    /**
-     * Whether Data API is enabled.
-     * true = "Data API + Connection String" (default)
-     * false = "Only Connection String"
-     */
-    dataApiEnabled?: boolean
-    /**
-     * Data API schema configuration. Only relevant when dataApiEnabled is true.
-     * true = "Use dedicated API schema for Data API"
-     * false = "Use public schema for Data API" (default)
-     */
-    useApiSchema?: boolean
-    /**
-     * Postgres engine type selection.
-     * true = "Postgres with OrioleDB" (alpha)
-     * false = "Postgres" (default)
-     */
-    useOrioleDb?: boolean
   }
   groups: Omit<TelemetryGroups, 'project'>
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -314,6 +314,24 @@ export interface ProjectCreationSimpleVersionConfirmModalOpenedEvent {
    */
   properties: {
     instanceSize?: string
+    /**
+     * Whether Data API is enabled.
+     * true = "Data API + Connection String" (default)
+     * false = "Only Connection String"
+     */
+    dataApiEnabled?: boolean
+    /**
+     * Data API schema configuration. Only relevant when dataApiEnabled is true.
+     * true = "Use dedicated API schema for Data API"
+     * false = "Use public schema for Data API" (default)
+     */
+    useApiSchema?: boolean
+    /**
+     * Postgres engine type selection.
+     * true = "Postgres with OrioleDB" (alpha)
+     * false = "Postgres" (default)
+     */
+    useOrioleDb?: boolean
   }
   groups: Omit<TelemetryGroups, 'project'>
 }


### PR DESCRIPTION
## Summary

Adds security and configuration options to the project creation telemetry events. When users create a new project, we now track their choices for Data API enablement, API schema configuration, and Postgres engine type (OrioleDB). This provides visibility into how users are configuring their projects' security settings.

## Changes

- Add `dataApiEnabled`, `useApiSchema`, and `useOrioleDb` properties to `ProjectCreationSimpleVersionSubmittedEvent` interface
- Add the same properties to `ProjectCreationSimpleVersionConfirmModalOpenedEvent` interface for consistency
- Update both track calls in the project creation form to include the new properties

## Testing

Tested local and on preview event with new properties shows up on posthog. 

**Quick test:**
1. Navigate to `/new/{org-slug}` to create a new project
2. Expand "Security options" and configure Data API settings
3. Submit the form and check the telemetry POST request includes `dataApiEnabled`, `useApiSchema`, and `useOrioleDb` properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced telemetry tracking during project creation to capture additional configuration options, improving our ability to understand user preferences and usage patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->