### PR TITLE
fix: use appropriate console methods for logging across packages and www

### DIFF
--- a/apps/www/data/contribute/index.ts
+++ b/apps/www/data/contribute/index.ts
@@ -147,7 +147,7 @@ export async function getUnansweredThreads(
   }
 
   if (channel && channel !== 'all') {
-    console.log('channel', channel)
+    console.debug('channel', channel)
     query = query.eq('source', channel.toLowerCase())
   }
 

--- a/apps/www/supabase/functions/hubspot-notification/index.ts
+++ b/apps/www/supabase/functions/hubspot-notification/index.ts
@@ -103,7 +103,7 @@ serve(async (req) => {
   // Will create a deal using HubSpot's workflow tool instead of via API
 
   if (!formResponse.ok) {
-    console.log(`Failed to submit form data to HubSpot`, await formResponse.json())
+    console.error(`Failed to submit form data to HubSpot`, await formResponse.json())
     return new Response(`Failed to submit form data to HubSpot`, {
       status: 500,
     })

--- a/packages/common/configcat.ts
+++ b/packages/common/configcat.ts
@@ -30,7 +30,7 @@ async function getClient() {
   if (client) return client
 
   if (!process.env.NEXT_PUBLIC_CONFIGCAT_SDK_KEY && !process.env.NEXT_PUBLIC_CONFIGCAT_PROXY_URL) {
-    console.log('Skipping ConfigCat set up as env vars are not present')
+    console.info('Skipping ConfigCat set up as env vars are not present')
     return undefined
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging improvement)

## What is the current behavior?

Several files use `console.log` where more specific console methods would be appropriate:

1. **`packages/common/configcat.ts`** - Uses `console.log` for an informational message about skipping ConfigCat setup
2. **`apps/www/supabase/functions/hubspot-notification/index.ts`** - Uses `console.log` for a HubSpot form submission failure
3. **`apps/www/data/contribute/index.ts`** - Uses `console.log` for a debug message about query parameters

## What is the new behavior?

1. `console.log` -> `console.info` for the ConfigCat setup skip message (informational, not an error)
2. `console.log` -> `console.error` for the HubSpot failure (this is an error condition returning 500)
3. `console.log` -> `console.debug` for the contribute page channel filter (debug-level query logging)

## Additional context

No functional changes. Only the console method is changed to match the severity of the logged content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging levels across the application for improved diagnostic capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->