### PR TITLE
fix(studio): copy schema behavior on safari

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -1,12 +1,6 @@
-import { Copy, Download, Edit, Globe, Lock, MoreVertical, Trash } from 'lucide-react'
-import Link from 'next/link'
-import { type CSSProperties } from 'react'
-import { toast } from 'sonner'
-
-import { formatSql } from '@/lib/formatSql'
 import { useFlag, useParams } from 'common'
-import { useTableFilter } from 'components/grid/hooks/useTableFilter'
 import { buildTableEditorUrl } from 'components/grid/SupabaseGrid.utils'
+import { useTableFilter } from 'components/grid/hooks/useTableFilter'
 import { getEntityLintDetails } from 'components/interfaces/TableGridEditor/TableEntity.utils'
 import { EntityTypeIcon } from 'components/ui/EntityTypeIcon'
 import { InlineLink } from 'components/ui/InlineLink'
@@ -19,17 +13,19 @@ import type { TableApiAccessData, TableApiAccessMap } from 'data/privileges/tabl
 import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { Copy, Download, Edit, Globe, Lock, MoreVertical, Trash } from 'lucide-react'
+import Link from 'next/link'
+import { type CSSProperties } from 'react'
+import { toast } from 'sonner'
 import {
-  useRoleImpersonationStateSnapshot,
   type RoleImpersonationState,
+  useRoleImpersonationStateSnapshot,
 } from 'state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { createTabId, useTabsStateSnapshot } from 'state/tabs'
 import {
   Badge,
   Button,
-  cn,
-  copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -42,8 +38,12 @@ import {
   TooltipContent,
   TooltipTrigger,
   TreeViewItemVariant,
+  cn,
+  copyToClipboard,
 } from 'ui'
+
 import { useExportAllRowsAsCsv, useExportAllRowsAsSql } from './ExportAllRows'
+import { formatSql } from '@/lib/formatSql'
 
 export interface EntityListItemProps {
   id: number | string
@@ -275,8 +275,9 @@ export const EntityListItem = ({
                     })
 
                     try {
-                      await copyToClipboard(formattedSchema)
-                      toast.success('Table schema copied to clipboard', { id: toastId })
+                      await copyToClipboard(formattedSchema, () => {
+                        toast.success('Table schema copied to clipboard', { id: toastId })
+                      })
                     } catch (err: any) {
                       toast.error('Failed to copy schema: ' + (err.message || err), { id: toastId })
                     }

--- a/packages/ui/src/lib/utils/clipboard.ts
+++ b/packages/ui/src/lib/utils/clipboard.ts
@@ -22,17 +22,13 @@ export const copyToClipboard = async (str: string | Promise<string>, callback = 
       const text = new ClipboardItem({
         'text/plain': Promise.resolve(str).then((text) => new Blob([text], { type: 'text/plain' })),
       })
-      // [Joshen] Adding a timeout based on this comment here about a workaround
-      // https://stackoverflow.com/questions/62327358/javascript-clipboard-api-safari-ios-notallowederror-message
-      setTimeout(() => {
-        navigator.clipboard.write([text]).then(callback)
-      }, 0)
+      return navigator.clipboard.write([text]).then(callback)
     } else {
       // NOTE: Firefox has support for ClipboardItem and navigator.clipboard.write,
       // but those are behind `dom.events.asyncClipboard.clipboardItem` preference.
       // Good news is that other than Safari, Firefox does not care about
       // Clipboard API being used async in a Promise.
-      Promise.resolve(str)
+      return Promise.resolve(str)
         .then((text) => navigator.clipboard?.writeText(text))
         .then(callback)
     }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The clipboard copy operation for table schema would show the success toast before the copy actually completed.

## What is the new behavior?

Move the toast showing to the callback so it appears only after the copy finishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard success confirmation now appears reliably after the copy completes.

* **New Features**
  * Copied table schemas are automatically formatted for improved readability.

* **Improvements**
  * Enhanced clipboard behavior for better reliability across browsers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->