### PR TITLE
fix(studio): replace hardcoded bg-gray-400 with semantic bg-surface-400 in SparkBar

### DIFF
--- a/apps/studio/components/ui/SparkBar.tsx
+++ b/apps/studio/components/ui/SparkBar.tsx
@@ -66,7 +66,7 @@ const SparkBar = ({
     return (
       <div
         className={`relative rounded w-5 overflow-hidden border p-1 ${
-          bgClass ? bgClass : 'bg-gray-400'
+          bgClass ? bgClass : 'bg-surface-400'
         } ${borderClass ? borderClass : 'border-none'}`}
         style={{ height: totalHeight }}
       >


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The vertical variant of `SparkBar` uses a hardcoded `bg-gray-400` as its default background, while the horizontal variant already uses the semantic `bg-surface-400` token.

## What is the new behavior?

Replaced `bg-gray-400` with `bg-surface-400` in the vertical variant, matching the horizontal variant and ensuring the component respects the theme system in both light and dark modes.

## Additional context

Single line change in `apps/studio/components/ui/SparkBar.tsx`. The horizontal variant (line 51) already uses `bg-surface-400` — this fix makes the vertical variant (line 69) consistent.