### PR TITLE
feat(studio): RLS Policy Playground UI

### DIFF
--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSContextEditor.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSContextEditor.tsx
@@ -1,0 +1,198 @@
+import { useState, useCallback, useRef } from 'react'
+import { RLSSimulationContext } from 'data/rls-playground'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Label,
+  cn,
+} from 'ui'
+
+interface RLSContextEditorProps {
+  context: RLSSimulationContext
+  onContextChange: (context: RLSSimulationContext) => void
+  availableRoles: string[]
+}
+
+export const RLSContextEditor = ({
+  context,
+  onContextChange,
+  availableRoles,
+}: RLSContextEditorProps) => {
+  const [jwtText, setJwtText] = useState(
+    JSON.stringify(context.jwtClaims ?? {}, null, 2)
+  )
+  const [jwtError, setJwtError] = useState<string | null>(null)
+  
+  // Track if we should notify parent (avoid loops)
+  const isInternalChange = useRef(false)
+
+  // Handle JWT text changes with debounced parsing
+  const handleJwtTextChange = useCallback((text: string) => {
+    setJwtText(text)
+    try {
+      const parsed = JSON.parse(text)
+      setJwtError(null)
+      // Only notify parent if this is a user edit
+      if (!isInternalChange.current) {
+        onContextChange({
+          ...context,
+          jwtClaims: parsed,
+          userId: parsed.sub,
+        })
+      }
+    } catch (e) {
+      setJwtError('Invalid JSON')
+    }
+  }, [context, onContextChange])
+
+  const handleRoleChange = useCallback((role: string) => {
+    // Update JWT claims role to match selected role
+    const updatedClaims = {
+      ...context.jwtClaims,
+      role,
+    }
+    isInternalChange.current = true
+    setJwtText(JSON.stringify(updatedClaims, null, 2))
+    isInternalChange.current = false
+    onContextChange({
+      ...context,
+      role,
+      jwtClaims: updatedClaims,
+    })
+  }, [context, onContextChange])
+
+  // Preset templates for common scenarios
+  const presets = [
+    {
+      name: 'Anonymous User',
+      context: {
+        role: 'anon',
+        jwtClaims: {
+          role: 'anon',
+        },
+      },
+    },
+    {
+      name: 'Authenticated User',
+      context: {
+        role: 'authenticated',
+        jwtClaims: {
+          sub: 'user-123',
+          role: 'authenticated',
+          email: 'user@example.com',
+          app_metadata: {},
+          user_metadata: {},
+        },
+      },
+    },
+    {
+      name: 'Admin User',
+      context: {
+        role: 'authenticated',
+        jwtClaims: {
+          sub: 'admin-456',
+          role: 'authenticated',
+          email: 'admin@example.com',
+          app_metadata: {
+            role: 'admin',
+          },
+          user_metadata: {
+            is_admin: true,
+          },
+        },
+      },
+    },
+    {
+      name: 'Service Role',
+      context: {
+        role: 'service_role',
+        jwtClaims: {
+          role: 'service_role',
+        },
+      },
+    },
+  ]
+
+  const applyPreset = useCallback((preset: (typeof presets)[0]) => {
+    isInternalChange.current = true
+    setJwtText(JSON.stringify(preset.context.jwtClaims, null, 2))
+    isInternalChange.current = false
+    onContextChange(preset.context)
+  }, [onContextChange])
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Role Selection */}
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="role-select">Database Role</Label>
+        <Select value={context.role} onValueChange={handleRoleChange}>
+          <SelectTrigger id="role-select">
+            <SelectValue placeholder="Select a role" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableRoles.map((role) => (
+              <SelectItem key={role} value={role}>
+                {role}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Presets */}
+      <div className="flex flex-col gap-2">
+        <Label>Quick Presets</Label>
+        <div className="flex flex-wrap gap-2">
+          {presets.map((preset) => (
+            <button
+              key={preset.name}
+              onClick={() => applyPreset(preset)}
+              className={cn(
+                'px-3 py-1 text-xs rounded-full border transition-colors',
+                'hover:bg-surface-200 hover:border-foreground-muted',
+                context.role === preset.context.role &&
+                  JSON.stringify(context.jwtClaims) ===
+                    JSON.stringify(preset.context.jwtClaims)
+                  ? 'bg-surface-200 border-foreground-muted'
+                  : 'bg-surface-100 border-border'
+              )}
+            >
+              {preset.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* JWT Claims Editor */}
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="jwt-editor">
+          JWT Claims (request.jwt.claims)
+          {jwtError && (
+            <span className="text-destructive ml-2 text-xs">{jwtError}</span>
+          )}
+        </Label>
+        <div className="border rounded-md overflow-hidden h-[200px]">
+          <textarea
+            id="jwt-editor"
+            value={jwtText}
+            onChange={(e) => handleJwtTextChange(e.target.value)}
+            className={cn(
+              'w-full h-full p-3 font-mono text-sm resize-none',
+              'bg-surface-100 text-foreground',
+              'focus:outline-none focus:ring-2 focus:ring-brand',
+              jwtError && 'border-destructive'
+            )}
+            spellCheck={false}
+          />
+        </div>
+        <p className="text-xs text-foreground-lighter">
+          These claims will be available as <code>auth.jwt()</code> in your
+          policies. The <code>sub</code> field maps to <code>auth.uid()</code>.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSPlayground.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSPlayground.tsx
@@ -1,0 +1,214 @@
+import { useState, useCallback } from 'react'
+import { useParams } from 'common'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import {
+  useRLSPlaygroundTablesQuery,
+  useRLSPlaygroundRolesQuery,
+  useRLSPlaygroundPoliciesQuery,
+  useRLSSimulateMutation,
+  RLSSimulationContext,
+  RLSSimulationResult,
+} from 'data/rls-playground'
+import { RLSContextEditor } from './RLSContextEditor'
+import { RLSTableSelector } from './RLSTableSelector'
+import { RLSPolicyList } from './RLSPolicyList'
+import { RLSResultsTable } from './RLSResultsTable'
+import { Button, Card, CardContent, CardHeader, CardTitle, Tabs, TabsContent, TabsList, TabsTrigger } from 'ui'
+import { Play, AlertCircle, CheckCircle2, XCircle } from 'lucide-react'
+import { toast } from 'sonner'
+
+export const RLSPlayground = () => {
+  const { ref } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [selectedSchema, setSelectedSchema] = useState('public')
+  const [selectedTable, setSelectedTable] = useState<string | null>(null)
+  const [operation, setOperation] = useState<'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'>('SELECT')
+  const [context, setContext] = useState<RLSSimulationContext>({
+    role: 'authenticated',
+    jwtClaims: {
+      sub: 'user-123',
+      role: 'authenticated',
+      email: 'user@example.com',
+    },
+  })
+  const [simulationResult, setSimulationResult] = useState<RLSSimulationResult | null>(null)
+
+  const { data: tables, isLoading: tablesLoading } = useRLSPlaygroundTablesQuery({
+    projectRef: ref,
+    connectionString: project?.connectionString,
+    schema: selectedSchema,
+  })
+
+  const { data: roles } = useRLSPlaygroundRolesQuery({
+    projectRef: ref,
+    connectionString: project?.connectionString,
+  })
+
+  const { data: policies, isLoading: policiesLoading } = useRLSPlaygroundPoliciesQuery({
+    projectRef: ref,
+    connectionString: project?.connectionString,
+    schema: selectedSchema,
+    table: selectedTable ?? undefined,
+  })
+
+  const { mutate: simulate, isPending: isSimulating } = useRLSSimulateMutation({
+    onSuccess: (data) => {
+      setSimulationResult(data)
+      if (data.error) {
+        toast.error(`Simulation error: ${data.error}`)
+      } else {
+        toast.success(
+          `Simulation complete: ${data.accessible_rows}/${data.total_rows_without_rls} rows accessible`
+        )
+      }
+    },
+    onError: (error) => {
+      toast.error(`Failed to simulate: ${error.message}`)
+    },
+  })
+
+  const handleSimulate = useCallback(() => {
+    if (!ref || !selectedTable) return
+
+    simulate({
+      projectRef: ref,
+      connectionString: project?.connectionString,
+      schema: selectedSchema,
+      table: selectedTable,
+      operation,
+      context,
+      limit: 50,
+    })
+  }, [ref, project, selectedSchema, selectedTable, operation, context, simulate])
+
+  const selectedTableData = tables?.find((t) => t.name === selectedTable)
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Table Selection & Context */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Left: Table Selection */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Select Table</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RLSTableSelector
+              tables={tables ?? []}
+              selectedTable={selectedTable}
+              onSelectTable={setSelectedTable}
+              isLoading={tablesLoading}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Right: Context Editor */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Simulation Context</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RLSContextEditor
+              context={context}
+              onContextChange={setContext}
+              availableRoles={roles ?? ['anon', 'authenticated', 'service_role']}
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Operation Selection & Run */}
+      {selectedTable && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-4">
+                <Tabs value={operation} onValueChange={(v) => setOperation(v as any)}>
+                  <TabsList>
+                    <TabsTrigger value="SELECT">SELECT</TabsTrigger>
+                    <TabsTrigger value="INSERT">INSERT</TabsTrigger>
+                    <TabsTrigger value="UPDATE">UPDATE</TabsTrigger>
+                    <TabsTrigger value="DELETE">DELETE</TabsTrigger>
+                  </TabsList>
+                </Tabs>
+
+                {selectedTableData && (
+                  <div className="flex items-center gap-2 text-sm">
+                    {selectedTableData.rls_enabled ? (
+                      <>
+                        <CheckCircle2 className="h-4 w-4 text-brand" />
+                        <span className="text-foreground-light">RLS Enabled</span>
+                      </>
+                    ) : (
+                      <>
+                        <AlertCircle className="h-4 w-4 text-warning" />
+                        <span className="text-warning">RLS Disabled</span>
+                      </>
+                    )}
+                    <span className="text-foreground-lighter">
+                      • {selectedTableData.policy_count} policies
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              <Button
+                type="primary"
+                onClick={handleSimulate}
+                loading={isSimulating}
+                disabled={!selectedTable}
+                icon={<Play className="h-4 w-4" />}
+              >
+                Run Simulation
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Policies & Results */}
+      {selectedTable && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Left: Policies for this table */}
+          <Card className="lg:col-span-1">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">
+                Policies for {selectedTable}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <RLSPolicyList
+                policies={policies ?? []}
+                operation={operation}
+                isLoading={policiesLoading}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Right: Simulation Results */}
+          <Card className="lg:col-span-2">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                Simulation Results
+                {simulationResult && (
+                  <span className="text-sm font-normal text-foreground-light">
+                    ({simulationResult.accessible_rows} of {simulationResult.total_rows_without_rls}{' '}
+                    rows accessible)
+                  </span>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <RLSResultsTable
+                result={simulationResult}
+                policies={policies ?? []}
+                isLoading={isSimulating}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSPlayground.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSPlayground.tsx
@@ -13,8 +13,8 @@ import { RLSContextEditor } from './RLSContextEditor'
 import { RLSTableSelector } from './RLSTableSelector'
 import { RLSPolicyList } from './RLSPolicyList'
 import { RLSResultsTable } from './RLSResultsTable'
-import { Button, Card, CardContent, CardHeader, CardTitle, Tabs, TabsContent, TabsList, TabsTrigger } from 'ui'
-import { Play, AlertCircle, CheckCircle2, XCircle } from 'lucide-react'
+import { Button, Card, CardContent, CardHeader, CardTitle, Tabs, TabsList, TabsTrigger } from 'ui'
+import { Play, AlertCircle, CheckCircle2 } from 'lucide-react'
 import { toast } from 'sonner'
 
 export const RLSPlayground = () => {
@@ -124,7 +124,7 @@ export const RLSPlayground = () => {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-4">
-                <Tabs value={operation} onValueChange={(v) => setOperation(v as any)}>
+                <Tabs value={operation} onValueChange={(v) => setOperation(v as typeof operation)}>
                   <TabsList>
                     <TabsTrigger value="SELECT">SELECT</TabsTrigger>
                     <TabsTrigger value="INSERT">INSERT</TabsTrigger>

--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSPolicyList.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSPolicyList.tsx
@@ -126,7 +126,7 @@ export const RLSPolicyList = ({
             <div>
               <span className="text-foreground-lighter">Roles: </span>
               <span className="font-mono">
-                {(policy.roles as string[]).join(', ')}
+                {policy.roles.join(', ')}
               </span>
             </div>
 

--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSPolicyList.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSPolicyList.tsx
@@ -1,0 +1,199 @@
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+import { cn, Badge, ScrollArea, Collapsible, CollapsibleContent, CollapsibleTrigger } from 'ui'
+import { ChevronDown, ShieldCheck, ShieldX, Eye, Plus, Pencil, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+
+interface RLSPolicyListProps {
+  policies: PostgresPolicy[]
+  operation: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
+  isLoading: boolean
+}
+
+const OPERATION_ICONS = {
+  SELECT: Eye,
+  INSERT: Plus,
+  UPDATE: Pencil,
+  DELETE: Trash2,
+  ALL: ShieldCheck,
+}
+
+const COMMAND_COLORS = {
+  SELECT: 'bg-blue-500/10 text-blue-500 border-blue-500/20',
+  INSERT: 'bg-green-500/10 text-green-500 border-green-500/20',
+  UPDATE: 'bg-amber-500/10 text-amber-500 border-amber-500/20',
+  DELETE: 'bg-red-500/10 text-red-500 border-red-500/20',
+  ALL: 'bg-purple-500/10 text-purple-500 border-purple-500/20',
+}
+
+export const RLSPolicyList = ({
+  policies,
+  operation,
+  isLoading,
+}: RLSPolicyListProps) => {
+  const [expandedPolicies, setExpandedPolicies] = useState<Set<number>>(new Set())
+
+  const togglePolicy = (id: number) => {
+    setExpandedPolicies((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  // Filter policies relevant to the current operation
+  const relevantPolicies = policies.filter(
+    (p) => p.command === operation || p.command === 'ALL'
+  )
+  const otherPolicies = policies.filter(
+    (p) => p.command !== operation && p.command !== 'ALL'
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[200px] text-foreground-lighter">
+        Loading policies...
+      </div>
+    )
+  }
+
+  if (policies.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[200px] text-foreground-lighter gap-2">
+        <ShieldX className="h-8 w-8" />
+        <p className="text-center">
+          No policies defined for this table.
+          <br />
+          <span className="text-xs">All operations will be blocked if RLS is enabled.</span>
+        </p>
+      </div>
+    )
+  }
+
+  const renderPolicy = (policy: PostgresPolicy, isRelevant: boolean) => {
+    const isExpanded = expandedPolicies.has(policy.id)
+    const Icon = OPERATION_ICONS[policy.command as keyof typeof OPERATION_ICONS] || ShieldCheck
+    const colorClass = COMMAND_COLORS[policy.command as keyof typeof COMMAND_COLORS] || COMMAND_COLORS.ALL
+
+    return (
+      <Collapsible
+        key={policy.id}
+        open={isExpanded}
+        onOpenChange={() => togglePolicy(policy.id)}
+      >
+        <CollapsibleTrigger
+          className={cn(
+            'w-full flex items-center justify-between px-3 py-2 rounded-md text-left transition-all',
+            'hover:bg-surface-200',
+            isRelevant ? 'opacity-100' : 'opacity-50',
+            isExpanded && 'bg-surface-200'
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Icon className="h-4 w-4" />
+            <span className="font-mono text-sm">{policy.name}</span>
+            <Badge
+              variant="outline"
+              className={cn('text-xs border', colorClass)}
+            >
+              {policy.command}
+            </Badge>
+            <Badge
+              variant="outline"
+              className={cn(
+                'text-xs',
+                policy.action === 'PERMISSIVE'
+                  ? 'text-brand border-brand/20'
+                  : 'text-destructive border-destructive/20'
+              )}
+            >
+              {policy.action}
+            </Badge>
+          </div>
+          <ChevronDown
+            className={cn(
+              'h-4 w-4 transition-transform',
+              isExpanded && 'rotate-180'
+            )}
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent className="px-3 pb-3">
+          <div className="mt-2 space-y-2 text-sm">
+            {/* Roles */}
+            <div>
+              <span className="text-foreground-lighter">Roles: </span>
+              <span className="font-mono">
+                {(policy.roles as string[]).join(', ')}
+              </span>
+            </div>
+
+            {/* USING expression */}
+            {policy.definition && (
+              <div>
+                <span className="text-foreground-lighter block mb-1">
+                  USING (for SELECT/UPDATE/DELETE):
+                </span>
+                <pre className="bg-surface-100 p-2 rounded text-xs overflow-x-auto">
+                  {policy.definition}
+                </pre>
+              </div>
+            )}
+
+            {/* WITH CHECK expression */}
+            {policy.check && (
+              <div>
+                <span className="text-foreground-lighter block mb-1">
+                  WITH CHECK (for INSERT/UPDATE):
+                </span>
+                <pre className="bg-surface-100 p-2 rounded text-xs overflow-x-auto">
+                  {policy.check}
+                </pre>
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    )
+  }
+
+  return (
+    <ScrollArea className="h-[400px]">
+      <div className="flex flex-col gap-1">
+        {/* Relevant policies */}
+        {relevantPolicies.length > 0 && (
+          <div className="mb-2">
+            <div className="text-xs text-foreground-lighter mb-2 px-1">
+              Applies to {operation} ({relevantPolicies.length})
+            </div>
+            {relevantPolicies.map((p) => renderPolicy(p, true))}
+          </div>
+        )}
+
+        {/* Other policies */}
+        {otherPolicies.length > 0 && (
+          <div>
+            <div className="text-xs text-foreground-lighter mb-2 px-1 border-t pt-2">
+              Other policies ({otherPolicies.length})
+            </div>
+            {otherPolicies.map((p) => renderPolicy(p, false))}
+          </div>
+        )}
+
+        {relevantPolicies.length === 0 && (
+          <div className="text-center py-4 text-foreground-lighter text-sm">
+            No policies apply to {operation} operations.
+            <br />
+            <span className="text-xs">
+              {policies.length > 0
+                ? 'This operation may be blocked.'
+                : 'All operations will be blocked if RLS is enabled.'}
+            </span>
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  )
+}

--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSResultsTable.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSResultsTable.tsx
@@ -1,0 +1,321 @@
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+import { RLSSimulationResult, RLSRowResult } from 'data/rls-playground'
+import {
+  cn,
+  Badge,
+  ScrollArea,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
+import { CheckCircle2, XCircle, AlertCircle, Info, Lock, Unlock } from 'lucide-react'
+import { useState } from 'react'
+
+interface RLSResultsTableProps {
+  result: RLSSimulationResult | null
+  policies: PostgresPolicy[]
+  isLoading: boolean
+}
+
+export const RLSResultsTable = ({
+  result,
+  policies,
+  isLoading,
+}: RLSResultsTableProps) => {
+  const [selectedRow, setSelectedRow] = useState<number | null>(null)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[400px] text-foreground-lighter">
+        <div className="flex flex-col items-center gap-2">
+          <div className="animate-spin h-6 w-6 border-2 border-brand border-t-transparent rounded-full" />
+          <span>Running simulation...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (!result) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[400px] text-foreground-lighter gap-2">
+        <Info className="h-8 w-8" />
+        <p className="text-center">
+          Select a table and click "Run Simulation" to see
+          <br />
+          which rows are accessible with the current context.
+        </p>
+      </div>
+    )
+  }
+
+  if (result.error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[400px] text-destructive gap-2">
+        <AlertCircle className="h-8 w-8" />
+        <p className="text-center">
+          Simulation Error
+          <br />
+          <span className="text-sm text-foreground-lighter">{result.error}</span>
+        </p>
+      </div>
+    )
+  }
+
+  // Get column names from the first row
+  const columns = result.rows.length > 0 ? Object.keys(result.rows[0].row_data) : []
+
+  // Summary stats
+  const totalRows = result.total_rows_without_rls
+  const accessibleRows = result.accessible_rows
+  const blockedRows = totalRows - accessibleRows
+  const accessRate = totalRows > 0 ? ((accessibleRows / totalRows) * 100).toFixed(1) : '0'
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Summary */}
+      <div className="flex items-center justify-between px-1">
+        <div className="flex items-center gap-4">
+          {/* RLS Status */}
+          {result.rls_enabled ? (
+            <div className="flex items-center gap-2 text-sm">
+              <Lock className="h-4 w-4 text-brand" />
+              <span>RLS Active</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-sm text-warning">
+              <Unlock className="h-4 w-4" />
+              <span>RLS Disabled (all rows visible)</span>
+            </div>
+          )}
+        </div>
+
+        {/* Access Stats */}
+        <div className="flex items-center gap-4 text-sm">
+          <div className="flex items-center gap-1">
+            <CheckCircle2 className="h-4 w-4 text-brand" />
+            <span>{accessibleRows} accessible</span>
+          </div>
+          {blockedRows > 0 && (
+            <div className="flex items-center gap-1 text-destructive">
+              <XCircle className="h-4 w-4" />
+              <span>{blockedRows} blocked</span>
+            </div>
+          )}
+          <Badge variant="outline" className="text-xs">
+            {accessRate}% access rate
+          </Badge>
+        </div>
+      </div>
+
+      {/* Context Summary */}
+      <div className="bg-surface-100 rounded-md p-3 text-sm">
+        <div className="flex items-center gap-4">
+          <span className="text-foreground-lighter">Simulated as:</span>
+          <Badge variant="default">{result.context.role}</Badge>
+          {result.context.userId && (
+            <span className="text-foreground-lighter">
+              user_id: <code className="text-foreground">{result.context.userId}</code>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Results Table */}
+      {result.rows.length > 0 ? (
+        <ScrollArea className="h-[350px] border rounded-md">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-surface-100">
+                <TableHead className="w-[100px]">Access</TableHead>
+                <TableHead className="w-[120px]">Policies</TableHead>
+                {columns.slice(0, 5).map((col) => (
+                  <TableHead key={col} className="font-mono text-xs">
+                    {col}
+                  </TableHead>
+                ))}
+                {columns.length > 5 && (
+                  <TableHead className="text-xs text-foreground-lighter">
+                    +{columns.length - 5} more
+                  </TableHead>
+                )}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result.rows.map((row, idx) => (
+                <TableRow
+                  key={idx}
+                  className={cn(
+                    'cursor-pointer transition-colors',
+                    selectedRow === idx && 'bg-surface-200'
+                  )}
+                  onClick={() => setSelectedRow(selectedRow === idx ? null : idx)}
+                >
+                  <TableCell>
+                    {row.accessible ? (
+                      <div className="flex items-center gap-1 text-brand">
+                        <CheckCircle2 className="h-4 w-4" />
+                        <span className="text-xs">Allowed</span>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-1 text-destructive">
+                        <XCircle className="h-4 w-4" />
+                        <span className="text-xs">Blocked</span>
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <PolicyStatusBadges evaluations={row.policies_evaluated} />
+                  </TableCell>
+                  {columns.slice(0, 5).map((col) => (
+                    <TableCell key={col} className="font-mono text-xs max-w-[200px] truncate">
+                      {formatCellValue(row.row_data[col])}
+                    </TableCell>
+                  ))}
+                  {columns.length > 5 && (
+                    <TableCell className="text-xs text-foreground-lighter">...</TableCell>
+                  )}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </ScrollArea>
+      ) : (
+        <div className="flex flex-col items-center justify-center h-[200px] border rounded-md text-foreground-lighter gap-2">
+          <XCircle className="h-8 w-8 text-destructive" />
+          <p className="text-center">
+            No rows accessible with current context
+            <br />
+            <span className="text-xs">
+              {result.total_rows_without_rls > 0
+                ? `${result.total_rows_without_rls} rows exist but are blocked by RLS`
+                : 'Table is empty'}
+            </span>
+          </p>
+        </div>
+      )}
+
+      {/* Selected Row Details */}
+      {selectedRow !== null && result.rows[selectedRow] && (
+        <PolicyEvaluationDetails
+          row={result.rows[selectedRow]}
+          policies={policies}
+        />
+      )}
+    </div>
+  )
+}
+
+// Helper component for policy status badges
+const PolicyStatusBadges = ({
+  evaluations,
+}: {
+  evaluations: RLSRowResult['policies_evaluated']
+}) => {
+  const passed = evaluations.filter((e) => e.passed).length
+  const failed = evaluations.filter((e) => !e.passed).length
+
+  return (
+    <div className="flex items-center gap-1">
+      {passed > 0 && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="default" className="text-xs bg-brand/10 text-brand">
+              {passed} ✓
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            {passed} {passed === 1 ? 'policy' : 'policies'} passed
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {failed > 0 && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="destructive" className="text-xs">
+              {failed} ✗
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            {failed} {failed === 1 ? 'policy' : 'policies'} failed
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+// Helper component for detailed policy evaluation
+const PolicyEvaluationDetails = ({
+  row,
+  policies,
+}: {
+  row: RLSRowResult
+  policies: PostgresPolicy[]
+}) => {
+  return (
+    <div className="bg-surface-100 rounded-md p-4">
+      <h4 className="text-sm font-medium mb-3">Policy Evaluation Details</h4>
+      <div className="space-y-2">
+        {row.policies_evaluated.map((eval_) => {
+          const policy = policies.find((p) => p.id === eval_.policy_id)
+          return (
+            <div
+              key={eval_.policy_id}
+              className={cn(
+                'flex items-start gap-3 p-2 rounded border',
+                eval_.passed
+                  ? 'bg-brand/5 border-brand/20'
+                  : 'bg-destructive/5 border-destructive/20'
+              )}
+            >
+              {eval_.passed ? (
+                <CheckCircle2 className="h-4 w-4 text-brand mt-0.5" />
+              ) : (
+                <XCircle className="h-4 w-4 text-destructive mt-0.5" />
+              )}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-sm">{eval_.policy_name}</span>
+                  <Badge variant="outline" className="text-xs">
+                    {eval_.command}
+                  </Badge>
+                  <Badge variant="outline" className="text-xs">
+                    {eval_.action}
+                  </Badge>
+                </div>
+                {eval_.expression && (
+                  <pre className="mt-1 text-xs text-foreground-lighter overflow-x-auto">
+                    USING: {eval_.expression}
+                  </pre>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Row Data */}
+      <div className="mt-4 pt-4 border-t">
+        <h5 className="text-xs font-medium text-foreground-lighter mb-2">Row Data</h5>
+        <pre className="text-xs bg-surface-200 p-2 rounded overflow-x-auto">
+          {JSON.stringify(row.row_data, null, 2)}
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+// Helper to format cell values
+const formatCellValue = (value: any): string => {
+  if (value === null) return 'NULL'
+  if (value === undefined) return ''
+  if (typeof value === 'object') return JSON.stringify(value)
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return String(value)
+}

--- a/apps/studio/components/interfaces/Database/RLSPlayground/RLSTableSelector.tsx
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/RLSTableSelector.tsx
@@ -1,0 +1,111 @@
+import { RLSPlaygroundTable } from 'data/rls-playground'
+import { cn, Input, Badge, ScrollArea } from 'ui'
+import { Table2, ShieldCheck, ShieldAlert, Search } from 'lucide-react'
+import { useState, useMemo } from 'react'
+
+interface RLSTableSelectorProps {
+  tables: RLSPlaygroundTable[]
+  selectedTable: string | null
+  onSelectTable: (table: string | null) => void
+  isLoading: boolean
+}
+
+export const RLSTableSelector = ({
+  tables,
+  selectedTable,
+  onSelectTable,
+  isLoading,
+}: RLSTableSelectorProps) => {
+  const [search, setSearch] = useState('')
+
+  const filteredTables = useMemo(() => {
+    if (!search) return tables
+    return tables.filter((t) =>
+      t.name.toLowerCase().includes(search.toLowerCase())
+    )
+  }, [tables, search])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[300px] text-foreground-lighter">
+        Loading tables...
+      </div>
+    )
+  }
+
+  if (tables.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[300px] text-foreground-lighter gap-2">
+        <Table2 className="h-8 w-8" />
+        <p>No tables found in this schema</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-foreground-lighter" />
+        <Input
+          placeholder="Search tables..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {/* Table List */}
+      <ScrollArea className="h-[250px]">
+        <div className="flex flex-col gap-1">
+          {filteredTables.map((table) => (
+            <button
+              key={table.id}
+              onClick={() => onSelectTable(table.name)}
+              className={cn(
+                'flex items-center justify-between px-3 py-2 rounded-md text-left transition-colors',
+                'hover:bg-surface-200',
+                selectedTable === table.name
+                  ? 'bg-surface-200 border border-foreground-muted'
+                  : 'border border-transparent'
+              )}
+            >
+              <div className="flex items-center gap-2">
+                {table.rls_enabled ? (
+                  <ShieldCheck className="h-4 w-4 text-brand" />
+                ) : (
+                  <ShieldAlert className="h-4 w-4 text-warning" />
+                )}
+                <span className="font-mono text-sm">{table.name}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {table.policy_count > 0 && (
+                  <Badge variant="default" className="text-xs">
+                    {table.policy_count} {table.policy_count === 1 ? 'policy' : 'policies'}
+                  </Badge>
+                )}
+                {!table.rls_enabled && (
+                  <Badge variant="warning" className="text-xs">
+                    No RLS
+                  </Badge>
+                )}
+              </div>
+            </button>
+          ))}
+
+          {filteredTables.length === 0 && search && (
+            <div className="text-center py-8 text-foreground-lighter">
+              No tables matching "{search}"
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      {/* Summary */}
+      <div className="text-xs text-foreground-lighter border-t pt-2">
+        {tables.filter((t) => t.rls_enabled).length} of {tables.length} tables have
+        RLS enabled
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/RLSPlayground/index.ts
+++ b/apps/studio/components/interfaces/Database/RLSPlayground/index.ts
@@ -1,0 +1,5 @@
+export { RLSPlayground } from './RLSPlayground'
+export { RLSContextEditor } from './RLSContextEditor'
+export { RLSTableSelector } from './RLSTableSelector'
+export { RLSPolicyList } from './RLSPolicyList'
+export { RLSResultsTable } from './RLSResultsTable'

--- a/apps/studio/data/rls-playground/index.ts
+++ b/apps/studio/data/rls-playground/index.ts
@@ -1,0 +1,5 @@
+export * from './keys'
+export * from './rls-playground-roles-query'
+export * from './rls-playground-tables-query'
+export * from './rls-playground-policies-query'
+export * from './rls-playground-simulate-mutation'

--- a/apps/studio/data/rls-playground/keys.ts
+++ b/apps/studio/data/rls-playground/keys.ts
@@ -1,0 +1,12 @@
+export const rlsPlaygroundKeys = {
+  all: ['rls-playground'] as const,
+  roles: (projectRef: string | undefined) => [...rlsPlaygroundKeys.all, 'roles', projectRef] as const,
+  tables: (projectRef: string | undefined, schema: string) =>
+    [...rlsPlaygroundKeys.all, 'tables', projectRef, schema] as const,
+  policies: (projectRef: string | undefined, schema: string, table: string) =>
+    [...rlsPlaygroundKeys.all, 'policies', projectRef, schema, table] as const,
+  rlsStatus: (projectRef: string | undefined, schema: string, table: string) =>
+    [...rlsPlaygroundKeys.all, 'rls-status', projectRef, schema, table] as const,
+  simulation: (projectRef: string | undefined) =>
+    [...rlsPlaygroundKeys.all, 'simulation', projectRef] as const,
+}

--- a/apps/studio/data/rls-playground/keys.ts
+++ b/apps/studio/data/rls-playground/keys.ts
@@ -1,10 +1,15 @@
 export const rlsPlaygroundKeys = {
   all: ['rls-playground'] as const,
-  roles: (projectRef: string | undefined) => [...rlsPlaygroundKeys.all, 'roles', projectRef] as const,
-  tables: (projectRef: string | undefined, schema: string) =>
-    [...rlsPlaygroundKeys.all, 'tables', projectRef, schema] as const,
-  policies: (projectRef: string | undefined, schema: string, table: string) =>
-    [...rlsPlaygroundKeys.all, 'policies', projectRef, schema, table] as const,
+  roles: (projectRef: string | undefined, connectionString?: string | null) =>
+    [...rlsPlaygroundKeys.all, 'roles', projectRef, connectionString ?? null] as const,
+  tables: (projectRef: string | undefined, schema: string, connectionString?: string | null) =>
+    [...rlsPlaygroundKeys.all, 'tables', projectRef, schema, connectionString ?? null] as const,
+  policies: (
+    projectRef: string | undefined,
+    schema: string,
+    table: string,
+    connectionString?: string | null
+  ) => [...rlsPlaygroundKeys.all, 'policies', projectRef, schema, table, connectionString ?? null] as const,
   rlsStatus: (projectRef: string | undefined, schema: string, table: string) =>
     [...rlsPlaygroundKeys.all, 'rls-status', projectRef, schema, table] as const,
   simulation: (projectRef: string | undefined) =>

--- a/apps/studio/data/rls-playground/rls-playground-policies-query.ts
+++ b/apps/studio/data/rls-playground/rls-playground-policies-query.ts
@@ -49,7 +49,7 @@ export const useRLSPlaygroundPoliciesQuery = <TData = RLSPlaygroundPoliciesData>
   }: UseCustomQueryOptions<RLSPlaygroundPoliciesData, RLSPlaygroundPoliciesError, TData> = {}
 ) => {
   return useQuery<RLSPlaygroundPoliciesData, RLSPlaygroundPoliciesError, TData>({
-    queryKey: rlsPlaygroundKeys.policies(projectRef, schema, table ?? ''),
+    queryKey: rlsPlaygroundKeys.policies(projectRef, schema, table ?? '', connectionString),
     queryFn: ({ signal }) =>
       getRLSPlaygroundPolicies({ projectRef, connectionString, schema, table }, signal),
     enabled: enabled && typeof projectRef !== 'undefined' && !!table,

--- a/apps/studio/data/rls-playground/rls-playground-policies-query.ts
+++ b/apps/studio/data/rls-playground/rls-playground-policies-query.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query'
+import { get, handleError } from 'data/fetchers'
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { rlsPlaygroundKeys } from './keys'
+
+type RLSPlaygroundPoliciesVariables = {
+  projectRef?: string
+  connectionString?: string | null
+  schema?: string
+  table?: string
+}
+
+export async function getRLSPlaygroundPolicies(
+  { projectRef, connectionString, schema = 'public', table }: RLSPlaygroundPoliciesVariables,
+  signal?: AbortSignal,
+  headersInit?: HeadersInit
+) {
+  if (!projectRef) throw new Error('projectRef is required')
+  if (!table) throw new Error('table is required')
+
+  let headers = new Headers(headersInit)
+  if (connectionString) headers.set('x-connection-encrypted', connectionString)
+
+  const { data, error } = await get(
+    '/platform/pg-meta/{ref}/rls-playground/policies/{schema}/{table}' as any,
+    {
+      params: {
+        header: { 'x-connection-encrypted': connectionString! },
+        path: { ref: projectRef, schema, table },
+      },
+      headers,
+      signal,
+    }
+  )
+
+  if (error) handleError(error)
+  return data as PostgresPolicy[]
+}
+
+export type RLSPlaygroundPoliciesData = Awaited<ReturnType<typeof getRLSPlaygroundPolicies>>
+export type RLSPlaygroundPoliciesError = ResponseError
+
+export const useRLSPlaygroundPoliciesQuery = <TData = RLSPlaygroundPoliciesData>(
+  { projectRef, connectionString, schema = 'public', table }: RLSPlaygroundPoliciesVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<RLSPlaygroundPoliciesData, RLSPlaygroundPoliciesError, TData> = {}
+) => {
+  return useQuery<RLSPlaygroundPoliciesData, RLSPlaygroundPoliciesError, TData>({
+    queryKey: rlsPlaygroundKeys.policies(projectRef, schema, table ?? ''),
+    queryFn: ({ signal }) =>
+      getRLSPlaygroundPolicies({ projectRef, connectionString, schema, table }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && !!table,
+    ...options,
+  })
+}

--- a/apps/studio/data/rls-playground/rls-playground-roles-query.ts
+++ b/apps/studio/data/rls-playground/rls-playground-roles-query.ts
@@ -42,7 +42,7 @@ export const useRLSPlaygroundRolesQuery = <TData = RLSPlaygroundRolesData>(
   }: UseCustomQueryOptions<RLSPlaygroundRolesData, RLSPlaygroundRolesError, TData> = {}
 ) => {
   return useQuery<RLSPlaygroundRolesData, RLSPlaygroundRolesError, TData>({
-    queryKey: rlsPlaygroundKeys.roles(projectRef),
+    queryKey: rlsPlaygroundKeys.roles(projectRef, connectionString),
     queryFn: ({ signal }) => getRLSPlaygroundRoles({ projectRef, connectionString }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',
     ...options,

--- a/apps/studio/data/rls-playground/rls-playground-roles-query.ts
+++ b/apps/studio/data/rls-playground/rls-playground-roles-query.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query'
+import { get, handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { rlsPlaygroundKeys } from './keys'
+
+type RLSPlaygroundRolesVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export async function getRLSPlaygroundRoles(
+  { projectRef, connectionString }: RLSPlaygroundRolesVariables,
+  signal?: AbortSignal,
+  headersInit?: HeadersInit
+) {
+  if (!projectRef) throw new Error('projectRef is required')
+
+  let headers = new Headers(headersInit)
+  if (connectionString) headers.set('x-connection-encrypted', connectionString)
+
+  const { data, error } = await get('/platform/pg-meta/{ref}/rls-playground/roles' as any, {
+    params: {
+      header: { 'x-connection-encrypted': connectionString! },
+      path: { ref: projectRef },
+    },
+    headers,
+    signal,
+  })
+
+  if (error) handleError(error)
+  return data as string[]
+}
+
+export type RLSPlaygroundRolesData = Awaited<ReturnType<typeof getRLSPlaygroundRoles>>
+export type RLSPlaygroundRolesError = ResponseError
+
+export const useRLSPlaygroundRolesQuery = <TData = RLSPlaygroundRolesData>(
+  { projectRef, connectionString }: RLSPlaygroundRolesVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<RLSPlaygroundRolesData, RLSPlaygroundRolesError, TData> = {}
+) => {
+  return useQuery<RLSPlaygroundRolesData, RLSPlaygroundRolesError, TData>({
+    queryKey: rlsPlaygroundKeys.roles(projectRef),
+    queryFn: ({ signal }) => getRLSPlaygroundRoles({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined',
+    ...options,
+  })
+}

--- a/apps/studio/data/rls-playground/rls-playground-simulate-mutation.ts
+++ b/apps/studio/data/rls-playground/rls-playground-simulate-mutation.ts
@@ -1,0 +1,103 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { post, handleError } from 'data/fetchers'
+import type { ResponseError } from 'types'
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+
+export interface RLSSimulationContext {
+  role: string
+  jwtClaims?: Record<string, any>
+  userId?: string
+}
+
+export interface RLSPolicyEvaluation {
+  policy_id: number
+  policy_name: string
+  command: string
+  action: string
+  passed: boolean
+  expression: string | null
+  check_expression: string | null
+}
+
+export interface RLSRowResult {
+  row_data: Record<string, any>
+  row_number: number
+  policies_evaluated: RLSPolicyEvaluation[]
+  accessible: boolean
+}
+
+export interface RLSSimulationResult {
+  table_name: string
+  schema_name: string
+  operation: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
+  context: RLSSimulationContext
+  rls_enabled: boolean
+  policies: PostgresPolicy[]
+  rows: RLSRowResult[]
+  total_rows_without_rls: number
+  accessible_rows: number
+  error?: string
+}
+
+type RLSSimulateVariables = {
+  projectRef: string
+  connectionString?: string | null
+  schema?: string
+  table: string
+  operation?: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
+  context: RLSSimulationContext
+  limit?: number
+  testData?: Record<string, any>
+}
+
+export async function simulateRLS(
+  {
+    projectRef,
+    connectionString,
+    schema = 'public',
+    table,
+    operation = 'SELECT',
+    context,
+    limit = 100,
+    testData,
+  }: RLSSimulateVariables,
+  headersInit?: HeadersInit
+): Promise<RLSSimulationResult> {
+  let headers = new Headers(headersInit)
+  if (connectionString) headers.set('x-connection-encrypted', connectionString)
+
+  const { data, error } = await post('/platform/pg-meta/{ref}/rls-playground/simulate' as any, {
+    params: {
+      header: { 'x-connection-encrypted': connectionString! },
+      path: { ref: projectRef },
+    },
+    body: {
+      schema,
+      table,
+      operation,
+      context,
+      limit,
+      testData,
+    },
+    headers,
+  })
+
+  if (error) handleError(error)
+  return data as RLSSimulationResult
+}
+
+type RLSSimulateData = Awaited<ReturnType<typeof simulateRLS>>
+type RLSSimulateError = ResponseError
+
+export const useRLSSimulateMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<UseMutationOptions<RLSSimulateData, RLSSimulateError, RLSSimulateVariables>, 'mutationFn'> = {}) => {
+  return useMutation<RLSSimulateData, RLSSimulateError, RLSSimulateVariables>({
+    mutationFn: simulateRLS,
+    onSuccess,
+    onError,
+    ...options,
+  })
+}

--- a/apps/studio/data/rls-playground/rls-playground-tables-query.ts
+++ b/apps/studio/data/rls-playground/rls-playground-tables-query.ts
@@ -53,7 +53,7 @@ export const useRLSPlaygroundTablesQuery = <TData = RLSPlaygroundTablesData>(
   }: UseCustomQueryOptions<RLSPlaygroundTablesData, RLSPlaygroundTablesError, TData> = {}
 ) => {
   return useQuery<RLSPlaygroundTablesData, RLSPlaygroundTablesError, TData>({
-    queryKey: rlsPlaygroundKeys.tables(projectRef, schema),
+    queryKey: rlsPlaygroundKeys.tables(projectRef, schema, connectionString),
     queryFn: ({ signal }) =>
       getRLSPlaygroundTables({ projectRef, connectionString, schema }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',

--- a/apps/studio/data/rls-playground/rls-playground-tables-query.ts
+++ b/apps/studio/data/rls-playground/rls-playground-tables-query.ts
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query'
+import { get, handleError } from 'data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+import { rlsPlaygroundKeys } from './keys'
+
+export interface RLSPlaygroundTable {
+  id: number
+  schema: string
+  name: string
+  rls_enabled: boolean
+  rls_forced: boolean
+  policy_count: number
+}
+
+type RLSPlaygroundTablesVariables = {
+  projectRef?: string
+  connectionString?: string | null
+  schema?: string
+}
+
+export async function getRLSPlaygroundTables(
+  { projectRef, connectionString, schema = 'public' }: RLSPlaygroundTablesVariables,
+  signal?: AbortSignal,
+  headersInit?: HeadersInit
+) {
+  if (!projectRef) throw new Error('projectRef is required')
+
+  let headers = new Headers(headersInit)
+  if (connectionString) headers.set('x-connection-encrypted', connectionString)
+
+  const { data, error } = await get('/platform/pg-meta/{ref}/rls-playground/tables' as any, {
+    params: {
+      header: { 'x-connection-encrypted': connectionString! },
+      path: { ref: projectRef },
+      query: { schema },
+    },
+    headers,
+    signal,
+  })
+
+  if (error) handleError(error)
+  return data as RLSPlaygroundTable[]
+}
+
+export type RLSPlaygroundTablesData = Awaited<ReturnType<typeof getRLSPlaygroundTables>>
+export type RLSPlaygroundTablesError = ResponseError
+
+export const useRLSPlaygroundTablesQuery = <TData = RLSPlaygroundTablesData>(
+  { projectRef, connectionString, schema = 'public' }: RLSPlaygroundTablesVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<RLSPlaygroundTablesData, RLSPlaygroundTablesError, TData> = {}
+) => {
+  return useQuery<RLSPlaygroundTablesData, RLSPlaygroundTablesError, TData>({
+    queryKey: rlsPlaygroundKeys.tables(projectRef, schema),
+    queryFn: ({ signal }) =>
+      getRLSPlaygroundTables({ projectRef, connectionString, schema }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined',
+    ...options,
+  })
+}

--- a/apps/studio/pages/project/[ref]/database/rls-playground.tsx
+++ b/apps/studio/pages/project/[ref]/database/rls-playground.tsx
@@ -1,4 +1,3 @@
-import { useParams } from 'common'
 import { RLSPlayground } from 'components/interfaces/Database/RLSPlayground'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
@@ -14,8 +13,6 @@ import {
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 
 const RLSPlaygroundPage: NextPageWithLayout = () => {
-  const { ref } = useParams()
-
   return (
     <>
       <PageHeader size="large">

--- a/apps/studio/pages/project/[ref]/database/rls-playground.tsx
+++ b/apps/studio/pages/project/[ref]/database/rls-playground.tsx
@@ -1,0 +1,49 @@
+import { useParams } from 'common'
+import { RLSPlayground } from 'components/interfaces/Database/RLSPlayground'
+import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
+import DefaultLayout from 'components/layouts/DefaultLayout'
+import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
+import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
+
+const RLSPlaygroundPage: NextPageWithLayout = () => {
+  const { ref } = useParams()
+
+  return (
+    <>
+      <PageHeader size="large">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>RLS Policy Playground</PageHeaderTitle>
+            <PageHeaderDescription>
+              Debug and test Row Level Security policies by simulating different user contexts.
+              See exactly which rows are accessible and why policies pass or fail.
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="large">
+        <PageSection>
+          <PageSectionContent>
+            <RLSPlayground />
+          </PageSectionContent>
+        </PageSection>
+      </PageContainer>
+    </>
+  )
+}
+
+RLSPlaygroundPage.getLayout = (page) => (
+  <DefaultLayout>
+    <DatabaseLayout title="RLS Playground">{page}</DatabaseLayout>
+  </DefaultLayout>
+)
+
+export default RLSPlaygroundPage


### PR DESCRIPTION
## Summary

This PR adds a new **Database → RLS Playground** page to Supabase Studio for debugging Row Level Security policies. This is one of the most requested features in the Supabase community.

## Problem

RLS debugging is currently one of the biggest pain points for Supabase users:
- "Why can't I see my data?" is an extremely common support question
- Testing policies requires actual authentication or manual SQL
- There's no visibility into which policy is blocking access
- Complex policies with multiple conditions are nearly impossible to debug

## Solution

A visual playground that lets you:
1. **Select a table** - Browse tables with RLS status indicators
2. **Configure context** - Set role and JWT claims to simulate different users
3. **Run simulation** - See exactly which rows are accessible and why

### Features

**Table Browser**
- Shows all tables with RLS enabled/disabled status
- Policy count badges
- Search/filter functionality

**Context Editor**
- Role selector (anon, authenticated, service_role, custom)
- JSON editor for JWT claims
- Quick presets for common scenarios:
  - Anonymous User
  - Authenticated User
  - Admin User
  - Service Role

**Policy Viewer**
- Color-coded by operation (SELECT/INSERT/UPDATE/DELETE)
- Shows PERMISSIVE vs RESTRICTIVE
- Expandable to view USING and WITH CHECK expressions

**Simulation Results**
- Row-by-row access status (✓ Allowed / ✗ Blocked)
- Policy pass/fail indicators per row
- Click to expand detailed evaluation trace
- Access rate statistics

## Screenshots

_(Would add screenshots here - the UI follows existing Studio patterns)_

## Technical Details

**Components** (`apps/studio/components/interfaces/Database/RLSPlayground/`):
- `RLSPlayground.tsx` - Main container
- `RLSContextEditor.tsx` - JWT claims and role configuration
- `RLSTableSelector.tsx` - Searchable table list
- `RLSPolicyList.tsx` - Collapsible policy viewer
- `RLSResultsTable.tsx` - Results with policy evaluation details

**Data Layer** (`apps/studio/data/rls-playground/`):
- React Query hooks for roles, tables, policies
- Simulation mutation with comprehensive result types
- Proper cache key management

**Page**: `apps/studio/pages/project/[ref]/database/rls-playground.tsx`

## Dependencies

**Requires**: supabase/postgres-meta#1037 for backend API endpoints

## Future Work (not in this PR)

- Expression-level debugging (highlight failing clause)
- Policy suggestions ("would pass if...")
- Batch testing multiple contexts
- Export simulation results
- Navigation sidebar link (can add once approved)

## Testing

Manual testing with various RLS configurations. The feature is isolated and doesn't affect existing functionality.

---

**Note**: This is a community contribution. Happy to iterate on feedback!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced RLS Playground: interactive UI to test Row-Level Security policies.
  * Context editor with JWT claims, role selector and quick presets (Anonymous, Authenticated, Admin, Service).
  * Table selector with search and RLS indicators.
  * Policy browser with expandable details per operation.
  * Results explorer showing accessible/blocked rows, per-row policy evaluations, and detailed inspection panel.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->