### PR TITLE
fix(studio): allow sorting auth users table when not actively searching

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/SortDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/SortDropdown.tsx
@@ -15,6 +15,7 @@ import {
 
 interface SortDropdownProps {
   specificFilterColumn: string
+  filterKeywords: string
   sortColumn: string
   sortOrder: string
   sortByValue: string
@@ -26,6 +27,7 @@ interface SortDropdownProps {
 
 export const SortDropdown = ({
   specificFilterColumn,
+  filterKeywords,
   sortColumn,
   sortOrder,
   sortByValue,
@@ -34,7 +36,7 @@ export const SortDropdown = ({
   setSortByValue,
   improvedSearchEnabled = false,
 }: SortDropdownProps) => {
-  if (specificFilterColumn !== 'freeform' && !improvedSearchEnabled) {
+  if (specificFilterColumn !== 'freeform' && !improvedSearchEnabled && !!filterKeywords) {
     return (
       <ButtonTooltip
         disabled

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -302,8 +302,9 @@ export const UsersV2 = () => {
       providers: selectedProviders,
       sort: sortColumn as 'id' | 'created_at' | 'email' | 'phone',
       order: sortOrder as 'asc' | 'desc',
-      // improved search will always have a column specified
-      ...(specificFilterColumn !== 'freeform' || improvedSearchEnabled
+      // Use column-based search when: improved search is enabled, or when
+      // searching on a specific column with active keywords
+      ...((improvedSearchEnabled || (specificFilterColumn !== 'freeform' && !!filterKeywords))
         ? { column: specificFilterColumn as OptimizedSearchColumns }
         : { column: undefined }),
 
@@ -343,7 +344,7 @@ export const UsersV2 = () => {
   const updateStorageFilter = (value: SpecificFilterColumn) => {
     setLocalStorageFilter(value)
     setSpecificFilterColumn(value)
-    if (value !== 'freeform' && !improvedSearchEnabled) {
+    if (value !== 'freeform' && !improvedSearchEnabled && !!filterKeywords) {
       updateSortByValue('id:asc')
     }
   }
@@ -692,6 +693,7 @@ export const UsersV2 = () => {
 
                 <SortDropdown
                   specificFilterColumn={specificFilterColumn}
+                  filterKeywords={filterKeywords}
                   sortColumn={sortColumn}
                   sortOrder={sortOrder}
                   sortByValue={sortByValue}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The sort dropdown in the Authentication > Users page is always disabled when a specific column filter (e.g., "Email address") is selected, even when no search keywords have been entered. Since the default filter is "Email address", users cannot change the sort order on initial page load.

The disabled state shows: "Sorting cannot be changed when searching on a specific column."

Closes #39658

## What is the new behavior?

Sorting is now only restricted when the user is **actively searching** (has entered keywords) with a specific column filter selected. When no search keywords are entered, the sort dropdown is fully functional regardless of the selected filter column.

This is safe because:
- Column-based cursor pagination (which requires fixed sort order) is only used when there are actual search keywords
- Without keywords, the query falls back to page-based pagination which supports arbitrary sorting

## Changes

- **`SortDropdown.tsx`**: Added `filterKeywords` prop; only disables sort when keywords is non-empty
- **`UsersV2.tsx`**: 
  - Pass `filterKeywords` to `SortDropdown`
  - Only use column-based search when keywords are present (or improved search is enabled)
  - Only reset sort to `id:asc` when changing filter column with active keywords

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the interaction between search and sort functionality in the Auth Users interface. The sort dropdown now properly respects active filter keywords, and automatic sort reset behavior has been refined when changing filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->