### PR TITLE
Add flag disabled UI handler for code redeem page

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
@@ -5,12 +5,10 @@ import { useFlag } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Calendar, PartyPopper } from 'lucide-react'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import {
-  Button,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -25,10 +23,11 @@ import {
   Input_Shadcn_,
   Separator,
 } from 'ui'
-import { Admonition, ShimmeringLoader } from 'ui-patterns'
+import { Admonition, ShimmeringLoader, TimestampInfo } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
+import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
 import { useOrganizationCreditCodeRedemptionMutation } from '@/data/organizations/organization-credit-code-redemption-mutation'
 import { useOrganizationCustomerProfileQuery } from '@/data/organizations/organization-customer-profile-query'
 import { useOrganizationQuery } from '@/data/organizations/organization-query'
@@ -79,12 +78,17 @@ export const CreditCodeRedemption = ({
   })
 
   const {
-    mutateAsync: redeemCode,
+    mutate: redeemCode,
     isPending: redeemingCode,
     error: errorRedeemingCode,
     data: codeRedemptionResult,
     reset: resetCodeRedemption,
-  } = useOrganizationCreditCodeRedemptionMutation()
+  } = useOrganizationCreditCodeRedemptionMutation({
+    onSuccess: () => {
+      form.setValue('code', '')
+      resetCaptcha()
+    },
+  })
 
   const resetCaptcha = () => {
     captchaTokenRef.current = null
@@ -111,16 +115,7 @@ export const CreditCodeRedemption = ({
 
   const onSubmit: SubmitHandler<CreditCodeRedemptionForm> = async ({ code }) => {
     const token = await initHcaptcha()
-
-    await redeemCode(
-      { slug, code, hcaptchaToken: token },
-      {
-        onSuccess: () => {
-          form.setValue('code', '')
-          resetCaptcha()
-        },
-      }
-    )
+    redeemCode({ slug, code, hcaptchaToken: token })
   }
 
   const onCodeRedemptionDialogVisibilityChange = (visible: boolean) => {
@@ -198,11 +193,11 @@ export const CreditCodeRedemption = ({
         {codeRedemptionResult ? (
           <div className="p-8">
             <div className="text-center flex items-center justify-center">
-              <PartyPopper className="h-20 w-20" />
+              <PartyPopper strokeWidth={1} className="h-14 w-14" />
             </div>
 
             <div className="text-center">
-              <p className="font-bold text-lg mt-2">Credits Redeemed!</p>
+              <p className=" text-lg mt-2">Credits redeemed!</p>
             </div>
             <Separator className="my-4" />
             <div className="flex w-full justify-center items-center">
@@ -217,12 +212,12 @@ export const CreditCodeRedemption = ({
               <div className="mt-2 flex items-center justify-center gap-2 text-sm text-muted-foreground bg-muted/50 py-3 px-4 rounded-lg">
                 <Calendar className="h-4 w-4" />
                 <span>
-                  {'Expires on '}
-                  {new Date(codeRedemptionResult.credits_expire_at).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
+                  Expires on{' '}
+                  <TimestampInfo
+                    className="text-sm"
+                    utcTimestamp={codeRedemptionResult.credits_expire_at}
+                    labelFormat="MMMM DD, YYYY"
+                  />
                 </span>
               </div>
             )}
@@ -230,11 +225,15 @@ export const CreditCodeRedemption = ({
             {org?.plan.id === 'free' && (
               <div className="mt-4 space-y-4">
                 <Separator />
-                <Button className="w-full" size={'medium'} type="primary" asChild>
-                  <Link href={`/org/${org?.slug}/billing?panel=subscriptionPlan`}>
-                    Upgrade Your Organization
-                  </Link>
-                </Button>
+                <UpgradePlanButton
+                  plan="Pro"
+                  className="w-full"
+                  source="code-redeem"
+                  size="medium"
+                  slug={org.slug}
+                >
+                  Upgrade organization
+                </UpgradePlanButton>
               </div>
             )}
           </div>
@@ -288,9 +287,9 @@ export const CreditCodeRedemption = ({
 
                     <Admonition type="note" title="Potential future charges">
                       <p>
-                        Credits are applied to <strong>{org?.name}</strong> only and can't be shared
-                        or transferred to other organizations. Credits are automatically used toward
-                        invoices.
+                        Credits are applied to <strong>{org?.name}</strong> only and cannot be
+                        shared or transferred to other organizations. Credits are automatically used
+                        toward invoices.
                       </p>
                       <p className="mt-2">
                         When credits run out on a paid plan, your default payment method will be

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
@@ -5,10 +5,12 @@ import { useFlag } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Calendar, PartyPopper } from 'lucide-react'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import {
+  Button,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -190,7 +192,7 @@ export const CreditCodeRedemption = ({
           }}
         />
 
-        {codeRedemptionResult ? (
+        {!!codeRedemptionResult ? (
           <div className="p-8">
             <div className="text-center flex items-center justify-center">
               <PartyPopper strokeWidth={1} className="h-14 w-14" />
@@ -222,20 +224,19 @@ export const CreditCodeRedemption = ({
               </div>
             )}
 
-            {org?.plan.id === 'free' && (
-              <div className="mt-4 space-y-4">
-                <Separator />
-                <UpgradePlanButton
-                  plan="Pro"
-                  className="w-full"
-                  source="code-redeem"
-                  size="medium"
-                  slug={org.slug}
-                >
-                  Upgrade organization
-                </UpgradePlanButton>
+            <div className="mt-4 flex flex-col gap-y-4">
+              <Separator />
+              <div className="flex justify-center items-center gap-x-2">
+                {org?.plan.id === 'free' && (
+                  <UpgradePlanButton plan="Pro" source="code-redeem" slug={org.slug}>
+                    Upgrade organization
+                  </UpgradePlanButton>
+                )}
+                <Button asChild type="default">
+                  <Link href={`/org/${org?.slug}`}>Go to organization</Link>
+                </Button>
               </div>
-            )}
+            </div>
           </div>
         ) : (
           <>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
@@ -300,7 +300,7 @@ export const CreditCodeRedemption = ({
                     {errorRedeemingCode && (
                       <Admonition
                         type="warning"
-                        title="Code cannot be redeemed"
+                        title="Unable to redeem code"
                         description={errorRedeemingCode?.message}
                       />
                     )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditCodeRedemption.tsx
@@ -1,19 +1,15 @@
 import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Alert, AlertDescription, AlertTitle } from '@ui/components/shadcn/ui/alert'
 import { useFlag } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { AlertCircle, Calendar, PartyPopper } from 'lucide-react'
+import { Calendar, PartyPopper } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import {
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Alert_Shadcn_,
   Button,
   Dialog,
   DialogContent,
@@ -24,19 +20,19 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   DialogTrigger,
-  FormField_Shadcn_,
   Form_Shadcn_,
+  FormField_Shadcn_,
   Input_Shadcn_,
   Separator,
 } from 'ui'
-import { ShimmeringLoader } from 'ui-patterns'
+import { Admonition, ShimmeringLoader } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { z } from 'zod'
 
 import { useOrganizationCreditCodeRedemptionMutation } from '@/data/organizations/organization-credit-code-redemption-mutation'
 import { useOrganizationCustomerProfileQuery } from '@/data/organizations/organization-customer-profile-query'
 import { useOrganizationQuery } from '@/data/organizations/organization-query'
-import useLatest from '@/hooks/misc/useLatest'
+import { useLatest } from '@/hooks/misc/useLatest'
 
 const FORM_ID = 'credit-code-redemption'
 
@@ -51,51 +47,36 @@ export const CreditCodeRedemption = ({
   modalVisible = false,
   onClose,
 }: {
-  slug: string | undefined
+  slug?: string
   modalVisible?: boolean
   onClose?: () => void
 }) => {
+  const router = useRouter()
+  const redeemCodeEnabled = useFlag('redeemCodeEnabled')
+  const [codeRedemptionModalVisible, setCodeRedemptionModalVisible] = useState(
+    modalVisible || false
+  )
+
+  const { data: org, isLoading: isOrgLoading } = useOrganizationQuery({ slug })
+  const { data: customerProfile, isLoading: isCustomerProfileLoading } =
+    useOrganizationCustomerProfileQuery({ slug })
+
   const { can: canRedeemCode, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
     PermissionAction.BILLING_WRITE,
     'stripe.subscriptions',
     undefined,
-    {
-      organizationSlug: slug,
-    }
+    { organizationSlug: slug }
   )
 
-  const redeemCodeEnabled = useFlag('redeemCodeEnabled')
-
-  const { data: org, isLoading: isOrgLoading } = useOrganizationQuery({ slug })
-
-  const router = useRouter()
+  const captchaRef = useRef<HCaptcha>(null)
+  const captchaTokenRef = useRef<string | null>(null)
+  const codeRedemptionDisabled =
+    !canRedeemCode || !isPermissionsLoaded || isOrgLoading || isCustomerProfileLoading
 
   const form = useForm<CreditCodeRedemptionForm>({
     resolver: zodResolver(FormSchema),
-    defaultValues: {
-      code: '',
-    },
+    defaultValues: { code: '' },
   })
-
-  const { data: customerProfile, isLoading: isCustomerProfileLoading } =
-    useOrganizationCustomerProfileQuery({ slug })
-
-  useEffect(() => {
-    if (!router.isReady) return
-
-    const queryCode = router.query.code
-    const codeFromParams = Array.isArray(queryCode) ? queryCode[0] : queryCode
-
-    if (typeof codeFromParams === 'string' && codeFromParams.trim().length > 2) {
-      form.setValue('code', codeFromParams)
-    }
-  }, [router.isReady, router.query.code, form])
-
-  const [codeRedemptionModalVisible, setCodeRedemptionModalVisible] = useState(
-    modalVisible || false
-  )
-  const captchaRef = useRef<HCaptcha>(null)
-  const captchaTokenRef = useRef<string | null>(null)
 
   const {
     mutateAsync: redeemCode,
@@ -128,21 +109,11 @@ export const CreditCodeRedemption = ({
   }
   const initHcaptchaRef = useLatest(initHcaptcha)
 
-  useEffect(() => {
-    if (codeRedemptionModalVisible) {
-      initHcaptchaRef.current()
-    }
-  }, [codeRedemptionModalVisible, initHcaptchaRef])
-
   const onSubmit: SubmitHandler<CreditCodeRedemptionForm> = async ({ code }) => {
     const token = await initHcaptcha()
 
     await redeemCode(
-      {
-        slug,
-        code,
-        hcaptchaToken: token,
-      },
+      { slug, code, hcaptchaToken: token },
       {
         onSuccess: () => {
           form.setValue('code', '')
@@ -161,12 +132,24 @@ export const CreditCodeRedemption = ({
     }
   }
 
-  if (!redeemCodeEnabled) {
-    return null
-  }
+  useEffect(() => {
+    if (!router.isReady) return
 
-  const codeRedemptionDisabled =
-    !canRedeemCode || !isPermissionsLoaded || isOrgLoading || isCustomerProfileLoading
+    const queryCode = router.query.code
+    const codeFromParams = Array.isArray(queryCode) ? queryCode[0] : queryCode
+
+    if (typeof codeFromParams === 'string' && codeFromParams.trim().length > 2) {
+      form.setValue('code', codeFromParams)
+    }
+  }, [router.isReady, router.query.code, form])
+
+  useEffect(() => {
+    if (codeRedemptionModalVisible) {
+      initHcaptchaRef.current()
+    }
+  }, [codeRedemptionModalVisible, initHcaptchaRef])
+
+  if (!redeemCodeEnabled) return null
 
   return (
     <Dialog open={codeRedemptionModalVisible} onOpenChange={onCodeRedemptionDialogVisibilityChange}>
@@ -191,7 +174,7 @@ export const CreditCodeRedemption = ({
         </DialogTrigger>
       )}
 
-      <DialogContent onInteractOutside={(e) => e.preventDefault()} size={'large'}>
+      <DialogContent size="medium" onInteractOutside={(e) => e.preventDefault()}>
         <HCaptcha
           ref={captchaRef}
           sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
@@ -224,9 +207,9 @@ export const CreditCodeRedemption = ({
             <Separator className="my-4" />
             <div className="flex w-full justify-center items-center">
               <div className="flex items-center space-x-1">
-                <h4 className="opacity-50">$</h4>
-                <h1 className="relative text-2xl">{codeRedemptionResult.amount_cents / 100}</h1>
-                <h4 className="opacity-50"> credits applied</h4>
+                <p className="opacity-50 text-sm">$</p>
+                <p className="text-2xl">{codeRedemptionResult.amount_cents / 100}</p>
+                <p className="opacity-50 text-sm"> credits applied</p>
               </div>
             </div>
 
@@ -282,10 +265,10 @@ export const CreditCodeRedemption = ({
                       control={form.control}
                       name="code"
                       render={({ field }) => (
-                        <FormItemLayout label="Code" className="gap-1">
+                        <FormItemLayout label="Code" className="gap-1" layout="horizontal">
                           <Input_Shadcn_
                             {...field}
-                            className="uppercase"
+                            className="uppercase w-56 ml-auto"
                             placeholder="ABCD-1234-EFGH-5678"
                           />
                         </FormItemLayout>
@@ -293,35 +276,34 @@ export const CreditCodeRedemption = ({
                     />
 
                     {customerProfile && customerProfile.balance < 0 && (
-                      <div className="mt-2 flex w-full justify-between items-center">
-                        <span>Current Balance</span>
-                        <div className="flex items-center space-x-1">
-                          <h4 className="opacity-50">$</h4>
-                          <h1 className="relative">{customerProfile.balance / -100}</h1>
-                          <h4 className="opacity-50">/credits</h4>
+                      <div className="flex w-full justify-between items-center">
+                        <span className="text-sm">Current Balance</span>
+                        <div className="flex items-center gap-x-1">
+                          <p className="opacity-50 text-sm">$</p>
+                          <p className="text-2xl">{customerProfile.balance / -100}</p>
+                          <p className="opacity-50 text-sm">/credits</p>
                         </div>
                       </div>
                     )}
 
-                    <Alert variant={'default'} className="mt-4">
-                      <AlertCircle className="h-4 w-4" />
-                      <AlertTitle>Potential future charges</AlertTitle>
-                      <AlertDescription>
+                    <Admonition type="note" title="Potential future charges">
+                      <p>
                         Credits are applied to <strong>{org?.name}</strong> only and can't be shared
                         or transferred to other organizations. Credits are automatically used toward
-                        invoices. When credits run out on a paid plan, your default payment method
-                        will be charged—your plan won't be downgraded automatically.
-                      </AlertDescription>
-                    </Alert>
+                        invoices.
+                      </p>
+                      <p className="mt-2">
+                        When credits run out on a paid plan, your default payment method will be
+                        charged—your plan won't be downgraded automatically.
+                      </p>
+                    </Admonition>
 
                     {errorRedeemingCode && (
-                      <Alert_Shadcn_ variant="destructive">
-                        <AlertCircle className="h-4 w-4 text-foreground-light" />
-                        <AlertTitle_Shadcn_>Code cannot be redeemed</AlertTitle_Shadcn_>
-                        <AlertDescription_Shadcn_>
-                          {errorRedeemingCode?.message}
-                        </AlertDescription_Shadcn_>
-                      </Alert_Shadcn_>
+                      <Admonition
+                        type="warning"
+                        title="Code cannot be redeemed"
+                        description={errorRedeemingCode?.message}
+                      />
                     )}
                   </DialogSection>
 

--- a/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
@@ -12,11 +12,13 @@ export const OrganizationCard = ({
   href,
   isLink = true,
   className,
+  onClick,
 }: {
   organization: Organization
   href?: string
   isLink?: boolean
   className?: string
+  onClick?: () => void
 }) => {
   const isUserMFAEnabled = useIsMFAEnabled()
   const { data } = useOrgProjectsInfiniteQuery({ slug: organization.slug })
@@ -32,6 +34,7 @@ export const OrganizationCard = ({
       )}
       icon={<Boxes size={18} strokeWidth={1} className="text-foreground" />}
       title={organization.name}
+      onClick={onClick}
       description={
         <div className="flex items-center justify-between text-xs text-foreground-light font-sans">
           <div className="flex items-center gap-x-1.5">

--- a/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
+++ b/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
@@ -1,9 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { PropsWithChildren, useState } from 'react'
-import { SubmitHandler, useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import z from 'zod'
-
 import { useOrganizationRolesV2Query } from 'data/organization-members/organization-roles-query'
 import { useOrganizationMembersQuery } from 'data/organizations/organization-members-query'
 import {
@@ -13,6 +8,9 @@ import {
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useTrack } from 'lib/telemetry/track'
+import { PropsWithChildren, useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
   Badge,
   Button,
@@ -34,6 +32,7 @@ import {
   TooltipTrigger,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import z from 'zod'
 
 const FormSchema = z.object({
   note: z.string().optional(),
@@ -48,6 +47,7 @@ interface RequestUpgradeToBillingOwnersProps {
   /** Used in the default message template, e.g: "Upgrade to ..." */
   featureProposition?: string
   className?: string
+  size?: 'tiny' | 'medium'
 }
 
 export const RequestUpgradeToBillingOwners = ({
@@ -57,6 +57,7 @@ export const RequestUpgradeToBillingOwners = ({
   featureProposition,
   children,
   className,
+  size,
 }: PropsWithChildren<RequestUpgradeToBillingOwnersProps>) => {
   const [open, setOpen] = useState(false)
   const track = useTrack()
@@ -156,7 +157,7 @@ export const RequestUpgradeToBillingOwners = ({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button block={block} type="primary" className={className}>
+        <Button block={block} type="primary" size={size} className={className}>
           {buttonText}
         </Button>
       </DialogTrigger>

--- a/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
+++ b/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
@@ -47,7 +47,6 @@ interface RequestUpgradeToBillingOwnersProps {
   /** Used in the default message template, e.g: "Upgrade to ..." */
   featureProposition?: string
   className?: string
-  size?: 'tiny' | 'medium'
 }
 
 export const RequestUpgradeToBillingOwners = ({
@@ -57,7 +56,6 @@ export const RequestUpgradeToBillingOwners = ({
   featureProposition,
   children,
   className,
-  size,
 }: PropsWithChildren<RequestUpgradeToBillingOwnersProps>) => {
   const [open, setOpen] = useState(false)
   const track = useTrack()
@@ -157,7 +155,7 @@ export const RequestUpgradeToBillingOwners = ({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button block={block} type="primary" size={size} className={className}>
+        <Button block={block} type="primary" className={className}>
           {buttonText}
         </Button>
       </DialogTrigger>

--- a/apps/studio/components/ui/UpgradePlanButton.tsx
+++ b/apps/studio/components/ui/UpgradePlanButton.tsx
@@ -25,7 +25,6 @@ interface UpgradePlanButtonProps {
   disabled?: boolean
   className?: string
   slug?: string
-  size?: 'tiny' | 'medium'
 }
 
 /**
@@ -43,7 +42,6 @@ export const UpgradePlanButton = ({
   children,
   className,
   slug: slugParam,
-  size,
 }: PropsWithChildren<UpgradePlanButtonProps>) => {
   const { ref } = useParams()
   const { data: organization } = useSelectedOrganizationQuery()
@@ -91,7 +89,6 @@ export const UpgradePlanButton = ({
         addon={addon}
         featureProposition={featureProposition}
         className={className}
-        size={size}
       >
         {children}
       </RequestUpgradeToBillingOwners>
@@ -103,7 +100,6 @@ export const UpgradePlanButton = ({
       <ButtonTooltip
         disabled
         type={variant}
-        size={size}
         className={className}
         tooltip={{
           content: {
@@ -118,7 +114,7 @@ export const UpgradePlanButton = ({
   }
 
   return (
-    <Button asChild type={variant} size={size} disabled={disabled} className={className}>
+    <Button asChild type={variant} disabled={disabled} className={className}>
       {link}
     </Button>
   )

--- a/apps/studio/components/ui/UpgradePlanButton.tsx
+++ b/apps/studio/components/ui/UpgradePlanButton.tsx
@@ -1,13 +1,13 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import Link from 'next/link'
-import { PropsWithChildren } from 'react'
-
 import { useFlag, useParams } from 'common'
 import { SupportLink } from 'components/interfaces/Support/SupportLink'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import Link from 'next/link'
+import { PropsWithChildren } from 'react'
 import { Button } from 'ui'
+
 import { ButtonTooltip } from './ButtonTooltip'
 import { RequestUpgradeToBillingOwners } from './RequestUpgradeToBillingOwners'
 
@@ -24,6 +24,8 @@ interface UpgradePlanButtonProps {
   featureProposition?: string
   disabled?: boolean
   className?: string
+  slug?: string
+  size?: 'tiny' | 'medium'
 }
 
 /**
@@ -40,18 +42,22 @@ export const UpgradePlanButton = ({
   disabled,
   children,
   className,
+  slug: slugParam,
+  size,
 }: PropsWithChildren<UpgradePlanButtonProps>) => {
   const { ref } = useParams()
   const { data: organization } = useSelectedOrganizationQuery()
   const isFreePlan = organization?.plan?.id === 'free'
-  const slug = organization?.slug ?? '_'
+  const slug = slugParam ?? organization?.slug ?? '_'
 
   const projectUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
   const { billingAll } = useIsFeatureEnabled(['billing:all'])
 
   const { can: canUpdateSubscription } = useAsyncCheckPermissions(
     PermissionAction.BILLING_WRITE,
-    'stripe.subscriptions'
+    'stripe.subscriptions',
+    undefined,
+    { organizationSlug: slug }
   )
 
   const subject = `Enquiry to upgrade ${!!plan ? `to ${plan} ` : ''}plan for organization`
@@ -85,6 +91,7 @@ export const UpgradePlanButton = ({
         addon={addon}
         featureProposition={featureProposition}
         className={className}
+        size={size}
       >
         {children}
       </RequestUpgradeToBillingOwners>
@@ -96,6 +103,7 @@ export const UpgradePlanButton = ({
       <ButtonTooltip
         disabled
         type={variant}
+        size={size}
         className={className}
         tooltip={{
           content: {
@@ -110,7 +118,7 @@ export const UpgradePlanButton = ({
   }
 
   return (
-    <Button asChild type={variant} disabled={disabled} className={className}>
+    <Button asChild type={variant} size={size} disabled={disabled} className={className}>
       {link}
     </Button>
   )

--- a/apps/studio/data/organizations/organization-credit-code-redemption-mutation.ts
+++ b/apps/studio/data/organizations/organization-credit-code-redemption-mutation.ts
@@ -60,10 +60,13 @@ export const useOrganizationCreditCodeRedemptionMutation = ({
   return useMutation<RedeemCodeData, ResponseError, OrganizationCreditCodeRedemptionVariables>({
     mutationFn: (vars) => redeemCode(vars),
     async onSuccess(data, variables, context) {
-      const { slug, code } = variables
+      const { slug } = variables
 
-      await queryClient.invalidateQueries({ queryKey: organizationKeys.customerProfile(slug) })
-      await queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgSubscription(slug) })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: organizationKeys.customerProfile(slug) }),
+        queryClient.invalidateQueries({ queryKey: subscriptionKeys.orgSubscription(slug) }),
+      ])
+
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/pages/redeem.tsx
+++ b/apps/studio/pages/redeem.tsx
@@ -1,7 +1,8 @@
+import { useFlag } from 'common'
 import Link from 'next/link'
 import { useState } from 'react'
 import { Button, Loading } from 'ui'
-import { ShimmeringLoader } from 'ui-patterns'
+import { Admonition, ShimmeringLoader } from 'ui-patterns'
 
 import { CreditCodeRedemption } from '@/components/interfaces/Organization/BillingSettings/CreditCodeRedemption'
 import { OrganizationCard } from '@/components/interfaces/Organization/OrganizationCard'
@@ -16,14 +17,15 @@ import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import type { NextPageWithLayout } from '@/types'
 
 const RedeemCreditsContent = () => {
+  const redeemCodeEnabled = useFlag('redeemCodeEnabled')
+  const [selectedOrg, setSelectedOrg] = useState<string | null>(null)
+
   const {
     data: organizations,
     isLoading: areOrganizationsLoading,
     isFetched: isOrganizationsFetched,
     isSuccess: wasOrganizationsRequestSuccessful,
   } = useOrganizationsQuery()
-
-  const [selectedOrg, setSelectedOrg] = useState<string | null>(null)
 
   if (!isOrganizationsFetched) {
     return (
@@ -46,33 +48,46 @@ const RedeemCreditsContent = () => {
 
   return (
     <div className="grid md:grid-cols-2 pt-10 gap-8">
-      <div>
-        <p>
-          To redeem your credits, select one of your organizations. The credits will be applied to
-          that organization only and cannot be transferred or shared between organizations.
-        </p>
-        <p className="mt-8">
-          <span className="font-bold text-foreground-light">Want to start fresh?</span> Create a new
-          organization first. You will have to revisit this link after creating the organization to
-          redeem the code.
-        </p>
-        <Button asChild className="mt-4" size="tiny" type="primary">
-          <Link href={`/new`}>Create organization</Link>
-        </Button>
+      <div className="flex flex-col gap-y-8">
+        <div className="flex flex-col gap-y-1">
+          <p>To redeem your credits, select one of your organizations.</p>
+          <p className="text-sm text-foreground-light text-balance">
+            The credits will be applied to that organization only and cannot be transferred or
+            shared between organizations.
+          </p>
+        </div>
+
+        <div>
+          <p>Want to start fresh?</p>
+          <p className="mt-1 text-sm text-foreground-light text-balance">
+            Create a new organization first. You will have to revisit this link after creating the
+            organization to redeem the code.
+          </p>
+          <Button asChild className="mt-4 w-min" size="tiny" type="primary">
+            <Link href={`/new`}>Create organization</Link>
+          </Button>
+        </div>
       </div>
 
-      <div className="space-y-2">
-        {organizations?.map((org) => (
-          <div key={org.id} onClickCapture={() => setSelectedOrg(org.slug)}>
-            <OrganizationCard isLink={false} organization={org} />
-          </div>
-        ))}
+      <div className="flex flex-col gap-y-2">
+        {redeemCodeEnabled ? (
+          organizations?.map((org) => (
+            <OrganizationCard
+              key={org.id}
+              isLink={false}
+              organization={org}
+              onClick={() => setSelectedOrg(org.slug)}
+            />
+          ))
+        ) : (
+          <Admonition type="note" title="Code redemption coming soon" />
+        )}
       </div>
 
       {selectedOrg && (
         <CreditCodeRedemption
+          modalVisible
           slug={selectedOrg}
-          modalVisible={true}
           onClose={() => setSelectedOrg(null)}
         />
       )}

--- a/apps/studio/pages/redeem.tsx
+++ b/apps/studio/pages/redeem.tsx
@@ -1,7 +1,7 @@
 import { useFlag } from 'common'
 import Link from 'next/link'
 import { useState } from 'react'
-import { Button, Loading } from 'ui'
+import { Button } from 'ui'
 import { Admonition, ShimmeringLoader } from 'ui-patterns'
 
 import { CreditCodeRedemption } from '@/components/interfaces/Organization/BillingSettings/CreditCodeRedemption'
@@ -13,6 +13,7 @@ import {
   ScaffoldHeader,
   ScaffoldTitle,
 } from '@/components/layouts/Scaffold'
+import AlertError from '@/components/ui/AlertError'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import type { NextPageWithLayout } from '@/types'
 
@@ -22,28 +23,31 @@ const RedeemCreditsContent = () => {
 
   const {
     data: organizations,
-    isLoading: areOrganizationsLoading,
-    isFetched: isOrganizationsFetched,
-    isSuccess: wasOrganizationsRequestSuccessful,
+    error: errorOrganizations,
+    isLoading: isLoadingOrganizations,
+    isError: isErrorOrganizations,
   } = useOrganizationsQuery()
 
-  if (!isOrganizationsFetched) {
+  if (isLoadingOrganizations) {
     return (
-      <Loading active={areOrganizationsLoading}>
-        <div className="grid md:grid-cols-2 pt-10 gap-8">
-          <ShimmeringLoader className="w-full" />
-
-          <div className="space-y-4">
-            <ShimmeringLoader className="w-full h-14" />
-            <ShimmeringLoader className="w-full h-14" />
-          </div>
+      <div className="grid md:grid-cols-2 pt-10 gap-8">
+        <ShimmeringLoader className="w-full" />
+        <div className="space-y-4">
+          <ShimmeringLoader className="w-full h-14" />
+          <ShimmeringLoader className="w-full h-14" />
         </div>
-      </Loading>
+      </div>
     )
   }
 
-  if (!wasOrganizationsRequestSuccessful) {
-    return <p className="mt-4">Error loading redeem credit page. Try again later.</p>
+  if (isErrorOrganizations) {
+    return (
+      <AlertError
+        className="mt-4"
+        error={errorOrganizations}
+        subject="Failed to retrieve organizations"
+      />
+    )
   }
 
   return (
@@ -64,7 +68,7 @@ const RedeemCreditsContent = () => {
             organization to redeem the code.
           </p>
           <Button asChild className="mt-4 w-min" size="tiny" type="primary">
-            <Link href={`/new`}>Create organization</Link>
+            <Link href="/new">Create organization</Link>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Context

Adds a UI state for when the feature flag for code redeem is disabled
<img width="1270" height="424" alt="image" src="https://github.com/user-attachments/assets/90e97869-f1e5-456b-9170-4a0a576f1064" />

## Other changes involved

Mostly refactor + clean up here
- Pass `onClick` event to `OrganizationCard`, rather than declaring an extra parent `div` to handle the click event
- Use `Admonition` instead of the `Alert` components within `CreditCodeRedemption`
- Adjust element semantics in `CreditCodeRedemption` (Opting for `p` instead of `h4` and `h1` to show credit related information)
- Use `UpgradePlanButton` component for upgrade CTA (Handles behaviour depending if user has perms to update plan of the organization)
- Use `TimestampInfo` component for expires at
- Fix error handling when calling `redeemCode` (use `mutate` instead of `mutateAsync` which requires a try catch)

## To Test

- [ ] Need to verify that the `TimestampInfo` component renders correctly after redeeming a code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization selection with modal-driven credit code redemption and URL prefill.
  * Upgrade button accepts an organization slug and integrates into the upgrade flow.
  * Organization cards support an optional click handler for custom interactions.

* **UI/UX Improvements**
  * Success/error messaging switched to admonition styling; expiry dates shown with timestamps.
  * Horizontal form layout, medium dialog sizing, compact balance/code presentation, and invisible CAPTCHA with reset on success.
  * Feature gated by a flag with clearer loading/error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->