### PR TITLE
fix(studio): fix broken links in README.md

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -28,13 +28,13 @@ Project settings are managed outside of the Dashboard. If you use docker compose
     - Type: `chore | fix | feature`
     - The branch name is arbitrary — just make sure it summarizes the work.
 - When you send a PR to `master`, it will automatically tag members of the frontend team for review.
-- Review the [contributing checklists](contributing/contributing-checklists.md) to help test your feature before sending a PR.
+- Review the [main contributing guidelines](../../CONTRIBUTING.md) before sending a PR.
 - The Dashboard is under active development. You should run `git pull` frequently to make sure you're up to date.
 
 ### Developer Quickstart
 
 > [!NOTE]  
-> **Supabase internal use:** To develop on Studio locally with the backend services, see the instructions in the [internal `infrastructure` repo](https://github.com/supabase/platform/blob/develop/docs/contributing.md).
+> **Supabase internal use:** To develop on Studio locally with the backend services, see the instructions in the internal `supabase/platform` repo.
 
 ```bash
 # You'll need to be on Node v20


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes broken links in the Studio README.md as reported in #38764.

## What is the current behavior?

The README contains:
1. A link to `contributing/contributing-checklists.md` which doesn't exist (returns 404)
2. A link to `https://github.com/supabase/platform/blob/develop/docs/contributing.md` which is a private repo

## What is the new behavior?

1. Replaced the broken contributing checklist link with a reference to the main `CONTRIBUTING.md` in the repository root
2. Updated the internal note to reference the private repo without a direct link (since external contributors can't access it anyway)

Fixes #38764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines and internal resource references in studio documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->