### PR TITLE
Use OrganizationCard component for org wildcard route

### DIFF
--- a/apps/studio/pages/org/_/[[...routeSlug]].tsx
+++ b/apps/studio/pages/org/_/[[...routeSlug]].tsx
@@ -26,10 +26,10 @@ const GenericOrganizationPage: NextPage = () => {
   const urlRewriterFactory = (slug: string | string[] | undefined) => {
     return (orgSlug: string) => {
       if (!Array.isArray(slug)) {
-        return `/org/${orgSlug}/general${!!queryString ? `${queryString}` : ''}`
+        return `/org/${orgSlug}/general${!!queryString ? `?${queryString}` : ''}`
       } else {
         const slugPath = slug.reduce((a: string, b: string) => `${a}/${b}`, '').slice(1)
-        return `/org/${orgSlug}/${slugPath}${!!queryString ? `${queryString}` : ''}`
+        return `/org/${orgSlug}/${slugPath}${!!queryString ? `?${queryString}` : ''}`
       }
     }
   }

--- a/apps/studio/pages/org/_/[[...routeSlug]].tsx
+++ b/apps/studio/pages/org/_/[[...routeSlug]].tsx
@@ -1,6 +1,3 @@
-import { NextPage } from 'next'
-import { useRouter } from 'next/router'
-
 import {
   Header,
   LoadingCardView,
@@ -8,29 +5,31 @@ import {
 } from 'components/interfaces/Home/ProjectList/EmptyStates'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
-import CardButton from 'components/ui/CardButton'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { withAuth } from 'hooks/misc/withAuth'
+import { NextPage } from 'next'
+import { useRouter } from 'next/router'
 import { cn } from 'ui'
 
-// [Joshen] Thinking we can deprecate this page in favor of /organizations
+import { OrganizationCard } from '@/components/interfaces/Organization/OrganizationCard'
+
 const GenericOrganizationPage: NextPage = () => {
   const router = useRouter()
-
-  const { data: organizations, isPending: isLoading } = useOrganizationsQuery()
   const { routeSlug, ...queryParams } = router.query
   const queryString =
     Object.keys(queryParams).length > 0
       ? new URLSearchParams(queryParams as Record<string, string>).toString()
       : ''
 
+  const { data: organizations, isPending: isLoading } = useOrganizationsQuery()
+
   const urlRewriterFactory = (slug: string | string[] | undefined) => {
     return (orgSlug: string) => {
       if (!Array.isArray(slug)) {
-        return `/org/${orgSlug}/general?${queryString}`
+        return `/org/${orgSlug}/general${!!queryString ? `${queryString}` : ''}`
       } else {
         const slugPath = slug.reduce((a: string, b: string) => `${a}/${b}`, '').slice(1)
-        return `/org/${orgSlug}/${slugPath}?${queryString}`
+        return `/org/${orgSlug}/${slugPath}${!!queryString ? `${queryString}` : ''}`
       }
     }
   }
@@ -57,24 +56,12 @@ const GenericOrganizationPage: NextPage = () => {
                       'sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3'
                     )}
                   >
-                    {organizations?.map((organization) => (
-                      <li key={organization.slug} className="col-span-1">
-                        <CardButton
-                          linkHref={urlRewriterFactory(routeSlug)(organization.slug)}
-                          title={
-                            <div className="flex w-full flex-row justify-between gap-1">
-                              <span className="flex-shrink truncate">{organization.name}</span>
-                            </div>
-                          }
-                          footer={
-                            <div className="flex items-end justify-between">
-                              <span className="text-sm lowercase text-foreground-light">
-                                {organization.slug}
-                              </span>
-                            </div>
-                          }
-                        />
-                      </li>
+                    {organizations?.map((org) => (
+                      <OrganizationCard
+                        key={org.id}
+                        organization={org}
+                        href={urlRewriterFactory(routeSlug)(org.slug)}
+                      />
                     ))}
                   </ul>
                 )}


### PR DESCRIPTION
## Context

For UI consistency - use `OrganizationCard` component for org wildcard route as per the /organizations page

### Before
<img width="1228" height="501" alt="image" src="https://github.com/user-attachments/assets/0a7442f0-d041-4657-9142-c475dbca630c" />

### After
<img width="1216" height="328" alt="image" src="https://github.com/user-attachments/assets/795a39f5-70ea-4681-b087-845fd022ae60" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL generation to avoid dangling or empty query strings when navigating organizations.

* **Refactor**
  * Replaced previous button-based organization items with card-based organization components for a cleaner presentation.
  * Deferred organization data initialization until after navigation query computation to ensure correct results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->