### PR TITLE
Update vector bucket SQL queries for wrappers ext 0.5.7

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
@@ -1,8 +1,4 @@
 import type { PostgresExtension } from '@supabase/postgres-meta'
-import { Database, ExternalLinkIcon, Plus } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
-
 import { DocsButton } from 'components/ui/DocsButton'
 import { useDatabaseExtensionEnableMutation } from 'data/database-extensions/database-extension-enable-mutation'
 import { useSchemasQuery } from 'data/database/schemas-query'
@@ -10,6 +6,9 @@ import { executeSql } from 'data/sql/execute-sql-query'
 import { useIsOrioleDb, useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from 'hooks/useProtectedSchemas'
 import { DOCS_URL } from 'lib/constants'
+import { Database, ExternalLinkIcon, Plus } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -108,6 +107,8 @@ const EnableExtensionModal = ({ visible, extension, onCancel }: EnableExtensionM
     return undefined
   }
 
+  const isLoading = fetchingSchemaInfo || isSchemasLoading
+
   const validate = (values: any) => {
     const errors: any = {}
     if (values.schema === 'custom' && !values.name) errors.name = 'Required field'
@@ -170,7 +171,7 @@ const EnableExtensionModal = ({ visible, extension, onCancel }: EnableExtensionM
                   </Admonition>
                 )}
 
-                {fetchingSchemaInfo || isSchemasLoading ? (
+                {isLoading ? (
                   <div className="space-y-2">
                     <ShimmeringLoader />
                     <div className="w-3/4">
@@ -269,7 +270,7 @@ const EnableExtensionModal = ({ visible, extension, onCancel }: EnableExtensionM
                 <Button type="default" disabled={isEnabling} onClick={() => onCancel()}>
                   Cancel
                 </Button>
-                <Button htmlType="submit" disabled={isEnabling} loading={isEnabling}>
+                <Button htmlType="submit" disabled={isEnabling || isLoading} loading={isEnabling}>
                   Enable extension
                 </Button>
               </Modal.Content>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
@@ -166,12 +166,12 @@ insert into
 values
   (
     'doc-1',
-    '[${dimensionExample}]'${!updatedImportForeignSchemaSyntax ? '::embd' : ''}${sqlComment},
+    '[${dimensionExample}]'${updatedImportForeignSchemaSyntax ? '::s3vec' : '::embd'}${sqlComment},
     '{${metadataKeys.map((key) => `"${key}": "${key} value"`).join(', ')}}'::jsonb
   ),
   (
     'doc-2',
-    '[${dimensionExample}]'${!updatedImportForeignSchemaSyntax ? '::embd' : ''}${sqlComment},
+    '[${dimensionExample}]'${updatedImportForeignSchemaSyntax ? '::s3vec' : '::embd'}${sqlComment},
     '{${metadataKeys.map((key) => `"${key}": "${key} value"`).join(', ')}}'::jsonb
   );`
 

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/VectorBucketDetails/VectorBucketTableExamplesSheet.tsx
@@ -1,8 +1,3 @@
-import { ChevronDown, ListPlus } from 'lucide-react'
-import Link from 'next/link'
-import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useState } from 'react'
-
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { DocsButton } from 'components/ui/DocsButton'
@@ -11,26 +6,33 @@ import { VectorBucketIndex } from 'data/storage/vector-buckets-indexes-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { SqlEditor } from 'icons'
 import { DOCS_URL } from 'lib/constants'
+import { ChevronDown, ListPlus } from 'lucide-react'
+import Link from 'next/link'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useState } from 'react'
 import {
   Button,
-  cn,
   CodeBlock,
-  Command_Shadcn_,
   CommandGroup_Shadcn_,
   CommandItem_Shadcn_,
   CommandList_Shadcn_,
-  Popover_Shadcn_,
+  Command_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
+  Popover_Shadcn_,
   Sheet,
   SheetContent,
   SheetHeader,
   SheetSection,
   SheetTitle,
   SheetTrigger,
+  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+
+import { useS3VectorsWrapperExtension } from '../useS3VectorsWrapper'
 import { useS3VectorsWrapperInstance } from '../useS3VectorsWrapperInstance'
+import { isGreaterThanOrEqual } from '@/lib/semver'
 
 interface VectorBucketTableExamplesSheetProps {
   index: VectorBucketIndex
@@ -147,6 +149,11 @@ function VectorBucketIndexExamples({
   const { data: wrapperInstance } = useS3VectorsWrapperInstance({ bucketId })
   const foreignTable = wrapperInstance?.tables?.find((x) => x.name === indexName)
 
+  const { extension: wrappersExtension } = useS3VectorsWrapperExtension()
+  const updatedImportForeignSchemaSyntax = !!wrappersExtension?.installed_version
+    ? isGreaterThanOrEqual(wrappersExtension.installed_version, '0.5.7')
+    : false
+
   const dimensionLabel = `Data should match ${dimension} dimension${dimension > 1 ? 's' : ''}`
   const startValue = 0.1
   const dimensionComment = generateDimensionComment(dimension)
@@ -159,12 +166,12 @@ insert into
 values
   (
     'doc-1',
-    '[${dimensionExample}]'::embd${sqlComment},
+    '[${dimensionExample}]'${!updatedImportForeignSchemaSyntax ? '::embd' : ''}${sqlComment},
     '{${metadataKeys.map((key) => `"${key}": "${key} value"`).join(', ')}}'::jsonb
   ),
   (
     'doc-2',
-    '[${dimensionExample}]'::embd${sqlComment},
+    '[${dimensionExample}]'${!updatedImportForeignSchemaSyntax ? '::embd' : ''}${sqlComment},
     '{${metadataKeys.map((key) => `"${key}": "${key} value"`).join(', ')}}'::jsonb
   );`
 

--- a/apps/studio/data/fdw/fdw-import-foreign-schema-mutation.ts
+++ b/apps/studio/data/fdw/fdw-import-foreign-schema-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-
 import { entityTypeKeys } from 'data/entity-types/keys'
 import { foreignTableKeys } from 'data/foreign-tables/keys'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
 import { vaultSecretsKeys } from 'data/vault/keys'
+import { toast } from 'sonner'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+
 import { fdwKeys } from './keys'
 
 export type FDWImportForeignSchemaVariables = {

--- a/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/buckets/[bucketId].tsx
@@ -1,26 +1,23 @@
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { BUCKET_TYPES } from 'components/interfaces/Storage/Storage.constants'
-import { useSelectedVectorBucket } from 'components/interfaces/Storage/VectorBuckets/useSelectedVectorBuckets'
 import { VectorBucketDetails } from 'components/interfaces/Storage/VectorBuckets/VectorBucketDetails'
+import { useSelectedVectorBucket } from 'components/interfaces/Storage/VectorBuckets/useSelectedVectorBuckets'
 import { DefaultLayout } from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import StorageLayout from 'components/layouts/StorageLayout/StorageLayout'
 import { DocsButton } from 'components/ui/DocsButton'
 import { VectorBucket as VectorBucketIcon } from 'icons'
-import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { toast } from 'sonner'
 import type { NextPageWithLayout } from 'types'
 
 const VectorsBucketPage: NextPageWithLayout = () => {
-  const config = BUCKET_TYPES['vectors']
   const router = useRouter()
   const { ref, bucketId } = useParams()
-  const { projectRef } = useStorageExplorerStateSnapshot()
-
   const { data: bucket, isSuccess } = useSelectedVectorBucket()
+
+  const config = BUCKET_TYPES['vectors']
 
   useEffect(() => {
     if (isSuccess && !bucket) {
@@ -39,7 +36,7 @@ const VectorsBucketPage: NextPageWithLayout = () => {
         </div>
       }
       breadcrumbs={[
-        { label: 'Vectors', href: `/project/${projectRef}/storage/vectors` },
+        { label: 'Vectors', href: `/project/${ref}/storage/vectors` },
         {
           label: 'Buckets',
         },


### PR DESCRIPTION
## Context

There's some changes for Vector Buckets with the wrappers extension on version 0.5.7 and above

The "Query from Postgres" CTA (which runs an import foreign schema command) no longer accepts the bucket name as part of the schema options (ref [changelog](https://github.com/supabase/wrappers/releases/tag/v0.5.7)), and instead takes the bucket name as the remote schema name.

So changes here are to update the SQL for importing foreign schema for vector buckets if wrappers extension is above 0.5.7

Also - the `::embd` type no longer seems to exist in 0.5.7 as well, so updated the example code too

## To test

Can probably test on a new US East 1 project on the preview
- [ ] Verify creating a vector bucket table + can query from postgres (via the Insert vectors CTA after creating a table)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed breadcrumb navigation links for vector bucket pages.

* **Improvements**
  * Unified loading state for schema workflows and disabled actions while loading.
  * Enhanced version compatibility checks for foreign schema imports to support newer extension syntax.
  * Adjusted generated SQL for vector data to use the appropriate embedding syntax based on extension version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->