### PR TITLE
fix(table-editor): restore scroll and header interactions for empty t…

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -232,6 +232,9 @@ export const Grid = memo(
         <div
           className={cn('flex flex-col relative transition-colors', containerClass)}
           style={{ width: width || '100%', height: height || '50vh' }}
+          onDragOver={onDragOver}
+          onDragLeave={onDragOver}
+          onDrop={onFileDrop}
         >
           {/* Render no rows fallback outside of the DataGrid */}
           {(rows ?? []).length === 0 && (
@@ -241,9 +244,6 @@ export const Grid = memo(
                 isTableEmpty && isDraggedOver && 'border-2 border-dashed',
                 isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
               )}
-              onDragOver={onDragOver}
-              onDragLeave={onDragOver}
-              onDrop={onFileDrop}
             >
               {isLoading && !isDisabled && (
                 <GenericSkeletonLoader className="w-full top-9 absolute p-2" />

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -237,7 +237,7 @@ export const Grid = memo(
           {(rows ?? []).length === 0 && (
             <div
               className={cn(
-                'absolute w-full inset-0 flex flex-col items-center justify-center p-2 z-[1]',
+                'absolute w-full inset-0 flex flex-col items-center justify-center p-2 z-[1] pointer-events-none',
                 isTableEmpty && isDraggedOver && 'border-2 border-dashed',
                 isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
               )}
@@ -255,7 +255,9 @@ export const Grid = memo(
                 <>
                   {page > 1 ? (
                     <div className="flex flex-col items-center justify-center">
-                      <p className="text-sm text-light">This page does not have any data</p>
+                      <p className="text-sm text-light pointer-events-auto">
+                        This page does not have any data
+                      </p>
                       <div className="flex items-center space-x-2 mt-4">
                         <Button
                           type="default"


### PR DESCRIPTION
### I have read the CONTRIBUTING.md file.
**YES**

---

### What kind of change does this PR introduce?

**Bug fix (UI / Table Editor)**

### Description

This PR fixes multiple issues in the Table Editor when a table has **zero rows**:

- Horizontal scrolling was disabled, preventing access to off-screen columns
- Column header actions (sort, edit, freeze, delete, etc.) were not clickable
- The “Add new column (+)” button in the grid header was not functional

### What problem does this PR solve?

- Users can now:
  - Scroll horizontally in empty tables
  - Interact with column headers and their actions
  - Use the “+” button to add columns without inserting a row first

This restores expected Table Editor behavior and removes the need for workarounds.

Fixes #42594
Fixes #42590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored drag-and-drop handling at the grid level so dragging and dropping works reliably when the empty-data overlay is present.
  * Fixed pointer-event behavior on the empty-data overlay to prevent it from blocking interactions.
  * Re-enabled pointer events for the empty-page message and primary action so buttons remain clickable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->