### PR TITLE
chore(studio): hide password managers from edge functions

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -217,6 +217,10 @@ const AddNewSecretForm = () => {
                           <Input
                             {...field}
                             placeholder="e.g. CLIENT_KEY"
+                            data-1p-ignore
+                            data-lpignore="true"
+                            data-form-type="other"
+                            data-bwignore
                             onPaste={(e) => handlePaste(e.nativeEvent)}
                           />
                         </FormControl_Shadcn_>


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Chore
- Resolves DEPR-163

## What is the current behavior?

1Password and other password managers’ widgets pop up in the _Name_ `input` despite that being irrelevant to password managers.
 
## What is the new behavior?

We tell that field to ignore password mangers.

## Additional context

Apple’s own password manager does not have an attribute and the secret value is password-like, so I’m unable to hide theirs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved form behavior with password managers by updating input configuration settings on the edge function secrets form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->