### PR TITLE
Chore/deprecate use query state with select part 04

### DIFF
--- a/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
@@ -4,12 +4,6 @@ import type {
   OAuthClient,
   UpdateOAuthClientParams,
 } from '@supabase/supabase-js'
-import { Plus, Trash2, Upload, X } from 'lucide-react'
-import { type ChangeEvent, useEffect, useRef, useState } from 'react'
-import { useFieldArray, useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import * as z from 'zod'
-
 import { useParams } from 'common'
 import { InlineLink } from 'components/ui/InlineLink'
 import Panel from 'components/ui/Panel'
@@ -18,15 +12,20 @@ import { useOAuthServerAppCreateMutation } from 'data/oauth-server-apps/oauth-se
 import { useOAuthServerAppRegenerateSecretMutation } from 'data/oauth-server-apps/oauth-server-app-regenerate-secret-mutation'
 import { useOAuthServerAppUpdateMutation } from 'data/oauth-server-apps/oauth-server-app-update-mutation'
 import { DOCS_URL } from 'lib/constants'
+import { Plus, Trash2, Upload, X } from 'lucide-react'
+import { useEffect, useRef, useState, type ChangeEvent } from 'react'
+import { useFieldArray, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
   Button,
+  cn,
+  Form_Shadcn_,
   FormControl_Shadcn_,
   FormDescription_Shadcn_,
   FormField_Shadcn_,
   FormItem_Shadcn_,
   FormLabel_Shadcn_,
   FormMessage_Shadcn_,
-  Form_Shadcn_,
   Input_Shadcn_,
   Separator,
   Sheet,
@@ -37,11 +36,11 @@ import {
   SheetSection,
   SheetTitle,
   Switch,
-  cn,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import * as z from 'zod'
 
 interface CreateOrUpdateOAuthAppSheetProps {
   visible: boolean
@@ -87,12 +86,14 @@ export const CreateOrUpdateOAuthAppSheet = ({
   onCancel,
 }: CreateOrUpdateOAuthAppSheetProps) => {
   const { ref: projectRef } = useParams()
-  const isEditMode = !!appToEdit
-  const [showRegenerateDialog, setShowRegenerateDialog] = useState(false)
   const uploadButtonRef = useRef<HTMLInputElement>(null)
+
+  const [showRegenerateDialog, setShowRegenerateDialog] = useState(false)
   const [logoFile, setLogoFile] = useState<File>()
   const [logoUrl, setLogoUrl] = useState<string>()
   const [logoRemoved, setLogoRemoved] = useState(false)
+
+  const isEditMode = !!appToEdit
   const hasLogo = logoUrl !== undefined
   const isPublicClient = appToEdit?.client_type === 'public'
 
@@ -391,10 +392,10 @@ export const CreateOrUpdateOAuthAppSheet = ({
                               <Button
                                 type="default"
                                 onClick={handleRegenerateSecret}
-                                className="w-full"
+                                className="w-min"
                                 disabled={isRegenerating}
                               >
-                                Regenerate Client Secret
+                                Regenerate client secret
                               </Button>
                             </>
                           )}

--- a/apps/studio/components/interfaces/Auth/OAuthApps/DeleteOAuthAppModal.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/DeleteOAuthAppModal.tsx
@@ -1,6 +1,5 @@
 import type { OAuthClient } from '@supabase/supabase-js'
 import { useParams } from 'common'
-
 import { useProjectEndpointQuery } from 'data/config/project-endpoint-query'
 import type { OAuthServerAppDeleteVariables } from 'data/oauth-server-apps/oauth-server-app-delete-mutation'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
@@ -39,7 +38,8 @@ export const DeleteOAuthAppModal = ({
       visible={visible}
       title={
         <>
-          Confirm to delete OAuth app <code className="text-sm">{selectedApp?.client_name}</code>
+          Confirm to delete OAuth app{' '}
+          <code className="text-code-inline">{selectedApp?.client_name}</code>
         </>
       }
       confirmLabel="Confirm delete"

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -11,7 +11,7 @@ import { useOAuthServerAppsQuery } from 'data/oauth-server-apps/oauth-server-app
 import { Edit, MoreVertical, Plus, RotateCw, Search, Trash, X } from 'lucide-react'
 import Link from 'next/link'
 import { parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -68,8 +68,6 @@ export const OAuthAppsList = () => {
   } = useAuthConfigQuery({ projectRef })
   const isOAuthServerEnabled = !!authConfig?.OAUTH_SERVER_ENABLED
 
-  const deletingOAuthAppIdRef = useRef<string | null>(null)
-
   const [newOAuthApp, setNewOAuthApp] = useState<OAuthClient | undefined>(undefined)
   const [showRegenerateDialog, setShowRegenerateDialog] = useState(false)
   const [selectedApp, setSelectedApp] = useState<OAuthClient>()
@@ -118,9 +116,6 @@ export const OAuthAppsList = () => {
     onSuccess: () => {
       toast.success(`Successfully deleted OAuth app`)
       setSelectedAppToDelete(null)
-    },
-    onError: () => {
-      deletingOAuthAppIdRef.current = null
     },
   })
 
@@ -447,7 +442,6 @@ export const OAuthAppsList = () => {
         selectedApp={appToDelete}
         setVisible={setSelectedAppToDelete}
         onDelete={(params: Parameters<typeof deleteOAuthApp>[0]) => {
-          deletingOAuthAppIdRef.current = params.clientId ?? null
           deleteOAuthApp(params)
         }}
         isLoading={isDeletingApp}

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthAppsList.tsx
@@ -1,10 +1,4 @@
 import type { OAuthClient } from '@supabase/supabase-js'
-import { Edit, MoreVertical, Plus, RotateCw, Search, Trash, X } from 'lucide-react'
-import Link from 'next/link'
-import { parseAsBoolean, parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
@@ -14,14 +8,18 @@ import { useProjectEndpointQuery } from 'data/config/project-endpoint-query'
 import { useOAuthServerAppDeleteMutation } from 'data/oauth-server-apps/oauth-server-app-delete-mutation'
 import { useOAuthServerAppRegenerateSecretMutation } from 'data/oauth-server-apps/oauth-server-app-regenerate-secret-mutation'
 import { useOAuthServerAppsQuery } from 'data/oauth-server-apps/oauth-server-apps-query'
-import { handleErrorOnDelete, useQueryStateWithSelect } from 'hooks/misc/useQueryStateWithSelect'
+import { Edit, MoreVertical, Plus, RotateCw, Search, Trash, X } from 'lucide-react'
+import Link from 'next/link'
+import { parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import {
-  Badge,
   Button,
   Card,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
   Table,
@@ -36,6 +34,7 @@ import { Admonition } from 'ui-patterns/admonition'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
+
 import { CreateOrUpdateOAuthAppSheet } from './CreateOrUpdateOAuthAppSheet'
 import { DeleteOAuthAppModal } from './DeleteOAuthAppModal'
 import { NewOAuthAppBanner } from './NewOAuthAppBanner'
@@ -62,61 +61,60 @@ type OAuthAppsSortOrder = OAuthAppsSort extends `${string}:${infer Order}` ? Ord
 
 export const OAuthAppsList = () => {
   const { ref: projectRef } = useParams()
-  const { data: authConfig, isPending: isAuthConfigLoading } = useAuthConfigQuery({ projectRef })
+  const {
+    data: authConfig,
+    isPending: isAuthConfigLoading,
+    isSuccess: isSuccessAuthConfig,
+  } = useAuthConfigQuery({ projectRef })
   const isOAuthServerEnabled = !!authConfig?.OAUTH_SERVER_ENABLED
+
+  const deletingOAuthAppIdRef = useRef<string | null>(null)
+
   const [newOAuthApp, setNewOAuthApp] = useState<OAuthClient | undefined>(undefined)
   const [showRegenerateDialog, setShowRegenerateDialog] = useState(false)
   const [selectedApp, setSelectedApp] = useState<OAuthClient>()
   const [filteredRegistrationTypes, setFilteredRegistrationTypes] = useState<string[]>([])
   const [filteredClientTypes, setFilteredClientTypes] = useState<string[]>([])
-  const deletingOAuthAppIdRef = useRef<string | null>(null)
+  const [filterString, setFilterString] = useState<string>('')
 
-  const { data, isPending: isLoading, isError, error } = useOAuthServerAppsQuery({ projectRef })
+  const { data: endpointData } = useProjectEndpointQuery({ projectRef })
+  const {
+    data,
+    error,
+    isPending: isLoading,
+    isSuccess,
+    isError,
+  } = useOAuthServerAppsQuery({ projectRef })
+  const oAuthApps = useMemo(() => data?.clients || [], [data])
 
   const { mutateAsync: regenerateSecret, isPending: isRegenerating } =
     useOAuthServerAppRegenerateSecretMutation({
       onSuccess: (data) => {
-        if (data) {
-          setNewOAuthApp(data)
-        }
+        if (data) setNewOAuthApp(data)
       },
     })
 
-  const { data: endpointData } = useProjectEndpointQuery({ projectRef })
-
-  const oAuthApps = useMemo(() => data?.clients || [], [data])
+  const [sort, setSort] = useQueryState(
+    'sort',
+    parseAsStringLiteral<OAuthAppsSort>(OAUTH_APPS_SORT_VALUES).withDefault('name:asc')
+  )
 
   const [showCreateSheet, setShowCreateSheet] = useQueryState(
     'new',
-    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
+    parseAsBoolean.withDefault(false)
   )
 
-  // Prevent opening the create sheet if OAuth Server is disabled
-  useEffect(() => {
-    if (!isOAuthServerEnabled && showCreateSheet) {
-      setShowCreateSheet(false)
-    }
-  }, [isOAuthServerEnabled, showCreateSheet, setShowCreateSheet])
+  const [selectedAppToEdit, setSelectedAppToEdit] = useQueryState('edit', parseAsString)
+  const appToEdit = oAuthApps?.find((app) => app.client_id === selectedAppToEdit)
 
-  const { setValue: setSelectedAppToEdit, value: appToEdit } = useQueryStateWithSelect({
-    urlKey: 'edit',
-    select: (client_id: string) =>
-      client_id ? oAuthApps?.find((app) => app.client_id === client_id) : undefined,
-    enabled: !!oAuthApps?.length,
-    onError: (_error, selectedId) =>
-      handleErrorOnDelete(deletingOAuthAppIdRef, selectedId, `OAuth App not found`),
-  })
+  const [selectedAppToDelete, setSelectedAppToDelete] = useQueryState('delete', parseAsString)
+  const appToDelete = oAuthApps?.find((app) => app.client_id === selectedAppToDelete)
 
-  const { setValue: setSelectedAppToDelete, value: appToDelete } = useQueryStateWithSelect({
-    urlKey: 'delete',
-    select: (client_id: string) =>
-      client_id ? oAuthApps?.find((app) => app.client_id === client_id) : undefined,
-    enabled: !!oAuthApps?.length,
-    onError: (_error, selectedId) =>
-      handleErrorOnDelete(deletingOAuthAppIdRef, selectedId, `OAuth App not found`),
-  })
-
-  const { mutate: deleteOAuthApp, isPending: isDeletingApp } = useOAuthServerAppDeleteMutation({
+  const {
+    mutate: deleteOAuthApp,
+    isPending: isDeletingApp,
+    isSuccess: isSuccessDelete,
+  } = useOAuthServerAppDeleteMutation({
     onSuccess: () => {
       toast.success(`Successfully deleted OAuth app`)
       setSelectedAppToDelete(null)
@@ -125,13 +123,6 @@ export const OAuthAppsList = () => {
       deletingOAuthAppIdRef.current = null
     },
   })
-
-  const [filterString, setFilterString] = useState<string>('')
-
-  const [sort, setSort] = useQueryState(
-    'sort',
-    parseAsStringLiteral<OAuthAppsSort>(OAUTH_APPS_SORT_VALUES).withDefault('name:asc')
-  )
 
   const filteredAndSortedOAuthApps = useMemo(() => {
     const filtered = filterOAuthApps({
@@ -193,6 +184,27 @@ export const OAuthAppsList = () => {
   const isCreateMode = showCreateSheet && isOAuthServerEnabled
   const isEditMode = !!appToEdit
   const isCreateOrUpdateSheetVisible = isCreateMode || isEditMode
+
+  // Prevent opening the create sheet if OAuth Server is disabled
+  useEffect(() => {
+    if (isSuccessAuthConfig && !isOAuthServerEnabled && showCreateSheet) {
+      setShowCreateSheet(false)
+    }
+  }, [isSuccessAuthConfig, isOAuthServerEnabled, showCreateSheet, setShowCreateSheet])
+
+  useEffect(() => {
+    if (isSuccess && !!selectedAppToEdit && !appToEdit) {
+      toast('App not found')
+      setSelectedAppToEdit(null)
+    }
+  }, [appToEdit, isSuccess, selectedAppToEdit, setSelectedAppToEdit])
+
+  useEffect(() => {
+    if (isSuccess && !!selectedAppToDelete && !appToDelete && !isSuccessDelete) {
+      toast('App not found')
+      setSelectedAppToDelete(null)
+    }
+  }, [appToDelete, isSuccess, isSuccessDelete, selectedAppToDelete, setSelectedAppToDelete])
 
   if (isAuthConfigLoading || (isOAuthServerEnabled && isLoading)) {
     return <GenericSkeletonLoader />
@@ -291,7 +303,7 @@ export const OAuthAppsList = () => {
             <Table containerProps={{ stickyLastColumn: true }}>
               <TableHeader>
                 <TableRow>
-                  <TableHead>
+                  <TableHead className="w-48 max-w-48 flex">
                     <TableHeadSort column="name" currentSort={sort} onSortChange={handleSortChange}>
                       Name
                     </TableHeadSort>
@@ -340,7 +352,7 @@ export const OAuthAppsList = () => {
                 {filteredAndSortedOAuthApps.length > 0 &&
                   filteredAndSortedOAuthApps.map((app) => (
                     <TableRow key={app.client_id} className="w-full">
-                      <TableCell className="w-48 max-w-48 flex" title={app.client_name}>
+                      <TableCell title={app.client_name}>
                         <Button
                           type="text"
                           className="text-link-table-cell text-sm p-0 hover:bg-transparent title [&>span]:!w-full"
@@ -351,16 +363,16 @@ export const OAuthAppsList = () => {
                         </Button>
                       </TableCell>
                       <TableCell title={app.client_id}>
-                        <Badge className="font-mono">{app.client_id}</Badge>
+                        <code className="text-code-inline">{app.client_id}</code>
                       </TableCell>
-                      <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
-                        {app.client_type}
-                      </TableCell>
-                      <TableCell className="text-xs text-foreground-light max-w-28 capitalize">
-                        {app.registration_type}
-                      </TableCell>
-                      <TableCell className="text-xs text-foreground-light min-w-28 max-w-40 w-1/6">
-                        <TimestampInfo utcTimestamp={app.created_at} labelFormat="D MMM, YYYY" />
+                      <TableCell className="max-w-28 capitalize">{app.client_type}</TableCell>
+                      <TableCell className="max-w-28 capitalize">{app.registration_type}</TableCell>
+                      <TableCell className="min-w-28 max-w-40 w-1/6">
+                        <TimestampInfo
+                          className="text-sm"
+                          utcTimestamp={app.created_at}
+                          labelFormat="D MMM, YYYY"
+                        />
                       </TableCell>
                       <TableCell className="max-w-20 bg-surface-100 @[944px]:hover:bg-surface-200 px-6">
                         <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l @[944px]:border-l-0">
@@ -376,7 +388,7 @@ export const OAuthAppsList = () => {
                                 }}
                               >
                                 <Edit size={12} />
-                                <p>Update</p>
+                                <p>Edit OAuth app</p>
                               </DropdownMenuItem>
                               {app.client_type === 'confidential' && (
                                 <DropdownMenuItem
@@ -390,12 +402,13 @@ export const OAuthAppsList = () => {
                                   <p>Regenerate client secret</p>
                                 </DropdownMenuItem>
                               )}
+                              <DropdownMenuSeparator />
                               <DropdownMenuItem
                                 className="space-x-2"
                                 onClick={() => setSelectedAppToDelete(app.client_id)}
                               >
                                 <Trash size={12} />
-                                <p>Delete</p>
+                                <p>Delete OAuth app</p>
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>

--- a/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
@@ -35,7 +35,7 @@ export const DeleteHookModal = () => {
 
   async function handleDelete() {
     if (!project) return console.error('Project ref is required')
-    if (!selectedHook) return toast.error('Unable find selected hook')
+    if (!selectedHook) return toast.error('Unable to find selected hook')
 
     deleteDatabaseTrigger({
       trigger: selectedHook,

--- a/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/DeleteHookModal.tsx
@@ -1,44 +1,42 @@
-import type { PostgresTrigger } from '@supabase/postgres-meta'
-import { toast } from 'sonner'
-
 import { TextConfirmModal } from 'components/ui/TextConfirmModalWrapper'
 import { useDatabaseTriggerDeleteMutation } from 'data/database-triggers/database-trigger-delete-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { parseAsString, useQueryState } from 'nuqs'
+import { useEffect } from 'react'
+import { toast } from 'sonner'
 
-interface DeleteHookModalProps {
-  visible: boolean
-  selectedHook?: PostgresTrigger
-  onClose: () => void
-  onDeleteStart?: (hookId: string) => void
-}
+import { useDatabaseHooksQuery } from '@/data/database-triggers/database-triggers-query'
 
-const DeleteHookModal = ({
-  selectedHook,
-  visible,
-  onClose,
-  onDeleteStart,
-}: DeleteHookModalProps) => {
+export const DeleteHookModal = () => {
+  const { data: project } = useSelectedProjectQuery()
+
+  const { data: hooks = [], isSuccess } = useDatabaseHooksQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  const [selectedHookIdToDelete, setSelectedHookIdToDelete] = useQueryState(
+    'delete',
+    parseAsString.withDefault('')
+  )
+  const selectedHook = hooks.find((hook) => hook.id.toString() === selectedHookIdToDelete)
   const { name, schema } = selectedHook ?? {}
 
-  const { data: project } = useSelectedProjectQuery()
-  const { mutate: deleteDatabaseTrigger, isPending: isDeleting } = useDatabaseTriggerDeleteMutation(
-    {
-      onSuccess: () => {
-        toast.success(`Successfully deleted ${name}`)
-        onClose()
-      },
-    }
-  )
+  const {
+    mutate: deleteDatabaseTrigger,
+    isPending: isDeleting,
+    isSuccess: isSuccessDelete,
+  } = useDatabaseTriggerDeleteMutation({
+    onSuccess: () => {
+      toast.success(`Successfully deleted ${name}`)
+      setSelectedHookIdToDelete(null)
+    },
+  })
 
   async function handleDelete() {
-    if (!project) {
-      return console.error('Project ref is required')
-    }
-    if (!selectedHook) {
-      return toast.error('Unable find selected hook')
-    }
+    if (!project) return console.error('Project ref is required')
+    if (!selectedHook) return toast.error('Unable find selected hook')
 
-    onDeleteStart?.(selectedHook.id.toString())
     deleteDatabaseTrigger({
       trigger: selectedHook,
       projectRef: project.ref,
@@ -46,12 +44,19 @@ const DeleteHookModal = ({
     })
   }
 
+  useEffect(() => {
+    if (isSuccess && !!selectedHookIdToDelete && !selectedHook && !isSuccessDelete) {
+      toast('Webhook not found')
+      setSelectedHookIdToDelete(null)
+    }
+  }, [isSuccess, isSuccessDelete, selectedHook, selectedHookIdToDelete, setSelectedHookIdToDelete])
+
   return (
     <TextConfirmModal
       variant="destructive"
-      visible={visible}
-      size="medium"
-      onCancel={() => onClose()}
+      visible={!!selectedHook}
+      size="small"
+      onCancel={() => setSelectedHookIdToDelete(null)}
       onConfirm={handleDelete}
       title="Delete database webhook"
       loading={isDeleting}
@@ -68,5 +73,3 @@ const DeleteHookModal = ({
     />
   )
 }
-
-export default DeleteHookModal

--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -118,7 +118,9 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
                 <FormControl_Shadcn_>
                   <Input_Shadcn_ {...field} placeholder="my_webhook" />
                 </FormControl_Shadcn_>
-                <p className="text-xs text-foreground-lighter">Do not use spaces/whitespaces</p>
+                <p className="mt-2 text-xs text-foreground-lighter">
+                  Do not use spaces/whitespaces
+                </p>
               </FormItemLayout>
             )}
           />

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
@@ -1,9 +1,4 @@
-import { PostgresTrigger } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { includes, noop } from 'lodash'
-import { Edit3, MoreVertical, Trash } from 'lucide-react'
-import Image from 'next/legacy/image'
-
 import { useParams } from 'common'
 import Table from 'components/to-be-cleaned/Table'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
@@ -11,6 +6,10 @@ import { useDatabaseHooksQuery } from 'data/database-triggers/database-triggers-
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH } from 'lib/constants'
+import { includes } from 'lodash'
+import { Edit3, MoreVertical, Trash } from 'lucide-react'
+import Image from 'next/legacy/image'
+import { parseAsString, useQueryState } from 'nuqs'
 import {
   Badge,
   Button,
@@ -24,22 +23,18 @@ import {
 export interface HookListProps {
   schema: string
   filterString: string
-  editHook: (hook: PostgresTrigger) => void
-  deleteHook: (hook: PostgresTrigger) => void
 }
 
-export const HookList = ({
-  schema,
-  filterString,
-  editHook = noop,
-  deleteHook = noop,
-}: HookListProps) => {
+export const HookList = ({ schema, filterString }: HookListProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const { data: hooks } = useDatabaseHooksQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+
+  const [, setSelectedHookIdToEdit] = useQueryState('edit', parseAsString.withDefault(''))
+  const [, setSelectedHookIdToDelete] = useQueryState('delete', parseAsString.withDefault(''))
 
   const restUrl = project?.restUrl
   const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
@@ -109,12 +104,18 @@ export const HookList = ({
 
                     <DropdownMenuContent side="left">
                       <>
-                        <DropdownMenuItem className="space-x-2" onClick={() => editHook(x)}>
+                        <DropdownMenuItem
+                          className="space-x-2"
+                          onClick={() => setSelectedHookIdToEdit(x.id.toString())}
+                        >
                           <Edit3 size="14" />
                           <p>Edit hook</p>
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem className="space-x-2" onClick={() => deleteHook(x)}>
+                        <DropdownMenuItem
+                          className="space-x-2"
+                          onClick={() => setSelectedHookIdToDelete(x.id.toString())}
+                        >
                           <Trash stroke="red" size="14" />
                           <p>Delete hook</p>
                         </DropdownMenuItem>

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/SchemaTable.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/SchemaTable.tsx
@@ -1,22 +1,13 @@
-import { PostgresTrigger } from '@supabase/postgres-meta'
-import { noop } from 'lodash'
-
 import Table from 'components/to-be-cleaned/Table'
+
 import { HookList } from './HookList'
 
 interface SchemaTableProps {
   schema: string
   filterString: string
-  editHook: (hook: PostgresTrigger) => void
-  deleteHook: (hook: PostgresTrigger) => void
 }
 
-export const SchemaTable = ({
-  schema,
-  filterString,
-  editHook = noop,
-  deleteHook = noop,
-}: SchemaTableProps) => {
+export const SchemaTable = ({ schema, filterString }: SchemaTableProps) => {
   return (
     <div key={schema}>
       <div className="sticky top-0 backdrop-blur backdrop-filter">
@@ -44,14 +35,7 @@ export const SchemaTable = ({
             <Table.th key="buttons" className="w-[5%]"></Table.th>
           </>
         }
-        body={
-          <HookList
-            filterString={filterString}
-            schema={schema}
-            editHook={editHook}
-            deleteHook={deleteHook}
-          />
-        }
+        body={<HookList filterString={filterString} schema={schema} />}
       />
     </div>
   )

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
@@ -1,14 +1,13 @@
 import parser from 'cron-parser'
+import { useDatabaseCronJobRunCommandMutation } from 'data/database-cron-jobs/database-cron-job-run-mutation'
+import { CronJob } from 'data/database-cron-jobs/database-cron-jobs-infinite-query'
+import { useDatabaseCronJobToggleMutation } from 'data/database-cron-jobs/database-cron-jobs-toggle-mutation'
 import dayjs from 'dayjs'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Copy, Edit, Minus, MoreVertical, Play, Trash } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useState } from 'react'
 import { toast } from 'sonner'
-
-import { useDatabaseCronJobRunCommandMutation } from 'data/database-cron-jobs/database-cron-job-run-mutation'
-import { CronJob } from 'data/database-cron-jobs/database-cron-jobs-infinite-query'
-import { useDatabaseCronJobToggleMutation } from 'data/database-cron-jobs/database-cron-jobs-toggle-mutation'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import {
   Badge,
   Button,
@@ -150,7 +149,7 @@ export const CronJobTableCell = ({
               onClick={(e) => e.stopPropagation()}
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-60 space-y-1">
+          <DropdownMenuContent align="end" className="w-44 space-y-1">
             <Tooltip>
               <TooltipTrigger className="w-full">
                 <DropdownMenuItem

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.useCronJobsData.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.useCronJobsData.ts
@@ -27,6 +27,7 @@ type UseCronJobsDataParams = ConnectionVars & {
 
 interface CronJobsGridState {
   rows: Array<CronJob>
+  isSuccess: boolean
   isLoading: boolean
   error: ResponseError | null
   isRefetching: boolean
@@ -63,6 +64,7 @@ export function useCronJobsData({
   const {
     data: cronJobsData,
     error: cronJobsError,
+    isSuccess: isCronJobsSuccess,
     isLoading: isCronJobsLoading,
     isRefetching: isCronJobsRefetching,
     isFetchingNextPage,
@@ -81,6 +83,7 @@ export function useCronJobsData({
   const {
     data: cronJobsMinimalData,
     error: cronJobsMinimalError,
+    isSuccess: isCronJobsMinimalSuccess,
     isLoading: isCronJobsMinimalLoading,
     isRefetching: isCronJobsMinimalRefetching,
     isFetchingNextPage: isFetchingNextPageMinimal,
@@ -128,6 +131,7 @@ export function useCronJobsData({
     grid: {
       rows: cronJobs,
       error: useMinimalQuery ? cronJobsMinimalError : cronJobsError,
+      isSuccess: useMinimalQuery ? isCronJobsMinimalSuccess : isCronJobsSuccess,
       isLoading: useMinimalQuery ? isCronJobsMinimalLoading : isCronJobsLoading,
       isRefetching: useMinimalQuery ? isCronJobsMinimalRefetching : isCronJobsRefetching,
       isFetchingNextPage: useMinimalQuery ? isFetchingNextPageMinimal : isFetchingNextPage,

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/AddNewSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/AddNewSecretModal.tsx
@@ -1,27 +1,27 @@
-import { Eye, EyeOff } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
-
 import { useVaultSecretCreateMutation } from 'data/vault/vault-secret-create-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { Eye, EyeOff } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import { Button, Form, Input, Modal } from 'ui'
 
-interface AddNewSecretModalProps {
-  visible: boolean
-  onClose: () => void
-}
-
-const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
+export const AddNewSecretModal = () => {
   const { data: project } = useSelectedProjectQuery()
   const [showSecretValue, setShowSecretValue] = useState(false)
 
   const { mutateAsync: addSecret } = useVaultSecretCreateMutation()
 
+  const [showAddSecretModal, setShowAddSecretModal] = useQueryState(
+    'new',
+    parseAsBoolean.withDefault(false)
+  )
+
   useEffect(() => {
-    if (visible) {
+    if (showAddSecretModal) {
       setShowSecretValue(false)
     }
-  }, [visible])
+  }, [showAddSecretModal])
 
   const validate = (values: any) => {
     const errors: any = {}
@@ -46,7 +46,7 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
         secret: values.secret,
       })
       toast.success(`Successfully added new secret ${values.name}`)
-      onClose()
+      setShowAddSecretModal(null)
     } catch (error: any) {
       // [Joshen] No error handler required as they are all handled within the mutations already
     } finally {
@@ -55,7 +55,13 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
   }
 
   return (
-    <Modal hideFooter size="medium" visible={visible} onCancel={onClose} header="Add new secret">
+    <Modal
+      hideFooter
+      size="medium"
+      visible={showAddSecretModal}
+      onCancel={() => setShowAddSecretModal(null)}
+      header="Add new secret"
+    >
       <Form
         id="add-new-secret-form"
         initialValues={{ name: '', description: '', secret: '' }}
@@ -86,7 +92,11 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
               </Modal.Content>
               <Modal.Separator />
               <Modal.Content className="flex items-center justify-end space-x-2">
-                <Button type="default" disabled={isSubmitting} onClick={onClose}>
+                <Button
+                  type="default"
+                  disabled={isSubmitting}
+                  onClick={() => setShowAddSecretModal(null)}
+                >
                   Cancel
                 </Button>
                 <Button htmlType="submit" disabled={isSubmitting} loading={isSubmitting}>
@@ -100,5 +110,3 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
     </Modal>
   )
 }
-
-export default AddNewSecretModal

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/DeleteSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/DeleteSecretModal.tsx
@@ -1,22 +1,31 @@
-import { toast } from 'sonner'
-
 import { useVaultSecretDeleteMutation } from 'data/vault/vault-secret-delete-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import type { VaultSecret } from 'types'
+import { parseAsString, useQueryState } from 'nuqs'
+import { useEffect } from 'react'
+import { toast } from 'sonner'
 import { Modal } from 'ui'
 
-interface DeleteSecretModalProps {
-  selectedSecret: VaultSecret | undefined
-  onClose: () => void
-  onDeleteStart?: (secretId: string) => void
-}
+import { useVaultSecretsQuery } from '@/data/vault/vault-secrets-query'
 
-const DeleteSecretModal = ({ selectedSecret, onClose, onDeleteStart }: DeleteSecretModalProps) => {
+export const DeleteSecretModal = () => {
   const { data: project } = useSelectedProjectQuery()
-  const { mutate: deleteSecret, isPending: isDeleting } = useVaultSecretDeleteMutation({
+
+  const { data: secrets = [], isSuccess } = useVaultSecretsQuery({
+    projectRef: project?.ref!,
+    connectionString: project?.connectionString,
+  })
+
+  const [secretIdToDelete, setSelectedSecretToDelete] = useQueryState('delete', parseAsString)
+  const selectedSecret = secrets.find((secret) => secret.id === secretIdToDelete)
+
+  const {
+    mutate: deleteSecret,
+    isPending: isDeleting,
+    isSuccess: isSuccessDelete,
+  } = useVaultSecretDeleteMutation({
     onSuccess: () => {
       toast.success(`Successfully deleted secret ${selectedSecret?.name}`)
-      onClose()
+      setSelectedSecretToDelete(null)
     },
     onError: (error) => {
       toast.error(`Failed to delete secret: ${error.message}`)
@@ -27,7 +36,6 @@ const DeleteSecretModal = ({ selectedSecret, onClose, onDeleteStart }: DeleteSec
     if (!project) return console.error('Project is required')
     if (!selectedSecret) return
 
-    onDeleteStart?.(selectedSecret.id)
     deleteSecret({
       projectRef: project.ref,
       connectionString: project?.connectionString,
@@ -35,15 +43,23 @@ const DeleteSecretModal = ({ selectedSecret, onClose, onDeleteStart }: DeleteSec
     })
   }
 
+  useEffect(() => {
+    if (isSuccess && !!secretIdToDelete && !selectedSecret && !isSuccessDelete) {
+      toast('Secret not found')
+      setSelectedSecretToDelete(null)
+    }
+  }, [isSuccess, isSuccessDelete, secretIdToDelete, selectedSecret, setSelectedSecretToDelete])
+
   return (
     <Modal
       size="small"
+      variant="danger"
       alignFooter="right"
-      visible={selectedSecret !== undefined}
-      onCancel={onClose}
-      onConfirm={onConfirmDeleteSecret}
-      loading={isDeleting}
       header="Confirm to delete secret"
+      visible={!!selectedSecret}
+      loading={isDeleting}
+      onCancel={() => setSelectedSecretToDelete(null)}
+      onConfirm={onConfirmDeleteSecret}
     >
       <Modal.Content className="space-y-4">
         <p className="text-sm">
@@ -59,5 +75,3 @@ const DeleteSecretModal = ({ selectedSecret, onClose, onDeleteStart }: DeleteSec
     </Modal>
   )
 }
-
-export default DeleteSecretModal

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/DeleteSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/DeleteSecretModal.tsx
@@ -11,7 +11,7 @@ export const DeleteSecretModal = () => {
   const { data: project } = useSelectedProjectQuery()
 
   const { data: secrets = [], isSuccess } = useVaultSecretsQuery({
-    projectRef: project?.ref!,
+    projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
 

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/EditSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/EditSecretModal.tsx
@@ -1,13 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Eye, EyeOff } from 'lucide-react'
-import { useState } from 'react'
-import { type SubmitHandler, useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import { z } from 'zod'
-
 import { useVaultSecretDecryptedValueQuery } from 'data/vault/vault-secret-decrypted-value-query'
 import { useVaultSecretUpdateMutation } from 'data/vault/vault-secret-update-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { Eye, EyeOff } from 'lucide-react'
+import { parseAsString, useQueryState } from 'nuqs'
+import { useEffect, useState } from 'react'
+import { useForm, type SubmitHandler } from 'react-hook-form'
+import { toast } from 'sonner'
 import type { VaultSecret } from 'types'
 import {
   Button,
@@ -25,12 +24,9 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+import { z } from 'zod'
 
-interface EditSecretModalProps {
-  visible: boolean
-  secret: VaultSecret
-  onClose: () => void
-}
+import { useVaultSecretsQuery } from '@/data/vault/vault-secrets-query'
 
 const SecretSchema = z.object({
   name: z.string().min(1, 'Please provide a name for your secret'),
@@ -40,22 +36,33 @@ const SecretSchema = z.object({
 
 const formId = 'edit-vault-secret-form'
 
-const EditSecretModal = ({ visible, secret, onClose }: EditSecretModalProps) => {
-  const [showSecretValue, setShowSecretValue] = useState(false)
+export const EditSecretModal = () => {
   const { data: project } = useSelectedProjectQuery()
+
+  const { data: secrets = [], isSuccess } = useVaultSecretsQuery({
+    projectRef: project?.ref!,
+    connectionString: project?.connectionString,
+  })
+  const [secretIdToEdit, setSelectedSecretToEdit] = useQueryState('edit', parseAsString)
+  const secret = secrets.find((secret) => secret.id === secretIdToEdit)
+
+  const [showSecretValue, setShowSecretValue] = useState(false)
+
   const { data, isPending: isLoadingSecretValue } = useVaultSecretDecryptedValueQuery(
     {
       projectRef: project?.ref,
-      id: secret.id,
+      id: secret?.id,
       connectionString: project?.connectionString,
     },
     { enabled: !!project?.ref }
   )
+
   const values = {
-    name: secret.name ?? '',
-    description: secret.description ?? '',
-    secret: secret.decryptedSecret ?? data ?? '',
+    name: secret?.name ?? '',
+    description: secret?.description ?? '',
+    secret: secret?.decryptedSecret ?? data ?? '',
   }
+
   const form = useForm<z.infer<typeof SecretSchema>>({
     resolver: zodResolver(SecretSchema),
     defaultValues: values,
@@ -66,6 +73,7 @@ const EditSecretModal = ({ visible, secret, onClose }: EditSecretModalProps) => 
 
   const onSubmit: SubmitHandler<z.infer<typeof SecretSchema>> = async (values) => {
     if (!project) return console.error('Project is required')
+    if (!secret) return console.error('Secret is required')
 
     const payload: Partial<VaultSecret> = {
       secret: values.secret,
@@ -84,7 +92,7 @@ const EditSecretModal = ({ visible, secret, onClose }: EditSecretModalProps) => 
         {
           onSuccess: () => {
             toast.success('Successfully updated secret')
-            onClose()
+            setSelectedSecretToEdit(null)
           },
           onError: (error) => {
             toast.error(`Failed to update secret: ${error.message}`)
@@ -94,13 +102,20 @@ const EditSecretModal = ({ visible, secret, onClose }: EditSecretModalProps) => 
     }
   }
 
+  useEffect(() => {
+    if (isSuccess && !!secretIdToEdit && !secret) {
+      toast('Secret not found')
+      setSelectedSecretToEdit(null)
+    }
+  }, [isSuccess, secretIdToEdit, secret, setSelectedSecretToEdit])
+
   return (
     <Dialog
-      open={visible}
+      open={!!secret}
       onOpenChange={(open) => {
         if (!open) {
           form.reset()
-          onClose()
+          setSelectedSecretToEdit(null)
         }
       }}
     >
@@ -189,7 +204,7 @@ const EditSecretModal = ({ visible, secret, onClose }: EditSecretModalProps) => 
                 disabled={isSubmitting}
                 onClick={() => {
                   form.reset()
-                  onClose()
+                  setSelectedSecretToEdit(null)
                 }}
               >
                 Cancel
@@ -204,5 +219,3 @@ const EditSecretModal = ({ visible, secret, onClose }: EditSecretModalProps) => 
     </Dialog>
   )
 }
-
-export default EditSecretModal

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/EditSecretModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/EditSecretModal.tsx
@@ -40,7 +40,7 @@ export const EditSecretModal = () => {
   const { data: project } = useSelectedProjectQuery()
 
   const { data: secrets = [], isSuccess } = useVaultSecretsQuery({
-    projectRef: project?.ref!,
+    projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
   const [secretIdToEdit, setSelectedSecretToEdit] = useQueryState('edit', parseAsString)

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretRow.tsx
@@ -1,7 +1,14 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
+import { useVaultSecretDecryptedValueQuery } from 'data/vault/vault-secret-decrypted-value-query'
 import dayjs from 'dayjs'
+import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { Edit3, Eye, EyeOff, Key, Loader, MoreVertical, Trash } from 'lucide-react'
+import { parseAsString, useQueryState } from 'nuqs'
 import { useState } from 'react'
+import type { VaultSecret } from 'types'
 import {
   Button,
   DropdownMenu,
@@ -9,28 +16,23 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'ui'
-
-import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
-import { useVaultSecretDecryptedValueQuery } from 'data/vault/vault-secret-decrypted-value-query'
-import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { Edit3, Eye, EyeOff, Key, Loader, MoreVertical, Trash } from 'lucide-react'
-import type { VaultSecret } from 'types'
 import { Input } from 'ui-patterns/DataInputs/Input'
+
 import { SecretTableColumn } from './Secrets.types'
 
 interface SecretRowProps {
   row: VaultSecret
   col: SecretTableColumn
-  onSelectEdit: (secret: VaultSecret) => void
-  onSelectRemove: (secret: VaultSecret) => void
 }
 
-export const SecretRow = ({ row, col, onSelectEdit, onSelectRemove }: SecretRowProps) => {
+export const SecretRow = ({ row, col }: SecretRowProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const [revealSecret, setRevealSecret] = useState(false)
   const name = row?.name ?? 'No name provided'
+
+  const [, setSelectedSecretToEdit] = useQueryState('edit', parseAsString)
+  const [, setSelectedSecretToDelete] = useQueryState('delete', parseAsString)
 
   const { can: canManageSecrets } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
@@ -59,7 +61,7 @@ export const SecretRow = ({ row, col, onSelectEdit, onSelectRemove }: SecretRowP
             <DropdownMenuItemTooltip
               className="gap-x-2"
               disabled={!canManageSecrets}
-              onClick={() => onSelectEdit(row)}
+              onClick={() => setSelectedSecretToEdit(row.id)}
               tooltip={{
                 content: { side: 'left', text: 'You need additional permissions to edit secrets' },
               }}
@@ -73,7 +75,7 @@ export const SecretRow = ({ row, col, onSelectEdit, onSelectRemove }: SecretRowP
             <DropdownMenuItemTooltip
               className="gap-x-2"
               disabled={!canManageSecrets}
-              onClick={() => onSelectRemove(row)}
+              onClick={() => setSelectedSecretToDelete(row.id)}
               tooltip={{
                 content: {
                   side: 'left',

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/Secrets.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/Secrets.utils.tsx
@@ -1,7 +1,7 @@
 import type { Column } from 'react-data-grid'
-
 import type { VaultSecret } from 'types'
 import { cn } from 'ui'
+
 import { SecretRow } from './SecretRow'
 import { SecretTableColumn } from './Secrets.types'
 
@@ -13,13 +13,7 @@ export const SECRET_TABLE_COLUMNS: SecretTableColumn[] = [
   { id: 'actions', name: '', minWidth: 75, width: 75 },
 ]
 
-export const formatSecretColumns = ({
-  onSelectEdit,
-  onSelectRemove,
-}: {
-  onSelectEdit: (secret: VaultSecret) => void
-  onSelectRemove: (secret: VaultSecret) => void
-}): Column<VaultSecret>[] => {
+export const formatSecretColumns = (): Column<VaultSecret>[] => {
   return SECRET_TABLE_COLUMNS.map((col) => {
     const result: Column<VaultSecret> = {
       key: col.id,
@@ -43,14 +37,7 @@ export const formatSecretColumns = ({
           </div>
         )
       },
-      renderCell: ({ row }) => (
-        <SecretRow
-          row={row}
-          col={col}
-          onSelectEdit={onSelectEdit}
-          onSelectRemove={onSelectRemove}
-        />
-      ),
+      renderCell: ({ row }) => <SecretRow row={row} col={col} />,
     }
     return result
   })

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretsManagement.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretsManagement.tsx
@@ -1,24 +1,20 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { sortBy } from 'lodash'
-import { RefreshCw, Search, X } from 'lucide-react'
-import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import DataGrid, { Row } from 'react-data-grid'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { DocsButton } from 'components/ui/DocsButton'
 import { useVaultSecretsQuery } from 'data/vault/vault-secrets-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { handleErrorOnDelete, useQueryStateWithSelect } from 'hooks/misc/useQueryStateWithSelect'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
+import { sortBy } from 'lodash'
+import { RefreshCw, Search, X } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useEffect, useMemo, useState } from 'react'
+import DataGrid, { Row } from 'react-data-grid'
 import type { VaultSecret } from 'types'
 import {
   Button,
   cn,
-  Input,
   LoadingLine,
   Select_Shadcn_,
   SelectContent_Shadcn_,
@@ -26,23 +22,20 @@ import {
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
 } from 'ui'
-import AddNewSecretModal from './AddNewSecretModal'
-import DeleteSecretModal from './DeleteSecretModal'
-import EditSecretModal from './EditSecretModal'
+import { Input } from 'ui-patterns/DataInputs/Input'
+
+import { AddNewSecretModal } from './AddNewSecretModal'
+import { DeleteSecretModal } from './DeleteSecretModal'
+import { EditSecretModal } from './EditSecretModal'
 import { formatSecretColumns } from './Secrets.utils'
+import AlertError from '@/components/ui/AlertError'
 
 export const SecretsManagement = () => {
   const { search } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
-  // Track the ID being deleted to exclude it from error checking
-  const deletingSecretIdRef = useRef<string | null>(null)
-
   const [searchValue, setSearchValue] = useState<string>('')
-  const [showAddSecretModal, setShowAddSecretModal] = useQueryState(
-    'new',
-    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
-  )
+  const [, setShowAddSecretModal] = useQueryState('new', parseAsBoolean.withDefault(false))
   const [selectedSort, setSelectedSort] = useState<'updated_at' | 'name'>('updated_at')
 
   const { can: canManageSecrets } = useAsyncCheckPermissions(
@@ -52,31 +45,16 @@ export const SecretsManagement = () => {
 
   const {
     data,
+    error,
+    isError,
     isPending: isLoading,
     isRefetching,
     refetch,
-    error,
-    isError,
   } = useVaultSecretsQuery({
     projectRef: project?.ref!,
     connectionString: project?.connectionString,
   })
   const allSecrets = useMemo(() => data || [], [data])
-
-  const { setValue: setSelectedSecretToEdit, value: secretToEdit } = useQueryStateWithSelect({
-    urlKey: 'edit',
-    select: (id: string) => (id ? allSecrets?.find((secret) => secret.id === id) : undefined),
-    enabled: !!allSecrets && !isLoading,
-    onError: () => toast.error(`Secret not found`),
-  })
-
-  const { setValue: setSelectedSecretToRemove, value: secretToDelete } = useQueryStateWithSelect({
-    urlKey: 'delete',
-    select: (id: string) => (id ? allSecrets?.find((secret) => secret.id === id) : undefined),
-    enabled: !!allSecrets && !isLoading,
-    onError: (_error, selectedId) =>
-      handleErrorOnDelete(deletingSecretIdRef, selectedId, `Secret not found`),
-  })
 
   const secrets = useMemo(() => {
     const filtered =
@@ -94,18 +72,11 @@ export const SecretsManagement = () => {
     return sortBy(filtered, (s) => (s.name || '').toLowerCase())
   }, [allSecrets, searchValue, selectedSort])
 
+  const columns = useMemo(() => formatSecretColumns(), [])
+
   useEffect(() => {
     if (search !== undefined) setSearchValue(search)
   }, [search])
-
-  const columns = useMemo(
-    () =>
-      formatSecretColumns({
-        onSelectEdit: (secret) => setSelectedSecretToEdit(secret.id),
-        onSelectRemove: (secret) => setSelectedSecretToRemove(secret.id),
-      }),
-    [setSelectedSecretToEdit, setSelectedSecretToRemove]
-  )
 
   return (
     <>
@@ -126,9 +97,7 @@ export const SecretsManagement = () => {
                       size="tiny"
                       type="text"
                       icon={<X />}
-                      onClick={() => {
-                        setSearchValue('')
-                      }}
+                      onClick={() => setSearchValue('')}
                       className="p-0 h-5 w-5"
                     />
                   ),
@@ -183,8 +152,8 @@ export const SecretsManagement = () => {
           <LoadingLine loading={isLoading || isRefetching} />
 
           {isError ? (
-            <div className="px-6 py-6 space-x-2 flex items-center justify-center">
-              <p className="text-sm text-foreground">Failed to load secrets</p>
+            <div className="flex-grow p-4">
+              <AlertError error={error} subject="Failed to load secrets" />
             </div>
           ) : (
             <DataGrid
@@ -226,27 +195,11 @@ export const SecretsManagement = () => {
         </div>
       </div>
 
-      <AddNewSecretModal
-        visible={showAddSecretModal}
-        onClose={() => setShowAddSecretModal(false)}
-      />
-      {secretToEdit && (
-        <EditSecretModal
-          visible={!!secretToEdit}
-          secret={secretToEdit}
-          onClose={() => setSelectedSecretToEdit(null)}
-        />
-      )}
-      <DeleteSecretModal
-        selectedSecret={secretToDelete}
-        onDeleteStart={(secretId) => {
-          deletingSecretIdRef.current = secretId
-        }}
-        onClose={() => {
-          deletingSecretIdRef.current = null
-          setSelectedSecretToRemove(null)
-        }}
-      />
+      <AddNewSecretModal />
+
+      <EditSecretModal />
+
+      <DeleteSecretModal />
     </>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretsManagement.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretsManagement.tsx
@@ -51,7 +51,7 @@ export const SecretsManagement = () => {
     isRefetching,
     refetch,
   } = useVaultSecretsQuery({
-    projectRef: project?.ref!,
+    projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
   const allSecrets = useMemo(() => data || [], [data])

--- a/apps/studio/components/interfaces/Integrations/Webhooks/ListTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Webhooks/ListTab.tsx
@@ -1,67 +1,15 @@
-import { PostgresTrigger } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
-import { useMemo, useRef } from 'react'
 
-import DeleteHookModal from '@/components/interfaces/Database/Hooks/DeleteHookModal'
+import { DeleteHookModal } from '@/components/interfaces/Database/Hooks/DeleteHookModal'
 import { EditHookPanel } from '@/components/interfaces/Database/Hooks/EditHookPanel'
 import { HooksList } from '@/components/interfaces/Database/Hooks/HooksList/HooksList'
-import NoPermission from '@/components/ui/NoPermission'
-import { useDatabaseHooksQuery } from '@/data/database-triggers/database-triggers-query'
+import { NoPermission } from '@/components/ui/NoPermission'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { handleErrorOnDelete, useQueryStateWithSelect } from '@/hooks/misc/useQueryStateWithSelect'
-import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export const WebhooksListTab = () => {
-  const { data: project } = useSelectedProjectQuery()
-
-  // Track the ID being deleted to exclude it from error checking
-  const deletingHookIdRef = useRef<string | null>(null)
-
-  const [showCreateHookForm, setShowCreateHookForm] = useQueryState(
-    'new',
-    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
-  )
-
-  const [selectedHookIdToEdit, setSelectedHookIdToEdit] = useQueryState(
-    'edit',
-    parseAsString.withDefault('').withOptions({ history: 'push', clearOnDefault: true })
-  )
-
   const { can: canReadWebhooks, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_READ,
     'triggers'
-  )
-
-  const { data: hooks, isPending: isLoadingHooks } = useDatabaseHooksQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
-
-  const { setValue: setSelectedHookToDelete, value: selectedHookToDelete } =
-    useQueryStateWithSelect({
-      urlKey: 'delete',
-      select: (id: string) => (id ? hooks?.find((hook) => hook.id.toString() === id) : undefined),
-      enabled: !!hooks && !isLoadingHooks,
-      onError: (_error, selectedId) =>
-        handleErrorOnDelete(deletingHookIdRef, selectedId, `Webhook not found`),
-    })
-
-  const createHook = () => {
-    setShowCreateHookForm(true)
-  }
-
-  const editHook = (hook: PostgresTrigger) => {
-    setSelectedHookIdToEdit(hook.id.toString())
-  }
-
-  const deleteHook = (hook: PostgresTrigger) => {
-    setSelectedHookToDelete(hook.id.toString())
-  }
-
-  const selectedHookToEdit = useMemo(
-    () => hooks?.find((hook) => hook.id.toString() === selectedHookIdToEdit),
-    [hooks, selectedHookIdToEdit]
   )
 
   if (isPermissionsLoaded && !canReadWebhooks) {
@@ -70,27 +18,9 @@ export const WebhooksListTab = () => {
 
   return (
     <div className="p-10">
-      <HooksList createHook={createHook} editHook={editHook} deleteHook={deleteHook} />
-      <EditHookPanel
-        key={selectedHookToEdit?.id}
-        visible={showCreateHookForm || !!selectedHookToEdit}
-        selectedHook={selectedHookToEdit}
-        onClose={() => {
-          setShowCreateHookForm(false)
-          setSelectedHookIdToEdit('')
-        }}
-      />
-      <DeleteHookModal
-        visible={!!selectedHookToDelete}
-        selectedHook={selectedHookToDelete}
-        onClose={() => {
-          deletingHookIdRef.current = null
-          setSelectedHookToDelete(null)
-        }}
-        onDeleteStart={(hookId: string) => {
-          deletingHookIdRef.current = hookId
-        }}
-      />
+      <HooksList />
+      <EditHookPanel />
+      <DeleteHookModal />
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/Webhooks/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Webhooks/OverviewTab.tsx
@@ -1,6 +1,4 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import NoPermission from 'components/ui/NoPermission'
@@ -8,8 +6,10 @@ import { useHooksEnableMutation } from 'data/database/hooks-enable-mutation'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { toast } from 'sonner'
 import { Admonition } from 'ui-patterns'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+
 import { IntegrationOverviewTab } from '../Integration/IntegrationOverviewTab'
 
 export const WebhooksOverviewTab = () => {
@@ -73,7 +73,7 @@ export const WebhooksOverviewTab = () => {
               HTTP endpoint
             </p>
             <ButtonTooltip
-              className="w-fit"
+              className="mt-2 w-fit"
               onClick={() => enableHooksForProject()}
               disabled={isEnablingHooks}
               tooltip={{

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -104,7 +104,9 @@ export const WrapperRow = ({ wrapper }: WrapperRowProps) => {
         {encryptedMetadata.map((metadata) => (
           <div key={metadata.name} className="flex items-center space-x-2 text-sm">
             <Link
-              href={`/project/${ref}/settings/vault/secrets?search=${wrapper.name}_${metadata.name}`}
+              href={`/project/${ref}/settings/vault/secrets?search=${encodeURIComponent(
+                `${wrapper.name}_${metadata.name}`
+              )}`}
               className="transition text-foreground-light hover:text-foreground flex items-center space-x-2 max-w-28"
             >
               <span className="truncate" title={metadata.label}>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperRow.tsx
@@ -1,53 +1,30 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { partition } from 'lodash'
-import { ChevronRight, Edit, ExternalLink, Table2, Trash } from 'lucide-react'
-import Link from 'next/link'
-import { MutableRefObject, useState } from 'react'
-
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import type { FDW } from 'data/fdw/fdws-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import {
-  Badge,
-  Sheet,
-  SheetContent,
-  TableCell,
-  TableRow,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from 'ui'
+import { partition } from 'lodash'
+import { ChevronRight, Edit, ExternalLink, Table2, Trash } from 'lucide-react'
+import Link from 'next/link'
+import { parseAsString, useQueryState } from 'nuqs'
+import { Badge, TableCell, TableRow, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
 import { INTEGRATIONS } from '../Landing/Integrations.constants'
-import DeleteWrapperModal from './DeleteWrapperModal'
-import { EditWrapperSheet } from './EditWrapperSheet'
 import { convertKVStringArrayToJson, formatWrapperTables } from './Wrappers.utils'
 
 interface WrapperRowProps {
   wrapper: FDW
-  selectedWrapperToEdit?: FDW
-  selectedWrapperToDelete?: FDW
-  setSelectedWrapperToEdit: (value: string | null) => void
-  setSelectedWrapperToDelete: (value: string | null) => void
-  deletingWrapperIdRef: MutableRefObject<string | null>
 }
 
-export const WrapperRow = ({
-  wrapper,
-  selectedWrapperToEdit,
-  selectedWrapperToDelete,
-  setSelectedWrapperToEdit,
-  setSelectedWrapperToDelete,
-  deletingWrapperIdRef,
-}: WrapperRowProps) => {
+export const WrapperRow = ({ wrapper }: WrapperRowProps) => {
   const { ref, id } = useParams()
   const { can: canManageWrappers } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'wrappers'
   )
 
-  const editWrapperShown = selectedWrapperToEdit?.id === wrapper.id
-  const [isClosingEditWrapper, setIsClosingEditWrapper] = useState(false)
+  const [, setSelectedWrapperToEdit] = useQueryState('edit', parseAsString)
+  const [, setSelectedWrapperToDelete] = useQueryState('delete', parseAsString)
 
   const integration = INTEGRATIONS.find((i) => i.id === id)
 
@@ -64,152 +41,116 @@ export const WrapperRow = ({
   const _tables = formatWrapperTables(wrapper, integration?.meta)
 
   return (
-    <>
-      <TableRow>
-        <TableCell className="gap-2 align-top !py-3 min-w-80">
-          {wrapper.name}
+    <TableRow>
+      <TableCell className="gap-2 align-top !py-3 min-w-80">
+        {wrapper.name}
 
-          {visibleMetadata.map((metadata) => (
-            <div
-              key={metadata.name}
-              className="flex items-center space-x-2 text-sm text-foreground-light"
-            >
-              <span className="text-foreground-lighter text-nowrap">{metadata.label}:</span>
-              <span className="truncate max-w-72" title={serverOptions[metadata.name]}>
-                {serverOptions[metadata.name]}
-              </span>
-            </div>
-          ))}
-        </TableCell>
+        {visibleMetadata.map((metadata) => (
+          <div
+            key={metadata.name}
+            className="flex items-center space-x-2 text-sm text-foreground-light"
+          >
+            <span className="text-foreground-lighter text-nowrap">{metadata.label}:</span>
+            <span className="truncate max-w-72" title={serverOptions[metadata.name]}>
+              {serverOptions[metadata.name]}
+            </span>
+          </div>
+        ))}
+      </TableCell>
 
-        <TableCell className="space-y-2 !p-4">
-          {_tables?.map((table) => {
-            const target = table.table ?? table.object ?? table.src_key
+      <TableCell className="space-y-2 !p-4">
+        {_tables?.map((table) => {
+          const target = table.table ?? table.object ?? table.src_key
 
-            return (
-              <div key={table.id} className="flex items-center">
-                <Badge className="bg-surface-300 bg-opacity-100 gap-2 font-mono text-[0.75rem] h-6 text-foreground rounded-r-none">
-                  <div className="relative w-3 h-3 flex items-center justify-center">
-                    {integration.icon({ className: 'p-0' })}
-                  </div>
+          return (
+            <div key={table.id} className="flex items-center">
+              <Badge className="bg-surface-300 bg-opacity-100 gap-2 font-mono text-[0.75rem] h-6 text-foreground rounded-r-none">
+                <div className="relative w-3 h-3 flex items-center justify-center">
+                  {integration.icon({ className: 'p-0' })}
+                </div>
+                <Tooltip>
+                  <TooltipTrigger className="truncate max-w-28">{target}</TooltipTrigger>
+                  <TooltipContent
+                    side="bottom"
+                    className="max-w-64 whitespace-pre-wrap break-words"
+                  >
+                    {target}
+                  </TooltipContent>
+                </Tooltip>
+                <ChevronRight size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
+              </Badge>
+
+              <Link href={`/project/${ref}/editor/${table.id}`}>
+                <Badge className="transition hover:bg-surface-300 px-2 rounded-l-none gap-1.5 h-6 font-mono text-[0.75rem] border-l-0">
+                  <Table2 size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
                   <Tooltip>
-                    <TooltipTrigger className="truncate max-w-28">{target}</TooltipTrigger>
+                    <TooltipTrigger className="truncate max-w-28">
+                      {table.schema}.{table.table_name}
+                    </TooltipTrigger>
                     <TooltipContent
                       side="bottom"
                       className="max-w-64 whitespace-pre-wrap break-words"
                     >
-                      {target}
+                      {table.schema}.{table.table_name}
                     </TooltipContent>
                   </Tooltip>
-                  <ChevronRight
-                    size={12}
-                    strokeWidth={1.5}
-                    className="text-foreground-lighter/50"
-                  />
                 </Badge>
-
-                <Link href={`/project/${ref}/editor/${table.id}`}>
-                  <Badge className="transition hover:bg-surface-300 px-2 rounded-l-none gap-1.5 h-6 font-mono text-[0.75rem] border-l-0">
-                    <Table2 size={12} strokeWidth={1.5} className="text-foreground-lighter/50" />
-                    <Tooltip>
-                      <TooltipTrigger className="truncate max-w-28">
-                        {table.schema}.{table.table_name}
-                      </TooltipTrigger>
-                      <TooltipContent
-                        side="bottom"
-                        className="max-w-64 whitespace-pre-wrap break-words"
-                      >
-                        {table.schema}.{table.table_name}
-                      </TooltipContent>
-                    </Tooltip>
-                  </Badge>
-                </Link>
-              </div>
-            )
-          })}
-        </TableCell>
-        <TableCell>
-          {encryptedMetadata.map((metadata) => (
-            <div key={metadata.name} className="flex items-center space-x-2 text-sm">
-              <Link
-                href={`/project/${ref}/settings/vault/secrets?search=${wrapper.name}_${metadata.name}`}
-                className="transition text-foreground-light hover:text-foreground flex items-center space-x-2 max-w-28"
-              >
-                <span className="truncate" title={metadata.label}>
-                  {metadata.label}
-                </span>
-                <div>
-                  <ExternalLink size={12} strokeWidth={1.5} className="text-foreground-lighter" />
-                </div>
               </Link>
             </div>
-          ))}
-        </TableCell>
-        <TableCell className="flex-nowrap">
-          <div className="flex items-center gap-x-2">
-            <ButtonTooltip
-              disabled={!canManageWrappers}
-              type="default"
-              icon={<Edit strokeWidth={1.5} />}
-              className="px-1.5"
-              onClick={() => setSelectedWrapperToEdit(wrapper.id.toString())}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text: !canManageWrappers
-                    ? 'You need additional permissions to edit wrappers'
-                    : 'Edit wrapper',
-                },
-              }}
-            />
-            <ButtonTooltip
-              type="default"
-              disabled={!canManageWrappers}
-              icon={<Trash strokeWidth={1.5} />}
-              className="px-1.5"
-              onClick={() => setSelectedWrapperToDelete(wrapper.id.toString())}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text: !canManageWrappers
-                    ? 'You need additional permissions to delete wrappers'
-                    : 'Delete wrapper',
-                },
-              }}
-            />
+          )
+        })}
+      </TableCell>
+      <TableCell>
+        {encryptedMetadata.map((metadata) => (
+          <div key={metadata.name} className="flex items-center space-x-2 text-sm">
+            <Link
+              href={`/project/${ref}/settings/vault/secrets?search=${wrapper.name}_${metadata.name}`}
+              className="transition text-foreground-light hover:text-foreground flex items-center space-x-2 max-w-28"
+            >
+              <span className="truncate" title={metadata.label}>
+                {metadata.label}
+              </span>
+              <div>
+                <ExternalLink size={12} strokeWidth={1.5} className="text-foreground-lighter" />
+              </div>
+            </Link>
           </div>
-        </TableCell>
-      </TableRow>
-      <Sheet
-        open={editWrapperShown}
-        onOpenChange={(open) => {
-          if (!open) {
-            setIsClosingEditWrapper(true)
-          }
-        }}
-      >
-        <SheetContent size="lg" tabIndex={undefined}>
-          {selectedWrapperToEdit && (
-            <EditWrapperSheet
-              wrapper={selectedWrapperToEdit}
-              wrapperMeta={integration.meta}
-              onClose={() => {
-                setSelectedWrapperToEdit(null)
-                setIsClosingEditWrapper(false)
-              }}
-              isClosing={isClosingEditWrapper}
-              setIsClosing={setIsClosingEditWrapper}
-            />
-          )}
-        </SheetContent>
-      </Sheet>
-      {selectedWrapperToDelete && (
-        <DeleteWrapperModal
-          selectedWrapper={selectedWrapperToDelete}
-          onClose={() => setSelectedWrapperToDelete(null)}
-          deletingWrapperIdRef={deletingWrapperIdRef}
-        />
-      )}
-    </>
+        ))}
+      </TableCell>
+      <TableCell className="flex-nowrap">
+        <div className="flex items-center gap-x-2">
+          <ButtonTooltip
+            disabled={!canManageWrappers}
+            type="default"
+            icon={<Edit strokeWidth={1.5} />}
+            className="px-1.5"
+            onClick={() => setSelectedWrapperToEdit(wrapper.id.toString())}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text: !canManageWrappers
+                  ? 'You need additional permissions to edit wrappers'
+                  : 'Edit wrapper',
+              },
+            }}
+          />
+          <ButtonTooltip
+            type="default"
+            disabled={!canManageWrappers}
+            icon={<Trash strokeWidth={1.5} />}
+            className="px-1.5"
+            onClick={() => setSelectedWrapperToDelete(wrapper.id.toString())}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text: !canManageWrappers
+                  ? 'You need additional permissions to delete wrappers'
+                  : 'Delete wrapper',
+              },
+            }}
+          />
+        </div>
+      </TableCell>
+    </TableRow>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
@@ -97,7 +97,7 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
             <TableRow>
               <TableCell colSpan={4}>
                 {wrappers.length} {integration?.name}
-                {wrappers.length > 1 ? 's' : ''} created
+                {wrappers.length === 0 || wrappers.length > 1 ? 's' : ''} created
               </TableCell>
             </TableRow>
           </TableFooter>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
@@ -1,13 +1,14 @@
-import { useMemo, useRef } from 'react'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { useFDWsQuery } from 'data/fdw/fdws-query'
-import { handleErrorOnDelete, useQueryStateWithSelect } from 'hooks/misc/useQueryStateWithSelect'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { parseAsString, useQueryState } from 'nuqs'
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import {
   Card,
   cn,
+  Sheet,
+  SheetContent,
   Table,
   TableBody,
   TableCell,
@@ -16,7 +17,10 @@ import {
   TableHeader,
   TableRow,
 } from 'ui'
+
 import { INTEGRATIONS } from '../Landing/Integrations.constants'
+import { DeleteWrapperModal } from './DeleteWrapperModal'
+import { EditWrapperSheet } from './EditWrapperSheet'
 import { WrapperRow } from './WrapperRow'
 import { wrapperMetaComparator } from './Wrappers.utils'
 
@@ -29,7 +33,9 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
   const { data: project } = useSelectedProjectQuery()
   const integration = INTEGRATIONS.find((i) => i.id === id)
 
-  const { data } = useFDWsQuery({
+  const [isClosingEditWrapper, setIsClosingEditWrapper] = useState(false)
+
+  const { data, isSuccess } = useFDWsQuery({
     projectRef: ref,
     connectionString: project?.connectionString,
   })
@@ -42,27 +48,15 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
     [data, integration]
   )
 
-  // Track the ID being deleted to exclude it from error checking
-  const deletingWrapperIdRef = useRef<string | null>(null)
+  const [selectedWrapperIdToEdit, setSelectedWrapperToEdit] = useQueryState('edit', parseAsString)
+  const selectedWrapperToEdit = wrappers.find((w) => w.id.toString() === selectedWrapperIdToEdit)
 
-  const { setValue: setSelectedWrapperToEdit, value: selectedWrapperToEdit } =
-    useQueryStateWithSelect({
-      urlKey: 'edit',
-      select: (wrapperId: string) =>
-        wrapperId ? wrappers.find((w) => w.id.toString() === wrapperId) : undefined,
-      enabled: !!wrappers.length,
-      onError: () => toast.error(`Wrapper not found`),
-    })
-
-  const { setValue: setSelectedWrapperToDelete, value: selectedWrapperToDelete } =
-    useQueryStateWithSelect({
-      urlKey: 'delete',
-      select: (wrapperId: string) =>
-        wrapperId ? wrappers.find((w) => w.id.toString() === wrapperId) : undefined,
-      enabled: !!wrappers.length,
-      onError: (_error, selectedId) =>
-        handleErrorOnDelete(deletingWrapperIdRef, selectedId, `Wrapper not found`),
-    })
+  useEffect(() => {
+    if (isSuccess && !!selectedWrapperIdToEdit && !selectedWrapperToEdit) {
+      toast('Wrapper not found')
+      setSelectedWrapperToEdit(null)
+    }
+  }, [isSuccess, selectedWrapperIdToEdit, selectedWrapperToEdit, setSelectedWrapperToEdit])
 
   if (!integration || integration.type !== 'wrapper') {
     return (
@@ -73,50 +67,66 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
   }
 
   return (
-    <Card className="max-w-5xl">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[220px]">Name</TableHead>
-            <TableHead>Tables</TableHead>
-            <TableHead>Encrypted key</TableHead>
-            <TableHead className="w-24">
-              <span className="sr-only">Actions</span>
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {(isLatest ? wrappers.slice(0, 3) : wrappers).map((x) => {
-            return (
-              <WrapperRow
-                key={x.id}
-                wrapper={x}
-                selectedWrapperToEdit={selectedWrapperToEdit}
-                selectedWrapperToDelete={selectedWrapperToDelete}
-                setSelectedWrapperToEdit={setSelectedWrapperToEdit}
-                setSelectedWrapperToDelete={setSelectedWrapperToDelete}
-                deletingWrapperIdRef={deletingWrapperIdRef}
-              />
-            )
-          })}
-        </TableBody>
-        <TableFooter
-          className={cn(
-            'text-xs font-normal text-center text-foreground-muted',
-            // Prevent the footer from being highlighted on hover
-            '[&>tr>td]:hover:bg-inherit',
-            // Conditionally remove the border-top if there are no wrappers
-            wrappers.length === 0 ? 'border-t-0' : ''
+    <>
+      <Card className="max-w-5xl">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[220px]">Name</TableHead>
+              <TableHead>Tables</TableHead>
+              <TableHead>Encrypted key</TableHead>
+              <TableHead className="w-24">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(isLatest ? wrappers.slice(0, 3) : wrappers).map((x) => {
+              return <WrapperRow key={x.id} wrapper={x} />
+            })}
+          </TableBody>
+          <TableFooter
+            className={cn(
+              'text-xs font-normal text-center text-foreground-muted',
+              // Prevent the footer from being highlighted on hover
+              '[&>tr>td]:hover:bg-inherit',
+              // Conditionally remove the border-top if there are no wrappers
+              wrappers.length === 0 ? 'border-t-0' : ''
+            )}
+          >
+            <TableRow>
+              <TableCell colSpan={4}>
+                {wrappers.length} {integration?.name}
+                {wrappers.length > 1 ? 's' : ''} created
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </Card>
+
+      <Sheet
+        open={!!selectedWrapperToEdit}
+        onOpenChange={(open) => {
+          if (!open) setIsClosingEditWrapper(true)
+        }}
+      >
+        <SheetContent size="lg" tabIndex={undefined}>
+          {selectedWrapperToEdit && (
+            <EditWrapperSheet
+              wrapper={selectedWrapperToEdit}
+              wrapperMeta={integration.meta}
+              onClose={() => {
+                setSelectedWrapperToEdit(null)
+                setIsClosingEditWrapper(false)
+              }}
+              isClosing={isClosingEditWrapper}
+              setIsClosing={setIsClosingEditWrapper}
+            />
           )}
-        >
-          <TableRow>
-            <TableCell colSpan={4}>
-              {wrappers.length} {integration?.name}
-              {wrappers.length > 1 ? 's' : ''} created
-            </TableCell>
-          </TableRow>
-        </TableFooter>
-      </Table>
-    </Card>
+        </SheetContent>
+      </Sheet>
+
+      <DeleteWrapperModal />
+    </>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
@@ -1,16 +1,15 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { HTMLProps, ReactNode, useCallback, useState } from 'react'
-
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { FDW, useFDWsQuery } from 'data/fdw/fdws-query'
+import { useFDWsQuery } from 'data/fdw/fdws-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useConfirmOnClose, type ConfirmOnCloseModalProps } from 'hooks/ui/useConfirmOnClose'
+import { HTMLProps, ReactNode, useCallback, useState } from 'react'
 import { Sheet, SheetContent } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
 import { CreateWrapperSheet } from './CreateWrapperSheet'
-import DeleteWrapperModal from './DeleteWrapperModal'
 import { WRAPPERS } from './Wrappers.constants'
 import { wrapperMetaComparator } from './Wrappers.utils'
 import { WrapperTable } from './WrapperTable'
@@ -18,7 +17,6 @@ import { WrapperTable } from './WrapperTable'
 export const WrappersTab = () => {
   const { id } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const [selectedWrapperForDelete, setSelectedWrapperForDelete] = useState<FDW | null>(null)
   const [createWrapperShown, setCreateWrapperShown] = useState(false)
 
   const { can: canCreateWrapper } = useAsyncCheckPermissions(
@@ -104,12 +102,6 @@ export const WrappersTab = () => {
   return (
     <Container>
       <WrapperTable />
-      {selectedWrapperForDelete && (
-        <DeleteWrapperModal
-          selectedWrapper={selectedWrapperForDelete}
-          onClose={() => setSelectedWrapperForDelete(null)}
-        />
-      )}
       <CloseConfirmationModal {...closeConfirmationModalProps} />
     </Container>
   )

--- a/apps/studio/data/vault/keys.ts
+++ b/apps/studio/data/vault/keys.ts
@@ -1,5 +1,5 @@
 export const vaultSecretsKeys = {
   list: (projectRef: string | undefined) => ['projects', projectRef, 'secrets'] as const,
-  getDecryptedValue: (projectRef: string | undefined, id: string) =>
-    ['projects', projectRef, 'secrets', id] as const,
+  getDecryptedValue: (projectRef: string | undefined, id: string | undefined) =>
+    ['projects', projectRef, 'secrets', id].filter(Boolean),
 }

--- a/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
+++ b/apps/studio/data/vault/vault-secret-decrypted-value-query.ts
@@ -1,6 +1,7 @@
 import { Query } from '@supabase/pg-meta/src/query'
 import { useQuery } from '@tanstack/react-query'
 import { UseCustomQueryOptions } from 'types'
+
 import { executeSql } from '../sql/execute-sql-query'
 import { vaultSecretsKeys } from './keys'
 
@@ -27,13 +28,15 @@ const vaultSecretDecryptedValuesQuery = (ids: string[]) => {
 export type VaultSecretsDecryptedValueVariables = {
   projectRef?: string
   connectionString?: string | null
-  id: string
+  id?: string
 }
 
 export const getDecryptedValue = async (
   { projectRef, connectionString, id }: VaultSecretsDecryptedValueVariables,
   signal?: AbortSignal
 ) => {
+  if (!id) throw new Error('ID is required')
+
   const sql = vaultSecretDecryptedValueQuery(id)
   const { result } = await executeSql(
     {


### PR DESCRIPTION
## Context

Related to FE-2461

More refactoring to clean up usage of `useQueryStateWithSelect`, in the following pages
- Auth OAuth Apps
- Cron Jobs
- Vaults Secrets Management
- Database Hooks
- Wrappers

## To test

In each of those pages, verify that
- [ ] Clicking the "new" cta updates the URL params, and refreshing should re-open the sheet
- [ ] Editing an existing item should update URL params, and refreshing should re-open the sheet with the right item
  - Verify that if the URL param has the wrong id, page should not open the sheet, show a toast, and reset the URL param
- [ ] Deleting an existing item should update URL params, and refreshing should re-open the sheet with the right item
  - Verify that if the URL param has the wrong id, page should not open the sheet, show a toast, and reset the URL param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added "item not found" toasts and clearer feedback after create/update/delete actions; prevent opening create flows when server features are disabled.

* **Style**
  * Standardized button labels, sizes and modal/dialog spacing; refined table column widths and inline code formatting for readability.

* **Refactor**
  * Simplified UI state flows across OAuth Apps, Hooks/Webhooks, Cron Jobs, Vault Secrets, and Wrappers to use consistent URL-driven interactions and centralized modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->