### PR TITLE
feat(docs)remove-grafana-link

### DIFF
--- a/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
@@ -6,11 +6,6 @@ description: 'Use Grafana Cloud’s managed Prometheus to visualize Supabase met
 
 Grafana Cloud gives you a fully managed Prometheus endpoint plus hosted Grafana dashboards, which makes it the fastest way to explore the Supabase Metrics API without operating your own infrastructure.
 
-<Admonition type="note">
-
-Grafana maintains a [Supabase integration guide](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-supabase/) for Grafana Cloud. It runs on the same Metrics API documented here, but is community-maintained by Grafana, so feature coverage might differ from what Supabase officially supports.
-
-</Admonition>
 
 ## Prerequisites
 

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -8,11 +8,6 @@ Self-hosting [Prometheus](https://prometheus.io/docs/prometheus/latest/installat
 
 <$Partial path="metrics_access.mdx" />
 
-<Admonition type="note">
-
-Grafana also documents a [Supabase integration reference](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-supabase/). While it targets Grafana Cloud, the scrape and agent settings apply equally to self-hosted clusters and offer a community-maintained companion to this guide.
-
-</Admonition>
 
 ## Architecture
 


### PR DESCRIPTION
Removing link to grafana integration which causes confusion. Several orgs have reported bad dashboards for something we do not maintain, and we'd prefer they follow our docs, and use our json for the dashboard

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

We link to the official grafana docs, but it's not actively maintained and creates confusion

## What is the new behavior?

We remove it

## Additional context

User complain to our support and customer success folks, but we can't adapt it, so it's confusing for our customers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed informational notes from Grafana Cloud and self-hosted telemetry guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->