### PR TITLE
Joshen/fe 2441 backup restore dialog shows incorrect utc timestamp

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -119,7 +119,7 @@ export const BackupsList = () => {
                 displayAs="utc"
                 utcTimestamp={selectedBackup.inserted_at}
                 labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
-                className="text-left !text-sm font-mono tracking-tight"
+                className="!text-sm"
               />
             </p>
           )}

--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -1,20 +1,21 @@
-import dayjs from 'dayjs'
-import { Clock } from 'lucide-react'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import Panel from 'components/ui/Panel'
 import { UpgradeToPro } from 'components/ui/UpgradeToPro'
 import { useBackupRestoreMutation } from 'data/database/backup-restore-mutation'
 import { DatabaseBackup, useBackupsQuery } from 'data/database/backups-query'
 import { useSetProjectStatus } from 'data/projects/project-detail-query'
+import dayjs from 'dayjs'
 import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import { Admonition } from 'ui-patterns/admonition'
+import { Clock } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { TimestampInfo } from 'ui-patterns'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { Admonition } from 'ui-patterns/admonition'
+
 import { BackupItem } from './BackupItem'
 import { BackupsEmpty } from './BackupsEmpty'
 import { BackupsStorageAlert } from './BackupsStorageAlert'
@@ -111,11 +112,17 @@ export const BackupsList = () => {
         }}
       >
         <div className="space-y-3">
-          <p className="text-sm">
-            This will restore your database to the backup made on{' '}
-            {dayjs(selectedBackup?.inserted_at).format('DD MMM YYYY')} at{' '}
-            {dayjs(selectedBackup?.inserted_at).format('HH:mm:ss')} UTC.
-          </p>
+          {!!selectedBackup && (
+            <p className="text-sm">
+              This will restore your database to the backup made on{' '}
+              <TimestampInfo
+                displayAs="utc"
+                utcTimestamp={selectedBackup.inserted_at}
+                labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
+                className="text-left !text-sm font-mono tracking-tight"
+              />
+            </p>
+          )}
 
           <Admonition
             showIcon={false}

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -1,7 +1,3 @@
-import { Book, Maximize2, X } from 'lucide-react'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
 import { generateSnippetTitle } from 'components/interfaces/SQLEditor/SQLEditor.constants'
@@ -18,29 +14,33 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
 import { useProfile } from 'lib/profile'
