### PR TITLE
chore: Add "Tanun Chalermsinsuwan" to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -195,6 +195,7 @@ Szymon Mentel
 Sugu Sougoumarane
 Supun Sudaraka Kalidasa
 Taha Le Bras
+Tanun Chalermsinsuwan
 Taryn King
 Terry Sutton
 Thomas E


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

`https://supabase.com/humans.txt` does not have Tanun's name

## What is the new behavior?

`https://supabase.com/humans.txt` will have Tanun's name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team member information in public team listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->