### PR TITLE
fix(studio): use console.error instead of console.log in useLocalStorage hook

### DIFF
--- a/apps/studio/hooks/misc/useLocalStorage.ts
+++ b/apps/studio/hooks/misc/useLocalStorage.ts
@@ -18,7 +18,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
       return item ? JSON.parse(item) : initialValue
     } catch (error) {
       // If error also return initialValue
-      console.log(error)
+      console.error(error)
       return initialValue
     }
   })
@@ -38,7 +38,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
         }
       } catch (error) {
         // A more advanced implementation would handle the error case
-        console.log(error)
+        console.error(error)
       }
     },
     [key, storedValue]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging improvement)

## What is the current behavior?

The `useLocalStorage` hook in `apps/studio/hooks/misc/useLocalStorage.ts` uses `console.log(error)` in two catch blocks. Errors caught during localStorage read/write operations are logged with `console.log`, which makes them easy to miss in the console and doesn't properly categorize them as errors.

## What is the new behavior?

Replaces `console.log(error)` with `console.error(error)` in both catch blocks of the `useLocalStorage` hook:
1. The catch block in the state initializer (reading from localStorage)
2. The catch block in the `setValue` function (writing to localStorage)

This ensures errors are properly categorized and visible in browser dev tools' error filter.

## Additional context

This is a targeted fix — only the two `console.log` calls in error handlers are changed. No functional behavior is modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging in local storage operations for better debugging and issue diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->