### PR TITLE
Hide actions in schema visualizer if schema has no tables

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -78,7 +78,7 @@ export const SchemaGraph = () => {
   })
 
   const {
-    data: tables,
+    data: tables = [],
     error: errorTables,
     isSuccess: isSuccessTables,
     isPending: isLoadingTables,
@@ -89,6 +89,7 @@ export const SchemaGraph = () => {
     schema: selectedSchema,
     includeColumns: true,
   })
+  const hasNoTables = isSuccessSchemas && tables.length === 0
 
   const schema = (schemas ?? []).find((s) => s.name === selectedSchema)
   const [, setStoredPositions] = useLocalStorage(
@@ -221,66 +222,68 @@ export const SchemaGraph = () => {
               selectedSchemaName={selectedSchema}
               onSelectSchema={setSelectedSchema}
             />
-            <div className="flex items-center gap-x-2">
-              <ButtonTooltip
-                type="outline"
-                icon={copied ? <Check /> : <Copy />}
-                onClick={() => {
-                  if (tables) {
-                    copyToClipboard(tablesToSQL(tables))
-                    setCopied(true)
-                  }
-                }}
-                tooltip={{
-                  content: {
-                    side: 'bottom',
-                    text: (
-                      <div className="max-w-[180px] space-y-2 text-foreground-light">
-                        <p className="text-foreground">Note</p>
-                        <p>
-                          This schema is for context or debugging only. Table order and constraints
-                          may be invalid. Not meant to be run as-is.
-                        </p>
-                      </div>
-                    ),
-                  },
-                }}
-              >
-                Copy as SQL
-              </ButtonTooltip>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <ButtonTooltip
-                    aria-label="Download Schema"
-                    type="default"
-                    loading={isDownloading}
-                    className="px-1.5"
-                    icon={<Download />}
-                    tooltip={{ content: { side: 'bottom', text: 'Download current view' } }}
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-32">
-                  <DropdownMenuItem onClick={() => downloadImage('png')}>
-                    Download as PNG
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => downloadImage('svg')}>
-                    Download as SVG
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <ButtonTooltip
-                type="default"
-                onClick={resetLayout}
-                tooltip={{
-                  content: {
-                    side: 'bottom',
-                    text: 'Automatically arrange the layout of all nodes',
-                  },
-                }}
-              >
-                Auto layout
-              </ButtonTooltip>
-            </div>
+            {!hasNoTables && (
+              <div className="flex items-center gap-x-2">
+                <ButtonTooltip
+                  type="outline"
+                  icon={copied ? <Check /> : <Copy />}
+                  onClick={() => {
+                    if (tables) {
+                      copyToClipboard(tablesToSQL(tables))
+                      setCopied(true)
+                    }
+                  }}
+                  tooltip={{
+                    content: {
+                      side: 'bottom',
+                      text: (
+                        <div className="max-w-[180px] space-y-2 text-foreground-light">
+                          <p className="text-foreground">Note</p>
+                          <p>
+                            This schema is for context or debugging only. Table order and
+                            constraints may be invalid. Not meant to be run as-is.
+                          </p>
+                        </div>
+                      ),
+                    },
+                  }}
+                >
+                  Copy as SQL
+                </ButtonTooltip>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <ButtonTooltip
+                      aria-label="Download Schema"
+                      type="default"
+                      loading={isDownloading}
+                      className="px-1.5"
+                      icon={<Download />}
+                      tooltip={{ content: { side: 'bottom', text: 'Download current view' } }}
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="w-32">
+                    <DropdownMenuItem onClick={() => downloadImage('png')}>
+                      Download as PNG
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => downloadImage('svg')}>
+                      Download as SVG
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <ButtonTooltip
+                  type="default"
+                  onClick={resetLayout}
+                  tooltip={{
+                    content: {
+                      side: 'bottom',
+                      text: 'Automatically arrange the layout of all nodes',
+                    },
+                  }}
+                >
+                  Auto layout
+                </ButtonTooltip>
+              </div>
+            )}
           </>
         )}
       </div>
@@ -297,7 +300,7 @@ export const SchemaGraph = () => {
       )}
       {isSuccessTables && (
         <>
-          {tables.length === 0 ? (
+          {hasNoTables ? (
             <div className="flex items-center justify-center w-full h-full">
               <Admonition
                 type="default"


### PR DESCRIPTION
## Context

In database/tables (Schema visualizer), if the schema has no tables, clicking on "Auto layout" causes a client error as we're trying to run the `dagre.layout` on a graph with 0 nodes and edges

Opting to hide all actions on the Schema Visualizer if there's no tables (understandably we've been leaning towards disabled states rather than hiding, but in this case i was thinking hiding is better since that's an empty state - unless some actions were applicable in the empty state, but in this case none of the actions are)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of the database schema interface by strengthening empty state handling
  * Ensured database actions are properly hidden when no tables exist in the schema

* **Refactor**
  * Consolidated schema state validation logic for better code maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->