### PR TITLE
test(assistant): add eval case for `execute_sql` usage on default "Generate sample data" prompt

### DIFF
--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -94,4 +94,16 @@ export const dataset: AssistantEvalCase[] = [
         'Uses quotes around schema/table/columns with capital letters, special characters, and reserved keywords.',
     },
   },
+  {
+    input: {
+      prompt: 'Generate sample data for a blog with users, posts, and comments tables',
+    },
+    expected: {
+      requiredTools: ['execute_sql'],
+    },
+    metadata: {
+      category: ['sql_generation', 'schema_design'],
+      description: 'Invokes `execute_sql` from default "Generate sample data" prompt',
+    },
+  },
 ]


### PR DESCRIPTION
Adds eval case that verifies our default "Generate sample data" prompt invokes the `execute_sql` to render an interactive SQL widget instead of spitting out plaintext SQL.

No prompt changes needed as the case already scores 100%

Resolves AI-347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new evaluation case for SQL generation workflow testing, featuring sample data creation across blog-related database tables (users, posts, and comments) with the execute_sql tool requirement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->