### PR TITLE
fix(self-hosted): update storage to 1.37.1 to resolve migrations

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -242,7 +242,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.33.5
+    image: supabase/storage-api:v1.37.1
     restart: unless-stopped
     volumes:
       - ./volumes/storage:/var/lib/storage:z


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update storage-api image to v1.37.1 to address a problem with migrations (see PR [storage#845](https://github.com/supabase/storage/pull/845)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage service to a newer version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->