### PR TITLE
chore(studio): remove feature flag for dataApiExposedBadge

### DIFF
--- a/apps/studio/hooks/misc/useDataApiGrantTogglesEnabled.ts
+++ b/apps/studio/hooks/misc/useDataApiGrantTogglesEnabled.ts
@@ -1,6 +1,5 @@
-import { useFlag } from 'common'
-import { IS_TEST_ENV } from 'lib/constants'
 import { usePHFlag } from '../ui/useFlag'
+import { IS_TEST_ENV } from '@/lib/constants'
 
 /**
  * Determine whether a user has access to Data API grant toggles.
@@ -12,7 +11,6 @@ import { usePHFlag } from '../ui/useFlag'
  * without requiring the feature flag infrastructure.
  */
 export const useDataApiGrantTogglesEnabled = (): boolean => {
-  const isDataApiBadgesEnabled = useFlag('dataApiExposedBadge')
   const isTableEditorApiAccessEnabled = usePHFlag<boolean>('tableEditorApiAccessToggle')
 
   // In test environment, enable the feature for E2E testing
@@ -20,5 +18,5 @@ export const useDataApiGrantTogglesEnabled = (): boolean => {
     return true
   }
 
-  return isDataApiBadgesEnabled && !!isTableEditorApiAccessEnabled
+  return !!isTableEditorApiAccessEnabled
 }

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1,8 +1,9 @@
-import { expect, Page } from '@playwright/test'
 import fs from 'fs'
 import path from 'path'
-import { createTable as dbCreateTable, dropTable } from '../utils/db/index.js'
+import { expect, Page } from '@playwright/test'
+
 import { env } from '../env.config.js'
+import { createTable as dbCreateTable, dropTable } from '../utils/db/index.js'
 import { releaseFileOnceCleanup, withFileOnceSetup } from '../utils/once-per-file.js'
 import { resetLocalStorage } from '../utils/reset-local-storage.js'
 import { test } from '../utils/test.js'
@@ -165,7 +166,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameActions}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
     await page.getByRole('menuitem', { name: 'Copy name' }).click()
     await page.waitForTimeout(500)
@@ -176,7 +177,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameActions}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
     await page.getByRole('menuitem', { name: 'Copy table schema' }).click()
     await waitForApiResponse(page, 'pg-meta', ref, 'query?key=table-definition-') // wait for endpoint to generate schema
@@ -193,7 +194,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameActions}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
     await page.getByRole('menuitem', { name: 'Duplicate table' }).click()
     await page.getByRole('button', { name: 'Save' }).click()
@@ -367,7 +368,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameGridEditor}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
     await page.getByRole('menuitem', { name: 'Edit table' }).click()
     await page.getByTestId('table-name-input').fill(tableNameUpdated)
@@ -386,7 +387,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameUpdated}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
     // Open nested export submenu via keyboard (more stable than hover in headless)
     const exportDataItemCsv = page.getByRole('menuitem', { name: 'Export data' })
@@ -425,7 +426,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameUpdated}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
     // Open nested export submenu via keyboard (more stable than hover in headless)
     const exportDataItemSql = page.getByRole('menuitem', { name: 'Export data' })
@@ -459,7 +460,7 @@ testRunner('table editor', () => {
     await page
       .getByRole('button', { name: `View ${tableNameUpdated}`, exact: true })
       .getByRole('button')
-      .nth(1)
+      .nth(2)
       .click()
 
     const exportDataItemCli = page.getByRole('menuitem', { name: 'Export data' })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Cleanup / chore — removing a feature flag that has been at 100% rollout with no issues.

## What is the current behavior?

The `dataApiExposedBadge` feature flag is checked at runtime via ConfigCat, even though it has been set to 100% for a while with no issues.

## What is the new behavior?

The feature flag check is removed and the gated behavior is now unconditionally enabled. A reminder has been set to delete the flag from ConfigCat in a month.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified API-access and tooltip logic in the Studio table editor and removed a legacy feature-flag dependency; component public interface updated to include additional context.
  * Consolidated import paths and internal hook logic for more consistent behavior and easier maintenance.
* **Tests**
  * Adjusted end-to-end test flows to match updated editor menu interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->