### PR TITLE
fix: table editor panel separator resize behavior

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -143,10 +143,10 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
                 id="panel-left"
                 className={cn(
                   'hidden md:block',
-                  'transition-all duration-[120ms]',
+                  'transition-[max-width,min-width,width] duration-[120ms]',
                   sideBarIsOpen
                     ? resizableSidebar
-                      ? 'min-w-64 max-w-[32rem]'
+                      ? 'min-w-64'
                       : 'min-w-64 max-w-64'
                     : 'w-0 flex-shrink-0 max-w-0'
                 )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The sliding separator of the left panel in the Table Editor does not function properly:

- Resizing by dragging feels sluggish due to CSS `transition-all` animating `flex-grow`, which `react-resizable-panels` uses internally for drag resize
- The panel often remains at full width or snaps back because the CSS `max-w-[32rem]` constraint conflicts with the library's percentage-based `maxSize` prop

## What is the new behavior?

- The drag separator responds immediately and smoothly to mouse movement
- The panel resizes reliably within the bounds defined by the `minSize` and `maxSize` props

## Changes

Two targeted fixes in `apps/studio/components/layouts/ProjectLayout/index.tsx`:

1. **Changed `transition-all` to `transition-[max-width,min-width,width]`** — The `transition-all` was animating `flex-grow`, causing a 120ms delay on every drag frame. The sidebar open/close animation only needs width property transitions, so scoping the transition to `max-width`, `min-width`, and `width` preserves that animation while eliminating interference with drag.

2. **Removed `max-w-[32rem]` when `resizableSidebar` is true** — The CSS max-width was clamping the panel at 512px regardless of what `react-resizable-panels` set via flex-grow. This caused the panel to appear stuck or snap back. The library's `maxSize={33}` (percentage-based) already enforces the upper bound correctly.

Closes #27801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined left sidebar animation for improved smoothness.
  * Increased maximum expandable width of the left sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->