### PR TITLE
fix(design-system): remove modal from sidebar (fragment doesn't exist)

### DIFF
--- a/apps/design-system/config/docs.ts
+++ b/apps/design-system/config/docs.ts
@@ -128,11 +128,6 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: 'Modal',
-          href: '/docs/fragments/modal',
-          items: [],
-        },
-        {
           title: 'Page Container',
           href: '/docs/fragments/page-container',
           items: [],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes "Modal" from the sidebar, since it doesn't exist in fragments. Probably covered by "Dialog".

## What is the current behavior?

Clicking on "Modal" at the sidebar leads to 404.
<img width="2118" height="1546" alt="shot 2026-02-13 at 10 30 38Z@2x" src="https://github.com/user-attachments/assets/94119b2f-6026-43e0-9b9d-468c8cfb245b" />


## What is the new behavior?

"Modal" has been removed from `docs.ts`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Modal documentation link from the Fragment Components section in the docs sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->