### PR TITLE
fix: replace hardcoded text-black with text-foreground in integration icons

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -59,7 +59,7 @@ const SUPABASE_INTEGRATIONS: IntegrationDefinition[] = [
     missingExtensionsAlert: <UpgradeDatabaseAlert minimumVersion="15.6.1.143" />,
     name: `Queues`,
     icon: ({ className, ...props } = {}) => (
-      <Layers className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
+      <Layers className={cn('inset-0 p-2 text-foreground w-full h-full', className)} {...props} />
     ),
     description: 'Lightweight message queue in Postgres',
     docsUrl: 'https://github.com/tembo-io/pgmq',
@@ -119,7 +119,7 @@ const SUPABASE_INTEGRATIONS: IntegrationDefinition[] = [
     requiredExtensions: ['pg_cron'],
     name: `Cron`,
     icon: ({ className, ...props } = {}) => (
-      <Clock5 className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
+      <Clock5 className={cn('inset-0 p-2 text-foreground w-full h-full', className)} {...props} />
     ),
     description: 'Schedule recurring Jobs in Postgres',
     docsUrl: 'https://github.com/citusdata/pg_cron',
@@ -174,7 +174,7 @@ const SUPABASE_INTEGRATIONS: IntegrationDefinition[] = [
     name: `Vault`,
     status: 'beta',
     icon: ({ className, ...props } = {}) => (
-      <Vault className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
+      <Vault className={cn('inset-0 p-2 text-foreground w-full h-full', className)} {...props} />
     ),
     description: 'Application level encryption for your project',
     docsUrl: DOCS_URL,
@@ -217,7 +217,7 @@ const SUPABASE_INTEGRATIONS: IntegrationDefinition[] = [
     type: 'postgres_extension' as const,
     name: `Database Webhooks`,
     icon: ({ className, ...props } = {}) => (
-      <Webhook className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
+      <Webhook className={cn('inset-0 p-2 text-foreground w-full h-full', className)} {...props} />
     ),
     description:
       'Send real-time data from your database to another system when a table event occurs',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling)

## What is the current behavior?

Integration icon components for Queues, Cron, Vault, and Database Webhooks in `Integrations.constants.tsx` use hardcoded `text-black`, which does not adapt to dark mode. This is inconsistent with the featured card view in the same file which correctly uses `text-foreground` (line 66).

## What is the new behavior?

Replaced `text-black` with `text-foreground` in all 4 integration icon definitions (Queues, Cron, Vault, Database Webhooks) so the icons properly adapt to the current theme.

## Additional context

File changed: `apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx`

The featured card rendering at line 66 already uses `text-foreground` for icons, so this change makes the non-featured card icons consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of integration icons for Queues, Cron, Vault, and Database Webhooks to improve visual consistency and readability across the integrations interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->