### PR TITLE
fix: correct GitHub and GitLab capitalization in user-facing text

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -574,7 +574,7 @@ export const SocialLoginItems: Array<Partial<NavMenuSection>> = [
     hasLightIcon: true,
   },
   {
-    name: 'Gitlab',
+    name: 'GitLab',
     icon: '/docs/img/icons/gitlab-icon',
     url: '/guides/auth/social-login/auth-gitlab',
   },

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
@@ -225,7 +225,7 @@ View all the available [Third Party OAuth providers](https://supabase.com).
 
 After they have logged in, all interactions using the Supabase JS client will be performed as "that user".
 
-Generate your Client ID and secret from: [Google](https://console.developers.google.com/apis/credentials), [Github](https://github.com/settings/applications/new), [Gitlab](https://gitlab.com/oauth/applications), [Facebook](https://developers.facebook.com/apps), and [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud).`,
+Generate your Client ID and secret from: [Google](https://console.developers.google.com/apis/credentials), [GitHub](https://github.com/settings/applications/new), [GitLab](https://gitlab.com/oauth/applications), [Facebook](https://developers.facebook.com/apps), and [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud).`,
     js: (apikey?: string, endpoint?: string) => `
 const { data, error } = await supabase.auth.signInWithOAuth({
   provider: 'github'

--- a/apps/ui-library/content/docs/nextjs/social-auth.mdx
+++ b/apps/ui-library/content/docs/nextjs/social-auth.mdx
@@ -6,7 +6,7 @@ description: Social authentication block for Next.js
 <BlockPreview name="social-auth/auth/login" />
 
 <Callout className="mt-4">
-  The block is using Github provider by default, but can be easily switched by changing a single
+  The block is using GitHub provider by default, but can be easily switched by changing a single
   parameter.
 </Callout>
 

--- a/apps/ui-library/content/docs/nuxtjs/social-auth.mdx
+++ b/apps/ui-library/content/docs/nuxtjs/social-auth.mdx
@@ -6,7 +6,7 @@ description: Social authentication block for Nuxt.js
 <BlockPreview name="social-auth/auth/login" />
 
 <Callout className="mt-4">
-  The block is using Github provider by default, but can be easily switched by changing a single
+  The block is using GitHub provider by default, but can be easily switched by changing a single
   parameter.
 </Callout>
 

--- a/apps/www/components/LaunchWeek/7/Releases/components/index.tsx
+++ b/apps/www/components/LaunchWeek/7/Releases/components/index.tsx
@@ -261,7 +261,7 @@ export const SectionButtons = ({
       )}
       {!!github && (
         <ChipLink href={github} target="_blank">
-          Github
+          GitHub
           <div className="bg-[#313131] rounded-full hidden sm:inline-block p-1 ml-2">
             <GithubSvg />
           </div>

--- a/apps/www/components/Wrapped/Pages/Devs.tsx
+++ b/apps/www/components/Wrapped/Pages/Devs.tsx
@@ -68,7 +68,7 @@ const gridStats: GridStat[] = [
     suffix: 'PB',
   },
   {
-    headline: 'One of the top 100 repos on Github',
+    headline: 'One of the top 100 repos on GitHub',
     number: 94_500,
     increment: 0,
     suffix: 'stars',

--- a/apps/www/pages/auth.tsx
+++ b/apps/www/pages/auth.tsx
@@ -125,7 +125,7 @@ function AuthPage() {
               <h4 className="h4">All the social providers</h4>
               <p className="p text-base">
                 Enable social logins with the click of a button. Google, Facebook, GitHub, Azure
-                (Microsoft), Gitlab, Twitter, Discord, and many more.
+                (Microsoft), GitLab, Twitter, Discord, and many more.
               </p>
             </div>
             <div className="col-span-12 mb-10 lg:col-span-3 lg:col-start-5 lg:mb-0">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (text correction)

## What is the current behavior?

Several user-facing strings use "Github" instead of "GitHub" and "Gitlab" instead of "GitLab", which don't match the official brand capitalization.

**GitHub fixes:**
- `apps/www/components/Wrapped/Pages/Devs.tsx` - "top 100 repos on Github"
- `apps/www/components/LaunchWeek/7/Releases/components/index.tsx` - chip link text
- `apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts` - markdown link text
- `apps/ui-library/content/docs/nuxtjs/social-auth.mdx` - "Github provider"
- `apps/ui-library/content/docs/nextjs/social-auth.mdx` - "Github provider"

**GitLab fixes:**
- `apps/www/pages/auth.tsx` - social providers list
- `apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts` - nav menu name
- `apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts` - markdown link text

## What is the new behavior?

All instances now use the official brand capitalization: "GitHub" and "GitLab".

## Additional context

Only user-facing text was changed. Lucide icon imports (`Github` from `lucide-react`) and Kotlin SDK enum values (`Github`, `Gitlab`) were left unchanged as those are API/library identifiers.