### PR TITLE
fix(studio): improve column type visibility in table editor

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -173,16 +173,17 @@ const ColumnType = ({
             role="combobox"
             size={'small'}
             aria-expanded={open}
+            title={value || 'Choose a column type...'}
             className={cn('w-full justify-between', !value && 'text-foreground-lighter')}
             iconRight={<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />}
           >
             {value ? (
-              <div className="flex gap-2 items-center">
-                <span>{inferIcon(getOptionByName(value)?.type ?? '')}</span>
-                {value.replaceAll('"', '')}
+              <div className="flex gap-2 items-center min-w-0">
+                <span className="shrink-0">{inferIcon(getOptionByName(value)?.type ?? '')}</span>
+                <span className="truncate">{value.replaceAll('"', '')}</span>
               </div>
             ) : (
-              'Choose a column type...'
+              <span className="truncate">Choose a column type...</span>
             )}
           </Button>
         </PopoverTrigger_Shadcn_>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -220,7 +220,7 @@ const Column = ({
           )}
         </div>
       </div>
-      <div className="w-[25%]">
+      <div className="w-[28%]">
         <div className="w-[95%]">
           <ColumnType
             value={column.format}
@@ -238,7 +238,7 @@ const Column = ({
           />
         </div>
       </div>
-      <div className={`${isNewRecord ? 'w-[25%]' : 'w-[30%]'}`}>
+      <div className={`${isNewRecord ? 'w-[22%]' : 'w-[27%]'}`}>
         <div className="w-[95%]">
           <InputWithSuggestions
             data-testid={`${column.name}-default-value`}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The column type dropdown in the table editor is always truncated, making it impossible to differentiate between similar types like 'timestamp' and 'timestamptz'. The placeholder text 'Choose a column type...' is also truncated.

## What is the new behavior?
- Column types are more visible with increased column width (25% → 28%)
- Full type name is shown on hover via title attribute
- Text overflow is handled gracefully with proper truncation

## Changes Made
- Added `title` attribute to the column type button for full text visibility on hover
- Restructured button content with proper flex layout and `min-w-0`
- Added `shrink-0` to icon and `truncate` to text for proper overflow handling
- Increased type column width from 25% to 28%
- Adjusted default value column width accordingly (25%/30% → 22%/27%)

Fixes #41579