### PR TITLE
fix(studio): enable tables roles access query in local mode

### DIFF
--- a/apps/studio/data/tables/tables-roles-access-query.ts
+++ b/apps/studio/data/tables/tables-roles-access-query.ts
@@ -44,10 +44,6 @@ export const useTablesRolesAccessQuery = <TData = TablesRolesAccessData>(
     queryKey: tableKeys.rolesAccess(projectRef, schema),
     queryFn: ({ signal }) =>
       getTablesWithAnonAuthenticatedAccess({ projectRef, connectionString, schema }, signal),
-    enabled:
-      enabled &&
-      typeof projectRef !== 'undefined' &&
-      typeof schema !== 'undefined' &&
-      !!connectionString,
+    enabled: enabled && typeof projectRef !== 'undefined' && typeof schema !== 'undefined',
     ...options,
   })


### PR DESCRIPTION
Local/self-hosted Supabase Studio was incorrectly showing "API disabled" for tables with valid RLS policies due to a query not running in local mode.

Fixes #42553

## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

In local/self-hosted Supabase Studio, tables incorrectly show:

- "This table cannot be accessed via the Data API as no permissions exist for the anon or authenticated roles"
- Missing globe icons in the Table Editor
- "API disabled" label on the RLS policies page

This happens even when tables have proper RLS policies and GRANT privileges.

## What is the new behaviour?

The tables roles access query now runs correctly in local/self-hosted mode, and Studio displays accurate Data API access status for tables.

## Additional context

Root cause:

`useTablesRolesAccessQuery` included a strict `!!connectionString` check in its `enabled` condition:

```ts
enabled &&
typeof projectRef !== 'undefined' &&
typeof schema !== 'undefined' &&
!!connectionString
````

In local/self-hosted mode, `connectionString` is returned as an empty string (`''`) from:

`apps/studio/pages/api/platform/projects/[ref]/index.ts`

Since `!!''` evaluates to `false`, the query never executed and defaulted to an empty Set, causing Studio to assume no API access for all tables.

Solution:

Removed the `!!connectionString` guard, aligning this hook with other queries (e.g. `useTablePrivilegesQuery`) that already work correctly in local mode.

Additional note:

The bug appears to have been introduced in #39601 (commit `9c4919948a`) during a refactor.
`executeSql` already handles empty `connectionString` values safely, so this check was unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified table roles and access query conditions to improve reliability and enable the query in additional scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->