### PR TITLE
fix(studio): maintenance banner separate from incident banner

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -1,26 +1,36 @@
 import { PropsWithChildren } from 'react'
 
+import { MaintenanceBanner } from '@/components/layouts/AppLayout/MaintenanceBanner'
 import { useIncidentStatusQuery } from '@/data/platform/incident-status-query'
 import { useFlag } from 'common'
 import { ClockSkewBanner } from 'components/layouts/AppLayout/ClockSkewBanner'
 import { IncidentBanner } from 'components/layouts/AppLayout/IncidentBanner'
 import { NoticeBanner } from 'components/layouts/AppLayout/NoticeBanner'
+import { partition } from 'lodash'
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
-  const { data: incidents } = useIncidentStatusQuery()
+  const { data: allStatusPageEvents } = useIncidentStatusQuery()
+  const [maintenanceEvents, incidents] = partition(
+    allStatusPageEvents ?? [],
+    (event) => event.impact === 'maintenance'
+  )
 
   const ongoingIncident =
     useFlag('ongoingIncident') ||
     process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true' ||
-    (incidents?.length ?? 0) > 0
+    incidents.length > 0
   const showNoticeBanner = useFlag('showNoticeBanner')
   const clockSkewBanner = useFlag('clockSkewBanner')
+
+  const ongoingMaintenance = maintenanceEvents.length > 0
+  const showMaintenanceBanner = ongoingMaintenance && !ongoingIncident
 
   return (
     <div className="flex flex-col">
       <div className="flex-shrink-0">
         {ongoingIncident && <IncidentBanner />}
+        {showMaintenanceBanner && <MaintenanceBanner />}
         {showNoticeBanner && <NoticeBanner />}
         <OrganizationResourceBanner />
         {clockSkewBanner && <ClockSkewBanner />}

--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -1,3 +1,4 @@
+import { partition } from 'lodash'
 import { PropsWithChildren } from 'react'
 
 import { MaintenanceBanner } from '@/components/layouts/AppLayout/MaintenanceBanner'
@@ -6,7 +7,6 @@ import { useFlag } from 'common'
 import { ClockSkewBanner } from 'components/layouts/AppLayout/ClockSkewBanner'
 import { IncidentBanner } from 'components/layouts/AppLayout/IncidentBanner'
 import { NoticeBanner } from 'components/layouts/AppLayout/NoticeBanner'
-import { partition } from 'lodash'
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
@@ -20,17 +20,15 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
     useFlag('ongoingIncident') ||
     process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true' ||
     incidents.length > 0
+  const ongoingMaintenance = maintenanceEvents.length > 0
+
   const showNoticeBanner = useFlag('showNoticeBanner')
   const clockSkewBanner = useFlag('clockSkewBanner')
-
-  const ongoingMaintenance = maintenanceEvents.length > 0
-  const showMaintenanceBanner = ongoingMaintenance && !ongoingIncident
 
   return (
     <div className="flex flex-col">
       <div className="flex-shrink-0">
-        {ongoingIncident && <IncidentBanner />}
-        {showMaintenanceBanner && <MaintenanceBanner />}
+        {ongoingIncident ? <IncidentBanner /> : ongoingMaintenance ? <MaintenanceBanner /> : null}
         {showNoticeBanner && <NoticeBanner />}
         <OrganizationResourceBanner />
         {clockSkewBanner && <ClockSkewBanner />}

--- a/apps/studio/components/layouts/AppLayout/MaintenanceBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/MaintenanceBanner.tsx
@@ -1,0 +1,20 @@
+import { HeaderBanner } from 'components/interfaces/Organization/HeaderBanner'
+import { InlineLink } from 'components/ui/InlineLink'
+
+/**
+ * Used to display ongoing maintenance
+ */
+export function MaintenanceBanner() {
+  return (
+    <HeaderBanner
+      variant="warning"
+      title="Scheduled maintenance is in progress"
+      description={
+        <>
+          Follow the <InlineLink href="https://status.supabase.com">status page</InlineLink> for
+          updates
+        </>
+      }
+    />
+  )
+}

--- a/apps/studio/components/layouts/AppLayout/MaintenanceBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/MaintenanceBanner.tsx
@@ -7,7 +7,7 @@ import { InlineLink } from 'components/ui/InlineLink'
 export function MaintenanceBanner() {
   return (
     <HeaderBanner
-      variant="warning"
+      variant="note"
       title="Scheduled maintenance is in progress"
       description={
         <>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Scheduled maintenance events show up as incidents.

## What is the new behavior?

Created a separate banner for maintenance so it doesn't show up as an incident.

## Additional context

Resolves FE-2407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maintenance event notifications to the studio interface; a maintenance banner now appears with a link to the status page when maintenance is ongoing.
  * Banner logic updated so incident alerts take precedence over maintenance; notices and clock-skew warnings remain unchanged and banner order is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->