### PR TITLE
chore: add E2E tests for simulating a drag and drop CSV

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -230,6 +230,7 @@ export const Grid = memo(
 
       return (
         <div
+          data-testid="table-editor-grid-container"
           className={cn('flex flex-col relative transition-colors', containerClass)}
           style={{ width: width || '100%', height: height || '50vh' }}
           onDragOver={onDragOver}

--- a/e2e/studio/features/files/table-editor-drag-drop.csv
+++ b/e2e/studio/features/files/table-editor-drag-drop.csv
@@ -1,0 +1,4 @@
+id,pw_column
+1,drag drop value 1
+2,drag drop value 2
+3,drag drop value 3

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1204,7 +1204,7 @@ testRunner('table editor', () => {
       return dt
     }, csvBuffer.toString('base64'))
 
-    const gridContainer = page.locator('[class*="flex flex-col relative transition-colors"]')
+    const gridContainer = page.getByTestId('table-editor-grid-container')
 
     await gridContainer.dispatchEvent('dragover', { dataTransfer })
     await expect(

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test'
 import fs from 'fs'
 import path from 'path'
+import { createTable as dbCreateTable, dropTable } from '../utils/db/index.js'
 import { env } from '../env.config.js'
 import { releaseFileOnceCleanup, withFileOnceSetup } from '../utils/once-per-file.js'
 import { resetLocalStorage } from '../utils/reset-local-storage.js'
@@ -1171,5 +1172,66 @@ testRunner('table editor', () => {
     // Clean up
     await deleteTable(page, ref, sourceTableName)
     await deleteTable(page, ref, targetTableName)
+  })
+
+  test('CSV drag and drop imports data on empty table', async ({ page, ref }) => {
+    const tableName = 'pw_table_csv_drag_drop'
+
+    await dropTable(tableName)
+    await dbCreateTable(tableName, columnName)
+
+    const loadPromise = waitForTableToLoad(page, ref)
+    await page.goto(toUrl(`/project/${ref}/editor?schema=public`))
+    await loadPromise
+
+    await page.getByRole('button', { name: `View ${tableName}`, exact: true }).click()
+    await page.waitForURL(/\/editor\/\d+\?schema=public$/)
+
+    await expect(
+      page.getByText('or drag and drop a CSV file here'),
+      'Empty table should show drag and drop hint'
+    ).toBeVisible()
+
+    const csvFilePath = path.join(import.meta.dirname, 'files', 'table-editor-drag-drop.csv')
+    const csvBuffer = fs.readFileSync(csvFilePath)
+
+    // Synthesize a DataTransfer with the CSV file to simulate a browser file drag-and-drop
+    const dataTransfer = await page.evaluateHandle((csvBase64: string) => {
+      const dt = new DataTransfer()
+      const bytes = Uint8Array.from(atob(csvBase64), (c) => c.charCodeAt(0))
+      const file = new File([bytes], 'table-editor-drag-drop.csv', { type: 'text/csv' })
+      dt.items.add(file)
+      return dt
+    }, csvBuffer.toString('base64'))
+
+    const gridContainer = page.locator('[class*="flex flex-col relative transition-colors"]')
+
+    await gridContainer.dispatchEvent('dragover', { dataTransfer })
+    await expect(
+      page.getByText('Drop your CSV file here'),
+      'Drag feedback should show when CSV is dragged over'
+    ).toBeVisible()
+
+    await gridContainer.dispatchEvent('drop', { dataTransfer })
+
+    await expect(
+      page.getByText('A total of 3 rows will be'),
+      'Import dialog should show correct row count from CSV'
+    ).toBeVisible({ timeout: 10_000 })
+
+    const waitForCsvInsert = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=', {
+      method: 'POST',
+    })
+    await page.getByRole('button', { name: 'Import data' }).click()
+    await waitForCsvInsert
+    await waitForGridDataToLoad(page, ref)
+
+    await expect(
+      page.getByText('3 records'),
+      'Table should show 3 records after drag and drop import'
+    ).toBeVisible()
+    await expect(page.getByRole('gridcell', { name: 'drag drop value 1' })).toBeVisible()
+
+    await dropTable(tableName)
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore: test drag and drop on table editor 

follow up for https://github.com/supabase/supabase/issues/42655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that validates CSV drag-and-drop import on an empty table, the import dialog flow, and successful population of rows in the grid.
* **Chores**
  * Added a test identifier to the grid container to improve reliability of UI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->