### PR TITLE
chore(www): supabase.design redirect

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -3067,11 +3067,6 @@ module.exports = [
   // design
   {
     permanent: true,
-    source: '/design',
-    destination: '/design-system',
-  },
-  {
-    permanent: true,
     source: '/:path*',
     has: [
       {
@@ -3080,5 +3075,10 @@ module.exports = [
       },
     ],
     destination: 'https://supabase.com/design-system/:path*',
+  },
+  {
+    permanent: true,
+    source: '/design',
+    destination: '/design-system',
   },
 ]

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -3038,11 +3038,6 @@ module.exports = [
     source: '/mcp',
     destination: '/docs/guides/getting-started/mcp',
   },
-  {
-    permanent: true,
-    source: '/design',
-    destination: '/design-system',
-  },
 
   // marketing
 
@@ -3067,5 +3062,23 @@ module.exports = [
     permanent: true,
     source: '/docs/guides/platform/fly-postgres',
     destination: '/docs/guides/database/overview',
+  },
+
+  // design
+  {
+    permanent: true,
+    source: '/design',
+    destination: '/design-system',
+  },
+  {
+    permanent: true,
+    source: '/:path*',
+    has: [
+      {
+        type: 'host',
+        value: 'supabase.design',
+      },
+    ],
+    destination: 'https://supabase.com/design-system/:path*',
   },
 ]


### PR DESCRIPTION
Redirects https://supabase.design -> https://supabase.com/design-system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated URL routing to redirect /design to /design-system (permanent).
  * Added a host-based permanent redirect so requests from the supabase.design domain forward to the design-system on supabase.com.
  * Ensures both the explicit /design path and any paths on the design subdomain resolve to the canonical design-system site.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->