### PR TITLE
fix(studio): replace hardcoded bg-gray/bg-blue with bg-selection in file components

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -90,7 +90,7 @@ export const FileExplorerRowEditing = ({
   return (
     <div
       style={style}
-      className="storage-row flex items-center justify-between rounded bg-gray-500"
+      className="storage-row flex items-center justify-between rounded bg-selection"
     >
       <div className="flex h-full flex-grow items-center px-2.5">
         <div>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
@@ -51,7 +51,7 @@ const SpreadSheetFileUpload = ({
       {!uploadedFile ? (
         <div
           className={`flex h-48 cursor-pointer items-center justify-center rounded-md border border-dashed border-strong ${
-            isDraggedOver ? 'bg-gray-500' : ''
+            isDraggedOver ? 'bg-selection' : ''
           }`}
           onDragOver={onDragOver}
           onDragLeave={onDragOver}

--- a/apps/studio/components/ui/FileExplorerAndEditor/index.tsx
+++ b/apps/studio/components/ui/FileExplorerAndEditor/index.tsx
@@ -340,7 +340,7 @@ export const FileExplorerAndEditor = ({
 
   return (
     <div
-      className={`flex-1 overflow-hidden flex h-full relative ${isDragOver ? 'bg-blue-50' : ''}`}
+      className={`flex-1 overflow-hidden flex h-full relative ${isDragOver ? 'bg-selection' : ''}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

Three components use hardcoded background colors for interactive states (drag-over, editing):

- `FileExplorerRowEditing.tsx`: `bg-gray-500` for the editing row background
- `SpreadSheetFileUpload.tsx`: `bg-gray-500` for the drag-over highlight
- `FileExplorerAndEditor/index.tsx`: `bg-blue-50` for the drag-over highlight

These hardcoded colors do not adapt to theme changes.

## What is the new behavior?

All three replaced with `bg-selection`, which is the semantic token already used by the sibling `FileExplorerRow.tsx` component for selected/highlighted states. This ensures consistent theming across all file explorer and upload components.

## Additional context

Files changed:
- `apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx`
- `apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx`
- `apps/studio/components/ui/FileExplorerAndEditor/index.tsx`

The `bg-selection` token is already used in the same directory's `FileExplorerRow.tsx` (lines 318-320) for opened, selected, and previewed states, making this the correct semantic replacement.