### PR TITLE
docs(swift): add missing Xcode framework linking step

### DIFF
--- a/apps/docs/docs/ref/swift/installing.mdx
+++ b/apps/docs/docs/ref/swift/installing.mdx
@@ -22,6 +22,8 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
 
     If you use Xcode, follow [Apple's dependencies guide](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to add supabase-swift to your project. Use https://github.com/supabase-community/supabase-swift.git for the url when Xcode asks.
 
+    After adding the package dependency, you also need to add `Supabase` (or the individual libraries you need) to your target. Select your target in Xcode, go to **General > Frameworks, Libraries, and Embedded Content**, click the **+** button, and add the `Supabase` library. Without this step, your build will fail with "No such module 'Supabase'".
+
     If you don't want the full Supabase environment, you can add individual packages, such as Functions, `Auth`, `Realtime`, `Storage`, or `PostgREST`.
 
   </RefSubLayout.Details>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation fix

## What is the current behavior?
The Swift installation guide tells users to follow Apple's dependencies guide to add supabase-swift, but omits a crucial step: manually adding the `Supabase` library to the target's "Frameworks, Libraries, and Embedded Content" section. Without this, Xcode builds fail with "No such module 'Supabase'".

This has been reported in multiple places (see also [supabase/supabase-swift discussion #19764](https://github.com/orgs/supabase/discussions/19764)).

Closes #38509

## What is the new behavior?
Added a paragraph after the Xcode installation step explaining that users need to:
1. Select their target in Xcode
2. Go to **General > Frameworks, Libraries, and Embedded Content**
3. Click **+** and add the `Supabase` library

## Additional context
This is a common gotcha for iOS developers new to Supabase. The package dependency gets added to the project but not linked to the target, causing the "No such module" build error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Swift installation guide with clarification on adding the Supabase library to the Xcode target via General > Frameworks, Libraries, and Embedded Content to prevent build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->