### PR TITLE
fix(studio): replace hardcoded gray colors with semantic tokens in BreadcrumbsView

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/BreadcrumbsView.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/BreadcrumbsView.tsx
@@ -30,8 +30,8 @@ export const BreadcrumbsView = ({ defaultValue: breadcrumbs }: BreadcrumbsViewPr
 
               <a
                 onClick={breadcrumb.onClick || (() => {})}
-                className={`text-gray-1100 block px-2 py-1 text-xs leading-5 focus:bg-gray-100 focus:text-gray-900 focus:outline-none ${
-                  breadcrumb.onClick ? 'cursor-pointer hover:text-white' : ''
+                className={`text-foreground block px-2 py-1 text-xs leading-5 focus:bg-surface-200 focus:text-foreground focus:outline-none ${
+                  breadcrumb.onClick ? 'cursor-pointer hover:text-foreground' : ''
                 }`}
               >
                 {breadcrumb.label}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

`BreadcrumbsView.tsx` uses hardcoded Tailwind gray color classes (`text-gray-1100`, `focus:bg-gray-100`, `focus:text-gray-900`, `hover:text-white`) that don't respect the app's theme system.

## What is the new behavior?

Replaced with semantic color tokens:
- `text-gray-1100` → `text-foreground`
- `focus:bg-gray-100` → `focus:bg-surface-200`
- `focus:text-gray-900` → `focus:text-foreground`
- `hover:text-white` → `hover:text-foreground`

This ensures the breadcrumb navigation respects the theme in both light and dark modes.

## Additional context

Single file change in `apps/studio/components/layouts/ProjectLayout/LayoutHeader/BreadcrumbsView.tsx`.