### PR TITLE
feat(telemetry): track log explorer query execution

### DIFF
--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -41,6 +41,7 @@ import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useUpgradePrompt } from 'hooks/misc/useUpgradePrompt'
 import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
+import { useTrack } from 'lib/telemetry/track'
 import type { LogSqlSnippets, NextPageWithLayout } from 'types'
 import {
   buildLogQueryParams,
@@ -68,6 +69,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { profile } = useProfile()
   const { ref, q, queryId } = useParams()
+  const track = useTrack()
   const projectRef = ref as string
   const { logsShowMetadataIpTemplate } = useIsFeatureEnabled(['logs:show_metadata_ip_template'])
 
@@ -201,6 +203,8 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   }
 
   const handleRun = (value?: string | React.MouseEvent<HTMLButtonElement>) => {
+    track('log_explorer_query_run_button_clicked', { is_saved_query: !!queryId })
+
     const query = typeof value === 'string' ? value || editorValue : editorValue
     const resolvedParams = buildLogQueryParams(datePickerValue, query)
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2676,6 +2676,24 @@ export interface RlsEventTriggerBannerCreateButtonClickedEvent {
 }
 
 /**
+ * User clicked the Run button in the log explorer.
+ *
+ * @group Events
+ * @source studio
+ * @page /project/{ref}/logs/explorer
+ */
+export interface LogExplorerQueryRunButtonClickedEvent {
+  action: 'log_explorer_query_run_button_clicked'
+  properties: {
+    /**
+     * Whether the user is editing a saved query
+     */
+    is_saved_query: boolean
+  }
+  groups: TelemetryGroups
+}
+
+/**
  * @hidden
  */
 export type TelemetryEvent =
@@ -2745,6 +2763,7 @@ export type TelemetryEvent =
   | ImportDataAddedEvent
   | SendFeedbackButtonClickedEvent
   | SqlEditorQueryRunButtonClickedEvent
+  | LogExplorerQueryRunButtonClickedEvent
   | StudioPricingPlanCtaClickedEvent
   | StudioPricingSidePanelOpenedEvent
   | ReportsDatabaseGrafanaBannerClickedEvent


### PR DESCRIPTION
## Summary

Adds telemetry for log explorer query execution. We had zero tracking on log explorer usage — the SQL Editor tracks `sql_editor_query_run_button_clicked` but the log explorer had no equivalent. This adds parity so we can answer questions about how much users rely on the log explorer.

## Changes

- Add `LogExplorerQueryRunButtonClickedEvent` interface and union member in `telemetry-constants.ts`
- Fire `log_explorer_query_run_button_clicked` in `handleRun()` on the log explorer page
- Include `is_saved_query` property to distinguish saved vs ad-hoc queries

## Testing

- [x] Type-checked — no errors in modified files
- [x] Verified `useTrack()` auto-injects project/org groups
- [x] Tested event in local n preview and event gets sent to posthog staging

**Quick test:**
1. Go to `/project/{ref}/logs/explorer`
2. Run a query
3. Verify `log_explorer_query_run_button_clicked` event fires in telemetry with `is_saved_query: false`
4. Open a saved query and run it — verify `is_saved_query: true`

## Linear

- fixes GROWTH-624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added telemetry event tracking for the logs explorer Run button, distinguishing between saved and ad-hoc queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->