### PR TITLE
fix: update chart position

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 /packages/shared-data/plans.ts @supabase/billing
 /packages/common/telemetry-constants.ts @supabase/growth-eng
 /packages/pg-meta @supabase/postgres @avallete
+/packages/ui-patterns @supabase/design
 
 /apps/studio/ @supabase/Dashboard
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,5 @@
 /apps/studio/pages/new/index.tsx                                    @supabase/security
 
 /apps/studio/data/sql/queries/                                      @supabase/postgres @avallete
+
+/packages/shared-data/compute-disk-limits.ts @supabase/infra

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-packages/shared-data/compute-disk-limits.ts @supabase/infra
-packages/shared-data/index.ts @supabase/infra
-

--- a/packages/ui-patterns/src/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/src/LogsBarChart/index.tsx
@@ -97,7 +97,7 @@ export const LogsBarChart = ({
           />
           <ChartTooltip
             animationDuration={0}
-            position={{ y: 80 }}
+            position={{ y: 16 }}
             content={(props) => {
               if (!props.active || !props.payload || props.payload.length === 0) {
                 return null


### PR DESCRIPTION
- updates chart tooltip position

BEFORE
<img width="486" height="392" alt="CleanShot 2026-02-05 at 13 47 52@2x" src="https://github.com/user-attachments/assets/d1b77b6a-7e35-494c-9097-d900183a5c83" />
AFTER
<img width="704" height="486" alt="CleanShot 2026-02-05 at 13 48 27@2x" src="https://github.com/user-attachments/assets/fbe71474-16ca-4dd3-8b03-8fa3289e3805" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted chart tooltip vertical placement in logs visualization for improved visibility and user experience.

* **Chores**
  * Updated repository ownership/metadata entries to reflect current maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->