### PR TITLE
fix(studio): replace hardcoded tooltip colors in StackedBarChart

### DIFF
--- a/apps/studio/components/ui/Charts/StackedBarChart.tsx
+++ b/apps/studio/components/ui/Charts/StackedBarChart.tsx
@@ -196,13 +196,13 @@ const StackedBarChart: React.FC<Props> = ({
               return String(value) + suffix
             }}
             cursor={false}
-            labelClassName="text-white"
+            labelClassName="text-foreground"
             contentStyle={{
-              backgroundColor: '#444444',
-              borderColor: '#444444',
+              backgroundColor: 'hsl(var(--background-surface-300))',
+              borderColor: 'hsl(var(--border-default))',
               fontSize: '12px',
             }}
-            wrapperClassName="bg-gray-600 rounded min-w-md"
+            wrapperClassName="rounded min-w-md"
             active={!!syncId && syncTooltip && hoveredIndex !== null}
           />
         </BarChart>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling)

## What is the current behavior?
The `StackedBarChart` component uses hardcoded color values for its Recharts tooltip:
- `bg-gray-600` wrapper class
- `text-white` label class  
- Inline `backgroundColor: '#444444'` and `borderColor: '#444444'`

These hardcoded colors break the design system's theming and do not adapt to light/dark mode properly.

## What is the new behavior?
Replaces hardcoded colors with semantic design tokens:
- `text-white` -> `text-foreground` for the tooltip label
- `#444444` background/border -> `hsl(var(--background-surface-300))` / `hsl(var(--border-default))` CSS variables
- Removed `bg-gray-600` wrapper class (background is handled by `contentStyle`)

This aligns with the design system's semantic color token conventions and ensures the tooltip adapts correctly across themes.

## Additional context
The sibling chart components (`AreaChart`, `BarChart`) already use semantic patterns for their tooltips. This change brings `StackedBarChart` in line with the rest of the chart library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tooltip styling in stacked bar charts for improved visual consistency. Text color and background styling now align with the application's theme system, ensuring tooltips display correctly across different color schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->