### PR TITLE
fix(studio): replace hardcoded colors with semantic tokens in API docs components

### DIFF
--- a/apps/studio/components/interfaces/Docs/Param.tsx
+++ b/apps/studio/components/interfaces/Docs/Param.tsx
@@ -68,7 +68,7 @@ const Param = ({
               Type
             </label>
             <div>
-              <span className="flex grow-0 bg-slate-300 px-2 py-0.5 rounded-md text-foreground-light">
+              <span className="flex grow-0 bg-surface-300 px-2 py-0.5 rounded-md text-foreground-light">
                 <span className="flex items-center gap-2 text-sm">
                   <Code size="14" />
                   <span>{getColumnType(type, format)}</span>
@@ -81,7 +81,7 @@ const Param = ({
               Format
             </label>
             <div>
-              <span className="flex grow-0 bg-slate-300 px-2 py-0.5 rounded-md text-foreground-light">
+              <span className="flex grow-0 bg-surface-300 px-2 py-0.5 rounded-md text-foreground-light">
                 <span className="flex items-center gap-2 text-sm">
                   <Database size="14" />
                   <span>{format}</span>

--- a/apps/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/apps/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -57,7 +57,7 @@ export const ResourceContent = ({
   return (
     <>
       <h2 className="doc-section__table-name text-foreground mt-0 flex items-center px-6 gap-2">
-        <span className="bg-slate-300 p-2 rounded-lg">
+        <span className="bg-surface-300 p-2 rounded-lg">
           <Table2 size={18} />
         </span>
         <span className="text-2xl font-bold">{resourceId}</span>
@@ -154,7 +154,7 @@ export const ResourceContent = ({
           </div>
           <div className="doc-section">
             <article className="code-column text-foreground">
-              <h4 className="mt-0 text-white">Filtering</h4>
+              <h4 className="mt-0 text-foreground">Filtering</h4>
               <p>Supabase provides a wide range of filters.</p>
               <p>
                 <a


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The Studio API documentation components use hardcoded color classes:

- `Param.tsx`: `bg-slate-300` on type/format badge backgrounds (2 instances)
- `ResourceContent.tsx`: `bg-slate-300` on the table icon background
- `ResourceContent.tsx`: `text-white` on the "Filtering" heading

These hardcoded colors do not adapt to theme changes.

## What is the new behavior?

Replaced with semantic tokens:
- `bg-slate-300` → `bg-surface-300` (3 instances) — consistent with badge/tag backgrounds used elsewhere in the codebase (e.g., `ActionCard.tsx`, `ReportMenuItem.tsx`)
- `text-white` → `text-foreground` — the parent article already has `text-foreground`, so this heading should use the same semantic token

## Additional context

Files changed:
- `apps/studio/components/interfaces/Docs/Param.tsx`
- `apps/studio/components/interfaces/Docs/ResourceContent.tsx`