### PR TITLE
Remove default freeze on PK column in table editor

### DIFF
--- a/apps/studio/components/grid/utils/gridColumns.tsx
+++ b/apps/studio/components/grid/utils/gridColumns.tsx
@@ -19,11 +19,11 @@ import { AddColumn } from '../components/grid/AddColumn'
 import { ColumnHeader } from '../components/grid/ColumnHeader'
 import { SelectColumn } from '../components/grid/SelectColumn'
 import {
+  isPendingAddRow,
   type ColumnType,
   type SupaColumn,
   type SupaRow,
   type SupaTable,
-  isPendingAddRow,
 } from '../types'
 import {
   isArrayColumn,
@@ -72,7 +72,7 @@ export function getGridColumns(
       sortable: true,
       width: columnWidth,
       minWidth: COLUMN_MIN_WIDTH,
-      frozen: x.isPrimaryKey || false,
+      frozen: false,
       isLastFrozenColumn: false,
       renderHeaderCell: (props) => (
         <ColumnHeader

--- a/apps/studio/components/grid/utils/queueOperationUtils.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.ts
@@ -1,10 +1,10 @@
 import type { QueryClient } from '@tanstack/react-query'
-import { type Entity, isTableLike } from 'data/table-editor/table-editor-types'
+import { isTableLike, type Entity } from 'data/table-editor/table-editor-types'
 import { tableRowKeys } from 'data/table-rows/keys'
 import type { TableRowsData } from 'data/table-rows/table-rows-query'
 import type { Dictionary } from 'types'
 
-import { PendingAddRow, PendingDeleteRow, SupaRow, isPendingAddRow } from '../types'
+import { isPendingAddRow, PendingAddRow, PendingDeleteRow, SupaRow } from '../types'
 import {
   EditCellContentOperation,
   NewQueuedOperation,


### PR DESCRIPTION
## Context

Just removes the default column freeze behaviour on primary key columns in the table editor. Behaviour should still persist if freezing manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Grid columns are no longer frozen based on primary key designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->