### PR TITLE
fix:  CSV drag and drop

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -232,6 +232,9 @@ export const Grid = memo(
         <div
           className={cn('flex flex-col relative transition-colors', containerClass)}
           style={{ width: width || '100%', height: height || '50vh' }}
+          onDragOver={onDragOver}
+          onDragLeave={onDragOver}
+          onDrop={onFileDrop}
         >
           {/* Render no rows fallback outside of the DataGrid */}
           {(rows ?? []).length === 0 && (
@@ -241,9 +244,6 @@ export const Grid = memo(
                 isTableEmpty && isDraggedOver && 'border-2 border-dashed',
                 isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
               )}
-              onDragOver={onDragOver}
-              onDragLeave={onDragOver}
-              onDrop={onFileDrop}
             >
               {isLoading && !isDisabled && (
                 <GenericSkeletonLoader className="w-full top-9 absolute p-2" />


### PR DESCRIPTION
## Problem

Drag-and-drop CSV import functionality is broken in the Table Editor when tables are empty. The `pointer-events-none` CSS class on the empty state overlay blocks all pointer events, including drag events, preventing users from dropping CSV files onto empty tables.

## Solution

Move drag event handlers (`onDragOver`, `onDragLeave`, `onDrop`) from the inner overlay div to the parent container div. 
This allows:
- Drag events to be captured by the parent container
- The overlay to retain `pointer-events-none` for proper horizontal scrolling
-  (as intended in #42618)
- Interactive elements inside to use `pointer-events-auto`

This follows the existing pattern used in `FileExplorerColumn.tsx` where drag handlers are on the parent container while visual overlays have `pointer-events-none`.

 ## Related 
- Closes https://github.com/supabase/supabase/issues/42655  
- Extends https://github.com/supabase/supabase/pull/42618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop event detection scope in the grid component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->