### PR TITLE
docs: fix outdated supabase.io URLs across docs and design-system

### DIFF
--- a/apps/design-system/registry/default/example/metric-card-with-icon-link-tooltip.tsx
+++ b/apps/design-system/registry/default/example/metric-card-with-icon-link-tooltip.tsx
@@ -34,7 +34,7 @@ export default function MetricsCardDemo() {
   return (
     <div className="w-1/2">
       <MetricCard isLoading={!data.length}>
-        <MetricCardHeader href="https://www.supabase.io">
+        <MetricCardHeader href="https://supabase.com">
           <MetricCardIcon>
             <User2 size={14} strokeWidth={1.5} />
           </MetricCardIcon>

--- a/apps/design-system/registry/default/example/metric-card.tsx
+++ b/apps/design-system/registry/default/example/metric-card.tsx
@@ -32,7 +32,7 @@ export default function MetricsCardDemo() {
   return (
     <div className="w-1/2">
       <MetricCard isLoading={!data.length}>
-        <MetricCardHeader href="https://www.supabase.io">
+        <MetricCardHeader href="https://supabase.com">
           <MetricCardLabel tooltip="The number of active users over the last 24 hours">
             Active Users
           </MetricCardLabel>

--- a/apps/docs/content/guides/auth/third-party/clerk.mdx
+++ b/apps/docs/content/guides/auth/third-party/clerk.mdx
@@ -76,7 +76,7 @@ import Clerk
 import Supabase
 
 let supabase = SupabaseClient(
-  supabaseURL: URL(string: "https://project-ref.supabase.io")!,
+  supabaseURL: URL(string: "https://project-ref.supabase.co")!,
   supabaseKey: "supabase.anon.key",
   options: SupabaseClientOptions(
     auth: SupabaseClientOptions.AuthOptions(

--- a/apps/docs/content/guides/local-development/overview.mdx
+++ b/apps/docs/content/guides/local-development/overview.mdx
@@ -7,7 +7,7 @@ video: 'https://www.youtube-nocookie.com/v/vyHyYpvjaks'
 tocVideo: 'vyHyYpvjaks'
 ---
 
-Supabase is a flexible platform that lets you decide how you want to build your projects. You can use the Dashboard directly to get up and running quickly, or use a proper local setup. We suggest you work locally and deploy your changes to a linked project on the [Supabase Platform](https://app.supabase.io/).
+Supabase is a flexible platform that lets you decide how you want to build your projects. You can use the Dashboard directly to get up and running quickly, or use a proper local setup. We suggest you work locally and deploy your changes to a linked project on the [Supabase Platform](https://supabase.com/dashboard).
 
 Develop locally using the CLI to run a local Supabase stack. You can use the integrated Studio Dashboard to make changes, then capture your changes in schema migration files, which can be saved in version control.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

Several files still reference the old `supabase.io` domain:

- `apps/docs/content/guides/auth/third-party/clerk.mdx` uses `https://project-ref.supabase.io` in the Swift code example — the correct domain for project API URLs is `supabase.co`
- `apps/docs/content/guides/local-development/overview.mdx` links to `https://app.supabase.io/` — the dashboard has moved to `https://supabase.com/dashboard`
- `apps/design-system/registry/default/example/metric-card*.tsx` examples use `https://www.supabase.io` — the correct URL is `https://supabase.com`

## What is the new behavior?

All outdated `supabase.io` URLs are updated to their correct current domains:

- `project-ref.supabase.io` -> `project-ref.supabase.co`
- `app.supabase.io` -> `supabase.com/dashboard`
- `www.supabase.io` -> `supabase.com`

## Additional context

The `supabase.io` domain was the original domain used by Supabase before migrating to `supabase.com` (for the website/dashboard) and `supabase.co` (for project API endpoints). These references were missed during the original migration in 2022.

Note: Email addresses like `enterprise@supabase.io` and SAML endpoints at `alt.supabase.io` were intentionally left unchanged as they may still be valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform URLs in design system examples to current domain references.
  * Updated documentation links to reflect current platform URL structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->