### PR TITLE
Chore/fix robots tag for docs

### DIFF
--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -100,6 +100,11 @@ const nextConfig = {
                 ? 'max-age=31536000; includeSubDomains; preload'
                 : '',
           },
+        ],
+      },
+      {
+        source: '/(docs|blog)/:path*',
+        headers: [
           {
             key: 'X-Robots-Tag',
             value: 'all',

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -111,6 +111,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/dashboard/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex',
+          },
+        ],
+      },
     ]
   },
   async rewrites() {

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -100,6 +100,10 @@ const nextConfig = {
                 ? 'max-age=31536000; includeSubDomains; preload'
                 : '',
           },
+          {
+            key: 'X-Robots-Tag',
+            value: 'all',
+          },
         ],
       },
     ]


### PR DESCRIPTION
## Context

Update next.config in `www` to 
- set `x-robots-tag` to `all` for `/docs` and `/blog`
- set `x-robots-tag` to `noindex` for `/dashboard`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled search engine indexing for documentation and blog pages (X‑Robots-Tag: all).
  * Marked dashboard pages to be excluded from search engine indexing (X‑Robots-Tag: noindex).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->