### PR TITLE
docs: upgrade getSession to getUser in Refine tutorial (security best practice)

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,7 +233,7 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
+      const { data } = await supabaseClient.auth.getUser()
       const { session } = data
 
       if (!session) {


### PR DESCRIPTION
### Summary
This PR updates the authentication logic in the Refine tutorial documentation to use getUser() instead of the deprecated getSession(), as per Supabase's latest security guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication tutorial to reflect the current recommended method for retrieving user information in auth provider checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->