### PR TITLE
chore(studio): remove unused databaseIcon export and Database import from ListIcons

### DIFF
--- a/apps/studio/components/to-be-cleaned/ListIcons.tsx
+++ b/apps/studio/components/to-be-cleaned/ListIcons.tsx
@@ -1,5 +1,3 @@
-import { Database } from 'lucide-react'
-
 export const vercelIcon = (
   <div className="flex items-center justify-center rounded bg-black p-1">
     <svg
@@ -10,11 +8,5 @@ export const vercelIcon = (
     >
       <path d="M577.344 0L1154.69 1000H0L577.344 0Z" />
     </svg>
-  </div>
-)
-
-export const databaseIcon = (
-  <div className="flex items-center justify-center rounded bg-green-500 p-1 [[data-theme*=dark]_&]:text-typography-body-dark ">
-    <Database size={12} strokeWidth={2} />
   </div>
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dead code removal

## What is the current behavior?

`ListIcons.tsx` exports a `databaseIcon` constant and imports `Database` from `lucide-react`, but `databaseIcon` is never imported anywhere in the codebase. It also uses the outdated `[[data-theme*=dark]_&]:text-typography-body-dark` class selector which is no longer part of the theme system.

## What is the new behavior?

Removed the unused `databaseIcon` export and the `Database` import from `lucide-react`. The file now only exports `vercelIcon`, which is the only export actually used (imported by `choose-project.tsx` and `SidePanelVercelProjectLinker.tsx`).

## Additional context

Single file change in `apps/studio/components/to-be-cleaned/ListIcons.tsx`. Verified with a codebase-wide search that `databaseIcon` has zero imports.