### PR TITLE
fix(studio): colour contrast for selected file storage item

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -315,8 +315,9 @@ export const FileExplorerRow = ({
         className={cn(
           'storage-row group flex h-full items-center px-2.5',
           'hover:bg-panel-footer-light [[data-theme*=dark]_&]:hover:bg-panel-footer-dark',
-          `${isOpened ? 'bg-surface-200' : ''}`,
-          `${isPreviewed ? 'bg-green-500 hover:bg-green-500' : ''}`,
+          `${isOpened ? 'bg-selection' : ''}`,
+          `${isSelected ? 'bg-selection' : ''}`,
+          `${isPreviewed ? 'bg-selection hover:bg-selection' : ''}`,
           `${item.status !== STORAGE_ROW_STATUS.LOADING ? 'cursor-pointer' : ''}`
         )}
         onClick={(event) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix
- Resolves DEPR-334

## What is the current behavior?

Not enough colour contrast on selected item. It’s hard to tel what’s selected, especially on light mode.

## What is the new behavior?

Updated the storage explorer row styling to use `bg-selection` for selected, opened, and previewed rows, which increases contrast in light mode.

| Before | After |
| --- | --- |
| <img width="1166" height="759" alt="Buckets  Supabase-60C5BBB5-FB94-44AA-9435-E9610ACB25AA" src="https://github.com/user-attachments/assets/4f6071eb-70de-4389-89bf-3f3d127d32a9" /> | <img width="1166" height="759" alt="Buckets  Supabase" src="https://github.com/user-attachments/assets/7c3d7f53-a340-4718-8224-e5a3bb184181" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated file explorer row background styling to provide consistent visual feedback for opened, previewed, and selected item states in the storage interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->