### PR TITLE
fix(studio): edge function logs detail panel scroll issue

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -388,7 +388,7 @@ const LogTable = ({
   if (!data) return null
 
   return (
-    <section className={'h-full flex w-full flex-col flex-1'}>
+    <section className={'h-full flex w-full flex-col flex-1 min-h-0'}>
       {!queryType && <LogsExplorerTableHeader />}
 
       <ResizablePanelGroup direction="horizontal">

--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -289,7 +289,7 @@ export const LogsPreviewer = ({
   }
 
   return (
-    <div className="flex-1 flex flex-col h-full">
+    <div className="flex-1 flex flex-col h-full min-h-0">
       <PreviewFilterPanel {...filterPanelProps} />
       {children}
       <div
@@ -331,7 +331,7 @@ export const LogsPreviewer = ({
       </div>
       <div className="relative flex flex-col flex-grow flex-1 overflow-auto">
         <ShimmerLine active={isLoading} />
-        <LoadingOpacity active={isLoading}>
+        <LoadingOpacity active={isLoading} className="min-h-0">
           <LogTable
             projectRef={projectRef}
             isLoading={isLoading}

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
@@ -16,7 +16,7 @@ export const LogPage: NextPageWithLayout = () => {
   if (selectedFunction === undefined || isLoading) return null
 
   return (
-    <div className="flex-1">
+    <div className="flex-1 min-h-0">
       <LogsPreviewer
         condensedLayout
         projectRef={ref as string}


### PR DESCRIPTION
## Summary

When viewing Edge Function logs (`/functions/[slug]/logs`), clicking a log row after scrolling down forces the user to scroll back up to see the detail panel — the detail panel content renders at the top of a shared scroll container instead of being visible alongside the selected log.

**Root cause:** Classic CSS flexbox `min-height: auto` issue. Flex items in the height chain don't constrain to their parent's available height, so the entire content expands and shares a single scroll container instead of each panel scrolling independently.

**Fix:** Add `min-h-0` to four flex containers in the height chain so `h-full` resolves properly down to the `ResizablePanelGroup`. Both panels (DataGrid log list and LogSelection detail panel) then get a fixed pixel height and scroll independently.

### Changes

| File | Change |
|------|--------|
| `LogsPreviewer.tsx` | `min-h-0` on root div |
| `LogsPreviewer.tsx` | `className="min-h-0"` on `<LoadingOpacity>` |
| `LogTable.tsx` | `min-h-0` on `<section>` wrapping `ResizablePanelGroup` |
| `logs.tsx` (Edge Function logs page) | `min-h-0` on wrapper div |

### Before
![supabase-before](https://github.com/user-attachments/assets/6ec28652-0635-449e-bbbf-60abb40c19c6)
https://github.com/user-attachments/assets/2def2aa9-c5df-46bd-936c-c1cd6b3d9b2d
*(Clicking a log while scrolled down requires scrolling back up to see the detail panel)*

### After
![supabase-after](https://github.com/user-attachments/assets/9a354424-7632-4065-9e27-449735c1d2f5)
https://github.com/user-attachments/assets/71ed4d00-5158-4cc5-8390-90521ce132f4
*(Detail panel is immediately visible and scrolls independently)*

## Test plan

- [ ] Navigate to an Edge Function's logs page (`/functions/[slug]/logs`)
- [ ] Ensure enough log rows exist to scroll
- [ ] Scroll down in the log list, click a row
- [ ] Verify the detail panel on the right is immediately visible without scrolling up
- [ ] Verify the detail panel scrolls independently when content is long
- [ ] Verify the log list (DataGrid) still scrolls independently
- [ ] Verify the resizable handle between panels still works
- [ ] Check the Logs Explorer page (`/logs/explorer`) for regressions
- [ ] Check other log types (API, database, auth) for regressions

Thx to ClaudeCode ofc 💯 