### PR TITLE
fix(studio): address multiple styling issues in report blocks

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
@@ -53,11 +53,11 @@ export const ReportBlockContainer = ({
             ) : (
               <Code size={16} strokeWidth={1.5} className="text-foreground-muted" />
             )}
-            <div className={cn('flex items-center gap-2 flex-1 transition-opacity')}>
+            <div className={cn('flex items-center gap-2 flex-1 min-w-0 transition-opacity')}>
               <h3 className="heading-meta truncate">{label}</h3>
               {badge && <div className="flex items-center shrink-0">{badge}</div>}
             </div>
-            <div className="flex items-center">{actions}</div>
+            <div className="flex items-center shrink-0">{actions}</div>
           </div>
         </TooltipTrigger>
         {tooltip && (

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -201,7 +201,7 @@ export const CustomTooltip = ({
       return (
         <div key={entry.name} className="flex items-center w-full">
           {getIcon(entry.color, isMax)}
-          <span className="text-foreground-lighter ml-1 flex-grow cursor-default select-none">
+          <span className="text-foreground-lighter ml-1 flex-grow cursor-default select-none truncate">
             {attribute?.label || entry.name}
           </span>
           <span className="ml-3.5 flex items-end gap-1">
@@ -221,8 +221,8 @@ export const CustomTooltip = ({
     return (
       <div
         className={cn(
-          'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg px-2.5 py-1.5 text-xs shadow-xl transition-opacity opacity-100',
-          !isActiveHoveredChart && 'opacity-0'
+          'grid min-w-[8rem] max-w-[18rem] items-start gap-1.5 rounded-lg border border-border/50 bg px-2.5 py-1.5 text-xs shadow-xl',
+          isActiveHoveredChart ? 'opacity-100' : 'opacity-0'
         )}
       >
         <p className="text-foreground-light text-xs">{localTimeZone}</p>

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -215,7 +215,7 @@ export const QueryBlock = ({
 
       {showSql && (
         <div
-          className={cn('shrink-0 grow-1 w-full h-full overflow-y-auto max-h-[min(300px, 100%)]', {
+          className={cn('shrink-0 grow-1 w-full h-full overflow-y-auto overscroll-contain max-h-[min(300px, 100%)]', {
             'border-b': results !== undefined,
           })}
         >
@@ -317,7 +317,7 @@ export const QueryBlock = ({
             </div>
           ) : (
             results && (
-              <div className={cn('flex-1 w-full overflow-auto relative max-h-64')}>
+              <div className={cn('flex-1 w-full overflow-auto overscroll-contain relative max-h-64')}>
                 <Results rows={results} />
               </div>
             )

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -237,7 +237,7 @@ export const getReportAttributesV2: (
       showMaxValue: true,
       hideChartType: false,
       showGrid: true,
-      YAxisProps: { width: 30 },
+      YAxisProps: { width: 40 },
       defaultChartStyle: 'bar',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#database-connections`,
       attributes: [
@@ -270,7 +270,7 @@ export const getReportAttributesV2: (
       showMaxValue: true,
       hideChartType: false,
       showGrid: true,
-      YAxisProps: { width: 30 },
+      YAxisProps: { width: 40 },
       defaultChartStyle: 'bar',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#database-connections`,
       attributes: [
@@ -333,7 +333,7 @@ export const getReportAttributesV2: (
       showLegend: true,
       showMaxValue: true,
       showGrid: true,
-      YAxisProps: { width: 30 },
+      YAxisProps: { width: 40 },
       hideChartType: false,
       defaultChartStyle: 'bar',
       docsUrl: `${DOCS_URL}/guides/platform/compute-and-disk#limits-and-constraints`,
@@ -365,7 +365,7 @@ export const getReportAttributesV2: (
       showLegend: false,
       showMaxValue: false,
       showGrid: true,
-      YAxisProps: { width: 30 },
+      YAxisProps: { width: 40 },
       hideChartType: false,
       defaultChartStyle: 'bar',
       attributes: [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Multiple styling issues in report blocks as described in #42640:

1. **Tooltip text overflowing**: Chart tooltips have no max-width, so long attribute labels overflow the tooltip border
2. **Y-axis labels truncated**: Connection charts use `width: 30` for Y-axis, which truncates values like "10,000" to "0,000"
3. **Block actions hidden by long titles**: The actions container in report block headers can be squeezed out by long titles
4. **Scroll propagation**: Scrolling inside a report block's content area also scrolls the parent page

Closes #42640

## What is the new behavior?

1. **Tooltip**: Added `max-w-[18rem]` to constrain tooltip width and `truncate` on label text to prevent overflow
2. **Y-axis**: Increased width from 30px to 40px for connection count charts, accommodating locale-formatted 5-digit numbers
3. **Block actions**: Added `shrink-0` to the actions container and `min-w-0` to the label container so the title truncates instead of pushing actions off-screen
4. **Scroll**: Added `overscroll-contain` to scrollable areas in QueryBlock to prevent scroll event propagation
5. **Tooltip animation**: Removed `transition-opacity` from chart tooltip to prevent drift animation when Recharts repositions it

## Additional context

The tooltip drift fix (removing `transition-opacity`) is also addressed separately in #42674 but is included here since it's part of the same component being modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label truncation and layout behavior in report containers.
  * Enhanced tooltip visibility, sizing, and text truncation in charts.
  * Adjusted scrolling behavior in query result blocks.
  * Optimized Y-axis spacing in database connection charts for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->