### PR TITLE
fix(studio): fix Safari clipboard API for async copy operations

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
@@ -1,9 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
-import { Eye, EyeOff } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
-
 import { InputVariants } from '@ui/components/shadcn/ui/input'
 import { useParams } from 'common'
 import CopyButton from 'components/ui/CopyButton'
@@ -11,7 +7,9 @@ import { useAPIKeyIdQuery } from 'data/api-keys/api-key-id-query'
 import { APIKeysData } from 'data/api-keys/api-keys-query'
 import { apiKeysKeys } from 'data/api-keys/keys'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Eye, EyeOff } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Button, Tooltip, TooltipContent, TooltipTrigger, cn } from 'ui'
 
 export function ApiKeyPill({
   apiKey,
@@ -23,6 +21,8 @@ export function ApiKeyPill({
 
   // State that controls whether to show the full API key
   const [show, setShowState] = useState(false)
+  // Prefetched key for Safari clipboard compatibility
+  const [prefetchedKey, setPrefetchedKey] = useState<string | null>(null)
 
   const isSecret = apiKey.type === 'secret'
 
@@ -78,31 +78,35 @@ export function ApiKeyPill({
     setShowState(!show)
   }
 
-  async function onCopy() {
-    // If key is already revealed, use that value
-    if (data?.api_key) return data?.api_key ?? ''
+  async function prefetchKey() {
+    // Pre-fetch key on hover so it's ready when user clicks
+    // Safari requires clipboard data to be available immediately
+    if (prefetchedKey || data?.api_key || !isSecret) return
 
     try {
-      // Fetch full key and immediately clear from cache after copying
       const result = await refetchApiKey()
+      if (result.isSuccess && result.data.api_key) {
+        setPrefetchedKey(result.data.api_key)
+      }
       queryClient.removeQueries({
         queryKey: apiKeysKeys.single(projectRef, apiKey.id as string),
         exact: true,
       })
+    } catch (err) {
+      console.error('Failed to prefetch API key:', err)
+    }
+  }
 
-      if (result.isSuccess) return result.data.api_key ?? ''
+  function onCopy() {
+    // Use already-revealed key, prefetched key, or fall back to masked key
+    const key = data?.api_key ?? prefetchedKey ?? apiKey.api_key
 
-      if (error) {
-        toast.error('Failed to copy secret API key')
-        return ''
-      }
-    } catch (error) {
-      console.error('Failed to fetch API key:', error)
-      return ''
+    // Clear prefetched key after copying for security
+    if (prefetchedKey) {
+      setTimeout(() => setPrefetchedKey(null), 0)
     }
 
-    // Fallback to the masked version if fetch fails
-    return apiKey.api_key
+    return key
   }
 
   // States for disabling buttons/showing tooltips
@@ -165,6 +169,8 @@ export function ApiKeyPill({
             iconOnly
             className="rounded-full px-2 pointer-events-auto"
             disabled={isRestricted || isLoadingPermission}
+            onMouseEnter={prefetchKey}
+            onMouseLeave={() => setPrefetchedKey(null)}
           />
         </TooltipTrigger>
         <TooltipContent side="bottom">

--- a/apps/studio/components/interfaces/Functions/CommandRender.tsx
+++ b/apps/studio/components/interfaces/Functions/CommandRender.tsx
@@ -1,6 +1,5 @@
 import { Check, Copy } from 'lucide-react'
 import { forwardRef, useState } from 'react'
-
 import { cn, copyToClipboard } from 'ui'
 
 const CommandRender = forwardRef<HTMLDivElement, { commands: any[]; className?: string }>(
@@ -33,7 +32,7 @@ const Command = ({ item }: any) => {
             <button
               type="button"
               className="text-foreground-lighter hover:text-foreground"
-              onClick={() => {
+              onPointerDownCapture={() => {
                 function onCopy(value: any) {
                   setIsCopied(true)
                   copyToClipboard(value)

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableInstructions.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableInstructions.tsx
@@ -1,32 +1,32 @@
+import { useParams } from 'common'
 import { Eye, EyeOff } from 'lucide-react'
 import { useMemo, useState } from 'react'
-
-import { useParams } from 'common'
-import CommandRender from 'components/interfaces/Functions/CommandRender'
-import { convertKVStringArrayToJson } from 'components/interfaces/Integrations/Wrappers/Wrappers.utils'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import CopyButton from 'components/ui/CopyButton'
-import { InlineLink } from 'components/ui/InlineLink'
-import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import {
-  getDecryptedValues,
-  useVaultSecretDecryptedValueQuery,
-} from 'data/vault/vault-secret-decrypted-value-query'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { DOCS_URL } from 'lib/constants'
-import {
-  Accordion_Shadcn_,
   AccordionContent_Shadcn_,
   AccordionItem_Shadcn_,
   AccordionTrigger_Shadcn_,
+  Accordion_Shadcn_,
   Card,
   CardFooter,
   CardHeader,
   CardTitle,
   CodeBlock,
 } from 'ui'
+
 import { useAnalyticsBucketWrapperInstance } from '../useAnalyticsBucketWrapperInstance'
 import { getPyicebergSnippet } from './CreateTableInstructions.constants'
+import CommandRender from '@/components/interfaces/Functions/CommandRender'
+import { convertKVStringArrayToJson } from '@/components/interfaces/Integrations/Wrappers/Wrappers.utils'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import CopyButton from '@/components/ui/CopyButton'
+import { InlineLink } from '@/components/ui/InlineLink'
+import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
+import {
+  getDecryptedValues,
+  useVaultSecretDecryptedValueQuery,
+} from '@/data/vault/vault-secret-decrypted-value-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { DOCS_URL } from '@/lib/constants'
 
 export const CreateTableInstructions = ({
   hideHeader = false,
@@ -39,6 +39,7 @@ export const CreateTableInstructions = ({
   const { data: project } = useSelectedProjectQuery()
   const [showKeys, setShowKeys] = useState(false)
   const [isFetchingSecretsOnCopy, setIsFetchingSecretsOnCopy] = useState(false)
+  const [prefetchedSecrets, setPrefetchedSecrets] = useState<Record<string, string> | null>(null)
 
   const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
   const { data: wrapperInstance } = useAnalyticsBucketWrapperInstance({ bucketId })
@@ -174,37 +175,47 @@ export const CreateTableInstructions = ({
                 <CopyButton
                   type="default"
                   loading={isFetchingSecretsOnCopy}
-                  asyncText={async () => {
-                    if (!!decryptedS3AccessKey && !!decryptedS3SecretKey && !!decryptedToken) {
-                      return getPyicebergSnippet({
-                        ref,
-                        warehouse: wrapperValues.warehouse,
-                        catalogUri: wrapperValues.catalog_uri,
-                        s3Endpoint: wrapperValues['s3.endpoint'],
-                        s3Region: projectSettings?.region,
-                        s3AccessKey: decryptedS3AccessKey,
-                        s3SecretKey: decryptedS3SecretKey,
-                        token: decryptedToken,
-                      })
-                    } else {
+                  onMouseEnter={async () => {
+                    // Pre-fetch secrets on hover so they're ready when user clicks
+                    // Safari requires clipboard data to be available immediately
+                    if (!prefetchedSecrets && !decryptedS3AccessKey) {
                       setIsFetchingSecretsOnCopy(true)
-                      const decryptedSecrets = await getDecryptedValues({
+                      const secrets = await getDecryptedValues({
                         projectRef: project?.ref,
                         connectionString: project?.connectionString,
                         ids: [s3AccessKeyVaultID, s3SecretKeyVaultID, tokenVaultID],
                       })
+                      setPrefetchedSecrets(secrets)
                       setIsFetchingSecretsOnCopy(false)
-                      return getPyicebergSnippet({
-                        ref,
-                        warehouse: wrapperValues.warehouse,
-                        catalogUri: wrapperValues.catalog_uri,
-                        s3Endpoint: wrapperValues['s3.endpoint'],
-                        s3Region: projectSettings?.region,
-                        s3AccessKey: decryptedSecrets[s3AccessKeyVaultID],
-                        s3SecretKey: decryptedSecrets[s3SecretKeyVaultID],
-                        token: decryptedSecrets[tokenVaultID],
-                      })
                     }
+                  }}
+                  onMouseLeave={() => {
+                    // Clear prefetched secrets when mouse leaves for security
+                    setPrefetchedSecrets(null)
+                  }}
+                  asyncText={() => {
+                    // Use prefetched secrets or already-revealed secrets
+                    const s3AccessKey =
+                      decryptedS3AccessKey ?? prefetchedSecrets?.[s3AccessKeyVaultID]
+                    const s3SecretKey =
+                      decryptedS3SecretKey ?? prefetchedSecrets?.[s3SecretKeyVaultID]
+                    const token = decryptedToken ?? prefetchedSecrets?.[tokenVaultID]
+
+                    // Clear prefetched secrets after copying for security
+                    if (prefetchedSecrets) {
+                      setTimeout(() => setPrefetchedSecrets(null), 0)
+                    }
+
+                    return getPyicebergSnippet({
+                      ref,
+                      warehouse: wrapperValues.warehouse,
+                      catalogUri: wrapperValues.catalog_uri,
+                      s3Endpoint: wrapperValues['s3.endpoint'],
+                      s3Region: projectSettings?.region,
+                      s3AccessKey,
+                      s3SecretKey,
+                      token,
+                    })
                   }}
                 />
                 <ButtonTooltip

--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -1,6 +1,5 @@
 import { Check, Copy } from 'lucide-react'
 import { ComponentProps, forwardRef, useEffect, useState } from 'react'
-
 import { Button, cn, copyToClipboard } from 'ui'
 
 type CopyButtonBaseProps = {
@@ -47,12 +46,16 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     return (
       <Button
         ref={ref}
-        onClick={(e) => {
+        onPointerDownCapture={(e) => {
+          // Safari requires clipboard operations to happen on pointerdown (not click)
+          // and in the capture phase (before the event reaches child elements like icons).
+          // Without this, Safari's user gesture detection fails.
+          if (e.button !== 0) return // Only handle left click
           const textToCopy = asyncText ? asyncText() : text
           setShowCopied(true)
           copyToClipboard(textToCopy)
-          onClick?.(e)
         }}
+        onClick={onClick}
         {...props}
         className={cn({ 'px-1': iconOnly }, props.className)}
         icon={

--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -46,17 +46,14 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     return (
       <Button
         ref={ref}
+        {...props}
         onPointerDownCapture={(e) => {
-          // Safari requires clipboard operations to happen on pointerdown (not click)
-          // and in the capture phase (before the event reaches child elements like icons).
-          // Without this, Safari's user gesture detection fails.
-          if (e.button !== 0) return // Only handle left click
-          const textToCopy = asyncText ? asyncText() : text
+          if (e.button !== 0) return
           setShowCopied(true)
-          copyToClipboard(textToCopy)
+          const textPromise = asyncText ? asyncText() : Promise.resolve(text)
+          copyToClipboard(textPromise)
         }}
         onClick={onClick}
-        {...props}
         className={cn({ 'px-1': iconOnly }, props.className)}
         icon={
           showCopied ? <Check strokeWidth={2} className="text-brand" /> : props.icon ?? <Copy />

--- a/packages/ui/src/lib/utils/clipboard.ts
+++ b/packages/ui/src/lib/utils/clipboard.ts
@@ -10,10 +10,10 @@ import { toast } from 'sonner'
  *
  * Copied code from https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
  */
-export const copyToClipboard = async (str: string | Promise<string>, callback = noop) => {
+export const copyToClipboard = (str: string | Promise<string>, callback = noop) => {
   const focused = window.document.hasFocus()
   if (focused) {
-    if (typeof ClipboardItem && navigator.clipboard?.write) {
+    if (typeof ClipboardItem !== 'undefined' && navigator.clipboard?.write) {
       // NOTE: Safari locks down the clipboard API to only work when triggered
       // by a direct user interaction. You can't use it async in a promise.
       // But! You can wrap the promise in a ClipboardItem, and give that to


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Safari's clipboard API fails with "The request is not allowed by the user agent" when copying content asynchronously. Safari has strict requirements which can be resolved with some combination of these:
1. The clipboard operation must happen on pointerdown, not click
2. The event must be handled in the capture phase
3. The Promise passed to ClipboardItem must resolve within the same event loop tick

## What is the new behavior?

- CopyButton uses `onPointerDownCapture` instead of `onClick` for clipboard operations
- CopyButton uses ClipboardItem API directly instead of copyToClipboard utility
- CreateTableInstructions pre-fetches secrets on hover so they're available synchronously when user clicks
- Clears prefetched secrets on mouse leave and after copy for security
- Fixed typeof check for ClipboardItem in clipboard.ts

## Additional context