### PR TITLE
fix: card paddings

### DIFF
--- a/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -1,3 +1,7 @@
+import { useDatabaseRoleUpdateMutation } from 'data/database-roles/database-role-update-mutation'
+import { PgRole } from 'data/database-roles/database-roles-query'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { ChevronUp, HelpCircle, MoreVertical, Trash } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -15,10 +19,6 @@ import {
   TooltipTrigger,
 } from 'ui'
 
-import { useDatabaseRoleUpdateMutation } from 'data/database-roles/database-role-update-mutation'
-import { PgRole } from 'data/database-roles/database-roles-query'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { ChevronUp, HelpCircle, MoreVertical, Trash } from 'lucide-react'
 import { ROLE_PERMISSIONS } from './Roles.constants'
 
 interface RoleRowProps {
@@ -93,7 +93,7 @@ export const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps
               <button
                 id="collapsible-trigger"
                 type="button"
-                className="group flex w-full items-center justify-between rounded py-3 px-[var(--card-padding-x)] text-foreground"
+                className="group flex w-full items-center justify-between rounded py-3 px-card text-foreground"
                 onClick={(event: any) => {
                   if (event.target.id === 'collapsible-trigger') setIsExpanded(!isExpanded)
                 }}

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -1,10 +1,5 @@
-import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { partition, sortBy } from 'lodash'
-import { Plus, Search, X } from 'lucide-react'
-import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useRef, useState } from 'react'
-
 import type { PostgresRole } from '@supabase/postgres-meta'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { NoSearchResults } from 'components/ui/NoSearchResults'
 import SparkBar from 'components/ui/SparkBar'
