### PR TITLE
fix: link 'disable PostgREST access' to Data API settings

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -469,7 +469,14 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
                   <p>
                     Foreign tables do not enforce RLS, which may allow unrestricted access. To
                     secure them, either move foreign tables to a private schema not exposed by
-                    PostgREST, or <a href="">disable PostgREST access</a> entirely.
+                    PostgREST, or{' '}
+                    <Link
+                      href={`/project/${ref}/integrations/data_api/overview`}
+                      className="underline hover:text-foreground transition"
+                    >
+                      disable PostgREST access
+                    </Link>{' '}
+                    entirely.
                   </p>
 
                   <div className="mt-2">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (broken link in UI)

## What is the current behavior?

In the Table Editor's foreign table security popover (`GridHeaderActions.tsx`), the text "disable PostgREST access" is wrapped in `<a href="">` — an empty anchor that navigates nowhere useful when clicked (just reloads the current page fragment).

```tsx
<a href="">disable PostgREST access</a>
```

## What is the new behavior?

Replaced with a Next.js `Link` pointing to the project's Data API overview page (`/project/${ref}/integrations/data_api/overview`) where the PostgREST enable/disable toggle actually lives:

```tsx
<Link
  href={`/project/${ref}/integrations/data_api/overview`}
  className="underline hover:text-foreground transition"
>
  disable PostgREST access
</Link>
```

## Additional context

The `Link` import from `next/link` was already present in the file. The styling uses `underline` for inline link appearance consistent with the surrounding text context.