### PR TITLE
chore: use appropriate console log levels in www and docs

### DIFF
--- a/apps/docs/generator/sdk.ts
+++ b/apps/docs/generator/sdk.ts
@@ -15,7 +15,7 @@ export default async function gen(inputFileName: string, outputDir: string) {
       break
 
     default:
-      console.log('Unrecognized specification version:', spec.sdkspec)
+      console.warn('Unrecognized specification version:', spec.sdkspec)
       break
   }
 }

--- a/apps/docs/lib/refGenerator/helpers.ts
+++ b/apps/docs/lib/refGenerator/helpers.ts
@@ -14,7 +14,7 @@ export function extractTsDocNode(nodeToFind: string, definition: any) {
     previousNode = currentNode
     currentNode = previousNode.children.find((x) => x.name == nodePath[i]) || null
     if (currentNode == null) {
-      console.log(`Cant find ${nodePath[i]} in ${previousNode.children.map((x) => '\n' + x.name)}`)
+      console.warn(`Cant find ${nodePath[i]} in ${previousNode.children.map((x) => '\n' + x.name)}`)
       break
     }
     i++

--- a/apps/www/lib/customerio.ts
+++ b/apps/www/lib/customerio.ts
@@ -200,7 +200,7 @@ export class CustomerioAppClient {
       return null
     }
 
-    console.log('Found customer with ID:', customer.id)
+    console.debug('Found customer with ID:', customer.id)
 
     // Now get the specific attributes for this customer
     try {

--- a/apps/www/supabase/functions/hubspot-notification/index.ts
+++ b/apps/www/supabase/functions/hubspot-notification/index.ts
@@ -103,7 +103,7 @@ serve(async (req) => {
   // Will create a deal using HubSpot's workflow tool instead of via API
 
   if (!formResponse.ok) {
-    console.log(`Failed to submit form data to HubSpot`, await formResponse.json())
+    console.error(`Failed to submit form data to HubSpot`, await formResponse.json())
     return new Response(`Failed to submit form data to HubSpot`, {
       status: 500,
     })

--- a/apps/www/supabase/functions/lw11-og/handler.tsx
+++ b/apps/www/supabase/functions/lw11-og/handler.tsx
@@ -84,7 +84,7 @@ export async function handler(req: Request) {
       .eq('username', username)
       .maybeSingle()
 
-    if (error) console.log('fetch error', error.message)
+    if (error) console.error('fetch error', error.message)
     if (!data) throw new Error(error?.message ?? 'user not found')
     const { name, ticketNumber, metadata, secret } = data
 

--- a/apps/www/supabase/functions/lwx-og/handler.tsx
+++ b/apps/www/supabase/functions/lwx-og/handler.tsx
@@ -78,7 +78,7 @@ export async function handler(req: Request) {
       .eq('username', username)
       .maybeSingle()
 
-    if (error) console.log('fetch error', error.message)
+    if (error) console.error('fetch error', error.message)
     if (!data) throw new Error(error?.message ?? 'user not found')
     const { name, ticketNumber, metadata } = data
 
@@ -320,7 +320,7 @@ export async function handler(req: Request) {
         username,
         platinum,
       }),
-    }).catch((err) => console.log('generate og err', err))
+    }).catch((err) => console.error('generate og err', err))
 
     const NEW_TIMESTAMP = new Date()
 

--- a/apps/www/supabase/functions/lwx-ticket/handler.tsx
+++ b/apps/www/supabase/functions/lwx-ticket/handler.tsx
@@ -74,7 +74,7 @@ export async function handler(req: Request) {
       .eq('username', username)
       .maybeSingle()
 
-    if (error) console.log('fetch error', error.message)
+    if (error) console.error('fetch error', error.message)
     if (!data) throw new Error(error?.message ?? 'user not found')
 
     const { name, ticketNumber, metadata } = data


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code quality improvement

## What is the current behavior?

Several files use `console.log` for error conditions, warnings, or debug information where more specific log levels would be appropriate:

- Error conditions logged with `console.log` instead of `console.error`
- Warnings logged with `console.log` instead of `console.warn`
- Debug/trace information logged with `console.log` instead of `console.debug`

## What is the new behavior?

Each `console.log` call is replaced with the appropriate log level:

| File | Change | Reason |
|------|--------|--------|
| `hubspot-notification/index.ts` | `log` -> `error` | Failed HubSpot form submission |
| `customerio.ts` | `log` -> `debug` | Routine success debug info |
| `lw11-og/handler.tsx` | `log` -> `error` | Database fetch error |
| `lwx-og/handler.tsx` (x2) | `log` -> `error` | Database fetch error + OG generation error |
| `lwx-ticket/handler.tsx` | `log` -> `error` | Database fetch error |
| `docs/generator/sdk.ts` | `log` -> `warn` | Unrecognized spec version |
| `docs/lib/refGenerator/helpers.ts` | `log` -> `warn` | Missing node in definition tree |

## Additional context

Using correct log levels makes it easier to filter and monitor logs in production, and follows standard logging practices where `error` indicates failures, `warn` indicates unexpected but recoverable conditions, and `debug` indicates routine diagnostic information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging levels across internal modules for better error tracking and diagnostics. Standard logging statements updated to use appropriate severity levels (debug, warn, error) to enhance troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->