### PR TITLE
fix: Bring Vite before create-react-app in connect on the dashboard

### DIFF
--- a/apps/studio/components/interfaces/Connect/Connect.constants.ts
+++ b/apps/studio/components/interfaces/Connect/Connect.constants.ts
@@ -127,19 +127,6 @@ export const FRAMEWORKS: ConnectionType[] = [
     guideLink: `${DOCS_URL}/guides/getting-started/quickstarts/reactjs`,
     children: [
       {
-        key: 'create-react-app',
-        label: 'Create React App',
-        icon: 'react',
-        children: [
-          {
-            key: 'supabasejs',
-            label: 'supabase-js',
-            icon: 'supabase',
-            children: [],
-          },
-        ],
-      },
-      {
         key: 'vite',
         label: 'Vite',
         icon: 'vite',
@@ -149,6 +136,19 @@ export const FRAMEWORKS: ConnectionType[] = [
             label: 'Supabase-js',
             children: [],
             icon: 'supabase',
+          },
+        ],
+      },
+      {
+        key: 'create-react-app',
+        label: 'Create React App',
+        icon: 'react',
+        children: [
+          {
+            key: 'supabasejs',
+            label: 'supabase-js',
+            icon: 'supabase',
+            children: [],
           },
         ],
       },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

`create-react-app` is deprecated, so this PR brings vite before `create-react-app` when opening React in the connect dialog. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered React framework options in the connection interface and updated associated icons and labels for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->