### PR TITLE
docs: replace deprecated getSession with getUser in Refine tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,15 +233,14 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const { data, error } = await supabaseClient.auth.getUser()
 
-      if (!session) {
+      if (error || !data?.user) {
         return {
           authenticated: false,
-          error: {
+          error: error || {
             message: 'Check failed',
-            name: 'Session not found',
+            name: 'User not found',
           },
           logout: true,
           redirectTo: '/login',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Refine tutorial's `authProvider.check` method uses the unrecommended `getSession()` to verify if a user is authenticated.

Related issue: #42193

## What is the new behavior?

Switched to `getUser()` which contacts the Supabase Auth server to verify the user, matching the recommended approach. This is also consistent with `getIdentity` in the same file already using `getUser()`.

## Additional context

Kept the change minimal -- only the `check` method needed updating since the rest of the authProvider was already using the right methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the getting started tutorial with improved authentication error messaging for clearer feedback on authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->