### PR TITLE
fix: correct TypeScript capitalization across studio, docs, and www

### DIFF
--- a/apps/docs/app/guides/database/database-advisors/page.tsx
+++ b/apps/docs/app/guides/database/database-advisors/page.tsx
@@ -162,7 +162,7 @@ const getLints = async () => {
 
   if (!Array.isArray(response.data)) {
     throw Error(
-      'Reading a directory, not a file. Should not reach this, solely to appease Typescript.'
+      'Reading a directory, not a file. Should not reach this, solely to appease TypeScript.'
     )
   }
 

--- a/apps/docs/scripts/search/sources/lint-warnings-guide.ts
+++ b/apps/docs/scripts/search/sources/lint-warnings-guide.ts
@@ -37,7 +37,7 @@ export class LintWarningsGuideLoader extends BaseLoader {
 
     if (!Array.isArray(response.data)) {
       throw Error(
-        'Reading a directory, not a file. Should not reach this, solely to appease Typescript.'
+        'Reading a directory, not a file. Should not reach this, solely to appease TypeScript.'
       )
     }
 

--- a/apps/studio/components/interfaces/Home/Home.constants.ts
+++ b/apps/studio/components/interfaces/Home/Home.constants.ts
@@ -23,7 +23,7 @@ export const EXAMPLE_PROJECTS = [
   {
     framework: 'Expo',
     title: 'Expo Starter',
-    description: 'Template bottom tabs with auth flow (Typescript)',
+    description: 'Template bottom tabs with auth flow (TypeScript)',
     url: 'https://github.com/codingki/react-native-expo-template/tree/master/template-typescript-bottom-tabs-supabase-auth-flow',
     type: 'mobile',
   },

--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts
@@ -2,7 +2,7 @@ export const PERMISSIONS_DESCRIPTIONS = {
   ANALYTICS: 'access to analytics logs.',
   AUTH: 'access to auth configurations and SSO providers.',
   DATABASE:
-    'access to Postgres configurations, SQL snippets, SSL enforcement configurations and Typescript schema types.',
+    'access to Postgres configurations, SQL snippets, SSL enforcement configurations and TypeScript schema types.',
   DOMAINS: 'access to custom domains and vanity subdomains.',
   EDGE_FUNCTIONS: 'access to edge functions.',
   ENVIRONMENT: 'access to environments/branches.',

--- a/apps/www/components/LaunchWeek/X/Releases/data/lwx_advent_days.tsx
+++ b/apps/www/components/LaunchWeek/X/Releases/data/lwx_advent_days.tsx
@@ -347,7 +347,7 @@ export const days: AdventDay[] = [
       },
       {
         url: '/blog/client-libraries-v2#typescript-v2-updates',
-        label: 'Typescript',
+        label: 'TypeScript',
         icon: (
           <svg
             width="100%"

--- a/apps/www/data/Examples.ts
+++ b/apps/www/data/Examples.ts
@@ -162,7 +162,7 @@ const Examples: Example[] = [
     tags: ['Expo', 'React'],
     products: [PRODUCT_NAMES.DATABASE],
     title: 'Expo React Native Starter',
-    description: 'Template bottom tabs with auth flow (Typescript)',
+    description: 'Template bottom tabs with auth flow (TypeScript)',
     author: 'codingki',
     author_url: 'https://github.com/codingki',
     author_img: 'https://avatars.githubusercontent.com/u/39829726',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (text correction)

## What is the current behavior?

Several files use "Typescript" (lowercase 's') instead of the official camelCase "TypeScript":

- `apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts` - OAuth permission description
- `apps/studio/components/interfaces/Home/Home.constants.ts` - Expo starter template description
- `apps/docs/scripts/search/sources/lint-warnings-guide.ts` - error message string
- `apps/docs/app/guides/database/database-advisors/page.tsx` - error message string
- `apps/www/data/Examples.ts` - Expo template description
- `apps/www/components/LaunchWeek/X/Releases/data/lwx_advent_days.tsx` - advent calendar label

## What is the new behavior?

All instances now use the correct "TypeScript" capitalization (capital 'S'), matching the official branding.

## Additional context

Companion to PRs fixing "Javascript" -> "JavaScript" across the codebase.