### PR TITLE
fix(studio): include view options (security_invoker) in displayed view definition

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx
@@ -53,17 +53,28 @@ export const TableDefinition = ({ entity }: TableDefinitionProps) => {
     }
   )
 
-  const { data: definition, isLoading } = isViewLike(entity) ? viewResult : tableResult
+  const isViewEntity = isViewLike(entity)
+  const { data, isLoading } = isViewEntity ? viewResult : tableResult
+
+  const definition = isViewEntity && data && typeof data === 'object' && 'definition' in data
+    ? (data as { definition: string; options: string | null }).definition
+    : (data as string | undefined)
+
+  const viewOptions = isViewEntity && data && typeof data === 'object' && 'options' in data
+    ? (data as { definition: string; options: string | null }).options
+    : null
+
+  const optionsClause = viewOptions ? ` with (${viewOptions})` : ''
 
   const prepend = isView(entity)
-    ? `create view ${entity.schema}.${entity.name} as\n`
+    ? `create view ${entity.schema}.${entity.name}${optionsClause} as\n`
     : isMaterializedView(entity)
-      ? `create materialized view ${entity.schema}.${entity.name} as\n`
+      ? `create materialized view ${entity.schema}.${entity.name}${optionsClause} as\n`
       : ''
 
   const formattedDefinition = useMemo(
     () => (definition ? formatSql(prepend + definition) : undefined),
-    [definition]
+    [definition, prepend]
   )
 
   const handleEditorOnMount = async (editor: any, monaco: any) => {

--- a/apps/studio/data/database/entity-definitions-query.ts
+++ b/apps/studio/data/database/entity-definitions-query.ts
@@ -26,11 +26,23 @@ with records as (
         'NO_TRIGGERS'
       )
       when 'v' then concat(
-        'create view ', concat(nc.nspname, '.', c.relname), ' as',
+        'create view ', concat(nc.nspname, '.', c.relname),
+        case
+          when c.reloptions is not null and array_length(c.reloptions, 1) > 0
+          then concat(' with (', array_to_string(c.reloptions, ', '), ')')
+          else ''
+        end,
+        ' as',
         pg_get_viewdef(concat(nc.nspname, '.', c.relname), true)
       )
       when 'm' then concat(
-        'create materialized view ', concat(nc.nspname, '.', c.relname), ' as',
+        'create materialized view ', concat(nc.nspname, '.', c.relname),
+        case
+          when c.reloptions is not null and array_length(c.reloptions, 1) > 0
+          then concat(' with (', array_to_string(c.reloptions, ', '), ')')
+          else ''
+        end,
+        ' as',
         pg_get_viewdef(concat(nc.nspname, '.', c.relname), true)
       )
       when 'f' then concat('create foreign table ', nc.nspname, '.', c.relname, ' ( ... )')

--- a/apps/studio/data/database/view-definition-query.ts
+++ b/apps/studio/data/database/view-definition-query.ts
@@ -15,15 +15,22 @@ export const getViewDefinitionSql = ({ id }: GetViewDefinitionArgs) => {
 
   const sql = /* SQL */ `
     with table_info as (
-      select 
+      select
         n.nspname::text as schema,
         c.relname::text as name,
+        c.reloptions,
         to_regclass(concat('"', n.nspname, '"."', c.relname, '"')) as regclass
       from pg_class c
       join pg_namespace n on n.oid = c.relnamespace
       where c.oid = ${id}
     )
-    select pg_get_viewdef(t.regclass, true) as definition
+    select
+      pg_get_viewdef(t.regclass, true) as definition,
+      case
+        when t.reloptions is not null and array_length(t.reloptions, 1) > 0
+        then array_to_string(t.reloptions, ', ')
+        else null
+      end as options
     from table_info t
   `.trim()
 
@@ -50,10 +57,13 @@ export async function getViewDefinition(
     signal
   )
 
-  return result[0].definition.trim()
+  return {
+    definition: result[0].definition.trim(),
+    options: result[0].options ?? null,
+  }
 }
 
-export type ViewDefinitionData = string
+export type ViewDefinitionData = { definition: string; options: string | null }
 export type ViewDefinitionError = ExecuteSqlError
 
 export const useViewDefinitionQuery = <TData = ViewDefinitionData>(


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (security-relevant)

## What is the current behavior?
When viewing a `security_invoker` view's definition in the Studio table editor, the `WITH (security_invoker = true)` clause is missing from the displayed SQL. If a developer copies this definition to the SQL editor and runs `CREATE OR REPLACE VIEW`, the view silently changes to a security definer view, removing all RLS protection.

Closes #35823

## What is the new behavior?
View options (including `security_invoker`) are now included in the displayed `CREATE VIEW` statement. The fix reads `c.reloptions` from `pg_class` and includes them as a `WITH (...)` clause when present.

Changes in three files:
1. **`view-definition-query.ts`**: Updated the SQL query to also return `reloptions` as an `options` field
2. **`TableDefinition.tsx`**: Uses the returned options to include `WITH (...)` in the prepended `CREATE VIEW` statement
3. **`entity-definitions-query.ts`**: Same fix for entity definitions used elsewhere (e.g., AI context)

## Additional context
The fix follows the same pattern already used for table definitions in `database-table-definition.ts`. For views without options, the behavior is unchanged (no `WITH` clause is added).

Example output before:
```sql
CREATE VIEW public.my_view AS SELECT ...
```

Example output after:
```sql
CREATE VIEW public.my_view WITH (security_invoker = true) AS SELECT ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Views and materialized views now properly display their complete SQL definitions, including any associated options in the statement generation.
  * Enhanced extraction of view options to provide more comprehensive view definition information throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->