### PR TITLE
chore: change primary button for resumes

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -236,9 +236,23 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
 
         {isPauseStatusSuccess && !isRestoreDisabled && (
           <CardFooter className="flex justify-end items-center gap-x-2">
+            {isFreePlan ? (
+              <Button asChild type="default">
+                <Link
+                  href={`/org/${orgSlug}/billing?panel=subscriptionPlan&source=projectPausedStateRestore`}
+                >
+                  Upgrade to Pro
+                </Link>
+              </Button>
+            ) : (
+              <Button asChild type="default">
+                <Link href={`/project/${ref}/settings/general`}>View project settings</Link>
+              </Button>
+            )}
+
             <ButtonTooltip
               size="tiny"
-              type="default"
+              type="primary"
               disabled={!canResumeProject}
               onClick={onSelectRestore}
               tooltip={{
@@ -252,20 +266,6 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
             >
               Resume project
             </ButtonTooltip>
-
-            {isFreePlan ? (
-              <Button asChild type="primary">
-                <Link
-                  href={`/org/${orgSlug}/billing?panel=subscriptionPlan&source=projectPausedStateRestore`}
-                >
-                  Upgrade to Pro
-                </Link>
-              </Button>
-            ) : (
-              <Button asChild type="default">
-                <Link href={`/project/${ref}/settings/general`}>View project settings</Link>
-              </Button>
-            )}
           </CardFooter>
         )}
 


### PR DESCRIPTION
Currently seems to be leading to accidental upgrades+support tickets, so we are making the resume project the primary button instead of the upgrade

<img width="665" height="363" alt="Screenshot 2026-02-04 at 9 36 22 AM" src="https://github.com/user-attachments/assets/ef65d430-059c-4746-bc3b-122ec7021cd1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan-specific actions in project paused state: Free plan users see "Upgrade to Pro" option with billing link, while paid plan users see "View project settings" option.

* **Style**
  * Updated Resume button to use primary styling for better visual prominence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->