### PR TITLE
chore(docs): add clarity to enabling SSO for organizations

### DIFF
--- a/apps/docs/content/guides/platform/sso.mdx
+++ b/apps/docs/content/guides/platform/sso.mdx
@@ -49,13 +49,13 @@ When SSO is enabled for an organization:
 
 - Review the steps above to configure your setup.
 - Invite users to the organization and ensure they join with their SSO linked account.
-- If a user is already a member of the organization under a non SSO account, they will need to be removed first and re-invited for them to join under their SSO account.
+- If a user is already a member of the organization under a non SSO account, they will need to be removed and invited again for them to join under their SSO account.
 
 <Admonition type="note">
 
 **No automatic linking:** Each user account verified using a SSO identity provider will not be automatically linked to existing user accounts in the system. That is, if a user `valid.email@supabase.io` had signed up with a password, and then uses their company SSO login with your project, there will be two `valid.email@supabase.io` user accounts in the system.
 
-Users will need to ensure they are logged with the correct account when accept invites or logging in.
+Users will need to ensure they are logged in with the correct account when accepting invites or accessing organizations/projects.
 
 </Admonition>
 

--- a/apps/docs/content/guides/platform/sso.mdx
+++ b/apps/docs/content/guides/platform/sso.mdx
@@ -45,6 +45,19 @@ When SSO is enabled for an organization:
 - If an SSO user with the following email of `alice@foocorp.com` attempts to sign in with a GitHub account that uses the same email, a separate Supabase account is created and will not be linked to the SSO user's account.
 - SSO users will only see organizations/projects they've been invited to or auto-joined into. See [access control](/docs/guides/platform/access-control) for more details.
 
+## Enabling SSO for an organization
+
+- Review the steps above to configure your setup.
+- Invite users to the organization and ensure they join with their SSO linked account.
+- If a user is already a member of the organization under a non SSO account, they will need to be removed first and reinvited for them to join under their SSO account.
+
+<Admonition type="note">
+**No automatic linking:** Each user account verified using a SSO identity provider will not be automatically linked to existing user accounts in the system. That is, if a user `valid.email@supabase.io` had signed up with a password, and then uses their company SSO login with your project, there will be two `valid.email@supabase.io` user accounts in the system.
+
+Users will need to ensure they are logged with the correct account when accept invites or logging in.
+
+</Admonition>
+
 ## Disabling SSO for an organization
 
 If you disable the SSO provider for an organization, **all SSO users will immediately be unable to sign in**. Before disabling SSO, ensure you have at least one non-SSO owner account to prevent being locked out.

--- a/apps/docs/content/guides/platform/sso.mdx
+++ b/apps/docs/content/guides/platform/sso.mdx
@@ -49,9 +49,10 @@ When SSO is enabled for an organization:
 
 - Review the steps above to configure your setup.
 - Invite users to the organization and ensure they join with their SSO linked account.
-- If a user is already a member of the organization under a non SSO account, they will need to be removed first and reinvited for them to join under their SSO account.
+- If a user is already a member of the organization under a non SSO account, they will need to be removed first and re-invited for them to join under their SSO account.
 
 <Admonition type="note">
+
 **No automatic linking:** Each user account verified using a SSO identity provider will not be automatically linked to existing user accounts in the system. That is, if a user `valid.email@supabase.io` had signed up with a password, and then uses their company SSO login with your project, there will be two `valid.email@supabase.io` user accounts in the system.
 
 Users will need to ensure they are logged with the correct account when accept invites or logging in.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add clarify around enabling SSO for an organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Enabling SSO for an organization" subsection with step-by-step setup, user invitation, and re-invitation instructions to support SSO adoption.
  * Added an admonition clarifying that SSO identities are not automatically linked to existing non-SSO accounts, showing a concrete example of potential duplicate accounts and advising which account to use when accepting invites or logging in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->