### PR TITLE
feat(studio): storage tiering lifecycle rule generator (AWS S3)

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -42,6 +42,7 @@ import { PageContainer } from 'ui-patterns/PageContainer'
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { StorageFileSizeLimitErrorMessage } from './StorageFileSizeLimitErrorMessage'
+import { StorageTieringGenerator } from './StorageTieringGenerator'
 import {
   StorageListV2MigratingCallout,
   StorageListV2MigrationCallout,
@@ -459,6 +460,16 @@ export const StorageSettings = () => {
                         </CardFooter>
                       </Card>
                     </form>
+
+                    <div className="space-y-2">
+                      <div>
+                        <h3 className="text-base font-medium">Storage tiering (AWS lifecycle rules)</h3>
+                        <p className="text-sm text-foreground-light">
+                          Generate S3 lifecycle/tiering rules for cost savings (manual apply).
+                        </p>
+                      </div>
+                      <StorageTieringGenerator />
+                    </div>
                   </>
                 )}
               </>

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageTieringGenerator.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageTieringGenerator.tsx
@@ -1,0 +1,247 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import * as z from 'zod'
+
+import { useParams } from 'common'
+import { useBucketsQuery } from 'data/storage/buckets-query'
+import {
+  Button,
+  Card,
+  CardContent,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Form_Shadcn_,
+  FormMessage_Shadcn_,
+  Input_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+  Select_Shadcn_,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+const FormSchema = z.object({
+  bucket: z.string().trim().min(1, 'Select a bucket'),
+  prefix: z.string().trim().optional(),
+  transitionToIAAfterDays: z.coerce.number().int().min(0).optional(),
+  transitionToGlacierAfterDays: z.coerce.number().int().min(0).optional(),
+  expireAfterDays: z.coerce.number().int().min(0).optional(),
+  abortMultipartAfterDays: z.coerce.number().int().min(0).default(7),
+})
+
+type FormValues = z.infer<typeof FormSchema>
+
+/**
+ * StorageTieringGenerator
+ *
+ * Supabase Storage runs on S3-compatible backends, but S3 lifecycle/tiering is configured at the bucket level.
+ * Supabase Cloud does not currently apply bucket lifecycle configuration on users' behalf.
+ *
+ * This UI generates a copy/paste-able AWS S3 LifecycleConfiguration JSON for cost-saving tiering rules.
+ */
+export const StorageTieringGenerator = () => {
+  const { ref: projectRef } = useParams()
+
+  const { data: buckets, isFetching } = useBucketsQuery({ projectRef })
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      bucket: '',
+      prefix: '',
+      transitionToIAAfterDays: 30,
+      transitionToGlacierAfterDays: 90,
+      expireAfterDays: undefined,
+      abortMultipartAfterDays: 7,
+    },
+  })
+
+  const values = form.watch()
+
+  const lifecycleJson = useMemo(() => {
+    const prefix = values.prefix?.trim() || undefined
+
+    // Build a single rule. Keep this minimal and explicit.
+    const rule: any = {
+      ID: 'supabase-studio-tiering-rule',
+      Status: 'Enabled',
+      Filter: prefix ? { Prefix: prefix } : {},
+      AbortIncompleteMultipartUpload: {
+        DaysAfterInitiation: values.abortMultipartAfterDays ?? 7,
+      },
+    }
+
+    const transitions: Array<{ Days: number; StorageClass: string }> = []
+    if (typeof values.transitionToIAAfterDays === 'number') {
+      transitions.push({ Days: values.transitionToIAAfterDays, StorageClass: 'STANDARD_IA' })
+    }
+    if (typeof values.transitionToGlacierAfterDays === 'number') {
+      transitions.push({ Days: values.transitionToGlacierAfterDays, StorageClass: 'GLACIER_IR' })
+    }
+    if (transitions.length > 0) rule.Transitions = transitions
+
+    if (typeof values.expireAfterDays === 'number') {
+      rule.Expiration = { Days: values.expireAfterDays }
+    }
+
+    return JSON.stringify({ Rules: [rule] }, null, 2)
+  }, [
+    values.prefix,
+    values.transitionToIAAfterDays,
+    values.transitionToGlacierAfterDays,
+    values.expireAfterDays,
+    values.abortMultipartAfterDays,
+  ])
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(lifecycleJson)
+      toast.success('Copied lifecycle JSON')
+    } catch {
+      toast.error('Failed to copy')
+    }
+  }
+
+  const bucketOptions = (buckets ?? []).map((b) => ({ id: b.id, name: b.name }))
+
+  return (
+    <Card>
+      <CardContent className="space-y-6">
+        <div>
+          <p className="text-sm text-foreground-light">
+            Cost-saving storage tiering in AWS is typically configured via S3 bucket lifecycle rules.
+            Supabase Cloud doesn’t currently apply lifecycle configuration automatically, but you can use this
+            generator to create rules and apply them in AWS.
+          </p>
+        </div>
+
+        <Form_Shadcn_ {...form}>
+          <form className="space-y-4">
+            <FormField_Shadcn_
+              name="bucket"
+              control={form.control}
+              render={({ field }) => (
+                <FormItemLayout label="Bucket" layout="flex-row-reverse">
+                  <FormControl_Shadcn_>
+                    <Select_Shadcn_
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      disabled={isFetching}
+                    >
+                      <SelectTrigger_Shadcn_>
+                        <SelectValue_Shadcn_ placeholder={isFetching ? 'Loading…' : 'Select a bucket'} />
+                      </SelectTrigger_Shadcn_>
+                      <SelectContent_Shadcn_>
+                        {bucketOptions.map((b) => (
+                          <SelectItem_Shadcn_ key={b.id} value={b.name}>
+                            {b.name}
+                          </SelectItem_Shadcn_>
+                        ))}
+                      </SelectContent_Shadcn_>
+                    </Select_Shadcn_>
+                  </FormControl_Shadcn_>
+                  <FormMessage_Shadcn_ />
+                </FormItemLayout>
+              )}
+            />
+
+            <FormField_Shadcn_
+              name="prefix"
+              control={form.control}
+              render={({ field }) => (
+                <FormItemLayout
+                  label="Prefix (optional)"
+                  description="Apply rule only to objects under this prefix (e.g. uploads/, logs/, backups/)."
+                  layout="flex-row-reverse"
+                >
+                  <FormControl_Shadcn_>
+                    <Input_Shadcn_ placeholder="uploads/" {...field} />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <FormField_Shadcn_
+                name="transitionToIAAfterDays"
+                control={form.control}
+                render={({ field }) => (
+                  <FormItemLayout label="Transition to STANDARD_IA after (days)" layout="flex-row-reverse">
+                    <FormControl_Shadcn_>
+                      <Input_Shadcn_ type="number" min={0} {...field} />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField_Shadcn_
+                name="transitionToGlacierAfterDays"
+                control={form.control}
+                render={({ field }) => (
+                  <FormItemLayout label="Transition to GLACIER_IR after (days)" layout="flex-row-reverse">
+                    <FormControl_Shadcn_>
+                      <Input_Shadcn_ type="number" min={0} {...field} />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField_Shadcn_
+                name="expireAfterDays"
+                control={form.control}
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Expire after (days)"
+                    description="Optional: permanently delete objects after N days."
+                    layout="flex-row-reverse"
+                  >
+                    <FormControl_Shadcn_>
+                      <Input_Shadcn_ type="number" min={0} {...field} value={field.value ?? ''} />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                )}
+              />
+
+              <FormField_Shadcn_
+                name="abortMultipartAfterDays"
+                control={form.control}
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Abort incomplete multipart uploads after (days)"
+                    description="Prevents cost leakage from abandoned multipart uploads."
+                    layout="flex-row-reverse"
+                  >
+                    <FormControl_Shadcn_>
+                      <Input_Shadcn_ type="number" min={0} {...field} />
+                    </FormControl_Shadcn_>
+                  </FormItemLayout>
+                )}
+              />
+            </div>
+
+            <FormItemLayout
+              label="Generated AWS S3 LifecycleConfiguration JSON"
+              description="Apply this in AWS S3 (Bucket → Management → Lifecycle rules) or via the AWS CLI/SDK."
+              layout="flex-col"
+            >
+              <pre
+                data-testid="storage-tiering-json"
+                className="text-xs p-3 bg-surface-100 border rounded overflow-auto max-h-72"
+              >
+                {lifecycleJson}
+              </pre>
+              <div className="flex items-center gap-2">
+                <Button type="default" onClick={onCopy} disabled={!values.bucket}>
+                  Copy JSON
+                </Button>
+              </div>
+            </FormItemLayout>
+          </form>
+        </Form_Shadcn_>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageTieringGenerator.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageTieringGenerator.tsx
@@ -47,11 +47,26 @@ const FormSchema = z
       })
     }
 
