### PR TITLE
fix(studio): replace hardcoded tooltip colors with semantic tokens in BarChart and AreaChart

### DIFF
--- a/apps/studio/components/ui/Charts/AreaChart.tsx
+++ b/apps/studio/components/ui/Charts/AreaChart.tsx
@@ -127,7 +127,7 @@ const AreaChart = ({
           <Tooltip
             content={(props) =>
               syncId && syncTooltip && hoveredIndex !== null ? (
-                <div className="bg-black/90 text-white p-2 rounded text-xs">
+                <div className="bg-surface-300 text-foreground p-2 rounded text-xs">
                   <div className="font-medium">
                     {dayjs(data[hoveredIndex]?.[xAxisKey]).format(customDateFormat)}
                   </div>

--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -173,7 +173,7 @@ function BarChart<D extends Datum = Datum>({
           <Tooltip
             content={(props) =>
               syncId && isHovered && isCurrentChart && hoveredIndex !== null ? (
-                <div className="bg-black/90 text-white p-2 rounded text-xs">
+                <div className="bg-surface-300 text-foreground p-2 rounded text-xs">
                   <div className="font-medium">
                     {dayjs(data[hoveredIndex]?.[xAxisKey]).format(customDateFormat)}
                   </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The custom tooltip in `BarChart` and `AreaChart` components uses hardcoded colors (`bg-black/90 text-white`) that don't adapt to the current theme. This breaks visual consistency in light mode and doesn't follow the project's semantic color token convention.

## What is the new behavior?

Replaces `bg-black/90 text-white` with `bg-surface-300 text-foreground` in both chart tooltip components, ensuring they respect the active theme and are consistent with other tooltip styles in the codebase.

**Files changed:**
- `apps/studio/components/ui/Charts/BarChart.tsx`
- `apps/studio/components/ui/Charts/AreaChart.tsx`

## Additional context

Per the project's styling guidelines, Tailwind classes should use semantic color tokens (`bg-surface-*`, `text-foreground`, etc.) instead of hardcoded colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tooltip styling in area and bar charts for improved visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->