### PR TITLE
fix(docs): remove debug console.log statements and fix await on non-Promise

### DIFF
--- a/apps/docs/components/StepHike/index.tsx
+++ b/apps/docs/components/StepHike/index.tsx
@@ -46,9 +46,8 @@ const Step = ({ children, title, step }) => {
   const { ref } = useInView({
     rootMargin: '10px 20px 30px 40px',
     threshold: 1,
-    onChange: (inView, entry) => {
-      if (window.scrollY === 0) console.log('out of view', title)
-      if (inView) console.log('in view', title) // highlightSelectedTocItem(entry.target.id)
+    onChange: (_inView, _entry) => {
+      // Intentionally empty — highlighting logic removed
     },
   })
 

--- a/apps/docs/generator/index.ts
+++ b/apps/docs/generator/index.ts
@@ -73,7 +73,7 @@ export default async function DocGenerator({
       break
 
     default:
-      await console.log('Unrecognized type: ', type)
+      console.warn('Unrecognized type: ', type)
       break
   }
   return 'Done'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (code cleanup)

## What is the current behavior?

1. **StepHike component** (`apps/docs/components/StepHike/index.tsx`): The intersection observer `onChange` callback contains two leftover `console.log` debug statements that log "out of view" and "in view" messages to the console on every scroll interaction. The `highlightSelectedTocItem` call they were debugging is commented out.

2. **Docs generator** (`apps/docs/generator/index.ts`): Uses `await console.log(...)` in the default switch case, which is a bug — `console.log` does not return a Promise, making the `await` misleading.

## What is the new behavior?

1. **StepHike**: Removes the debug `console.log` calls and replaces the callback body with an intentionally-empty comment, since the highlighting logic was already removed.

2. **Docs generator**: Removes the unnecessary `await` and changes `console.log` to `console.warn` since an unrecognized type is a warning-level event.

## Additional context

No functional changes to docs rendering or generation output. These are pure cleanup fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unintended side effects from the Step component's view tracking behavior that could interfere with page interactions.

* **Improvements**
  * Enhanced diagnostic messaging for unrecognized documentation types to better support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->