### PR TITLE
Set isStatementTimeoutDisabled for EditorPanel

### DIFF
--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -1,7 +1,3 @@
-import { Book, Maximize2, X } from 'lucide-react'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
 import { generateSnippetTitle } from 'components/interfaces/SQLEditor/SQLEditor.constants'
@@ -18,29 +14,33 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
 import { useProfile } from 'lib/profile'
+import { Book, Maximize2, X } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { useEditorPanelStateSnapshot } from 'state/editor-panel-state'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import {
   Button,
-  cn,
   CodeBlock,
-  Command_Shadcn_,
   CommandEmpty_Shadcn_,
   CommandGroup_Shadcn_,
   CommandInput_Shadcn_,
   CommandItem_Shadcn_,
   CommandList_Shadcn_,
-  HoverCard_Shadcn_,
+  Command_Shadcn_,
   HoverCardContent_Shadcn_,
   HoverCardTrigger_Shadcn_,
+  HoverCard_Shadcn_,
   KeyboardShortcut,
-  Popover_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
+  Popover_Shadcn_,
   SQL_ICON,
+  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+
 import { containsUnknownFunction, isReadOnlySelect } from '../AIAssistantPanel/AIAssistant.utils'
 import { AIEditor } from '../AIEditor'
 import { ButtonTooltip } from '../ButtonTooltip'
@@ -124,6 +124,7 @@ export const EditorPanel = () => {
       sql: suffixWithLimit(currentValue, 100),
       projectRef: project?.ref,
       connectionString: project?.connectionString,
+      isStatementTimeoutDisabled: true,
       handleError: (executeError) => {
         throw executeError
       },


### PR DESCRIPTION
## Context

Resolves https://github.com/supabase/supabase/issues/42304

Realised that the Inline Editor behaves differently from the SQL Editor in which [`isStatementTimeoutDisabled`](https://github.com/supabase/supabase/pull/36367) is not set to true for the former which hence runs queries within a transaction.

PR here sets that to true which should align the behaviour between both editors

IMO though - the long term fix is just consolidating the editors so that the behaviours are the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL statements in the editor can now execute without timeout restrictions, allowing long-running queries to complete successfully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->