### PR TITLE
fix(generator): fix typos and remove debug console.log in tsdoc.ts

### DIFF
--- a/packages/generator/tsdoc.ts
+++ b/packages/generator/tsdoc.ts
@@ -26,11 +26,9 @@ interface KV {
 }
 
 async function dereference({ input, output }: { input: string; output: string }) {
-  console.log('input', input)
-
   const specRaw = fs.readFileSync(input, 'utf8')
   const spec = JSON.parse(specRaw)
-  const kv = chilrenReducer({}, spec)
+  const kv = childrenReducer({}, spec)
 
   // console.log('kv', kv)
   const dereferenced = dereferenceReducer(spec, kv)
@@ -39,9 +37,9 @@ async function dereference({ input, output }: { input: string; output: string })
   // console.log('JSON.stringify(dereferenced)', JSON.stringify(spec))
 }
 
-function chilrenReducer(acc: KV, child: any): KV {
+function childrenReducer(acc: KV, child: any): KV {
   if (!!child.children) {
-    child.children.forEach((x: any) => chilrenReducer(acc, x))
+    child.children.forEach((x: any) => childrenReducer(acc, x))
   }
 
   const { id }: { id: string } = child
@@ -50,7 +48,7 @@ function chilrenReducer(acc: KV, child: any): KV {
 }
 
 // Recurse through all children, and if the `type.type` == 'reference'
-// then it will add a key "dereferecnced" to the object.
+// then it will add a key "dereferenced" to the object.
 function dereferenceReducer(child: any, kv: KV) {
   if (!!child.children) {
     child.children.forEach((x: any) => dereferenceReducer(x, kv))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (typo correction and debug cleanup)

## What is the current behavior?

In `packages/generator/tsdoc.ts`:

1. The function `chilrenReducer` has a typo — it should be `childrenReducer`
2. A comment on line 53 says "dereferecnced" instead of "dereferenced"
3. There is a leftover `console.log('input', input)` debug statement at line 29

## What is the new behavior?

1. Renamed `chilrenReducer` to `childrenReducer` (3 occurrences: definition, 2 call sites)
2. Fixed typo in comment: "dereferecnced" -> "dereferenced"
3. Removed the debug `console.log('input', input)` statement

## Additional context

No functional changes — the function behavior is identical, only the name and comments are corrected, and a debug log is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internal naming inconsistencies and documentation errors to improve code quality.

* **Chores**
  * Removed debug code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->