### PR TITLE
fix: add search path to extensions for index advisor

### DIFF
--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -35,7 +35,7 @@ export async function getIndexAdvisorResult({
   const { result: results } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from index_advisor('${escapedQuery}');`,
+    sql: `set search_path to public, extensions; select * from index_advisor('${escapedQuery}');`,
   })
 
   if (!results || results.length === 0) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Set missing search path to support extension calling for older postgres version (PG15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index advisor query execution to ensure proper schema context during analysis operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->