### PR TITLE
docs: fix inconsistent key naming in schedule-functions

### DIFF
--- a/apps/docs/content/guides/functions/schedule-functions.mdx
+++ b/apps/docs/content/guides/functions/schedule-functions.mdx
@@ -31,7 +31,7 @@ Store `project_url` and `anon_key` in Supabase Vault:
 
 ```sql
 select vault.create_secret('https://project-ref.supabase.co', 'project_url');
-select vault.create_secret('YOUR_SUPABASE_PUBLISHABLE_KEY', 'publishable_key');
+select vault.create_secret('YOUR_SUPABASE_ANON_KEY', 'anon_key');
 ```
 
 Make a POST request to a Supabase Edge Function every minute:


### PR DESCRIPTION
## Summary
Fixed inconsistent key naming in the Edge Functions scheduling documentation.

## Problem
The vault setup example stored the key with the name `publishable_key`:
```sql
select vault.create_secret('YOUR_SUPABASE_PUBLISHABLE_KEY', 'publishable_key');
```

But the cron job example retrieved it using `anon_key`:
```sql
(select decrypted_secret from vault.decrypted_secrets where name = 'anon_key')
```

## Solution
Updated the vault setup to use `anon_key` consistently:
```sql
select vault.create_secret('YOUR_SUPABASE_ANON_KEY', 'anon_key');
```

Fixes #42398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated Edge Function integration guide to clarify the correct authentication key required for API request authorization headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->