+import { Book, Maximize2, X } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { useEditorPanelStateSnapshot } from 'state/editor-panel-state'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import {
   Button,
-  cn,
   CodeBlock,
-  Command_Shadcn_,
   CommandEmpty_Shadcn_,
   CommandGroup_Shadcn_,
   CommandInput_Shadcn_,
   CommandItem_Shadcn_,
   CommandList_Shadcn_,
-  HoverCard_Shadcn_,
+  Command_Shadcn_,
   HoverCardContent_Shadcn_,
   HoverCardTrigger_Shadcn_,
+  HoverCard_Shadcn_,
   KeyboardShortcut,
-  Popover_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
+  Popover_Shadcn_,
   SQL_ICON,
+  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+
 import { containsUnknownFunction, isReadOnlySelect } from '../AIAssistantPanel/AIAssistant.utils'
 import { AIEditor } from '../AIEditor'
 import { ButtonTooltip } from '../ButtonTooltip'
@@ -124,6 +124,7 @@ export const EditorPanel = () => {
       sql: suffixWithLimit(currentValue, 100),
       projectRef: project?.ref,
       connectionString: project?.connectionString,
+      isStatementTimeoutDisabled: true,
       handleError: (executeError) => {
         throw executeError
       },

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -1,3 +1,7 @@
+import { Book, Maximize2, X } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { isExplainQuery } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
 import { generateSnippetTitle } from 'components/interfaces/SQLEditor/SQLEditor.constants'
@@ -14,33 +18,29 @@ import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
 import { useProfile } from 'lib/profile'
-import { Book, Maximize2, X } from 'lucide-react'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
 import { useEditorPanelStateSnapshot } from 'state/editor-panel-state'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import {
   Button,
+  cn,
   CodeBlock,
+  Command_Shadcn_,
   CommandEmpty_Shadcn_,
   CommandGroup_Shadcn_,
   CommandInput_Shadcn_,
   CommandItem_Shadcn_,
   CommandList_Shadcn_,
-  Command_Shadcn_,
+  HoverCard_Shadcn_,
   HoverCardContent_Shadcn_,
   HoverCardTrigger_Shadcn_,
-  HoverCard_Shadcn_,
   KeyboardShortcut,
+  Popover_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
-  Popover_Shadcn_,
   SQL_ICON,
-  cn,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
-
 import { containsUnknownFunction, isReadOnlySelect } from '../AIAssistantPanel/AIAssistant.utils'
 import { AIEditor } from '../AIEditor'
 import { ButtonTooltip } from '../ButtonTooltip'
@@ -124,7 +124,6 @@ export const EditorPanel = () => {
       sql: suffixWithLimit(currentValue, 100),
       projectRef: project?.ref,
       connectionString: project?.connectionString,
-      isStatementTimeoutDisabled: true,
       handleError: (executeError) => {
         throw executeError
       },

--- a/apps/studio/data/database/backups-query.ts
+++ b/apps/studio/data/database/backups-query.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
-
 import type { components } from 'data/api'
 import { get, handleError } from 'data/fetchers'
 import { useIsOrioleDbInAws } from 'hooks/misc/useSelectedProject'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
+
 import { databaseKeys } from './keys'
 
 export type BackupsVariables = {
@@ -21,6 +21,29 @@ export async function getBackups({ projectRef }: BackupsVariables, signal?: Abor
   })
 
   if (error) handleError(error)
+
+  return {
+    region: 'ap-southeast-1',
+    pitr_enabled: false,
+    walg_enabled: true,
+    backups: [
+      {
+        isPhysicalBackup: true,
+        id: 141661,
+        inserted_at: '2026-01-24T15:55:44.027Z',
+        status: 'COMPLETED',
+        project_id: 139767,
+      },
+      {
+        isPhysicalBackup: true,
+        id: 137324,
+        inserted_at: '2026-01-17T15:56:56.988Z',
+        status: 'COMPLETED',
+        project_id: 139767,
+      },
+    ],
+    physicalBackupData: {},
+  }
   return data
 }
 

--- a/apps/studio/data/database/backups-query.ts
+++ b/apps/studio/data/database/backups-query.ts
@@ -21,29 +21,6 @@ export async function getBackups({ projectRef }: BackupsVariables, signal?: Abor
   })
 
   if (error) handleError(error)
-
-  return {
-    region: 'ap-southeast-1',
-    pitr_enabled: false,
-    walg_enabled: true,
-    backups: [
-      {
-        isPhysicalBackup: true,
-        id: 141661,
-        inserted_at: '2026-01-24T15:55:44.027Z',
-        status: 'COMPLETED',
-        project_id: 139767,
-      },
-      {
-        isPhysicalBackup: true,
-        id: 137324,
-        inserted_at: '2026-01-17T15:56:56.988Z',
-        status: 'COMPLETED',
-        project_id: 139767,
-      },
-    ],
-    physicalBackupData: {},
-  }
   return data
 }
 


### PR DESCRIPTION
## Context

Clicking "Restore" on a scheduled backup shows the confirmation modal, in which the backup date does not align with what's shown on the back up row (the latter is the correct one)

<img width="1812" height="292" alt="image" src="https://github.com/user-attachments/assets/7ec159af-5826-4364-8066-2de6840243dc" />

<img width="400" height="586" alt="image" src="https://github.com/user-attachments/assets/12c6f2d1-1dfb-4c90-9a79-5fa1a99dd688" />

Am opting to use the same `TimestampInfo` component in the confirmation modal - which will align the values shown in both UI

<img width="578" height="350" alt="image" src="https://github.com/user-attachments/assets/54ad8b76-c535-403e-b976-41b9b1fc05bd" />
