### PR TITLE
docs: replace deprecated getSession with getUser in tutorials

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,15 +233,14 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const { data: { user }, error } = await supabaseClient.auth.getUser()
 
-      if (!session) {
+      if (error || !user) {
         return {
           authenticated: false,
           error: {
             message: 'Check failed',
-            name: 'Session not found',
+            name: 'User not found',
           },
           logout: true,
           redirectTo: '/login',

--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -271,10 +271,17 @@ const App: Component = () => {
   const [session, setSession] = createSignal<AuthSession | null>(null)
 
   createEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session)
+    // Use getUser() to verify authentication status
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        // Get session only after verifying user exists
+        supabase.auth.getSession().then(({ data: { session } }) => {
+          setSession(session)
+        })
+      }
     })
 
+    // Listen for auth state changes
     supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
     })


### PR DESCRIPTION
## Summary
- Updated Refine tutorial to use `getUser()` instead of `getSession()` in the `authProvider.check` method
- Updated SolidJS tutorial to verify user with `getUser()` before getting session

## Why
The `getSession()` method can return stale/cached data and is not recommended for authentication verification. Using `getUser()` ensures the authentication status is properly verified by making a request to the Supabase Auth server.

## Files Changed
- `apps/docs/content/guides/getting-started/tutorials/with-refine.mdx`
- `apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx`

## Test plan
- [x] Verified code follows Supabase auth best practices
- [ ] Documentation renders correctly

Fixes #42193
Fixes #42192