### PR TITLE
fix(studio): disable retries on GitHub authorization check

### DIFF
--- a/apps/studio/data/integrations/github-authorization-query.ts
+++ b/apps/studio/data/integrations/github-authorization-query.ts
@@ -4,7 +4,6 @@ import { get } from 'data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 import { integrationKeys } from './keys'
 
-// FIXME(kamil): Do not retry, a single check is fine.
 export async function getGitHubAuthorization(signal?: AbortSignal) {
   const { data, error } = await get('/platform/integrations/github/authorization', {
     signal,
@@ -27,6 +26,7 @@ export const useGitHubAuthorizationQuery = <TData = GitHubAuthorizationData>({
     queryFn: ({ signal }) => getGitHubAuthorization(signal),
     enabled,
     staleTime: 0,
+    retry: false,
     ...options,
   })
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `useGitHubAuthorizationQuery` hook uses React Query's default retry behavior (3 retries with exponential backoff). This means when checking if a user has authorized the GitHub integration, a failed authorization check is retried 3 times before settling. This is unnecessary since a single check is sufficient to determine authorization status.

There was an existing FIXME comment from a maintainer:
```
// FIXME(kamil): Do not retry, a single check is fine.
```

## What is the new behavior?

- Added `retry: false` to the query configuration so authorization checks are not retried on failure
- Removed the FIXME comment since the issue is now resolved

This is a minimal, targeted fix that addresses exactly what the FIXME requested.

## Additional context

File changed: `apps/studio/data/integrations/github-authorization-query.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GitHub authorization query to prevent automatic retries on failure, providing more predictable error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->