### PR TITLE
fix(studio): use semantic color token in SparkBar vertical variant

### DIFF
--- a/apps/studio/components/ui/SparkBar.tsx
+++ b/apps/studio/components/ui/SparkBar.tsx
@@ -66,7 +66,7 @@ const SparkBar = ({
     return (
       <div
         className={`relative rounded w-5 overflow-hidden border p-1 ${
-          bgClass ? bgClass : 'bg-gray-400'
+          bgClass ? bgClass : 'bg-surface-400'
         } ${borderClass ? borderClass : 'border-none'}`}
         style={{ height: totalHeight }}
       >


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The `SparkBar` component has an inconsistency in its color fallbacks:
- **Horizontal variant** (line 51): uses `bg-surface-400` (semantic token) -- correct
- **Vertical variant** (line 69): uses `bg-gray-400` (hardcoded color) -- incorrect

Hardcoded color values like `bg-gray-400` don't adapt to the design system's theme tokens and can cause visual inconsistencies, especially with dark/light mode theming.

## What is the new behavior?

The vertical variant's background fallback is changed from `bg-gray-400` to `bg-surface-400`, matching the horizontal variant and following the project's convention of using semantic Tailwind color tokens.

## Additional context

File changed: `apps/studio/components/ui/SparkBar.tsx`

The project's `CLAUDE.md` explicitly states: "Use Tailwind with semantic color tokens, not hardcoded colors" and lists `bg-surface-400` among the background tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default background color for the vertical SparkBar variant to match the horizontal variant's styling, ensuring visual consistency across component variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->