### PR TITLE
docs: add OAuth example to SvelteKit SSR documentation

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -303,6 +303,46 @@ language="typescript"
 />
 </$CodeTabs>
 
+### Add OAuth login (optional)
+
+To add OAuth login (e.g., GitHub, Google), create a server action that redirects to the OAuth provider, and a callback route to handle the response.
+
+#### Create the OAuth action
+
+Add an `oauth` action to your auth page that initiates the OAuth flow:
+
+<$CodeSample
+path="/auth/sveltekit-full/src/routes/auth/+page.server.ts"
+meta="name=src/routes/auth/+page.server.ts"
+language="typescript"
+/>
+
+#### Create the callback route
+
+Create a callback route at `src/routes/auth/callback/+server.ts` to exchange the OAuth code for a session:
+
+<$CodeSample
+path="/auth/sveltekit-full/src/routes/auth/callback/+server.ts"
+meta="name=src/routes/auth/callback/+server.ts"
+language="typescript"
+/>
+
+#### Add OAuth buttons to your page
+
+Add buttons to trigger the OAuth flow:
+
+<$CodeSample
+path="/auth/sveltekit-full/src/routes/auth/+page.svelte"
+meta="name=src/routes/auth/+page.svelte"
+language="svelte"
+/>
+
+<Admonition type="note">
+
+Make sure to add your callback URL (e.g., `http://localhost:5173/auth/callback` for local development) to your [redirect allow list](/docs/guides/auth/redirect-urls) in the Supabase Dashboard.
+
+</Admonition>
+
 ## Congratulations
 
 You're done! To recap, you've successfully:

--- a/examples/auth/sveltekit-full/src/routes/auth/+page.server.ts
+++ b/examples/auth/sveltekit-full/src/routes/auth/+page.server.ts
@@ -32,7 +32,15 @@ export const actions: Actions = {
   },
   oauth: async ({ request, locals: { supabase }, url }) => {
     const formData = await request.formData()
-    const provider = formData.get('provider') as Provider
+    const providerValue = formData.get('provider')
+
+    // Validate provider is a non-empty string
+    if (!providerValue || typeof providerValue !== 'string') {
+      console.error('Invalid provider')
+      redirect(303, '/auth/error')
+    }
+
+    const provider = providerValue as Provider
 
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider,

--- a/examples/auth/sveltekit-full/src/routes/auth/+page.server.ts
+++ b/examples/auth/sveltekit-full/src/routes/auth/+page.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit'
+import type { Provider } from '@supabase/supabase-js'
 
 import type { Actions } from './$types'
 
@@ -28,5 +29,23 @@ export const actions: Actions = {
     } else {
       redirect(303, '/private')
     }
+  },
+  oauth: async ({ request, locals: { supabase }, url }) => {
+    const formData = await request.formData()
+    const provider = formData.get('provider') as Provider
+
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo: `${url.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      console.error(error)
+      redirect(303, '/auth/error')
+    }
+
+    redirect(303, data.url)
   },
 }

--- a/examples/auth/sveltekit-full/src/routes/auth/+page.server.ts
+++ b/examples/auth/sveltekit-full/src/routes/auth/+page.server.ts
@@ -41,7 +41,7 @@ export const actions: Actions = {
       },
     })
 
-    if (error) {
+    if (error || !data.url) {
       console.error(error)
       redirect(303, '/auth/error')
     }

--- a/examples/auth/sveltekit-full/src/routes/auth/+page.svelte
+++ b/examples/auth/sveltekit-full/src/routes/auth/+page.svelte
@@ -1,3 +1,4 @@
+<h2>Login with Email</h2>
 <form method="POST" action="?/login">
   <label>
     Email
@@ -9,4 +10,17 @@
   </label>
   <button>Login</button>
   <button formaction="?/signup">Sign up</button>
+</form>
+
+<hr />
+
+<h2>Login with OAuth</h2>
+<form method="POST" action="?/oauth">
+  <input type="hidden" name="provider" value="github" />
+  <button>Login with GitHub</button>
+</form>
+
+<form method="POST" action="?/oauth">
+  <input type="hidden" name="provider" value="google" />
+  <button>Login with Google</button>
 </form>

--- a/examples/auth/sveltekit-full/src/routes/auth/callback/+server.ts
+++ b/examples/auth/sveltekit-full/src/routes/auth/callback/+server.ts
@@ -1,0 +1,18 @@
+import { redirect } from '@sveltejs/kit'
+
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+  const code = url.searchParams.get('code')
+  const next = url.searchParams.get('next') ?? '/'
+
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      redirect(303, `/${next.slice(1)}`)
+    }
+  }
+
+  // Return the user to an error page with instructions
+  redirect(303, '/auth/error')
+}

--- a/examples/auth/sveltekit-full/src/routes/auth/callback/+server.ts
+++ b/examples/auth/sveltekit-full/src/routes/auth/callback/+server.ts
@@ -9,7 +9,9 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      redirect(303, `/${next.slice(1)}`)
+      // Ensure the redirect path starts with a single slash
+      const redirectPath = next.startsWith('/') ? next : `/${next}`
+      redirect(303, redirectPath)
     }
   }
 

--- a/examples/auth/sveltekit-full/src/routes/auth/callback/+server.ts
+++ b/examples/auth/sveltekit-full/src/routes/auth/callback/+server.ts
@@ -9,9 +9,9 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      // Ensure the redirect path starts with a single slash
-      const redirectPath = next.startsWith('/') ? next : `/${next}`
-      redirect(303, redirectPath)
+      // Ensure the redirect path is a safe relative path
+      const isSafePath = next.startsWith('/') && !next.startsWith('//')
+      redirect(303, isSafePath ? next : '/')
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation update

## What is the current behavior?
The SvelteKit SSR documentation lacks an OAuth example, making it difficult for developers to implement OAuth login with server-side rendering.

Closes #23618

## What is the new behavior?
Added a complete OAuth example to the SvelteKit SSR documentation including:
- OAuth server action in `+page.server.ts` that initiates the OAuth flow
- Callback route handler in `+server.ts` that exchanges the code for a session
- OAuth buttons in `+page.svelte` for GitHub and Google login
- Documentation with code samples and a note about configuring redirect URLs

## Additional context
The implementation follows the existing PKCE flow pattern already documented in `oauth_pkce_flow.mdx` and integrates with the existing SvelteKit example code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Login with OAuth" options (GitHub, Google) and related UI on the auth page.
  * Added server-side OAuth handling and a callback flow to exchange authorization codes and complete sign-in.

* **Documentation**
  * Expanded server-side authentication guides with an optional OAuth workflow and guidance on configuring redirect URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->