### PR TITLE
fix(studio): make policy command buttons responsive to prevent overflow

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyAllowedOperation.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyAllowedOperation.tsx
@@ -11,28 +11,31 @@ const PolicyAllowedOperation = ({
   onSelectOperation = noop,
 }: PolicyAllowedOperationProps) => {
   return (
-    <div className="flex justify-between space-x-12">
-      <div className="flex w-1/3 flex-col space-y-2">
+    <div className="flex flex-col md:flex-row gap-4 md:gap-12">
+      <div className="flex md:w-1/3 flex-col space-y-2">
         <label className="text-base text-foreground-light" htmlFor="allowed-operation">
           Allowed operation
         </label>
         <p className="text-sm text-foreground-lighter">Select an operation for this policy</p>
       </div>
-      <div className="w-2/3">
-        <div className="flex items-center space-x-8">
-          <Radio.Group type="small-cards" size="tiny" id="allowed-operation">
-            {['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'ALL'].map((op) => (
-              <Radio
-                key={op}
-                name="allowed-operation"
-                label={op}
-                value={op}
-                checked={operation === op}
-                onChange={(e) => onSelectOperation(e.target.value)}
-              />
-            ))}
-          </Radio.Group>
-        </div>
+      <div className="md:w-2/3">
+        <Radio.Group
+          type="small-cards"
+          size="tiny"
+          id="allowed-operation"
+          groupClassName="flex flex-row flex-wrap gap-3"
+        >
+          {['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'ALL'].map((op) => (
+            <Radio
+              key={op}
+              name="allowed-operation"
+              label={op}
+              value={op}
+              checked={operation === op}
+              onChange={(e) => onSelectOperation(e.target.value)}
+            />
+          ))}
+        </Radio.Group>
       </div>
     </div>
   )


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix — responsive layout for the Policy Command radio buttons in the RLS policy editor modal.

### What is the current behavior?

The Policy Command radio buttons (SELECT, INSERT, UPDATE, DELETE, ALL) in the "Create a new Row Level Security policy" modal overflow their container at narrow viewport widths (~685px or less). The buttons break out of the modal boundaries.

### What is the new behavior?

- The label/control layout now stacks vertically on small screens and switches to a side-by-side row on `md` breakpoints — matching the responsive pattern already used by `PolicyName` and `PolicyRoles` in the same modal.
- The radio button group uses `flex-wrap` so buttons wrap to a new row instead of overflowing when horizontal space is insufficient.

### Changes

**`apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyAllowedOperation.tsx`**
- Replaced fixed `flex justify-between space-x-12` with `flex flex-col md:flex-row gap-4 md:gap-12`
- Changed `w-1/3` / `w-2/3` to `md:w-1/3` / `md:w-2/3` so widths only apply at `md+`
- Removed the unnecessary intermediate `div` wrapper with `space-x-8`
- Added `groupClassName="flex flex-row flex-wrap gap-3"` to the `Radio.Group` to enable wrapping

### To Verify

1. Open the Supabase Dashboard → Authentication → Policies
2. Click "Create policy" to open the RLS policy modal
3. Resize the browser window to ~685px width or less
4. Confirm the Policy Command buttons wrap to a new row instead of overflowing

Closes #42584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for Auth Policies interface, with optimized arrangement adapting from column to row layout on medium screens for better space utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->