### PR TITLE
fix: correct typos in organization-not-found error messages

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -27,8 +27,8 @@ export const OrgNotFound = ({ slug }: { slug?: string }) => {
               ) : (
                 <>This organization </>
               )}
-              does not exist or you do not have permission to access to it. Contact the the owner if
-              you believe this is a mistake.
+              does not exist or you do not have permission to access it. Contact the owner if you
+              believe this is a mistake.
             </>
           }
         />

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -60,8 +60,8 @@ const OrganizationsPage: NextPageWithLayout = () => {
             description={
               <>
                 The organization <code className="text-code-inline">{orgSlug}</code> does not exist
-                or you do not have permission to access to it. Contact the the owner if you believe
-                this is a mistake.
+                or you do not have permission to access it. Contact the owner if you believe this is
+                a mistake.
               </>
             }
           />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (text typos in user-facing error messages)

## What is the current behavior?

The organization-not-found admonition displays:

> ...does not exist or you do not have permission to access **to** it. Contact **the the** owner if you believe this is a mistake.

Two issues:
1. **"the the owner"** — duplicated word
2. **"access to it"** — incorrect preposition (should be "access it")

This appears in both `apps/studio/pages/organizations.tsx` and `apps/studio/components/interfaces/Organization/OrgNotFound.tsx`.

## What is the new behavior?

> ...does not exist or you do not have permission to access it. Contact the owner if you believe this is a mistake.

## Additional context

Purely textual fix — no logic changes.