### PR TITLE
fix: correct HTTPS and OpenAI capitalization

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.constants.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.constants.ts
@@ -45,7 +45,7 @@ const httpRequestSchema = z.object({
     .trim()
     .min(1, 'Please provide a URL')
     .regex(urlRegex(), 'Please provide a valid URL')
-    .refine((value) => value.startsWith('http'), 'Please include HTTP/HTTPs to your URL'),
+    .refine((value) => value.startsWith('http'), 'Please include HTTP/HTTPS in your URL'),
   timeoutMs: z.coerce.number().int().gte(1000).lte(5000).default(1000),
   httpHeaders: z.array(z.object({ name: z.string(), value: z.string() })),
   httpBody: z

--- a/apps/www/components/Products/VectorAI/OpenAIImage.tsx
+++ b/apps/www/components/Products/VectorAI/OpenAIImage.tsx
@@ -287,7 +287,7 @@ const OpenAIImage = ({ isHovered }: { isHovered: boolean }) => {
           }
           layout="fill"
           objectFit="contain"
-          alt="OpenAi logo"
+          alt="OpenAI logo"
         />
       </div>
       <LazyMotion features={domAnimation}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (text correction)

## What is the current behavior?

1. `apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.constants.ts`: Validation error says "Please include HTTP/HTTPs to your URL" - incorrect capitalization ("HTTPs") and awkward grammar ("to your URL")
2. `apps/www/components/Products/VectorAI/OpenAIImage.tsx`: Image alt text says "OpenAi logo" instead of "OpenAI logo"

## What is the new behavior?

1. Fixed to "Please include HTTP/HTTPS in your URL" (correct all-caps HTTPS + better preposition)
2. Fixed alt text to "OpenAI logo" (matching the official brand name)

## Additional context

No behavioral changes. Text corrections only.