### PR TITLE
docs(refine): use getClaims instead of getSession in authProvider.check (Fixes #42193)

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,10 +233,10 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const { data } = await supabaseClient.auth.getClaims()
+      const claims = data?.claims
 
-      if (!session) {
+      if (!claims) {
         return {
           authenticated: false,
           error: {


### PR DESCRIPTION
Fixes #42193

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Refine tutorial uses `getSession()` in `authProvider.check` for authentication verification.

## What is the new behavior?

Uses `getClaims()` instead of `getSession()` in `authProvider.check`, in line with Supabase’s recommended approach for auth checks.

## Additional context

Replaces `getSession()` / `session` with `getClaims()` / `claims` in the Refine tutorial so the docs match current Supabase auth recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state management in the Refine integration to use more reliable verification methods, enhancing the accuracy of user authentication checks and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->