### PR TITLE
fix(studio): replace legacy scale tokens and data-theme selectors with semantic tokens

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -172,7 +172,7 @@ const FormField = ({
                 onClick={() => setHidden(!hidden)}
               />
             ) : (
-              <span className="mr-3 text-scale-900">
+              <span className="mr-3 text-foreground-lighter">
                 {properties.units ? (
                   <ReactMarkdown unwrapDisallowed disallowedElements={['p']}>
                     {properties.units}

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -89,7 +89,7 @@ export const TableNode = ({
                 'bg-surface-100',
                 'border-t',
                 'border-t-[0.5px]',
-                'hover:bg-scale-500 transition cursor-default',
+                'hover:bg-surface-200 transition cursor-default',
                 itemHeight
               )}
               key={column.id}

--- a/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
@@ -177,8 +177,8 @@ const MessagesTable = ({
                 return cn([
                   'font-mono tracking-tight',
                   isEqual(row, focusedLog)
-                    ? 'bg-scale-800 rdg-row--focused'
-                    : 'bg-200 hover:bg-scale-300 cursor-pointer',
+                    ? 'bg-surface-300 rdg-row--focused'
+                    : 'bg-200 hover:bg-surface-200 cursor-pointer',
                   isErrorLog(row) && '!bg-warning-300',
                 ])
               }}

--- a/apps/studio/components/interfaces/SQLEditor/DownloadSnippetModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/DownloadSnippetModal.tsx
@@ -73,7 +73,7 @@ const DownloadSnippetModal = ({ id, ...props }: DownloadSnippetModalProps) => {
                     <div className="flex flex-col gap-y-1">
                       <p className="text-base">{snippet.title}</p>
                       <Markdown
-                        className="text-sm text-scale-1000 [&>p>code]:!break-normal"
+                        className="text-sm text-foreground-light [&>p>code]:!break-normal"
                         content={snippet.description}
                       />
                     </div>

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.Divider.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.Divider.tsx
@@ -1,7 +1,5 @@
 const LogsDivider = () => {
-  return (
-    <div className="h-px w-full bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark"></div>
-  )
+  return <div className="h-px w-full bg-border-muted"></div>
 }
 
 export default LogsDivider


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

Several Studio components use deprecated Tailwind classes that are no longer defined in the theme system:
- `text-scale-900`, `text-scale-1000` — legacy text color tokens
- `bg-scale-300`, `bg-scale-500`, `bg-scale-800` — legacy background tokens
- `bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark` — old theme selector pattern

These classes have no effect since the `scale-*` colors were removed from the Tailwind config.

## What is the new behavior?

Replaced with current semantic tokens:
- `text-scale-900` → `text-foreground-lighter`
- `text-scale-1000` → `text-foreground-light`
- `hover:bg-scale-500` → `hover:bg-surface-200`
- `bg-scale-800` → `bg-surface-300` (focused row)
- `hover:bg-scale-300` → `hover:bg-surface-200` (hover row)
- `bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark` → `bg-border-muted`

## Files changed

- `Logs.Divider.tsx` — divider background
- `SchemaTableNode.tsx` — column row hover
- `FormField.tsx` — units label text
- `DownloadSnippetModal.tsx` — snippet description text
- `MessagesTable.tsx` — focused/hover row backgrounds

## Additional context

Five files across different Studio feature areas, all sharing the same underlying issue of referencing deprecated color tokens.