### PR TITLE
docs(mcp): document tools, feature groups, and configuration options

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -188,8 +188,8 @@ We recommend the following best practices to mitigate security risks when using 
 
 - **Don't connect to production**: Use the MCP server with a development project, not production. LLMs are great at helping design and test applications, so leverage them in a safe environment without exposing real data. Be sure that your development environment contains non-production data (or obfuscated data).
 - **Don't give to your customers**: The MCP server operates under the context of your developer permissions, so you should not give it to your customers or end users. Instead, use it internally as a developer tool to help you build and test your applications.
-- **Read-only mode**: If you must connect to real data, set the server to [read-only](https://github.com/supabase-community/supabase-mcp#read-only-mode) mode, which executes all queries as a read-only Postgres user.
-- **Project scoping**: Scope your MCP server to a [specific project](https://github.com/supabase-community/supabase-mcp#project-scoped-mode), limiting access to only that project's resources. This prevents LLMs from accessing data from other projects in your Supabase account.
+- **Read-only mode**: If you must connect to real data, set the server to [read-only](#configuration-options) mode, which executes all queries as a read-only Postgres user.
+- **Project scoping**: Scope your MCP server to a [specific project](#configuration-options), limiting access to only that project's resources. This prevents LLMs from accessing data from other projects in your Supabase account.
 - **Branching**: Use Supabase's [branching feature](/docs/guides/deployment/branching) to create a development branch for your database. This allows you to test changes in a safe environment before merging them to production.
 - **Feature groups**: Restrict which [tool groups](#available-tools) are available using the `features` [configuration option](#configuration-options). This helps reduce the attack surface and limits the actions that LLMs can perform to only those that you need.
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -59,7 +59,7 @@ The Supabase MCP server provides tools organized into feature groups. All groups
 - `get_edge_function` - Get a specific Edge Function
 - `deploy_edge_function` - Deploy an Edge Function
 
-### Account Management
+### Account management
 
 <Admonition type="note">
 
@@ -76,7 +76,7 @@ Disabled when using project-scoped mode (`project_ref` parameter).
 
 - `search_docs` - Search Supabase documentation
 
-### Branching (Experimental)
+### Branching (experimental)
 
 <Admonition type="note">
 
@@ -87,7 +87,7 @@ Requires a paid plan.
 - `create_branch` / `list_branches` / `delete_branch` - Branch management
 - `merge_branch` / `reset_branch` / `rebase_branch` - Branch operations
 
-### Storage (Disabled by default)
+### Storage (disabled by default)
 
 - `list_storage_buckets` - List storage buckets
 - `get_storage_config` / `update_storage_config` - Storage configuration
@@ -96,11 +96,11 @@ Requires a paid plan.
 
 The [configuration panel above](#step-2-configure-your-ai-tool) can set these options for you. If you prefer to configure manually, the following URL query parameters are available:
 
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `read_only=true` | Execute all queries as a read-only Postgres user | `?read_only=true` |
-| `project_ref=<id>` | Scope to a specific project (disables account tools) | `?project_ref=abc123` |
-| `features=<groups>` | Enable only specific tool groups (comma-separated) | `?features=database,docs` |
+| Parameter           | Description                                          | Example                   |
+| ------------------- | ---------------------------------------------------- | ------------------------- |
+| `read_only=true`    | Execute all queries as a read-only Postgres user     | `?read_only=true`         |
+| `project_ref=<id>`  | Scope to a specific project (disables account tools) | `?project_ref=abc123`     |
+| `features=<groups>` | Enable only specific tool groups (comma-separated)   | `?features=database,docs` |
 
 Parameters can be combined: `https://mcp.supabase.com/mcp?project_ref=abc123&read_only=true`
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -30,6 +30,86 @@ To verify the client has access to the MCP server tools, try asking it to query 
 
 For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/guides/getting-started/ai-prompts) collection.
 
+## Available tools
+
+The Supabase MCP server provides tools organized into feature groups. All groups except Storage are enabled by default. You can enable or disable specific groups using the [configuration panel above](#step-2-configure-your-ai-tool).
+
+### Database
+
+- `list_tables` - List all tables in the database
+- `list_extensions` - List available/installed Postgres extensions
+- `list_migrations` - List database migrations
+- `apply_migration` - Apply a database migration
+- `execute_sql` - Execute SQL queries
+
+### Debugging
+
+- `get_logs` - Retrieve service logs (API, Postgres, Edge Functions, Auth, Storage, Realtime)
+- `get_advisors` - Get security and performance advisors
+
+### Development
+
+- `get_project_url` - Get the API URL for a project
+- `get_publishable_keys` - Get anon/public keys
+- `generate_typescript_types` - Generate TypeScript types from schema
+
+### Edge Functions
+
+- `list_edge_functions` - List all Edge Functions
+- `get_edge_function` - Get a specific Edge Function
+- `deploy_edge_function` - Deploy an Edge Function
+
+### Account Management
+
+<Admonition type="note">
+
+Disabled when using project-scoped mode (`project_ref` parameter).
+
+</Admonition>
+
+- `list_projects` / `get_project` - List or get project details
+- `create_project` / `pause_project` / `restore_project` - Manage projects
+- `list_organizations` / `get_organization` - Organization management
+- `get_cost` / `confirm_cost` - Cost information
+
+### Docs
+
+- `search_docs` - Search Supabase documentation
+
+### Branching (Experimental)
+
+<Admonition type="note">
+
+Requires a paid plan.
+
+</Admonition>
+
+- `create_branch` / `list_branches` / `delete_branch` - Branch management
+- `merge_branch` / `reset_branch` / `rebase_branch` - Branch operations
+
+### Storage (Disabled by default)
+
+- `list_storage_buckets` - List storage buckets
+- `get_storage_config` / `update_storage_config` - Storage configuration
+
+## Configuration options
+
+The [configuration panel above](#step-2-configure-your-ai-tool) can set these options for you. If you prefer to configure manually, the following URL query parameters are available:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `read_only=true` | Execute all queries as a read-only Postgres user | `?read_only=true` |
+| `project_ref=<id>` | Scope to a specific project (disables account tools) | `?project_ref=abc123` |
+| `features=<groups>` | Enable only specific tool groups (comma-separated) | `?features=database,docs` |
+
+Parameters can be combined: `https://mcp.supabase.com/mcp?project_ref=abc123&read_only=true`
+
+<Admonition type="tip">
+
+When using [Supabase CLI](/docs/guides/cli) for local development, the MCP server is available at `http://localhost:54321/mcp`.
+
+</Admonition>
+
 ## Manual authentication
 
 By default the hosted Supabase MCP server uses [dynamic client registration](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#dynamic-client-registration) to authenticate with your Supabase org. This means that you don't need to manually create a personal access token (PAT) or OAuth app to use the server.
@@ -111,7 +191,13 @@ We recommend the following best practices to mitigate security risks when using 
 - **Read-only mode**: If you must connect to real data, set the server to [read-only](https://github.com/supabase-community/supabase-mcp#read-only-mode) mode, which executes all queries as a read-only Postgres user.
 - **Project scoping**: Scope your MCP server to a [specific project](https://github.com/supabase-community/supabase-mcp#project-scoped-mode), limiting access to only that project's resources. This prevents LLMs from accessing data from other projects in your Supabase account.
 - **Branching**: Use Supabase's [branching feature](/docs/guides/deployment/branching) to create a development branch for your database. This allows you to test changes in a safe environment before merging them to production.
-- **Feature groups**: The server allows you to enable or disable specific [tool groups](https://github.com/supabase-community/supabase-mcp#feature-groups), so you can control which tools are available to the LLM. This helps reduce the attack surface and limits the actions that LLMs can perform to only those that you need.
+- **Feature groups**: Control which tool groups are available by adding the `features` parameter to your MCP server URL:
+
+  ```
+  https://mcp.supabase.com/mcp?features=database,docs,debugging
+  ```
+
+  Available groups: `account`, `database`, `debugging`, `development`, `docs`, `functions`, `branching`, `storage`. All except `storage` are enabled by default. This helps reduce the attack surface and limits the actions that LLMs can perform to only those that you need.
 
 ## On GitHub
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -191,13 +191,7 @@ We recommend the following best practices to mitigate security risks when using 
 - **Read-only mode**: If you must connect to real data, set the server to [read-only](https://github.com/supabase-community/supabase-mcp#read-only-mode) mode, which executes all queries as a read-only Postgres user.
 - **Project scoping**: Scope your MCP server to a [specific project](https://github.com/supabase-community/supabase-mcp#project-scoped-mode), limiting access to only that project's resources. This prevents LLMs from accessing data from other projects in your Supabase account.
 - **Branching**: Use Supabase's [branching feature](/docs/guides/deployment/branching) to create a development branch for your database. This allows you to test changes in a safe environment before merging them to production.
-- **Feature groups**: Control which tool groups are available by adding the `features` parameter to your MCP server URL:
-
-  ```
-  https://mcp.supabase.com/mcp?features=database,docs,debugging
-  ```
-
-  Available groups: `account`, `database`, `debugging`, `development`, `docs`, `functions`, `branching`, `storage`. All except `storage` are enabled by default. This helps reduce the attack surface and limits the actions that LLMs can perform to only those that you need.
+- **Feature groups**: Restrict which [tool groups](#available-tools) are available using the `features` [configuration option](#configuration-options). This helps reduce the attack surface and limits the actions that LLMs can perform to only those that you need.
 
 ## On GitHub
 


### PR DESCRIPTION
Adds more MCP docs on which tools, features, options, etc are available on the Supabase MCP server. Currently these only live in the [repo README](https://github.com/supabase-community/supabase-mcp), so this adds them to the official docs which many folks land on first.

### Preview
https://docs-git-docs-mcp-tools-and-options-supabase.vercel.app/docs/guides/getting-started/mcp

Resolves AI-357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an "Available tools" section documenting MCP tool groups and their available commands
  * Updated internal documentation anchors to improve navigation between related configuration topics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->