### PR TITLE
fix(studio): replace hardcoded colors with semantic tokens in SavingIndicator

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/SavingIndicator.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/SavingIndicator.tsx
@@ -44,7 +44,7 @@ const SavingIndicator = ({ id }: SavingIndicatorProps) => {
           <Button
             type="text"
             size="tiny"
-            icon={<RefreshCcw className="text-gray-1100" strokeWidth={2} />}
+            icon={<RefreshCcw className="text-foreground-light" strokeWidth={2} />}
             onClick={retry}
           >
             Retry
@@ -68,7 +68,7 @@ const SavingIndicator = ({ id }: SavingIndicatorProps) => {
           isSnippetOwner ? (
             <Tooltip>
               <TooltipTrigger>
-                <AlertCircle className="text-red-900" size={14} strokeWidth={2} />
+                <AlertCircle className="text-destructive" size={14} strokeWidth={2} />
               </TooltipTrigger>
               <TooltipContent>Failed to save changes</TooltipContent>
             </Tooltip>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

`SavingIndicator.tsx` in the SQL Editor utility panel uses hardcoded color classes:
- `text-gray-1100` for the retry icon
- `text-red-900` for the error alert icon

These do not adapt to theme changes and are inconsistent with the project's semantic color token convention.

## What is the new behavior?

Replaced with semantic tokens:
- `text-gray-1100` → `text-foreground-light` (retry icon)
- `text-red-900` → `text-destructive` (error alert icon)

## Additional context

File changed: `apps/studio/components/interfaces/SQLEditor/UtilityPanel/SavingIndicator.tsx`

This follows the convention documented in CLAUDE.md to use semantic color tokens (`text-foreground-light`, `text-destructive`) instead of hardcoded color values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color styling for status indicators in the SQL Editor's Saving Indicator component to enhance visual consistency and improve status clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->