### PR TITLE
docs: replace deprecated getSession with getClaims

### DIFF
--- a/apps/docs/content/_partials/get_session_warning.mdx
+++ b/apps/docs/content/_partials/get_session_warning.mdx
@@ -1,6 +1,6 @@
 <Admonition type="danger">
 
-Note that `auth.getSession` reads the auth token and the unencoded session data from the local storage medium. It _doesn't_ send a request back to the Supabase Auth server unless the local session is expired.
+Note that `auth.getClaims` reads the auth token and the unencoded session data from the local storage medium. It _doesn't_ send a request back to the Supabase Auth server unless the local session is expired.
 
 You should **never** trust the unencoded session data if you're writing server code, since it could be tampered with by the sender. If you need verified, trustworthy user data, call `auth.getUser` instead, which always makes a request to the Auth server to fetch trusted data.
 


### PR DESCRIPTION
## Description

Updated documentation to replace deprecated `auth.getSession` with `auth.getClaims` as mentioned in issue #42193.

This ensures examples follow the recommended API usage.

## Checklist

- [x] I have read the CONTRIBUTING.md file.

## Type of change

Docs update

## Current behavior

Documentation examples were using deprecated `auth.getSession`.

## New behavior

Documentation now uses `auth.getClaims` instead.

Closes #42193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication documentation to correct method references, ensuring developers have accurate guidance for implementing token and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->