### PR TITLE
fix: remove debug console.log in FilterPopover and use console.error in AuthProvidersFormValidation

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -484,7 +484,7 @@ const EXTERNAL_PROVIDER_APPLE = {
                     body.aud === 'https://appleid.apple.com'
                   )
                 } catch (e: any) {
-                  console.log(e)
+                  console.error(e)
                   return false
                 }
 
@@ -502,7 +502,7 @@ const EXTERNAL_PROVIDER_APPLE = {
                   const body = JSON.parse(parts[1])
                   return Date.now() > body.exp - 7 * 24 * 60 * 60 * 1000
                 } catch (e: any) {
-                  console.log(e)
+                  console.error(e)
                   return false
                 }
 

--- a/apps/studio/components/ui/FilterPopover.tsx
+++ b/apps/studio/components/ui/FilterPopover.tsx
@@ -163,7 +163,6 @@ export const FilterPopover = <T extends Record<string, any>>({
       !isFetching &&
       !isFetchingNextPage
     ) {
-      console.log('Fetch next page')
       fetchNextPage()
     }
   }, [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / Code cleanup

## What is the current behavior?

- `FilterPopover.tsx` has a debug `console.log('Fetch next page')` that logs to the browser console every time the next page of filter options is fetched
- `AuthProvidersFormValidation.tsx` uses `console.log(e)` in catch blocks when parsing Apple auth secret keys, which should use `console.error` for proper error-level logging

## What is the new behavior?

- Removed the debug `console.log('Fetch next page')` from `FilterPopover.tsx` as it provides no value to end users
- Changed `console.log(e)` to `console.error(e)` in two catch blocks in `AuthProvidersFormValidation.tsx` so errors during Apple secret key validation are logged at the correct severity level

## Additional context

Files changed:
- `apps/studio/components/ui/FilterPopover.tsx`
- `apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging consistency in authentication provider validation.
  * Removed debug console output from pagination component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->