### PR TITLE
fix: update header title to wrap in span instead of fragments

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/HeaderTitle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/HeaderTitle.tsx
@@ -5,11 +5,10 @@ interface HeaderTitleProps {
 
 export const HeaderTitle = ({ isNewRecord, tableName }: HeaderTitleProps) => {
   let header = `${isNewRecord ? 'Add new' : 'Update'} row ${isNewRecord ? 'to' : 'from'} `
-
   return (
-    <>
+    <span>
       {header}
       {tableName && <span className="text-code font-mono">{tableName}</span>}
-    </>
+    </span>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix missing space in Table Editor row panel header ("Add new row totest" → "Add new row to test") by wrapping the HeaderTitle content in a span to prevent flexbox whitespace collapsing between sibling elements. Its only used in a single place 

<img width="670" height="50" alt="Screenshot 2026-02-16 at 2 11 03 PM" src="https://github.com/user-attachments/assets/29ab98b3-bb3e-488d-ac05-c934f7e028a0" />
