### PR TITLE
Enable nonce skipping for Google social login

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -202,7 +202,7 @@ To use the Google provider in local development:
    enabled = true
    client_id = "<client-id>"
    secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET)"
-   skip_nonce_check = false
+   skip_nonce_check = true
    ```
 
 If you have multiple client IDs, such as one for Web, iOS and Android, concatenate all of the client IDs with a comma but make sure the web's client ID is first in the list.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## Info

it says to enable skip nonce for supabase dashboard but has it false for local dev. failed for me unless enabled just wanted to share

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Google authentication configuration guide for local development with revised nonce verification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->