### PR TITLE
docs: replace getSession with getUser in Solidjs tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -268,24 +268,32 @@ import Account from './Account'
 import Auth from './Auth'
 
 const App: Component = () => {
-  const [session, setSession] = createSignal<AuthSession | null>(null)
+  const [user, setUser] = createSignal<User | null>(null)
+
+  const fetchUser = async () => {
+    const { data, error } = await supabase.auth.getUser()
+    if (error) {
+      setUser(null)
+      return
+    }
+    setUser(data.user)
+  }
 
   createEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session)
-    })
+    fetchUser()
 
-    supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
+    supabase.auth.onAuthStateChange(() => {
+      fetchUser()
     })
   })
 
   return (
     <div class="container" style={{ padding: '50px 0 100px 0' }}>
-      {!session() ? <Auth /> : <Account session={session()!} />}
+      {!user() ? <Auth /> : <Account user={user()!} />}
     </div>
   )
 }
+
 
 export default App
 ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The SolidJS getting started tutorial uses the unrecommended `getSession()` method to manage authentication state.

Related issue: #42192

## What is the new behavior?

The tutorial now uses `getUser()` to retrieve the authenticated user and re-check authentication on auth state changes, aligning with current Supabase auth best practices and the Angular tutorial.

## Additional context

This updates the tutorial to avoid relying on session state while keeping the behavior unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
  * Updated the SolidJS getting started tutorial with revised authentication patterns and guidance. The example code now reflects improved user state management techniques for building authenticated applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->