### PR TITLE
test(studio): add db utils for checking database state

### DIFF
--- a/e2e/studio/utils/db/client.ts
+++ b/e2e/studio/utils/db/client.ts
@@ -1,0 +1,33 @@
+// Default Supabase CLI constants (hardcoded for local development)
+const SERVICE_ROLE_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+const API_URL = 'http://127.0.0.1:54321'
+
+/**
+ * Execute a SQL query against the local Supabase database via pg-meta.
+ *
+ * Uses the local Supabase API gateway to route to pg-meta, which executes
+ * the query against PostgreSQL using the default local connection.
+ *
+ * @param sql - The SQL query to execute
+ * @param params - Optional array of parameters for parameterized queries
+ * @returns Array of result rows
+ * @throws Error if the query fails
+ */
+export async function query<T>(sql: string, params?: Array<unknown>): Promise<Array<T>> {
+  const response = await fetch(`${API_URL}/pg/query`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SERVICE_ROLE_KEY,
+    },
+    body: JSON.stringify({ query: sql, parameters: params }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(`Database query failed: ${error.message || JSON.stringify(error)}`)
+  }
+
+  return response.json()
+}

--- a/e2e/studio/utils/db/index.ts
+++ b/e2e/studio/utils/db/index.ts
@@ -1,0 +1,2 @@
+export { query } from './client.js'
+export { tableExists } from './queries.js'

--- a/e2e/studio/utils/db/queries.ts
+++ b/e2e/studio/utils/db/queries.ts
@@ -1,0 +1,19 @@
+import { query } from './client.js'
+
+/**
+ * Check if a table exists in the specified schema.
+ *
+ * @param schema - The schema name (e.g., 'public')
+ * @param tableName - The table name to check
+ * @returns true if the table exists, false otherwise
+ */
+export async function tableExists(schema: string, tableName: string): Promise<boolean> {
+  const result = await query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = $1 AND table_name = $2
+     ) as exists`,
+    [schema, tableName]
+  )
+  return result[0]?.exists ?? false
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Test utilities

## What is the current behavior?

E2E tests that need to verify database state go through the SQL Editor, which is unnecessarily slow and prone to future breakage.

## What is the new behavior?

Adds shared db utils for checking database state in Studio E2E tests by querying the database directly. Refactors API access tests to use the new utilities.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored API access privilege verification to use direct database queries instead of SQL editor interaction.
  * Added database utility functions for e2e tests to query table existence and access privileges.
  * Updated test signatures to simplify privilege verification calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->