### PR TITLE
chore: update docker images for self-hosted 2025-01-27

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2025.12.23-sha-f3af2c3
+    image: supabase/studio:2026.01.27-sha-6aa59ff
     restart: unless-stopped
     healthcheck:
       test:
@@ -62,7 +62,7 @@ services:
       SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
     volumes:
       - ./volumes/snippets:/app/snippets:Z
-  
+
   kong:
     container_name: supabase-kong
     image: kong:2.8.1
@@ -93,7 +93,7 @@ services:
 
   auth:
     container_name: supabase-auth
-    image: supabase/gotrue:v2.184.0
+    image: supabase/gotrue:v2.185.0
     restart: unless-stopped
     healthcheck:
       test:
@@ -176,7 +176,7 @@ services:
 
   rest:
     container_name: supabase-rest
-    image: postgrest/postgrest:v14.1
+    image: postgrest/postgrest:v14.3
     restart: unless-stopped
     depends_on:
       db:
@@ -200,7 +200,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.68.0
+    image: supabase/realtime:v2.72.0
     restart: unless-stopped
     depends_on:
       db:
@@ -240,7 +240,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.33.0
+    image: supabase/storage-api:v1.33.5
     restart: unless-stopped
     volumes:
       - ./volumes/storage:/var/lib/storage:z
@@ -307,7 +307,7 @@ services:
 
   meta:
     container_name: supabase-meta
-    image: supabase/postgres-meta:v0.95.1
+    image: supabase/postgres-meta:v0.95.2
     restart: unless-stopped
     depends_on:
       db:
@@ -326,7 +326,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.69.28
+    image: supabase/edge-runtime:v1.70.0
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:Z
@@ -350,7 +350,7 @@ services:
 
   analytics:
     container_name: supabase-analytics
-    image: supabase/logflare:1.27.0
+    image: supabase/logflare:1.30.3
     restart: unless-stopped
     ports:
       - 4000:4000

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,5 +1,16 @@
 # Docker Image Versions
 
+## 2026-01-27
+- supabase/studio:2026.01.27-sha-6aa59ff (prev supabase/studio:2025.12.17-sha-43f4f7f)
+- supabase/gotrue:v2.185.0 (prev supabase/gotrue:v2.184.0)
+- postgrest/postgrest:v14.3 (prev postgrest/postgrest:v14.1)
+- supabase/realtime:v2.72.0 (prev supabase/realtime:v2.68.0)
+- supabase/storage-api:v1.33.5 (prev supabase/storage-api:v1.33.0)
+- darthsim/imgproxy:v3.30.1 (prev darthsim/imgproxy:v3.8.0)
+- supabase/postgres-meta:v0.95.2 (prev supabase/postgres-meta:v0.95.1)
+- supabase/edge-runtime:v1.70.0 (prev supabase/edge-runtime:v1.69.28)
+- supabase/logflare:1.30.3 (prev supabase/logflare:1.27.0)
+
 ## 2025-12-18
 - supabase/studio:2025.12.17-sha-43f4f7f (prev supabase/studio:2025.12.09-sha-434634f)
 - supabase/gotrue:v2.184.0 (prev supabase/gotrue:v2.183.0)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updating images for [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting/docker) to latest:

- supabase/studio:2026.01.27-sha-6aa59ff (prev supabase/studio:2025.12.17-sha-43f4f7f)
- supabase/gotrue:v2.185.0 (prev supabase/gotrue:v2.184.0)
- postgrest/postgrest:v14.3 (prev postgrest/postgrest:v14.1)
- supabase/realtime:v2.72.0 (prev supabase/realtime:v2.68.0)
- supabase/storage-api:v1.33.5 (prev supabase/storage-api:v1.33.0)
- darthsim/imgproxy:v3.30.1 (prev darthsim/imgproxy:v3.8.0)
- supabase/postgres-meta:v0.95.2 (prev supabase/postgres-meta:v0.95.1)
- supabase/edge-runtime:v1.70.0 (prev supabase/edge-runtime:v1.69.28)
- supabase/logflare:1.30.3 (prev supabase/logflare:1.27.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker service images to newer versions including authentication, API gateway, real-time messaging, storage, metadata management, serverless functions, and analytics services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->