### PR TITLE
Add error handling for deleting files in storage explorer

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
@@ -36,7 +36,6 @@ export const ConfirmDeleteModal = () => {
         await deleteFiles({ files: selectedItemsToDelete })
       }
     } catch (err) {
-      // console.log('ERROR', err)
     } finally {
       setDeleting(false)
     }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ConfirmDeleteModal.tsx
@@ -1,28 +1,15 @@
-import { noop } from 'lodash'
 import { useEffect, useState } from 'react'
 
+import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
-import { StorageItem } from '../Storage.types'
+import { STORAGE_ROW_TYPES } from '../Storage.constants'
 
-interface ConfirmDeleteModalProps {
-  visible: boolean
-  selectedItemsToDelete: StorageItem[]
-  onSelectCancel: () => void
-  onSelectDelete: () => void
-}
-
-export const ConfirmDeleteModal = ({
-  visible = false,
-  selectedItemsToDelete = [],
-  onSelectCancel = noop,
-  onSelectDelete = noop,
-}: ConfirmDeleteModalProps) => {
+export const ConfirmDeleteModal = () => {
   const [deleting, setDeleting] = useState(false)
+  const { selectedItemsToDelete, deleteFolder, deleteFiles, setSelectedItemsToDelete } =
+    useStorageExplorerStateSnapshot()
 
-  useEffect(() => {
-    setDeleting(false)
-  }, [visible])
-
+  const visible = selectedItemsToDelete.length > 0
   const multipleFiles = selectedItemsToDelete.length > 1
 
   const title = multipleFiles
@@ -37,18 +24,36 @@ export const ConfirmDeleteModal = ({
       ? `Are you sure you want to delete the selected ${selectedItemsToDelete[0].type.toLowerCase()}?`
       : ``
 
-  const onConfirmDelete = () => {
-    setDeleting(true)
-    onSelectDelete()
+  const onDeleteSelectedFiles = async () => {
+    try {
+      setDeleting(true)
+      if (
+        selectedItemsToDelete.length === 1 &&
+        selectedItemsToDelete[0].type === STORAGE_ROW_TYPES.FOLDER
+      ) {
+        await deleteFolder(selectedItemsToDelete[0])
+      } else {
+        await deleteFiles({ files: selectedItemsToDelete })
+      }
+    } catch (err) {
+      // console.log('ERROR', err)
+    } finally {
+      setDeleting(false)
+    }
   }
+
+  useEffect(() => {
+    setDeleting(false)
+  }, [visible])
 
   return (
     <ConfirmationModal
+      size="medium"
       visible={visible}
       title={<span className="break-words">{title}</span>}
-      size="medium"
-      onCancel={onSelectCancel}
-      onConfirm={onConfirmDelete}
+      loading={deleting}
+      onCancel={() => setSelectedItemsToDelete([])}
+      onConfirm={onDeleteSelectedFiles}
       variant="destructive"
       alert={{
         base: { variant: 'destructive' },
@@ -58,5 +63,3 @@ export const ConfirmDeleteModal = ({
     />
   )
 }
-
-export default ConfirmDeleteModal

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -5,7 +5,7 @@ import { useDebounce } from '@uidotdev/usehooks'
 import { useParams } from 'common'
 import { useProjectStorageConfigQuery } from 'data/config/project-storage-config-query'
 import type { Bucket } from 'data/storage/buckets-query'
-import useLatest from 'hooks/misc/useLatest'
+import { useLatest } from 'hooks/misc/useLatest'
 import { IS_PLATFORM } from 'lib/constants'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import { useSelectedBucket } from '../FilesBuckets/useSelectedBucket'
@@ -26,7 +26,6 @@ export const StorageExplorer = () => {
     view,
     columns,
     selectedItems,
-    selectedItemsToDelete,
     openedFolders,
     selectedItemsToMove,
     selectedBucket,
@@ -34,9 +33,7 @@ export const StorageExplorer = () => {
     fetchFolderContents,
     fetchMoreFolderContents,
     fetchFoldersByPath,
-    deleteFolder,
     uploadFiles,
-    deleteFiles,
     moveFiles,
     popColumnAtIndex,
     popOpenedFoldersAtIndex,
@@ -44,7 +41,6 @@ export const StorageExplorer = () => {
     clearSelectedItems,
     setSelectedFilePreview,
     setSelectedItemsToMove,
-    setSelectedItemsToDelete,
   } = useStorageExplorerStateSnapshot()
 
   useProjectStorageConfigQuery({ projectRef: ref }, { enabled: IS_PLATFORM })
@@ -153,24 +149,6 @@ export const StorageExplorer = () => {
     await moveFiles(newPath)
   }
 
-  const onDeleteSelectedFiles = async () => {
-    if (selectedItemsToDelete.length === 1) {
-      const [itemToDelete] = selectedItemsToDelete
-      if (!itemToDelete) return
-
-      switch (itemToDelete.type) {
-        case STORAGE_ROW_TYPES.FOLDER:
-          await deleteFolder(itemToDelete)
-          break
-        case STORAGE_ROW_TYPES.FILE:
-          await deleteFiles({ files: [itemToDelete] })
-          break
-      }
-    } else {
-      await deleteFiles({ files: selectedItemsToDelete })
-    }
-  }
-
   /** Misc UI methods */
   const onSelectColumnEmptySpace = (columnIndex: number) => {
     popColumnAtIndex(columnIndex)
@@ -207,12 +185,9 @@ export const StorageExplorer = () => {
         />
         <PreviewPane />
       </div>
-      <ConfirmDeleteModal
-        visible={selectedItemsToDelete.length > 0}
-        selectedItemsToDelete={selectedItemsToDelete}
-        onSelectCancel={() => setSelectedItemsToDelete([])}
-        onSelectDelete={onDeleteSelectedFiles}
-      />
+
+      <ConfirmDeleteModal />
+
       <MoveItemsModal
         bucketName={selectedBucket.name}
         visible={selectedItemsToMove.length > 0}
@@ -220,6 +195,7 @@ export const StorageExplorer = () => {
         onSelectCancel={() => setSelectedItemsToMove([])}
         onSelectMove={onMoveSelectedFiles}
       />
+
       <CustomExpiryModal />
     </div>
   )

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import * as tus from 'tus-js-client'
 import { proxy, useSnapshot } from 'valtio'
 
+import { ResponseError } from '@/types'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import {
   inverseValidObjectKeyRegex,
@@ -1448,34 +1449,52 @@ function createStorageExplorerState({
 
       const toastId = toast.loading(`Deleting ${prefixes.length} file(s)...`)
 
-      await deleteBucketObject({
-        projectRef: state.projectRef,
-        bucketId: state.selectedBucket.id,
-        paths: prefixes,
-      })
-
-      if (!isDeleteFolder) {
-        // If parent folders are empty, reinstate .emptyFolderPlaceholder to persist them
-        const parentFolderPrefixes = uniq(
-          prefixes.map((prefix) => {
-            const segments = prefix.split('/')
-            return segments.slice(0, segments.length - 1).join('/')
-          })
-        )
-        await Promise.all(
-          parentFolderPrefixes.map((prefix) => state.validateParentFolderEmpty(prefix))
-        )
-
-        toast.success(`Successfully deleted ${prefixes.length} file(s)`, {
-          id: toastId,
-          closeButton: true,
-          duration: SONNER_DEFAULT_DURATION,
-          description: undefined,
+      try {
+        await deleteBucketObject({
+          projectRef: state.projectRef,
+          bucketId: state.selectedBucket.id,
+          paths: prefixes,
         })
-        await state.refetchAllOpenedFolders()
-        state.setSelectedItemsToDelete([])
-      } else {
-        toast.dismiss(toastId)
+
+        if (!isDeleteFolder) {
+          // If parent folders are empty, reinstate .emptyFolderPlaceholder to persist them
+          const parentFolderPrefixes = uniq(
+            prefixes.map((prefix) => {
+              const segments = prefix.split('/')
+              return segments.slice(0, segments.length - 1).join('/')
+            })
+          )
+          await Promise.all(
+            parentFolderPrefixes.map((prefix) => state.validateParentFolderEmpty(prefix))
+          )
+
+          toast.success(`Successfully deleted ${prefixes.length} file(s)`, {
+            id: toastId,
+            closeButton: true,
+            duration: SONNER_DEFAULT_DURATION,
+            description: undefined,
+          })
+          await state.refetchAllOpenedFolders()
+          state.setSelectedItemsToDelete([])
+        } else {
+          toast.dismiss(toastId)
+        }
+      } catch (err) {
+        if (!isDeleteFolder) {
+          toast.error(`Failed to delete ${prefixes.length} file(s)`, {
+            id: toastId,
+            closeButton: true,
+            duration: SONNER_DEFAULT_DURATION,
+            description: (err as ResponseError).message,
+          })
+
+          if (!files.some((f) => f.prefix)) {
+            files.forEach((file) => {
+              const { name, columnIndex } = file
+              state.updateRowStatus({ name, status: STORAGE_ROW_STATUS.READY, columnIndex })
+            })
+          }
+        }
       }
     },
 

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1494,6 +1494,9 @@ function createStorageExplorerState({
               state.updateRowStatus({ name, status: STORAGE_ROW_STATUS.READY, columnIndex })
             })
           }
+        } else {
+          toast.dismiss(toastId)
+          throw err
         }
       }
     },


### PR DESCRIPTION
## Context

When deleting a file in the storage explorer, we're currently missing an error handler if the deletion errors out which lands the user in a state where
- There's no UI indication of the error
- The UI gets stuck in a loading state

Can be reproduced by having a table reference the `storage.objects` table via a foreign key (e.g on the `id` column), and have a record reference one of your storage objects. Then trying deleting that object in the storage explorer thereafter.

## Changes involved
- Update loading toast to an error if the deletion fails for any reason
  <img width="402" height="107" alt="image" src="https://github.com/user-attachments/assets/7f203d74-9630-43fb-a392-a86b936d392e" />
- Reset FileExplorerRows to `READY` state after error

## To test
Easiest way to reproduce is via the foreign key reference
- [ ] Verify that error handler works for deleting files
- [ ] Verify that error handler works for deleting folders
  - Foreign key reference an object within a folder, then try deleting the folder)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the deletion confirmation modal to be self-contained for a cleaner user flow.

* **Improvements**
  * More robust deletion flow with clearer loading states and automatic reset when the modal reopens.
  * Better success/error feedback (toasts) and validation to detect empty parent folders after deletion.

* **Bug Fixes**
  * Cancelling clears selection reliably; errors during deletion now surface appropriate messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->