### PR TITLE
fix(studio): replace hardcoded hover color with semantic token in ProjectUsage

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -220,7 +220,7 @@ const PanelHeader = (props: any) => {
       <div
         className={
           'flex items-center space-x-3 opacity-80 transition ' +
-          (props.href ? 'cursor-pointer hover:text-gray-1200 hover:opacity-100' : '')
+          (props.href ? 'cursor-pointer hover:text-foreground hover:opacity-100' : '')
         }
       >
         <div>{props.icon}</div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

`ProjectUsage.tsx` uses `hover:text-gray-1200` for the hover state on panel header links. This hardcoded color does not respect theme changes.

## What is the new behavior?

Replaced `hover:text-gray-1200` with `hover:text-foreground`, which is the semantic token for primary text color and correctly adapts to both light and dark themes.

## Additional context

File changed: `apps/studio/components/interfaces/Home/ProjectUsage.tsx`

`text-gray-1200` is the darkest gray variant, which maps directly to `text-foreground` in the semantic token system.