### PR TITLE
fix: correct comment typo and remove debug lines in generate-keys.sh

### DIFF
--- a/docker/utils/generate-keys.sh
+++ b/docker/utils/generate-keys.sh
@@ -35,7 +35,7 @@ fi
 
 jwt_secret="$(gen_base64 30)"
 
-# Used in get_token()
+# Used in gen_token()
 header='{"alg":"HS256","typ":"JWT"}'
 iat=$(date +%s)
 exp=$((iat + 5 * 3600 * 24 * 365)) # 5 years
@@ -43,9 +43,6 @@ exp=$((iat + 5 * 3600 * 24 * 365)) # 5 years
 # Normalizes JSON formatting so that the token matches https://www.jwt.io/ results
 anon_payload="{\"role\":\"anon\",\"iss\":\"supabase\",\"iat\":$iat,\"exp\":$exp}"
 service_role_payload="{\"role\":\"service_role\",\"iss\":\"supabase\",\"iat\":$iat,\"exp\":$exp}"
-
-#echo "anon_payload=$anon_payload"
-#echo "service_role_payload=$service_role_payload"
 
 anon_key=$(gen_token "$anon_payload")
 service_role_key=$(gen_token "$service_role_payload")
@@ -65,8 +62,6 @@ minio_root_password=$(gen_hex 16)
 echo ""
 echo "JWT_SECRET=${jwt_secret}"
 echo ""
-#echo "Issued at: $iat"
-#echo "Expire: $exp"
 echo "ANON_KEY=${anon_key}"
 echo "SERVICE_ROLE_KEY=${service_role_key}"
 echo ""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (comment typo + dead code cleanup)

## What is the current behavior?

In `docker/utils/generate-keys.sh`:
1. Line 38 comment says `# Used in get_token()` but the actual function is named `gen_token()` (defined at line 22)
2. There are 4 commented-out debug `echo` lines (payload dumps and timestamp values) that are development leftovers

## What is the new behavior?

1. Comment corrected to reference the actual function name `gen_token()`
2. Removed 4 commented-out debug echo lines that served no purpose

## Additional context

Trivial cleanup — no behavior change, no functional impact. The script runs identically before and after this change.