### PR TITLE
fix(ui-patterns): replace hardcoded bg-gray-600 with semantic token in BadgeDisabled

### DIFF
--- a/packages/ui-patterns/src/MultiSelectDeprecated/Badges.tsx
+++ b/packages/ui-patterns/src/MultiSelectDeprecated/Badges.tsx
@@ -7,7 +7,7 @@ export const BadgeDisabled = ({ name }: { name: string }) => (
   <div
     className={[
       'text-typography-body-light [[data-theme*=dark]_&]:text-typography-body-dark',
-      'flex cursor-not-allowed items-center space-x-2 rounded bg-gray-600',
+      'flex cursor-not-allowed items-center space-x-2 rounded bg-surface-300',
       'py-0.5 px-2 text-sm',
     ].join(' ')}
   >


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling)

## What is the current behavior?
The `BadgeDisabled` component in `packages/ui-patterns/src/MultiSelectDeprecated/Badges.tsx` uses a hardcoded `bg-gray-600` background color, while its sibling `BadgeSelected` component in the same file already uses the semantic `bg-surface-300` token.

## What is the new behavior?
Replaces `bg-gray-600` with `bg-surface-300` to match the `BadgeSelected` component and ensure consistent theming across both badge variants.

## Additional context
File: `packages/ui-patterns/src/MultiSelectDeprecated/Badges.tsx`

Both `BadgeDisabled` and `BadgeSelected` are deprecated in favor of the new `./multi-select` component, but this fix ensures visual consistency while the deprecated components are still in use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined disabled badge styling with refreshed color treatment for improved visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->