### PR TITLE
chore(docs): mark Kubernetes guide as maintained

### DIFF
--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -41,7 +41,7 @@ There are several other ways to deploy Supabase with the help of community-drive
           title={
             <span className="flex items-center gap-2">
               {x.name}
-                  <Badge>Maintainer needed</Badge>
+              {x.maintainerNeeded !== false && <Badge>Maintainer needed</Badge>}
             </span>
           }
         >

--- a/apps/docs/lib/guidesData.ts
+++ b/apps/docs/lib/guidesData.ts
@@ -14,11 +14,13 @@ export const guidesData = {
       name: 'Kubernetes',
       description: 'Helm charts to deploy a Supabase on Kubernetes.',
       href: 'https://github.com/supabase-community/supabase-kubernetes',
+      maintainerNeeded: false,
     },
     {
       name: 'Traefik',
       description: 'A self-hosted Supabase setup with Traefik as a reverse proxy.',
       href: 'https://github.com/supabase-community/supabase-traefik',
+      maintainerNeeded: true,
     },
   ],
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Kubernetes guide is marked with "Maintainer needed", even though it now has an active maintainer.

## What is the new behavior?

The Kubernetes guide is now marked as maintained (maintainerNeeded: false), and the "Maintainer needed" badge is conditionally rendered based on the maintainerNeeded flag.

## Additional context

This updates the guides data to reflect the current maintenance status of the Kubernetes deployment option.
Related: supabase-community/supabase-kubernetes/issues/120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Self-hosting guides now show a "Maintainer needed" badge only when applicable.
  * Guide entries updated to indicate maintainer availability for Kubernetes (marked as maintained) and Traefik (marked as needing a maintainer), helping users identify community support needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->