### PR TITLE
fix(studio): use text-foreground for Vercel icon in project list

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -131,7 +131,7 @@ export const ProjectCard = ({
                   />
                 )}
                 {isVercelIntegrated && (
-                  <div className="bg-surface-100 w-5 h-5 p-1 border border-strong rounded-md flex items-center justify-center text-black dark:text-white">
+                  <div className="bg-surface-100 w-5 h-5 p-1 border border-strong rounded-md flex items-center justify-center text-foreground">
                     <InlineSVG
                       src={`${BASE_PATH}/img/icons/vercel-icon.svg`}
                       title="Vercel Icon"

--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectTableRow.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectTableRow.tsx
@@ -102,7 +102,7 @@ export const ProjectTableRow = ({
             {(isGithubIntegrated || isVercelIntegrated) && (
               <div className="flex items-center gap-x-1.5">
                 {isVercelIntegrated && (
-                  <div className="bg-surface-100 w-5 h-5 p-1 border border-strong rounded-md flex items-center text-black dark:text-white">
+                  <div className="bg-surface-100 w-5 h-5 p-1 border border-strong rounded-md flex items-center text-foreground">
                     <InlineSVG
                       src={`${BASE_PATH}/img/icons/vercel-icon.svg`}
                       title="Vercel Icon"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling)

## What is the current behavior?
The Vercel integration icon containers in `ProjectCard.tsx` and `ProjectTableRow.tsx` use `text-black dark:text-white` to manually handle dark mode text color.

## What is the new behavior?
Replaces `text-black dark:text-white` with the semantic `text-foreground` token, which automatically handles light/dark mode transitions.

| File | Before | After |
|------|--------|-------|
| `ProjectCard.tsx` | `text-black dark:text-white` | `text-foreground` |
| `ProjectTableRow.tsx` | `text-black dark:text-white` | `text-foreground` |

## Additional context
Part of ongoing effort to replace manual dark mode color overrides with semantic design tokens per the project's styling guidelines. The `text-foreground` token is the standard replacement for the `text-black dark:text-white` pattern throughout the codebase.