### PR TITLE
fix: move React key prop to outermost Dialog in template list

### DIFF
--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -321,10 +321,9 @@ curl --request POST 'http://localhost:54321/functions/v1/hello-world' \\
         <ScaffoldSectionTitle className="text-xl mt-12">Explore our templates</ScaffoldSectionTitle>
         <ResourceList>
           {templates.map((template) => (
-            <Dialog>
+            <Dialog key={template.name}>
               <DialogTrigger asChild>
                 <ResourceItem
-                  key={template.name}
                   media={<Code strokeWidth={1.5} size={16} className="-translate-y-[9px]" />}
                 >
                   <div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (React key prop placement)

## What is the current behavior?

In `FunctionsInstructionsLocal`, the "Explore our templates" section renders a list of `<Dialog>` components via `.map()`, but the `key` prop is placed on the inner `<ResourceItem>` instead of the outermost `<Dialog>`:

```tsx
{templates.map((template) => (
  <Dialog>                          {/* <-- no key here */}
    <DialogTrigger asChild>
      <ResourceItem
        key={template.name}        {/* <-- key on wrong element */}
```

React requires the `key` to be on the outermost element returned by `.map()` for correct list reconciliation. Without it, React may log a "Each child in a list should have a unique key prop" warning and fail to properly reconcile items when the list changes.

## What is the new behavior?

```tsx
{templates.map((template) => (
  <Dialog key={template.name}>     {/* <-- key on outermost element */}
    <DialogTrigger asChild>
      <ResourceItem
        media={...}                 {/* key removed from here */}
```

## Additional context

Single line change — moves `key` from `ResourceItem` to `Dialog`.