### PR TITLE
fix(studio): replace text-white dark:text-black with text-contrast in ReplicationPipelineStatus

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.utils.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.utils.tsx
@@ -91,7 +91,7 @@ export const getDisabledStateConfig = ({
           text: 'text-brand-900',
           subtext: 'text-brand-700',
           iconBg: 'bg-brand-600',
-          icon: 'text-white dark:text-black',
+          icon: 'text-contrast',
         }
       : isDisabling || statusName === 'starting' || statusName === 'unknown'
         ? {
@@ -99,7 +99,7 @@ export const getDisabledStateConfig = ({
             text: 'text-warning-900',
             subtext: 'text-warning-700',
             iconBg: 'bg-warning-600',
-            icon: 'text-white dark:text-black',
+            icon: 'text-contrast',
           }
         : statusName === 'failed'
           ? {
@@ -107,14 +107,14 @@ export const getDisabledStateConfig = ({
               text: 'text-destructive-900',
               subtext: 'text-destructive-700',
               iconBg: 'bg-destructive-600',
-              icon: 'text-white dark:text-black',
+              icon: 'text-contrast',
             }
           : {
               bg: 'bg-surface-100',
               text: 'text-foreground',
               subtext: 'text-foreground-light',
               iconBg: 'bg-foreground-lighter',
-              icon: 'text-white dark:text-black',
+              icon: 'text-contrast',
             }
 
   return { title, message, badge, icon, colors }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The `ReplicationPipelineStatus.utils.tsx` file uses hardcoded `text-white dark:text-black` for icon colors across all four status states (enabling/restarting, disabling/starting/unknown, failed, default).

## What is the new behavior?

Replaced all four instances with the semantic `text-contrast` token, which is the established pattern in the codebase for icons that need to contrast with colored backgrounds (see `UserOverview.tsx`, `Success.tsx`, `LinkSupportTicketPage.tsx` for existing usage).

## Additional context

Single file change in `apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.utils.tsx`. Four occurrences replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved icon contrast in the replication pipeline status interface for better visual clarity across different states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->