### PR TITLE
fix: improve bucket link handling in storage explorer

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
@@ -36,7 +36,7 @@ export const CustomExpiryModal = () => {
         onSubmit={async (values: any, { setSubmitting }: any) => {
           setSubmitting(true)
           await onCopyUrl(
-            selectedFileCustomExpiry!.name,
+            selectedFileCustomExpiry!,
             values.expiresIn * unitMap[values.units as 'days' | 'weeks' | 'months' | 'years']
           )
           setSubmitting(false)

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -169,106 +169,104 @@ export const FileExplorerRow = ({
   const rowOptions =
     item.type === STORAGE_ROW_TYPES.FOLDER
       ? [
-        ...(canUpdateFiles
-          ? [
-            {
-              name: 'Rename',
-              icon: <Edit size={14} strokeWidth={1} />,
-              onClick: () => setSelectedItemToRename(itemWithColumnIndex),
-            },
-          ]
-          : []),
-        {
-          name: 'Download',
-          icon: <Download size={14} strokeWidth={1} />,
-          onClick: () => downloadFolder(itemWithColumnIndex),
-        },
-        {
-          name: 'Copy path to folder',
-          icon: <Copy size={14} strokeWidth={1} />,
-          onClick: () => copyPathToFolder(openedFolders, itemWithColumnIndex),
-        },
-        ...(canUpdateFiles
-          ? [
-            { name: 'Separator', icon: undefined, onClick: undefined },
-            {
-              name: 'Delete',
-              icon: <Trash2 size={14} strokeWidth={1} />,
-              onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
-            },
-          ]
-          : []),
-      ]
-      : [
-        ...(!item.isCorrupted
-          ? [
-            ...(isPublic
-              ? [
-                {
-                  name: 'Get URL',
-                  icon: <Copy size={14} strokeWidth={1} />,
-                  onClick: () => onCopyUrl(itemWithColumnIndex),
-                },
-              ]
-              : [
-                {
-                  name: 'Get URL',
-                  icon: <Copy size={14} strokeWidth={1} />,
-                  children: [
-                    {
-                      name: 'Expire in 1 week',
-                      onClick: () =>
-                        onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.WEEK),
-                    },
-                    {
-                      name: 'Expire in 1 month',
-                      onClick: () =>
-                        onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.MONTH),
-                    },
-                    {
-                      name: 'Expire in 1 year',
-                      onClick: () =>
-                        onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.YEAR),
-                    },
-                    {
-                      name: 'Custom expiry',
-                      onClick: () => setSelectedFileCustomExpiry(itemWithColumnIndex),
-                    },
-                  ],
-                },
-              ]),
-            ...(canUpdateFiles
-              ? [
+          ...(canUpdateFiles
+            ? [
                 {
                   name: 'Rename',
                   icon: <Edit size={14} strokeWidth={1} />,
                   onClick: () => setSelectedItemToRename(itemWithColumnIndex),
                 },
-                {
-                  name: 'Move',
-                  icon: <Move size={14} strokeWidth={1} />,
-                  onClick: () => setSelectedItemsToMove([itemWithColumnIndex]),
-                },
-                {
-                  name: 'Download',
-                  icon: <Download size={14} strokeWidth={1} />,
-                  onClick: () => downloadFile(itemWithColumnIndex),
-                },
-                { name: 'Separator', icon: undefined, onClick: undefined },
               ]
-              : []),
-          ]
-          : []),
-        ...(canUpdateFiles
-          ? [
-            {
-              name: 'Delete',
-              icon: <Trash2 size={14} strokeWidth={1} />,
-              onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
-            },
-          ]
-          : []),
-      ]
+            : []),
+          {
+            name: 'Download',
+            icon: <Download size={14} strokeWidth={1} />,
+            onClick: () => downloadFolder(itemWithColumnIndex),
+          },
+          {
+            name: 'Copy path to folder',
+            icon: <Copy size={14} strokeWidth={1} />,
+            onClick: () => copyPathToFolder(openedFolders, itemWithColumnIndex),
+          },
+          ...(canUpdateFiles
+            ? [
+                { name: 'Separator', icon: undefined, onClick: undefined },
+                {
+                  name: 'Delete',
+                  icon: <Trash2 size={14} strokeWidth={1} />,
+                  onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
+                },
+              ]
+            : []),
+        ]
+      : [
+          ...(!item.isCorrupted
+            ? [
+                ...(isPublic
+                  ? [
+                      {
+                        name: 'Get URL',
+                        icon: <Copy size={14} strokeWidth={1} />,
+                        onClick: () => onCopyUrl(itemWithColumnIndex),
+                      },
+                    ]
+                  : [
+                      {
+                        name: 'Get URL',
+                        icon: <Copy size={14} strokeWidth={1} />,
+                        children: [
+                          {
+                            name: 'Expire in 1 week',
+                            onClick: () => onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.WEEK),
+                          },
+                          {
+                            name: 'Expire in 1 month',
+                            onClick: () =>
+                              onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.MONTH),
+                          },
+                          {
+                            name: 'Expire in 1 year',
+                            onClick: () => onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.YEAR),
+                          },
+                          {
+                            name: 'Custom expiry',
+                            onClick: () => setSelectedFileCustomExpiry(itemWithColumnIndex),
+                          },
+                        ],
+                      },
+                    ]),
+                ...(canUpdateFiles
+                  ? [
+                      {
+                        name: 'Rename',
+                        icon: <Edit size={14} strokeWidth={1} />,
+                        onClick: () => setSelectedItemToRename(itemWithColumnIndex),
+                      },
+                      {
+                        name: 'Move',
+                        icon: <Move size={14} strokeWidth={1} />,
+                        onClick: () => setSelectedItemsToMove([itemWithColumnIndex]),
+                      },
+                      {
+                        name: 'Download',
+                        icon: <Download size={14} strokeWidth={1} />,
+                        onClick: () => downloadFile(itemWithColumnIndex),
+                      },
+                      { name: 'Separator', icon: undefined, onClick: undefined },
+                    ]
+                  : []),
+              ]
+            : []),
+          ...(canUpdateFiles
+            ? [
+                {
+                  name: 'Delete',
+                  icon: <Trash2 size={14} strokeWidth={1} />,
+                  onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
+                },
+              ]
+            : []),
+        ]
 
   const size = item.metadata ? formatBytes(item.metadata.size) : '-'
   const mimeType = item.metadata ? item.metadata.mimetype : '-'
