### PR TITLE
Reduce changelog discussion page size

### DIFF
--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -64,7 +64,7 @@ async function fetchDiscussions(
   const query = `
     query troubleshootDiscussions($cursor: String, $owner: String!, $repo: String!, $categoryId: ID!) {
       repository(owner: $owner, name: $repo) {
-        discussions(first: 50, after: $cursor, categoryId: $categoryId, orderBy: { field: CREATED_AT, direction: DESC }) {
+        discussions(first: 10, after: $cursor, categoryId: $categoryId, orderBy: { field: CREATED_AT, direction: DESC }) {
           totalCount
           pageInfo {
             hasPreviousPage


### PR DESCRIPTION
Summary
- clamp the changelog discussion fetch to 10 items per page so pagination doesn’t load excessive data
- keep prior sorting and pagination metadata intact while requesting fewer discussions

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted changelog page loading behavior to improve performance by fetching smaller data batches per request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->