### PR TITLE
fix: correct "supbase" typos to "supabase" in docs

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -3031,14 +3031,14 @@ export const reference = {
           enabled: sdkCsharpEnabled,
         },
         {
-          name: 'supbase-python',
+          name: 'supabase-python',
           url: '/reference/python/start',
           level: 'reference_python',
           icon: '/img/icons/menu/reference-python' as `/${string}`,
           enabled: sdkPythonEnabled,
         },
         {
-          name: 'supbase-swift',
+          name: 'supabase-swift',
           url: '/reference/swift/start',
           level: 'reference_swift',
           items: [],

--- a/apps/docs/content/guides/auth/social-login/auth-workos.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-workos.mdx
@@ -65,7 +65,7 @@ Visit the WorkOS dashboard and click the redirects button in the left navigation
 
 On the redirects page, enter your Supabase project's `Callback URL (for OAuth)` which you saved in the previous step, as shown below:
 
-![Set your Supbase project redirect URL in the WorkOS dashboard](/docs/img/guides/auth-workos/workos-set-supabase-redirect.png)
+![Set your Supabase project redirect URL in the WorkOS dashboard](/docs/img/guides/auth-workos/workos-set-supabase-redirect.png)
 
 ## Step 5. Add login code to your client app
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (typo correction)

## What is the current behavior?

Three places misspell "supabase" as "supbase":

1. `apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts` line 3034: `name: 'supbase-python'` (should match pattern of `supabase-js`, `supabase-dart`, `supabase-csharp`)
2. Same file line 3041: `name: 'supbase-swift'`
3. `apps/docs/content/guides/auth/social-login/auth-workos.mdx` line 68: "Set your **Supbase** project redirect URL" in image alt text

## What is the new behavior?

All instances corrected to "supabase":
1. `name: 'supabase-python'`
2. `name: 'supabase-swift'`
3. "Set your **Supabase** project redirect URL"

## Additional context

No behavioral changes. The `name` field in NavigationMenu.constants.ts is used as an identifier for the navigation items.