### PR TITLE
feat(assistant): detect HIPAA customers in assistant logic

### DIFF
--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -19,13 +19,15 @@ export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] &
 
 export async function getProjectSettings(
   { projectRef }: ProjectSettingsVariables,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  headers?: Record<string, string>
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
   const { data, error } = await get('/platform/projects/{ref}/settings', {
     params: { path: { ref: projectRef } },
     signal,
+    headers,
   })
 
   if (error) handleError(error)

--- a/apps/studio/data/subscriptions/org-subscription-query.ts
+++ b/apps/studio/data/subscriptions/org-subscription-query.ts
@@ -13,13 +13,15 @@ export type OrgSubscriptionVariables = {
 
 export async function getOrgSubscription(
   { orgSlug }: OrgSubscriptionVariables,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  headers?: Record<string, string>
 ) {
   if (!orgSlug) throw new Error('orgSlug is required')
 
   const { error, data } = await get('/platform/organizations/{slug}/billing/subscription', {
     params: { path: { slug: orgSlug } },
     signal,
+    headers,
   })
 
   if (error) handleError(error)

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -45,6 +45,7 @@ export async function generateAssistantResponse({
   getSchemas?: () => Promise<string>
   projectRef?: string
   chatName?: string
+  hasHipaaAddon?: boolean
   promptProviderOptions?: Record<string, any>
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -45,7 +45,7 @@ export async function generateAssistantResponse({
   getSchemas?: () => Promise<string>
   projectRef?: string
   chatName?: string
-  hasHipaaAddon?: boolean
+  isHipaaEnabled?: boolean
   promptProviderOptions?: Record<string, any>
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -45,6 +45,7 @@ export async function generateAssistantResponse({
   getSchemas?: () => Promise<string>
   projectRef?: string
   chatName?: string
+  // TODO(mattrossman): use for excluding HIPAA projects from assistant tracing
   isHipaaEnabled?: boolean
   promptProviderOptions?: Record<string, any>
   providerOptions?: Record<string, any>

--- a/apps/studio/lib/ai/org-ai-details.test.ts
+++ b/apps/studio/lib/ai/org-ai-details.test.ts
@@ -10,25 +10,53 @@ vi.mock('data/projects/project-detail-query', () => ({
   getProjectDetail: vi.fn(),
 }))
 
+vi.mock('data/subscriptions/org-subscription-query', () => ({
+  getOrgSubscription: vi.fn(),
+}))
+
+vi.mock('data/config/project-settings-v2-query', () => ({
+  getProjectSettings: vi.fn(),
+}))
+
 vi.mock('hooks/misc/useOrgOptedIntoAi', () => ({
   getAiOptInLevel: vi.fn(),
+}))
+
+vi.mock('components/interfaces/Billing/Subscription/Subscription.utils', () => ({
+  subscriptionHasHipaaAddon: vi.fn(),
 }))
 
 describe('ai/org-ai-details', () => {
   let mockGetOrganizations: ReturnType<typeof vi.fn>
   let mockGetProjectDetail: ReturnType<typeof vi.fn>
+  let mockGetOrgSubscription: ReturnType<typeof vi.fn>
+  let mockGetProjectSettings: ReturnType<typeof vi.fn>
   let mockGetAiOptInLevel: ReturnType<typeof vi.fn>
+  let mockSubscriptionHasHipaaAddon: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
     vi.clearAllMocks()
 
     const orgsQuery = await import('data/organizations/organizations-query')
     const projectQuery = await import('data/projects/project-detail-query')
+    const subscriptionQuery = await import('data/subscriptions/org-subscription-query')
+    const settingsQuery = await import('data/config/project-settings-v2-query')
     const aiHook = await import('hooks/misc/useOrgOptedIntoAi')
+    const subscriptionUtils = await import(
+      'components/interfaces/Billing/Subscription/Subscription.utils'
+    )
 
     mockGetOrganizations = vi.mocked(orgsQuery.getOrganizations)
     mockGetProjectDetail = vi.mocked(projectQuery.getProjectDetail)
+    mockGetOrgSubscription = vi.mocked(subscriptionQuery.getOrgSubscription)
+    mockGetProjectSettings = vi.mocked(settingsQuery.getProjectSettings)
     mockGetAiOptInLevel = vi.mocked(aiHook.getAiOptInLevel)
+    mockSubscriptionHasHipaaAddon = vi.mocked(subscriptionUtils.subscriptionHasHipaaAddon)
+
+    // Default mocks for subscription/settings (no HIPAA)
+    mockGetOrgSubscription.mockResolvedValue({ addons: [] })
+    mockGetProjectSettings.mockResolvedValue({ is_sensitive: false })
+    mockSubscriptionHasHipaaAddon.mockReturnValue(false)
   })
 
   describe('getOrgAIDetails', () => {
@@ -92,6 +120,7 @@ describe('ai/org-ai-details', () => {
       expect(result).toEqual({
         aiOptInLevel: 'schema_only',
         isLimited: true,
+        hasHipaaAddon: false,
       })
     })
 
@@ -238,6 +267,113 @@ describe('ai/org-ai-details', () => {
       })
 
       expect(result.isLimited).toBe(false) // Pro plan
+    })
+
+    it('should return hasHipaaAddon true when subscription has HIPAA addon and project is sensitive', async () => {
+      const mockOrg = {
+        id: 1,
+        slug: 'test-org',
+        plan: { id: 'enterprise' },
+        opt_in_tags: [],
+      }
+      const mockProject = { organization_id: 1 }
+
+      mockGetOrganizations.mockResolvedValue([mockOrg])
+      mockGetProjectDetail.mockResolvedValue(mockProject)
+      mockGetAiOptInLevel.mockReturnValue('schema')
+      mockSubscriptionHasHipaaAddon.mockReturnValue(true)
+      mockGetProjectSettings.mockResolvedValue({ is_sensitive: true })
+
+      const result = await getOrgAIDetails({
+        orgSlug: 'test-org',
+        authorization: 'Bearer token',
+        projectRef: 'test-project',
+      })
+
+      expect(result.hasHipaaAddon).toBe(true)
+    })
+
+    it('should return hasHipaaAddon false when subscription has HIPAA addon but project is not sensitive', async () => {
+      const mockOrg = {
+        id: 1,
+        slug: 'test-org',
+        plan: { id: 'enterprise' },
+        opt_in_tags: [],
+      }
+      const mockProject = { organization_id: 1 }
+
+      mockGetOrganizations.mockResolvedValue([mockOrg])
+      mockGetProjectDetail.mockResolvedValue(mockProject)
+      mockGetAiOptInLevel.mockReturnValue('schema')
+      mockSubscriptionHasHipaaAddon.mockReturnValue(true)
+      mockGetProjectSettings.mockResolvedValue({ is_sensitive: false })
+
+      const result = await getOrgAIDetails({
+        orgSlug: 'test-org',
+        authorization: 'Bearer token',
+        projectRef: 'test-project',
+      })
+
+      expect(result.hasHipaaAddon).toBe(false)
+    })
+
+    it('should return hasHipaaAddon false when project is sensitive but no HIPAA addon', async () => {
+      const mockOrg = {
+        id: 1,
+        slug: 'test-org',
+        plan: { id: 'pro' },
+        opt_in_tags: [],
+      }
+      const mockProject = { organization_id: 1 }
+
+      mockGetOrganizations.mockResolvedValue([mockOrg])
+      mockGetProjectDetail.mockResolvedValue(mockProject)
+      mockGetAiOptInLevel.mockReturnValue('schema')
+      mockSubscriptionHasHipaaAddon.mockReturnValue(false)
+      mockGetProjectSettings.mockResolvedValue({ is_sensitive: true })
+
+      const result = await getOrgAIDetails({
+        orgSlug: 'test-org',
+        authorization: 'Bearer token',
+        projectRef: 'test-project',
+      })
+
+      expect(result.hasHipaaAddon).toBe(false)
+    })
+
+    it('should fetch subscription and project settings with authorization headers', async () => {
+      const mockOrg = {
+        id: 1,
+        slug: 'test-org',
+        plan: { id: 'pro' },
+      }
+      const mockProject = { organization_id: 1 }
+
+      mockGetOrganizations.mockResolvedValue([mockOrg])
+      mockGetProjectDetail.mockResolvedValue(mockProject)
+      mockGetAiOptInLevel.mockReturnValue('schema')
+
+      await getOrgAIDetails({
+        orgSlug: 'test-org',
+        authorization: 'Bearer token',
+        projectRef: 'test-project',
+      })
+
+      const expectedHeaders = {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      }
+
+      expect(mockGetOrgSubscription).toHaveBeenCalledWith(
+        { orgSlug: 'test-org' },
+        undefined,
+        expectedHeaders
+      )
+      expect(mockGetProjectSettings).toHaveBeenCalledWith(
+        { projectRef: 'test-project' },
+        undefined,
+        expectedHeaders
+      )
     })
   })
 })

--- a/apps/studio/lib/ai/org-ai-details.test.ts
+++ b/apps/studio/lib/ai/org-ai-details.test.ts
@@ -120,7 +120,7 @@ describe('ai/org-ai-details', () => {
       expect(result).toEqual({
         aiOptInLevel: 'schema_only',
         isLimited: true,
-        hasHipaaAddon: false,
+        isHipaaEnabled: false,
       })
     })
 
@@ -269,7 +269,7 @@ describe('ai/org-ai-details', () => {
       expect(result.isLimited).toBe(false) // Pro plan
     })
 
-    it('should return hasHipaaAddon true when subscription has HIPAA addon and project is sensitive', async () => {
+    it('should return isHipaaEnabled true when subscription has HIPAA addon and project is sensitive', async () => {
       const mockOrg = {
         id: 1,
         slug: 'test-org',
@@ -290,10 +290,10 @@ describe('ai/org-ai-details', () => {
         projectRef: 'test-project',
       })
 
-      expect(result.hasHipaaAddon).toBe(true)
+      expect(result.isHipaaEnabled).toBe(true)
     })
 
-    it('should return hasHipaaAddon false when subscription has HIPAA addon but project is not sensitive', async () => {
+    it('should return isHipaaEnabled false when subscription has HIPAA addon but project is not sensitive', async () => {
       const mockOrg = {
         id: 1,
         slug: 'test-org',
@@ -314,10 +314,10 @@ describe('ai/org-ai-details', () => {
         projectRef: 'test-project',
       })
 
-      expect(result.hasHipaaAddon).toBe(false)
+      expect(result.isHipaaEnabled).toBe(false)
     })
 
-    it('should return hasHipaaAddon false when project is sensitive but no HIPAA addon', async () => {
+    it('should return isHipaaEnabled false when project is sensitive but no HIPAA addon', async () => {
       const mockOrg = {
         id: 1,
         slug: 'test-org',
@@ -338,7 +338,7 @@ describe('ai/org-ai-details', () => {
         projectRef: 'test-project',
       })
 
-      expect(result.hasHipaaAddon).toBe(false)
+      expect(result.isHipaaEnabled).toBe(false)
     })
 
     it('should fetch subscription and project settings with authorization headers', async () => {

--- a/apps/studio/lib/ai/org-ai-details.ts
+++ b/apps/studio/lib/ai/org-ai-details.ts
@@ -1,5 +1,8 @@
+import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscription/Subscription.utils'
+import { getProjectSettings } from 'data/config/project-settings-v2-query'
 import { getOrganizations } from 'data/organizations/organizations-query'
 import { getProjectDetail } from 'data/projects/project-detail-query'
+import { getOrgSubscription } from 'data/subscriptions/org-subscription-query'
 import { getAiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
 
 export const getOrgAIDetails = async ({
@@ -16,9 +19,11 @@ export const getOrgAIDetails = async ({
     ...(authorization && { Authorization: authorization }),
   }
 
-  const [organizations, selectedProject] = await Promise.all([
+  const [organizations, selectedProject, subscription, projectSettings] = await Promise.all([
     getOrganizations({ headers }),
     getProjectDetail({ ref: projectRef }, undefined, headers),
+    getOrgSubscription({ orgSlug }, undefined, headers),
+    getProjectSettings({ projectRef }, undefined, headers),
   ])
 
   const selectedOrg = organizations.find((org) => org.slug === orgSlug)
@@ -30,9 +35,11 @@ export const getOrgAIDetails = async ({
 
   const aiOptInLevel = getAiOptInLevel(selectedOrg?.opt_in_tags)
   const isLimited = selectedOrg?.plan.id === 'free'
+  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && !!projectSettings?.is_sensitive
 
   return {
     aiOptInLevel,
     isLimited,
+    hasHipaaAddon,
   }
 }

--- a/apps/studio/lib/ai/org-ai-details.ts
+++ b/apps/studio/lib/ai/org-ai-details.ts
@@ -35,11 +35,11 @@ export const getOrgAIDetails = async ({
 
   const aiOptInLevel = getAiOptInLevel(selectedOrg?.opt_in_tags)
   const isLimited = selectedOrg?.plan.id === 'free'
-  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && !!projectSettings?.is_sensitive
+  const isHipaaEnabled = subscriptionHasHipaaAddon(subscription) && !!projectSettings?.is_sensitive
 
   return {
     aiOptInLevel,
     isLimited,
-    hasHipaaAddon,
+    isHipaaEnabled,
   }
 }

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -89,6 +89,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
   let aiOptInLevel: AiOptInLevel = 'disabled'
   let isLimited = false
+  let hasHipaaAddon = false
 
   if (!IS_PLATFORM) {
     aiOptInLevel = 'schema'
@@ -97,7 +98,11 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   if (IS_PLATFORM && orgSlug && authorization && projectRef) {
     try {
       // Get organizations and compute opt in level server-side
-      const { aiOptInLevel: orgAIOptInLevel, isLimited: orgAILimited } = await getOrgAIDetails({
+      const {
+        aiOptInLevel: orgAIOptInLevel,
+        isLimited: orgAILimited,
+        hasHipaaAddon: orgHasHipaaAddon,
+      } = await getOrgAIDetails({
         orgSlug,
         authorization,
         projectRef,
@@ -105,6 +110,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
       aiOptInLevel = orgAIOptInLevel
       isLimited = orgAILimited
+      hasHipaaAddon = orgHasHipaaAddon
     } catch (error) {
       return res.status(400).json({
         error: 'There was an error fetching your organization details',
@@ -174,6 +180,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       getSchemas: aiOptInLevel !== 'disabled' ? getSchemas : undefined,
       projectRef,
       chatName,
+      hasHipaaAddon,
       promptProviderOptions,
       providerOptions,
       abortSignal: abortController.signal,

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -89,7 +89,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
   let aiOptInLevel: AiOptInLevel = 'disabled'
   let isLimited = false
-  let hasHipaaAddon = false
+  let isHipaaEnabled = false
 
   if (!IS_PLATFORM) {
     aiOptInLevel = 'schema'
@@ -101,7 +101,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       const {
         aiOptInLevel: orgAIOptInLevel,
         isLimited: orgAILimited,
-        hasHipaaAddon: orgHasHipaaAddon,
+        isHipaaEnabled: orgIsHipaaEnabled,
       } = await getOrgAIDetails({
         orgSlug,
         authorization,
@@ -110,7 +110,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
       aiOptInLevel = orgAIOptInLevel
       isLimited = orgAILimited
-      hasHipaaAddon = orgHasHipaaAddon
+      isHipaaEnabled = orgIsHipaaEnabled
     } catch (error) {
       return res.status(400).json({
         error: 'There was an error fetching your organization details',
@@ -180,7 +180,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       getSchemas: aiOptInLevel !== 'disabled' ? getSchemas : undefined,
       projectRef,
       chatName,
-      hasHipaaAddon,
+      isHipaaEnabled,
       promptProviderOptions,
       providerOptions,
       abortSignal: abortController.signal,


### PR DESCRIPTION
Detects HIPAA customers server-side in the assistant code path. Threads `isHipaaEnabled` boolean through `getOrgAIDetails` → `generate-v4` → `generateAssistantResponse`. The motivation is to support online evals down the road, where we'll want to exclude HIPAA projects from Assistant tracing.

This PR follows existing patterns for checking if HIPAA is enabled for a project (org has HIPAA addon + project is sensitive). Example [[1]](https://github.com/supabase/supabase/blob/a5dd0a96716561443778f38a518b61d6cac95c19/apps/studio/components/interfaces/Settings/Addons/Addons.tsx#L75), [[2]](https://github.com/supabase/supabase/blob/6858d4e18d9359d573fe3dff73bc4e5fa1cfe219/apps/studio/hooks/misc/useOrgOptedIntoAi.ts#L69).

```ts
const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && settings?.is_sensitive
```

(I call it `isHipaaEnabled` in this PR to avoid it being misunderstood as just the org-level addon, rather it's a combo of that addon being present AND high compliance being enabled on the project). 

### Verification steps

<details><summary>Click to view the steps I followed to sanity check it works with the local stack</summary>

Tested locally with `mise fullstack`:

1. Found my org's subscription ID:

   ```sh
   docker exec platform-db-1 psql -U postgres -c "SELECT id, customer_id, status FROM orb.subscriptions;"
   ```

2. Added HIPAA addon to it:

   ```sh
   docker exec platform-db-1 psql -U postgres -c "
     UPDATE orb.subscriptions
     SET price_intervals = price_intervals || '[{\"price\": {\"unit_config\": {\"unit_amount\": \"350.00\"}, \"external_price_id\": \"addon_security_hipaa\", \"item\": {\"name\": \"HIPAA\"}}}]'::jsonb
     WHERE id = '<subscription_id>';"
   ```

2. Toggled on High Compliance (Project Settings → General)

3. Added a temporary log after `getOrgAIDetails` in `generate-v4.ts`:

   ```ts
   console.log('[HIPAA]', { isHipaaEnabled })
   ```

4. Sent a message in the AI Assistant → `isHipaaEnabled: true`

5. Toggled off High Compliance → resent → `isHipaaEnabled: false`

6. Removed addon from subscription, left project toggle on → `isHipaaEnabled: false`

   ```sql
   -- Find addon index:
   SELECT ordinality - 1 as idx FROM orb.subscriptions,
     jsonb_array_elements(price_intervals) WITH ORDINALITY AS elem(val, ordinality)
     WHERE id = '<subscription_id>'
     AND val->'price'->>'external_price_id' = 'addon_security_hipaa';

   -- Remove by index:
   UPDATE orb.subscriptions SET price_intervals = price_intervals - <idx>
     WHERE id = '<subscription_id>';
   ```

All three cases confirm `isHipaaEnabled` requires both the org addon and the project-level toggle.


</details> 

Closes AI-434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HIPAA mode detection and exposed it in AI workflows.
  * API request functions now accept optional custom authorization headers for downstream calls.

* **Tests**
  * Added tests covering HIPAA scenarios and verifying authorization header propagation in related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->