### PR TITLE
fix(studio): allow add column button to work on empty tables

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -237,7 +237,7 @@ export const Grid = memo(
           {(rows ?? []).length === 0 && (
             <div
               className={cn(
-                'absolute w-full inset-0 flex flex-col items-center justify-center p-2 z-[1] pointer-events-none',
+                'absolute w-full left-0 right-0 bottom-0 top-[35px] flex flex-col items-center justify-center p-2 z-[1] pointer-events-none',
                 isTableEmpty && isDraggedOver && 'border-2 border-dashed',
                 isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
               )}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The "+" button in the grid header to add a new column is not clickable when a table has no rows. The button only becomes functional after at least 1 row is inserted.

The root cause: the empty state overlay uses `inset-0` which positions it from `top: 0`, covering the entire grid container including the header row. Even though the overlay has `pointer-events-none`, the combination of the overlay's `z-[1]` stacking context and the DataGrid's `contain: strict` (which creates its own stacking context) prevents click events from reaching the header in certain browsers.

Closes #42590

## What is the new behavior?
The empty state overlay now starts at `top: 35px` (matching the grid header row height) instead of `top: 0`, so it no longer covers the header row. The "+" add column button is now clickable regardless of whether the table has rows.

## Additional context
The fix is a single CSS class change: replacing `inset-0` with explicit `left-0 right-0 bottom-0 top-[35px]` to skip the header area. The `35px` value matches react-data-grid's default header row height used by this component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vertical positioning of the empty state placeholder in the grid when no rows are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->