### PR TITLE
feat(telemetry): dedupe experiment exposure events by PostHog session ID

### DIFF
--- a/apps/studio/hooks/misc/useRealtimeExperiment.ts
+++ b/apps/studio/hooks/misc/useRealtimeExperiment.ts
@@ -1,8 +1,7 @@
-import { useMemo } from 'react'
-
-import { usePHFlag } from 'hooks/ui/useFlag'
 import { useTrackExperimentExposure } from 'hooks/misc/useTrackExperimentExposure'
+import { usePHFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM } from 'lib/constants'
+import { useMemo } from 'react'
 
 export enum RealtimeButtonVariant {
   CONTROL = 'control',
@@ -42,11 +41,9 @@ export function useRealtimeExperiment({
 
   const shouldTrack = IS_PLATFORM && isTable && !!realtimeButtonVariant
 
-  useTrackExperimentExposure(
-    'realtime',
-    shouldTrack ? realtimeButtonVariant : undefined,
-    { table_has_realtime_enabled: isRealtimeEnabled }
-  )
+  useTrackExperimentExposure('realtime', shouldTrack ? realtimeButtonVariant : undefined, {
+    table_has_realtime_enabled: isRealtimeEnabled,
+  })
 
   return {
     activeVariant,

--- a/apps/studio/hooks/misc/useRealtimeExperiment.ts
+++ b/apps/studio/hooks/misc/useRealtimeExperiment.ts
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 
 import { usePHFlag } from 'hooks/ui/useFlag'
+import { useTrackExperimentExposure } from 'hooks/misc/useTrackExperimentExposure'
 import { IS_PLATFORM } from 'lib/constants'
-import { useTrack } from 'lib/telemetry/track'
 
 export enum RealtimeButtonVariant {
   CONTROL = 'control',
@@ -30,9 +30,7 @@ export function useRealtimeExperiment({
   isTable = false,
   isRealtimeEnabled = false,
 }: UseRealtimeExperimentOptions): UseRealtimeExperimentResult {
-  const track = useTrack()
   const realtimeButtonVariant = usePHFlag<RealtimeButtonVariant>('realtimeButtonVariant')
-  const hasTrackedExposure = useRef(false)
 
   const activeVariant = useMemo(() => {
     if (!IS_PLATFORM) return null
@@ -42,25 +40,13 @@ export function useRealtimeExperiment({
     return realtimeButtonVariant
   }, [isTable, realtimeButtonVariant])
 
-  useEffect(() => {
-    if (!IS_PLATFORM) return
-    if (hasTrackedExposure.current) return
-    if (!isTable || !realtimeButtonVariant) return
+  const shouldTrack = IS_PLATFORM && isTable && !!realtimeButtonVariant
 
-    hasTrackedExposure.current = true
-
-    try {
-      track('realtime_experiment_exposed', {
-        experiment_id: 'realtimeButtonVariant',
-        variant: realtimeButtonVariant,
-        table_has_realtime_enabled: isRealtimeEnabled,
-      })
-    } catch (error) {
-      // Reset tracking flag on error to allow retry
-      hasTrackedExposure.current = false
-      console.error('Failed to track realtime experiment exposure:', error)
-    }
-  }, [isTable, realtimeButtonVariant, isRealtimeEnabled, track])
+  useTrackExperimentExposure(
+    'realtime',
+    shouldTrack ? realtimeButtonVariant : undefined,
+    { table_has_realtime_enabled: isRealtimeEnabled }
+  )
 
   return {
     activeVariant,

--- a/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
+++ b/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
@@ -1,10 +1,9 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useMemo } from 'react'
-
-import { usePHFlag } from 'hooks/ui/useFlag'
 import { useTrackExperimentExposure } from 'hooks/misc/useTrackExperimentExposure'
+import { usePHFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM } from 'lib/constants'
+import { useMemo } from 'react'
 
 dayjs.extend(utc)
 

--- a/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
+++ b/apps/studio/hooks/misc/useTableCreateGeneratePolicies.ts
@@ -1,10 +1,10 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 
 import { usePHFlag } from 'hooks/ui/useFlag'
+import { useTrackExperimentExposure } from 'hooks/misc/useTrackExperimentExposure'
 import { IS_PLATFORM } from 'lib/constants'
-import { useTrack } from 'lib/telemetry/track'
 
 dayjs.extend(utc)
 
@@ -50,9 +50,7 @@ export function useTableCreateGeneratePolicies({
   isNewRecord = false,
   projectInsertedAt,
 }: UseTableCreateGeneratePoliciesOptions): UseTableCreateGeneratePoliciesResult {
-  const track = useTrack()
   const tableCreateGeneratePoliciesFlag = usePHFlag<string>('tableCreateGeneratePolicies')
-  const hasTrackedExposure = useRef(false)
 
   const enabled = useMemo(() => {
     if (!IS_PLATFORM) return false
@@ -60,28 +58,24 @@ export function useTableCreateGeneratePolicies({
     return true
   }, [tableCreateGeneratePoliciesFlag])
 
-  useEffect(() => {
-    if (!IS_PLATFORM) return
-    if (hasTrackedExposure.current) return
-    if (!isNewRecord) return
-    if (!isValidExperimentVariant(tableCreateGeneratePoliciesFlag)) return
-    if (!projectInsertedAt) return
+  const daysSinceCreation = useMemo(() => {
+    if (!projectInsertedAt) return undefined
+    const insertedDate = dayjs.utc(projectInsertedAt)
+    if (!insertedDate.isValid()) return undefined
+    return dayjs.utc().diff(insertedDate, 'day')
+  }, [projectInsertedAt])
 
-    try {
-      const insertedDate = dayjs.utc(projectInsertedAt)
-      if (!insertedDate.isValid()) return
+  const shouldTrack =
+    IS_PLATFORM &&
+    isNewRecord &&
+    isValidExperimentVariant(tableCreateGeneratePoliciesFlag) &&
+    daysSinceCreation !== undefined
 
-      const daysSinceCreation = dayjs.utc().diff(insertedDate, 'day')
-      track('table_create_generate_policies_experiment_exposed', {
-        experiment_id: 'tableCreateGeneratePolicies',
-        variant: tableCreateGeneratePoliciesFlag,
-        days_since_project_creation: daysSinceCreation,
-      })
-      hasTrackedExposure.current = true
-    } catch {
-      hasTrackedExposure.current = false
-    }
-  }, [isNewRecord, tableCreateGeneratePoliciesFlag, projectInsertedAt, track])
+  useTrackExperimentExposure(
+    'table_create_generate_policies',
+    shouldTrack ? tableCreateGeneratePoliciesFlag : undefined,
+    { days_since_project_creation: daysSinceCreation }
+  )
 
   return {
     enabled,

--- a/apps/studio/hooks/misc/useTrackExperimentExposure.ts
+++ b/apps/studio/hooks/misc/useTrackExperimentExposure.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+import { hasConsented, posthogClient } from 'common'
+
+export function useTrackExperimentExposure(
+  experimentId: string,
+  variant: string | undefined,
+  extraProperties?: Record<string, any>
+) {
+  useEffect(() => {
+    if (!variant) return
+
+    posthogClient.captureExperimentExposure(
+      experimentId,
+      { variant, ...extraProperties },
+      hasConsented()
+    )
+  }, [experimentId, variant])
+}

--- a/apps/studio/hooks/misc/useTrackExperimentExposure.ts
+++ b/apps/studio/hooks/misc/useTrackExperimentExposure.ts
@@ -1,6 +1,5 @@
-import { useEffect } from 'react'
-
 import { hasConsented, posthogClient } from 'common'
+import { useEffect } from 'react'
 
 export function useTrackExperimentExposure(
   experimentId: string,

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -19,6 +19,7 @@ class PostHogClient {
   private pendingGroups: Record<string, string> = {}
   private pendingIdentification: { userId: string; properties?: Record<string, any> } | null = null
   private pendingEvents: Array<{ event: string; properties: Record<string, any> }> = []
+  private pendingExposures: Array<{ experimentId: string; properties: Record<string, any> }> = []
   private config: PostHogClientConfig
   private readonly maxPendingEvents = MAX_PENDING_EVENTS
 
@@ -84,6 +85,12 @@ class PostHogClient {
         this.pendingEvents = []
 
         this.initialized = true
+
+        // Flush any pending experiment exposures (with deduplication)
+        this.pendingExposures.forEach(({ experimentId, properties }) => {
+          this.fireExposureIfNew(experimentId, properties)
+        })
+        this.pendingExposures = []
       },
     }
 
@@ -181,6 +188,57 @@ class PostHogClient {
     } catch (error) {
       console.error('PostHog getDistinctId failed:', error)
       return undefined
+    }
+  }
+
+  /**
+   * Returns PostHog's session_id for the current session.
+   * Returns undefined until PostHog's `loaded` callback fires.
+   */
+  getSessionId(): string | undefined {
+    if (!this.initialized) return undefined
+
+    try {
+      return posthog.get_session_id()
+    } catch (error) {
+      console.error('PostHog getSessionId failed:', error)
+      return undefined
+    }
+  }
+
+  /**
+   * Captures an experiment exposure event with session-based deduplication.
+   * Events are queued if PostHog is not yet initialized, then deduped on flush.
+   */
+  captureExperimentExposure(
+    experimentId: string,
+    properties: Record<string, any>,
+    hasConsent: boolean = true
+  ) {
+    if (!hasConsent) return
+
+    if (!this.initialized) {
+      this.pendingExposures.push({ experimentId, properties })
+      return
+    }
+
+    this.fireExposureIfNew(experimentId, properties)
+  }
+
+  private fireExposureIfNew(experimentId: string, properties: Record<string, any>) {
+    const sessionId = this.getSessionId()
+    if (!sessionId) return
+
+    const storageKey = `ph_exposed:${experimentId}`
+
+    try {
+      if (sessionStorage.getItem(storageKey) === sessionId) return
+
+      const eventName = `${experimentId}_experiment_exposed`
+      posthog.capture(eventName, { experiment_id: experimentId, ...properties })
+      sessionStorage.setItem(storageKey, sessionId)
+    } catch (error) {
+      console.error('PostHog experiment exposure capture failed:', error)
     }
   }
 }

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -166,6 +166,7 @@ class PostHogClient {
     this.pendingIdentification = null
     this.pendingGroups = {}
     this.pendingEvents = []
+    this.pendingExposures = []
 
     if (!this.initStarted) return
 
@@ -218,7 +219,13 @@ class PostHogClient {
     if (!hasConsent) return
 
     if (!this.initialized) {
-      this.pendingExposures.push({ experimentId, properties })
+      // Only queue if not already queued for this experiment (first exposure wins)
+      if (!this.pendingExposures.some((e) => e.experimentId === experimentId)) {
+        if (this.pendingExposures.length >= this.maxPendingEvents) {
+          this.pendingExposures.shift()
+        }
+        this.pendingExposures.push({ experimentId, properties })
+      }
       return
     }
 


### PR DESCRIPTION
## Summary

Adds session-based deduplication for experiment exposure events. Previously, exposure events used `useRef` which reset on page refresh, causing duplicate events. Now events dedupe by PostHog session ID using `sessionStorage`, firing once per session even across page refreshes.

## Changes

- Add `captureExperimentExposure()` method to `PostHogClient` with session-based dedupe
- Add `getSessionId()` method to retrieve PostHog session ID
- Create `useTrackExperimentExposure` hook for clean usage
- Migrate existing experiments to new hook:
  - RLS option experiment (`/new/[slug]`)
  - Realtime button experiment
  - Table create generate policies experiment

## How it works

1. Event triggered → if PostHog not ready, queue to `pendingExposures[]`
2. PostHog `loaded` → flush queue through `fireExposureIfNew()`
3. `fireExposureIfNew()` checks `sessionStorage['ph_exposed:{experimentId}']`
4. If value matches current session ID → skip (already fired)
5. If differs or missing → fire event, store session ID

## Testing

- [x] Tested locally and on preview - verified on project creation page
- [x] PostHog events sent successfully (200 responses)
- [x] Session deduplication working (no duplicate events on page refresh or org switch)
- [x] Lint passes with 0 errors

**Quick test:**
1. Go to `/new/<org-slug>` project creation page
2. Check `sessionStorage` for `ph_exposed:project_creation_rls_option` key
3. Refresh page - event should not fire again (same session ID)

## Linear

Resolves GROWTH-608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable experiment exposure reporting with session-aware deduplication, queued delivery, and consent respect to ensure events are recorded when available.
* **Bug Fixes**
  * Prevents duplicate exposure events within a session and avoids firing exposures without a valid session.
* **Refactor**
  * Consolidated disparate exposure-tracking logic into a unified hook-based approach, simplifying tracking across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->