### PR TITLE
fix(studio): replace debug console.log with console.debug in FilterPopover

### DIFF
--- a/apps/studio/components/ui/FilterPopover.tsx
+++ b/apps/studio/components/ui/FilterPopover.tsx
@@ -163,7 +163,7 @@ export const FilterPopover = <T extends Record<string, any>>({
       !isFetching &&
       !isFetchingNextPage
     ) {
-      console.log('Fetch next page')
+      console.debug('Fetch next page')
       fetchNextPage()
     }
   }, [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging hygiene)

## What is the current behavior?

`FilterPopover.tsx` uses `console.log('Fetch next page')` for pagination debug logging, which pollutes the browser console in production.

## What is the new behavior?

Replaced with `console.debug('Fetch next page')` to keep the message available for debugging without cluttering the production console.

## Additional context

Single line change in `apps/studio/components/ui/FilterPopover.tsx` line 166.