@@ -339,8 +337,9 @@ export const FileExplorerRow = ({
           <div className="relative w-[30px]" onClick={(event) => event.stopPropagation()}>
             {!isSelected && (
               <div
-                className={`absolute ${item.type === STORAGE_ROW_TYPES.FILE ? 'group-hover:hidden' : ''
-                  }`}
+                className={`absolute ${
+                  item.type === STORAGE_ROW_TYPES.FILE ? 'group-hover:hidden' : ''
+                }`}
                 style={{ top: '2px' }}
               >
                 <RowIcon
@@ -353,8 +352,9 @@ export const FileExplorerRow = ({
             )}
             <Checkbox
               label={''}
-              className={`w-full ${item.type !== STORAGE_ROW_TYPES.FILE ? 'invisible' : ''} ${isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-                }`}
+              className={`w-full ${item.type !== STORAGE_ROW_TYPES.FILE ? 'invisible' : ''} ${
+                isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+              }`}
               checked={isSelected}
               onChange={(event) => {
                 event.stopPropagation()
@@ -387,8 +387,9 @@ export const FileExplorerRow = ({
         )}
 
         <div
-          className={`flex items-center justify-end ${view === STORAGE_VIEWS.LIST ? 'flex-grow' : 'w-[10%]'
-            }`}
+          className={`flex items-center justify-end ${
+            view === STORAGE_VIEWS.LIST ? 'flex-grow' : 'w-[10%]'
+          }`}
           onClick={(event) =>
             // Stops click event from this div, to resolve an issue with menu item's click event triggering unexpected row select
             event.stopPropagation()

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -169,106 +169,106 @@ export const FileExplorerRow = ({
   const rowOptions =
     item.type === STORAGE_ROW_TYPES.FOLDER
       ? [
-          ...(canUpdateFiles
-            ? [
+        ...(canUpdateFiles
+          ? [
+            {
+              name: 'Rename',
+              icon: <Edit size={14} strokeWidth={1} />,
+              onClick: () => setSelectedItemToRename(itemWithColumnIndex),
+            },
+          ]
+          : []),
+        {
+          name: 'Download',
+          icon: <Download size={14} strokeWidth={1} />,
+          onClick: () => downloadFolder(itemWithColumnIndex),
+        },
+        {
+          name: 'Copy path to folder',
+          icon: <Copy size={14} strokeWidth={1} />,
+          onClick: () => copyPathToFolder(openedFolders, itemWithColumnIndex),
+        },
+        ...(canUpdateFiles
+          ? [
+            { name: 'Separator', icon: undefined, onClick: undefined },
+            {
+              name: 'Delete',
+              icon: <Trash2 size={14} strokeWidth={1} />,
+              onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
+            },
+          ]
+          : []),
+      ]
+      : [
+        ...(!item.isCorrupted
+          ? [
+            ...(isPublic
+              ? [
+                {
+                  name: 'Get URL',
+                  icon: <Copy size={14} strokeWidth={1} />,
+                  onClick: () => onCopyUrl(itemWithColumnIndex),
+                },
+              ]
+              : [
+                {
+                  name: 'Get URL',
+                  icon: <Copy size={14} strokeWidth={1} />,
+                  children: [
+                    {
+                      name: 'Expire in 1 week',
+                      onClick: () =>
+                        onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.WEEK),
+                    },
+                    {
+                      name: 'Expire in 1 month',
+                      onClick: () =>
+                        onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.MONTH),
+                    },
+                    {
+                      name: 'Expire in 1 year',
+                      onClick: () =>
+                        onCopyUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.YEAR),
+                    },
+                    {
+                      name: 'Custom expiry',
+                      onClick: () => setSelectedFileCustomExpiry(itemWithColumnIndex),
+                    },
+                  ],
+                },
+              ]),
+            ...(canUpdateFiles
+              ? [
                 {
                   name: 'Rename',
                   icon: <Edit size={14} strokeWidth={1} />,
                   onClick: () => setSelectedItemToRename(itemWithColumnIndex),
                 },
-              ]
-            : []),
-          {
-            name: 'Download',
-            icon: <Download size={14} strokeWidth={1} />,
-            onClick: () => downloadFolder(itemWithColumnIndex),
-          },
-          {
-            name: 'Copy path to folder',
-            icon: <Copy size={14} strokeWidth={1} />,
-            onClick: () => copyPathToFolder(openedFolders, itemWithColumnIndex),
-          },
-          ...(canUpdateFiles
-            ? [
+                {
+                  name: 'Move',
+                  icon: <Move size={14} strokeWidth={1} />,
+                  onClick: () => setSelectedItemsToMove([itemWithColumnIndex]),
+                },
+                {
+                  name: 'Download',
+                  icon: <Download size={14} strokeWidth={1} />,
+                  onClick: () => downloadFile(itemWithColumnIndex),
+                },
                 { name: 'Separator', icon: undefined, onClick: undefined },
-                {
-                  name: 'Delete',
-                  icon: <Trash2 size={14} strokeWidth={1} />,
-                  onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
-                },
               ]
-            : []),
-        ]
-      : [
-          ...(!item.isCorrupted
-            ? [
-                ...(isPublic
-                  ? [
-                      {
-                        name: 'Get URL',
-                        icon: <Copy size={14} strokeWidth={1} />,
-                        onClick: () => onCopyUrl(itemWithColumnIndex.name),
-                      },
-                    ]
-                  : [
-                      {
-                        name: 'Get URL',
-                        icon: <Copy size={14} strokeWidth={1} />,
-                        children: [
-                          {
-                            name: 'Expire in 1 week',
-                            onClick: () =>
-                              onCopyUrl(itemWithColumnIndex.name, URL_EXPIRY_DURATION.WEEK),
-                          },
-                          {
-                            name: 'Expire in 1 month',
-                            onClick: () =>
-                              onCopyUrl(itemWithColumnIndex.name, URL_EXPIRY_DURATION.MONTH),
-                          },
-                          {
-                            name: 'Expire in 1 year',
-                            onClick: () =>
-                              onCopyUrl(itemWithColumnIndex.name, URL_EXPIRY_DURATION.YEAR),
-                          },
-                          {
-                            name: 'Custom expiry',
-                            onClick: () => setSelectedFileCustomExpiry(itemWithColumnIndex),
-                          },
-                        ],
-                      },
-                    ]),
-                ...(canUpdateFiles
-                  ? [
-                      {
-                        name: 'Rename',
-                        icon: <Edit size={14} strokeWidth={1} />,
-                        onClick: () => setSelectedItemToRename(itemWithColumnIndex),
-                      },
-                      {
-                        name: 'Move',
-                        icon: <Move size={14} strokeWidth={1} />,
-                        onClick: () => setSelectedItemsToMove([itemWithColumnIndex]),
-                      },
-                      {
-                        name: 'Download',
-                        icon: <Download size={14} strokeWidth={1} />,
-                        onClick: () => downloadFile(itemWithColumnIndex),
-                      },
-                      { name: 'Separator', icon: undefined, onClick: undefined },
-                    ]
-                  : []),
-              ]
-            : []),
-          ...(canUpdateFiles
-            ? [
-                {
-                  name: 'Delete',
-                  icon: <Trash2 size={14} strokeWidth={1} />,
-                  onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
-                },
-              ]
-            : []),
-        ]
+              : []),
+          ]
+          : []),
+        ...(canUpdateFiles
+          ? [
+            {
+              name: 'Delete',
+              icon: <Trash2 size={14} strokeWidth={1} />,
+              onClick: () => setSelectedItemsToDelete([itemWithColumnIndex]),
+            },
+          ]
+          : []),
+      ]
 
   const size = item.metadata ? formatBytes(item.metadata.size) : '-'
   const mimeType = item.metadata ? item.metadata.mimetype : '-'
@@ -339,9 +339,8 @@ export const FileExplorerRow = ({
           <div className="relative w-[30px]" onClick={(event) => event.stopPropagation()}>
             {!isSelected && (
               <div
-                className={`absolute ${
-                  item.type === STORAGE_ROW_TYPES.FILE ? 'group-hover:hidden' : ''
-                }`}
+                className={`absolute ${item.type === STORAGE_ROW_TYPES.FILE ? 'group-hover:hidden' : ''
+                  }`}
                 style={{ top: '2px' }}
               >
                 <RowIcon
@@ -354,9 +353,8 @@ export const FileExplorerRow = ({
             )}
             <Checkbox
               label={''}
-              className={`w-full ${item.type !== STORAGE_ROW_TYPES.FILE ? 'invisible' : ''} ${
-                isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-              }`}
+              className={`w-full ${item.type !== STORAGE_ROW_TYPES.FILE ? 'invisible' : ''} ${isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                }`}
               checked={isSelected}
               onChange={(event) => {
                 event.stopPropagation()
@@ -389,9 +387,8 @@ export const FileExplorerRow = ({
         )}
 
         <div
-          className={`flex items-center justify-end ${
-            view === STORAGE_VIEWS.LIST ? 'flex-grow' : 'w-[10%]'
-          }`}
+          className={`flex items-center justify-end ${view === STORAGE_VIEWS.LIST ? 'flex-grow' : 'w-[10%]'
+            }`}
           onClick={(event) =>
             // Stops click event from this div, to resolve an issue with menu item's click event triggering unexpected row select
             event.stopPropagation()

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ItemContextMenu.tsx
@@ -34,7 +34,7 @@ export const ItemContextMenu = ({ id = '' }: ItemContextMenuProps) => {
     switch (event) {
       case 'copy':
         if (expiresIn !== undefined && expiresIn < 0) return setSelectedFileCustomExpiry(item)
-        else return onCopyUrl(item.name, expiresIn)
+        else return onCopyUrl(item, expiresIn)
       case 'rename':
         return setSelectedItemToRename(item)
       case 'move':

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -212,7 +212,7 @@ export const PreviewPane = () => {
               <Button
                 type="outline"
                 icon={<Copy />}
-                onClick={() => onCopyUrl(file.name)}
+                onClick={() => onCopyUrl(file)}
                 disabled={file.isCorrupted}
               >
                 Get URL
@@ -232,19 +232,19 @@ export const PreviewPane = () => {
                 <DropdownMenuContent side="bottom" align="center">
                   <DropdownMenuItem
                     key="expires-one-week"
-                    onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.WEEK)}
+                    onClick={() => onCopyUrl(file, URL_EXPIRY_DURATION.WEEK)}
                   >
                     Expire in 1 week
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     key="expires-one-month"
-                    onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.MONTH)}
+                    onClick={() => onCopyUrl(file, URL_EXPIRY_DURATION.MONTH)}
                   >
                     Expire in 1 month
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     key="expires-one-year"
-                    onClick={() => onCopyUrl(file.name, URL_EXPIRY_DURATION.YEAR)}
+                    onClick={() => onCopyUrl(file, URL_EXPIRY_DURATION.YEAR)}
                   >
                     Expire in 1 year
                   </DropdownMenuItem>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/useCopyUrl.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/useCopyUrl.tsx
@@ -8,6 +8,7 @@ import { copyToClipboard } from 'ui'
 import { URL_EXPIRY_DURATION } from '../Storage.constants'
 import { getPathAlongOpenedFolders } from './StorageExplorer.utils'
 import { fetchFileUrl } from './useFetchFileUrlQuery'
+import { StorageItem, StorageItemWithColumn } from '../Storage.types'
 
 export const useCopyUrl = () => {
   const { projectRef, selectedBucket, openedFolders } = useStorageExplorerStateSnapshot()
@@ -19,9 +20,9 @@ export const useCopyUrl = () => {
   const apiUrl = `${protocol}://${endpoint ?? '-'}`
 
   const getFileUrl = useCallback(
-    (fileName: string, expiresIn?: URL_EXPIRY_DURATION) => {
+    (item: StorageItemWithColumn | StorageItem, expiresIn?: URL_EXPIRY_DURATION) => {
       const pathToFile = getPathAlongOpenedFolders({ openedFolders, selectedBucket }, false)
-      const formattedPathToFile = [pathToFile, fileName].join('/')
+      const formattedPathToFile = item.path ?? [pathToFile, item.name].join('/')
 
       return fetchFileUrl(
         formattedPathToFile,
@@ -35,15 +36,15 @@ export const useCopyUrl = () => {
   )
 
   const onCopyUrl = useCallback(
-    (name: string, expiresIn?: URL_EXPIRY_DURATION) => {
-      const formattedUrl = getFileUrl(name, expiresIn).then((url) => {
+    (item: StorageItemWithColumn | StorageItem, expiresIn?: URL_EXPIRY_DURATION) => {
+      const formattedUrl = getFileUrl(item, expiresIn).then((url) => {
         return customDomainData?.customDomain?.status === 'active'
           ? url.replace(apiUrl, `https://${customDomainData.customDomain.hostname}`)
           : url
       })
 
       return copyToClipboard(formattedUrl, () => {
-        toast.success(`Copied URL for ${name} to clipboard.`)
+        toast.success(`Copied URL for ${item.name} to clipboard.`)
       })
     },
     [

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/useFetchFileUrlQuery.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/useFetchFileUrlQuery.tsx
@@ -46,7 +46,7 @@ export const useFetchFileUrlQuery = (
 ) => {
   const { openedFolders, selectedBucket } = useStorageExplorerStateSnapshot()
   const pathToFile = getPathAlongOpenedFolders({ openedFolders, selectedBucket }, false)
-  const formattedPathToFile = [pathToFile, file?.name].join('/')
+  const formattedPathToFile = file?.path ?? [pathToFile, file?.name].join('/')
 
   return useQuery<string, ResponseError, string>({
     queryKey: [projectRef, 'buckets', bucket.public, bucket.id, 'file', formattedPathToFile],


### PR DESCRIPTION
## Summary

Fix  Edge case in incorrect URL generation in Storage Explorer when clicking "Get URL" on files located outside the currently opened folder.

## Problem

When inside a subfolder ( `bucket/folder/`), 
clicking "Get URL" on a file from a parent directory (`bucket/image.jpg`) generates a broken 404 link like `bucket/folder/image.jpg`
instead of the correct `bucket/image.jpg`.

## Solution

Use the file's intrinsic `path` property from the API response for URL generation, instead of constructing the path from the current UI navigation context.

## Related

- closes https://github.com/supabase/supabase/issues/42357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced "Get URL / Copy URL" so it consistently uses the full file item (prefers explicit file path when present) and works uniformly across preview, row, and context menus.
  * Expiry actions now reliably apply selected expiry when copying URLs.

* **Bug Fixes**
  * Fixed inconsistent URL generation when items include an explicit path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->