### PR TITLE
Shift replication alpha access request CTA into DestinationPanel

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -1,12 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { AnimatePresence, motion } from 'framer-motion'
-import { snakeCase } from 'lodash'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import * as z from 'zod'
-
 import { useFlag, useParams } from 'common'
 import { CreateAnalyticsBucketSheet } from 'components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketSheet'
 import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
@@ -26,19 +19,26 @@ import { useReplicationSourcesQuery } from 'data/replication/sources-query'
 import { useStartPipelineMutation } from 'data/replication/start-pipeline-mutation'
 import { useUpdateDestinationPipelineMutation } from 'data/replication/update-destination-pipeline-mutation'
 import {
-  useValidateDestinationMutation,
   type ValidationFailure,
+  useValidateDestinationMutation,
 } from 'data/replication/validate-destination-mutation'
 import { useValidatePipelineMutation } from 'data/replication/validate-pipeline-mutation'
 import { useIcebergNamespaceCreateMutation } from 'data/storage/iceberg-namespace-create-mutation'
 import { useS3AccessKeyCreateMutation } from 'data/storage/s3-access-key-create-mutation'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { snakeCase } from 'lodash'
 import { Loader2 } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
   PipelineStatusRequestStatus,
   usePipelineRequestStatus,
 } from 'state/replication-pipeline-request-status'
 import { Button, DialogSectionSeparator, Form_Shadcn_, SheetFooter, SheetSection } from 'ui'
