### PR TITLE
fix(docs): add missing db id for troubleshooting guide

### DIFF
--- a/apps/docs/content/troubleshooting/realtime-concurrent-peak-connections-quota-jdDqcp.mdx
+++ b/apps/docs/content/troubleshooting/realtime-concurrent-peak-connections-quota-jdDqcp.mdx
@@ -4,6 +4,7 @@ github_url = "https://github.com/orgs/supabase/discussions/19391"
 date_created = "2023-12-03T17:05:20+00:00"
 topics = ["realtime", "self-hosting"]
 keywords = ["quota", "connections"]
+database_id = "01e0dd67-5208-4e65-b489-2afd5a0b2af3"
 ---
 
 The "Concurrent Peak Connections" quota refers to the maximum number of simultaneous connections to Supabase Realtime.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Missing database ID on troubleshooting guide causes its last-updated to always show up as the present time

## What is the new behavior?

Connected to database entry so correct last-updated date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal metadata for troubleshooting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->