### PR TITLE
Update Pricing for Log Drains on Pro tier

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -602,7 +602,7 @@ export function LogDrainDestinationSheetForm({
             <ul className="text-right text-foreground-light divide-y divide-dashed text-sm">
               <li className="flex items-center justify-between gap-2 py-2" translate="no">
                 <span className="text-foreground-lighter">Additional drain cost</span>
-                <span className="text-foreground">$60 per month</span>
+                <span className="text-foreground">$10 per month</span>
               </li>
               <li className="flex items-center justify-between gap-2 py-2" translate="no">
                 <span className="text-foreground-lighter">Per million events</span>

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -96,7 +96,7 @@ export function LogDrains({
               title={src.name}
               description={src.description}
               icon={src.icon}
-              rightLabel={IS_PLATFORM ? 'Additional $60' : undefined}
+              rightLabel={IS_PLATFORM ? 'Additional $10' : undefined}
               onClick={() => {
                 onNewDrainClick(src.value)
               }}

--- a/apps/studio/components/interfaces/LogDrains/LogDrainsEmpty.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainsEmpty.tsx
@@ -12,7 +12,7 @@ export const LogDrainsEmpty = () => {
       step: 1,
       title: 'Pricing',
       description:
-        'Log Drains are available as a project Add-On for all Team and Enterprise users. Each Log Drain costs $60 per month.',
+        'Log Drains are available as a project Add-On for all Team and Enterprise users. Each Log Drain costs $10 per month.',
       label: 'See our pricing',
       link: `${DOCS_URL}/guides/platform/manage-your-usage/log-drains`,
     },

--- a/apps/studio/pages/project/[ref]/settings/log-drains.tsx
+++ b/apps/studio/pages/project/[ref]/settings/log-drains.tsx
@@ -169,7 +169,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
           </p>
           {IS_PLATFORM && (
             <p>
-              This will incur an additional <span className="text-foreground">$60 per month</span>{' '}
+              This will incur an additional <span className="text-foreground">$10 per month</span>{' '}
               charge to your subscription.
             </p>
           )}
@@ -221,7 +221,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
                           <div className="space-y-1">
                             <p className="block text-foreground">{drainType.name}</p>
                             {IS_PLATFORM && (
-                              <p className="text-xs text-foreground-lighter">Additional $60</p>
+                              <p className="text-xs text-foreground-lighter">Additional $10</p>
                             )}
                           </div>
                         </div>

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -62,6 +62,7 @@ export const plans: PricingInformation[] = [
       'Email support',
       'Daily backups stored for 7 days',
       '7-day log retention',
+      ['Add Log Drains', 'additional $10 per drain, per project']
     ],
     preface: 'Everything in the Free Plan, plus:',
     cta: 'Get Started',
@@ -85,7 +86,6 @@ export const plans: PricingInformation[] = [
       'Priority email support & SLAs',
       'Daily backups stored for 14 days',
       '28-day log retention',
-      ['Add Log Drains', 'additional $60 per drain, per project'],
     ],
     preface: 'Everything in the Pro Plan, plus:',
     cta: 'Get Started',

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -590,8 +590,8 @@ export const pricing: Pricing = {
         title: 'Log Drain',
         plans: {
           free: false,
-          pro: false,
-          team: ['$60 per drain per month', '+ $0.20 per million events', '+ $0.09 per GB egress'],
+          pro: ['$10 per drain per month', '+ $0.20 per million events', '+ $0.09 per GB egress'],
+          team: true,
           enterprise: 'Custom',
         },
         usage_based: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

feature: pricing udpate

## What is the current behavior?

Log drains are only on team tier

## What is the new behavior?

Log Drains will be avaliable on pro tier, this PR only updates the pricing page.

## Additional context

Add any other context or screenshots.
