### PR TITLE
fix(studio): replace legacy panel-border-interior tokens with semantic border-muted

### DIFF
--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -187,7 +187,7 @@ const JWTSettings = () => {
                 </div>
               }
             >
-              <Panel.Content className="space-y-6 border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+              <Panel.Content className="space-y-6 border-t border-muted">
                 {isError ? (
                   <div className="flex items-center justify-center py-8 space-x-2">
                     <AlertCircle size={16} strokeWidth={1.5} />

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -502,7 +502,7 @@ export const NewOrgForm = ({
 
             {form.watch('plan') === 'PRO' && (
               <>
-                <Panel.Content className="border-b border-panel-border-interior-light dark:border-panel-border-interior-dark">
+                <Panel.Content className="border-b border-muted">
                   <FormField_Shadcn_
                     control={form.control}
                     name="spend_cap"

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/DecryptedReadOnlyInput.tsx
@@ -44,7 +44,7 @@ export const DecryptedReadOnlyInput = ({
     : value
 
   return (
-    <CardContent className="py-6 border-b border-panel-border-interior-light">
+    <CardContent className="py-6 border-b border-muted">
       <FormItemLayout
         layout="horizontal"
         label={

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -124,13 +124,7 @@ export const DisplayApiSettings = ({
         </div>
       ) : (
         apiKeys.map((x, i: number) => (
-          <Panel.Content
-            key={x.api_key}
-            className={
-              i >= 1 &&
-              'border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark'
-            }
-          >
+          <Panel.Content key={x.api_key} className={i >= 1 && 'border-t border-muted'}>
             <FormLayout
               layout="horizontal"
               label={

--- a/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
@@ -66,7 +66,7 @@ export const DisplayConfigSettings = () => {
               layout="horizontal"
             />
           </Panel.Content>
-          <Panel.Content className="border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+          <Panel.Content className="border-t border-muted">
             <Input
               label="JWT Secret"
               readOnly


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling consistency)

## What is the current behavior?

Several settings and form components use legacy border tokens with verbose theme selectors:
- `border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark`
- `border-panel-border-interior-light dark:border-panel-border-interior-dark`
- `border-panel-border-interior-light`

Per the tailwind config, both light and dark variants of `panel-border-interior` resolve to `hsl(var(--border-muted))`, making the dark-mode selectors redundant.

## What is the new behavior?

Replaced all occurrences with the semantic `border-muted` token:
- `DisplayConfigSettings.tsx` — panel content border
- `DisplayApiSettings.tsx` — API key section borders
- `jwt-settings.tsx` — JWT settings panel border
- `DecryptedReadOnlyInput.tsx` — card content border
- `NewOrgForm.tsx` — PRO plan section border

## Additional context

Five files across different Studio areas. The change is functionally identical — both old and new classes resolve to the same CSS value (`hsl(var(--border-muted))`).