### PR TITLE
fix(studio): replace manual dark mode colors with bg-foreground in UserOverview

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -477,11 +477,11 @@ export const RowData = ({ property, value }: { property: string; value?: string 
         {typeof value === 'boolean' ? (
           <div className="h-[26px] flex items-center justify-center min-w-[70px]">
             {value ? (
-              <div className="rounded-full w-4 h-4 dark:bg-white bg-black flex items-center justify-center">
+              <div className="rounded-full w-4 h-4 bg-foreground flex items-center justify-center">
                 <Check size={10} className="text-contrast" strokeWidth={4} />
               </div>
             ) : (
-              <div className="rounded-full w-4 h-4 dark:bg-white bg-black flex items-center justify-center">
+              <div className="rounded-full w-4 h-4 bg-foreground flex items-center justify-center">
                 <X size={10} className="text-contrast" strokeWidth={4} />
               </div>
             )}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling)

## What is the current behavior?
The boolean indicator icons (checkmark/X) in `UserOverview.tsx` use `bg-black dark:bg-white` to manually handle dark mode, duplicating logic that the design system's semantic tokens already provide.

## What is the new behavior?
Replaces `dark:bg-white bg-black` with the semantic `bg-foreground` token. The `bg-foreground` token resolves to black in light mode and white in dark mode, which is the exact same behavior but expressed through the design system.

The component already uses `text-contrast` for the icon color inside these circles, confirming that the design system's color tokens are the intended approach.

## Additional context
File: `apps/studio/components/interfaces/Auth/Users/UserOverview.tsx`

This is a two-line change affecting the boolean property indicator icons (Check and X) in the user details panel.