### PR TITLE
fix(studio): improve slider filter icons in DataTable

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTableSheetRowAction.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableSheetRowAction.tsx
@@ -1,11 +1,11 @@
 import { Table } from '@tanstack/react-table'
 import { endOfDay, endOfHour, startOfDay, startOfHour } from 'date-fns'
 import {
+  ArrowDownWideNarrow,
+  ArrowUpNarrowWide,
   CalendarClock,
   CalendarDays,
   CalendarSearch,
-  ChevronLeft,
-  ChevronRight,
   Copy,
   Equal,
   Search,
@@ -85,16 +85,14 @@ export function DataTableSheetRowAction<TData, TFields extends DataTableFilterFi
               onClick={() => column?.setFilterValue([0, value])}
               className="flex items-center gap-2"
             >
-              {/* FIXME: change icon as it is not clear */}
-              <ChevronLeft size={16} />
+              <ArrowDownWideNarrow size={16} />
               Less or equal than
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => column?.setFilterValue([value, 5000])}
               className="flex items-center gap-2"
             >
-              {/* FIXME: change icon as it is not clear */}
-              <ChevronRight size={16} />
+              <ArrowUpNarrowWide size={16} />
               Greater or equal than
             </DropdownMenuItem>
             <DropdownMenuItem


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix / UI improvement

## What is the current behavior?
The slider filter options in DataTable use `ChevronLeft` and `ChevronRight` icons for "Less or equal than" and "Greater or equal than" options. These icons are not intuitive for representing numerical comparisons.

There were FIXME comments in the code noting this issue:
```tsx
{/* FIXME: change icon as it is not clear */}
<ChevronLeft size={16} />
```

## What is the new behavior?
Replaced the icons with more semantically appropriate alternatives:
- `ArrowDownWideNarrow` for "Less or equal than" - visually represents filtering down/descending
- `ArrowUpNarrowWide` for "Greater or equal than" - visually represents filtering up/ascending

These icons better convey the comparison semantics and are more intuitive for users.

## Additional context
File: `apps/studio/components/ui/DataTable/DataTableSheetRowAction.tsx`

Before | After
--- | ---
ChevronLeft (←) | ArrowDownWideNarrow (↓▽)
ChevronRight (→) | ArrowUpNarrowWide (↑△)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icons in the data table component for improved visual consistency and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->