### PR TITLE
fix(studio): handle unexpected error response formats in self-hosted query (Replaces PR #41980)

### DIFF
--- a/apps/studio/.env
+++ b/apps/studio/.env
@@ -1,5 +1,6 @@
 STUDIO_PG_META_URL=http://localhost:8000/pg
 POSTGRES_PASSWORD=your-super-secret-and-long-postgres-password
+PG_META_CRYPTO_KEY=your-encryption-key-32-chars-min
 
 DEFAULT_ORGANIZATION_NAME=Default Organization
 DEFAULT_PROJECT_NAME=Default Project

--- a/apps/studio/lib/api/self-hosted/constants.ts
+++ b/apps/studio/lib/api/self-hosted/constants.ts
@@ -1,6 +1,6 @@
 // Constants specific to self-hosted environments
 
-export const ENCRYPTION_KEY = process.env.PG_META_CRYPTO_KEY || 'SAMPLE_KEY'
+export const ENCRYPTION_KEY = process.env.PG_META_CRYPTO_KEY || 'your-encryption-key-32-chars-min'
 export const POSTGRES_PORT = process.env.POSTGRES_PORT || 5432
 export const POSTGRES_HOST = process.env.POSTGRES_HOST || 'db'
 export const POSTGRES_DATABASE = process.env.POSTGRES_DB || 'postgres'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #41698 , #41875 

In self-hosted environments, the SQL Editor and Authentication pages return 500 errors and throw Zod validation errors:

_Invalid input: expected string, received undefined_
<img width="2476" height="1114" alt="error" src="https://github.com/user-attachments/assets/d317d926-28be-4916-acef-b12315f9b37b" />

**Root causes:**

**1. `PG_META_CRYPTO_KEY` mismatch**: The Docker `.env` defines `PG_META_CRYPTO_KEY`, but `apps/studio/.env` was missing this variable. Additionally, the fallback value in `apps/studio/lib/api/self-hosted/constants.ts` didn't match the Docker `.env` value, causing encryption key mismatches and 500 errors from pg-meta endpoints.
<img width="960" height="59" alt="Screenshot 2026-01-17 at 9 26 08 PM" src="https://github.com/user-attachments/assets/8c24fa2b-229c-49a4-b1ee-36e3f15140f1" />


**2. Strict Zod validation**: `databaseErrorSchema.parse()` throws when error response fields like code or formattedError are undefined.

## What is the new behavior?

**1. Synced `PG_META_CRYPTO_KEY` configuration:**
- Added `PG_META_CRYPTO_KEY` to `apps/studio/.env`
- Updated the fallback value in `constants.ts` to match the Docker `.env` default
<img width="964" height="59" alt="Screenshot 2026-01-17 at 9 28 31 PM" src="https://github.com/user-attachments/assets/ad55cd42-14b1-4a6b-bbdf-6c9a0be6ef73" />
<img width="1388" height="364" alt="Screenshot 2026-01-17 at 9 29 30 PM" src="https://github.com/user-attachments/assets/6a8c7d6c-d163-4c5f-ad5e-4148a050b888" />

**2. Resilient error handling:** Uses `safeParse()` instead of `parse()` for graceful handling of unexpected error response formats
  <img width="1277" height="329" alt="Screenshot 2026-01-17 at 10 07 12 PM" src="https://github.com/user-attachments/assets/e15f0dee-ce69-4235-9a7b-e5d8e8257fea" />

## Additional context
- Replaces PR #41980 . Re-opened to follow the branch naming convention.
- Reported by users deploying via Coolify on AWS and Raspberry Pi
- Downgrading to supabase/studio:2025.10.01-sha-8460121 was a confirmed workaround
- This fix addresses both the root cause (env var mismatch) and adds defensive error handling for edge cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment configuration variables to support PostgreSQL database credentials and encryption key settings for self-hosted deployments, including separate user roles for read-write and read-only database access.

* **Bug Fixes**
  * Enhanced error response handling with fallback mechanisms to gracefully manage API responses that don't match expected formats, improving system stability and error reporting reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->