### PR TITLE
fix(studio): remove tooltip transition-opacity to prevent drift animation

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -221,8 +221,8 @@ export const CustomTooltip = ({
     return (
       <div
         className={cn(
-          'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg px-2.5 py-1.5 text-xs shadow-xl transition-opacity opacity-100',
-          !isActiveHoveredChart && 'opacity-0'
+          'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg px-2.5 py-1.5 text-xs shadow-xl',
+          isActiveHoveredChart ? 'opacity-100' : 'opacity-0'
         )}
       >
         <p className="text-foreground-light text-xs">{localTimeZone}</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Chart tooltips in Logs & Analytics drift/slide from the left side of the chart when hovering over bars. This happens because Recharts initially positions the tooltip at `left: 0` before repositioning it to the cursor location, and the `transition-opacity` CSS class on the `CustomTooltip` component makes this repositioning visible as a smooth drift animation.

Closes #36360

## What is the new behavior?

The tooltip appears instantly at the correct position without any drift animation. The opacity toggle between `opacity-0` and `opacity-100` still works for showing/hiding the tooltip when entering/leaving the chart, but without the CSS transition that caused the visible repositioning.

## Additional context

The fix removes the `transition-opacity` Tailwind class from the tooltip wrapper div in `ComposedChart.utils.tsx`. The opacity is still toggled based on `isActiveHoveredChart`, but the change is now instant rather than animated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tooltip visibility handling in chart components while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->