### PR TITLE
feat: improve empty secrets description

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -64,7 +64,7 @@ export const EdgeFunctionSecrets = () => {
   const secrets =
     searchString.length > 0
       ? data?.filter((secret) => secret.name.toLowerCase().includes(searchString.toLowerCase())) ??
-      []
+        []
       : data ?? []
 
   const headers = [
@@ -161,8 +161,10 @@ export const EdgeFunctionSecrets = () => {
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No secrets created</p>
                               <p className="text-sm text-foreground-lighter">
-                                This project has no custom secrets yet. <code className="text-code-inline !text-foreground-lighter whitespace-nowrap">SUPABASE_*</code>
-                                {' '}
+                                This project has no custom secrets yet.{' '}
+                                <code className="text-code-inline !text-foreground-lighter whitespace-nowrap">
+                                  SUPABASE_*
+                                </code>{' '}
                                 <InlineLink
                                   href={`${DOCS_URL}/guides/functions/secrets#default-secrets`}
                                 >

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -64,7 +64,7 @@ export const EdgeFunctionSecrets = () => {
   const secrets =
     searchString.length > 0
       ? data?.filter((secret) => secret.name.toLowerCase().includes(searchString.toLowerCase())) ??
-        []
+      []
       : data ?? []
 
   const headers = [
@@ -160,10 +160,9 @@ export const EdgeFunctionSecrets = () => {
                           <TableRow className="[&>td]:hover:bg-inherit">
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No secrets created</p>
-                              <p className="text-sm text-foreground-light prose">
-                                This project has no custom secrets yet. <br />
-                                <code>SUPABASE_*</code>
-                                {''}
+                              <p className="text-sm text-foreground-lighter">
+                                This project has no custom secrets yet. <code className="text-code-inline whitespace-nowrap">SUPABASE_*</code>
+                                {' '}
                                 <InlineLink
                                   href={`${DOCS_URL}/guides/functions/secrets#default-secrets`}
                                 >

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -17,6 +17,8 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import AddNewSecretForm from './AddNewSecretForm'
 import EdgeFunctionSecret from './EdgeFunctionSecret'
 import { EditSecretSheet } from './EditSecretSheet'
+import { InlineLink } from '@/components/ui/InlineLink'
+import { DOCS_URL } from '@/lib/constants'
 
 export const EdgeFunctionSecrets = () => {
   const { ref: projectRef } = useParams()
@@ -158,8 +160,15 @@ export const EdgeFunctionSecrets = () => {
                           <TableRow className="[&>td]:hover:bg-inherit">
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No secrets created</p>
-                              <p className="text-sm text-foreground-light">
-                                There are no secrets associated with your project yet
+                              <p className="text-sm text-foreground-light prose">
+                                This project has no custom secrets yet. <code>SUPABASE_*</code>
+                                {''}
+                                <InlineLink
+                                  href={`${DOCS_URL}/guides/functions/secrets#default-secrets`}
+                                >
+                                  default secrets
+                                </InlineLink>{' '}
+                                are still available.
                               </p>
                             </TableCell>
                           </TableRow>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -161,7 +161,7 @@ export const EdgeFunctionSecrets = () => {
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No secrets created</p>
                               <p className="text-sm text-foreground-lighter">
-                                This project has no custom secrets yet. <code className="text-code-inline whitespace-nowrap">SUPABASE_*</code>
+                                This project has no custom secrets yet. <code className="text-code-inline !text-foreground-lighter whitespace-nowrap">SUPABASE_*</code>
                                 {' '}
                                 <InlineLink
                                   href={`${DOCS_URL}/guides/functions/secrets#default-secrets`}

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -161,7 +161,8 @@ export const EdgeFunctionSecrets = () => {
                             <TableCell colSpan={headers.length}>
                               <p className="text-sm text-foreground">No secrets created</p>
                               <p className="text-sm text-foreground-light prose">
-                                This project has no custom secrets yet. <code>SUPABASE_*</code>
+                                This project has no custom secrets yet. <br />
+                                <code>SUPABASE_*</code>
                                 {''}
                                 <InlineLink
                                   href={`${DOCS_URL}/guides/functions/secrets#default-secrets`}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Empty secrets page doesn't mention default `SUPABASE_*` envs.

<details>

<img width="2888" height="1418" alt="image" src="https://github.com/user-attachments/assets/20a5ab71-9bb5-44c9-8dc4-0069f7605fcb" />

</details>

## What is the new behavior?

Add mentions to available default secrets as well useful doc link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified the Edge Functions "No secrets created" state to note that SUPABASE_* default environment variables are available.
  * Enhanced empty-state content with an explicit SUPABASE_* code example, lighter text styling for readability, and an inline link to the documentation for default secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->