### PR TITLE
fix: do not expose analytics by default

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -356,7 +356,6 @@ services:
     container_name: supabase-analytics
     image: supabase/logflare:1.30.3
     restart: unless-stopped
-    # Not exposed to host - access analytics dashboard only through Kong
     # ports:
     #   - 4000:4000
     # Uncomment to use Big Query backend for analytics

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -356,8 +356,9 @@ services:
     container_name: supabase-analytics
     image: supabase/logflare:1.30.3
     restart: unless-stopped
-    ports:
-      - 4000:4000
+    # Not exposed to host - access analytics dashboard only through Kong
+    # ports:
+    #   - 4000:4000
     # Uncomment to use Big Query backend for analytics
     # volumes:
     #   - type: bind

--- a/docker/volumes/api/kong.yml
+++ b/docker/volumes/api/kong.yml
@@ -197,29 +197,29 @@ services:
       - name: cors
 
   ## Analytics routes
-  - name: analytics-v1-api
-    _comment: 'Analytics: /analytics/v1/api/endpoints/* -> http://logflare:4000/api/endpoints/*'
-    url: http://analytics:4000/api/endpoints
-    routes:
-      - name: analytics-v1-api
-        strip_path: true
-        paths:
-          - /analytics/v1/api/endpoints/
-
-  # auth on analytics dashboard
-  - name: analytics-v1
-    _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
-    url: http://analytics:4000/
-    routes:
-      - name: dashboard-v1-all
-        strip_path: true
-        paths:
-          - /analytics/v1
-    plugins:
-      - name: cors
-      - name: basic-auth
-        config:
-          hide_credentials: true
+  ## Not used - Studio and Vector talk directly to analytics via Docker networking.
+  ## If external access is needed, add routes with key-auth matching Logflare's x-api-key auth.
+  # - name: analytics-v1-api
+  #   _comment: 'Analytics: /analytics/v1/api/endpoints/* -> http://logflare:4000/api/endpoints/*'
+  #   url: http://analytics:4000/api/endpoints
+  #   routes:
+  #     - name: analytics-v1-api
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1/api/endpoints/
+  # - name: analytics-v1
+  #   _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
+  #   url: http://analytics:4000/
+  #   routes:
+  #     - name: dashboard-v1-all
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1
+  #   plugins:
+  #     - name: cors
+  #     - name: basic-auth
+  #       config:
+  #         hide_credentials: true
 
   ## Secure Database routes
   - name: meta

--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -177,7 +177,8 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
     uri: 'http://analytics:4000/api/logs?source_name=gotrue.logs.prod'
@@ -189,7 +190,8 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
     uri: 'http://analytics:4000/api/logs?source_name=realtime.logs.prod'
@@ -201,7 +203,8 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
     uri: 'http://analytics:4000/api/logs?source_name=postgREST.logs.prod'
@@ -213,13 +216,13 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
-    # We must route the sink through kong because ingesting logs before logflare is fully initialised will
-    # lead to broken queries from studio. This works by the assumption that containers are started in the
-    # following order: vector > db > logflare > kong
-    uri: 'http://kong:8000/analytics/v1/api/logs?source_name=postgres.logs'
+    # Route directly to analytics like other sinks. Retry handles the startup
+    # race where analytics may not be ready yet when early DB logs arrive.
+    uri: 'http://analytics:4000/api/logs?source_name=postgres.logs'
   logflare_functions:
     type: 'http'
     inputs:
@@ -228,7 +231,8 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
     uri: 'http://analytics:4000/api/logs?source_name=deno-relay-logs'
@@ -240,7 +244,8 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
     uri: 'http://analytics:4000/api/logs?source_name=storage.logs.prod.2'
@@ -253,7 +258,8 @@ sinks:
       codec: 'json'
     method: 'post'
     request:
-      retry_max_duration_secs: 10
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
       headers:
         x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
     uri: 'http://analytics:4000/api/logs?source_name=cloudflare.logs.prod'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Following updates in PR #42854, review and change Analytics/Logflare configuration in [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting):

- Send Postgres logs directly to the Logflare container (not via Kong)
- Remove Logflare routes from Kong (no component uses those anymore)
- Do not expose Logflare on 0.0.0.0:4000 (not externally reachable by default)
- Bump timeouts for sinks in Vector

Changed configuration in:
- volumes/api/kong.yml
- volumes/logs/vector.yml
- docker-compose.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Analytics endpoints are no longer exposed on the host port and related gateway route entries were disabled.
* **Reliability**
  * Improved log delivery reliability with increased retry/backoff settings and adjusted routing to handle service startup races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->