### PR TITLE
chore(studio): remove debug console.log statements

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -206,8 +206,6 @@ const calculateChartBucketing = (search: SearchParamsType | Record<string, any>)
   const hourDiff = endTime.diff(startTime, 'hour')
   const dayDiff = endTime.diff(startTime, 'day')
 
-  console.log(`Time difference: ${minuteDiff} minutes, ${hourDiff} hours, ${dayDiff} days`)
-
   // Adjust bucketing based on time range
   if (dayDiff >= 2) {
     truncationLevel = 'DAY'

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
@@ -70,7 +70,6 @@ export const LayoutSidebarProvider = ({ children }: PropsWithChildren) => {
           sidebarURLParamRef.current as (typeof SIDEBAR_KEYS)[keyof typeof SIDEBAR_KEYS]
         )
       ) {
-        console.log('Open sidebar based on URL')
         openSidebar(sidebarURLParamRef.current)
       } else if (
         !!sidebarLocalStorageRef.current &&

--- a/apps/studio/components/ui/FilterPopover.tsx
+++ b/apps/studio/components/ui/FilterPopover.tsx
@@ -163,7 +163,6 @@ export const FilterPopover = <T extends Record<string, any>>({
       !isFetching &&
       !isFetchingNextPage
     ) {
-      console.log('Fetch next page')
       fetchNextPage()
     }
   }, [


### PR DESCRIPTION
## What kind of change does this PR introduce?
Code cleanup

## What is the current behavior?
Three debug console.log statements are present in production Studio code:

- `UnifiedLogs.queries.ts`: Logs time difference calculations on every chart bucketing
- `FilterPopover.tsx`: Logs 'Fetch next page' on every pagination trigger
- `LayoutSidebarProvider.tsx`: Logs 'Open sidebar based on URL' on sidebar initialization

## What is the new behavior?
Debug console.log statements are removed. No functional changes.

## Additional context
These appear to be leftover debugging statements that were not cleaned up before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements from chart bucketing, sidebar initialization, and pagination features to improve code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->