### PR TITLE
feat: added CMD + Enter for action form

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar.tsx
@@ -1,5 +1,7 @@
+import { useHotKey } from 'hooks/ui/useHotKey'
+import { getModKeyLabel } from 'lib/helpers'
 import { noop } from 'lodash'
-import { PropsWithChildren, useState } from 'react'
+import { PropsWithChildren, useCallback, useMemo, useState } from 'react'
 import { Button } from 'ui'
 
 interface ActionBarProps {
@@ -11,6 +13,7 @@ interface ActionBarProps {
   applyFunction?: (resolve: any) => void
   closePanel: () => void
   formId?: string
+  visible?: boolean
 }
 
 export const ActionBar = ({
@@ -23,17 +26,48 @@ export const ActionBar = ({
   applyFunction = undefined,
   closePanel = noop,
   formId,
+  visible = true,
 }: PropsWithChildren<ActionBarProps>) => {
   const [isRunning, setIsRunning] = useState(false)
+  const modKeyLabel = useMemo(() => getModKeyLabel(), [])
 
-  // @ts-ignore
-  const applyCallback = () => new Promise((resolve) => applyFunction(resolve))
-
-  const onSelectApply = async () => {
+  const onSelectApply = useCallback(async () => {
+    const applyCallback = () => new Promise((resolve) => applyFunction?.(resolve))
     setIsRunning(true)
     await applyCallback()
     setIsRunning(false)
-  }
+  }, [applyFunction])
+
+  const handleSave = useCallback(
+    (event: KeyboardEvent) => {
+      // Don't trigger if already running/loading, or if apply is disabled/hidden
+      if (isRunning || loading || disableApply || hideApply) return
+
+      // Don't trigger if the user is in a textarea (allow multi-line entry)
+      // unless they explicitly press CMD+Enter
+      const activeElement = document.activeElement
+      const isTextarea = activeElement?.tagName === 'TEXTAREA'
+
+      // If in a textarea and this is just an Enter key (not CMD+Enter), don't submit
+      if (isTextarea && !event.metaKey && !event.ctrlKey) return
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (formId) {
+        // Form-based submission - programmatically submit the form
+        const form = document.getElementById(formId) as HTMLFormElement | null
+        if (form) {
+          form.requestSubmit()
+        }
+      } else if (applyFunction) {
+        onSelectApply()
+      }
+    },
+    [isRunning, loading, disableApply, hideApply, formId, applyFunction, onSelectApply]
+  )
+
+  useHotKey(handleSave, 'Enter', { enabled: visible })
 
   return (
     <div className="flex w-full justify-end space-x-3 border-t border-default px-3 py-4">
@@ -50,7 +84,8 @@ export const ActionBar = ({
           disabled={disableApply || isRunning || loading}
           loading={isRunning || loading}
         >
-          {applyButtonLabel}
+          <span>{applyButtonLabel}</span>
+          <span className="ml-2 text-xs text-foreground-lighter">{modKeyLabel}↵</span>
         </Button>
       ) : !hideApply ? (
         // New solution, when using the Form component, loading is handled by the Form itself
@@ -62,7 +97,8 @@ export const ActionBar = ({
           htmlType="submit"
           form={formId}
         >
-          {applyButtonLabel}
+          <span>{applyButtonLabel}</span>
+          <span className="ml-2 text-xs text-foreground-lighter">{modKeyLabel}↵</span>
         </Button>
       ) : (
         <div />

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -1,9 +1,4 @@
 import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
-import { isEmpty, noop } from 'lodash'
-import { ExternalLink, Plus } from 'lucide-react'
-import Link from 'next/link'
-import { useEffect, useState } from 'react'
-
 import { useParams } from 'common'
 import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms/FormSection'
 import {
@@ -19,8 +14,13 @@ import { useEnumeratedTypesQuery } from 'data/enumerated-types/enumerated-types-
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from 'hooks/useProtectedSchemas'
 import { DOCS_URL } from 'lib/constants'
+import { isEmpty, noop } from 'lodash'
+import { ExternalLink, Plus } from 'lucide-react'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import type { Dictionary } from 'types'
 import { Button, Checkbox, Input, SidePanel, Toggle } from 'ui'
+
 import { ActionBar } from '../ActionBar'
 import type { ForeignKey } from '../ForeignKeySelector/ForeignKeySelector.types'
 import { formatForeignKeys } from '../ForeignKeySelector/ForeignKeySelector.utils'
@@ -206,6 +206,7 @@ export const ColumnEditor = ({
           applyButtonLabel="Save"
           closePanel={closePanel}
           applyFunction={(resolve: () => void) => onSaveChanges(resolve)}
+          visible={visible}
         />
       }
     >

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -1,11 +1,11 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
-import { isEmpty, noop, partition } from 'lodash'
-import { useEffect, useMemo, useState } from 'react'
-
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { isEmpty, noop, partition } from 'lodash'
+import { useEffect, useMemo, useState } from 'react'
 import type { Dictionary } from 'types'
 import { SidePanel } from 'ui'
+
 import { ActionBar } from '../ActionBar'
 import { formatForeignKeys } from '../ForeignKeySelector/ForeignKeySelector.utils'
 import { ForeignRowSelector } from './ForeignRowSelector/ForeignRowSelector'
@@ -177,6 +177,7 @@ export const RowEditor = ({
           applyButtonLabel="Save"
           closePanel={closePanel}
           hideApply={!editable}
+          visible={visible}
         />
       }
     >

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -1,10 +1,4 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
-import { isEmpty, noop } from 'lodash'
-import { useContext, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
-
-import { useDataApiGrantTogglesEnabled } from '@/hooks/misc/useDataApiGrantTogglesEnabled'
-import { checkDataApiPrivilegesNonEmpty } from '@/lib/data-api-types'
 import type { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import { DocsButton } from 'components/ui/DocsButton'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
@@ -23,10 +17,14 @@ import { useProtectedSchemas } from 'hooks/useProtectedSchemas'
 import { DOCS_URL } from 'lib/constants'
 import { useTrack } from 'lib/telemetry/track'
 import { type PlainObject } from 'lib/type-helpers'
+import { isEmpty, noop } from 'lodash'
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import { TableEditorStateContext, useTableEditorStateSnapshot } from 'state/table-editor'
 import { Badge, Checkbox, Input, SidePanel } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
+
 import { ActionBar } from '../ActionBar'
 import type { ForeignKey } from '../ForeignKeySelector/ForeignKeySelector.types'
 import { formatForeignKeys } from '../ForeignKeySelector/ForeignKeySelector.utils'
@@ -47,6 +45,8 @@ import {
   generateTableFieldFromPostgresTable,
   validateFields,
 } from './TableEditor.utils'
+import { useDataApiGrantTogglesEnabled } from '@/hooks/misc/useDataApiGrantTogglesEnabled'
+import { checkDataApiPrivilegesNonEmpty } from '@/lib/data-api-types'
 
 type SaveTableParamsFor<Action extends SaveTableParams['action']> = Extract<
   SaveTableParams,
@@ -367,6 +367,7 @@ export const TableEditor = ({
           applyButtonLabel="Save"
           closePanel={closePanel}
           applyFunction={(resolve: () => void) => onSaveChanges(resolve)}
+          visible={visible}
         />
       }
     >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature: on the table editor for side panel, add a CMD + Enter to submit the form quickly. This can be used for editing rows, adding rows, columns etc.

Respects multi lines in text areas 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support for quicker saving and applying of changes in table editors, enhancing data entry workflows
  * Action buttons now display visual keyboard command hints to guide users toward available shortcuts for faster operations
  * Enhanced save behavior with improved context awareness, intelligently handling different input types and respecting multi-line text area inputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->