### PR TITLE
Fix rendering of OrganizationCard if isLink

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
@@ -1,9 +1,8 @@
-import { Boxes, Lock } from 'lucide-react'
-import Link from 'next/link'
-
 import { useIsMFAEnabled } from 'common'
 import { ActionCard } from 'components/ui/ActionCard'
 import { useOrgProjectsInfiniteQuery } from 'data/projects/org-projects-infinite-query'
+import { Boxes, Lock } from 'lucide-react'
+import Link from 'next/link'
 import { Fragment } from 'react'
 import type { Organization } from 'types'
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
@@ -62,8 +61,8 @@ export const OrganizationCard = ({
   )
 
   if (isLink) {
-    return <Fragment>{renderContent()}</Fragment>
-  } else {
     return <Link href={href ?? `/org/${organization.slug}`}>{renderContent()}</Link>
+  } else {
+    return <Fragment>{renderContent()}</Fragment>
   }
 }


### PR DESCRIPTION
## Context

Bug introduced [here](https://github.com/supabase/supabase/pull/42496) - just a small issue in which we're returning the wrong element if `isLink` in `OrganizationCard.tsx`

## To test

- [ ] Verify that you can click on an organization card in the /organizations page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization card component rendering to correctly handle link wrapping behavior based on configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->