### PR TITLE
fix: remove duplicate text-sm class in FunctionsEmptyState

### DIFF
--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -219,7 +219,7 @@ export const FunctionsInstructionsLocal = () => {
                 <Code size={20} />
                 <h4 className="text-base text-foreground">Create an Edge Function</h4>
               </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full">
+              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs max-w-full">
                 Create a new edge function called <code>hello-world</code> in your project via the
                 Supabase CLI.
               </p>
@@ -243,7 +243,7 @@ export const FunctionsInstructionsLocal = () => {
                 <Play size={20} />
                 <h4 className="text-base text-foreground">Run Edge Functions locally</h4>
               </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full">
+              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs max-w-full">
                 You can run your Edge Function locally using <code>supabase functions serve</code>.
               </p>
               <div className="mb-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (duplicate CSS class cleanup)

## What is the current behavior?

In `FunctionsInstructionsLocal`, two `<p>` elements have `text-sm` specified twice in their `className`:

```tsx
className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full"
//         ^^^^^^^^                                                       ^^^^^^^^
```

While Tailwind deduplicates at runtime, the duplicate is clearly unintentional and adds noise.

## What is the new behavior?

The second `text-sm` is removed from both elements, leaving:

```tsx
className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs max-w-full"
```

No visual change — purely a code cleanliness fix.