### PR TITLE
bug: fix refetch loop

### DIFF
--- a/apps/studio/components/grid/hooks/useFilterLifeCycle.ts
+++ b/apps/studio/components/grid/hooks/useFilterLifeCycle.ts
@@ -35,8 +35,19 @@ export function useSyncFiltersToUrl() {
   const snap = useTableEditorTableStateSnapshot()
   const { setParams } = useTableEditorFiltersSort()
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const previousFiltersRef = useRef<string>('')
 
   useEffect(() => {
+    // Serialize filters for comparison
+    const currentFiltersStr = JSON.stringify(snap.filters)
+
+    // Only proceed if filters have actually changed
+    if (currentFiltersStr === previousFiltersRef.current) {
+      return
+    }
+
+    previousFiltersRef.current = currentFiltersStr
+
     // Clear any existing timeout
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)

--- a/apps/studio/hooks/misc/useTableEditorFiltersSort.ts
+++ b/apps/studio/hooks/misc/useTableEditorFiltersSort.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 export const useTableEditorFiltersSort = () => {
   const router = useRouter()
@@ -21,21 +21,29 @@ export const useTableEditorFiltersSort = () => {
     sort?: string[]
   }
 
-  const setParams = (fn: (prevParams: SetParamsArgs) => SetParamsArgs) => {
-    const prevParams = { filter: filters, sort: sorts }
-    const newParams = fn(prevParams)
+  const setParams = useCallback(
+    (fn: (prevParams: SetParamsArgs) => SetParamsArgs) => {
+      const prevParams = { filter: filters, sort: sorts }
+      const newParams = fn(prevParams)
 
-    const hasFilter = newParams.filter !== undefined
-    const hasSort = newParams.sort !== undefined
+      const hasFilter = newParams.filter !== undefined
+      const hasSort = newParams.sort !== undefined
 
-    router.push({
-      query: {
-        ...router.query,
-        ...(hasFilter ? { filter: newParams.filter } : {}),
-        ...(hasSort ? { sort: newParams.sort } : {}),
-      },
-    })
-  }
+      router.push(
+        {
+          query: {
+            ...router.query,
+            ...(hasFilter ? { filter: newParams.filter } : {}),
+            ...(hasSort ? { sort: newParams.sort } : {}),
+          },
+        },
+        undefined,
+        { shallow: true }
+      )
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filters, sorts]
+  )
 
   return {
     filters,


### PR DESCRIPTION
Problem:
- new filters are creating an infinite fetch loop of ph.supabase.io 

#  Before:
  snap.filters change → effect → setParams() → router.push()
  → URL updates → filters/sorts recalc → setParams recreated
  → effect re-runs → INFINITE LOOP 🔄

 # After:
  snap.filters change → effect → comparison shows change → timeout scheduled
  → setParams() → router.push(shallow: true) → URL updates
  → filters/sorts recalc → setParams recreated → effect runs
  → comparison check: no content change → early return → LOOP BROKEN ✓

  The deep comparison prevents the effect from re-executing when only the dependency references change
  (due to URL updates), not the actual filter content. Test it out and the PostHog spam should stop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Prevented unnecessary URL updates** when filter state remains unchanged, improving application responsiveness.
* **Optimized filter and sort parameter handling** with enhanced callback efficiency and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->