### PR TITLE
fix(studio): prevent truncation of large values in copy/export operations

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -14,7 +14,7 @@ import {
 } from 'components/layouts/TableEditorLayout/ExportAllRows'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
-import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
+import { fetchSelectedTableRows, useTableRowsQuery } from 'data/table-rows/table-rows-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -298,31 +298,51 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   }
 
   const onCopyRows = (type: 'csv' | 'json' | 'sql') => {
-    const rows = allRows.filter((x) => snap.selectedRows.has(x.idx))
+    if (!project) return
 
-    if (type === 'csv') {
-      const csv = formatRowsForCSV({
-        rows,
-        columns: snap.table!.columns.map((column) => column.name),
-      })
-      copyToClipboard(csv)
-    } else if (type === 'sql') {
-      const sqlStatements = formatTableRowsToSQL(snap.table, rows)
-      copyToClipboard(sqlStatements)
-    } else if (type === 'json') {
-      copyToClipboard(JSON.stringify(rows))
-    }
+    const selectedRows = allRows.filter((x) => snap.selectedRows.has(x.idx))
 
-    toast.success('Copied rows to clipboard')
+    const rowsPromise = fetchSelectedTableRows({
+      projectRef: project.ref,
+      connectionString: project.connectionString,
+      table: snap.table,
+      selectedRows,
+      filters,
+      sorts,
+      roleImpersonationState: roleImpersonationState as RoleImpersonationState,
+    }).catch(() => {
+      toast.error('Failed to fetch full row data. Copied data may be truncated.')
+      return selectedRows
+    })
+
+    const textPromise = rowsPromise.then((rows) => {
+      if (type === 'csv') {
+        return formatRowsForCSV({
+          rows,
+          columns: snap.table!.columns.map((column) => column.name),
+        })
+      } else if (type === 'sql') {
+        return formatTableRowsToSQL(snap.table, rows)
+      } else {
+        return JSON.stringify(rows)
+      }
+    })
+
+    copyToClipboard(textPromise).then(() => {
+      toast.success('Copied rows to clipboard')
+    })
   }
 
   const exportParams = snap.allRowsSelected
     ? ({ type: 'fetch_all', filters, sorts } as const)
     : ({
-        type: 'provided_rows',
+        type: 'fetch_selected' as const,
         table: snap.table,
-        rows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
-      } as const)
+        selectedRows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
+        filters,
+        sorts,
+        roleImpersonationState: roleImpersonationState as RoleImpersonationState,
+      })
 
   const { exportCsv, confirmationModal: exportCsvConfirmationModal } = useExportAllRowsAsCsv(
     project

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -31,18 +31,18 @@ import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import {
   Button,
+  cn,
+  copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   Separator,
-  cn,
-  copyToClipboard,
 } from 'ui'
 
 import { ExportDialog } from './ExportDialog'
-import { formatRowsForCSV } from './Header.utils'
 import { FilterPopover } from './filter/FilterPopover'
+import { formatRowsForCSV } from './Header.utils'
 import { SortPopover } from './sort/SortPopover'
 
 export type HeaderProps = {

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -335,14 +335,14 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
 
   const exportParams = snap.allRowsSelected
     ? ({ type: 'fetch_all', filters, sorts } as const)
-    : ({
+    : {
         type: 'fetch_selected' as const,
         table: snap.table,
         selectedRows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
         filters,
         sorts,
         roleImpersonationState: roleImpersonationState as RoleImpersonationState,
-      })
+      }
 
   const { exportCsv, confirmationModal: exportCsvConfirmationModal } = useExportAllRowsAsCsv(
     project

--- a/apps/studio/components/grid/components/header/HeaderNew.tsx
+++ b/apps/studio/components/grid/components/header/HeaderNew.tsx
@@ -13,7 +13,7 @@ import {
 } from 'components/layouts/TableEditorLayout/ExportAllRows'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
-import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
+import { fetchSelectedTableRows, useTableRowsQuery } from 'data/table-rows/table-rows-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -299,31 +299,51 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   }
 
   const onCopyRows = (type: 'csv' | 'json' | 'sql') => {
-    const rows = allRows.filter((x) => snap.selectedRows.has(x.idx))
+    if (!project) return
 
-    if (type === 'csv') {
-      const csv = formatRowsForCSV({
-        rows,
-        columns: snap.table!.columns.map((column) => column.name),
-      })
-      copyToClipboard(csv)
-    } else if (type === 'sql') {
-      const sqlStatements = formatTableRowsToSQL(snap.table, rows)
-      copyToClipboard(sqlStatements)
-    } else if (type === 'json') {
-      copyToClipboard(JSON.stringify(rows))
-    }
+    const selectedRows = allRows.filter((x) => snap.selectedRows.has(x.idx))
 
-    toast.success('Copied rows to clipboard')
+    const rowsPromise = fetchSelectedTableRows({
+      projectRef: project.ref,
+      connectionString: project.connectionString,
+      table: snap.table,
+      selectedRows,
+      filters,
+      sorts,
+      roleImpersonationState: roleImpersonationState as RoleImpersonationState,
+    }).catch(() => {
+      toast.error('Failed to fetch full row data. Copied data may be truncated.')
+      return selectedRows
+    })
+
+    const textPromise = rowsPromise.then((rows) => {
+      if (type === 'csv') {
+        return formatRowsForCSV({
+          rows,
+          columns: snap.table!.columns.map((column) => column.name),
+        })
+      } else if (type === 'sql') {
+        return formatTableRowsToSQL(snap.table, rows)
+      } else {
+        return JSON.stringify(rows)
+      }
+    })
+
+    copyToClipboard(textPromise).then(() => {
+      toast.success('Copied rows to clipboard')
+    })
   }
 
   const exportParams = snap.allRowsSelected
     ? ({ type: 'fetch_all', filters, sorts } as const)
     : ({
-        type: 'provided_rows',
+        type: 'fetch_selected' as const,
         table: snap.table,
-        rows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
-      } as const)
+        selectedRows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
+        filters,
+        sorts,
+        roleImpersonationState: roleImpersonationState as RoleImpersonationState,
+      })
 
   const { exportCsv, confirmationModal: exportCsvConfirmationModal } = useExportAllRowsAsCsv(
     project

--- a/apps/studio/components/grid/components/header/HeaderNew.tsx
+++ b/apps/studio/components/grid/components/header/HeaderNew.tsx
@@ -336,14 +336,14 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
 
   const exportParams = snap.allRowsSelected
     ? ({ type: 'fetch_all', filters, sorts } as const)
-    : ({
+    : {
         type: 'fetch_selected' as const,
         table: snap.table,
         selectedRows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
         filters,
         sorts,
         roleImpersonationState: roleImpersonationState as RoleImpersonationState,
-      })
+      }
 
   const { exportCsv, confirmationModal: exportCsvConfirmationModal } = useExportAllRowsAsCsv(
     project

--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -3,11 +3,15 @@ import { ROW_CONTEXT_MENU_ID } from 'components/grid/constants'
 import type { SupaRow } from 'components/grid/types'
 import { queueRowDeletesWithOptimisticUpdate } from 'components/grid/utils/queueOperationUtils'
 import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { getCellValue } from 'data/table-rows/get-cell-value-mutation'
+import { fetchSelectedTableRows } from 'data/table-rows/table-rows-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { RoleImpersonationState } from 'lib/role-impersonation'
 import { Copy, Edit, Trash } from 'lucide-react'
 import { useCallback } from 'react'
 import { Item, ItemParams, Menu } from 'react-contexify'
 import { toast } from 'sonner'
+import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { DialogSectionSeparator, copyToClipboard } from 'ui'
@@ -26,6 +30,7 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
   const tableEditorSnap = useTableEditorStateSnapshot()
   const snap = useTableEditorTableStateSnapshot()
   const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
+  const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
   function onDeleteRow(p: RowContextMenuItemProps) {
     const rowIdx = p.props?.rowIdx
@@ -59,6 +64,19 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
     tableEditorSnap.onEditRow(row)
   }
 
+  const buildPkMatch = useCallback(
+    (row: SupaRow): Record<string, any> | null => {
+      const primaryKey = snap.table?.primaryKey
+      if (!primaryKey || primaryKey.length === 0) return null
+      const pkMatch: Record<string, any> = {}
+      for (const col of primaryKey) {
+        pkMatch[col] = row[col]
+      }
+      return pkMatch
+    },
+    [snap.table?.primaryKey]
+  )
+
   const onCopyCellContent = useCallback(
     (p: RowContextMenuItemProps) => {
       const rowIdx = p.props?.rowIdx
@@ -67,13 +85,28 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
       const row = rows[rowIdx]
       const columnKey = snap.gridColumns[snap.selectedCellPosition.idx as number].key
 
-      const value = row[columnKey]
-      const text = formatClipboardValue(value)
+      let valuePromise: Promise<string>
 
-      copyToClipboard(text)
-      toast.success('Copied cell value to clipboard')
+      const pkMatch = project ? buildPkMatch(row) : null
+      if (project && pkMatch) {
+        valuePromise = getCellValue({
+          projectRef: project.ref,
+          connectionString: project.connectionString,
+          table: { schema: snap.table.schema ?? 'public', name: snap.table.name },
+          column: columnKey,
+          pkMatch,
+        })
+          .then((value) => formatClipboardValue(value))
+          .catch(() => formatClipboardValue(row[columnKey]))
+      } else {
+        valuePromise = Promise.resolve(formatClipboardValue(row[columnKey]))
+      }
+
+      copyToClipboard(valuePromise).then(() => {
+        toast.success('Copied cell value to clipboard')
+      })
     },
-    [rows, snap.gridColumns, snap.selectedCellPosition]
+    [rows, snap.gridColumns, snap.selectedCellPosition, project, snap.table, buildPkMatch]
   )
 
   const onCopyRowContent = useCallback(
@@ -82,10 +115,28 @@ export const RowContextMenu = ({ rows }: RowContextMenuProps) => {
       if (rowIdx === undefined || rowIdx === null) return
 
       const row = rows[rowIdx]
-      copyToClipboard(JSON.stringify(row))
-      toast.success('Copied row to clipboard')
+
+      let textPromise: Promise<string>
+
+      if (project && snap.table) {
+        textPromise = fetchSelectedTableRows({
+          projectRef: project.ref,
+          connectionString: project.connectionString,
+          table: snap.table,
+          selectedRows: [row],
+          roleImpersonationState: roleImpersonationState as RoleImpersonationState,
+        })
+          .then((fullRows) => JSON.stringify(fullRows.length > 0 ? fullRows[0] : row))
+          .catch(() => JSON.stringify(row))
+      } else {
+        textPromise = Promise.resolve(JSON.stringify(row))
+      }
+
+      copyToClipboard(textPromise).then(() => {
+        toast.success('Copied row to clipboard')
+      })
     },
-    [rows]
+    [rows, project, snap.table, roleImpersonationState]
   )
 
   return (

--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -14,7 +14,7 @@ import { toast } from 'sonner'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
-import { DialogSectionSeparator, copyToClipboard } from 'ui'
+import { copyToClipboard, DialogSectionSeparator } from 'ui'
 
 import { formatClipboardValue } from '../../utils/common'
 

--- a/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
@@ -13,7 +13,7 @@ import type { Entity } from 'data/entity-types/entity-types-infinite-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
 import { getTableEditor, type TableEditorData } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
-import { fetchAllTableRows } from 'data/table-rows/table-rows-query'
+import { fetchAllTableRows, fetchSelectedTableRows } from 'data/table-rows/table-rows-query'
 import { useStaticEffectEvent } from 'hooks/useStaticEffectEvent'
 import { DOCS_URL } from 'lib/constants'
 import type { RoleImpersonationState } from 'lib/role-impersonation'
@@ -258,6 +258,17 @@ type UseExportAllRowsParams =
           table: SupaTable
           rows: Record<string, unknown>[]
         }
+      | {
+          /**
+           * Specific rows need to be re-fetched from the database without truncation.
+           */
+          type: 'fetch_selected'
+          table: SupaTable
+          selectedRows: Record<string, unknown>[]
+          filters?: Filter[]
+          sorts?: Sort[]
+          roleImpersonationState?: RoleImpersonationState
+        }
     ))
 
 type UseExportAllRowsReturn = {
@@ -287,43 +298,69 @@ export const useExportAllRowsGeneric = (
 
       const { projectRef, connectionString, entity, totalRows } = params
 
-      const exportResult =
-        params.type === 'provided_rows'
-          ? convertAndDownload(formatRowsForExport(params.rows, params.table), params.table, {
-              convertToOutputFormat,
-              convertToBlob,
-              save,
+      let exportResult: FetchAllRowsReturn
+
+      if (params.type === 'provided_rows') {
+        exportResult = convertAndDownload(
+          formatRowsForExport(params.rows, params.table),
+          params.table,
+          { convertToOutputFormat, convertToBlob, save }
+        )
+      } else if (params.type === 'fetch_selected') {
+        try {
+          const rows = await fetchSelectedTableRows({
+            projectRef,
+            connectionString: connectionString ?? undefined,
+            table: params.table,
+            selectedRows: params.selectedRows,
+            filters: params.filters,
+            sorts: params.sorts,
+            roleImpersonationState: params.roleImpersonationState,
+          })
+          if (rows.length === 0) {
+            exportResult = { status: 'error', error: new NoRowsToExportError(entity.name) }
+          } else {
+            exportResult = convertAndDownload(
+              formatRowsForExport(rows, params.table),
+              params.table,
+              { convertToOutputFormat, convertToBlob, save }
+            )
+          }
+        } catch (error: unknown) {
+          exportResult = { status: 'error', error: new FetchRowsError(entity.name, error) }
+        }
+      } else {
+        exportResult = await fetchAllRows({
+          queryClient,
+          projectRef: projectRef,
+          connectionString: connectionString,
+          entity: entity,
+          bypassConfirmation,
+          filters: params.filters,
+          sorts: params.sorts,
+          roleImpersonationState: params.roleImpersonationState,
+          totalRows: params.totalRows,
+          startCallback: () => {
+            startProgressTracker({
+              id: entity.id,
+              name: entity.name,
+              trackPercentage: totalRows !== undefined,
             })
-          : await fetchAllRows({
-              queryClient,
-              projectRef: projectRef,
-              connectionString: connectionString,
-              entity: entity,
-              bypassConfirmation,
-              filters: params.filters,
-              sorts: params.sorts,
-              roleImpersonationState: params.roleImpersonationState,
-              totalRows: params.totalRows,
-              startCallback: () => {
-                startProgressTracker({
+          },
+          progressCallback: totalRows
+            ? (value: number) =>
+                trackPercentageProgress({
                   id: entity.id,
                   name: entity.name,
-                  trackPercentage: totalRows !== undefined,
+                  totalRows: totalRows,
+                  value,
                 })
-              },
-              progressCallback: totalRows
-                ? (value: number) =>
-                    trackPercentageProgress({
-                      id: entity.id,
-                      name: entity.name,
-                      totalRows: totalRows,
-                      value,
-                    })
-                : undefined,
-              convertToOutputFormat,
-              convertToBlob,
-              save,
-            })
+            : undefined,
+          convertToOutputFormat,
+          convertToBlob,
+          save,
+        })
+      }
 
       if (exportResult.status === 'error') {
         const error = exportResult.error

--- a/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
@@ -1,8 +1,4 @@
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
-import saveAs from 'file-saver'
-import Papa from 'papaparse'
-import { useCallback, useState, type ReactNode } from 'react'
-
 import { IS_PLATFORM } from 'common'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import type { Filter, Sort, SupaTable } from 'components/grid/types'
@@ -14,10 +10,14 @@ import { tableEditorKeys } from 'data/table-editor/keys'
 import { getTableEditor, type TableEditorData } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { fetchAllTableRows, fetchSelectedTableRows } from 'data/table-rows/table-rows-query'
+import saveAs from 'file-saver'
 import { useStaticEffectEvent } from 'hooks/useStaticEffectEvent'
 import { DOCS_URL } from 'lib/constants'
 import type { RoleImpersonationState } from 'lib/role-impersonation'
+import Papa from 'papaparse'
+import { useCallback, useState, type ReactNode } from 'react'
 import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
+
 import {
   BlobCreationError,
   DownloadSaveError,

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -306,6 +306,81 @@ export const fetchAllTableRows = async ({
   return rows.filter((row) => row[ROLE_IMPERSONATION_NO_RESULTS] !== 1)
 }
 
+/**
+ * Fetches specific rows by primary key WITHOUT truncation.
+ * Used for copy/export operations that need full (untruncated) data.
+ * Falls back to fetchAllTableRows for tables without a primary key.
+ */
+export const fetchSelectedTableRows = async ({
+  projectRef,
+  connectionString,
+  table,
+  selectedRows,
+  filters = [],
+  sorts = [],
+  roleImpersonationState,
+}: {
+  projectRef: string
+  connectionString?: string | null
+  table: SupaTable
+  selectedRows: Record<string, unknown>[]
+  filters?: Filter[]
+  sorts?: Sort[]
+  roleImpersonationState?: RoleImpersonationState
+}): Promise<Record<string, unknown>[]> => {
+  if (IS_PLATFORM && !connectionString) {
+    console.error('Connection string is required')
+    return []
+  }
+
+  if (selectedRows.length === 0) {
+    return []
+  }
+
+  const primaryKey = table.primaryKey
+  if (!primaryKey || primaryKey.length === 0) {
+    return fetchAllTableRows({
+      projectRef,
+      connectionString,
+      table,
+      filters,
+      sorts,
+      roleImpersonationState,
+    })
+  }
+
+  const query = new Query()
+
+  const arrayBasedColumns = table.columns
+    .filter(
+      (column) => (column?.enum ?? []).length > 0 && column.dataType.toLowerCase() === 'array'
+    )
+    .map((column) => `"${column.name}"::text[]`)
+
+  let queryChains = query
+    .from(table.name, table.schema ?? undefined)
+    .select(arrayBasedColumns.length > 0 ? `*,${arrayBasedColumns.join(',')}` : '*')
+
+  if (primaryKey.length === 1) {
+    const pkCol = primaryKey[0]
+    queryChains = queryChains.filter(
+      pkCol,
+      'in',
+      selectedRows.map((r) => r[pkCol])
+    )
+  } else {
+    queryChains = queryChains.filter(
+      primaryKey,
+      'in',
+      selectedRows.map((r) => primaryKey.map((col) => r[col]))
+    )
+  }
+
+  const sql = wrapWithRoleImpersonation(queryChains.toSql(), roleImpersonationState)
+  const { result } = await executeSql({ projectRef, connectionString, sql })
+  return result.filter((row: any) => row[ROLE_IMPERSONATION_NO_RESULTS] !== 1)
+}
+
 export type TableRows = { rows: SupaRow[] }
 
 export type TableRowsVariables = Omit<GetTableRowsArgs, 'table'> & {

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -1,6 +1,6 @@
 import { Query, type QueryFilter } from '@supabase/pg-meta/src/query'
 import { getTableRowsSql } from '@supabase/pg-meta/src/query/table-row-query'
-import { type QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { IS_PLATFORM } from 'common'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import { Filter, Sort, SupaRow, SupaTable } from 'components/grid/types'
@@ -16,7 +16,7 @@ import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
 import { ResponseError, UseCustomQueryOptions } from 'types'
 
 import { handleError } from '../fetchers'
-import { ExecuteSqlError, executeSql } from '../sql/execute-sql-query'
+import { executeSql, ExecuteSqlError } from '../sql/execute-sql-query'
 import { tableRowKeys } from './keys'
 import { formatFilterValue } from './utils'
 


### PR DESCRIPTION
## Summary

- Fix copy-to-clipboard and file export operations in the Table Editor delivering truncated data for large JSONB/text columns
- The grid correctly truncates values at 10KB for display performance, but this truncated data was leaking into copy and export operations
- Add `fetchSelectedTableRows()` that re-fetches specific rows by primary key using `SELECT *` (no truncation CTE) before copy/export

## What changed

| File | Change |
|---|---|
| `apps/studio/data/table-rows/table-rows-query.ts` | Add `fetchSelectedTableRows` function |
| `apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx` | Add `fetch_selected` export type + handling |
| `apps/studio/components/grid/components/header/Header.tsx` | Use `fetch_selected` for export, fetch full data for copy |
| `apps/studio/components/grid/components/header/HeaderNew.tsx` | Same changes as Header.tsx |
| `apps/studio/components/grid/components/menu/RowContextMenu.tsx` | Fetch full cell/row data before copying |

## Affected operations

| Operation | Before | After |
|---|---|---|
| Grid display | Truncated (correct) | No change |
| Copy selected rows | Truncated (bug) | Full data |
| Export selected rows | Truncated (bug) | Full data |
| Export ALL rows | Full data (correct) | No change |
| Right-click → Copy cell | Truncated (bug) | Full data |
| Right-click → Copy row | Truncated (bug) | Full data |

## Design decisions

- **Safari compatibility**: Uses promise-based `copyToClipboard(Promise<string>)` pattern instead of `await`-then-copy, satisfying the `no-await-before-copy-to-clipboard` lint rule
- **No primary key fallback**: Falls back to `fetchAllTableRows` with current filters (same limitation as the existing "Load" button)
- **Composite PKs**: Handled via `inTupleFilterSql` which produces `(col1, col2) IN ((v1, v2), ...)`
- **Graceful error handling**: On fetch failure, falls back to truncated grid data with a toast warning
- **Empty selection guard**: Returns `[]` immediately if no rows are selected, preventing invalid SQL

## Test plan

- [ ] Verify TypeScript typecheck passes (`pnpm typecheck` - confirmed)
- [ ] Verify lint passes with 0 errors (`pnpm lint` - confirmed)
- [ ] Create table with JSONB column containing >10KB value
- [ ] Select rows - Copy as CSV/JSON/SQL - verify full data in clipboard
- [ ] Select rows - Export as CSV/JSON/SQL - verify full data in file
- [ ] Right-click - Copy cell on large JSONB - verify full value
- [ ] Right-click - Copy row - verify full row data
- [ ] Verify grid still displays truncated values (no regression)
- [ ] Test with table that has no primary key (fallback behavior)
- [ ] Test with composite primary key table

Fixes #37151
Fixes #42289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Copy operations now fetch full row data from the database for complete and accurate results
  * Added support for role impersonation in copy and export workflows
  * New export option to fetch and export selected rows while preserving applied filters and sorts

* **Bug Fixes**
  * Improved error handling in copy operations with automatic fallback to local data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->