+    // Expiration should always be after the last transition.
     if (typeof expireAfterDays === 'number' && typeof transitionToGlacierAfterDays === 'number') {
       if (expireAfterDays <= transitionToGlacierAfterDays) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Expiration must be after GLACIER_IR transition',
+          path: ['expireAfterDays'],
+        })
+      }
+    }
+
+    if (
+      typeof expireAfterDays === 'number' &&
+      typeof transitionToGlacierAfterDays !== 'number' &&
+      typeof transitionToIAAfterDays === 'number'
+    ) {
+      if (expireAfterDays <= transitionToIAAfterDays) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Expiration must be after STANDARD_IA transition',
           path: ['expireAfterDays'],
         })
       }

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -359,10 +359,14 @@ test.describe('Storage Settings - Self Hosted', () => {
   })
 })
 
-test('shows storage tiering lifecycle generator in storage settings', async ({ page, ref }) => {
-  // Navigate to Storage settings page
-  await page.goto(`/project/${ref}/storage/files/settings`)
+test.describe('Storage Settings - Platform', () => {
+  test.skip(!env.IS_PLATFORM, 'Storage settings only available on platform')
 
-  await expect(page.getByText('Storage tiering (AWS lifecycle rules)')).toBeVisible()
-  await expect(page.getByTestId('storage-tiering-json')).toBeVisible()
+  test('shows storage tiering lifecycle generator in storage settings', async ({ page, ref }) => {
+    // Navigate to Storage settings page
+    await page.goto(`/project/${ref}/storage/files/settings`)
+
+    await expect(page.getByText('Storage tiering (AWS lifecycle rules)')).toBeVisible()
+    await expect(page.getByTestId('storage-tiering-json')).toBeVisible()
+  })
 })

--- a/e2e/studio/features/storage.spec.ts
+++ b/e2e/studio/features/storage.spec.ts
@@ -358,3 +358,11 @@ test.describe('Storage Settings - Self Hosted', () => {
     ).toBeVisible()
   })
 })
