### PR TITLE
fix: correct JavaScript and TypeScript capitalization in UI text

### DIFF
--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -305,7 +305,7 @@ curl --request POST 'http://localhost:54321/functions/v1/hello-world' \\
               </div>
               <p className="text-sm text-foreground-light mt-1 mb-4 max-w-3xl">
                 Supabase Edge Runtime consists of a web server based on the Deno runtime, capable of
-                running Javascript, Typescript, and WASM services. You may self-host edge functions
+                running JavaScript, TypeScript, and WASM services. You may self-host edge functions
                 on providers like Fly.io, Digital Ocean, or AWS.
               </p>
               <div className="flex items-center gap-x-2">

--- a/apps/studio/components/interfaces/ProjectAPIDocs/LanguageSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/LanguageSelector.tsx
@@ -52,7 +52,7 @@ const LanguageSelector = ({ simplifiedVersion = false }: LanguageSelectorProps) 
             iconRight={!simplifiedVersion && <ChevronDown size={14} strokeWidth={2} />}
           >
             {!simplifiedVersion
-              ? `Language: ${snap.docsLanguage === 'js' ? 'Javascript' : 'Bash'}`
+              ? `Language: ${snap.docsLanguage === 'js' ? 'JavaScript' : 'Bash'}`
               : undefined}
           </Button>
         </PopoverTrigger_Shadcn_>
@@ -65,7 +65,7 @@ const LanguageSelector = ({ simplifiedVersion = false }: LanguageSelectorProps) 
                   onSelect={() => updateLanguage('js')}
                   onClick={() => updateLanguage('js')}
                 >
-                  <p>Javascript</p>
+                  <p>JavaScript</p>
                 </CommandItem_Shadcn_>
                 <CommandItem_Shadcn_
                   className="cursor-pointer"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (incorrect branding in user-facing text)

## What is the current behavior?

Three places in the studio use "Javascript" and "Typescript" (lowercase 's') which are incorrect capitalizations:

1. **FunctionsEmptyState.tsx** (self-hosting section): "running **Javascript**, **Typescript**, and WASM services"
2. **LanguageSelector.tsx** (dropdown label): "Language: **Javascript**"
3. **LanguageSelector.tsx** (menu item): "**Javascript**"

## What is the new behavior?

Corrected to the official camelCase names:
- "Javascript" -> "JavaScript"
- "Typescript" -> "TypeScript"

## Additional context

The official names are "JavaScript" (capital S) and "TypeScript" (capital S), as per the [ECMAScript specification](https://ecma-international.org/publications-and-standards/standards/ecma-262/) and [TypeScript website](https://www.typescriptlang.org/).