### PR TITLE
docs(realtime): clarify sync event behavior with join/leave events

### DIFF
--- a/apps/docs/content/guides/realtime/presence.mdx
+++ b/apps/docs/content/guides/realtime/presence.mdx
@@ -20,6 +20,16 @@ When any client subscribes, disconnects, or updates their presence payload, Supa
 - **`join`** — a new client has started tracking presence
 - **`leave`** — a client has stopped tracking presence
 
+<Admonition type="note" title="Sync events include join and leave">
+
+During a `sync` event, you may notice that `join` and `leave` events are also triggered, even when no users are actually joining or leaving. This is expected behavior.
+
+The `sync` event reconciles the client's local state with the server's authoritative state. As part of this reconciliation, Presence emits `leave` events for stale entries and `join` events for updated entries—even if the same user is simply refreshing their presence payload.
+
+When handling these events, keep in mind that they reflect state synchronization rather than actual user movement.
+
+</Admonition>
+
 The complete presence state returned by `presenceState()` looks like this:
 
 ```json


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement

## What is the current behavior?

The Presence documentation doesn't explain that `sync` events trigger `join` and `leave` events as part of state reconciliation. This can confuse developers who see these events firing without any actual users joining or leaving.

## What is the new behavior?

Added an Admonition note in the Presence documentation explaining:
- During a `sync` event, `join` and `leave` events are also triggered
- This is expected behavior for state reconciliation
- It reflects state synchronization rather than actual user movement

## Additional context

Fixes #41175

This addresses the confusion reported in the issue where developers were puzzled by seeing join/leave events during sync without any real user activity. The note helps set correct expectations for developers implementing Presence features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced real-time presence guides with clarification on synchronization behavior. Join and leave events may occur during sync as the system reconciles local state with server updates, removing stale entries and adding updated ones. These events reflect synchronization activity rather than actual user movement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->