### PR TITLE
Update database replication docs to mention about read replicas

### DIFF
--- a/apps/docs/content/guides/database/replication.mdx
+++ b/apps/docs/content/guides/database/replication.mdx
@@ -18,7 +18,13 @@ You might use database replication for:
 
 ## Replication methods
 
-Supabase supports two methods for replicating your database to external destinations:
+Supabase supports three methods for replicating your database to external destinations:
+
+### Read Replicas
+
+Additional databases that are kept in sync with your Primary database. These read-only databases can be deployed across multiple regions, for lower latency and better resource management.
+
+- [Set up Read Replicas](/docs/guides/platform/read-replicas)
 
 ### Replication
 


### PR DESCRIPTION
## Context

Part of unifying read replicas with the database replication page - updates the [docs](https://supabase.com/docs/guides/database/replication) for database replication to mention read replicas

## Before

<img width="993" height="675" alt="image" src="https://github.com/user-attachments/assets/52af7fe2-9a07-4f00-b179-1e6cd436e820" />

## After

<img width="1014" height="826" alt="image" src="https://github.com/user-attachments/assets/63441045-5962-4216-8178-5e0861ed910b" />
