### PR TITLE
fix: replace hardcoded text-white dark:text-black with text-contrast in ReplicationPipelineStatus

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.utils.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.utils.tsx
@@ -91,7 +91,7 @@ export const getDisabledStateConfig = ({
           text: 'text-brand-900',
           subtext: 'text-brand-700',
           iconBg: 'bg-brand-600',
-          icon: 'text-white dark:text-black',
+          icon: 'text-contrast',
         }
       : isDisabling || statusName === 'starting' || statusName === 'unknown'
         ? {
@@ -99,7 +99,7 @@ export const getDisabledStateConfig = ({
             text: 'text-warning-900',
             subtext: 'text-warning-700',
             iconBg: 'bg-warning-600',
-            icon: 'text-white dark:text-black',
+            icon: 'text-contrast',
           }
         : statusName === 'failed'
           ? {
@@ -107,14 +107,14 @@ export const getDisabledStateConfig = ({
               text: 'text-destructive-900',
               subtext: 'text-destructive-700',
               iconBg: 'bg-destructive-600',
-              icon: 'text-white dark:text-black',
+              icon: 'text-contrast',
             }
           : {
               bg: 'bg-surface-100',
               text: 'text-foreground',
               subtext: 'text-foreground-light',
               iconBg: 'bg-foreground-lighter',
-              icon: 'text-white dark:text-black',
+              icon: 'text-contrast',
             }
 
   return { title, message, badge, icon, colors }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling)

## What is the current behavior?

`ReplicationPipelineStatus.utils.tsx` uses hardcoded `text-white dark:text-black` for pipeline status icons across all status states (enabling, restarting, disabling, starting, unknown, failed, and default). This bypasses the design system's semantic color tokens.

## What is the new behavior?

Replaced all 4 instances of `text-white dark:text-black` with `text-contrast`, which is the semantic token for text that needs to contrast against colored backgrounds. This ensures proper theming support.

## Additional context

File changed: `apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.utils.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon colors in the Replication Pipeline Status interface for improved visual consistency across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->