### PR TITLE
fix(studio): replace legacy data-theme selectors with semantic tokens in SQL Editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -109,7 +109,7 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
   return (
     <>
       {rows.length === 0 ? (
-        <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+        <div className="bg-surface-100">
           <p className="m-0 border-0 px-4 py-3 font-mono text-sm text-foreground-light">
             Success. No rows returned
           </p>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabExplain.tsx
@@ -24,7 +24,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
 
   if (isExecuting) {
     return (
-      <div className="flex items-center gap-x-4 px-6 py-4 bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="flex items-center gap-x-4 px-6 py-4 bg-surface-100">
         <Loader2 size={14} className="animate-spin" />
         <p className="m-0 border-0 font-mono text-sm">Running EXPLAIN ANALYZE...</p>
       </div>
@@ -37,7 +37,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
     )
 
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
+      <div className="bg-surface-100 overflow-y-auto">
         <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4 pb-9">
           <div className="flex flex-col gap-y-1">
             {formattedError.length > 0 ? (
@@ -72,7 +72,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
 
   if (!explainResult || explainResult.rows.length === 0) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
+      <div className="bg-surface-100 overflow-y-auto">
         <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
           No execution plan available. The query will be analyzed when you switch to this tab.
         </p>
@@ -85,7 +85,7 @@ export function UtilityTabExplain({ id, isExecuting }: UtilityTabExplainProps) {
 
   if (!isValidExplain) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
+      <div className="bg-surface-100 overflow-y-auto">
         <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
           Unable to parse explain results. Please try running the query again.
         </p>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -49,7 +49,7 @@ const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
 
     if (isExecuting) {
       return (
-        <div className="flex items-center gap-x-4 px-6 py-4 bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+        <div className="flex items-center gap-x-4 px-6 py-4 bg-surface-100">
           <Loader2 size={14} className="animate-spin" />
           <p className="m-0 border-0 font-mono text-sm">Running...</p>
         </div>
@@ -66,7 +66,7 @@ const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
       )
 
       return (
-        <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
+        <div className="bg-surface-100 overflow-y-auto">
           <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
             {isTimeout ? (
               <div className="flex flex-col gap-y-1">
@@ -172,7 +172,7 @@ const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
       )
     } else if (!result) {
       return (
-        <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
+        <div className="bg-surface-100 overflow-y-auto">
           <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
             Click <code>Run</code> to execute your query.
           </p>
@@ -180,7 +180,7 @@ const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsProps>(
       )
     } else if (result.rows.length <= 0) {
       return (
-        <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark overflow-y-auto">
+        <div className="bg-surface-100 overflow-y-auto">
           <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Success. No rows returned</p>
         </div>
       )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

The SQL Editor utility panel components use the verbose legacy pattern:
```
bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark
```

Per the tailwind config, both `table-header-light` and `table-header-dark` map to the same CSS variable (`hsl(var(--background-surface-100))`), making the `[[data-theme*=dark]_&]` prefix entirely redundant.

## What is the new behavior?

Replaced all 9 occurrences with the semantic `bg-surface-100` token:
- `UtilityTabResults.tsx` — 4 occurrences (executing, error, no result, empty rows states)
- `UtilityTabExplain.tsx` — 4 occurrences (executing, error, no result, invalid explain states)
- `Results.tsx` — 1 occurrence (empty rows)

## Additional context

All three files are in `apps/studio/components/interfaces/SQLEditor/UtilityPanel/`. The change is purely cosmetic — both old and new classes resolve to the same CSS value, but the new form is simpler and follows current conventions.