### PR TITLE
refactor(studio): remove unpaginated buckets list

### DIFF
--- a/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
+++ b/apps/studio/components/interfaces/Storage/__tests__/DeleteBucketModal.test.tsx
@@ -63,7 +63,7 @@ describe(`DeleteBucketModal`, () => {
         status: 'ACTIVE_HEALTHY',
       },
     })
-    // useBucketsQuery
+    // usePaginatedBucketsQuery
     addAPIMock({
       method: `get`,
       path: `/platform/storage/:ref/buckets`,

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -133,25 +133,6 @@ export const useBucketQuery = <TData = BucketData>(
   })
 }
 
-/**
- * @deprecated - use usePaginatedBucketsQuery instead for better performance
- */
-export const useBucketsQuery = <TData = BucketsData>(
-  { projectRef }: BucketsVariables,
-  { enabled = true, ...options }: UseCustomQueryOptions<BucketsData, BucketsError, TData> = {}
-) => {
-  const { data: project } = useSelectedProjectQuery()
-  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
-
-  return useQuery<BucketsData, BucketsError, TData>({
-    queryKey: storageKeys.buckets(projectRef),
-    queryFn: ({ signal }) => getBuckets({ projectRef }, signal),
-    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
-    ...options,
-    retry: shouldRetryBucketsQuery,
-  })
-}
-
 export const useBucketNumberEstimateQuery = (
   { projectRef }: BucketsVariables,
   { enabled = true, ...options }: UseCustomQueryOptions<number | undefined, ResponseError> = {}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

The codebase still contains points to the unpaginated buckets endpoint.

## What is the new behavior?

Completely remove all calls to unpaginated buckets endpoint:

- Remove deprecated `useBucketsQuery` hook
- Update `useBucketPolicyCount` to not use unpaginated buckets list

## Additional context

Resolves FE-2118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal logic for storage bucket policy calculations by streamlining data dependencies and improving loading state handling.
  * Removed deprecated code to reduce maintenance overhead and improve codebase clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->