### PR TITLE
fix(example): correct onAuthStateChange destructuring in slack-clone

### DIFF
--- a/examples/slack-clone/nextjs-slack-clone/pages/_app.js
+++ b/examples/slack-clone/nextjs-slack-clone/pages/_app.js
@@ -31,7 +31,7 @@ export default function SupabaseSlackClone({ Component, pageProps }) {
 
     supabase.auth.getSession().then(({ data: { session } }) => saveSession(session))
 
-    const { subscription: authListener } = supabase.auth.onAuthStateChange(
+    const { data: { subscription: authListener } } = supabase.auth.onAuthStateChange(
       async (event, session) => {
         console.log(session)
         saveSession(session)


### PR DESCRIPTION
## Summary
Fixed incorrect destructuring of `onAuthStateChange` return value in the slack-clone example.

## Problem
The code was using:
```js
const { subscription: authListener } = supabase.auth.onAuthStateChange(...)
```

But `onAuthStateChange` returns `{ data: { subscription } }`, causing the error:
> TypeError: authListener is not defined

## Solution
Updated to correct destructuring:
```js
const { data: { subscription: authListener } } = supabase.auth.onAuthStateChange(...)
```

Note: The `nextjs-slack-clone-dotenvx` version already has this fix implemented correctly.

Fixes #42326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal authentication state handling to align with current API structure, ensuring compatibility with authentication flow without affecting user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->