### PR TITLE
chore: update images for self-hosted

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2026.01.27-sha-6aa59ff
+    image: supabase/studio:2026.02.16-sha-26c615c
     restart: unless-stopped
     healthcheck:
       test:
@@ -95,7 +95,7 @@ services:
 
   auth:
     container_name: supabase-auth
-    image: supabase/gotrue:v2.185.0
+    image: supabase/gotrue:v2.186.0
     restart: unless-stopped
     healthcheck:
       test:
@@ -178,7 +178,7 @@ services:
 
   rest:
     container_name: supabase-rest
-    image: postgrest/postgrest:v14.3
+    image: postgrest/postgrest:v14.5
     restart: unless-stopped
     depends_on:
       db:
@@ -202,7 +202,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.72.0
+    image: supabase/realtime:v2.76.5
     restart: unless-stopped
     depends_on:
       db:
@@ -242,7 +242,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.37.1
+    image: supabase/storage-api:v1.37.8
     restart: unless-stopped
     volumes:
       - ./volumes/storage:/var/lib/storage:z
@@ -330,7 +330,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.70.0
+    image: supabase/edge-runtime:v1.70.3
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:Z
@@ -354,7 +354,7 @@ services:
 
   analytics:
     container_name: supabase-analytics
-    image: supabase/logflare:1.30.3
+    image: supabase/logflare:1.31.2
     restart: unless-stopped
     # ports:
     #   - 4000:4000

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -8,6 +8,7 @@
 - supabase/storage-api:v1.37.8 (prev supabase/storage-api:v1.37.1)
 - supabase/edge-runtime:v1.70.3 (prev supabase/edge-runtime:v1.70.0)
 - supabase/logflare:1.31.2 (prev supabase/logflare:1.30.3)
+- timberio/vector:0.53.0-alpine (prev timberio/vector:0.28.1-alpine)
 
 ## 2026-02-05
 - supabase/storage-api:v1.37.1 (prev supabase/storage-api:v1.33.5)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,5 +1,14 @@
 # Docker Image Versions
 
+## 2026-02-16
+- supabase/studio:2026.02.16-sha-26c615c (prev supabase/studio:2026.01.27-sha-6aa59ff)
+- supabase/gotrue:v2.186.0 (prev supabase/gotrue:v2.185.0)
+- postgrest/postgrest:v14.5 (prev postgrest/postgrest:v14.3)
+- supabase/realtime:v2.76.5 (prev supabase/realtime:v2.72.0)
+- supabase/storage-api:v1.37.8 (prev supabase/storage-api:v1.37.1)
+- supabase/edge-runtime:v1.70.3 (prev supabase/edge-runtime:v1.70.0)
+- supabase/logflare:1.31.2 (prev supabase/logflare:1.30.3)
+
 ## 2026-02-05
 - supabase/storage-api:v1.37.1 (prev supabase/storage-api:v1.33.5)
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updating images for [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting/docker):

- supabase/studio:2026.02.16-sha-26c615c (prev supabase/studio:2026.01.27-sha-6aa59ff)
- supabase/gotrue:v2.186.0 (prev supabase/gotrue:v2.185.0)
- postgrest/postgrest:v14.5 (prev postgrest/postgrest:v14.3)
- supabase/realtime:v2.76.5 (prev supabase/realtime:v2.72.0)
- supabase/storage-api:v1.37.8 (prev supabase/storage-api:v1.37.1)
- supabase/edge-runtime:v1.70.3 (prev supabase/edge-runtime:v1.70.0)
- supabase/logflare:1.31.2 (prev supabase/logflare:1.30.3)
- timberio/vector:0.53.0-alpine (prev timberio/vector:0.28.1-alpine) -- via PR #42525


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded multiple backend service components to newer releases across the deployment stack.
* **Documentation**
  * Updated the deployment versions log to reflect the latest component releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->