### PR TITLE
fix: correct grammar in Realtime settings descriptions

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -267,7 +267,7 @@ export const RealtimeSettings = () => {
                                   <>
                                     <p className="prose max-w-full text-sm">
                                       Private mode is {isSettingToPrivate ? 'being ' : ''}
-                                      enabled, but no RLS policies exists on the{' '}
+                                      enabled, but no RLS policies exist on the{' '}
                                       <code className="text-code-inline">
                                         realtime.messages
                                       </code>{' '}
@@ -329,7 +329,7 @@ export const RealtimeSettings = () => {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Max concurrent clients"
-                          description="Sets maximum number of concurrent clients that can connect to your Realtime service"
+                          description="Sets the maximum number of concurrent clients that can connect to your Realtime service"
                         >
                           <FormControl_Shadcn_>
                             <PrePostTab postTab="clients">
@@ -353,7 +353,7 @@ export const RealtimeSettings = () => {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Max events per second"
-                          description="Sets maximum number of events per second that can be sent to your Realtime service"
+                          description="Sets the maximum number of events per second that can be sent to your Realtime service"
                         >
                           <FormControl_Shadcn_>
                             <PrePostTab postTab="events/s">
@@ -404,7 +404,7 @@ export const RealtimeSettings = () => {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Max presence events per second"
-                          description="Sets maximum number of presence events per second that can be sent to your Realtime service"
+                          description="Sets the maximum number of presence events per second that can be sent to your Realtime service"
                         >
                           <FormControl_Shadcn_>
                             <PrePostTab postTab="events/s">
@@ -455,7 +455,7 @@ export const RealtimeSettings = () => {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Max payload size in KB"
-                          description="Sets maximum number of payload size in KB that can be sent to your Realtime service"
+                          description="Sets the maximum payload size in KB that can be sent to your Realtime service"
                         >
                           <FormControl_Shadcn_>
                             <PrePostTab postTab="KB">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (grammar in user-facing UI text)

## What is the current behavior?

In the Realtime settings page (`RealtimeSettings.tsx`):

1. **Subject-verb disagreement**: "no RLS policies **exists** on the `realtime.messages` table"
2. **Nonsensical phrasing**: "Sets maximum number of **payload size** in KB" — "number of payload size" is ungrammatical
3. **Missing article**: All four setting descriptions say "Sets maximum..." instead of "Sets **the** maximum..."

## What is the new behavior?

1. "no RLS policies **exist** on the `realtime.messages` table"
2. "Sets **the** maximum **payload size** in KB that can be sent to your Realtime service"
3. All descriptions now consistently use "Sets **the** maximum..."

## Additional context

Purely textual fix — no logic changes.