### PR TITLE
Fix queue operations stale state + refactor to reuse existing methods

### DIFF
--- a/apps/studio/components/grid/components/footer/operations/SaveQueueActionBar.tsx
+++ b/apps/studio/components/grid/components/footer/operations/SaveQueueActionBar.tsx
@@ -1,20 +1,22 @@
-import { Eye } from 'lucide-react'
+import { useOperationQueueActions } from 'components/grid/hooks/useOperationQueueActions'
+import { useOperationQueueShortcuts } from 'components/grid/hooks/useOperationQueueShortcuts'
+import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { AnimatePresence, motion } from 'framer-motion'
+import { Eye } from 'lucide-react'
 import { createPortal } from 'react-dom'
+import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { Button } from 'ui'
 
-import {
-  useOperationQueueShortcuts,
-  getModKey,
-} from 'components/grid/hooks/useOperationQueueShortcuts'
-import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import { useTableEditorStateSnapshot } from 'state/table-editor'
-import { useOperationQueueActions } from 'components/grid/hooks/useOperationQueueActions'
+import { getModKeyLabel } from '@/lib/helpers'
+
+const modKey = getModKeyLabel()
 
 export const SaveQueueActionBar = () => {
   const snap = useTableEditorStateSnapshot()
   const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
   const { handleSave } = useOperationQueueActions()
+
+  useOperationQueueShortcuts()
 
   const operationCount = snap.operationQueue.operations.length
   const isSaving = snap.operationQueue.status === 'saving'
@@ -22,16 +24,6 @@ export const SaveQueueActionBar = () => {
 
   const isVisible =
     isQueueOperationsEnabled && snap.hasPendingOperations && !isOperationQueuePanelOpen
-
-  useOperationQueueShortcuts({
-    enabled: isQueueOperationsEnabled && snap.hasPendingOperations,
-    onSave: handleSave,
-    onTogglePanel: () => snap.onViewOperationQueue(),
-    isSaving,
-    hasOperations: operationCount > 0,
-  })
-
-  const modKey = getModKey()
 
   const content = (
     <AnimatePresence>
@@ -49,7 +41,7 @@ export const SaveQueueActionBar = () => {
             </span>
             <div className="flex items-center gap-3">
               <button
-                onClick={() => snap.onViewOperationQueue()}
+                onClick={() => snap.toggleViewOperationQueue()}
                 className="text-foreground-light hover:text-foreground transition-colors flex items-center"
                 aria-label="View Details"
               >

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -1,15 +1,14 @@
 import { THRESHOLD_COUNT } from '@supabase/pg-meta/src/query/table-row-query'
 import { keepPreviousData } from '@tanstack/react-query'
-import { isEqual } from 'lodash'
-import { ChevronDown, List } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-
 import { useParams } from 'common'
 import { useTableFilter } from 'components/grid/hooks/useTableFilter'
 import type { Sort } from 'components/grid/types'
 import { InlineLink } from 'components/ui/InlineLink'
 import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { isEqual } from 'lodash'
+import { ChevronDown, List } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   type RoleImpersonationState,
   useRoleImpersonationStateSnapshot,
@@ -23,6 +22,7 @@ import {
   Popover_Shadcn_,
 } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
 import { DropdownControl } from '../../common/DropdownControl'
 import SortRow from './SortRow'
 
@@ -278,8 +278,10 @@ export const SortPopoverPrimitive = ({
                       const hasSortNotPK = localSorts.some(
                         (x) => !snap.table.columns.find((y) => x.column === y.name)?.isPrimaryKey
                       )
-                      if (hasSortNotPK) setShowWarning(true)
-                    } else onSelectApplySorts()
+                      if (hasSortNotPK) return setShowWarning(true)
+                    }
+
+                    onSelectApplySorts()
                   }}
                 >
                   Apply sorting

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/OperationQueueSidePanel/OperationItem.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/OperationQueueSidePanel/OperationItem.tsx
@@ -1,12 +1,12 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { X } from 'lucide-react'
-import { Button } from 'ui'
-
 import { tableRowKeys } from 'data/table-rows/keys'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { X } from 'lucide-react'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
-import { EditCellContentPayload } from '@/state/table-editor-operation-queue.types'
+
 import { formatOperationItemValue } from './OperationQueueSidePanel.utils'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { EditCellContentPayload } from '@/state/table-editor-operation-queue.types'
 
 interface OperationItemProps {
   operationId: string
@@ -50,17 +50,18 @@ export const OperationItem = ({ operationId, tableId, content }: OperationItemPr
           <div className="text-xs text-foreground font-mono">{fullTableName}</div>
           <div className="text-sm text-foreground-muted mt-0.5">
             <span className="font-medium text-foreground">{columnName}</span>
-            <span className="text-foreground-muted mx-2">·</span>
+            <span className="text-foreground-muted mx-2">•</span>
             <span className="text-foreground text-xs">where {whereClause}</span>
           </div>
         </div>
-        <Button
+        <ButtonTooltip
           type="text"
           size="tiny"
           icon={<X size={14} />}
           onClick={handleDelete}
-          className="shrink-0"
+          className="shrink-0 w-7"
           aria-label="Remove operation"
+          tooltip={{ content: { side: 'bottom', text: 'Remove operation' } }}
         />
       </div>
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/OperationQueueSidePanel/OperationQueueSidePanel.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/OperationQueueSidePanel/OperationQueueSidePanel.tsx
@@ -1,15 +1,17 @@
 import { useOperationQueueActions } from 'components/grid/hooks/useOperationQueueActions'
-import { useOperationQueueShortcuts } from 'components/grid/hooks/useOperationQueueShortcuts'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { Button, SidePanel } from 'ui'
 
 import { OperationList } from './OperationList'
+import { getModKeyLabel } from '@/lib/helpers'
 import { QueuedOperation } from '@/state/table-editor-operation-queue.types'
 
 interface OperationQueueSidePanelProps {
   visible: boolean
   closePanel: () => void
 }
+
+const modKey = getModKeyLabel()
 
 export const OperationQueueSidePanel = ({ visible, closePanel }: OperationQueueSidePanelProps) => {
   const snap = useTableEditorStateSnapshot()
@@ -21,14 +23,6 @@ export const OperationQueueSidePanel = ({ visible, closePanel }: OperationQueueS
     onCancelSuccess: closePanel,
   })
 
-  const { modKey } = useOperationQueueShortcuts({
-    enabled: visible,
-    onSave: handleSave,
-    onTogglePanel: closePanel,
-    isSaving,
-    hasOperations: operations.length > 0,
-  })
-
   return (
     <SidePanel
       size="large"
@@ -37,7 +31,7 @@ export const OperationQueueSidePanel = ({ visible, closePanel }: OperationQueueS
       header={
         <div className="flex items-center justify-between w-full">
           <div className="flex flex-col gap-1">
-            <span>Pending Changes</span>
+            <span>Pending changes</span>
             <span className="text-xs text-foreground-light">
               {operations.length} operation{operations.length !== 1 ? 's' : ''}
             </span>

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -182,6 +182,11 @@ export const detectOS = () => {
   }
 }
 
+export const getModKeyLabel = () => {
+  const os = detectOS()
+  return os === 'macos' ? '⌘' : 'Ctrl+'
+}
+
 /**
  * Convert a list of tables to SQL
  * @param t - The list of tables

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -1,7 +1,4 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
-import { PropsWithChildren, createContext, useContext } from 'react'
-import { proxy, useSnapshot } from 'valtio'
-
 import { useConstant } from 'common'
 import type { SupaRow } from 'components/grid/types'
 import {
@@ -11,15 +8,16 @@ import {
 import { ForeignKey } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
 import type { EditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
 import type { TableField } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
+import { PropsWithChildren, createContext, useContext } from 'react'
 import type { Dictionary } from 'types'
+import { proxy, useSnapshot } from 'valtio'
 
 import {
   NewQueuedOperation,
-  QueuedOperationType,
-  type EditCellContentPayload,
   type OperationQueueState,
-  type QueuedOperation,
   type QueueStatus,
+  type QueuedOperation,
+  QueuedOperationType,
 } from './table-editor-operation-queue.types'
 
 export const TABLE_EDITOR_DEFAULT_ROWS_PER_PAGE = 100
@@ -203,10 +201,14 @@ export const createTableEditorState = () => {
         sidePanel: { type: 'csv-import', file },
       }
     },
-    onViewOperationQueue: () => {
-      state.ui = {
-        open: 'side-panel',
-        sidePanel: { type: 'operation-queue' },
+    toggleViewOperationQueue: () => {
+      if (state.ui.open === 'side-panel' && state.ui.sidePanel.type === 'operation-queue') {
+        state.closeSidePanel()
+      } else {
+        state.ui = {
+          open: 'side-panel',
+          sidePanel: { type: 'operation-queue' },
+        }
       }
     },
 


### PR DESCRIPTION
## Context

Related to this PR [here](https://github.com/supabase/supabase/pull/42265)

If you were to update a cell twice, then save, the value that get's saved is the first edited value.

There's a number of changes in this PR but the main thing is just `useOperationQueueActions` to declare `operations` outside of `handleSave` since `snap` wouldn't trigger the re-render of that function in the dependency array.

## Other changes

- Refactored `useOperationQueueShortcuts.ts`
  - Reuse an existing `useHotKey` method to handle the event listeners
  - Remove unnecessary prop drilling, call the necessary hooks within it instead
  - Simplify its calling by only calling this hook within `SaveQueueActionBar` (removed calling from `OperationQueueSidePanel`
- Add tooltip for OperatioItem "Remove operation"
- (Unrelated) Fix Table Editor sort "Apply sort" CTA not working for large tables when applying sort on an indexed column (e.g primary key)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Operation queue view now toggles open and closed with a single action
  * Simplified keyboard shortcuts: press **S** to save operations, **.** to toggle the queue view

* **Bug Fixes**
  * Sort operations on large tables with non-primary-key sorting now show a confirmation warning and require explicit user approval before applying

* **Improvements**
  * Operation queue panel automatically closes after successfully saving operations
  * Enhanced UI with improved delete action feedback and refined visual separators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->