### PR TITLE
chore: Update filters in the new experience to use grouping

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterPopoverNew.utils.ts
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverNew.utils.ts
@@ -1,5 +1,3 @@
-import { format } from 'date-fns'
-
 import type { SupaColumn } from 'components/grid/types'
 import {
   isBoolColumn,
@@ -8,8 +6,8 @@ import {
   isEnumColumn,
   isTimeColumn,
 } from 'components/grid/utils/types'
-import type { FilterProperty } from 'ui-patterns'
-import { FilterOperatorOptions } from './Filter.constants'
+import { format } from 'date-fns'
+import type { FilterProperty, OperatorDefinition } from 'ui-patterns'
 
 // Check if column is a date/datetime/time type
 function isDateLikeColumn(column: SupaColumn): boolean {
@@ -18,28 +16,45 @@ function isDateLikeColumn(column: SupaColumn): boolean {
   )
 }
 
-const DEFAULT_OPERATORS = FilterOperatorOptions.map((op) => ({
-  value: op.value,
-  label: op.label,
-}))
-
-const STRING_OPERATORS = [
-  { value: '~~*', label: 'ilike operator' },
-  ...DEFAULT_OPERATORS.filter((op) => op.value !== '~~*'),
+const COMPARISON_OPERATORS: OperatorDefinition[] = [
+  { value: '=', label: 'Equals', group: 'comparison' },
+  { value: '<>', label: 'Not equal', group: 'comparison' },
+  { value: '>', label: 'Greater than', group: 'comparison' },
+  { value: '<', label: 'Less than', group: 'comparison' },
+  { value: '>=', label: 'Greater or equal', group: 'comparison' },
+  { value: '<=', label: 'Less or equal', group: 'comparison' },
 ]
 
-const DATE_OPERATORS = [
-  { value: '>', label: 'greater than' },
-  { value: '>=', label: 'greater than or equal' },
-  { value: '<', label: 'less than' },
-  { value: '<=', label: 'less than or equal' },
-  { value: '=', label: 'equals' },
-  { value: '<>', label: 'not equal' },
+const PATTERN_OPERATORS: OperatorDefinition[] = [
+  { value: '~~', label: 'Like', group: 'pattern' },
+  { value: '~~*', label: 'iLike', group: 'pattern' },
 ]
 
-const BOOLEAN_OPERATORS = [
-  { value: '=', label: 'equals' },
-  { value: '<>', label: 'not equal' },
+const SET_NULL_OPERATORS: OperatorDefinition[] = [
+  { value: 'in', label: 'In list', group: 'setNull' },
+  { value: 'is', label: 'Is', group: 'setNull' },
+]
+
+const DEFAULT_OPERATORS: OperatorDefinition[] = [
+  ...COMPARISON_OPERATORS,
+  ...PATTERN_OPERATORS,
+  ...SET_NULL_OPERATORS,
+]
+
+const STRING_OPERATORS: OperatorDefinition[] = DEFAULT_OPERATORS
+
+const DATE_OPERATORS: OperatorDefinition[] = [
+  { value: '>', label: 'Greater than', group: 'comparison' },
+  { value: '>=', label: 'Greater or equal', group: 'comparison' },
+  { value: '<', label: 'Less than', group: 'comparison' },
+  { value: '<=', label: 'Less or equal', group: 'comparison' },
+  { value: '=', label: 'Equals', group: 'comparison' },
+  { value: '<>', label: 'Not equal', group: 'comparison' },
+]
+
+const BOOLEAN_OPERATORS: OperatorDefinition[] = [
+  { value: '=', label: 'Equals', group: 'comparison' },
+  { value: '<>', label: 'Not equal', group: 'comparison' },
 ]
 
 export function columnToFilterProperty(column: SupaColumn): FilterProperty {

--- a/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
+++ b/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
@@ -25,7 +25,7 @@ export function CommandListItem({
     <div
       ref={setRef}
       role="option"
-      aria-selected={isHighlighted}
+      aria-selected={isSelected}
       onClick={() => onSelect(item)}
       className={cn(
         'relative flex items-center justify-between gap-2 px-2 py-1.5 text-xs cursor-pointer select-none outline-none text-foreground-light',

--- a/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
+++ b/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
@@ -1,0 +1,46 @@
+import { Check } from 'lucide-react'
+import { cn } from 'ui'
+
+import { OperatorSymbolBadge } from './OperatorSymbolBadge'
+import { MenuItem } from './types'
+
+export type CommandListItemProps = {
+  item: MenuItem
+  isHighlighted: boolean
+  isSelected: boolean
+  includeIcon: boolean
+  onSelect: (item: MenuItem) => void
+  setRef: (el: HTMLDivElement | null) => void
+}
+
+export function CommandListItem({
+  item,
+  isHighlighted,
+  isSelected,
+  includeIcon,
+  onSelect,
+  setRef,
+}: CommandListItemProps) {
+  return (
+    <div
+      ref={setRef}
+      role="option"
+      aria-selected={isHighlighted}
+      onClick={() => onSelect(item)}
+      className={cn(
+        'relative flex items-center justify-between gap-2 px-2 py-1.5 text-xs cursor-pointer select-none outline-none',
+        isHighlighted && 'bg-surface-300',
+        !isHighlighted && 'hover:bg-surface-200'
+      )}
+    >
+      <span className="flex items-center gap-2">
+        {includeIcon && item.icon}
+        {item.label}
+      </span>
+      <span className="flex items-center gap-1.5">
+        {item.operatorSymbol && <OperatorSymbolBadge symbol={item.operatorSymbol} />}
+        {isSelected && <Check className="h-4 w-4 text-foreground-muted" strokeWidth={2} />}
+      </span>
+    </div>
+  )
+}

--- a/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
+++ b/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
@@ -28,7 +28,7 @@ export function CommandListItem({
       aria-selected={isHighlighted}
       onClick={() => onSelect(item)}
       className={cn(
-        'relative flex items-center justify-between gap-2 px-2 py-1.5 text-xs cursor-pointer select-none outline-none',
+        'relative flex items-center justify-between gap-2 px-2 py-1.5 text-xs cursor-pointer select-none outline-none text-foreground-light',
         isHighlighted && 'bg-surface-300',
         !isHighlighted && 'hover:bg-surface-200'
       )}

--- a/packages/ui-patterns/src/FilterBar/DefaultCommandList.helpers.tsx
+++ b/packages/ui-patterns/src/FilterBar/DefaultCommandList.helpers.tsx
@@ -1,0 +1,15 @@
+export function EmptyState() {
+  return <div className="py-6 text-center text-sm text-foreground-muted">No results found.</div>
+}
+
+export function GroupHeader({ label }: { label: string }) {
+  return (
+    <div className="px-2 py-1.5 text-xs text-foreground-lighter font-normal tracking-wide">
+      {label}
+    </div>
+  )
+}
+
+export function GroupSeparator() {
+  return <div className="h-px bg-border-muted my-1" />
+}

--- a/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
+++ b/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
@@ -45,7 +45,7 @@ export function DefaultCommandList({
   useEffect(() => {
     const itemEl = itemRefs.current.get(highlightedIndex)
     if (itemEl && listRef.current) {
-      itemEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+      itemEl.scrollIntoView({ block: 'center', behavior: 'smooth' })
     }
   }, [highlightedIndex])
 

--- a/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
+++ b/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useMemo, useRef } from 'react'
 
 import { CommandListItem } from './CommandListItem'

--- a/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
+++ b/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
@@ -29,9 +29,10 @@ export function DefaultCommandList({
     if (grouped) {
       return groupMenuItemsByOperator(items)
     }
+    // Non-grouped items are treated as a single uncategorized group
     return [
       {
-        group: undefined,
+        group: 'uncategorized',
         items: items.map((item, index) => ({ item, index })),
       },
     ]
@@ -65,7 +66,7 @@ export function DefaultCommandList({
   return (
     <div ref={listRef} className="max-h-[300px] overflow-y-auto py-1">
       {groups.map((groupData, groupIndex) => (
-        <div key={groupData.group ?? 'ungrouped'}>
+        <div key={groupData.group}>
           {groupIndex > 0 && showGroupHeaders && <GroupSeparator />}
           {showGroupHeaders && groupData.group && (
             <GroupHeader label={OPERATOR_GROUP_LABELS[groupData.group]} />

--- a/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
+++ b/packages/ui-patterns/src/FilterBar/DefaultCommandList.tsx
@@ -1,19 +1,17 @@
-import React from 'react'
-import {
-  Command_Shadcn_,
-  CommandEmpty_Shadcn_,
-  CommandGroup_Shadcn_,
-  CommandItem_Shadcn_,
-  CommandList_Shadcn_,
-} from 'ui'
+import { useEffect, useMemo, useRef } from 'react'
 
-import { MenuItem } from './menuItems'
+import { CommandListItem } from './CommandListItem'
+import { EmptyState, GroupHeader, GroupSeparator } from './DefaultCommandList.helpers'
+import { MenuItem, MenuItemGroup, OPERATOR_GROUP_LABELS } from './types'
+import { groupMenuItemsByOperator } from './utils'
 
-type DefaultCommandListProps = {
+export type DefaultCommandListProps = {
   items: MenuItem[]
   highlightedIndex: number
   onSelect: (item: MenuItem) => void
   includeIcon?: boolean
+  grouped?: boolean
+  selectedValue?: string
 }
 
 export function DefaultCommandList({
@@ -21,25 +19,70 @@ export function DefaultCommandList({
   highlightedIndex,
   onSelect,
   includeIcon = true,
+  grouped = false,
+  selectedValue,
 }: DefaultCommandListProps) {
+  const listRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
+
+  const groups: MenuItemGroup[] = useMemo(() => {
+    if (grouped) {
+      return groupMenuItemsByOperator(items)
+    }
+    return [
+      {
+        group: undefined,
+        items: items.map((item, index) => ({ item, index })),
+      },
+    ]
+  }, [grouped, items])
+
+  const showGroupHeaders = groups.length > 1
+
+  useEffect(() => {
+    const itemEl = itemRefs.current.get(highlightedIndex)
+    if (itemEl && listRef.current) {
+      itemEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }
+  }, [highlightedIndex])
+
+  const setItemRef = (index: number) => (el: HTMLDivElement | null) => {
+    if (el) {
+      itemRefs.current.set(index, el)
+    } else {
+      itemRefs.current.delete(index)
+    }
+  }
+
+  if (items.length === 0) {
+    return (
+      <div ref={listRef} className="max-h-[300px] overflow-y-auto py-1">
+        <EmptyState />
+      </div>
+    )
+  }
+
   return (
-    <Command_Shadcn_>
-      <CommandList_Shadcn_>
-        <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
-        <CommandGroup_Shadcn_>
-          {items.map((item, idx) => (
-            <CommandItem_Shadcn_
+    <div ref={listRef} className="max-h-[300px] overflow-y-auto py-1">
+      {groups.map((groupData, groupIndex) => (
+        <div key={groupData.group ?? 'ungrouped'}>
+          {groupIndex > 0 && showGroupHeaders && <GroupSeparator />}
+          {showGroupHeaders && groupData.group && (
+            <GroupHeader label={OPERATOR_GROUP_LABELS[groupData.group]} />
+          )}
+          {groupData.items.map(({ item, index }) => (
+            <CommandListItem
               key={`${item.value}-${item.label}`}
-              value={item.value}
-              onSelect={() => onSelect(item)}
-              className={`text-xs ${idx === highlightedIndex ? 'bg-surface-400' : ''}`}
-            >
-              {includeIcon && item.icon}
-              {item.label}
-            </CommandItem_Shadcn_>
+              item={item}
+              isHighlighted={index === highlightedIndex}
+              isSelected={selectedValue === item.value}
+              includeIcon={includeIcon}
+              onSelect={onSelect}
+              setRef={setItemRef(index)}
+            />
           ))}
-        </CommandGroup_Shadcn_>
-      </CommandList_Shadcn_>
-    </Command_Shadcn_>
+        </div>
+      ))}
+    </div>
   )
 }

--- a/packages/ui-patterns/src/FilterBar/FilterBarContext.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterBarContext.tsx
@@ -3,13 +3,13 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef } from 'react'
 
 import { useFilterBarState, useOptionsCache } from './hooks'
-import { MenuItem } from './menuItems'
 import {
   ActiveInputState,
   FilterBarAction,
   FilterGroup,
   FilterOptionObject,
   FilterProperty,
+  MenuItem,
 } from './types'
 import { useCommandHandling } from './useCommandHandling'
 import { useKeyboardNavigation } from './useKeyboardNavigation'

--- a/packages/ui-patterns/src/FilterBar/FilterCondition.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterCondition.tsx
@@ -260,6 +260,8 @@ export function FilterCondition({
             highlightedIndex={opHighlightedIndex}
             onSelect={handleSelectMenuItem}
             includeIcon={false}
+            selectedValue={condition.operator}
+            grouped
           />
         </PopoverContent_Shadcn_>
       </Popover_Shadcn_>

--- a/packages/ui-patterns/src/FilterBar/OperatorSymbolBadge.tsx
+++ b/packages/ui-patterns/src/FilterBar/OperatorSymbolBadge.tsx
@@ -4,7 +4,7 @@ export type OperatorSymbolBadgeProps = {
 
 export function OperatorSymbolBadge({ symbol }: OperatorSymbolBadgeProps) {
   return (
-    <span className="ml-auto text-xs text-foreground-muted bg-surface-200 rounded px-1.5 py-0.5 font-mono">
+    <span className="ml-auto text-xs text-brand bg-surface-200 rounded px-1.5 py-0.5 font-mono">
       {symbol}
     </span>
   )

--- a/packages/ui-patterns/src/FilterBar/OperatorSymbolBadge.tsx
+++ b/packages/ui-patterns/src/FilterBar/OperatorSymbolBadge.tsx
@@ -1,0 +1,11 @@
+export type OperatorSymbolBadgeProps = {
+  symbol: string
+}
+
+export function OperatorSymbolBadge({ symbol }: OperatorSymbolBadgeProps) {
+  return (
+    <span className="ml-auto text-xs text-foreground-muted bg-surface-200 rounded px-1.5 py-0.5 font-mono">
+      {symbol}
+    </span>
+  )
+}

--- a/packages/ui-patterns/src/FilterBar/menuItems.ts
+++ b/packages/ui-patterns/src/FilterBar/menuItems.ts
@@ -1,21 +1,10 @@
-import { ActiveInputState, FilterBarAction, FilterGroup, FilterProperty } from './types'
+import { ActiveInputState, FilterBarAction, FilterGroup, FilterProperty, MenuItem } from './types'
 import {
   findConditionByPath,
   isCustomOptionObject,
   isFilterOperatorObject,
   isFilterOptionObject,
 } from './utils'
-
-export type MenuItem = {
-  value: string
-  label: string
-  icon?: React.ReactNode
-  isCustom?: boolean
-  customOption?: (props: any) => React.ReactElement
-  isAction?: boolean
-  action?: FilterBarAction
-  actionInputValue?: string
-}
 
 export function buildOperatorItems(
   activeInput: Extract<ActiveInputState, { type: 'operator' }> | null,
@@ -45,9 +34,14 @@ export function buildOperatorItems(
     })
     .map((op) => {
       if (isFilterOperatorObject(op)) {
-        return { value: op.value, label: `${op.label} (${op.value})` }
+        return {
+          value: op.value,
+          label: op.label,
+          group: op.group,
+          operatorSymbol: op.value,
+        }
       }
-      return { value: op, label: op }
+      return { value: op, label: op, operatorSymbol: op }
     })
 }
 

--- a/packages/ui-patterns/src/FilterBar/types.ts
+++ b/packages/ui-patterns/src/FilterBar/types.ts
@@ -21,15 +21,21 @@ export type FilterOption = string | FilterOptionObject | CustomOptionObject
 export type AsyncOptionsFunction = (search?: string) => Promise<(string | FilterOptionObject)[]>
 export type SyncOptionsFunction = (search?: string) => (string | FilterOptionObject)[]
 
-export type FilterOperatorGroup = 'comparison' | 'pattern' | 'setNull'
+export type FilterOperatorGroup = 'comparison' | 'pattern' | 'setNull' | 'uncategorized'
 
 export const OPERATOR_GROUP_LABELS: Record<FilterOperatorGroup, string> = {
   comparison: 'COMPARISON',
   pattern: 'PATTERN MATCHING',
   setNull: 'SET & NULL CHECKS',
+  uncategorized: 'OTHER',
 }
 
-export const GROUP_ORDER: FilterOperatorGroup[] = ['comparison', 'pattern', 'setNull']
+export const GROUP_ORDER: FilterOperatorGroup[] = [
+  'comparison',
+  'pattern',
+  'setNull',
+  'uncategorized',
+]
 
 export type OperatorDefinition = {
   value: string
@@ -99,7 +105,7 @@ export type GroupedMenuItem = {
 }
 
 export type MenuItemGroup = {
-  group: FilterOperatorGroup | undefined
+  group: FilterOperatorGroup
   items: GroupedMenuItem[]
 }
 

--- a/packages/ui-patterns/src/FilterBar/types.ts
+++ b/packages/ui-patterns/src/FilterBar/types.ts
@@ -21,9 +21,26 @@ export type FilterOption = string | FilterOptionObject | CustomOptionObject
 export type AsyncOptionsFunction = (search?: string) => Promise<(string | FilterOptionObject)[]>
 export type SyncOptionsFunction = (search?: string) => (string | FilterOptionObject)[]
 
+export type FilterOperatorGroup = 'comparison' | 'pattern' | 'setNull'
+
+export const OPERATOR_GROUP_LABELS: Record<FilterOperatorGroup, string> = {
+  comparison: 'COMPARISON',
+  pattern: 'PATTERN MATCHING',
+  setNull: 'SET & NULL CHECKS',
+}
+
+export const GROUP_ORDER: FilterOperatorGroup[] = ['comparison', 'pattern', 'setNull']
+
+export type OperatorDefinition = {
+  value: string
+  label: string
+  group: FilterOperatorGroup
+}
+
 export type FilterOperatorObject = {
   value: string
   label: string
+  group?: FilterOperatorGroup
 }
 
 export type FilterOperator = string | FilterOperatorObject
@@ -61,6 +78,29 @@ export type FilterBarAction = {
     inputValue: string,
     context: { path: ConditionPath; activeFilters: FilterGroup }
   ) => void | Promise<void>
+}
+
+export type MenuItem = {
+  value: string
+  label: string
+  icon?: React.ReactNode
+  isCustom?: boolean
+  customOption?: (props: CustomOptionProps) => React.ReactElement
+  isAction?: boolean
+  action?: FilterBarAction
+  actionInputValue?: string
+  group?: FilterOperatorGroup
+  operatorSymbol?: string
+}
+
+export type GroupedMenuItem = {
+  item: MenuItem
+  index: number
+}
+
+export type MenuItemGroup = {
+  group: FilterOperatorGroup | undefined
+  items: GroupedMenuItem[]
 }
 
 export type SerializableFilterProperty = Pick<

--- a/packages/ui-patterns/src/FilterBar/useCommandHandling.ts
+++ b/packages/ui-patterns/src/FilterBar/useCommandHandling.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 
-import { MenuItem } from './menuItems'
-import { ActiveInputState, FilterGroup, FilterProperty } from './types'
+import { ActiveInputState, FilterGroup, FilterProperty, MenuItem } from './types'
 import { addFilterToGroup, addGroupToGroup, findGroupByPath, isCustomOptionObject } from './utils'
 
 export function useCommandHandling({

--- a/packages/ui-patterns/src/FilterBar/utils.test.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.test.ts
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { FilterGroup, FilterProperty } from './types'
+import { FilterGroup, FilterProperty, MenuItem } from './types'
 import {
   addFilterToGroup,
   addGroupToGroup,
   findConditionByPath,
   findGroupByPath,
+  groupMenuItemsByOperator,
   isAsyncOptionsFunction,
   isCustomOptionObject,
   isFilterOptionObject,
@@ -225,6 +226,100 @@ describe('FilterBar Utils', () => {
       expect(isSyncOptionsFunction(syncFn)).toBe(true)
       expect(isSyncOptionsFunction(asyncFn)).toBe(true) // Both are functions
       expect(isSyncOptionsFunction(array)).toBe(false)
+    })
+  })
+
+  describe('groupMenuItemsByOperator', () => {
+    it('returns empty array for empty input', () => {
+      expect(groupMenuItemsByOperator([])).toEqual([])
+    })
+
+    it('groups items by their group property', () => {
+      const items: MenuItem[] = [
+        { value: '=', label: 'Equals', group: 'comparison' },
+        { value: '~~', label: 'Like', group: 'pattern' },
+        { value: '<>', label: 'Not equal', group: 'comparison' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].group).toBe('comparison')
+      expect(result[0].items).toHaveLength(2)
+      expect(result[1].group).toBe('pattern')
+      expect(result[1].items).toHaveLength(1)
+    })
+
+    it('maintains original indices for keyboard navigation', () => {
+      const items: MenuItem[] = [
+        { value: '=', label: 'Equals', group: 'comparison' },
+        { value: '~~', label: 'Like', group: 'pattern' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result[0].items[0].index).toBe(0)
+      expect(result[1].items[0].index).toBe(1)
+    })
+
+    it('respects GROUP_ORDER for group ordering', () => {
+      const items: MenuItem[] = [
+        { value: 'in', label: 'In list', group: 'setNull' },
+        { value: '~~', label: 'Like', group: 'pattern' },
+        { value: '=', label: 'Equals', group: 'comparison' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result[0].group).toBe('comparison')
+      expect(result[1].group).toBe('pattern')
+      expect(result[2].group).toBe('setNull')
+    })
+
+    it('places ungrouped items at the end', () => {
+      const items: MenuItem[] = [
+        { value: 'custom', label: 'Custom' }, // no group
+        { value: '=', label: 'Equals', group: 'comparison' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].group).toBe('comparison')
+      expect(result[1].group).toBeUndefined()
+    })
+
+    it('handles single group scenario', () => {
+      const items: MenuItem[] = [
+        { value: '=', label: 'Equals', group: 'comparison' },
+        { value: '<>', label: 'Not equal', group: 'comparison' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].group).toBe('comparison')
+      expect(result[0].items).toHaveLength(2)
+    })
+
+    it('preserves item order within groups', () => {
+      const items: MenuItem[] = [
+        { value: '=', label: 'Equals', group: 'comparison' },
+        { value: '<>', label: 'Not equal', group: 'comparison' },
+        { value: '>', label: 'Greater than', group: 'comparison' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result[0].items[0].item.value).toBe('=')
+      expect(result[0].items[1].item.value).toBe('<>')
+      expect(result[0].items[2].item.value).toBe('>')
+    })
+
+    it('handles all items being ungrouped', () => {
+      const items: MenuItem[] = [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].group).toBeUndefined()
+      expect(result[0].items).toHaveLength(2)
     })
   })
 })

--- a/packages/ui-patterns/src/FilterBar/utils.test.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.test.ts
@@ -275,7 +275,7 @@ describe('FilterBar Utils', () => {
 
     it('places uncategorized items at the end', () => {
       const items: MenuItem[] = [
-        { value: 'custom', label: 'Custom' }, // no group
+        { value: 'custom', label: 'Custom', group: 'uncategorized' },
         { value: '=', label: 'Equals', group: 'comparison' },
       ]
       const result = groupMenuItemsByOperator(items)
@@ -283,6 +283,19 @@ describe('FilterBar Utils', () => {
       expect(result).toHaveLength(2)
       expect(result[0].group).toBe('comparison')
       expect(result[1].group).toBe('uncategorized')
+    })
+
+    it('treats items without a group as uncategorized', () => {
+      const items: MenuItem[] = [
+        { value: 'custom', label: 'Custom' },
+        { value: '=', label: 'Equals', group: 'comparison' },
+      ]
+      const result = groupMenuItemsByOperator(items)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].group).toBe('comparison')
+      expect(result[1].group).toBe('uncategorized')
+      expect(result[1].items[0].item.value).toBe('custom')
     })
 
     it('handles single group scenario', () => {
@@ -312,8 +325,8 @@ describe('FilterBar Utils', () => {
 
     it('handles all items being uncategorized', () => {
       const items: MenuItem[] = [
-        { value: 'a', label: 'A' },
-        { value: 'b', label: 'B' },
+        { value: 'a', label: 'A', group: 'uncategorized' },
+        { value: 'b', label: 'B', group: 'uncategorized' },
       ]
       const result = groupMenuItemsByOperator(items)
 

--- a/packages/ui-patterns/src/FilterBar/utils.test.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.test.ts
@@ -273,7 +273,7 @@ describe('FilterBar Utils', () => {
       expect(result[2].group).toBe('setNull')
     })
 
-    it('places ungrouped items at the end', () => {
+    it('places uncategorized items at the end', () => {
       const items: MenuItem[] = [
         { value: 'custom', label: 'Custom' }, // no group
         { value: '=', label: 'Equals', group: 'comparison' },
@@ -282,7 +282,7 @@ describe('FilterBar Utils', () => {
 
       expect(result).toHaveLength(2)
       expect(result[0].group).toBe('comparison')
-      expect(result[1].group).toBeUndefined()
+      expect(result[1].group).toBe('uncategorized')
     })
 
     it('handles single group scenario', () => {
@@ -310,7 +310,7 @@ describe('FilterBar Utils', () => {
       expect(result[0].items[2].item.value).toBe('>')
     })
 
-    it('handles all items being ungrouped', () => {
+    it('handles all items being uncategorized', () => {
       const items: MenuItem[] = [
         { value: 'a', label: 'A' },
         { value: 'b', label: 'B' },
@@ -318,7 +318,7 @@ describe('FilterBar Utils', () => {
       const result = groupMenuItemsByOperator(items)
 
       expect(result).toHaveLength(1)
-      expect(result[0].group).toBeUndefined()
+      expect(result[0].group).toBe('uncategorized')
       expect(result[0].items).toHaveLength(2)
     })
   })

--- a/packages/ui-patterns/src/FilterBar/utils.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.ts
@@ -3,6 +3,7 @@ import {
   CustomOptionObject,
   FilterCondition,
   FilterGroup,
+  FilterOperatorGroup,
   FilterOperatorObject,
   FilterOptionObject,
   FilterProperty,
@@ -262,39 +263,16 @@ export function updateGroupAtPath(
   }
 }
 
-/**
- * Groups menu items by their operator group property.
- * Items are grouped in the order specified by GROUP_ORDER.
- * Items without a group are placed at the end.
- *
- * @param items - Array of menu items to group
- * @returns Array of menu item groups with their items and original indices
- */
 export function groupMenuItemsByOperator(items: MenuItem[]): MenuItemGroup[] {
-  const grouped = new Map<MenuItem['group'], GroupedMenuItem[]>()
+  const grouped = items.reduce<Map<FilterOperatorGroup, GroupedMenuItem[]>>((acc, item, index) => {
+    const group: FilterOperatorGroup = item.group ?? 'uncategorized'
+    const existing = acc.get(group) ?? []
+    acc.set(group, [...existing, { item, index }])
+    return acc
+  }, new Map())
 
-  items.forEach((item, index) => {
-    const group = item.group
-    if (!grouped.has(group)) {
-      grouped.set(group, [])
-    }
-    grouped.get(group)!.push({ item, index })
-  })
-
-  const result: MenuItemGroup[] = []
-
-  // Add groups in defined order
-  for (const groupKey of GROUP_ORDER) {
-    if (grouped.has(groupKey)) {
-      result.push({ group: groupKey, items: grouped.get(groupKey)! })
-      grouped.delete(groupKey)
-    }
-  }
-
-  // Add ungrouped items last
-  if (grouped.has(undefined)) {
-    result.push({ group: undefined, items: grouped.get(undefined)! })
-  }
-
-  return result
+  return GROUP_ORDER.filter((groupKey) => grouped.has(groupKey)).map((groupKey) => ({
+    group: groupKey,
+    items: grouped.get(groupKey) ?? [],
+  }))
 }

--- a/packages/ui-patterns/src/FilterBar/utils.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.ts
@@ -6,7 +6,11 @@ import {
   FilterOperatorObject,
   FilterOptionObject,
   FilterProperty,
+  GROUP_ORDER,
+  GroupedMenuItem,
   isGroup,
+  MenuItem,
+  MenuItemGroup,
   SyncOptionsFunction,
 } from './types'
 
@@ -256,4 +260,41 @@ export function updateGroupAtPath(
       index === current ? updateGroupAtPath(condition as FilterGroup, rest, newGroup) : condition
     ),
   }
+}
+
+/**
+ * Groups menu items by their operator group property.
+ * Items are grouped in the order specified by GROUP_ORDER.
+ * Items without a group are placed at the end.
+ *
+ * @param items - Array of menu items to group
+ * @returns Array of menu item groups with their items and original indices
+ */
+export function groupMenuItemsByOperator(items: MenuItem[]): MenuItemGroup[] {
+  const grouped = new Map<MenuItem['group'], GroupedMenuItem[]>()
+
+  items.forEach((item, index) => {
+    const group = item.group
+    if (!grouped.has(group)) {
+      grouped.set(group, [])
+    }
+    grouped.get(group)!.push({ item, index })
+  })
+
+  const result: MenuItemGroup[] = []
+
+  // Add groups in defined order
+  for (const groupKey of GROUP_ORDER) {
+    if (grouped.has(groupKey)) {
+      result.push({ group: groupKey, items: grouped.get(groupKey)! })
+      grouped.delete(groupKey)
+    }
+  }
+
+  // Add ungrouped items last
+  if (grouped.has(undefined)) {
+    result.push({ group: undefined, items: grouped.get(undefined)! })
+  }
+
+  return result
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Filters are now grouped so it easier to navigate
- Cleaned up types
- Cleaned up default command line component, it was a bit messy with all the new changes
- Added unit tests on new util method

## Demo

https://github.com/user-attachments/assets/1e75ebcc-177d-4fed-b316-a9824c74b01a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators are grouped (comparison, pattern, set-null) with labeled sections and preselected operator highlighting.
  * New command-list UI: selectable items with optional icons, operator symbol badges, group headers/separators, and an empty-state message.

* **Refactor**
  * Internal operator definitions reworked for stronger typing and consistent grouping.

* **Tests**
  * Added coverage for grouping behavior and menu item ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->