### PR TITLE
docs: fix MFA opt-in RLS policy example to use security definer function

### DIFF
--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -236,28 +236,37 @@ create policy "Policy name."
 Users that have enrolled MFA on their account are expecting that your
 application only works for them if they've gone through MFA.
 
+Since the `authenticated` role does not have direct access to `auth.mfa_factors`, you need to wrap the check in a `security definer` function. This function runs with the permissions of the owner (`postgres`), which can query the `auth` schema.
+
+```sql
+create or replace function public.mfa_is_required()
+returns boolean as $$
+  select exists (
+    select 1
+    from auth.mfa_factors
+    where user_id = auth.uid()
+      and status = 'verified'
+  );
+$$ language sql security definer set search_path = '';
+```
+
+Then use this function in your RLS policy:
+
 ```sql
 create policy "Policy name."
   on table_name
   as restrictive -- very important!
   to authenticated
   using (
-    array[(select auth.jwt()->>'aal')] <@ (
-      select
-          case
-            when count(id) > 0 then array['aal2']
-            else array['aal1', 'aal2']
-          end as aal
-        from auth.mfa_factors
-        where ((select auth.uid()) = user_id) and status = 'verified'
-    ));
+    (select auth.jwt()->>'aal') = 'aal2'
+    or not (select public.mfa_is_required())
+  );
 ```
 
-- The policy will only accept only `aal2` when the user has at least one MFA
-  factor verified.
-- Otherwise, it will accept both `aal1` and `aal2`.
-- The `<@` operator is PostgreSQL's ["contained in"
-  operator.](https://www.postgresql.org/docs/current/functions-array.html)
+- The policy requires `aal2` only when the user has at least one verified MFA factor.
+- If the user has no verified factors, both `aal1` and `aal2` are accepted.
+- The `security definer` function is needed because the `authenticated` role
+  cannot directly query `auth.mfa_factors`.
 - **Using `as restrictive` ensures this policy will restrict all commands on the
   table regardless of other policies!**
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation fix (bug fix)

## What is the current behavior?
The MFA documentation's "Enforce only for users that have opted-in" RLS policy example directly queries `auth.mfa_factors`. However, the `authenticated` role does not have SELECT permission on this table, causing every request to fail with:

```
ERROR: 42501: permission denied for table mfa_factors
```

This has been reported as a bug multiple times (see also #17168 which was closed for inactivity).

Closes #36024

## What is the new behavior?
The example now uses a two-step approach:

1. A `security definer` function (`public.mfa_is_required()`) that safely queries `auth.mfa_factors` with postgres-level permissions
2. A simplified RLS policy that calls this function

The function uses `set search_path = ''` for security hardening, following Supabase best practices for security definer functions.

The RLS policy logic is also simplified from the previous array-based approach to a more readable boolean expression:
```sql
(select auth.jwt()->>'aal') = 'aal2' or not (select public.mfa_is_required())
```

## Additional context
The issue author provided a working workaround using the same `security definer` approach but placed the function in the `auth` schema. Since creating functions in the `auth` schema is no longer allowed (as of CLI v2.22.15), this fix places the function in the `public` schema instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MFA authentication guide with improved security verification approach.

* **Security**
  * Enhanced MFA verification mechanism for more reliable authentication factor validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->