### PR TITLE
fix: correct RLS permissions for storage move and copy operations

### DIFF
--- a/apps/docs/content/guides/storage/management/copy-move-objects.mdx
+++ b/apps/docs/content/guides/storage/management/copy-move-objects.mdx
@@ -74,7 +74,11 @@ await supabase.storage.from('avatars').move('public/avatar1.png', 'private/avata
 
 ## Permissions
 
-For a user to move and copy objects, they need `select` permission on the source object and `insert` permission on the destination object. For example:
+To **copy** objects, users need `select` permission on the source object and `insert` permission on the destination object. If the user also has `update` permission, the copy can be performed as an upsert, which will overwrite the destination object if it already exists.
+
+To **move** objects, users need `select` and `update` permissions on the object.
+
+For example:
 
 ```sql
 create policy "User can select their own objects (in any buckets)"
@@ -85,11 +89,19 @@ using (
     owner_id = (select auth.uid())
 );
 
-create policy "User can upload in their own folders (in any buckets)"
+create policy "User can insert in their own folders (in any buckets)"
 on storage.objects
 for insert
 to authenticated
 with check (
     (storage.folder(name))[1] = (select auth.uid())
+);
+
+create policy "User can update their own objects (in any buckets)"
+on storage.objects
+for update
+to authenticated
+using (
+    owner_id = (select auth.uid())
 );
 ```


### PR DESCRIPTION
### Summary

- The `move` operation requires `select` + `update` permissions (not `select` + `insert` as previously documented). The implementation was changed in [supabase/storage#400](https://github.com/supabase/storage/pull/400) to update the row in-place instead of deleting and reinserting, but the docs were never updated to reflect this.
- The `copy` operation requires `select` + `insert` by default. When the user also has `update` permission, the copy can be performed as an upsert, overwriting the destination if it already exists.
- Added an `update` policy example alongside the existing `select` and `insert` examples.

### Related

Fixes https://github.com/supabase/storage/issues/807


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for storage copy operations with clarified permissions requirements on source and destination.
  * Added upsert option details for users with update permissions.
  * Clarified move operation requirements for select and update permissions.
  * Updated policy examples with explicit operation names and owner authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->