### PR TITLE
Clarify pool size as portion of max database connections

### DIFF
--- a/apps/docs/content/guides/database/connection-management.mdx
+++ b/apps/docs/content/guides/database/connection-management.mdx
@@ -15,7 +15,7 @@ You can change how many database connections Supavisor can manage by altering th
 
 ![Connection Info and Certificate.](/docs/img/database/pool-size.png)
 
-The general rule is that if you are heavily using the PostgREST database API, you should be conscientious about raising your pool size past 40%. Otherwise, you can commit 80% to the pool. This leaves adequate room for the Authentication server and other utilities.
+The general rule is that if you are heavily using the PostgREST database API, you should be conscientious about raising your pool size past 40% of the Database Max Connections. Otherwise, you can commit 80% to the pool. This leaves adequate room for the Authentication server and other utilities.
 
 These numbers are generalizations and depends on other Supabase products that you use and the extent of their usage. The actual values depend on your concurrent peak connection usage. For instance, if you were only using 80 connections in a week period and your database max connections is set to 500, then realistically you could allocate the difference of 420 (minus a reasonable buffer) to service more demand.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to resolve ambiguity. Clarifies assigning pool size percentage in proportion to Database Max Connections, as it could be mistaken for a percentage of max client connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved clarity in the database connection management guide regarding pool size configuration thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->