### PR TITLE
fix: correct LinkedIn, YouTube, and Stack Overflow brand names

### DIFF
--- a/apps/docs/components/Navigation/Footer.tsx
+++ b/apps/docs/components/Navigation/Footer.tsx
@@ -81,7 +81,7 @@ const Footer = ({ className }: { className?: string }) => (
             href="https://youtube.com/c/supabase"
             className="text-foreground-muted hover:text-foreground transition"
           >
-            <span className="sr-only">Youtube</span>
+            <span className="sr-only">YouTube</span>
             <IconYoutubeSolid size={14} />
           </a>
         </div>

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
@@ -55,7 +55,7 @@ const ContentAccordionLink = React.memo(function ContentAccordionLink(props: any
   useEffect(() => {
     // scroll to active item
     if (activeItem && activeItemRef.current) {
-      // this is a hack, but seems a common one on Stackoverflow
+      // this is a hack, but seems a common one on Stack Overflow
       setTimeout(() => {
         activeItemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
       }, 0)

--- a/apps/www/components/Blog/ShareArticleActions.tsx
+++ b/apps/www/components/Blog/ShareArticleActions.tsx
@@ -29,7 +29,7 @@ const ShareArticleActions = ({
       </Link>
 
       <Link
-        aria-label="Share on Linkedin"
+        aria-label="Share on LinkedIn"
         href={`https://www.linkedin.com/shareArticle?url=${permalink}&text=${encodedTitle}`}
         target="_blank"
         className="text-foreground-lighter hover:text-foreground"

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -125,7 +125,7 @@ const Footer = (props: Props) => {
                 href="https://youtube.com/c/supabase"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
-                <span className="sr-only">Youtube</span>
+                <span className="sr-only">YouTube</span>
                 <IconYoutubeSolid size={22} />
               </a>
             </div>

--- a/apps/www/components/LaunchWeek/15/Ticketing/LW15TicketShare.tsx
+++ b/apps/www/components/LaunchWeek/15/Ticketing/LW15TicketShare.tsx
@@ -94,7 +94,7 @@ export default function LW15TicketShare() {
         asChild
       >
         <Link href={linkedInUrl} target="_blank">
-          {userData.shared_on_linkedin ? 'Shared on Linkedin' : 'Share on Linkedin'}
+          {userData.shared_on_linkedin ? 'Shared on LinkedIn' : 'Share on LinkedIn'}
         </Link>
       </Button>
     </div>

--- a/apps/www/data/Press.ts
+++ b/apps/www/data/Press.ts
@@ -46,7 +46,7 @@ const data: PressItem[] = [
     type: 'podcast',
     href: 'https://stackoverflow.blog/2022/05/17/open-source-is-winning-over-developers-and-investors-ep-442/',
     title: 'Open-source is winning over developers and investors',
-    publisher: 'Stackoverflow',
+    publisher: 'Stack Overflow',
   },
   {
     type: 'podcast',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (text correction)

## What is the current behavior?

Several user-facing strings use incorrect brand name capitalization:

- **LinkedIn**: "Linkedin" in share button aria-label and link text
- **YouTube**: "Youtube" in footer screen-reader-only text
- **Stack Overflow**: "Stackoverflow" in press page publisher name and code comment

## What is the new behavior?

All brand names now use their official capitalization:
- "Linkedin" -> "LinkedIn"
- "Youtube" -> "YouTube"
- "Stackoverflow" -> "Stack Overflow"

### Files changed:
- `apps/www/components/Blog/ShareArticleActions.tsx` - aria-label
- `apps/www/components/LaunchWeek/15/Ticketing/LW15TicketShare.tsx` - button text
- `apps/docs/components/Navigation/Footer.tsx` - sr-only text
- `apps/www/components/Footer/index.tsx` - sr-only text
- `apps/www/data/Press.ts` - publisher name
- `apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx` - comment

## Additional context

No behavioral changes. Only text and accessibility label corrections.