### PR TITLE
chore: cleanup E2E logic and fix flaky toast behaviour

### DIFF
--- a/e2e/studio/features/api-access-toggle.spec.ts
+++ b/e2e/studio/features/api-access-toggle.spec.ts
@@ -467,6 +467,12 @@ test.describe('API Access Toggle', () => {
   }) => {
     const tableName = `${TABLE_NAME_PREFIX}_preserve_grants`
 
+    await runSQL(page, ref, `DROP TABLE IF EXISTS ${tableName} CASCADE;`)
+
+    let loadPromise = waitForTableToLoad(page, ref)
+    await page.goto(toUrl(`/project/${ref}/editor?schema=public`))
+    await loadPromise
+
     // Step 1: Create a table with partial privileges (only SELECT and INSERT for anon)
     await page.getByRole('button', { name: 'New table', exact: true }).click()
     await expect(page.getByTestId('table-editor-side-panel')).toBeVisible()
@@ -514,7 +520,7 @@ test.describe('API Access Toggle', () => {
     })
 
     // Navigate back to table editor
-    let loadPromise = waitForTableToLoad(page, ref)
+    loadPromise = waitForTableToLoad(page, ref)
     await page.goto(toUrl(`/project/${ref}/editor?schema=public`))
     await loadPromise
 

--- a/e2e/studio/features/queue-table-operations.spec.ts
+++ b/e2e/studio/features/queue-table-operations.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from '@playwright/test'
 import { releaseFileOnceCleanup, withFileOnceSetup } from '../utils/once-per-file.js'
+import { runSQL } from '../utils/sql-helpers.js'
 import { deleteTable } from '../utils/table-helpers.js'
 import { test } from '../utils/test.js'
 import { toUrl } from '../utils/to-url.js'
@@ -12,27 +13,6 @@ const enableQueueOperations = async (page: Page) => {
   await page.evaluate((key) => {
     localStorage.setItem(key, 'true')
   }, QUEUE_OPERATIONS_KEY)
-}
-
-const runSQL = async (page: Page, ref: string, sql: string) => {
-  await page.goto(toUrl(`/project/${ref}/sql/new`))
-  await expect(page.getByText('Loading...')).not.toBeVisible({ timeout: 10000 })
-
-  await page.locator('.view-lines').click()
-  await page.keyboard.press('ControlOrMeta+KeyA')
-  await page.evaluate((text) => navigator.clipboard.writeText(text), sql)
-  await page.keyboard.press('ControlOrMeta+KeyV')
-
-  await page.getByTestId('sql-run-button').click()
-
-  const confirmButton = page.getByRole('button', { name: 'Run this query' })
-  if (await confirmButton.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await confirmButton.click()
-  }
-
-  await expect(
-    page.getByText('Success. No rows returned').or(page.getByText(/^\d+ rows?$/)).first()
-  ).toBeVisible()
 }
 
 const createTableSQL = async (

--- a/e2e/studio/features/queue-table-operations.spec.ts
+++ b/e2e/studio/features/queue-table-operations.spec.ts
@@ -32,7 +32,7 @@ const runSQL = async (page: Page, ref: string, sql: string) => {
 
   await expect(
     page.getByText('Success. No rows returned').or(page.getByText(/^\d+ rows?$/)).first()
-  ).toBeVisible({ timeout: 10000 })
+  ).toBeVisible()
 }
 
 const createTableSQL = async (
@@ -484,6 +484,9 @@ test.describe('Queue Table Operations', () => {
 
     await expect(page.getByText('1 pending change')).toBeVisible()
 
+    await expect(
+      page.getByRole('button', { name: `View ${tableName2}`, exact: true })
+    ).toBeVisible()
     await page.getByRole('button', { name: `View ${tableName2}`, exact: true }).click()
 
     await page.getByTestId('table-editor-insert-new-row').click()

--- a/e2e/studio/features/queue-table-operations.spec.ts
+++ b/e2e/studio/features/queue-table-operations.spec.ts
@@ -311,6 +311,7 @@ test.describe('Queue Table Operations', () => {
     await expect(page.getByRole('dialog').getByText('Pending changes')).toBeVisible()
 
     await page.keyboard.press('ControlOrMeta+.')
+    await expect(page.getByRole('dialog').getByText('Pending changes')).not.toBeVisible()
     await expect(page.getByRole('button', { name: 'View Details' })).toBeVisible()
 
     await page.keyboard.press('ControlOrMeta+s')

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -2,6 +2,7 @@ import { expect, Page } from '@playwright/test'
 import fs from 'fs'
 import path from 'path'
 import { env } from '../env.config.js'
+import { dismissToastsIfAny } from '../utils/dismiss-toast.js'
 import { releaseFileOnceCleanup, withFileOnceSetup } from '../utils/once-per-file.js'
 import { resetLocalStorage } from '../utils/reset-local-storage.js'
 import { test } from '../utils/test.js'
@@ -16,14 +17,6 @@ import {
 
 const tableNamePrefix = 'pw_table'
 const columnName = 'pw_column'
-
-const dismissToastsIfAny = async (page: Page) => {
-  const closeButtons = page.getByRole('button', { name: 'Close toast' })
-  const count = await closeButtons.count()
-  for (let i = 0; i < count; i++) {
-    await closeButtons.nth(i).click()
-  }
-}
 
 const createTable = async (page: Page, ref: string, tableName: string) => {
   // Ensure no toast overlays block the dialog trigger

--- a/e2e/studio/utils/dismiss-toast.ts
+++ b/e2e/studio/utils/dismiss-toast.ts
@@ -12,8 +12,13 @@ export const toKebabCase = (str: string) => str.replace(/([A-Z])/g, '-$1').toLow
 
 export const dismissToastsIfAny = async (page: Page) => {
   const closeButtons = page.getByRole('button', { name: 'Close toast' })
-  const count = await closeButtons.count()
-  for (let i = 0; i < count; i++) {
-    await closeButtons.nth(i).click()
+  let count = await closeButtons.count()
+  while (count > 0) {
+    try {
+      await closeButtons.first().click({ force: true, timeout: 2000 })
+    } catch {
+      // Toast may have auto-dismissed or been detached from the DOM
+    }
+    count = await closeButtons.count()
   }
 }

--- a/e2e/studio/utils/sql-helpers.ts
+++ b/e2e/studio/utils/sql-helpers.ts
@@ -1,0 +1,23 @@
+import { expect, Page } from '@playwright/test'
+import { toUrl } from './to-url.js'
+
+export const runSQL = async (page: Page, ref: string, sql: string) => {
+  await page.goto(toUrl(`/project/${ref}/sql/new`))
+  await expect(page.getByText('Loading...')).not.toBeVisible({ timeout: 10000 })
+
+  await page.locator('.view-lines').click()
+  await page.keyboard.press('ControlOrMeta+KeyA')
+  await page.evaluate((text) => navigator.clipboard.writeText(text), sql)
+  await page.keyboard.press('ControlOrMeta+KeyV')
+
+  await page.getByTestId('sql-run-button').click()
+
+  const confirmButton = page.getByRole('button', { name: 'Run this query' })
+  if (await confirmButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await confirmButton.click()
+  }
+
+  await expect(
+    page.getByText('Success. No rows returned').or(page.getByText(/^\d+ rows?$/)).first()
+  ).toBeVisible()
+}

--- a/e2e/studio/utils/sql-helpers.ts
+++ b/e2e/studio/utils/sql-helpers.ts
@@ -13,11 +13,11 @@ export const runSQL = async (page: Page, ref: string, sql: string) => {
   await page.getByTestId('sql-run-button').click()
 
   const confirmButton = page.getByRole('button', { name: 'Run this query' })
-  if (await confirmButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+  if (await confirmButton.isVisible({ timeout: 3000 }).catch(() => false)) {
     await confirmButton.click()
   }
 
   await expect(
     page.getByText('Success. No rows returned').or(page.getByText(/^\d+ rows?$/)).first()
-  ).toBeVisible()
+  ).toBeVisible({ timeout: 30000 })
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Updated api access toggle to use the same SQL runner as Queues
- Added clean up of tables for api access toggle
- Updated dismiss toast to handle case where the toast is gone