### PR TITLE
chore(studio): remove dead code from third-party auth create dialogs

### DIFF
--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAuth0Dialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAuth0Dialog.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Trash } from 'lucide-react'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -26,8 +25,6 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 interface CreateAuth0IntegrationProps {
   visible: boolean
   onClose: () => void
-  // TODO: Remove this if this Dialog is only used for creating.
-  onDelete: () => void
 }
 
 const FORM_ID = 'create-auth0-auth-integration-form'
@@ -41,14 +38,7 @@ const FormSchema = z.object({
     .regex(/^[A-Za-z0-9-.]+$/, 'Project IDs should only have alphanumeric characters and hyphens.'), // Only allow alphanumeric characters and hyphens.
 })
 
-export const CreateAuth0IntegrationDialog = ({
-  visible,
-  onClose,
-  onDelete,
-}: CreateAuth0IntegrationProps) => {
-  // TODO: Remove this if this Dialog is only used for creating.
-  const isCreating = true
-
+export const CreateAuth0IntegrationDialog = ({ visible, onClose }: CreateAuth0IntegrationProps) => {
   const { ref: projectRef } = useParams()
   const { mutate: createAuthIntegration, isPending } = useCreateThirdPartyAuthIntegrationMutation({
     onSuccess: () => {
@@ -90,9 +80,7 @@ export const CreateAuth0IntegrationDialog = ({
     <Dialog open={visible} onOpenChange={() => onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle className="truncate">
-            {isCreating ? `Add new Auth0 connection` : `Update existing Auth0 connection`}
-          </DialogTitle>
+          <DialogTitle className="truncate">Add new Auth0 connection</DialogTitle>
         </DialogHeader>
         <Separator />
         <DialogSection>
@@ -161,19 +149,11 @@ export const CreateAuth0IntegrationDialog = ({
           </Form_Shadcn_>
         </DialogSection>
         <DialogFooter>
-          {!isCreating && (
-            <div className="flex-1">
-              <Button type="danger" onClick={() => onDelete()} icon={<Trash />}>
-                Remove connection
-              </Button>
-            </div>
-          )}
-
           <Button disabled={isPending} type="default" onClick={() => onClose()}>
             Cancel
           </Button>
           <Button form={FORM_ID} htmlType="submit" disabled={isPending} loading={isPending}>
-            {isCreating ? 'Create connection' : 'Update connection'}
+            Create connection
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAwsCognitoAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAwsCognitoAuthDialog.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Trash } from 'lucide-react'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -28,8 +27,6 @@ import { AwsRegionSelector } from './AwsRegionSelector'
 interface CreateAwsCognitoAuthIntegrationProps {
   visible: boolean
   onClose: () => void
-  // TODO: Remove this if this Dialog is only used for creating.
-  onDelete: () => void
 }
 
 const FORM_ID = 'create-aws-cognito-auth-integration-form'
@@ -47,11 +44,7 @@ const FormSchema = z.object({
 export const CreateAwsCognitoAuthIntegrationDialog = ({
   visible,
   onClose,
-  onDelete,
 }: CreateAwsCognitoAuthIntegrationProps) => {
-  // TODO: Remove this if this Dialog is only used for creating.
-  const isCreating = true
-
   const { ref: projectRef } = useParams()
   const { mutate: createAuthIntegration, isPending } = useCreateThirdPartyAuthIntegrationMutation({
     onSuccess: () => {
@@ -96,11 +89,7 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
     <Dialog open={visible} onOpenChange={() => onClose()}>
       <DialogContent size="large">
         <DialogHeader>
-          <DialogTitle className="truncate">
-            {isCreating
-              ? `Add new Amazon Cognito Auth connection`
-              : `Update existing Amazon Cognito Auth connection`}
-          </DialogTitle>
+          <DialogTitle className="truncate">Add new Amazon Cognito Auth connection</DialogTitle>
           <DialogDescription>
             By adding an Amazon Cognito Auth connection, you can authenticate users using Amazon
             Cognito User Pools.
@@ -171,19 +160,11 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
           </Form_Shadcn_>
         </DialogSection>
         <DialogFooter>
-          {!isCreating && (
-            <div className="flex-1">
-              <Button type="danger" onClick={() => onDelete()} icon={<Trash />}>
-                Remove connection
-              </Button>
-            </div>
-          )}
-
           <Button disabled={isPending} type="default" onClick={() => onClose()}>
             Cancel
           </Button>
           <Button form={FORM_ID} htmlType="submit" disabled={isPending} loading={isPending}>
-            {isCreating ? 'Create connection' : 'Update connection'}
+            Create connection
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
@@ -27,8 +27,6 @@ interface CreateClerkAuthIntegrationProps {
   visible: boolean
   prod?: boolean
   onClose: () => void
-  // TODO: Remove this if this Dialog is only used for creating.
-  onDelete: () => void
 }
 
 const FORM_ID = 'create-firebase-auth-integration-form'
@@ -56,7 +54,6 @@ const FormSchema = z
 export const CreateClerkAuthIntegrationDialog = ({
   visible,
   onClose,
-  onDelete,
 }: CreateClerkAuthIntegrationProps) => {
   const { ref: projectRef } = useParams()
   const { mutate: createAuthIntegration, isPending } = useCreateThirdPartyAuthIntegrationMutation({

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Trash } from 'lucide-react'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -26,8 +25,6 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 interface CreateFirebaseAuthIntegrationProps {
   visible: boolean
   onClose: () => void
-  // TODO: Remove this if this Dialog is only used for creating.
-  onDelete: () => void
 }
 
 const FORM_ID = 'create-firebase-auth-integration-form'
@@ -44,11 +41,7 @@ const FormSchema = z.object({
 export const CreateFirebaseAuthIntegrationDialog = ({
   visible,
   onClose,
-  onDelete,
 }: CreateFirebaseAuthIntegrationProps) => {
-  // TODO: Remove this if this Dialog is only used for creating.
-  const isCreating = true
-
   const { ref: projectRef } = useParams()
   const { mutate: createAuthIntegration, isPending } = useCreateThirdPartyAuthIntegrationMutation({
     onSuccess: () => {
@@ -89,11 +82,7 @@ export const CreateFirebaseAuthIntegrationDialog = ({
     <Dialog open={visible} onOpenChange={() => onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle className="truncate">
-            {isCreating
-              ? `Add new Firebase Auth connection`
-              : `Update existing Firebase Auth connection`}
-          </DialogTitle>
+          <DialogTitle className="truncate">Add new Firebase Auth connection</DialogTitle>
         </DialogHeader>
 
         <Separator />
@@ -143,19 +132,11 @@ export const CreateFirebaseAuthIntegrationDialog = ({
           </Form_Shadcn_>
         </DialogSection>
         <DialogFooter>
-          {!isCreating && (
-            <div className="flex-1">
-              <Button type="danger" onClick={() => onDelete()} icon={<Trash />}>
-                Remove connection
-              </Button>
-            </div>
-          )}
-
           <Button disabled={isPending} type="default" onClick={() => onClose()}>
             Cancel
           </Button>
           <Button form={FORM_ID} htmlType="submit" disabled={isPending} loading={isPending}>
-            {isCreating ? 'Create connection' : 'Update connection'}
+            Create connection
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateWorkOSDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateWorkOSDialog.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Trash } from 'lucide-react'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -26,8 +25,6 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 interface CreateWorkOSIntegrationProps {
   visible: boolean
   onClose: () => void
-  // TODO: Remove this if this Dialog is only used for creating.
-  onDelete: () => void
 }
 
 const FORM_ID = 'create-work-os-integration-form'
@@ -50,11 +47,7 @@ const FormSchema = z.object({
 export const CreateWorkOSIntegrationDialog = ({
   visible,
   onClose,
-  onDelete,
 }: CreateWorkOSIntegrationProps) => {
-  // TODO: Remove this if this Dialog is only used for creating.
-  const isCreating = true
-
   const { ref: projectRef } = useParams()
   const { mutate: createAuthIntegration, isPending } = useCreateThirdPartyAuthIntegrationMutation({
     onSuccess: () => {
@@ -95,9 +88,7 @@ export const CreateWorkOSIntegrationDialog = ({
     <Dialog open={visible} onOpenChange={() => onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle className="truncate">
-            {isCreating ? `Add new WorkOS connection` : `Update existing WorkOS connection`}
-          </DialogTitle>
+          <DialogTitle className="truncate">Add new WorkOS connection</DialogTitle>
         </DialogHeader>
 
         <Separator />
@@ -152,19 +143,11 @@ export const CreateWorkOSIntegrationDialog = ({
           </Form_Shadcn_>
         </DialogSection>
         <DialogFooter>
-          {!isCreating && (
-            <div className="flex-1">
-              <Button type="danger" onClick={() => onDelete()} icon={<Trash />}>
-                Remove connection
-              </Button>
-            </div>
-          )}
-
           <Button disabled={isPending} type="default" onClick={() => onClose()}>
             Cancel
           </Button>
           <Button form={FORM_ID} htmlType="submit" disabled={isPending} loading={isPending}>
-            {isCreating ? 'Create connection' : 'Update connection'}
+            Create connection
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/index.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/index.tsx
@@ -133,31 +133,26 @@ export const ThirdPartyAuthForm = () => {
 
         <CreateFirebaseAuthIntegrationDialog
           visible={selectedIntegration === 'firebase'}
-          onDelete={() => {}}
           onClose={() => setSelectedIntegration(undefined)}
         />
 
         <CreateAwsCognitoAuthIntegrationDialog
           visible={selectedIntegration === 'awsCognito'}
-          onDelete={() => {}}
           onClose={() => setSelectedIntegration(undefined)}
         />
 
         <CreateAuth0IntegrationDialog
           visible={selectedIntegration === 'auth0'}
-          onDelete={() => {}}
           onClose={() => setSelectedIntegration(undefined)}
         />
 
         <CreateClerkAuthIntegrationDialog
           visible={selectedIntegration === 'clerk'}
-          onDelete={() => {}}
           onClose={() => setSelectedIntegration(undefined)}
         />
 
         <CreateWorkOSIntegrationDialog
           visible={selectedIntegration === 'workos'}
-          onDelete={() => {}}
           onClose={() => setSelectedIntegration(undefined)}
         />
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code cleanup / dead code removal

## What is the current behavior?

The five third-party auth integration dialogs (WorkOS, Firebase, Auth0, AWS Cognito, Clerk) contain dead code left over from when these components were planned to support both creating and updating integrations:

- **`onDelete` prop** is defined in each dialog's interface but always passed `() => {}` (a no-op) from the parent component
- **`isCreating = true`** is hardcoded as a constant with a TODO comment saying to remove it
- **Dead JSX** guarded by `!isCreating` renders a "Remove connection" button that can never appear
- **Unused `Trash` icon import** from lucide-react in 4 of the 5 dialogs
- **Conditional title/button text** (e.g., "Create connection" vs "Update connection") that always resolves to the "create" variant

Each dialog has inline TODO comments confirming this cleanup was intended:
```
// TODO: Remove this if this Dialog is only used for creating.
```

## What is the new behavior?

- Removed `onDelete` prop from all 5 dialog interfaces and their call sites
- Removed `isCreating` constant and its TODO comments
- Removed dead JSX (delete button, conditional title/button text)
- Removed unused `Trash` icon imports
- Simplified dialog titles and button labels to use the "create" text directly

**Files changed:**
- `CreateWorkOSDialog.tsx`
- `CreateFirebaseAuthDialog.tsx`
- `CreateAuth0Dialog.tsx`
- `CreateAwsCognitoAuthDialog.tsx`
- `CreateClerkAuthDialog.tsx`
- `ThirdPartyAuthForm/index.tsx` (call site)

## Additional context

This is a pure cleanup with no behavioral changes. The dialogs were always create-only (there is no update API for integrations), so the "update" code paths were never reachable. Net result: 92 lines of dead code removed across 6 files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed deletion capability from Auth provider integration dialogs (Firebase, AWS Cognito, Auth0, Clerk, and WorkOS).
  * Simplified dialogs to support creating new connections only; "Remove connection" functionality and related UI elements have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->