### PR TITLE
feat: add vitest configuration and tests for X-Robots-Tag headers

### DIFF
--- a/.github/workflows/www-tests.yml
+++ b/.github/workflows/www-tests.yml
@@ -5,6 +5,8 @@ on:
     branches: ['master']
     paths:
       - 'apps/www/**/*.ts*'
+      - 'apps/www/next.config.mjs'
+      - 'apps/www/next.config.js'
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:

--- a/.github/workflows/www-tests.yml
+++ b/.github/workflows/www-tests.yml
@@ -1,0 +1,48 @@
+name: Marketing site tests
+
+on:
+  pull_request:
+    branches: ['master']
+    paths:
+      - 'apps/www/**/*.ts*'
+
+# Cancel old builds on new commit for same workflow + branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          sparse-checkout: |
+            apps/www
+            packages
+            supabase
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm run test
+        working-directory: ./apps/www

--- a/apps/www/next.config.test.ts
+++ b/apps/www/next.config.test.ts
@@ -1,0 +1,26 @@
+import type { NextConfig } from 'next'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@sentry/nextjs', () => ({
+  withSentryConfig: (configFn: any) => (typeof configFn === 'function' ? configFn() : configFn),
+}))
+
+describe('next.config.mjs', () => {
+  it('expect the headers to always have X-Robots-Tag', async () => {
+    const { default: config } = (await import('./next.config.mjs')) as { default: NextConfig }
+    const headers = (await config.headers?.()) || []
+
+    expect(headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '/(docs|blog)/:path*',
+          headers: [{ key: 'X-Robots-Tag', value: 'all' }],
+        }),
+        expect.objectContaining({
+          source: '/dashboard/:path*',
+          headers: [{ key: 'X-Robots-Tag', value: 'noindex' }],
+        }),
+      ])
+    )
+  })
+})

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -14,6 +14,8 @@
     "pretypecheck": "next typegen",
     "typecheck": "pnpm run content:build && tsc --noEmit",
     "content:build": "node scripts/generateStaticContent.mjs",
+    "test": "vitest --run",
+    "test:watch": "vitest watch",
     "postbuild": "node ./internals/generate-sitemap.mjs && ./../../scripts/upload-static-assets.sh"
   },
   "dependencies": {
@@ -111,6 +113,8 @@
     "tsconfig": "workspace:*",
     "unist-util-visit-parents": "5.1.3",
     "uuid": "^9.0.1",
+    "vite-tsconfig-paths": "^4.3.2",
+    "vitest": "catalog:",
     "zod": "catalog:"
   },
   "license": "MIT"

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     }),
   ],
   test: {
-    globals: true,
     exclude: [...configDefaults.exclude, '.next/*'],
   },
 })

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -1,0 +1,14 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { configDefaults, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [
+    tsconfigPaths({
+      projects: ['.'],
+    }),
+  ],
+  test: {
+    globals: true,
+    exclude: [...configDefaults.exclude, '.next/*'],
+  },
+})

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -74,6 +74,7 @@ module.exports = defineConfig([
       'pages/**/*.tsx',
       'app/**/*.tsx',
       'components/interfaces/**/content/**/content.tsx',
+      'vitest.config.ts',
     ],
     rules: {
       'no-restricted-exports': [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1829,6 +1829,12 @@ importers:
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
+      vite-tsconfig-paths:
+        specifier: ^4.3.2
+        version: 4.3.2(supports-color@8.1.1)(typescript@5.9.2)(vite@7.1.11(@types/node@22.13.14)(jiti@2.5.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.1))
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@22.13.14)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@20.0.3(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@5.9.2))(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.1)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -12243,16 +12249,16 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -37945,7 +37951,7 @@ snapshots:
 
   vite-tsconfig-paths@4.3.2(supports-color@8.1.1)(typescript@5.9.2)(vite@7.1.11(@types/node@22.13.14)(jiti@2.5.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.1)):
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.9.2)
     optionalDependencies:


### PR DESCRIPTION
This pull request introduces a testing setup for the Next.js app using Vitest. The main changes include the addition of a test configuration, test scripts, and a sample test for the Next.js config. It also adds relevant dependencies to support Vitest and path resolution, and updates the lock file accordingly.

Testing infrastructure:

* Added a sample test file `next.config.test.ts` using Vitest to verify that specific headers are present in the Next.js configuration.
* Created a Vitest configuration file `vitest.config.ts` with TypeScript path resolution support via the `vite-tsconfig-paths` plugin.

Scripts and dependencies:

* Added `test` and `test:watch` scripts to `package.json` for running and watching tests, and included `vitest` and `vite-tsconfig-paths` as dev dependencies.