### PR TITLE
fix(studio): always render DeployEdgeFunctionButton on Edge Functions

### DIFF
--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -199,7 +199,7 @@ EdgeFunctionsPage.getLayout = (page: React.ReactElement) => {
                     Examples
                   </a>
                 </Button>
-                {IS_PLATFORM && <DeployEdgeFunctionButton />}
+                <DeployEdgeFunctionButton />
               </PageHeaderAside>
             </PageHeaderMeta>
           </PageHeader>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The **"Deploy Edge Function"** button is not displayed when running Studio locally (non-platform environments).

This happens because the button rendering is guarded by the `IS_PLATFORM` flag. As a result, users running Studio outside of the platform (e.g. local development) cannot create or deploy Edge Functions from the UI, even though this workflow is now supported.

## What is the new behavior?

The `DeployEdgeFunctionButton` is now always rendered, regardless of the `IS_PLATFORM` flag.

Since Studio now supports deploying Edge Functions outside of the platform environment, the guard is no longer necessary. This ensures that:

- The deploy/create function button is visible locally
- The UI behavior is consistent between platform and non-platform environments
- Developers can create and deploy Edge Functions during local development

## Additional context

This change removes the `IS_PLATFORM` conditional check around `DeployEdgeFunctionButton`.

No functional logic was modified beyond the conditional rendering.