### PR TITLE
fix(studio): fix DescrptionProps typo in Description component

### DIFF
--- a/apps/studio/components/interfaces/Docs/Description.tsx
+++ b/apps/studio/components/interfaces/Docs/Description.tsx
@@ -25,13 +25,13 @@ const temp_removePostgrestText = (content: string) => {
   return cleansed
 }
 
-interface DescrptionProps {
+interface DescriptionProps {
   content: string
   metadata: { table?: string; column?: string; rpc?: string }
   onChange: (value: string) => void
 }
 
-const Description = ({ content, metadata, onChange = noop }: DescrptionProps) => {
+const Description = ({ content, metadata, onChange = noop }: DescriptionProps) => {
   const contentText = temp_removePostgrestText(content || '').trim()
   const [value, setValue] = useState(contentText)
   const [isUpdating, setIsUpdating] = useState(false)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (typo)

## What is the current behavior?

The `Description` component in the API Docs feature has a misspelled interface name: `DescrptionProps` (missing 'i' in "Description"). This appears in both the interface declaration and the component parameter type annotation.

## What is the new behavior?

Renames `DescrptionProps` to `DescriptionProps` in `apps/studio/components/interfaces/Docs/Description.tsx` (2 occurrences: interface definition and component parameter type).

## Additional context

This is a companion fix to #42725 which fixed the related `onDesciptionUpdated` typo in `Param.tsx` and `ResourceContent.tsx`. The interface is internal-only, so this is a pure rename with no external impact.