### PR TITLE
docs: document node version support

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -35,7 +35,7 @@ To ensure a positive and inclusive environment, please read our [code of conduct
 You will need to install and configure the following dependencies on your machine to build [Supabase](https://supabase.com):
 
 - [Git](https://git-scm.com/)
-- [Node.js v22.x or higher](https://nodejs.org)
+- [Node.js](https://nodejs.org) version as documented in [.nvmrc](./.nvmrc)
 - [pnpm](https://pnpm.io/) version 9.x.x or higher
 - [make](https://www.gnu.org/software/make/) or the equivalent to `build-essentials` for your OS
 - [Docker](https://docs.docker.com/get-docker/) (to run studio locally)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

DEVELOPERS.md claims we support Node versions 22+ for the apps in supabase/supabase.

## What is the new behavior?

We only support running the apps in supabase/supabase with the Node version from our .nvmrc, make this explicit in DEVELOPERS.md

## Additional context

Resolves DOCS-672


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js version requirement documentation to reference the project's configuration file for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->