### PR TITLE
fix(studio): replace hardcoded hover:border-white with semantic token in EmptyStates

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/EmptyStates.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/EmptyStates.tsx
@@ -26,7 +26,7 @@ export const Header = () => {
           <img
             src={`${BASE_PATH}/img/supabase-logo.svg`}
             alt="Supabase"
-            className="border-default rounded border p-1 hover:border-white"
+            className="border-default rounded border p-1 hover:border-stronger"
             style={{ height: 24 }}
           />
         </Link>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The `Header` component in `EmptyStates.tsx` uses a hardcoded `hover:border-white` class on the Supabase logo image border. This doesn't adapt to the current theme and breaks the project's semantic color token convention.

## What is the new behavior?

Replaces `hover:border-white` with `hover:border-stronger`, which is the semantic token for a stronger border on hover and respects the active theme.

**File changed:**
- `apps/studio/components/interfaces/Home/ProjectList/EmptyStates.tsx`

## Additional context

Per the project's styling guidelines, Tailwind classes should use semantic color tokens instead of hardcoded colors.