### PR TITLE
fix: double updating the same cell references an old value

### DIFF
--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -1,7 +1,4 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
-import { PropsWithChildren, createContext, useContext } from 'react'
-import { proxy, useSnapshot } from 'valtio'
-
 import { useConstant } from 'common'
 import type { SupaRow } from 'components/grid/types'
 import {
@@ -11,15 +8,17 @@ import {
 import { ForeignKey } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
 import type { EditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
 import type { TableField } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
+import { PropsWithChildren, createContext, useContext } from 'react'
 import type { Dictionary } from 'types'
+import { proxy, useSnapshot } from 'valtio'
 
 import {
-  NewQueuedOperation,
-  QueuedOperationType,
   type EditCellContentPayload,
+  NewQueuedOperation,
   type OperationQueueState,
-  type QueuedOperation,
   type QueueStatus,
+  type QueuedOperation,
+  QueuedOperationType,
 } from './table-editor-operation-queue.types'
 
 export const TABLE_EDITOR_DEFAULT_ROWS_PER_PAGE = 100
@@ -332,4 +331,9 @@ export const TableEditorStateContextProvider = ({ children }: PropsWithChildren<
 export const useTableEditorStateSnapshot = (options?: Parameters<typeof useSnapshot>[1]) => {
   const state = useContext(TableEditorStateContext)
   return useSnapshot(state, options)
+}
+
+export const useOperationsQueueSnapshot = (options?: Parameters<typeof useSnapshot>[1]) => {
+  const state = useContext(TableEditorStateContext)
+  return useSnapshot(state.operationQueue.operations, options) as readonly QueuedOperation[]
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Double updating a cell was using the first updates value and not the most recent

## Test

- Make sure the staged changes feature is enabled
- Edit a cell to a new value
- Edit that same cell to another value
- It should only save the new value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal state management for operation queue handling in the table editor module to use a consistent snapshot pattern for more reliable state access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->