### PR TITLE
update clerk get token call

### DIFF
--- a/apps/docs/content/guides/auth/third-party/clerk.mdx
+++ b/apps/docs/content/guides/auth/third-party/clerk.mdx
@@ -81,7 +81,7 @@ let supabase = SupabaseClient(
   options: SupabaseClientOptions(
     auth: SupabaseClientOptions.AuthOptions(
       accessToken: {
-        try await Clerk.shared.session?.getToken()?.jwt
+        try await Clerk.shared.auth.getToken()
       }
     )
   )

--- a/apps/docs/content/guides/auth/third-party/clerk.mdx
+++ b/apps/docs/content/guides/auth/third-party/clerk.mdx
@@ -72,7 +72,7 @@ await Supabase.initialize(
 <TabPanel id="swift" label="Swift (iOS)">
 
 ```swift
-import Clerk
+import ClerkKit
 import Supabase
 
 let supabase = SupabaseClient(


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## Context

Clerk released version 1.0.0 of the iOS SDK which changed the import statement and get token method. This PR updates the docs to align with the latest version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Clerk third-party authentication guide: Swift sample now reflects the renamed SDK and the current token retrieval approach for generating access tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->