@@ -13,7 +8,12 @@ import { useMaxConnectionsQuery } from 'data/database/max-connections-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { handleErrorOnDelete, useQueryStateWithSelect } from 'hooks/misc/useQueryStateWithSelect'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { partition, sortBy } from 'lodash'
+import { Plus, Search, X } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useRef, useState } from 'react'
 import { Badge, Button, Input, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
 import { CreateRolePanel } from './CreateRolePanel'
 import { DeleteRoleModal } from './DeleteRoleModal'
 import { RoleRow } from './RoleRow'
@@ -186,7 +186,7 @@ export const RolesList = () => {
 
       <div className="space-y-4">
         <div>
-          <div className="bg-surface-100 border border-default px-[var(--card-padding-x)] py-3 rounded-t flex items-center space-x-4">
+          <div className="bg-surface-100 border border-default px-card py-3 rounded-t flex items-center space-x-4">
             <p className="text-sm text-foreground-light">Roles managed by Supabase</p>
             <Badge variant="success">Protected</Badge>
           </div>
@@ -204,7 +204,7 @@ export const RolesList = () => {
         </div>
 
         <div>
-          <div className="bg-surface-100 border border-default px-[var(--card-padding-x)] py-3 rounded-t">
+          <div className="bg-surface-100 border border-default px-card py-3 rounded-t">
             <p className="text-sm text-foreground-light">Other database roles</p>
           </div>
 

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -1,11 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { AnimatePresence, motion } from 'framer-motion'
-import { ChevronRight } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { MAX_WIDTH_CLASSES, PADDING_CLASSES, ScaffoldContainer } from 'components/layouts/Scaffold'
 import { DocsButton } from 'components/ui/DocsButton'
@@ -25,6 +19,7 @@ import { useProjectAddonUpdateMutation } from 'data/subscriptions/project-addon-
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { AddonVariantId } from 'data/subscriptions/types'
 import { useResourceWarningsQuery } from 'data/usage/resource-warnings-query'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -35,7 +30,11 @@ import {
   useSelectedProjectQuery,
 } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL, GB, PROJECT_STATUS } from 'lib/constants'
+import { ChevronRight } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
 import { CloudProvider } from 'shared-data'
+import { toast } from 'sonner'
 import {
   Button,
   cn,
@@ -46,6 +45,7 @@ import {
   Separator,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+
 import { FormFooterChangeBadge } from '../DataWarehouse/FormFooterChangeBadge'
 import { CreateDiskStorageSchema, DiskStorageSchemaType } from './DiskManagement.schema'
 import { DiskManagementMessage } from './DiskManagement.types'
@@ -444,7 +444,7 @@ export function DiskManagementForm() {
                   open={advancedSettingsOpen}
                   onOpenChange={() => setAdvancedSettingsOpenState((prev) => !prev)}
                 >
-                  <CollapsibleTrigger_Shadcn_ className="px-[var(--card-padding-x)] py-3 w-full border flex items-center gap-6 rounded-t data-[state=closed]:rounded-b group justify-between">
+                  <CollapsibleTrigger_Shadcn_ className="px-card py-3 w-full border flex items-center gap-6 rounded-t data-[state=closed]:rounded-b group justify-between">
                     <div className="flex flex-col items-start">
                       <span className="text-sm text-foreground">Advanced disk settings</span>
                       <span className="text-sm text-foreground-light text-left">
@@ -465,11 +465,11 @@ export function DiskManagementForm() {
                     )}
                   >
                     <div className="flex flex-col gap-y-8 py-8">
-                      <div className="px-[var(--card-padding-x)] flex flex-col gap-y-8">
+                      <div className="px-card flex flex-col gap-y-8">
                         <AutoScaleFields form={form} />
                       </div>
                       <Separator />
-                      <div className="px-[var(--card-padding-x)] flex flex-col gap-y-8">
+                      <div className="px-card flex flex-col gap-y-8">
                         <NoticeBar
                           type="default"
                           visible={!!disableIopsThroughputConfig}

--- a/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
@@ -251,7 +251,7 @@ export const ProjectUsageSection = () => {
                 </div>
               </div>
             </CardHeader>
-            <CardContent className="py-4 px-[var(--card-padding-x)] flex-1 h-full overflow-hidden">
+            <CardContent className="p-[var(--card-padding-x)] flex-1 h-full overflow-hidden">
               <Loading isFullHeight active={isLoading}>
                 <LogsBarChart
                   isFullHeight

--- a/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
@@ -251,7 +251,7 @@ export const ProjectUsageSection = () => {
                 </div>
               </div>
             </CardHeader>
-            <CardContent className="p-6 pt-4 flex-1 h-full overflow-hidden">
+            <CardContent className="py-4 px-[var(--card-padding-x)] flex-1 h-full overflow-hidden">
               <Loading isFullHeight active={isLoading}>
                 <LogsBarChart
                   isFullHeight

--- a/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
@@ -251,7 +251,7 @@ export const ProjectUsageSection = () => {
                 </div>
               </div>
             </CardHeader>
-            <CardContent className="p-[var(--card-padding-x)] flex-1 h-full overflow-hidden">
+            <CardContent className="p-card flex-1 h-full overflow-hidden">
               <Loading isFullHeight active={isLoading}>
                 <LogsBarChart
                   isFullHeight

--- a/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
+++ b/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
@@ -14,8 +14,8 @@ import { useCallback, useMemo, useState } from 'react'
 import { Badge, Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { DatabaseInfrastructureSection } from './DatabaseInfrastructureSection'
-import { ObservabilityOverviewFooter } from './ObservabilityOverviewFooter'
 import { useObservabilityOverviewData } from './ObservabilityOverview.utils'
+import { ObservabilityOverviewFooter } from './ObservabilityOverviewFooter'
 import { ServiceHealthTable } from './ServiceHealthTable'
 import { useSlowQueriesCount } from './useSlowQueriesCount'
 
@@ -162,7 +162,7 @@ export const ObservabilityOverview = () => {
             </TooltipContent>
           </Tooltip>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <Button type="outline" icon={<RefreshCw size={14} />} onClick={handleRefresh}>
             Refresh
           </Button>

--- a/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
+++ b/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
@@ -81,7 +81,7 @@ export const ServiceHealthCard = ({
         </div>
       </CardHeader>
 
-      <CardContent className="py-4 px-[var(--card-padding-x)] pt-4 flex-1 overflow-hidden max-h-[200px]">
+      <CardContent className="p-[var(--card-padding-x)] pt-4 flex-1 overflow-hidden max-h-[200px]">
         <Loading isFullHeight active={isLoading}>
           <LogsBarChart
             isFullHeight

--- a/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
+++ b/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
@@ -1,10 +1,10 @@
 import NoDataPlaceholder from 'components/ui/Charts/NoDataPlaceholder'
 import Link from 'next/link'
-import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle, Loading, cn } from 'ui'
+import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle, cn, Loading } from 'ui'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
 
 import type { LogsBarChartDatum } from '../HomeNew/ProjectUsage.metrics'
-import { type ServiceKey, getHealthStatus } from './ObservabilityOverview.utils'
+import { getHealthStatus, type ServiceKey } from './ObservabilityOverview.utils'
 
 const colorClassMap: Record<string, string> = {
   muted: 'bg-muted',
@@ -81,7 +81,7 @@ export const ServiceHealthCard = ({
         </div>
       </CardHeader>
 
-      <CardContent className="p-6 pt-4 flex-1 overflow-hidden max-h-[200px]">
+      <CardContent className="py-4 px-[var(--card-padding-x)] pt-4 flex-1 overflow-hidden max-h-[200px]">
         <Loading isFullHeight active={isLoading}>
           <LogsBarChart
             isFullHeight

--- a/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
+++ b/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
@@ -81,7 +81,7 @@ export const ServiceHealthCard = ({
         </div>
       </CardHeader>
 
-      <CardContent className="p-[var(--card-padding-x)] pt-4 flex-1 overflow-hidden max-h-[200px]">
+      <CardContent className="p-card pt-4 flex-1 overflow-hidden max-h-[200px]">
         <Loading isFullHeight active={isLoading}>
           <LogsBarChart
             isFullHeight

--- a/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
+++ b/apps/studio/components/interfaces/Observability/ServiceHealthCard.tsx
@@ -95,7 +95,7 @@ export const ServiceHealthCard = ({
         </Loading>
       </CardContent>
 
-      <CardFooter className="border-t pt-3 pb-4 px-4 flex gap-2">
+      <CardFooter className="border-t pt-3 pb-4 px-card flex gap-2">
         {reportUrl && (
           <Button type="default" size="tiny" asChild className="flex-1">
             <Link href={reportUrl}>View Report</Link>

--- a/apps/studio/components/interfaces/Observability/ServiceHealthTable.tsx
+++ b/apps/studio/components/interfaces/Observability/ServiceHealthTable.tsx
@@ -1,13 +1,11 @@
-import { HelpCircle } from 'lucide-react'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, HelpCircle } from 'lucide-react'
 import Link from 'next/link'
-import { Card, CardContent } from 'ui'
-import { Badge, Loading, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Badge, Card, CardContent, Loading, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
 
 import { ButtonTooltip } from '../../ui/ButtonTooltip'
 import type { LogsBarChartDatum } from '../HomeNew/ProjectUsage.metrics'
-import { type ServiceKey, getHealthStatus } from './ObservabilityOverview.utils'
+import { getHealthStatus, type ServiceKey } from './ObservabilityOverview.utils'
 
 type ServiceConfig = {
   key: ServiceKey
@@ -101,7 +99,7 @@ const ServiceRow = ({ service, data, onBarClick, datetimeFormat }: ServiceRowPro
   return (
     <Link
       href={reportUrl}
-      className="block group p-4 border-b border-default last:border-b-0 hover:bg-surface-200 transition-colors cursor-pointer"
+      className="block group py-4 px-card border-b border-default last:border-b-0 hover:bg-surface-200 transition-colors cursor-pointer"
     >
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -1,10 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import { z } from 'zod'
-
 import { Form, FormControl, FormField } from '@ui/components/shadcn/ui/form'
 import { useParams } from 'common'
 import {
@@ -20,6 +15,9 @@ import { useOrganizationCustomerProfileQuery } from 'data/organizations/organiza
 import { useOrganizationUpdateMutation } from 'data/organizations/organization-update-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import { FormMessage_Shadcn_, Input_Shadcn_ } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
@@ -29,6 +27,7 @@ import {
   MultiSelectorList,
   MultiSelectorTrigger,
 } from 'ui-patterns/multi-select'
+import { z } from 'zod'
 
 const FORM_ID = 'org-billing-email'
 const formSchema = z.object({
@@ -117,7 +116,7 @@ const BillingEmail = () => {
             <form id={FORM_ID} onSubmit={form.handleSubmit(onUpdateOrganizationEmail)}>
               <FormPanel
                 footer={
-                  <div className="flex py-4 px-[var(--card-padding-x)]">
+                  <div className="flex py-4 px-card">
                     <FormActions
                       form={FORM_ID}
                       isSubmitting={isUpdating}

--- a/apps/studio/components/ui/Forms/FormSection.tsx
+++ b/apps/studio/components/ui/Forms/FormSection.tsx
@@ -16,7 +16,7 @@ export const FormSection = ({
   className?: string
 }) => {
   const classes = [
-    'grid grid-cols-12 gap-6 px-[var(--card-padding-x)] py-4 md:py-8',
+    'grid grid-cols-12 gap-6 px-card py-4 md:py-8',
     `${disabled ? ' opacity-30' : ' opacity-100'}`,
     `${className}`,
   ]

--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -1,6 +1,5 @@
 import { Megaphone } from 'lucide-react'
 import { forwardRef, PropsWithChildren, ReactNode } from 'react'
-
 import { Badge, Button, cn, Loading } from 'ui'
 
 interface PanelProps {
@@ -34,7 +33,7 @@ function Panel(props: PropsWithChildren<PanelProps>) {
       {props.title && (
         <div
           className={cn(
-            'bg-surface-100 border-b border-default flex items-center px-[var(--card-padding-x)] py-4',
+            'bg-surface-100 border-b border-default flex items-center px-card py-4',
             props.titleClasses
           )}
         >
@@ -54,13 +53,13 @@ function Panel(props: PropsWithChildren<PanelProps>) {
 }
 
 function Content({ children, className }: { children: ReactNode; className?: string | false }) {
-  return <div className={cn('px-[var(--card-padding-x)] py-4', className)}>{children}</div>
+  return <div className={cn('px-card py-4', className)}>{children}</div>
 }
 
 function Footer({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <div className={cn('bg-surface-100 border-t border-default', className)}>
-      <div className="flex h-12 items-center px-[var(--card-padding-x)]">{children}</div>
+      <div className="flex h-12 items-center px-card">{children}</div>
     </div>
   )
 }
@@ -95,7 +94,7 @@ const PanelNotice = forwardRef<
         ref={ref}
         {...props}
         className={cn(
-          'relative px-[var(--card-padding-x)] py-5 bg-studio flex flex-col lg:flex-row lg:justify-between gap-6 overflow-hidden lg:items-center',
+          'relative px-card py-5 bg-studio flex flex-col lg:flex-row lg:justify-between gap-6 overflow-hidden lg:items-center',
           layout === 'vertical' && '!flex-col !items-start gap-y-2',
           className
         )}

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -414,6 +414,7 @@ const uiConfig = ui({
       },
       padding: {
         content: '21px',
+        card: 'var(--card-padding-x)',
       },
       // borderRadius: {
       //   lg: `var(--radius)`,

--- a/packages/ui-patterns/src/Chart/index.tsx
+++ b/packages/ui-patterns/src/Chart/index.tsx
@@ -62,7 +62,7 @@ interface ChartProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string
 }
 
-const chartTableClasses = `[&_tr]:border-b [&_tr]:border-border [&_thead_tr]:!bg-transparent [&_thead_th]:!py-2 [&_thead_th]:!px-6 [&_thead_th]:h-auto [&_tbody_td]:py-2.5 [&_tbody_td]:px-6 [&_tbody_td]:text-xs [&_table]:mb-1 [&_table]:border-b [&_table]:border-border`
+const chartTableClasses = `[&_tr]:border-b [&_tr]:border-border [&_thead_tr]:!bg-transparent [&_thead_th]:!py-2 [&_thead_th]:!px-[var(--card-padding-x)] [&_thead_th]:h-auto [&_tbody_td]:py-2.5 [&_tbody_td]:px-[var(--card-padding-x)] [&_tbody_td]:text-xs [&_table]:mb-1 [&_table]:border-b [&_table]:border-border`
 
 const Chart = React.forwardRef<HTMLDivElement, ChartProps>(
   ({ children, isLoading = false, isDisabled = false, className, ...props }, ref) => {
@@ -108,7 +108,7 @@ const ChartHeader = React.forwardRef<HTMLDivElement, ChartHeaderProps>(
       <div
         ref={ref}
         className={cn(
-          'py-4 px-6 flex flex-row justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
+          'p-[var(--card-padding-x)] flex flex-row justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
           align === 'center' ? 'items-center' : 'items-start',
           className
         )}
@@ -338,7 +338,11 @@ const ChartContent = React.forwardRef<HTMLDivElement, ChartContentProps>(
     }
 
     return (
-      <div ref={ref} className={cn('px-6 pt-4 pb-6', chartTableClasses, className)} {...props}>
+      <div
+        ref={ref}
+        className={cn('p-[var(--card-padding-x)]', chartTableClasses, className)}
+        {...props}
+      >
         {content}
       </div>
     )

--- a/packages/ui-patterns/src/Chart/index.tsx
+++ b/packages/ui-patterns/src/Chart/index.tsx
@@ -62,7 +62,7 @@ interface ChartProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string
 }
 
-const chartTableClasses = `[&_tr]:border-b [&_tr]:border-border [&_thead_tr]:!bg-transparent [&_thead_th]:!py-2 [&_thead_th]:!px-[var(--card-padding-x)] [&_thead_th]:h-auto [&_tbody_td]:py-2.5 [&_tbody_td]:px-[var(--card-padding-x)] [&_tbody_td]:text-xs [&_table]:mb-1 [&_table]:border-b [&_table]:border-border`
+const chartTableClasses = `[&_tr]:border-b [&_tr]:border-border [&_thead_tr]:!bg-transparent [&_thead_th]:!py-2 [&_thead_th]:!px-card [&_thead_th]:h-auto [&_tbody_td]:py-2.5 [&_tbody_td]:px-card [&_tbody_td]:text-xs [&_table]:mb-1 [&_table]:border-b [&_table]:border-border`
 
 const Chart = React.forwardRef<HTMLDivElement, ChartProps>(
   ({ children, isLoading = false, isDisabled = false, className, ...props }, ref) => {
@@ -108,7 +108,7 @@ const ChartHeader = React.forwardRef<HTMLDivElement, ChartHeaderProps>(
       <div
         ref={ref}
         className={cn(
-          'p-[var(--card-padding-x)] flex flex-row justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
+          'p-card flex flex-row justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
           align === 'center' ? 'items-center' : 'items-start',
           className
         )}
@@ -338,11 +338,7 @@ const ChartContent = React.forwardRef<HTMLDivElement, ChartContentProps>(
     }
 
     return (
-      <div
-        ref={ref}
-        className={cn('p-[var(--card-padding-x)]', chartTableClasses, className)}
-        {...props}
-      >
+      <div ref={ref} className={cn('p-card', chartTableClasses, className)} {...props}>
         {content}
       </div>
     )

--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -72,7 +72,7 @@ const MetricCardHeader = React.forwardRef<HTMLDivElement, MetricCardHeaderProps>
       <div
         ref={ref}
         className={cn(
-          'p-4 flex flex-row items-center justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
+          'p-[var(--card-padding-x)] flex flex-row items-center justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
           className
         )}
         {...props}
@@ -111,7 +111,7 @@ const MetricCardContent = React.forwardRef<HTMLDivElement, MetricCardContentProp
     <CardContent
       ref={ref}
       className={cn(
-        'p-4 pt-0 flex-1 flex h-full items-start gap-1 overflow-hidden border-b-0',
+        'p-[var(--card-padding-x)] pt-0 flex-1 flex h-full items-start gap-1 overflow-hidden border-b-0',
         orientation === 'horizontal' ? 'flex-row' : 'flex-col ',
         className
       )}

--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -72,7 +72,7 @@ const MetricCardHeader = React.forwardRef<HTMLDivElement, MetricCardHeaderProps>
       <div
         ref={ref}
         className={cn(
-          'py-4 px-6 flex flex-row items-center justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
+          'p-4 flex flex-row items-center justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
           className
         )}
         {...props}
@@ -111,7 +111,7 @@ const MetricCardContent = React.forwardRef<HTMLDivElement, MetricCardContentProp
     <CardContent
       ref={ref}
       className={cn(
-        'pb-4 px-6 pt-0 flex-1 flex h-full items-start gap-1 overflow-hidden border-b-0',
+        'p-4 pt-0 flex-1 flex h-full items-start gap-1 overflow-hidden border-b-0',
         orientation === 'horizontal' ? 'flex-row' : 'flex-col ',
         className
       )}

--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -72,7 +72,7 @@ const MetricCardHeader = React.forwardRef<HTMLDivElement, MetricCardHeaderProps>
       <div
         ref={ref}
         className={cn(
-          'p-[var(--card-padding-x)] flex flex-row items-center justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
+          'p-card flex flex-row items-center justify-between gap-2 space-y-0 pb-0 border-b-0 relative',
           className
         )}
         {...props}
@@ -111,7 +111,7 @@ const MetricCardContent = React.forwardRef<HTMLDivElement, MetricCardContentProp
     <CardContent
       ref={ref}
       className={cn(
-        'p-[var(--card-padding-x)] pt-0 flex-1 flex h-full items-start gap-1 overflow-hidden border-b-0',
+        'p-card pt-0 flex-1 flex h-full items-start gap-1 overflow-hidden border-b-0',
         orientation === 'horizontal' ? 'flex-row' : 'flex-col ',
         className
       )}

--- a/packages/ui/src/components/shadcn/ui/card.tsx
+++ b/packages/ui/src/components/shadcn/ui/card.tsx
@@ -20,7 +20,10 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('flex flex-col space-y-1.5 py-4 px-card border-b', className)}
+      className={cn(
+        'flex flex-col space-y-1.5 py-4 px-[var(--card-padding-x)] border-b',
+        className
+      )}
       {...props}
     />
   )
@@ -44,14 +47,22 @@ CardDescription.displayName = 'CardDescription'
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('py-4 px-card border-b last:border-none', className)} {...props} />
+    <div
+      ref={ref}
+      className={cn('py-4 px-[var(--card-padding-x)] border-b last:border-none', className)}
+      {...props}
+    />
   )
 )
 CardContent.displayName = 'CardContent'
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center py-4 px-card', className)} {...props} />
+    <div
+      ref={ref}
+      className={cn('flex items-center py-4 px-[var(--card-padding-x)]', className)}
+      {...props}
+    />
   )
 )
 CardFooter.displayName = 'CardFooter'

--- a/packages/ui/src/components/shadcn/ui/card.tsx
+++ b/packages/ui/src/components/shadcn/ui/card.tsx
@@ -20,10 +20,7 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn(
-        'flex flex-col space-y-1.5 py-4 px-[var(--card-padding-x)] border-b',
-        className
-      )}
+      className={cn('flex flex-col space-y-1.5 py-4 px-card border-b', className)}
       {...props}
     />
   )
@@ -47,22 +44,14 @@ CardDescription.displayName = 'CardDescription'
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn('py-4 px-[var(--card-padding-x)] border-b last:border-none', className)}
-      {...props}
-    />
+    <div ref={ref} className={cn('py-4 px-card border-b last:border-none', className)} {...props} />
   )
 )
 CardContent.displayName = 'CardContent'
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn('flex items-center py-4 px-[var(--card-padding-x)]', className)}
-      {...props}
-    />
+    <div ref={ref} className={cn('flex items-center py-4 px-card', className)} {...props} />
   )
 )
 CardFooter.displayName = 'CardFooter'


### PR DESCRIPTION
Uniform card paddings to use the `--card-padding-x` css var.

## Before
<img width="1459" height="763" alt="Screenshot 2026-02-13 at 12 21 57" src="https://github.com/user-attachments/assets/490d3121-4006-42f1-a406-b3fd712a4b28" />

## After
<img width="1457" height="746" alt="Screenshot 2026-02-13 at 12 22 11" src="https://github.com/user-attachments/assets/8d1fed69-a7d8-4d10-890e-ff55ca25e2ca" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced form validation in billing settings with structured data handling

* **Style**
  * Standardized padding and spacing across components for visual consistency
  * Updated layout spacing in observability and metrics components

* **Chores**
  * Reorganized imports and optimized Tailwind configuration with new padding token
<!-- end of auto-generated comment: release notes by coderabbit.ai -->