### PR TITLE
fix(studio): replace legacy data-theme selectors with semantic tokens in Storage Explorer

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -184,7 +184,7 @@ export const FileExplorerColumn = ({
       {snap.view === STORAGE_VIEWS.COLUMNS && (
         <div
           className={cn(
-            'sticky top-0 z-10 mb-0 flex items-center bg-table-header-light px-2.5 [[data-theme*=dark]_&]:bg-table-header-dark',
+            'sticky top-0 z-10 mb-0 flex items-center bg-surface-100 px-2.5',
             haveSelectedItems ? 'h-10 py-3 opacity-100' : 'h-0 py-0 opacity-0',
             'transition-all duration-200'
           )}
@@ -284,7 +284,7 @@ export const FileExplorerColumn = ({
 
       {/* List interface footer */}
       {snap.view === STORAGE_VIEWS.LIST && (
-        <div className="shrink-0 rounded-b-md z-10 flex min-w-min items-center bg-panel-footer-light px-2.5 py-2 [[data-theme*=dark]_&]:bg-panel-footer-dark w-full">
+        <div className="shrink-0 rounded-b-md z-10 flex min-w-min items-center bg-surface-100 px-2.5 py-2 w-full">
           <p className="text-sm">
             {formatBytes(columnItemsSize)} for {columnItems.length} items
           </p>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -314,7 +314,7 @@ export const FileExplorerRow = ({
       <div
         className={cn(
           'storage-row group flex h-full items-center px-2.5',
-          'hover:bg-panel-footer-light [[data-theme*=dark]_&]:hover:bg-panel-footer-dark',
+          'hover:bg-surface-100',
           `${isOpened ? 'bg-selection' : ''}`,
           `${isSelected ? 'bg-selection' : ''}`,
           `${isPreviewed ? 'bg-selection hover:bg-selection' : ''}`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

Storage Explorer components use verbose legacy theme patterns:
- `bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark`
- `bg-panel-footer-light [[data-theme*=dark]_&]:bg-panel-footer-dark`
- `hover:bg-panel-footer-light [[data-theme*=dark]_&]:hover:bg-panel-footer-dark`

Per the tailwind config, both light and dark variants of `table-header` and `panel-footer` resolve to the same CSS variable (`hsl(var(--background-surface-100))`), making the `[[data-theme*=dark]_&]` prefix redundant.

## What is the new behavior?

Replaced with the semantic `bg-surface-100` / `hover:bg-surface-100` tokens:
- `FileExplorerColumn.tsx` — header checkbox area + list footer
- `FileExplorerRow.tsx` — row hover state

## Additional context

Both files are in `apps/studio/components/interfaces/Storage/StorageExplorer/`. The change is functionally equivalent — both old and new classes resolve to the same CSS value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Improved visual consistency in the storage file explorer by updating interface styling with unified background colors across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->