### PR TITLE
fix(studio): replace hardcoded bg-gray-500 in file upload and storage editing

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -90,7 +90,7 @@ export const FileExplorerRowEditing = ({
   return (
     <div
       style={style}
-      className="storage-row flex items-center justify-between rounded bg-gray-500"
+      className="storage-row flex items-center justify-between rounded bg-selection"
     >
       <div className="flex h-full flex-grow items-center px-2.5">
         <div>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
@@ -51,7 +51,7 @@ const SpreadSheetFileUpload = ({
       {!uploadedFile ? (
         <div
           className={`flex h-48 cursor-pointer items-center justify-center rounded-md border border-dashed border-strong ${
-            isDraggedOver ? 'bg-gray-500' : ''
+            isDraggedOver ? 'bg-surface-200' : ''
           }`}
           onDragOver={onDragOver}
           onDragLeave={onDragOver}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling)

## What is the current behavior?
Two components use hardcoded `bg-gray-500` that does not adapt to light/dark themes:

1. **`SpreadSheetFileUpload.tsx`** - The drag-over highlight when importing CSV/TSV files uses `bg-gray-500`
2. **`FileExplorerRowEditing.tsx`** - The background of a storage row being renamed uses `bg-gray-500`

## What is the new behavior?

| Component | Before | After | Rationale |
|-----------|--------|-------|-----------|
| `SpreadSheetFileUpload` | `bg-gray-500` | `bg-surface-200` | Subtle highlight for drag-over state |
| `FileExplorerRowEditing` | `bg-gray-500` | `bg-selection` | Matches the selection pattern used by `FileExplorerRow` for opened/selected states |

Both tokens adapt properly across light and dark themes.

## Additional context
Part of ongoing effort to replace hardcoded color values with semantic design tokens per the project's styling guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated file explorer visual styling for improved consistency
  * Enhanced drag-and-drop visual feedback in file upload interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->