### PR TITLE
docs: add pgsodium/vault troubleshooting note for backup restore

### DIFF
--- a/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
@@ -197,6 +197,7 @@ breadcrumb: 'Migrations'
 - Setting the `session_replication_role` to `replica` disables all triggers so that columns are not double encrypted.
 - If you have created any [custom roles](/dashboard/project/_/database/roles) with `login` attribute, you have to manually set their passwords in the new project.
 - If you run into any permission errors related to `supabase_admin` during restore, edit the `schema.sql` file and comment out any lines containing `ALTER ... OWNER TO "supabase_admin"`.
+- If you get "permission denied" errors for `pgsodium.key` or `vault.secrets` tables during restore, comment out the related `COPY` and `setval` statements for these tables in your `data.sql` file. These system tables are managed internally and cannot be written to directly.
 
 ### Preserving migration history
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation fix

## What is the current behavior?
Users restoring a Supabase backup encounter "permission denied" errors for `pgsodium.key` and `vault.secrets` tables, with no guidance in the troubleshooting section on how to resolve it.

Example error:
```
psql:data.sql:5476: ERROR: permission denied for table key
```

Closes #34964

## What is the new behavior?
Added a troubleshooting bullet point explaining that users should comment out the related `COPY` and `setval` statements for `pgsodium.key` and `vault.secrets` in their `data.sql` file, since these system tables are managed internally and cannot be written to directly.

## Additional context
This follows the same pattern as the existing troubleshooting note about `supabase_admin` permission errors. The fix is a single line addition to the existing troubleshooting section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backup and restore troubleshooting guide with additional guidance for handling permission denied errors during database restoration. Includes specific notes on managing SQL statements that may require adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->