### PR TITLE
chore(studio): remove debug console.log from Reports and UnifiedLogs

### DIFF
--- a/apps/studio/components/interfaces/Reports/useReportFilters.ts
+++ b/apps/studio/components/interfaces/Reports/useReportFilters.ts
@@ -184,7 +184,6 @@ export const useReportFilters = ({
     const urlFilterJson = JSON.stringify(filtersFromUrl)
 
     if (currentFilterJson !== urlFilterJson) {
-      console.log('Syncing local filters from URL change:', { filtersFromUrl, localFilters })
       setLocalFilters(filtersFromUrl)
     }
   }, [queryFilters, isInitialized, convertQueryFiltersToReportFilters])
@@ -233,14 +232,6 @@ export const useReportFilters = ({
           )
       )
 
-      console.log('Filter Update:', {
-        localFilters,
-        reportFilterItems,
-        productFilters,
-        otherFilters,
-        newFilterState,
-      })
-
       // Remove only the non-product filters that we manage
       if (otherFilters.length > 0) {
         onRemoveFilters(otherFilters)
@@ -252,7 +243,6 @@ export const useReportFilters = ({
   }, [localFilters, isInitialized])
 
   const handleFilterChange = (newFilters: ReportFilter[]) => {
-    console.log('handleFilterChange called with:', newFilters)
     setLocalFilters(newFilters)
   }
 

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -206,8 +206,6 @@ const calculateChartBucketing = (search: SearchParamsType | Record<string, any>)
   const hourDiff = endTime.diff(startTime, 'hour')
   const dayDiff = endTime.diff(startTime, 'day')
 
-  console.log(`Time difference: ${minuteDiff} minutes, ${hourDiff} hours, ${dayDiff} days`)
-
   // Adjust bucketing based on time range
   if (dayDiff >= 2) {
     truncationLevel = 'DAY'


### PR DESCRIPTION
## What kind of change does this PR introduce?
Cleanup / Maintenance

## What is the current behavior?
Several debug `console.log` statements are present in production code:

1. **`useReportFilters.ts`** (3 occurrences):
   - `console.log('Syncing local filters from URL change:', ...)` (line 187)
   - `console.log('Filter Update:', ...)` (line 236) - logs full filter state objects
   - `console.log('handleFilterChange called with:', ...)` (line 255)

2. **`UnifiedLogs.queries.ts`** (1 occurrence):
   - `console.log('Time difference: ... minutes, ... hours, ... days')` (line 209)

These log verbose debugging information to the browser console in production.

## What is the new behavior?
All four debug `console.log` statements are removed. The underlying logic is unchanged -- only the unnecessary console output is cleaned up.

## Additional context
Files modified:
- `apps/studio/components/interfaces/Reports/useReportFilters.ts`
- `apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts`

Note: `console.log` statements in code snippets/templates (e.g., `Snippets.ts`, `Functions.templates.ts`) were intentionally left unchanged as they are part of example code shown to users.