### PR TITLE
fix(assistant): preserve ordered list numbering across split ol elements

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.test.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { OrderedList } from './MessageMarkdown'
+
+describe('OrderedList', () => {
+  test('sets counter-reset based on start prop for split lists', () => {
+    const { container } = render(
+      <OrderedList start={3}>
+        <li>Third item</li>
+      </OrderedList>
+    )
+    const ol = container.querySelector('ol')
+    expect(ol).toBeInTheDocument()
+    expect(ol).toHaveAttribute('start', '3')
+    expect(ol).toHaveStyle({ counterReset: 'item 2' })
+  })
+})

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -38,8 +38,19 @@ const Streamdown = dynamic<StreamdownProps>(
   { ssr: false }
 )
 
-export const OrderedList = memo(({ children }: { children?: ReactNode }) => (
-  <ol className="flex flex-col gap-y-4">{children}</ol>
+// Streamdown splits ordered lists with complex content (e.g. code blocks) into
+// separate <ol> elements. The `start` attribute preserves semantics for screen
+// readers, while `counterReset` is what actually fixes the visible numbering —
+// the prose config (tailwind.config.js) uses a custom CSS counter named "item"
+// with `listStyleType: 'none'`, so the `start` attribute alone has no visual effect.
+export const OrderedList = memo(({ children, start }: { children?: ReactNode; start?: number }) => (
+  <ol
+    className="flex flex-col gap-y-4"
+    start={start}
+    style={start !== undefined ? { counterReset: `item ${start - 1}` } : undefined}
+  >
+    {children}
+  </ol>
 ))
 OrderedList.displayName = 'OrderedList'
 


### PR DESCRIPTION
### Changes

- Accept `start` prop in `OrderedList` and use it to set `counterReset` on the `<ol>` element, fixing numbering when Streamdown splits lists across code blocks
- Add test for the above

### To Verify

Copy/paste the following into the Assistant chat (`Cmd + I` on dashboard)

~~~
Testing markdown lists with code blocks.

1. Thing 1
```
code
```

2. Thing 2
```
code
```

3. Thing 3
```
code
```
~~~

</p>
</details> 

| Before | After |
|--------|--------|
| <img width="1580" height="628" alt="CleanShot 2026-02-05 at 15 04 14@2x" src="https://github.com/user-attachments/assets/263be289-4a9a-4a8d-b907-cb62a26389cd" /> | <img width="1426" height="622" alt="CleanShot 2026-02-05 at 15 04 08@2x" src="https://github.com/user-attachments/assets/6bfb526b-30dc-4bcc-b507-0fa0418d3093" /> | 

Closes AI-401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ordered lists in the AI Assistant panel now support custom starting numbers, enabling proper continuation of numbered sequences. This ensures correct numbering when displaying complex content like code blocks within lists.

* **Tests**
  * Added test coverage for ordered list custom starting number functionality and style rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->