### PR TITLE
fix: replace deprecated scale-600 tokens and remove duplicate hover class

### DIFF
--- a/apps/studio/components/interfaces/Database/Privileges/PrivilegesHead.tsx
+++ b/apps/studio/components/interfaces/Database/Privileges/PrivilegesHead.tsx
@@ -50,7 +50,7 @@ const PrivilegesHead = ({
           onSelectSchema={onChangeSchema}
         />
         <TablesSelect selectedTable={selectedTable} tables={tables} onChangeTable={onChangeTable} />
-        <div className="h-[20px] w-px border-r border-scale-600"></div>
+        <div className="h-[20px] w-px border-r border-default"></div>
         <RolesSelect selectedRole={selectedRole} roles={roles} onChangeRole={onChangeRole} />
       </div>
 

--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover.tsx
@@ -189,7 +189,7 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                   </span>{' '}
                   channel:
                 </p>
-                <p className="text-xs border border-scale-600  py-0.5 px-1 rounded-md bg-surface-200">
+                <p className="text-xs border border-default py-0.5 px-1 rounded-md bg-surface-200">
                   {config.channelName}
                 </p>
               </div>

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/BlockField.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/BlockField.tsx
@@ -75,7 +75,7 @@ export const BlockField = ({
         filterFields={filterFields}
         value={stringValue}
         table={table}
-        className="flex justify-between items-center py-1 px-2  rounded hover:bg-accent/50 cursor-pointer w-full hover:bg-surface-400"
+        className="flex justify-between items-center py-1 px-2 rounded hover:bg-surface-400 cursor-pointer w-full"
       >
         {fieldContent}
       </DataTableSheetRowAction>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (styling cleanup)

## What is the current behavior?

1. **`BlockField.tsx`**: Has conflicting hover classes `hover:bg-accent/50` and `hover:bg-surface-400` on the same element, plus an extra space in the className
2. **`ChooseChannelPopover.tsx`**: Uses deprecated `border-scale-600` token (no longer in Tailwind config) plus an extra space
3. **`PrivilegesHead.tsx`**: Uses deprecated `border-scale-600` token

## What is the new behavior?

1. Removed redundant `hover:bg-accent/50` (kept `hover:bg-surface-400` which is the semantic token)
2. Replaced `border-scale-600` with `border-default` (the semantic equivalent)
3. Same replacement for PrivilegesHead

## Additional context

`border-scale-600` is a deprecated token that is no longer defined in the Tailwind config. The semantic replacement is `border-default` which adapts to both light and dark themes.