### PR TITLE
Fix resizeable panel error in LogTable

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -1,4 +1,10 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { IS_PLATFORM, useParams } from 'common'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { DownloadResultsButton } from 'components/ui/DownloadResultsButton'
+import { useSelectedLog } from 'hooks/analytics/useSelectedLog'
+import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useProfile } from 'lib/profile'
 import { isEqual } from 'lodash'
 import { Copy, Eye, EyeOff, Play } from 'lucide-react'
 import { Key, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
@@ -6,31 +12,25 @@ import { Item, Menu, useContextMenu } from 'react-contexify'
 import DataGrid, { Column, RenderRowProps, Row } from 'react-data-grid'
 import { createPortal } from 'react-dom'
 import { toast } from 'sonner'
-
-import { IS_PLATFORM, useParams } from 'common'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { DownloadResultsButton } from 'components/ui/DownloadResultsButton'
-import { useSelectedLog } from 'hooks/analytics/useSelectedLog'
-import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useProfile } from 'lib/profile'
 import type { ResponseError } from 'types'
 import {
   Button,
+  cn,
+  copyToClipboard,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
-  cn,
-  copyToClipboard,
 } from 'ui'
+
 import AuthColumnRenderer from './LogColumnRenderers/AuthColumnRenderer'
 import DatabaseApiColumnRender from './LogColumnRenderers/DatabaseApiColumnRender'
 import DatabasePostgresColumnRender from './LogColumnRenderers/DatabasePostgresColumnRender'
 import DefaultPreviewColumnRenderer from './LogColumnRenderers/DefaultPreviewColumnRenderer'
 import FunctionsEdgeColumnRender from './LogColumnRenderers/FunctionsEdgeColumnRender'
 import FunctionsLogsColumnRender from './LogColumnRenderers/FunctionsLogsColumnRender'
-import LogSelection from './LogSelection'
 import type { LogData, LogQueryError, QueryType } from './Logs.types'
 import { isDefaultLogPreviewFormat } from './Logs.utils'
+import LogSelection from './LogSelection'
 import { DefaultErrorRenderer } from './LogsErrorRenderers/DefaultErrorRenderer'
 import ResourcesExceededErrorRenderer from './LogsErrorRenderers/ResourcesExceededErrorRenderer'
 import { LogsTableEmptyState } from './LogsTableEmptyState'
@@ -64,7 +64,7 @@ type LogMap = { [id: string]: LogData }
  *
  * When in custom data display mode, the side panel will not open when focusing on logs.
  */
