### PR TITLE
fix(studio): properly escape single quotes in enum type values and descriptions

### DIFF
--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
@@ -94,7 +94,7 @@ const CreateEnumeratedTypeSidePanel = ({
       connectionString: project.connectionString,
       schema,
       name: data.name,
-      description: data.description?.replaceAll("'", "''"),
+      description: data.description,
       values: data.values.filter((x) => x.value.length > 0).map((x) => x.value.trim()),
     })
   }

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
@@ -110,7 +110,7 @@ const EditEnumeratedTypeSidePanel = ({
           isNew: x.isNew,
         })),
       ...(data.description !== selectedEnumeratedType.comment
-        ? { description: data.description?.replaceAll("'", "''") }
+        ? { description: data.description }
         : {}),
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
Creating or updating enumerated types with values or descriptions containing single quotes (e.g., "it's", "don't") fails with SQL syntax errors because the quotes are not escaped.

## What is the new behavior?
Single quotes in enum values and descriptions are properly escaped using standard SQL escaping (doubling the quote: `'` → `''`).

## Changes Made
- Added `escapeSqlString` helper function to both `enumerated-type-create-mutation.ts` and `enumerated-type-update-mutation.ts`
- Applied proper escaping to all enum values and descriptions
- Moved description escaping from the side panel components to the mutations for consistency and to avoid double-escaping

Fixes #41371