### PR TITLE
fix(studio): replace hardcoded bg-white and add text-foreground to IntegrationCard icons

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/IntegrationCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/IntegrationCard.tsx
@@ -23,7 +23,7 @@ export const IntegrationLoadingCard = () => {
   return (
     <div className={cn(INTEGRATION_CARD_STYLE, 'pl-5 pr-6 py-3 gap-3 inline-flex h-[110px]')}>
       <div className="w-10 h-10 relative">
-        <ShimmeringLoader className="w-full h-full bg-white border rounded-md" />
+        <ShimmeringLoader className="w-full h-full bg-surface-100 border rounded-md" />
       </div>
       <div className="grow basis-0 w-full flex flex-col justify-between items-start gap-y-2">
         <div className="w-full flex-col justify-start items-start gap-y-1 flex">
@@ -87,8 +87,8 @@ export const IntegrationCard = ({
       <Card className="h-full">
         <CardContent className="flex flex-col p-4 @2xl:p-6 h-full">
           <div className="flex items-start justify-between mb-4">
-            <div className="shrink-0 w-10 h-10 relative bg-white border rounded-md flex items-center justify-center">
-              {icon()}
+            <div className="shrink-0 w-10 h-10 relative bg-surface-100 border rounded-md flex items-center justify-center">
+              {icon({ className: 'w-full h-full text-foreground' })}
             </div>
             {isInstalled && (
               <div className="flex items-center gap-x-1">


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling / dark mode)

## What is the current behavior?
The `IntegrationCard` component has two issues:

1. **Hardcoded `bg-white`** on the icon container (line 90) and loading state shimmer (line 26), which does not adapt to dark mode
2. **Missing `text-foreground`** override on the `icon()` call (line 91) -- the featured card variant correctly passes `text-foreground` to the icon, but the non-featured variant does not, causing the icon to use its default `text-black` which is invisible on the hardcoded white background in dark mode

## What is the new behavior?

| Element | Before | After |
|---------|--------|-------|
| Icon container background | `bg-white` | `bg-surface-100` |
| Loading shimmer background | `bg-white` | `bg-surface-100` |
| Icon color override | `icon()` (no override) | `icon({ className: 'w-full h-full text-foreground' })` |

This makes the non-featured card consistent with the featured card variant and ensures proper dark mode support.

## Additional context
File: `apps/studio/components/interfaces/Integrations/Landing/IntegrationCard.tsx`

The featured card already correctly uses `text-foreground` for the icon (line 66). This PR aligns the non-featured card to the same pattern.