### PR TITLE
fix: 404 logo fix

### DIFF
--- a/apps/www/pages/404.tsx
+++ b/apps/www/pages/404.tsx
@@ -5,14 +5,11 @@ import { Button } from 'ui'
 
 import DefaultLayout from '../components/Layouts/Default'
 
-import { useTheme } from 'next-themes'
-
 import * as supabaseLogoWordmarkDark from 'common/assets/images/supabase-logo-wordmark--dark.png'
 import * as supabaseLogoWordmarkLight from 'common/assets/images/supabase-logo-wordmark--light.png'
 
 const Error404 = () => {
   const [show404, setShow404] = useState<boolean>(false)
-  const { resolvedTheme } = useTheme()
 
   useEffect(() => {
     setTimeout(() => {
@@ -29,14 +26,20 @@ const Error404 = () => {
               <div className="flex w-full items-center justify-between md:w-auto">
                 <a href="/">
                   <Image
-                    src={
-                      resolvedTheme?.includes('dark')
-                        ? supabaseLogoWordmarkDark
-                        : supabaseLogoWordmarkLight
-                    }
-                    alt="supabase logo"
+                    src={supabaseLogoWordmarkLight}
+                    width={124}
                     height={24}
-                    width={120}
+                    alt="Supabase Logo"
+                    className="dark:hidden"
+                    priority
+                  />
+                  <Image
+                    src={supabaseLogoWordmarkDark}
+                    width={124}
+                    height={24}
+                    alt="Supabase Logo"
+                    className="hidden dark:block"
+                    priority
                   />
                 </a>
               </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase logo is dark if on dark mode on the 404 page.

## What is the new behavior?

<img width="1470" height="829" alt="Screenshot 2026-01-30 at 10 24 38" src="https://github.com/user-attachments/assets/ee653a37-0a96-4280-b910-aac823c26325" />

Closes #42312 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved 404 page logo rendering implementation by restructuring how theme variants are displayed, maintaining consistent functionality and accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->