### PR TITLE
fix(studio): replace legacy text-scale-* and data-theme tokens in Realtime Inspector

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/MessageSelection.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/MessageSelection.tsx
@@ -84,13 +84,13 @@ const MessageSelection = ({ log, onClose }: MessageSelectionProps) => {
             </div>
             <Button
               type="text"
-              className="cursor-pointer transition hover:text-scale-1200 h-8 w-8 px-0 py-0 flex items-center justify-center"
+              className="cursor-pointer transition hover:text-foreground h-8 w-8 px-0 py-0 flex items-center justify-center"
               onClick={onClose}
             >
-              <X size={14} strokeWidth={2} className="text-scale-900" />
+              <X size={14} strokeWidth={2} className="text-foreground-lighter" />
             </Button>
           </div>
-          <div className="h-px w-full bg-scale-600 rounded" />
+          <div className="h-px w-full bg-border-muted rounded" />
         </div>
         <div className="flex flex-col space-y-6 py-4">
           {log && <SelectedRealtimeMessagePanel log={log} />}

--- a/apps/studio/components/interfaces/Realtime/Inspector/MessagesFormatters.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/MessagesFormatters.tsx
@@ -33,8 +33,10 @@ export const SelectionDetailedRow = ({
 }) => {
   return (
     <div className="grid grid-cols-12 group">
-      <span className="text-scale-900 text-sm col-span-4 whitespace-pre-wrap">{label}</span>
-      <span className="text-scale-1200 text-sm col-span-6 whitespace-pre-wrap break-all">
+      <span className="text-foreground-lighter text-sm col-span-4 whitespace-pre-wrap">
+        {label}
+      </span>
+      <span className="text-foreground text-sm col-span-6 whitespace-pre-wrap break-all">
         {valueRender ?? value}
       </span>
       {!hideCopy && (
@@ -65,7 +67,7 @@ export function jsonSyntaxHighlight(input: Object) {
       var cls = 'number text-tomato-900'
       if (/^"/.test(match)) {
         if (/:$/.test(match)) {
-          cls = 'key text-scale-1200'
+          cls = 'key text-foreground'
         } else {
           cls = 'string text-brand-600'
         }

--- a/apps/studio/components/interfaces/Realtime/Inspector/SelectedRealtimeMessagePanel.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SelectedRealtimeMessagePanel.tsx
@@ -2,18 +2,16 @@ import type { LogData } from './Messages.types'
 import { jsonSyntaxHighlight, SelectionDetailedTimestampRow } from './MessagesFormatters'
 
 const LogsDivider = () => {
-  return (
-    <div className="h-px w-full bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark" />
-  )
+  return <div className="h-px w-full bg-border-muted" />
 }
 
 export const SelectedRealtimeMessagePanel = ({ log }: { log: LogData }) => {
   return (
     <>
       <div className="px-8">
-        <span className="col-span-4 text-sm text-scale-900">Message</span>
+        <span className="col-span-4 text-sm text-foreground-lighter">Message</span>
 
-        <p className="text-wrap mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-scale-1200">
+        <p className="text-wrap mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-foreground">
           {log.message}
         </p>
       </div>

--- a/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
@@ -56,7 +56,7 @@ export const SendMessageModal = ({
           onChange={(v) => setValues({ ...values, message: v.target.value })}
         />
         <div className="flex flex-col gap-y-2">
-          <p className="text-sm text-scale-1100">Message payload</p>
+          <p className="text-sm text-foreground-light">Message payload</p>
           <CodeEditor
             id="message-payload"
             language="json"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The Realtime Inspector components use deprecated styling tokens:
- `text-scale-900`, `text-scale-1100`, `text-scale-1200` — legacy color scale tokens not defined in the current theme system
- `bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark` — old theme selector pattern
- `bg-scale-600` — legacy background token

These classes have no effect in the current theme, resulting in unstyled text and dividers.

## What is the new behavior?

Replaced with semantic tokens:
- `text-scale-900` → `text-foreground-lighter`
- `text-scale-1100` → `text-foreground-light`
- `text-scale-1200` → `text-foreground`
- `bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark` → `bg-border-muted`
- `bg-scale-600` → `bg-border-muted`

## Files changed

- `SelectedRealtimeMessagePanel.tsx` — divider + text colors
- `MessagesFormatters.tsx` — label/value text colors + JSON syntax highlight key color
- `MessageSelection.tsx` — close button colors + divider
- `SendMessageModal.tsx` — label text color

## Additional context

All four files are in `apps/studio/components/interfaces/Realtime/Inspector/`. The `bg-border-muted` pattern is already used elsewhere in the codebase for divider lines (e.g., `RecentItems.tsx`).