### PR TITLE
fix(docs): sync troubleshooting upstream workflow

### DIFF
--- a/.github/workflows/docs-sync-auto-troubleshooting.yml
+++ b/.github/workflows/docs-sync-auto-troubleshooting.yml
@@ -59,9 +59,16 @@ jobs:
           repository: supabase/troubleshooting
           path: troubleshooting-upstream
 
+      - name: Generate PR token
+        id: pr-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+
       - name: Sync supabase/troubleshooting changes back to supabase/supabase
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.pr-token.outputs.token }}
         run: |
           git config user.name 'github-docs-bot'
           git config user.email 'github-docs-bot@supabase.com'


### PR DESCRIPTION
GITHUB_TOKEN is no longer allowed to create PRs, so use the generated app token instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved authentication for automated sync workflows by switching to an app-generated token, enhancing reliability of automated documentation/troubleshooting syncs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->