### PR TITLE
fix: fix Postgres typo, placeholder text, and comment misspelling

### DIFF
--- a/apps/studio/lib/api/apiHelpers.ts
+++ b/apps/studio/lib/api/apiHelpers.ts
@@ -19,7 +19,7 @@ export function constructHeaders(headers: { [prop: string]: any }) {
       'Content-Type': headers['Content-Type'],
       'x-connection-encrypted': headers['x-connection-encrypted'],
     } as any
-    // clean up key with underfined value
+    // clean up key with undefined value
     Object.keys(cleansedHeaders).forEach((key) =>
       cleansedHeaders[key] === undefined ? delete cleansedHeaders[key] : {}
     )

--- a/apps/www/data/solutions/postgres-developers.tsx
+++ b/apps/www/data/solutions/postgres-developers.tsx
@@ -462,8 +462,8 @@ const data: () => {
           icon: '',
           subheading: (
             <>
-              Tap into the <span className="text-foreground">full Posgres ecosystem</span>,
-              including pgvector, PostGIS, pg_stat_statements, and over XX more Postgres extensions.
+              Tap into the <span className="text-foreground">full Postgres ecosystem</span>,
+              including pgvector, PostGIS, pg_stat_statements, and over 50 more Postgres extensions.
             </>
           ),
           image: (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (text correction)

## What is the current behavior?

1. `apps/www/data/solutions/postgres-developers.tsx` line 465: "full **Posgres** ecosystem" (missing 't')
2. Same file line 466: "over **XX** more Postgres extensions" (unfilled placeholder)
3. `apps/studio/lib/api/apiHelpers.ts` line 22: comment says "**underfined**" instead of "undefined"

## What is the new behavior?

1. Fixed to "full **Postgres** ecosystem"
2. Replaced placeholder with "over **50**" (consistent with the features page at `apps/www/data/features.tsx` which states "over 50 pre-configured extensions")
3. Fixed comment to "**undefined**"

## Additional context

No behavioral changes - only text/comment corrections.