### PR TITLE
docs: Update use of getSession() in Refine docs

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -232,37 +232,40 @@ const authProvider: AuthProvider = {
     return { error }
   },
   check: async () => {
-    try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+  try {
+    const {
+      data: { user },
+      error,
+    } = await supabaseClient.auth.getUser()
 
-      if (!session) {
-        return {
-          authenticated: false,
-          error: {
-            message: 'Check failed',
-            name: 'Session not found',
-          },
-          logout: true,
-          redirectTo: '/login',
-        }
-      }
-    } catch (error: any) {
+    if (error || !user) {
       return {
         authenticated: false,
-        error: error || {
+        error: {
           message: 'Check failed',
-          name: 'Not authenticated',
+          name: error?.name || 'User not found',
         },
         logout: true,
         redirectTo: '/login',
       }
     }
-
+  } catch (error: any) {
     return {
-      authenticated: true,
+      authenticated: false,
+      error: error || {
+        message: 'Check failed',
+        name: 'Not authenticated',
+      },
+      logout: true,
+      redirectTo: '/login',
     }
-  },
+  }
+
+  return {
+    authenticated: true,
+  }
+},
+
   getIdentity: async () => {
     const { data } = await supabaseClient.auth.getUser()
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -268,24 +268,32 @@ import Account from './Account'
 import Auth from './Auth'
 
 const App: Component = () => {
-  const [session, setSession] = createSignal<AuthSession | null>(null)
+  const [user, setUser] = createSignal<User | null>(null)
+
+  const fetchUser = async () => {
+    const { data, error } = await supabase.auth.getUser()
+    if (error) {
+      setUser(null)
+      return
+    }
+    setUser(data.user)
+  }
 
   createEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session)
-    })
+    fetchUser()
 
-    supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
+    supabase.auth.onAuthStateChange(() => {
+      fetchUser()
     })
   })
 
   return (
     <div class="container" style={{ padding: '50px 0 100px 0' }}>
-      {!session() ? <Auth /> : <Account session={session()!} />}
+      {!user() ? <Auth /> : <Account user={user()!} />}
     </div>
   )
 }
+
 
 export default App
 ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

The Refine getting started tutorial uses the unrecommended `getSession()` method to check authentication state.

Related issue: #42193

## What is the new behavior?

The tutorial now uses `getUser()` to verify the authenticated user, aligning with current Supabase auth best practices and matching the approach used in the Angular tutorial.

## Additional context

This change keeps the example behavior the same while updating it to use the recommended authentication API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Supabase integration guides to use direct user-based authentication checks for more reliable auth state handling.
  * Revised the SolidJS getting-started tutorial to fetch and track the current user and update UI rendering accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->