-const LogTable = ({
+export const LogTable = ({
   data = [],
   queryType,
   onHistogramToggle,
@@ -120,6 +120,9 @@ const LogTable = ({
   const hasId = columnNames.includes('id')
   const hasTimestamp = columnNames.includes('timestamp')
 
+  const panelContentMinSize = 40
+  const panelContentMaxSize = 60
+
   const LOGS_EXPLORER_CONTEXT_MENU_ID = 'logs-explorer-context-menu'
   const DEFAULT_COLUMNS = columnNames.map((v: keyof LogData, idx) => {
     const column = `logs-column-${idx}`
@@ -127,7 +130,7 @@ const LogTable = ({
       key: column,
       name: v as string,
       resizable: true,
-      renderCell: ({ row }: any) => {
+      renderCell: ({ row }) => {
         return (
           <span
             onContextMenu={(e) => {
@@ -140,7 +143,7 @@ const LogTable = ({
           </span>
         )
       },
-      renderHeaderCell: (props) => {
+      renderHeaderCell: () => {
         return <div className="flex items-center">{v}</div>
       },
       minWidth: 128,
@@ -392,7 +395,13 @@ const LogTable = ({
       {!queryType && <LogsExplorerTableHeader />}
 
       <ResizablePanelGroup direction="horizontal">
-        <ResizablePanel defaultSize={selectedLog ? 60 : 100}>
+        <ResizablePanel
+          id="log-table-content"
+          order={1}
+          minSize={panelContentMinSize}
+          maxSize={panelContentMaxSize}
+          defaultSize={panelContentMaxSize}
+        >
           <DataGrid
             role="table"
             style={{ height: '100%' }}
@@ -445,25 +454,31 @@ const LogTable = ({
             )}
         </ResizablePanel>
 
-        <ResizableHandle withHandle />
-
         {selectionOpen && (
-          <ResizablePanel minSize={40} defaultSize={50}>
-            <LogSelection
-              isLoading={isSelectedLogLoading || false}
-              projectRef={projectRef}
-              onClose={() => {
-                onSelectedLogChange?.(null)
-                setSelectionOpen(false)
-              }}
-              log={selectedLog}
-              error={selectedLogError}
-              queryType={queryType}
-            />
-          </ResizablePanel>
+          <>
+            <ResizableHandle withHandle />
+            <ResizablePanel
+              id="log-table-panel"
+              order={2}
+              minSize={100 - panelContentMaxSize}
+              maxSize={100 - panelContentMinSize}
+              defaultSize={100 - panelContentMaxSize}
+            >
+              <LogSelection
+                isLoading={isSelectedLogLoading || false}
+                projectRef={projectRef}
+                onClose={() => {
+                  onSelectedLogChange?.(null)
+                  setSelectionOpen(false)
+                }}
+                log={selectedLog}
+                error={selectedLogError}
+                queryType={queryType}
+              />
+            </ResizablePanel>
+          </>
         )}
       </ResizablePanelGroup>
     </section>
   )
 }
-export default LogTable

--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -27,7 +27,7 @@ import {
 import { DatePickerValue } from './Logs.DatePickers'
 import type { Filters, LogSearchCallback, LogTemplate, QueryType } from './Logs.types'
 import { maybeShowUpgradePromptIfNotEntitled } from './Logs.utils'
-import LogTable from './LogTable'
+import { LogTable } from './LogTable'
 import UpgradePrompt from './UpgradePrompt'
 
 /**

--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -1,8 +1,3 @@
-import { ChevronRight, CircleHelpIcon, Plus } from 'lucide-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import React, { useState } from 'react'
-
 import { IS_PLATFORM, useFlag, useParams } from 'common'
 import {
   useFeaturePreviewModal,
@@ -17,6 +12,10 @@ import { useContentQuery } from 'data/content/content-query'
 import { useReplicationSourcesQuery } from 'data/replication/sources-query'
 import { useCurrentOrgPlan } from 'hooks/misc/useCurrentOrgPlan'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { ChevronRight, CircleHelpIcon, Plus } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import React, { useState } from 'react'
 import {
   Badge,
   Button,
@@ -33,6 +32,7 @@ import {
   InnerSideMenuItem,
 } from 'ui-patterns/InnerSideMenu'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+
 import { FeaturePreviewSidebarPanel } from '../../ui/FeaturePreviewSidebarPanel'
 
 const SupaIcon = ({ className }: { className?: string }) => {
@@ -368,7 +368,7 @@ export function LogsSidebarMenuV2() {
           />
         )}
         {savedQueries.map((query) => (
-          <SavedQueriesItem item={query as any} key={query.id} /> // kemal: i know, i know, temp any fix.
+          <SavedQueriesItem item={query} key={query.id} />
         ))}
       </SidebarCollapsible>
 
@@ -381,7 +381,7 @@ export function LogsSidebarMenuV2() {
         illustration={
           <div className="flex items-center gap-4">
             {LOG_DRAIN_TYPES.map((type) =>
-              React.cloneElement(type.icon, { height: 20, width: 20 })
+              React.cloneElement(type.icon, { key: type.name, height: 20, width: 20 })
             )}
           </div>
         }

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -1,27 +1,24 @@
 import { useMonaco } from '@monaco-editor/react'
 import { useLocalStorage } from '@uidotdev/usehooks'
-import dayjs from 'dayjs'
-import type { editor } from 'monaco-editor'
-import { useRouter } from 'next/router'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { toast } from 'sonner'
-
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS, useParams } from 'common'
-
 import {
   EXPLORER_DATEPICKER_HELPERS,
+  getDefaultHelper,
   LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD,
   TEMPLATES,
-  getDefaultHelper,
 } from 'components/interfaces/Settings/Logs/Logs.constants'
-import { LogData, LogTemplate, LogsWarning } from 'components/interfaces/Settings/Logs/Logs.types'
 import { DatePickerValue } from 'components/interfaces/Settings/Logs/Logs.DatePickers'
+import { LogData, LogsWarning, LogTemplate } from 'components/interfaces/Settings/Logs/Logs.types'
 import {
   maybeShowUpgradePromptIfNotEntitled,
   useEditorHints,
 } from 'components/interfaces/Settings/Logs/Logs.utils'
+import {
+  buildLogQueryParams,
+  resolveLogDateRange,
+} from 'components/interfaces/Settings/Logs/logsDateRange'
 import LogsQueryPanel from 'components/interfaces/Settings/Logs/LogsQueryPanel'
-import LogTable from 'components/interfaces/Settings/Logs/LogTable'
+import { LogTable } from 'components/interfaces/Settings/Logs/LogTable'
 import UpgradePrompt from 'components/interfaces/Settings/Logs/UpgradePrompt'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
@@ -33,6 +30,7 @@ import {
   UpsertContentPayload,
   useContentUpsertMutation,
 } from 'data/content/content-upsert-mutation'
+import dayjs from 'dayjs'
 import useLogsQuery from 'hooks/analytics/useLogsQuery'
 import { useLogsUrlState } from 'hooks/analytics/useLogsUrlState'
 import { useCustomContent } from 'hooks/custom-content/useCustomContent'
@@ -42,11 +40,11 @@ import { useUpgradePrompt } from 'hooks/misc/useUpgradePrompt'
 import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
 import { useTrack } from 'lib/telemetry/track'
+import type { editor } from 'monaco-editor'
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import type { LogSqlSnippets, NextPageWithLayout } from 'types'
-import {
-  buildLogQueryParams,
-  resolveLogDateRange,
-} from 'components/interfaces/Settings/Logs/logsDateRange'
 import {
   Button,
   Form,

--- a/apps/studio/tests/features/logs/LogTable.test.tsx
+++ b/apps/studio/tests/features/logs/LogTable.test.tsx
@@ -1,12 +1,13 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import LogTable from 'components/interfaces/Settings/Logs/LogTable'
+import { LogTable } from 'components/interfaces/Settings/Logs/LogTable'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 import { beforeAll, expect, test, vi } from 'vitest'
+
 import { render } from '../../helpers'
 
 dayjs.extend(customParseFormat)


### PR DESCRIPTION
## Context

There's an error from the `LogTable` component `Previous layout not found` that's caused by trying to set `defaultSize` as a dynamic value for the `ResizablePanel` component. Theres 2 ways to address this really

Option 1: Set `id` param on `ResizablePanel` to be a dynamic: this came from a suggestion by the library's author [here](https://github.com/bvaughn/react-resizable-panels/issues/401#issuecomment-2351010630)

Option 2: Avoid dynamic values entirely

Opting for option 2 as the cleaner way to fix this. Just note as well that there's a couple of console warnings from the library about `Invalid layout total size` - this one's safe to ignore and is seemingly an issue with the current version of `react-resizable-panels` that we're using (v2, there's currently v4 already)

## To test

Tbh I couldn't reproduce this locally actually, but I happened to come across this same bug while debugging the `Invalid layout total size` warning in `DefaultLayout` by trying to set a dynamic value for `defaultSize` which made me realise the dynamic value was the one causing that error

<img width="534" height="89" alt="image" src="https://github.com/user-attachments/assets/3b696c16-ea66-481e-a698-d59841c7400d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved logs viewer layout with resizable panels for better content management and log selection display.
  * Reorganized internal component structure and module exports for improved maintainability.

* **Chores**
  * Updated test imports to reflect internal module restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->