### PR TITLE
fix: Add cursor-pointer to user dropdown menu items

### DIFF
--- a/apps/studio/components/interfaces/LocalDropdown.tsx
+++ b/apps/studio/components/interfaces/LocalDropdown.tsx
@@ -36,14 +36,14 @@ export const LocalDropdown = () => {
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" align="end" className="w-44">
         <DropdownMenuItem
-          className="flex gap-2"
+          className="flex gap-2 cursor-pointer"
           onClick={openFeaturePreviewModal}
           onSelect={openFeaturePreviewModal}
         >
           <FlaskConical size={14} strokeWidth={1.5} className="text-foreground-lighter" />
           Feature previews
         </DropdownMenuItem>
-        <DropdownMenuItem className="flex gap-2" onClick={() => setCommandMenuOpen(true)}>
+        <DropdownMenuItem className="flex gap-2 cursor-pointer" onClick={() => setCommandMenuOpen(true)}>
           <Command size={14} strokeWidth={1.5} className="text-foreground-lighter" />
           Command menu
         </DropdownMenuItem>
@@ -57,7 +57,7 @@ export const LocalDropdown = () => {
             }}
           >
             {singleThemes.map((theme: Theme) => (
-              <DropdownMenuRadioItem key={theme.value} value={theme.value}>
+              <DropdownMenuRadioItem key={theme.value} value={theme.value} className="cursor-pointer">
                 {theme.name}
               </DropdownMenuRadioItem>
             ))}

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -80,7 +80,7 @@ export function UserDropdown() {
             </div>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem className="flex gap-2" asChild>
+              <DropdownMenuItem className="flex gap-2 cursor-pointer" asChild>
                 <Link
                   href="/account/me"
                   onClick={() => {
@@ -94,14 +94,14 @@ export function UserDropdown() {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem
-                className="flex gap-2"
+                className="flex gap-2 cursor-pointer"
                 onClick={openFeaturePreviewModal}
                 onSelect={openFeaturePreviewModal}
               >
                 <FlaskConical size={14} strokeWidth={1.5} className="text-foreground-lighter" />
                 Feature previews
               </DropdownMenuItem>
-              <DropdownMenuItem className="flex gap-2" asChild>
+              <DropdownMenuItem className="flex gap-2 cursor-pointer" asChild>
                 <Link
                   href="https://supabase.com/changelog"
                   target="_blank"
@@ -124,7 +124,7 @@ export function UserDropdown() {
             }}
           >
             {singleThemes.map((theme: Theme) => (
-              <DropdownMenuRadioItem key={theme.value} value={theme.value}>
+              <DropdownMenuRadioItem key={theme.value} value={theme.value} className="cursor-pointer">
                 {theme.name}
               </DropdownMenuRadioItem>
             ))}
@@ -135,6 +135,7 @@ export function UserDropdown() {
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem
+                className="cursor-pointer"
                 onSelect={() => {
                   router.push('/logout')
                 }}


### PR DESCRIPTION
### Problem
Interactive menu items in the User Account dropdown lack pointer-cursor on hover, making the UI feel less interactive.

### Solution
Added `cursor-pointer` CSS class to all interactive dropdown menu items in `UserDropdown.tsx` and `LocalDropdown.tsx`.

### Changes Made

####  UserDropdown.tsx
- [x] Account preferences link
- [x] Feature previews button  
- [x] Changelog link
- [x] Theme selection radio items
- [x] Log out button

####  LocalDropdown.tsx
- [x] Feature previews button
- [x] Command menu button
- [x] Theme selection radio items

### Technical Details
- **Files**: 2 files modified
- **Change**: Added `cursor-pointer` class to `DropdownMenuItem` and `DropdownMenuRadioItem` components
- **Risk**: Very low - UI improvement only

### Testing
- [x] Cursor changes to pointer on hover for all interactive items
- [x] Existing functionality preserved
- [x] No breaking changes

Fixes #42360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cursor styling on dropdown menu items in account settings, feature previews, changelog, theme selection, and logout menus to provide consistent visual feedback across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->