### PR TITLE
fix(studio): allow TSV drag/drop imports in table editor

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -201,6 +201,7 @@ export const Grid = memo(
                 isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
               )}
               style={{ height: `calc(100% - 35px)` }}
+              data-testid="table-import-dropzone"
               onDragOver={onDragOver}
               onDragLeave={onDragOver}
               onDrop={onFileDrop}
@@ -229,9 +230,9 @@ export const Grid = memo(
                       <p className="text-sm text-light pointer-events-auto">
                         {isDraggedOver ? (
                           isValidFileDraggedOver ? (
-                            'Drop your CSV file here'
+                            'Drop your CSV or TSV file here'
                           ) : (
-                            <span className="text-destructive">Only CSV files are accepted</span>
+                            <span className="text-destructive">Only CSV or TSV files are accepted</span>
                           )
                         ) : (
                           'This table is empty'
@@ -262,10 +263,10 @@ export const Grid = memo(
                                 })
                               }}
                             >
-                              Import data from CSV
+                              Import data from CSV/TSV
                             </Button>
                             <p className="text-xs text-foreground-light pointer-events-auto">
-                              or drag and drop a CSV file here
+                              or drag and drop a CSV/TSV file here
                             </p>
                           </div>
                         )

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -174,7 +174,7 @@ export const acceptedFileExtension = (file: any) => {
 
 export function flagInvalidFileImport(file: File): boolean {
   if (!file || !UPLOAD_FILE_TYPES.includes(file.type) || !acceptedFileExtension(file)) {
-    toast.error("Couldn't import file: only CSV files are accepted")
+    toast.error("Couldn't import file: only CSV or TSV files are accepted")
     return true
   } else if (file.size > MAX_TABLE_EDITOR_IMPORT_CSV_SIZE) {
     toast.error(

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -35,7 +35,7 @@ export function useCsvFileDrop({
 
       if (event.type === 'dragover' && !isDraggedOver) {
         setIsDraggedOver(true)
-        setIsValidFile(item.type === 'text/csv')
+        setIsValidFile(item.type === 'text/csv' || item.type === 'text/tab-separated-values')
       } else if (event.type === 'dragleave' || event.type === 'drop') {
         setIsDraggedOver(false)
         setIsValidFile(false)

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,6 +1,7 @@
 import { type DragEvent, useCallback, useState } from 'react'
 
 import { type ImportDataFileDroppedEvent } from 'common/telemetry-constants'
+import { UPLOAD_FILE_TYPES } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.constants'
 import { flagInvalidFileImport } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
 
 interface UseCsvFileDropOptions {
@@ -35,7 +36,7 @@ export function useCsvFileDrop({
 
       if (event.type === 'dragover' && !isDraggedOver) {
         setIsDraggedOver(true)
-        setIsValidFile(item.type === 'text/csv' || item.type === 'text/tab-separated-values')
+        setIsValidFile(UPLOAD_FILE_TYPES.includes(item.type))
       } else if (event.type === 'dragleave' || event.type === 'drop') {
         setIsDraggedOver(false)
         setIsValidFile(false)

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1172,33 +1172,37 @@ testRunner('table editor', () => {
     await deleteTable(page, ref, sourceTableName)
     await deleteTable(page, ref, targetTableName)
   })
-})
 
-test('drag and drop accepts TSV files on empty table import dropzone', async ({ page, ref }) => {
-  const tableName = 'pw_table_tsv_drop'
+  test('drag and drop accepts TSV files on empty table import dropzone', async ({ page, ref }) => {
+    const tableName = 'pw_table_tsv_drop'
 
-  // Create empty table
-  await createTable(page, ref, tableName)
+    try {
+      // Create empty table
+      await createTable(page, ref, tableName)
 
-  // Navigate into table
-  await page.getByRole('button', { name: `View ${tableName}`, exact: true }).click()
-  await page.waitForURL(/\/editor\/\d+\?schema=public$/)
+      // Navigate into table
+      await page.getByRole('button', { name: `View ${tableName}`, exact: true }).click()
+      await page.waitForURL(/\/editor\/\d+\?schema=public$/)
 
-  const dropzone = page.getByTestId('table-import-dropzone')
-  await expect(dropzone).toBeVisible()
+      const dropzone = page.getByTestId('table-import-dropzone')
+      await expect(dropzone).toBeVisible()
 
-  // Simulate dragging a TSV file over the dropzone.
-  await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="table-import-dropzone"]')
-    if (!el) throw new Error('dropzone not found')
+      // Simulate dragging a TSV file over the dropzone.
+      await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="table-import-dropzone"]')
+        if (!el) throw new Error('dropzone not found')
 
-    const dt = new DataTransfer()
-    const file = new File(['col1\tcol2\n1\t2\n'], 'test.tsv', { type: 'text/tab-separated-values' })
-    dt.items.add(file)
+        const dt = new DataTransfer()
+        const file = new File(['col1\tcol2\n1\t2\n'], 'test.tsv', { type: 'text/tab-separated-values' })
+        dt.items.add(file)
 
-    const event = new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt })
-    el.dispatchEvent(event)
+        const event = new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt })
+        el.dispatchEvent(event)
+      })
+
+      await expect(page.getByText('Drop your CSV or TSV file here')).toBeVisible()
+    } finally {
+      await deleteTable(page, ref, tableName)
+    }
   })
-
-  await expect(page.getByText('Drop your CSV or TSV file here')).toBeVisible()
 })

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1173,3 +1173,32 @@ testRunner('table editor', () => {
     await deleteTable(page, ref, targetTableName)
   })
 })
+
+test('drag and drop accepts TSV files on empty table import dropzone', async ({ page, ref }) => {
+  const tableName = 'pw_table_tsv_drop'
+
+  // Create empty table
+  await createTable(page, ref, tableName)
+
+  // Navigate into table
+  await page.getByRole('button', { name: `View ${tableName}`, exact: true }).click()
+  await page.waitForURL(/\/editor\/\d+\?schema=public$/)
+
+  const dropzone = page.getByTestId('table-import-dropzone')
+  await expect(dropzone).toBeVisible()
+
+  // Simulate dragging a TSV file over the dropzone.
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="table-import-dropzone"]')
+    if (!el) throw new Error('dropzone not found')
+
+    const dt = new DataTransfer()
+    const file = new File(['col1\tcol2\n1\t2\n'], 'test.tsv', { type: 'text/tab-separated-values' })
+    dt.items.add(file)
+
+    const event = new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt })
+    el.dispatchEvent(event)
+  })
+
+  await expect(page.getByText('Drop your CSV or TSV file here')).toBeVisible()
+})


### PR DESCRIPTION
Fixes #41493

### What
TSV files are documented as supported for Table Editor imports, but the empty-table drag/drop dropzone currently:
- treats only `text/csv` as valid during dragover
- shows “Only CSV files are accepted”

This makes TSV drag/drop appear broken (and is confusing since the side panel mentions TSV support).

### Changes
- Accept `text/tab-separated-values` in the drag/drop validation hook.
- Update user-facing copy to say CSV/TSV.
- Update the import error toast copy to say CSV/TSV.
- Add a Playwright e2e check for TSV dragover on the empty-table dropzone.

### Test
- Added Playwright coverage under `e2e/studio/features/table-editor.spec.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table import now supports CSV and TSV formats. User-facing prompts, empty-state text, dropzone messaging, and import error wording updated to reflect both formats.

* **Tests**
  * Added end-to-end tests covering TSV drag-and-drop import on empty tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->