### PR TITLE
fix(studio): correctly parse schema and function name in cron job commands

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -129,12 +129,17 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
 
   const regexDBFunction = /select\s+[a-zA-Z-_]*\.?[a-zA-Z-_]*\s*\(\)/g
   if (command.toLocaleLowerCase().match(regexDBFunction)) {
-    const [schemaName, functionName] = command
+    const functionPart = command
       .replace('SELECT ', '')
       .replace(/\(.*\);*/, '')
-
       .trim()
-      .split('.')
+
+    const parts = functionPart.split('.')
+
+    // If there's a dot, we have schema.function format
+    // If no dot, assume 'public' schema and the whole part is the function name
+    const schemaName = parts.length > 1 ? parts[0] : 'public'
+    const functionName = parts.length > 1 ? parts[1] : parts[0]
 
     return {
       type: 'sql_function',


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When creating or editing a cron job with "Database function" type, the function name incorrectly appears in the "Schema" field while the "Function name" field shows "Select a function" (empty).

This happens when the cron job command is `SELECT my_function()` without a schema prefix.

## What is the new behavior?
Both formats are now parsed correctly:
- `SELECT public.my_function()` → Schema: "public", Function: "my_function"
- `SELECT my_function()` → Schema: "public" (default), Function: "my_function"

## Root Cause
The `parseCronJobCommand` function was splitting on `.` and assuming the result would always have 2 parts (schema and function). When there was no dot, the function name ended up in the schema variable and function name was undefined.

## Fix
- Check if the split produces multiple parts
- If yes, use the first part as schema and second as function name
- If no dot separator, default to "public" schema and use the whole part as function name

Fixes #41508