### PR TITLE
[FE-2380] chore(studio): feature flag for disabling oriole creation

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
@@ -1,23 +1,24 @@
-import { ChevronRight } from 'lucide-react'
-import { UseFormReturn } from 'react-hook-form'
-
+import { useFlag } from 'common'
 import { DocsButton } from 'components/ui/DocsButton'
 import Panel from 'components/ui/Panel'
 import { DOCS_URL } from 'lib/constants'
+import { ChevronRight } from 'lucide-react'
+import { UseFormReturn } from 'react-hook-form'
 import {
   Badge,
-  cn,
-  Collapsible_Shadcn_,
   CollapsibleContent_Shadcn_,
   CollapsibleTrigger_Shadcn_,
+  Collapsible_Shadcn_,
   FormControl_Shadcn_,
   FormField_Shadcn_,
   FormItem_Shadcn_,
   RadioGroupStacked,
   RadioGroupStackedItem,
+  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
 import { CreateProjectForm } from './ProjectCreation.schema'
 
 interface AdvancedConfigurationProps {
@@ -31,6 +32,8 @@ export const AdvancedConfiguration = ({
   layout = 'horizontal',
   collapsible = true,
 }: AdvancedConfigurationProps) => {
+  const disableOrioleProjectCreation = useFlag('disableOrioleProjectCreation')
+
   const content = (
     <>
       <FormField_Shadcn_
@@ -80,8 +83,11 @@ export const AdvancedConfiguration = ({
                         description="Not recommended for production workloads"
                         className={cn(
                           '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
-                          form.getValues('useOrioleDb') ? '!rounded-b-none' : ''
+                          form.getValues('useOrioleDb') || disableOrioleProjectCreation
+                            ? '!rounded-b-none'
+                            : ''
                         )}
+                        disabled={disableOrioleProjectCreation}
                       />
                     </FormControl_Shadcn_>
                   </FormItem_Shadcn_>
@@ -96,6 +102,14 @@ export const AdvancedConfiguration = ({
                 >
                   <DocsButton className="mt-2" href={`${DOCS_URL}/guides/database/orioledb`} />
                 </Admonition>
+              )}
+              {disableOrioleProjectCreation && (
+                <Admonition
+                  type="warning"
+                  className="rounded-t-none [&>div]:text-xs"
+                  title="OrioleDB is not available"
+                  description="OrioleDB is temporarily disabled for new projects. Please try again later."
+                />
               )}
             </FormItemLayout>
           </>

--- a/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
@@ -14,6 +14,9 @@ import {
   FormItem_Shadcn_,
   RadioGroupStacked,
   RadioGroupStackedItem,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -71,24 +74,32 @@ export const AdvancedConfiguration = ({
                   </FormItem_Shadcn_>
                   <FormItem_Shadcn_ asChild>
                     <FormControl_Shadcn_>
-                      <RadioGroupStackedItem
-                        value="true"
-                        // @ts-ignore
-                        label={
-                          <>
-                            Postgres with OrioleDB
-                            <Badge variant="warning">Alpha</Badge>
-                          </>
-                        }
-                        description="Not recommended for production workloads"
-                        className={cn(
-                          '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
-                          form.getValues('useOrioleDb') || disableOrioleProjectCreation
-                            ? '!rounded-b-none'
-                            : ''
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <RadioGroupStackedItem
+                            value="true"
+                            // @ts-ignore
+                            label={
+                              <>
+                                Postgres with OrioleDB
+                                <Badge variant="warning">Alpha</Badge>
+                              </>
+                            }
+                            description="Not recommended for production workloads"
+                            className={cn(
+                              '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
+                              form.getValues('useOrioleDb') ? '!rounded-b-none' : ''
+                            )}
+                            disabled={disableOrioleProjectCreation}
+                          />
+                        </TooltipTrigger>
+                        {disableOrioleProjectCreation && (
+                          <TooltipContent side="right" className="w-60 text-center">
+                            OrioleDB is temporarily disabled for new projects. Please try again
+                            later.
+                          </TooltipContent>
                         )}
-                        disabled={disableOrioleProjectCreation}
-                      />
+                      </Tooltip>
                     </FormControl_Shadcn_>
                   </FormItem_Shadcn_>
                 </RadioGroupStacked>
@@ -102,14 +113,6 @@ export const AdvancedConfiguration = ({
                 >
                   <DocsButton className="mt-2" href={`${DOCS_URL}/guides/database/orioledb`} />
                 </Admonition>
-              )}
-              {disableOrioleProjectCreation && (
-                <Admonition
-                  type="warning"
-                  className="rounded-t-none [&>div]:text-xs"
-                  title="OrioleDB is not available"
-                  description="OrioleDB is temporarily disabled for new projects. Please try again later."
-                />
               )}
             </FormItemLayout>
           </>

--- a/apps/studio/data/config/project-creation-postgres-versions-query.ts
+++ b/apps/studio/data/config/project-creation-postgres-versions-query.ts
@@ -58,7 +58,7 @@ export const useProjectCreationPostgresVersionsQuery = <TData = ProjectCreationP
 
 export const useAvailableOrioleImageVersion = (
   { cloudProvider, dbRegion, organizationSlug }: ProjectCreationPostgresVersionsVariables,
-  { enabled = true }: { enabled?: boolean }
+  { enabled = true }: { enabled?: boolean } = {}
 ) => {
   const { data } = useProjectCreationPostgresVersionsQuery(
     {

--- a/apps/studio/data/config/project-creation-postgres-versions-query.ts
+++ b/apps/studio/data/config/project-creation-postgres-versions-query.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-
 import { handleError, post } from 'data/fetchers'
 import { CloudProvider } from 'shared-data'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
+
 import { configKeys } from './keys'
 
 export type ProjectCreationPostgresVersionsVariables = {
@@ -58,7 +58,7 @@ export const useProjectCreationPostgresVersionsQuery = <TData = ProjectCreationP
 
 export const useAvailableOrioleImageVersion = (
   { cloudProvider, dbRegion, organizationSlug }: ProjectCreationPostgresVersionsVariables,
-  { enabled }: { enabled?: boolean }
+  { enabled = true }: { enabled?: boolean }
 ) => {
   const { data } = useProjectCreationPostgresVersionsQuery(
     {
@@ -66,7 +66,13 @@ export const useAvailableOrioleImageVersion = (
       dbRegion,
       organizationSlug,
     },
-    { enabled }
+    {
+      enabled,
+      select(data) {
+        return (data?.available_versions ?? []).find((x) => x.postgres_engine === '17-oriole')
+      },
+    }
   )
-  return (data?.available_versions ?? []).find((x) => x.postgres_engine === '17-oriole')
+
+  return data
 }

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -1,12 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import { z } from 'zod'
-
 import { LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
 import { AdvancedConfiguration } from 'components/interfaces/ProjectCreation/AdvancedConfiguration'
 import { CloudProviderSelector } from 'components/interfaces/ProjectCreation/CloudProviderSelector'
@@ -17,8 +10,8 @@ import { DisabledWarningDueToIncident } from 'components/interfaces/ProjectCreat
 import { FreeProjectLimitWarning } from 'components/interfaces/ProjectCreation/FreeProjectLimitWarning'
 import { OrganizationSelector } from 'components/interfaces/ProjectCreation/OrganizationSelector'
 import {
-  extractPostgresVersionDetails,
   PostgresVersionSelector,
+  extractPostgresVersionDetails,
 } from 'components/interfaces/ProjectCreation/PostgresVersionSelector'
 import { sizes } from 'components/interfaces/ProjectCreation/ProjectCreation.constants'
 import { FormSchema } from 'components/interfaces/ProjectCreation/ProjectCreation.schema'
@@ -54,11 +47,17 @@ import { withAuth } from 'hooks/misc/withAuth'
 import { usePHFlag } from 'hooks/ui/useFlag'
 import { DOCS_URL, PROJECT_STATUS, PROVIDERS, useDefaultProvider } from 'lib/constants'
 import { useTrack } from 'lib/telemetry/track'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
 import { AWS_REGIONS, type CloudProvider } from 'shared-data'
+import { toast } from 'sonner'
 import type { NextPageWithLayout } from 'types'
-import { Button, Form_Shadcn_, FormField_Shadcn_, useWatch_Shadcn_ } from 'ui'
-import { Admonition } from 'ui-patterns/admonition'
+import { Button, FormField_Shadcn_, Form_Shadcn_, useWatch_Shadcn_ } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { Admonition } from 'ui-patterns/admonition'
+import { z } from 'zod'
 
 const sizesWithNoCostConfirmationRequired: DesiredInstanceSize[] = ['micro', 'small']
 


### PR DESCRIPTION
Adds `disableOrioleProjectCreation` feature flag which prevents users from creating new projects using OrioleDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OrioleDB can be globally disabled for new project creation; the option is visually disabled and shows a tooltip warning when disabled.
  * Existing production-related cautions and temporary unavailability notices remain visible.

* **Refactor**
  * Improved database version lookup behavior and query option defaults for more reliable version selection.
  * Project creation UI now receives form state to ensure consistent disabled/tooltip behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->