### PR TITLE
fix(studio): replace hardcoded colors in API Docs components

### DIFF
--- a/apps/studio/components/interfaces/Docs/Param.tsx
+++ b/apps/studio/components/interfaces/Docs/Param.tsx
@@ -68,7 +68,7 @@ const Param = ({
               Type
             </label>
             <div>
-              <span className="flex grow-0 bg-slate-300 px-2 py-0.5 rounded-md text-foreground-light">
+              <span className="flex grow-0 bg-surface-300 px-2 py-0.5 rounded-md text-foreground-light">
                 <span className="flex items-center gap-2 text-sm">
                   <Code size="14" />
                   <span>{getColumnType(type, format)}</span>
@@ -81,7 +81,7 @@ const Param = ({
               Format
             </label>
             <div>
-              <span className="flex grow-0 bg-slate-300 px-2 py-0.5 rounded-md text-foreground-light">
+              <span className="flex grow-0 bg-surface-300 px-2 py-0.5 rounded-md text-foreground-light">
                 <span className="flex items-center gap-2 text-sm">
                   <Database size="14" />
                   <span>{format}</span>

--- a/apps/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/apps/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -57,7 +57,7 @@ export const ResourceContent = ({
   return (
     <>
       <h2 className="doc-section__table-name text-foreground mt-0 flex items-center px-6 gap-2">
-        <span className="bg-slate-300 p-2 rounded-lg">
+        <span className="bg-surface-300 p-2 rounded-lg">
           <Table2 size={18} />
         </span>
         <span className="text-2xl font-bold">{resourceId}</span>
@@ -154,7 +154,7 @@ export const ResourceContent = ({
           </div>
           <div className="doc-section">
             <article className="code-column text-foreground">
-              <h4 className="mt-0 text-white">Filtering</h4>
+              <h4 className="mt-0 text-foreground">Filtering</h4>
               <p>Supabase provides a wide range of filters.</p>
               <p>
                 <a


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling)

## What is the current behavior?
The API Docs components use hardcoded color values that do not adapt to the design system's theming:

- **`Param.tsx`**: Uses `bg-slate-300` for type/format badge backgrounds (lines 71, 84)
- **`ResourceContent.tsx`**: Uses `bg-slate-300` for the table icon background (line 60) and `text-white` for the "Filtering" heading (line 157)

These hardcoded values break theme consistency and may render poorly in dark mode.

## What is the new behavior?
Replaces all hardcoded colors with semantic design tokens:

| File | Before | After |
|------|--------|-------|
| `Param.tsx` | `bg-slate-300` | `bg-surface-300` |
| `ResourceContent.tsx` | `bg-slate-300` | `bg-surface-300` |
| `ResourceContent.tsx` | `text-white` | `text-foreground` |

These semantic tokens adapt properly across light and dark themes.

## Additional context
Part of ongoing effort to replace hardcoded color values with semantic design tokens per the project's styling guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined color styling in the documentation interface for improved visual consistency and theme alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->