### PR TITLE
docs(solidjs): use getUser instead of getSession (Fixes #42192)

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -138,15 +138,15 @@ Let's create a new component for that called `Account.tsx`.
 <$CodeTabs>
 
 ```tsx name=src/Account.tsx
-import { AuthSession } from '@supabase/supabase-js'
+import { User } from '@supabase/supabase-js'
 import { Component, createEffect, createSignal } from 'solid-js'
 import { supabase } from './supabaseClient'
 
 interface Props {
-  session: AuthSession
+  user: User
 }
 
-const Account: Component<Props> = ({ session }) => {
+const Account: Component<Props> = ({ user }) => {
   const [loading, setLoading] = createSignal(true)
   const [username, setUsername] = createSignal<string | null>(null)
   const [website, setWebsite] = createSignal<string | null>(null)
@@ -159,7 +159,6 @@ const Account: Component<Props> = ({ session }) => {
   const getProfile = async () => {
     try {
       setLoading(true)
-      const { user } = session
 
       const { data, error, status } = await supabase
         .from('profiles')
@@ -190,7 +189,6 @@ const Account: Component<Props> = ({ session }) => {
 
     try {
       setLoading(true)
-      const { user } = session
 
       const updates = {
         id: user.id,
@@ -217,7 +215,7 @@ const Account: Component<Props> = ({ session }) => {
   return (
     <div aria-live="polite">
       <form onSubmit={updateProfile} class="form-widget">
-        <div>Email: {session.user.email}</div>
+        <div>Email: {user.email}</div>
         <div>
           <label for="username">Name</label>
           <input
@@ -263,26 +261,26 @@ Now that we have all the components in place, let's update `App.tsx`:
 ```jsx name=src/App.tsx
 import { Component, createEffect, createSignal } from 'solid-js'
 import { supabase } from './supabaseClient'
-import { AuthSession } from '@supabase/supabase-js'
+import { User } from '@supabase/supabase-js'
 import Account from './Account'
 import Auth from './Auth'
 
 const App: Component = () => {
-  const [session, setSession] = createSignal<AuthSession | null>(null)
+  const [user, setUser] = createSignal<User | null>(null)
 
   createEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session)
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUser(user ?? null)
     })
 
     supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
+      setUser(session?.user ?? null)
     })
   })
 
   return (
     <div class="container" style={{ padding: '50px 0 100px 0' }}>
-      {!session() ? <Auth /> : <Account session={session()!} />}
+      {!user() ? <Auth /> : <Account user={user()!} />}
     </div>
   )
 }


### PR DESCRIPTION
Fixes #42192

In the SolidJS tutorial, replaced `getSession()` with `getUser()` for auth state in `App.tsx`, and updated the Account component to accept `user: User` instead of `session: AuthSession`. Uses the recommended approach for verifying auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the SolidJS getting-started tutorial with revised example code patterns for authentication state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->