### PR TITLE
fix(docker): use 127.0.0.1 for storage healthcheck in S3 compose

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -50,7 +50,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:5000/status"
+          "http://127.0.0.1:5000/status"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## Summary
Storage container incorrectly shows as unhealthy in S3 Docker setup due to IPv6/IPv4 mismatch.

## Problem
`localhost` resolves to IPv6 `[::1]` inside containers, but storage API binds to IPv4 only.
 Healthcheck fails with connection refused.

## Solution
Use `127.0.0.1` instead of `localhost` in healthcheck for explicit IPv4 resolution.

## Related
- Closes #42776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage service configuration to improve internal health-check reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->