### PR TITLE
fix(studio): support pg_cron $ syntax for last day of month in cron jobs

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.constants.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.constants.ts
@@ -1,18 +1,8 @@
-import { toString as CronToString } from 'cronstrue'
 import z from 'zod'
 
 import { urlRegex } from 'components/interfaces/Auth/Auth.constants'
 import { cronPattern, secondsPattern } from '../CronJobs.constants'
-
-const convertCronToString = (schedule: string) => {
-  // pg_cron can also use "30 seconds" format for schedule. Cronstrue doesn't understand that format so just use the
-  // original schedule when cronstrue throws
-  try {
-    return CronToString(schedule)
-  } catch (error) {
-    return schedule
-  }
-}
+import { formatScheduleString } from '../CronJobs.utils'
 
 const edgeFunctionSchema = z.object({
   type: z.literal('edge_function'),
@@ -75,7 +65,7 @@ const sqlFunctionSchema = z.object({
 
 const sqlSnippetSchema = z.object({
   type: z.literal('sql_snippet'),
-  snippet: z.string().trim().min(1),
+  snippet: z.string().trim().min(1, 'Please provide a SQL snippet to run'),
 })
 
 export const FormSchema = z
@@ -89,7 +79,7 @@ export const FormSchema = z
       .refine((value) => {
         if (cronPattern.test(value)) {
           try {
-            convertCronToString(value)
+            formatScheduleString(value)
             return true
           } catch {
             return false

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CronJobScheduleSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CronJobScheduleSection.tsx
@@ -44,6 +44,7 @@ export const CronJobScheduleSection = ({ form, supportsSeconds }: CronJobSchedul
     { name: 'Every minute', expression: '* * * * *' },
     { name: 'Every 5 minutes', expression: '*/5 * * * *' },
     { name: 'Every first of the month, at 00:00', expression: '0 0 1 * *' },
+    { name: 'Every last day of the month, at 00:00', expression: '0 0 $ * *' },
     { name: 'Every night at midnight', expression: '0 0 * * *' },
     { name: 'Every Monday at 2 AM', expression: '0 2 * * 1' },
   ] as const

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobPage.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobPage.tsx
@@ -1,4 +1,3 @@
-import { toString as CronToString } from 'cronstrue'
 import { Edit3, List } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -36,7 +35,7 @@ import {
 } from 'ui-patterns/PageHeader'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { CreateCronJobSheet } from './CreateCronJobSheet/CreateCronJobSheet'
-import { isSecondsFormat, parseCronJobCommand } from './CronJobs.utils'
+import { formatScheduleString, isSecondsFormat, parseCronJobCommand } from './CronJobs.utils'
 import { PreviousRunsTab } from './PreviousRunsTab'
 
 export const CronJobPage = () => {
@@ -81,16 +80,16 @@ export const CronJobPage = () => {
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="cursor-pointer underline decoration-dotted lowercase">
-            {isSecondsFormat(job.schedule)
-              ? job.schedule.toLowerCase()
-              : CronToString(job.schedule.toLowerCase())}
+            {formatScheduleString(job.schedule.toLowerCase())}
           </span>
         </TooltipTrigger>
         <TooltipContent side="bottom" align="center">
           <div className="text-xs">
             <p className="font-mono mb-1">{job.schedule.toLowerCase()}</p>
             {!isSecondsFormat(job.schedule) && (
-              <p className="text-foreground-light">{CronToString(job.schedule.toLowerCase())}</p>
+              <p className="text-foreground-light">
+                {formatScheduleString(job.schedule.toLowerCase())}
+              </p>
             )}
           </div>
         </TooltipContent>

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
@@ -47,9 +47,11 @@ const getNextRun = (schedule: string, lastRun?: string) => {
   // cron-parser can only deal with the traditional cron syntax but technically users can also
   // use strings like "30 seconds" now, For the latter case, we try our best to parse the next run
   // (can't guarantee as scope is quite big)
-  if (schedule.includes('*')) {
+  if (schedule.includes('*') || schedule.includes('$')) {
     try {
-      const interval = parser.parseExpression(schedule, { tz: 'UTC' })
+      // Normalize pg_cron's $ (last day of month) to cron-parser's L syntax
+      const normalizedSchedule = schedule.replace(/\$/g, 'L')
+      const interval = parser.parseExpression(normalizedSchedule, { tz: 'UTC' })
       return interval.next().getTime()
     } catch (error) {
       return undefined

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.constants.tsx
@@ -1,8 +1,16 @@
 import { EdgeFunctions, RESTApi, SqlEditor } from 'icons'
 import { ScrollText } from 'lucide-react'
 
-export const cronPattern =
-  /^(\*|(\d+|\*\/\d+)|\d+\/\d+|\d+-\d+|\d+(,\d+)*)(\s+(\*|(\d+|\*\/\d+)|\d+\/\d+|\d+-\d+|\d+(,\d+)*)){4}$/
+// Standard cron field pattern (no $)
+const cronFieldPattern = '(\\*|(\\d+|\\*\\/\\d+)|\\d+\\/\\d+|\\d+-\\d+|\\d+(,\\d+)*)'
+// Day-of-month field pattern (allows $ for pg_cron's "last day of month")
+const dayOfMonthPattern = '(\\*|\\$|(\\d+|\\*\\/\\d+)|\\d+\\/\\d+|\\d+-\\d+|\\d+(,\\d+)*)'
+
+// Cron pattern: minute hour day-of-month month day-of-week
+// Only day-of-month (3rd field) supports $ for pg_cron's "last day of month" syntax
+export const cronPattern = new RegExp(
+  `^${cronFieldPattern}\\s+${cronFieldPattern}\\s+${dayOfMonthPattern}\\s+${cronFieldPattern}\\s+${cronFieldPattern}$`
+)
 
 // detect seconds like "10 seconds" or normal cron syntax like "*/5 * * * *"
 export const secondsPattern = /^\d+\s+seconds*$/

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -236,12 +236,27 @@ describe('parseCronJobCommand', () => {
     { description: 'every weekend at 10 AM', command: '0 10 * * 0,6' },
     { description: 'every quarter hour', command: '*/15 * * * *' },
     { description: 'twice daily at 8 AM and 8 PM', command: '0 8,20 * * *' },
+    { description: 'last day of month at midnight (pg_cron $ syntax)', command: '0 0 $ * *' },
   ]
 
   // Replace the single cronPattern test with forEach
   cronPatternTests.forEach(({ description, command }) => {
     it(`should match the regex for a cronPattern with "${description}"`, () => {
       expect(command).toMatch(cronPattern)
+    })
+  })
+
+  // Test that $ is only allowed in day-of-month position (3rd field)
+  const invalidDollarPatternTests = [
+    { description: '$ in minute position', command: '$ * * * *' },
+    { description: '$ in hour position', command: '* $ * * *' },
+    { description: '$ in month position', command: '* * * $ *' },
+    { description: '$ in day-of-week position', command: '* * * * $' },
+  ]
+
+  invalidDollarPatternTests.forEach(({ description, command }) => {
+    it(`should NOT match cronPattern with ${description}`, () => {
+      expect(command).not.toMatch(cronPattern)
     })
   })
 })

--- a/apps/studio/components/interfaces/Integrations/CronJobs/SqlSnippetSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/SqlSnippetSection.tsx
@@ -16,7 +16,10 @@ export const SqlSnippetSection = ({ form }: SqlSnippetSectionProps) => {
         control={form.control}
         name="values.snippet"
         render={({ field }) => (
-          <FormItemLayout label="SQL Snippet" className="[&>div>label]:px-content">
+          <FormItemLayout
+            label="SQL Snippet"
+            className="[&>div>label]:px-content [&_[data-formlayout-id='message']]:px-content"
+          >
             <CodeEditor
               id="create-cron-job-editor"
               language="pgsql"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Supabase Studio cron job dashboard does not support pg_cron's `$` syntax for "last day of month" schedules. When users enter schedules like `0 0 $ * *`:
- Form validation shows "Invalid Cron format" error
- The "Next run" column fails to parse the schedule
- Schedule display shows raw `$` instead of human-readable text

Fixes #42176

## What is the new behavior?

- Cron schedules with `$` in the day-of-month position (3rd field) are now accepted
- Schedule displays show "the last day of the month" instead of raw `$`
- The "Next run" column correctly calculates the next execution date
- Added preset button "Every last day of the month, at 00:00"
- Improved SQL snippet validation error message ("Please provide a SQL snippet to run")

## Additional context

**Technical approach:**
- Updated `cronPattern` regex to validate `$` only in day-of-month position
- Added `formatScheduleString` helper to normalize `$` → `28` for cronstrue parsing, then replace "day 28" with "the last day" in output
- For cron-parser (Next run calculation), normalize `$` → `L` syntax
- Added comprehensive tests for `$` syntax validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preset option for scheduling jobs on the last day of each month at midnight.
  * Improved schedule display to show "the last day" instead of technical cron notation for better readability.

* **Bug Fixes**
  * Enhanced parsing and validation of last-day-of-month schedule expressions.

* **Improvements**
  * Added clearer validation message for SQL snippet input requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->