### PR TITLE
fix(www): use console.error for error logging across www app

### DIFF
--- a/apps/www/app/api-v2/ticket-og/route.tsx
+++ b/apps/www/app/api-v2/ticket-og/route.tsx
@@ -67,7 +67,7 @@ export async function GET(req: Request) {
       .eq('username', username)
       .maybeSingle()
 
-    if (error) console.log('Failed to fetch user. Inner error:', error.message)
+    if (error) console.error('Failed to fetch user. Inner error:', error.message)
     if (!user) throw new Error(error?.message ?? 'user not found')
 
     const FONT_SANS = fetch(new URL(FONT_URLS['SANS'], import.meta.url)).then((res) =>

--- a/apps/www/components/LaunchWeek/hooks/useLwGame.tsx
+++ b/apps/www/components/LaunchWeek/hooks/useLwGame.tsx
@@ -58,7 +58,7 @@ const useLwGame = (inputRef?: RefObject<HTMLInputElement>, disabled?: boolean) =
           .eq('launch_week', 'lw13')
           .eq('username', user.username)
           .then((res) => {
-            if (res.error) return console.log('error', res.error)
+            if (res.error) return console.error('error', res.error)
             setIsGameMode(false)
           })
 

--- a/apps/www/lib/events.ts
+++ b/apps/www/lib/events.ts
@@ -210,7 +210,7 @@ export const getStaticEvents = async (): Promise<{
     .select('id, city, country, link, start_at, timezone, launch_week')
     .eq('is_published', true)
 
-  if (error) console.log('meetups error: ', error)
+  if (error) console.error('meetups error: ', error)
 
   const meetupEvents: SupabaseEvent[] =
     meetups?.map((meetup: any) => ({

--- a/apps/www/pages/launch-week/6/index.tsx
+++ b/apps/www/pages/launch-week/6/index.tsx
@@ -80,7 +80,7 @@ export default function launchweek() {
       }
     } catch (error) {
       // alert('Error loading user data!')
-      console.log(error)
+      console.error(error)
     } finally {
       // setLoading(false)
     }

--- a/apps/www/supabase/functions/contact-notification/index.ts
+++ b/apps/www/supabase/functions/contact-notification/index.ts
@@ -12,7 +12,7 @@ serve(async (req) => {
       password: Deno.env.get('SMTP_PASSWORD')!,
     })
   } catch (error) {
-    console.log('error connecting to smtp: ', error)
+    console.error('error connecting to smtp: ', error)
     return new Response(error.message, { status: 500 })
   }
 
@@ -52,7 +52,7 @@ serve(async (req) => {
       content,
     })
   } catch (error: any) {
-    console.log('email sending failed with error: ', error)
+    console.error('email sending failed with error: ', error)
     return new Response(error.message, { status: 500 })
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging improvement)

## What is the current behavior?

Several error handlers and error-condition checks across the `apps/www` codebase use `console.log` to report errors, making them easy to miss in browser dev tools and server logs.

## What is the new behavior?

Replaces `console.log` with `console.error` in all error-handling contexts:

1. **`apps/www/supabase/functions/contact-notification/index.ts`** - SMTP connection error and email sending failure catch blocks (2 occurrences)
2. **`apps/www/lib/events.ts`** - Meetup fetch error logging
3. **`apps/www/pages/launch-week/6/index.tsx`** - Data loading error catch block
4. **`apps/www/components/LaunchWeek/hooks/useLwGame.tsx`** - Game state update error
5. **`apps/www/app/api-v2/ticket-og/route.tsx`** - User fetch error logging

## Additional context

No functional changes. Only the console method is changed to match the severity of the logged content. This ensures errors are properly categorized and visible in dev tools' error filter.