### PR TITLE
fix(design-system): UI Patterns routes

### DIFF
--- a/apps/design-system/config/docs.ts
+++ b/apps/design-system/config/docs.ts
@@ -61,7 +61,7 @@ export const docsConfig: DocsConfig = {
       items: [
         {
           title: 'Introduction',
-          href: '/docs/ui-patterns/ui-patterns',
+          href: '/docs/ui-patterns/introduction',
           items: [],
           priority: true,
         },
@@ -108,7 +108,7 @@ export const docsConfig: DocsConfig = {
       items: [
         {
           title: 'Introduction',
-          href: '/docs/fragments/fragment-components',
+          href: '/docs/fragments/introduction',
           items: [],
           priority: true,
         },
@@ -210,7 +210,7 @@ export const docsConfig: DocsConfig = {
       items: [
         {
           title: 'Introduction',
-          href: '/docs/components/atom-components',
+          href: '/docs/components/introduction',
           items: [],
           priority: true,
         },

--- a/apps/design-system/content/docs/ui-patterns/introduction.mdx
+++ b/apps/design-system/content/docs/ui-patterns/introduction.mdx
@@ -7,10 +7,10 @@ UI patterns are reusable design solutions that combine multiple components from 
 
 These patterns help ensure consistency across Supabase products by establishing standard approaches for:
 
-- **[Charts](/docs/ui-patterns/charts)**: Visualizing data consistently using standardized chart types and styling.
-- **[Empty States](/docs/ui-patterns/empty-states)**: Communicating the absence of data and guiding users toward meaningful actions.
-- **[Forms](/docs/ui-patterns/forms)**: Building cohesive form experiences in both page layouts and side panels.
-- **[Layout](/docs/ui-patterns/layout)**: Creating consistent page structures with proper spacing, max-widths, and content organization.
-- **[Navigation](/docs/ui-patterns/navigation)**: Organizing complex hierarchical navigation systems across multiple products and contexts.
+- **[Charts](charts)**: Visualizing data consistently using standardized chart types and styling.
+- **[Empty States](empty-states)**: Communicating the absence of data and guiding users toward meaningful actions.
+- **[Forms](forms)**: Building cohesive form experiences in both page layouts and side panels.
+- **[Layout](layout)**: Creating consistent page structures with proper spacing, max-widths, and content organization.
+- **[Navigation](navigation)**: Organizing complex hierarchical navigation systems across multiple products and contexts.
 
 UI patterns may incorporate external libraries (such as `react-markdown`, `reactflow`, `recharts`, etc) or compose various components from the `ui` package. They serve as blueprints for solving recurring design problems, ensuring that similar features across the application follow the same structural and interaction patterns.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Links on the UI Patterns introduction page are wrong and therefore 404
- Introduction pages on the sidebar are also wrong and 404 

## What is the new behavior?

Fixes for both of the above

## Additional context

Thanks [Emilio](https://github.com/supabase/supabase/pull/42309) for letting us know!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navigation structure in the design system documentation to direct users to introduction pages for UI Patterns, Fragments, and Components sections.
  * Refined internal documentation links for improved navigation consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->