### PR TITLE
chore: fix db extensions studio redirect links

### DIFF
--- a/packages/shared-data/extensions.json
+++ b/packages/shared-data/extensions.json
@@ -177,7 +177,7 @@
     "link": "/guides/database/extensions/index_advisor",
     "github_url": "https://github.com/supabase/index_advisor",
     "product": "Index Advisor Report",
-    "product_url": "/project/{ref}/advisors/query-performance"
+    "product_url": "/project/{ref}/observability/query-performance"
   },
   {
     "name": "intarray",
@@ -276,7 +276,7 @@
     "link": "/guides/database/extensions/pg_net",
     "github_url": "https://github.com/supabase/pg_net",
     "product": "Database Webhooks",
-    "product_url": "/project/{ref}/database/hooks"
+    "product_url": "/project/{ref}/integrations/webhooks"
   },
   {
     "name": "pg_prewarm",
@@ -294,7 +294,7 @@
     "link": "/guides/database/extensions/pg_stat_statements",
     "github_url": null,
     "product": "Query Performance",
-    "product_url": "/project/{ref}/advisors/query-performance"
+    "product_url": "/project/{ref}/observability/query-performance"
   },
   {
     "name": "pg_surgery",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- database webhook redirects to 404
- index and performance advisor display "project not found" banner before redirect

## Additional context
<img width="852" height="376" alt="CleanShot 2026-01-31 at 18 43 22@2x" src="https://github.com/user-attachments/assets/62f80f40-6d0c-4e1a-8e4f-71ec472a723d" />
<img width="2106" height="1128" alt="CleanShot 2026-01-31 at 18 44 37@2x" src="https://github.com/user-attachments/assets/18d39a85-5148-49de-93c9-8c25819bcf0e" />
<img width="2000" height="1061" src="https://github.com/user-attachments/assets/74011d16-caac-4b03-a747-9c9d8ecaf558" />
