### PR TITLE
fix(studio): fix typo in Param prop name onDesciptionUpdated

### DIFF
--- a/apps/studio/components/interfaces/Docs/Param.tsx
+++ b/apps/studio/components/interfaces/Docs/Param.tsx
@@ -31,7 +31,7 @@ interface ParamProps {
   required: boolean
   description: boolean
   metadata?: any
-  onDesciptionUpdated?: () => void
+  onDescriptionUpdated?: () => void
 }
 const Param = ({
   name,
@@ -40,7 +40,7 @@ const Param = ({
   required,
   description,
   metadata = {},
-  onDesciptionUpdated = noop,
+  onDescriptionUpdated = noop,
 }: ParamProps) => {
   return (
     <>
@@ -97,7 +97,7 @@ const Param = ({
           <Description
             content={description?.toString()}
             metadata={metadata}
-            onChange={onDesciptionUpdated}
+            onChange={onDescriptionUpdated}
           />
         </div>
       )}

--- a/apps/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/apps/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -92,7 +92,7 @@ export const ResourceContent = ({
                     table: resourceId,
                     column: x.id,
                   }}
-                  onDesciptionUpdated={refreshDocs}
+                  onDescriptionUpdated={refreshDocs}
                 />
               </div>
               <div className="code">


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (typo)

## What is the current behavior?
The `Param` component in the API Docs feature has a misspelled prop name: `onDesciptionUpdated` (missing 'r' in "Description"). This typo is propagated through the interface definition and the calling code in `ResourceContent.tsx`.

## What is the new behavior?
Renames `onDesciptionUpdated` to `onDescriptionUpdated` in both files:

- **`Param.tsx`**: Interface `ParamProps`, destructured prop, and usage (3 occurrences)
- **`ResourceContent.tsx`**: Prop passed to `<Param>` component (1 occurrence)

## Additional context
Files modified:
- `apps/studio/components/interfaces/Docs/Param.tsx`
- `apps/studio/components/interfaces/Docs/ResourceContent.tsx`

This is a purely internal rename with no runtime behavior change, since the prop is only used within these two files.