### PR TITLE
fix(studio): use appropriate console methods in error handlers and debug logging

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -484,7 +484,7 @@ const EXTERNAL_PROVIDER_APPLE = {
                     body.aud === 'https://appleid.apple.com'
                   )
                 } catch (e: any) {
-                  console.log(e)
+                  console.error(e)
                   return false
                 }
 
@@ -502,7 +502,7 @@ const EXTERNAL_PROVIDER_APPLE = {
                   const body = JSON.parse(parts[1])
                   return Date.now() > body.exp - 7 * 24 * 60 * 60 * 1000
                 } catch (e: any) {
-                  console.log(e)
+                  console.error(e)
                   return false
                 }
 

--- a/apps/studio/components/interfaces/Auth/Policies/Policies.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/Policies.utils.ts
@@ -393,7 +393,7 @@ export const generateAiPoliciesForTable = async ({
     // AI response now includes all structured fields
     return aiPolicies as GeneratedPolicy[]
   } catch (error) {
-    console.log('AI policy generation failed:', error)
+    console.error('AI policy generation failed:', error)
     return []
   }
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -1086,7 +1086,7 @@ export const insertRowsViaSpreadsheet = async (
       },
       complete: () => {
         const t2: any = new Date()
-        console.log(`Total time taken for importing spreadsheet: ${(t2 - t1) / 1000} seconds`)
+        console.debug(`Total time taken for importing spreadsheet: ${(t2 - t1) / 1000} seconds`)
         resolve({ error: insertError })
       },
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging improvement)

## What is the current behavior?

Several error handlers and debug statements in Studio use `console.log` where more specific console methods would be appropriate:

1. **AuthProvidersFormValidation.tsx** - Apple auth secret key validation catch blocks use `console.log(e)` for errors
2. **Policies.utils.ts** - AI policy generation failure catch block uses `console.log` for an error
3. **SidePanelEditor.utils.tsx** - Spreadsheet import timing uses `console.log` for a performance debug message

## What is the new behavior?

- Error handlers now use `console.error()` to properly categorize errors in browser dev tools
- Performance/debug logging now uses `console.debug()` to keep it filterable and out of default console output

**Files changed:**
- `apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx` - `console.log(e)` -> `console.error(e)` (2 occurrences)
- `apps/studio/components/interfaces/Auth/Policies/Policies.utils.ts` - `console.log(...)` -> `console.error(...)`
- `apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx` - `console.log(...)` -> `console.debug(...)`

## Additional context

No functional changes. Only the console method is changed to match the severity of the logged content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging severity for authentication provider validation and policy generation to enhance debugging and issue tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->