### PR TITLE
chore: sentry performance monitoring

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
@@ -739,8 +739,7 @@ export const postgresDetailsFields: BlockFieldConfig[] = [
     label: 'Session Started',
     getValue: (data, enrichedData) => {
       const startTime = enrichedData?.session_start_time || data?.session_start_time
-      // Convert microseconds to milliseconds for JavaScript Date
-      return startTime ? new Date(startTime / 1000).toLocaleString() : null
+      return startTime ? new Date(startTime).toLocaleString() : null
     },
     requiresEnrichedData: true,
   },

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
@@ -33,8 +33,7 @@ export const originFields: BlockFieldConfig[] = [
       if (!data?.timestamp && !data?.date) return null
       try {
         const timestamp = data?.timestamp || data?.date
-        // Convert microseconds to milliseconds for JavaScript Date
-        return new Date(timestamp / 1000).toLocaleString()
+        return new Date(timestamp).toLocaleString()      
       } catch {
         return 'Invalid date'
       }

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
@@ -33,7 +33,7 @@ export const originFields: BlockFieldConfig[] = [
       if (!data?.timestamp && !data?.date) return null
       try {
         const timestamp = data?.timestamp || data?.date
-        return new Date(timestamp).toLocaleString()      
+        return new Date(timestamp).toLocaleString()
       } catch {
         return 'Invalid date'
       }

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
@@ -33,7 +33,8 @@ export const originFields: BlockFieldConfig[] = [
       if (!data?.timestamp && !data?.date) return null
       try {
         const timestamp = data?.timestamp || data?.date
-        return new Date(timestamp).toLocaleString()
+        // Convert microseconds to milliseconds for JavaScript Date
+        return new Date(timestamp / 1000).toLocaleString()
       } catch {
         return 'Invalid date'
       }
@@ -739,7 +740,8 @@ export const postgresDetailsFields: BlockFieldConfig[] = [
     label: 'Session Started',
     getValue: (data, enrichedData) => {
       const startTime = enrichedData?.session_start_time || data?.session_start_time
-      return startTime ? new Date(startTime).toLocaleString() : null
+      // Convert microseconds to milliseconds for JavaScript Date
+      return startTime ? new Date(startTime / 1000).toLocaleString() : null
     },
     requiresEnrichedData: true,
   },

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -57,6 +57,10 @@ Sentry.init({
   }),
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Enable performance monitoring - Next.js routes and API calls are automatically instrumented
+  tracesSampleRate: 0.1, // Capture 10% of transactions for performance monitoring
+
   // [Ali] Filter out browser extensions and user scripts (FE-2094)
   // Using denyUrls to block known third-party script patterns
   denyUrls: [/userscript/i],

--- a/apps/studio/sentry.edge.config.ts
+++ b/apps/studio/sentry.edge.config.ts
@@ -12,4 +12,7 @@ Sentry.init({
   }),
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Enable performance monitoring
+  tracesSampleRate: 0.1, // Capture 10% of transactions for performance monitoring
 })

--- a/apps/studio/sentry.server.config.ts
+++ b/apps/studio/sentry.server.config.ts
@@ -11,6 +11,9 @@ Sentry.init({
   }),
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Enable performance monitoring
+  tracesSampleRate: 0.1, // Capture 10% of transactions for performance monitoring
   ignoreErrors: [
     // Used exclusively in Monaco Editor.
     'ResizeObserver',


### PR DESCRIPTION
  - Added tracesSampleRate: 0.1 to all three Sentry configuration files (client, server, edge)
    - Captures 10% of transactions for performance monitoring
    - Previously: No performance data was being collected (missing this config)
    - Now: Sentry will track route performance, error rates per route, and transaction data

  Why this was needed:
  - Without tracesSampleRate, Sentry's Performance tab was empty
  - Error rates per route were not visible
  - No transaction/route-level metrics were being collected
  - The SDK was only capturing errors without context about which routes they occurred on

  Impact:
  - Enables route-based error tracking (see which endpoints/pages have errors)
  - Provides performance metrics per route (page load times, API response times)
  - Allows monitoring of Web Vitals and navigation performance
  - 10% sample rate balances visibility with Sentry quota usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date display formatting in logs to ensure accurate timestamp representation.

* **Chores**
  * Enabled performance monitoring to collect transaction data and track application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->