+import * as z from 'zod'
+
 import { DestinationType } from '../DestinationPanel.types'
 import { AdvancedSettings } from './AdvancedSettings'
 import { CREATE_NEW_KEY, CREATE_NEW_NAMESPACE } from './DestinationForm.constants'

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
-
-import { useReplicationSourcesQuery } from '@/data/replication/sources-query'
-import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useFlag, useParams } from 'common'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
+import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
 import {
-  cn,
+  Button,
   DialogSectionSeparator,
   Sheet,
   SheetContent,
@@ -12,12 +12,18 @@ import {
   SheetHeader,
   SheetSection,
   SheetTitle,
+  cn,
 } from 'ui'
+
 import { EnableReplicationCallout } from '../EnableReplicationCallout'
+import { useIsETLPrivateAlpha } from '../useIsETLPrivateAlpha'
 import { DestinationForm } from './DestinationForm'
 import { DestinationType } from './DestinationPanel.types'
 import { DestinationTypeSelection } from './DestinationTypeSelection'
 import { ReadReplicaForm } from './ReadReplicaForm'
+import { DocsButton } from '@/components/ui/DocsButton'
+import { useReplicationSourcesQuery } from '@/data/replication/sources-query'
+import { DOCS_URL } from '@/lib/constants'
 
 interface DestinationPanelProps {
   visible: boolean
@@ -41,6 +47,7 @@ export const DestinationPanel = ({
   onSuccessCreateReadReplica,
 }: DestinationPanelProps) => {
   const { ref: projectRef } = useParams()
+  const enablePgReplicate = useIsETLPrivateAlpha()
   const unifiedReplication = useFlag('unifiedReplication')
   const { hasAccess: hasETLReplicationAccess } = useCheckEntitlements('replication.etl')
 
@@ -84,6 +91,35 @@ export const DestinationPanel = ({
 
             {selectedType === 'Read Replica' ? (
               <ReadReplicaForm onClose={onClose} onSuccess={() => onSuccessCreateReadReplica?.()} />
+            ) : unifiedReplication && !enablePgReplicate ? (
+              <SheetSection>
+                <div className={cn('border rounded-md p-6 flex flex-col gap-y-4')}>
+                  <div className="flex flex-col gap-y-1">
+                    <h4>Replicate data to external destinations in real-time</h4>
+                    <p className="text-sm text-foreground-light">
+                      We are currently in <span className="text-foreground">private alpha</span> and
+                      slowly onboarding new customers to ensure stable data pipelines. Request
+                      access below to join the waitlist. Read replicas are available now.
+                    </p>
+                  </div>
+                  <div className="flex gap-x-2">
+                    <Button
+                      asChild
+                      type="secondary"
+                      iconRight={<ArrowUpRight size={16} strokeWidth={1.5} />}
+                    >
+                      <Link
+                        href="https://forms.supabase.com/pg_replicate"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Request alpha access
+                      </Link>
+                    </Button>
+                    <DocsButton href={`${DOCS_URL}/guides/database/replication#replication`} />
+                  </div>
+                </div>
+              </SheetSection>
             ) : unifiedReplication && replicationNotEnabled ? (
               <SheetSection>
                 <EnableReplicationCallout

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -2,6 +2,7 @@ import { useFlag } from 'common'
 import { AnalyticsBucket, BigQuery, Database } from 'icons'
 import { Badge, RadioGroupStacked, RadioGroupStackedItem, cn } from 'ui'
 
+import { useIsETLPrivateAlpha } from '../useIsETLPrivateAlpha'
 import { DestinationType } from './DestinationPanel.types'
 import { InlineLink } from '@/components/ui/InlineLink'
 
@@ -16,6 +17,7 @@ export const DestinationTypeSelection = ({
   selectedType,
   setSelectedType,
 }: DestinationTypeSelectionProps) => {
+  const enablePgReplicate = useIsETLPrivateAlpha()
   const unifiedReplication = useFlag('unifiedReplication')
   const etlEnableBigQuery = useFlag('etlEnableBigQuery')
   const etlEnableIceberg = useFlag('etlEnableIceberg')
@@ -104,7 +106,7 @@ export const DestinationTypeSelection = ({
         )}
       </RadioGroupStacked>
 
-      {selectedType !== 'Read Replica' && (
+      {selectedType !== 'Read Replica' && enablePgReplicate && (
         <p className="mt-3 text-sm text-foreground-light">
           Replication is in alpha. Expect rapid changes and possible breaking updates.{' '}
           <InlineLink href="https://github.com/orgs/supabase/discussions/39416">

--- a/apps/studio/components/interfaces/Database/Replication/EnableReplicationCallout.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/EnableReplicationCallout.tsx
@@ -1,14 +1,9 @@
-import { useState } from 'react'
-import { toast } from 'sonner'
-
-import { DocsButton } from '@/components/ui/DocsButton'
-import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
-import { DOCS_URL } from '@/lib/constants'
 import { useParams } from 'common'
 import { useCreateTenantSourceMutation } from 'data/replication/create-tenant-source-mutation'
+import { useState } from 'react'
+import { toast } from 'sonner'
 import {
   Button,
-  cn,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -17,8 +12,13 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   DialogTrigger,
+  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+
+import { DocsButton } from '@/components/ui/DocsButton'
+import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
+import { DOCS_URL } from '@/lib/constants'
 
 const EnableReplicationModal = () => {
   const { ref: projectRef } = useParams()
@@ -93,7 +93,7 @@ export const EnableReplicationCallout = ({
   return (
     <div className={cn('border rounded-md p-4 md:p-12 flex flex-col gap-y-4', className)}>
       <div className="flex flex-col gap-y-1">
-        <h3>Replicate data to external destinations in real-time</h3>
+        <h4>Replicate data to external destinations in real-time</h4>
         <p className="text-sm text-foreground-light">
           {hasAccess ? 'Enable replication' : 'Upgrade to the Pro plan'} to start replicating your
           database changes to {type ?? 'data warehouses and analytics platforms'}

--- a/apps/studio/pages/project/[ref]/database/replication/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/replication/index.tsx
@@ -1,5 +1,4 @@
-import { ReplicationDiagram } from '@/components/interfaces/Database/Replication/ReplicationDiagram'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import { ReplicationComingSoon } from 'components/interfaces/Database/Replication/ComingSoon'
 import { Destinations } from 'components/interfaces/Database/Replication/Destinations'
 import { useIsETLPrivateAlpha } from 'components/interfaces/Database/Replication/useIsETLPrivateAlpha'
@@ -12,10 +11,13 @@ import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { PipelineRequestStatusProvider } from 'state/replication-pipeline-request-status'
 import type { NextPageWithLayout } from 'types'
 
+import { ReplicationDiagram } from '@/components/interfaces/Database/Replication/ReplicationDiagram'
+
 const DatabaseReplicationPage: NextPageWithLayout = () => {
   const { ref } = useParams()
   const enablePgReplicate = useIsETLPrivateAlpha()
   const showPgReplicate = useIsFeatureEnabled('database:replication')
+  const unifiedReplication = useFlag('unifiedReplication')
 
   if (!showPgReplicate) {
     return <UnknownInterface urlBack={`/project/${ref}/database/schemas`} />
@@ -23,7 +25,7 @@ const DatabaseReplicationPage: NextPageWithLayout = () => {
 
   return (
     <>
-      {enablePgReplicate ? (
+      {unifiedReplication || enablePgReplicate ? (
         <PipelineRequestStatusProvider>
           <ScaffoldContainer>
             <ScaffoldSection isFullWidth>


### PR DESCRIPTION
## Context

Part of unifying read replicas with database replication page

Shifts the Alpha Access request CTA for database replication into the Destination Panel if the feature flag for the new UI is toggled on. So that users can still manage their read replicas

<img width="858" height="535" alt="image" src="https://github.com/user-attachments/assets/ff19c3d4-d201-4d8b-ab01-ee5a9fe6a898" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PostgreSQL replication is now available as a private alpha feature. Users can request early access directly from the destination replication panel with a dedicated request button.
  * Enhanced replication configuration interface with new quick-action buttons for accessing documentation and plan upgrade options.

* **UI Improvements**
  * Refined replication panel layout for better navigation and feature discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->