### PR TITLE
docs: clarify anon key usage in scheduled edge functions

### DIFF
--- a/apps/docs/content/guides/functions/schedule-functions.mdx
+++ b/apps/docs/content/guides/functions/schedule-functions.mdx
@@ -29,10 +29,17 @@ To access the auth token securely for your Edge Function call, we recommend stor
 
 Store `project_url` and `anon_key` in Supabase Vault:
 
+> Note: This is a one-time setup step to store secrets securely in Supabase Vault.
+> Do not hard-code sensitive values directly in production SQL.
+
 ```sql
+-- One-time setup: store secrets securely in Supabase Vault
+-- Values shown here are placeholders
 select vault.create_secret('https://project-ref.supabase.co', 'project_url');
-select vault.create_secret('YOUR_SUPABASE_PUBLISHABLE_KEY', 'publishable_key');
+select vault.create_secret('YOUR_SUPABASE_ANON_KEY', 'anon_key');
 ```
+The scheduled job retrieves the anon key from Supabase Vault at runtime
+to authenticate the Edge Function request securely.
 
 Make a POST request to a Supabase Edge Function every minute:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The scheduling Edge Functions documentation uses inconsistent API keys in the examples.
The Vault setup references one key, while the cron job example uses a different one, which can confuse users about which key should be used and how secrets should be handled securely.

## What is the new behavior?

The documentation now consistently uses the same key and clearly explains how it is stored in Supabase Vault and retrieved at runtime by the scheduled job.
This makes the example clearer and avoids confusion around secret handling.

## Additional context

This appears to be the result of a partial update to the documentation where only one example was updated.
The change improves clarity and aligns the examples with recommended security practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated scheduled functions guide with improved authentication configuration.
- Added security best practices for storing sensitive credentials securely.
- Included guidance on avoiding hard-coded confidential values in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->