+
+test('shows storage tiering lifecycle generator in storage settings', async ({ page, ref }) => {
+  // Navigate to Storage settings page
+  await page.goto(`/project/${ref}/storage/files/settings`)
+
+  await expect(page.getByText('Storage tiering (AWS lifecycle rules)')).toBeVisible()
+  await expect(page.getByTestId('storage-tiering-json')).toBeVisible()
+})


### PR DESCRIPTION
## Summary
Adds a **Storage tiering (AWS lifecycle rules)** generator to Supabase Studio (Cloud UI) so users can create cost-saving S3 lifecycle/tiering rules per bucket/prefix.

## Why (research + rationale)
Supabase Storage runs on S3-compatible object storage. On AWS, the primary cost-savings mechanism is S3 **LifecycleConfiguration**:
- transitioning older objects to cheaper storage classes (e.g., STANDARD_IA, GLACIER_IR)
- expiring objects after N days
- aborting incomplete multipart uploads (prevents silent cost leakage)

Supabase Cloud doesn’t currently expose “automatic tiering” controls in Studio. However, many teams manage their underlying S3 lifecycle rules and want a safe, guided way to generate them.

This PR provides the **UI configuration** and outputs copy/paste JSON so users can apply it in AWS (Bucket → Management → Lifecycle rules) or via CLI.

## What changed
- Adds `StorageTieringGenerator` component under Storage Settings.
- Allows selecting a bucket and optional prefix.
- Generates a minimal `LifecycleConfiguration` JSON with:
  - Transition to STANDARD_IA after N days
  - Transition to GLACIER_IR after N days
  - Optional expiration after N days
  - Abort incomplete multipart uploads after N days (default 7)
- Includes a small Playwright e2e check to ensure the generator renders.

## Notes
- This PR intentionally does **not** apply rules automatically (no backend API/IAM credentials in Cloud UI). It generates a configuration users can apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storage Tiering section in Storage Settings that generates AWS S3 lifecycle rules JSON with configurable bucket, prefix, transition timings, expiration, and a copy-to-clipboard action; includes a UI note that generated rules should be applied in AWS.

* **Tests**
  * Added an end-to-end test verifying the Storage Tiering UI appears and displays the generated JSON.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->