### PR TITLE
chore: use appropriate console log levels in studio, design-system, and common

### DIFF
--- a/apps/design-system/lib/rehype-component.ts
+++ b/apps/design-system/lib/rehype-component.ts
@@ -20,7 +20,7 @@ function inspectComponentProps<T>(component: React.ComponentType<T>): void {
 
   for (const propName in defaultProps) {
     const propType = typeof defaultProps[propName]
-    console.log(`${propName}: ${propType}`)
+    console.debug(`${propName}: ${propType}`)
   }
 }
 
@@ -341,7 +341,7 @@ function getComponentSourceFileContent(node: UnistNode) {
 
   // Read the source file.
   const filePath = path.join(process.cwd(), src)
-  console.log('filePath', filePath)
+  console.debug('filePath', filePath)
   const source = fs.readFileSync(filePath, 'utf8')
 
   return source

--- a/apps/studio/pages/api/ai/docs.ts
+++ b/apps/studio/pages/api/ai/docs.ts
@@ -136,7 +136,7 @@ async function handlePost(request: NextRequest) {
       console.error(error)
     }
 
-    console.log('Returning generic 500 ApplicationError to client')
+    console.warn('Returning generic 500 ApplicationError to client')
 
     // TODO: include more response info in debug environments
     return new Response(

--- a/apps/studio/pages/api/ai/sql/title-v2.ts
+++ b/apps/studio/pages/api/ai/sql/title-v2.ts
@@ -73,7 +73,7 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
         })
       }
     } else {
-      console.log(`Unknown error: ${error}`)
+      console.error(`Unknown error: ${error}`)
     }
 
     return res.status(500).json({

--- a/packages/common/configcat.ts
+++ b/packages/common/configcat.ts
@@ -30,7 +30,7 @@ async function getClient() {
   if (client) return client
 
   if (!process.env.NEXT_PUBLIC_CONFIGCAT_SDK_KEY && !process.env.NEXT_PUBLIC_CONFIGCAT_PROXY_URL) {
-    console.log('Skipping ConfigCat set up as env vars are not present')
+    console.debug('Skipping ConfigCat set up as env vars are not present')
     return undefined
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code quality / cleanup

## What is the current behavior?

Several `console.log` calls are used where more specific log levels would be appropriate:

- `apps/studio/pages/api/ai/sql/title-v2.ts`: `console.log` used for logging unknown errors in error handler
- `apps/studio/pages/api/ai/docs.ts`: `console.log` used for notice about returning 500 error to client
- `packages/common/configcat.ts`: `console.log` used for informational setup skip message
- `apps/design-system/lib/rehype-component.ts`: `console.log` used for debug output (prop inspection and file path logging)

## What is the new behavior?

- `console.log('Unknown error:...')` -> `console.error(...)` in title-v2.ts (error-level)
- `console.log('Returning generic 500...')` -> `console.warn(...)` in docs.ts (warning-level)
- `console.log('Skipping ConfigCat...')` -> `console.debug(...)` in configcat.ts (debug-level)
- `console.log(...)` -> `console.debug(...)` in rehype-component.ts (debug-level)

## Additional context

Using appropriate log levels helps with log filtering and debugging. Error-level logs surface real issues, while debug-level logs can be silenced in production environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal logging level adjustments for improved developer diagnostics. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->