### PR TITLE
fix(studio): replace hardcoded colors with semantic tokens in BreadcrumbsView

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/BreadcrumbsView.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/BreadcrumbsView.tsx
@@ -30,8 +30,8 @@ export const BreadcrumbsView = ({ defaultValue: breadcrumbs }: BreadcrumbsViewPr
 
               <a
                 onClick={breadcrumb.onClick || (() => {})}
-                className={`text-gray-1100 block px-2 py-1 text-xs leading-5 focus:bg-gray-100 focus:text-gray-900 focus:outline-none ${
-                  breadcrumb.onClick ? 'cursor-pointer hover:text-white' : ''
+                className={`text-foreground-light block px-2 py-1 text-xs leading-5 focus:bg-selection focus:text-foreground focus:outline-none ${
+                  breadcrumb.onClick ? 'cursor-pointer hover:text-foreground' : ''
                 }`}
               >
                 {breadcrumb.label}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The `BreadcrumbsView` component uses hardcoded Tailwind color classes that don't follow the project's semantic color token convention:

- `text-gray-1100` (default text)
- `focus:bg-gray-100` (focus background)
- `focus:text-gray-900` (focus text)
- `hover:text-white` (hover text)

These hardcoded colors don't adapt properly to the design system's theme and may cause visual inconsistencies across light/dark modes.

## What is the new behavior?

Replaced with semantic color tokens:

| Before (hardcoded) | After (semantic) |
|---|---|
| `text-gray-1100` | `text-foreground-light` |
| `focus:bg-gray-100` | `focus:bg-selection` |
| `focus:text-gray-900` | `focus:text-foreground` |
| `hover:text-white` | `hover:text-foreground` |

These semantic tokens are consistent with the rest of the Studio codebase and will properly respond to theme changes.

## Additional context

File changed: `apps/studio/components/layouts/ProjectLayout/LayoutHeader/BreadcrumbsView.tsx`

Per `CLAUDE.md`: "Use Tailwind with semantic color tokens, not hardcoded colors."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated breadcrumb navigation styling to use branded color scheme. Improved visual feedback for hover and focus states with enhanced color contrast for better interaction visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->