### PR TITLE
Joshen/fe 2540 fix safari csv drag drop typeerror in table editor

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -97,12 +97,7 @@ export const Grid = memo(
 
       const { mutate: sendEvent } = useSendEventMutation()
 
-      const {
-        isValidFile: isValidFileDraggedOver,
-        isDraggedOver,
-        onDragOver,
-        onFileDrop,
-      } = useCsvFileDrop({
+      const { isDraggedOver, onDragOver, onFileDrop } = useCsvFileDrop({
         enabled: isTableEmpty && !isForeignTable,
         onFileDropped: (file) => tableEditorSnap.onImportData(valtioRef(file)),
         onTelemetryEvent: (eventName) => {
@@ -241,9 +236,7 @@ export const Grid = memo(
           {(rows ?? []).length === 0 && (
             <div
               className={cn(
-                'absolute w-full inset-0 flex flex-col items-center justify-center p-2 z-[1] pointer-events-none',
-                isTableEmpty && isDraggedOver && 'border-2 border-dashed',
-                isValidFileDraggedOver ? 'border-brand-600' : 'border-destructive-600'
+                'absolute w-full inset-0 flex flex-col items-center justify-center p-2 z-[1] pointer-events-none'
               )}
             >
               {isLoading && !isDisabled && (
@@ -272,18 +265,13 @@ export const Grid = memo(
                       </div>
                     </div>
                   ) : (filters ?? []).length === 0 ? (
-                    <div className="flex flex-col items-center justify-center">
-                      <p className="text-sm text-light pointer-events-auto">
-                        {isDraggedOver ? (
-                          isValidFileDraggedOver ? (
-                            'Drop your CSV file here'
-                          ) : (
-                            <span className="text-destructive">Only CSV files are accepted</span>
-                          )
-                        ) : (
-                          'This table is empty'
-                        )}
-                      </p>
+                    <div
+                      className={cn(
+                        'flex flex-col items-center justify-center w-full h-full mt-9 transition',
+                        isTableEmpty && isDraggedOver && 'border-2 border-dashed border-brand'
+                      )}
+                    >
+                      <p className="text-sm text-light pointer-events-auto">This table is empty</p>
                       {tableEntityType === ENTITY_TYPE.FOREIGN_TABLE ? (
                         <div className="flex items-center space-x-2 mt-4">
                           <p className="text-sm text-light pointer-events-auto">
@@ -292,30 +280,28 @@ export const Grid = memo(
                           </p>
                         </div>
                       ) : (
-                        !isDraggedOver && (
-                          <div className="flex flex-col items-center gap-4 mt-4">
-                            <Button
-                              type="default"
-                              className="pointer-events-auto"
-                              onClick={() => {
-                                tableEditorSnap.onImportData()
-                                sendEvent({
-                                  action: 'import_data_button_clicked',
-                                  properties: { tableType: 'Existing Table' },
-                                  groups: {
-                                    project: project?.ref ?? 'Unknown',
-                                    organization: org?.slug ?? 'Unknown',
-                                  },
-                                })
-                              }}
-                            >
-                              Import data from CSV
-                            </Button>
-                            <p className="text-xs text-foreground-light pointer-events-auto">
-                              or drag and drop a CSV file here
-                            </p>
-                          </div>
-                        )
+                        <div className="flex flex-col items-center gap-4 mt-4">
+                          <Button
+                            type="default"
+                            className="pointer-events-auto"
+                            onClick={() => {
+                              tableEditorSnap.onImportData()
+                              sendEvent({
+                                action: 'import_data_button_clicked',
+                                properties: { tableType: 'Existing Table' },
+                                groups: {
+                                  project: project?.ref ?? 'Unknown',
+                                  organization: org?.slug ?? 'Unknown',
+                                },
+                              })
+                            }}
+                          >
+                            Import data from CSV
+                          </Button>
+                          <p className="text-xs text-foreground-light pointer-events-auto">
+                            or drag and drop a CSV file here
+                          </p>
+                        </div>
                       )}
                     </div>
                   ) : (

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -27,8 +27,6 @@ export function useCsvFileDrop({
 
       const [item] = event.dataTransfer.items
 
-      console.log(event.dataTransfer.items)
-
       // ignore non files drop, like column headers
       if (item && item.kind !== 'file') return
 

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,7 +1,6 @@
-import { type DragEvent, useCallback, useState } from 'react'
-
 import { type ImportDataFileDroppedEvent } from 'common/telemetry-constants'
 import { flagInvalidFileImport } from 'components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
+import { useCallback, useState, type DragEvent } from 'react'
 
 interface UseCsvFileDropOptions {
   enabled: boolean
@@ -11,7 +10,6 @@ interface UseCsvFileDropOptions {
 
 interface UseCsvFileDropReturn {
   isDraggedOver: boolean
-  isValidFile: boolean
   onDragOver: (event: DragEvent<HTMLDivElement>) => void
   onFileDrop: (event: DragEvent<HTMLDivElement>) => void
 }
@@ -22,7 +20,6 @@ export function useCsvFileDrop({
   onTelemetryEvent,
 }: UseCsvFileDropOptions): UseCsvFileDropReturn {
   const [isDraggedOver, setIsDraggedOver] = useState(false)
-  const [isValidFile, setIsValidFile] = useState(false)
 
   const onDragOver = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
@@ -30,20 +27,20 @@ export function useCsvFileDrop({
 
       const [item] = event.dataTransfer.items
 
+      console.log(event.dataTransfer.items)
+
       // ignore non files drop, like column headers
       if (item && item.kind !== 'file') return
 
       if (event.type === 'dragover' && !isDraggedOver) {
         setIsDraggedOver(true)
-        setIsValidFile(item.type === 'text/csv')
       } else if (event.type === 'dragleave' || event.type === 'drop') {
         setIsDraggedOver(false)
-        setIsValidFile(false)
       }
       event.stopPropagation()
       event.preventDefault()
     },
-    [enabled, isDraggedOver, isValidFile]
+    [enabled, isDraggedOver]
   )
 
   const onFileDrop = useCallback(
@@ -68,7 +65,6 @@ export function useCsvFileDrop({
   )
 
   return {
-    isValidFile: isValidFile && isDraggedOver,
     isDraggedOver,
     onDragOver,
     onFileDrop,

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -1208,9 +1208,12 @@ testRunner('table editor', () => {
     const gridContainer = page.getByTestId('table-editor-grid-container')
 
     await gridContainer.dispatchEvent('dragover', { dataTransfer })
+
+    // After the refactor, the empty state text and import button remain visible during drag
+    // (no more "Drop your CSV file here" overlay), just a dashed border is shown
     await expect(
-      page.getByText('Drop your CSV file here'),
-      'Drag feedback should show when CSV is dragged over'
+      page.getByText('This table is empty'),
+      'Empty table message should remain visible during drag'
     ).toBeVisible()
 
     await gridContainer.dispatchEvent('drop', { dataTransfer })


### PR DESCRIPTION
## Context

Addresses an error when drag and dropping a CSV in the Table Editor when the table is empty, specifically on Safari leading to a `undefined is not an object (evaluating 'n.type')` error

For context, Safari obscures the item data from the drag event and only exposes it on the drop event ([ref](https://github.com/mdn/browser-compat-data/issues/24898)) hence why this issue

## Changes involved

Am opting to change the UX instead of fixing this browser specific behaviour
- Ignore file validity when dragging, let the on drop handle validate the type and reject unsupported files instead
  - This is better either way as currently our Table Editor shows "CSV files only", when we actually also support TSV files
- Also made a slight adjustment to the drag over UI - border around the grid empty area, rather than the whole grid
  - Before:
    <img width="1151" height="911" alt="image" src="https://github.com/user-attachments/assets/049199aa-86bc-4e88-8444-5a7ee236c8d0" />
  - After:
    <img width="1150" height="912" alt="image" src="https://github.com/user-attachments/assets/698ca8f3-a326-4a82-b1b4-4448aa8d777a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the empty-table display and CSV import interface for a more consistent user experience.
  * Import button and drag-and-drop hints now remain visible when the table is empty, removing prior conditional hiding during drag.
  * Streamlined empty-state styling and messaging for a cleaner, more predictable appearance.

* **Tests**
  * Updated end-to-end test expectations to reflect the persistent empty-state message during drag-over.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->