### PR TITLE
docs: fix Express OAuth callback example variable references

### DIFF
--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -240,11 +240,11 @@ app.get("/auth/callback", async function (req, res) {
       process.env.SUPABASE_PUBLISHABLE_KEY, {
     cookies: {
       getAll() {
-        return parseCookieHeader(context.req.headers.cookie ?? '')
+        return parseCookieHeader(req.headers.cookie ?? '')
       },
       setAll(cookiesToSet) {
         cookiesToSet.forEach(({ name, value, options }) =>
-          context.res.appendHeader('Set-Cookie', serializeCookieHeader(name, value, options))
+          res.appendHeader('Set-Cookie', serializeCookieHeader(name, value, options))
         )
       },
     },
@@ -252,7 +252,8 @@ app.get("/auth/callback", async function (req, res) {
     await supabase.auth.exchangeCodeForSession(code)
   }
 
-  res.redirect(303, `/${next.slice(1)}`)
+  const redirectPath = next.startsWith('/') ? next : `/${next}`
+  res.redirect(303, redirectPath)
 })
 ```
 

--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -252,7 +252,8 @@ app.get("/auth/callback", async function (req, res) {
     await supabase.auth.exchangeCodeForSession(code)
   }
 
-  const redirectPath = next.startsWith('/') ? next : `/${next}`
+  const isSafePath = next.startsWith('/') && !next.startsWith('//')
+  const redirectPath = isSafePath ? next : '/'
   res.redirect(303, redirectPath)
 })
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation fix

## What is the current behavior?
The Express callback example in the OAuth PKCE flow documentation has two bugs:

1. **Wrong variable references**: Uses `context.req` and `context.res` instead of `req` and `res`. The Express route handler receives `req` and `res` as parameters, not a `context` object.
2. **Brittle redirect path**: Uses `` `/${next.slice(1)}` `` which incorrectly strips the first character regardless of whether it's a `/`. For example, `next = "dashboard"` would become `/ashboard`.

## What is the new behavior?
1. Fixed `context.req.headers.cookie` → `req.headers.cookie` and `context.res.appendHeader` → `res.appendHeader`
2. Replaced brittle redirect with safe normalization: `next.startsWith('/') ? next : '/${next}'`

## Additional context
The other framework examples (Next.js, SvelteKit, Astro, Remix) in the same file correctly reference their request/response objects. Only the Express example had this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth PKCE flow examples to correct cookie handling and response header behavior.
  * Hardened redirect guidance to ensure only safe internal paths are used, preventing open-redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->