### PR TITLE
fix(studio): use console.debug for upload timing log in storage explorer

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1361,7 +1361,7 @@ function createStorageExplorerState({
       }
 
       const t2 = new Date()
-      console.log(
+      console.debug(
         `Total time taken for ${formattedFilesToUpload.length} files: ${((t2 as any) - (t1 as any)) / 1000} seconds`
       )
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging improvement)

## What is the current behavior?

The storage explorer's file upload function in `apps/studio/state/storage-explorer.tsx` uses `console.log` to output the total upload time, which clutters the browser console with debug-level information during normal operation.

## What is the new behavior?

Replaces `console.log` with `console.debug` for the upload timing message, keeping it filterable in browser dev tools and out of the default console output.

## Additional context

Single-line change. No functional behavior is modified — only the console severity level.