### PR TITLE
fix(studio): replace hardcoded bg-white in command menu integration icons

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx
@@ -333,8 +333,8 @@ export function useCreateCommands(options?: CommandOptions) {
         const getIcon = () => {
           if (isWrapper) {
             return (
-              <div className="w-6 h-6 relative bg-white border rounded-md flex items-center justify-center [&>img]:!p-1 [&>svg]:!p-1">
-                {integration.icon()}
+              <div className="w-6 h-6 relative bg-surface-100 border rounded-md flex items-center justify-center [&>img]:!p-1 [&>svg]:!p-1">
+                {integration.icon({ className: 'w-full h-full text-foreground' })}
               </div>
             )
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (styling / dark mode)

## What is the current behavior?
The `CreateCommands.tsx` component renders integration wrapper icons (for Wrappers like Stripe, Firebase, etc.) with a hardcoded `bg-white` background and calls `integration.icon()` without passing a `text-foreground` override. This causes the icon container to remain white in dark mode and the icon color defaults to `text-black` (from the constants file), making it potentially invisible or low-contrast in dark mode.

## What is the new behavior?
- Replaces `bg-white` with `bg-surface-100` for the icon container, adapting to the current theme
- Passes `text-foreground` override to `integration.icon()`, matching the pattern used in `IntegrationCard.tsx` for featured cards

## Additional context
File: `apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx`

This change aligns the command menu icon rendering with the existing `IntegrationCard` component pattern (see PR #42727 for the related fix in `IntegrationCard.tsx`).