### PR TITLE
feat(studio): add POSTGRES_SSL_MODE env variable

### DIFF
--- a/apps/studio/lib/api/self-hosted/constants.ts
+++ b/apps/studio/lib/api/self-hosted/constants.ts
@@ -8,3 +8,4 @@ export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD || 'postgres'
 export const POSTGRES_USER_READ_WRITE = process.env.POSTGRES_USER_READ_WRITE || 'supabase_admin'
 export const POSTGRES_USER_READ_ONLY =
   process.env.POSTGRES_USER_READ_ONLY || 'supabase_read_only_user'
+export const POSTGRES_SSL_MODE = process.env.POSTGRES_SSL_MODE || ''

--- a/apps/studio/lib/api/self-hosted/util.ts
+++ b/apps/studio/lib/api/self-hosted/util.ts
@@ -1,13 +1,15 @@
 import crypto from 'crypto-js'
 import { IS_PLATFORM } from 'lib/constants'
+
 import {
   ENCRYPTION_KEY,
   POSTGRES_DATABASE,
   POSTGRES_HOST,
   POSTGRES_PASSWORD,
   POSTGRES_PORT,
-  POSTGRES_USER_READ_WRITE,
+  POSTGRES_SSL_MODE,
   POSTGRES_USER_READ_ONLY,
+  POSTGRES_USER_READ_WRITE,
 } from './constants'
 
 /**
@@ -25,6 +27,7 @@ export function encryptString(stringToEncrypt: string): string {
 
 export function getConnectionString({ readOnly }: { readOnly: boolean }) {
   const postgresUser = readOnly ? POSTGRES_USER_READ_ONLY : POSTGRES_USER_READ_WRITE
+  const postgresOptions = POSTGRES_SSL_MODE != '' ? `?sslmode=${POSTGRES_SSL_MODE}` : ''
 
-  return `postgresql://${postgresUser}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}`
+  return `postgresql://${postgresUser}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}${postgresOptions}`
 }

--- a/turbo.json
+++ b/turbo.json
@@ -111,6 +111,7 @@
         "PG_META_CRYPTO_KEY",
         "POSTGRES_PASSWORD",
         "POSTGRES_HOST",
+        "POSTGRES_SSL_MODE",
         "POSTGRES_USER_READ_WRITE",
         "POSTGRES_USER_READ_ONLY",
         "POSTGRES_DB",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature request https://github.com/orgs/supabase/discussions/49367

## What is the current behavior?

When running an external PostgreSQL server with SSL enabled ( e.g. in Azure ), the connection string used in Studio cannot be constructed in a way to add the sslmode option. Connections will fail, saying
`Error: no pg_hba.conf entry for host "x.x.x.x", user "xxx", database "xxx", no encryption`

## What is the new behavior?

When the environment variable POSTGRES_SSL_MODE is set, adds sslmode option to the connection string

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL SSL/TLS mode support, letting deployments configure secure DB connections via an environment variable; connection URIs will include the configured SSL mode when present.

* **Chores**
  * Build configuration updated to pass the new environment variable through to the studio build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->