### PR TITLE
Add amdonition about schema to choose

### DIFF
--- a/apps/docs/content/guides/cron.mdx
+++ b/apps/docs/content/guides/cron.mdx
@@ -29,6 +29,13 @@ Under the hood, Supabase Cron uses the [`pg_cron`](https://github.com/citusdata/
 
 The extension creates a `cron` schema in your database and all Jobs are stored on the `cron.job` table. Every Job's run and its status is recorded on the `cron.job_run_details` table.
 
+<Admonition type="note">
+
+You will be asked to select a schema. The default we recommend is the `extension` schema, which is mostly for **pg_cron’s internal metadata** (job definitions + run history). You usually don’t need to touch it directly — managing jobs in the Dashboard is the normal workflow. Your cron job logic can still read and write data in your own schemas (like `public` or any custom schema).
+
+</Admonition>
+
+
 The Supabase Dashboard provides an interface for you to schedule Jobs and monitor Job runs. You can also do the same with SQL.
 
 ## Resources


### PR DESCRIPTION
- what schema should i choose when configuring pg_cron?
- what is internal workings that is not really relevant to 90% of decs?
- does it matter if i choose extension or some public schema i created?
- realistically what would i functionally do with the extension schema for cron? Do I need to think about this?

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?


## What is the new behavior?

Docs don't explain the step when instlling pg_cron that i need to choose a a schema. But there is mention of the cron schema. Which is not an option to choose but does explain some implementation details.

## Additional context

<img width="930" height="698" alt="image" src="https://github.com/user-attachments/assets/811bcb05-a68e-42b0-95fd-a818863ae894" />

