### PR TITLE
Add 131 unit tests for pg-meta SQL generation

### DIFF
--- a/packages/pg-meta/test/sql-generation/functions.test.ts
+++ b/packages/pg-meta/test/sql-generation/functions.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from 'vitest'
+
+import * as pgFunctions from '../../src/pg-meta-functions'
+import type { PGFunction } from '../../src/pg-meta-functions'
+
+describe('pg-meta-functions SQL generation', () => {
+  describe('list', () => {
+    test('should generate basic list query without options', () => {
+      const { sql } = pgFunctions.list()
+      expect(sql).toContain('select')
+      expect(sql).toContain('from f')
+      expect(sql).not.toContain('limit')
+      expect(sql).not.toContain('offset')
+    })
+
+    test('should include system schema filter when includeSystemSchemas is false', () => {
+      const { sql } = pgFunctions.list({ includeSystemSchemas: false })
+      expect(sql).toContain('where schema')
+      expect(sql).toContain('NOT IN')
+    })
+
+    test('should not include system schema filter when includeSystemSchemas is true', () => {
+      const { sql } = pgFunctions.list({ includeSystemSchemas: true })
+      expect(sql).not.toContain('NOT IN')
+    })
+
+    test('should apply limit when provided', () => {
+      const { sql } = pgFunctions.list({ limit: 10 })
+      expect(sql).toContain('limit 10')
+    })
+
+    test('should apply offset when provided', () => {
+      const { sql } = pgFunctions.list({ offset: 20 })
+      expect(sql).toContain('offset 20')
+    })
+
+    test('should apply both limit and offset', () => {
+      const { sql } = pgFunctions.list({ limit: 10, offset: 20 })
+      expect(sql).toContain('limit 10')
+      expect(sql).toContain('offset 20')
+    })
+
+    test('should filter by included schemas', () => {
+      const { sql } = pgFunctions.list({ includedSchemas: ['public', 'custom'] })
+      expect(sql).toContain('where schema')
+      expect(sql).toContain('IN')
+      expect(sql).toContain("'public'")
+      expect(sql).toContain("'custom'")
+    })
+
+    test('should filter by excluded schemas', () => {
+      const { sql } = pgFunctions.list({
+        includeSystemSchemas: true,
+        excludedSchemas: ['internal'],
+      })
+      expect(sql).toContain('NOT IN')
+      expect(sql).toContain("'internal'")
+    })
+  })
+
+  describe('retrieve', () => {
+    test('should retrieve by id', () => {
+      const { sql } = pgFunctions.retrieve({ id: 42 })
+      expect(sql).toContain('where id =')
+      expect(sql).toContain('42')
+    })
+
+    test('should retrieve by name, schema, and args', () => {
+      const { sql } = pgFunctions.retrieve({
+        name: 'my_func',
+        schema: 'public',
+        args: ['integer', 'text'],
+      })
+      expect(sql).toContain("'my_func'")
+      expect(sql).toContain("'public'")
+      expect(sql).toContain("'integer'")
+      expect(sql).toContain("'text'")
+    })
+
+    test('should retrieve by name with empty args', () => {
+      const { sql } = pgFunctions.retrieve({
+        name: 'no_args_func',
+        schema: 'public',
+        args: [],
+      })
+      expect(sql).toContain("'no_args_func'")
+      expect(sql).toContain("'public'")
+      // empty args should use literal empty string comparison
+      expect(sql).toContain("''")
+    })
+
+    test('should use public as default schema', () => {
+      const { sql } = pgFunctions.retrieve({
+        name: 'my_func',
+        schema: 'public',
+        args: [],
+      })
+      expect(sql).toContain("'public'")
+    })
+  })
+
+  describe('create', () => {
+    test('should generate basic create function SQL', () => {
+      const { sql } = pgFunctions.create({
+        name: 'hello',
+        definition: "SELECT 'hello'",
+      })
+      expect(sql).toContain('CREATE')
+      expect(sql).toContain('FUNCTION')
+      expect(sql).toContain('hello')
+      expect(sql).toContain('RETURNS void')
+      expect(sql).toContain('LANGUAGE sql')
+      expect(sql).toContain('VOLATILE')
+      expect(sql).toContain('SECURITY INVOKER')
+    })
+
+    test('should generate create function with custom return type and language', () => {
+      const { sql } = pgFunctions.create({
+        name: 'get_count',
+        definition: 'SELECT count(*) FROM users',
+        return_type: 'bigint',
+        language: 'plpgsql',
+      })
+      expect(sql).toContain('RETURNS bigint')
+      expect(sql).toContain('LANGUAGE plpgsql')
+    })
+
+    test('should generate create function with security definer', () => {
+      const { sql } = pgFunctions.create({
+        name: 'secure_func',
+        definition: 'SELECT 1',
+        security_definer: true,
+      })
+      expect(sql).toContain('SECURITY DEFINER')
+      expect(sql).not.toContain('SECURITY INVOKER')
+    })
+
+    test('should generate create function with args', () => {
+      const { sql } = pgFunctions.create({
+        name: 'add_nums',
+        definition: 'SELECT a + b',
+        args: ['a integer', 'b integer'],
+        return_type: 'integer',
+      })
+      expect(sql).toContain('a integer, b integer')
+    })
+
+    test('should generate create function with behavior', () => {
+      const { sql } = pgFunctions.create({
+        name: 'immutable_func',
+        definition: 'SELECT 42',
+        behavior: 'IMMUTABLE',
+        return_type: 'integer',
+      })
+      expect(sql).toContain('IMMUTABLE')
+    })
+
+    test('should generate create function with config params', () => {
+      const { sql } = pgFunctions.create({
+        name: 'configured_func',
+        definition: 'SELECT 1',
+        config_params: { search_path: "'public'" },
+      })
+      expect(sql).toContain("SET search_path TO 'public'")
+    })
+
+    test('should handle config params with FROM CURRENT', () => {
+      const { sql } = pgFunctions.create({
+        name: 'current_config_func',
+        definition: 'SELECT 1',
+        config_params: { search_path: 'FROM CURRENT' },
+      })
+      expect(sql).toContain('SET search_path FROM CURRENT')
+    })
+
+    test('should handle config params with empty string value', () => {
+      const { sql } = pgFunctions.create({
+        name: 'empty_config_func',
+        definition: 'SELECT 1',
+        config_params: { search_path: '""' },
+      })
+      expect(sql).toContain("SET search_path TO ''")
+    })
+
+    test('should use custom schema', () => {
+      const { sql } = pgFunctions.create({
+        name: 'custom_func',
+        schema: 'my_schema',
+        definition: 'SELECT 1',
+      })
+      expect(sql).toContain('my_schema')
+    })
+  })
+
+  describe('update', () => {
+    const mockFunction: PGFunction = {
+      id: 1,
+      schema: 'public',
+      name: 'old_func',
+      language: 'sql',
+      definition: 'SELECT 1',
+      complete_statement: 'CREATE FUNCTION public.old_func() RETURNS void AS $$ SELECT 1 $$ LANGUAGE sql',
+      args: [],
+      argument_types: '',
+      identity_argument_types: '',
+      return_type_id: 2278,
+      return_type: 'void',
+      return_type_relation_id: null,
+      is_set_returning_function: false,
+      behavior: 'VOLATILE',
+      security_definer: false,
+      config_params: null,
+    }
+
+    test('should generate update definition SQL', () => {
+      const { sql } = pgFunctions.update(mockFunction, {
+        definition: 'SELECT 2',
+      })
+      expect(sql).toContain('CREATE OR REPLACE FUNCTION')
+      expect(sql).toContain("'SELECT 2'")
+    })
+
+    test('should generate rename SQL when name changes', () => {
+      const { sql } = pgFunctions.update(mockFunction, {
+        name: 'new_func',
+      })
+      expect(sql).toContain('RENAME TO')
+      expect(sql).toContain('new_func')
+    })
+
+    test('should generate schema change SQL', () => {
+      const { sql } = pgFunctions.update(mockFunction, {
+        schema: 'new_schema',
+      })
+      expect(sql).toContain('SET SCHEMA')
+      expect(sql).toContain('new_schema')
+    })
+
+    test('should not generate rename SQL when name is the same', () => {
+      const { sql } = pgFunctions.update(mockFunction, {
+        name: 'old_func',
+      })
+      expect(sql).not.toContain('RENAME TO')
+    })
+
+    test('should not generate schema change SQL when schema is the same', () => {
+      const { sql } = pgFunctions.update(mockFunction, {
+        schema: 'public',
+      })
+      expect(sql).not.toContain('SET SCHEMA')
+    })
+
+    test('should handle combined name, schema, and definition update', () => {
+      const { sql } = pgFunctions.update(mockFunction, {
+        name: 'new_func',
+        schema: 'new_schema',
+        definition: 'SELECT 42',
+      })
+      expect(sql).toContain('CREATE OR REPLACE FUNCTION')
+      expect(sql).toContain('RENAME TO')
+      expect(sql).toContain('SET SCHEMA')
+    })
+  })
+
+  describe('remove', () => {
+    const mockFunction: PGFunction = {
+      id: 1,
+      schema: 'public',
+      name: 'drop_me',
+      language: 'sql',
+      definition: 'SELECT 1',
+      complete_statement: '',
+      args: [],
+      argument_types: '',
+      identity_argument_types: 'integer, text',
+      return_type_id: 2278,
+      return_type: 'void',
+      return_type_relation_id: null,
+      is_set_returning_function: false,
+      behavior: 'VOLATILE',
+      security_definer: false,
+      config_params: null,
+    }
+
+    test('should generate drop function SQL with restrict by default', () => {
+      const { sql } = pgFunctions.remove(mockFunction)
+      expect(sql).toContain('DROP FUNCTION')
+      expect(sql).toContain('public')
+      expect(sql).toContain('drop_me')
+      expect(sql).toContain('integer, text')
+      expect(sql).toContain('RESTRICT')
+    })
+
+    test('should generate drop function SQL with cascade', () => {
+      const { sql } = pgFunctions.remove(mockFunction, { cascade: true })
+      expect(sql).toContain('CASCADE')
+      expect(sql).not.toContain('RESTRICT')
+    })
+  })
+
+  describe('zod schemas', () => {
+    test('pgFunctionCreateZod should validate correct input', () => {
+      const result = pgFunctions.pgFunctionCreateZod.safeParse({
+        name: 'test_func',
+        definition: 'SELECT 1',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('pgFunctionCreateZod should reject missing name', () => {
+      const result = pgFunctions.pgFunctionCreateZod.safeParse({
+        definition: 'SELECT 1',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('pgFunctionCreateZod should reject missing definition', () => {
+      const result = pgFunctions.pgFunctionCreateZod.safeParse({
+        name: 'test_func',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('pgFunctionCreateZod should accept optional fields', () => {
+      const result = pgFunctions.pgFunctionCreateZod.safeParse({
+        name: 'test_func',
+        definition: 'SELECT 1',
+        args: ['a integer'],
+        behavior: 'IMMUTABLE',
+        config_params: { search_path: 'public' },
+        schema: 'custom',
+        language: 'plpgsql',
+        return_type: 'integer',
+        security_definer: true,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('pgFunctionCreateZod should reject invalid behavior', () => {
+      const result = pgFunctions.pgFunctionCreateZod.safeParse({
+        name: 'test_func',
+        definition: 'SELECT 1',
+        behavior: 'INVALID',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('pgFunctionUpdateZod should validate partial updates', () => {
+      const result = pgFunctions.pgFunctionUpdateZod.safeParse({
+        name: 'new_name',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('pgFunctionUpdateZod should accept empty object', () => {
+      const result = pgFunctions.pgFunctionUpdateZod.safeParse({})
+      expect(result.success).toBe(true)
+    })
+
+    test('pgFunctionDeleteZod should accept cascade option', () => {
+      const result = pgFunctions.pgFunctionDeleteZod.parse({ cascade: true })
+      expect(result.cascade).toBe(true)
+    })
+  })
+})

--- a/packages/pg-meta/test/sql-generation/helpers.test.ts
+++ b/packages/pg-meta/test/sql-generation/helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+
+import { coalesceRowsToArray, filterByList, exceptionIdentifierNotFound } from '../../src/helpers'
+
+describe('pg-meta helpers', () => {
+  describe('coalesceRowsToArray', () => {
+    test('should generate COALESCE with array_agg for given source and filter', () => {
+      const result = coalesceRowsToArray('columns', 'columns.id IS NOT NULL')
+      expect(result).toContain('COALESCE')
+      expect(result).toContain('array_agg(row_to_json(columns))')
+      expect(result).toContain('FILTER (WHERE columns.id IS NOT NULL)')
+      expect(result).toContain("'{}'" )
+      expect(result).toContain('AS columns')
+    })
+
+    test('should use the source name as the alias', () => {
+      const result = coalesceRowsToArray('my_table', 'my_table.active = true')
+      expect(result).toContain('AS my_table')
+      expect(result).toContain('row_to_json(my_table)')
+    })
+  })
+
+  describe('filterByList', () => {
+    test('should return IN clause when include list is provided', () => {
+      const result = filterByList(['public', 'custom'])
+      expect(result).toContain('IN')
+      expect(result).toContain("'public'")
+      expect(result).toContain("'custom'")
+    })
+
+    test('should return NOT IN clause when exclude list is provided', () => {
+      const result = filterByList(undefined, ['pg_catalog', 'information_schema'])
+      expect(result).toContain('NOT IN')
+      expect(result).toContain("'pg_catalog'")
+      expect(result).toContain("'information_schema'")
+    })
+
+    test('should prioritize include over exclude', () => {
+      const result = filterByList(['public'], ['pg_catalog'])
+      expect(result).toContain('IN')
+      expect(result).not.toContain('NOT IN')
+    })
+
+    test('should return empty string when no lists provided', () => {
+      const result = filterByList()
+      expect(result).toBe('')
+    })
+
+    test('should return empty string with empty arrays', () => {
+      const result = filterByList([], [])
+      expect(result).toBe('')
+    })
+
+    test('should merge defaultExclude with exclude', () => {
+      const result = filterByList(undefined, ['custom_exclude'], ['pg_catalog'])
+      expect(result).toContain('NOT IN')
+      expect(result).toContain("'pg_catalog'")
+      expect(result).toContain("'custom_exclude'")
+    })
+
+    test('should use defaultExclude alone when no exclude provided', () => {
+      const result = filterByList(undefined, undefined, ['pg_catalog'])
+      expect(result).toContain('NOT IN')
+      expect(result).toContain("'pg_catalog'")
+    })
+  })
+
+  describe('exceptionIdentifierNotFound', () => {
+    test('should generate RAISE EXCEPTION with entity name', () => {
+      const result = exceptionIdentifierNotFound('table', 'id = 42')
+      expect(result).toContain('raise exception')
+      expect(result).toContain('Cannot find table')
+      expect(result).toContain("'id = 42'")
+    })
+
+    test('should properly escape the where clause', () => {
+      const result = exceptionIdentifierNotFound('schema', "name = 'test'")
+      expect(result).toContain('raise exception')
+      expect(result).toContain('Cannot find schema')
+    })
+  })
+})

--- a/packages/pg-meta/test/sql-generation/policies.test.ts
+++ b/packages/pg-meta/test/sql-generation/policies.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from 'vitest'
+
+import pgPolicies from '../../src/pg-meta-policies'
+import type { PGPolicy } from '../../src/pg-meta-policies'
+
+describe('pg-meta-policies SQL generation', () => {
+  describe('list', () => {
+    test('should generate basic list query', () => {
+      const { sql } = pgPolicies.list()
+      expect(sql).toContain('select *')
+      expect(sql).toContain('from policies')
+    })
+
+    test('should exclude system schemas by default', () => {
+      const { sql } = pgPolicies.list()
+      expect(sql).toContain('where schema')
+      expect(sql).toContain('NOT IN')
+    })
+
+    test('should include system schemas when requested', () => {
+      const { sql } = pgPolicies.list({ includeSystemSchemas: true })
+      expect(sql).not.toContain('NOT IN')
+    })
+
+    test('should apply limit', () => {
+      const { sql } = pgPolicies.list({ limit: 50 })
+      expect(sql).toContain('limit 50')
+    })
+
+    test('should apply offset', () => {
+      const { sql } = pgPolicies.list({ offset: 10 })
+      expect(sql).toContain('offset 10')
+    })
+
+    test('should filter by included schemas', () => {
+      const { sql } = pgPolicies.list({ includedSchemas: ['public'] })
+      expect(sql).toContain("'public'")
+      expect(sql).toContain('IN')
+    })
+
+    test('should filter by excluded schemas', () => {
+      const { sql } = pgPolicies.list({
+        includeSystemSchemas: true,
+        excludedSchemas: ['private'],
+      })
+      expect(sql).toContain('NOT IN')
+      expect(sql).toContain("'private'")
+    })
+  })
+
+  describe('retrieve', () => {
+    test('should retrieve by id', () => {
+      const { sql } = pgPolicies.retrieve({ id: 123 })
+      expect(sql).toContain('id = ')
+      expect(sql).toContain('123')
+    })
+
+    test('should retrieve by name, schema, and table', () => {
+      const { sql } = pgPolicies.retrieve({
+        name: 'allow_read',
+        schema: 'public',
+        table: 'users',
+      })
+      expect(sql).toContain("name = 'allow_read'")
+      expect(sql).toContain("schema = 'public'")
+      expect(sql).toContain("table = 'users'")
+    })
+  })
+
+  describe('create', () => {
+    test('should generate basic create policy SQL', () => {
+      const { sql } = pgPolicies.create({
+        name: 'allow_select',
+        table: 'users',
+      })
+      expect(sql).toContain('create policy')
+      expect(sql).toContain('allow_select')
+      expect(sql).toContain('public')
+      expect(sql).toContain('users')
+      expect(sql).toContain('PERMISSIVE')
+      expect(sql).toContain('ALL')
+    })
+
+    test('should generate create policy with USING clause', () => {
+      const { sql } = pgPolicies.create({
+        name: 'rls_policy',
+        table: 'posts',
+        definition: 'auth.uid() = user_id',
+      })
+      expect(sql).toContain('using (auth.uid() = user_id)')
+    })
+
+    test('should generate create policy with WITH CHECK clause', () => {
+      const { sql } = pgPolicies.create({
+        name: 'insert_check',
+        table: 'posts',
+        check: 'auth.uid() = user_id',
+        command: 'INSERT',
+      })
+      expect(sql).toContain('with check (auth.uid() = user_id)')
+      expect(sql).toContain('INSERT')
+    })
+
+    test('should generate create policy with RESTRICTIVE action', () => {
+      const { sql } = pgPolicies.create({
+        name: 'restrict_policy',
+        table: 'sensitive_data',
+        action: 'RESTRICTIVE',
+      })
+      expect(sql).toContain('RESTRICTIVE')
+    })
+
+    test('should generate create policy with specific command', () => {
+      const { sql } = pgPolicies.create({
+        name: 'select_only',
+        table: 'users',
+        command: 'SELECT',
+      })
+      expect(sql).toContain('for SELECT')
+    })
+
+    test('should generate create policy with specific roles', () => {
+      const { sql } = pgPolicies.create({
+        name: 'admin_policy',
+        table: 'users',
+        roles: ['admin', 'superadmin'],
+      })
+      expect(sql).toContain('admin')
+      expect(sql).toContain('superadmin')
+    })
+
+    test('should generate create policy with custom schema', () => {
+      const { sql } = pgPolicies.create({
+        name: 'custom_policy',
+        schema: 'app',
+        table: 'profiles',
+      })
+      expect(sql).toContain('app')
+      expect(sql).toContain('profiles')
+    })
+
+    test('should generate create policy with both USING and WITH CHECK', () => {
+      const { sql } = pgPolicies.create({
+        name: 'full_policy',
+        table: 'posts',
+        definition: 'auth.uid() = author_id',
+        check: 'auth.uid() = author_id',
+        command: 'UPDATE',
+      })
+      expect(sql).toContain('using (auth.uid() = author_id)')
+      expect(sql).toContain('with check (auth.uid() = author_id)')
+    })
+  })
+
+  describe('update', () => {
+    const policyId = { name: 'old_policy', schema: 'public', table: 'users' }
+
+    test('should generate rename SQL', () => {
+      const { sql } = pgPolicies.update(policyId, { name: 'new_policy' })
+      expect(sql).toContain('RENAME TO')
+      expect(sql).toContain('new_policy')
+    })
+
+    test('should generate update definition SQL', () => {
+      const { sql } = pgPolicies.update(policyId, {
+        definition: 'auth.uid() = id',
+      })
+      expect(sql).toContain('USING (auth.uid() = id)')
+    })
+
+    test('should generate update check SQL', () => {
+      const { sql } = pgPolicies.update(policyId, {
+        check: 'auth.uid() = id',
+      })
+      expect(sql).toContain('WITH CHECK (auth.uid() = id)')
+    })
+
+    test('should generate update roles SQL', () => {
+      const { sql } = pgPolicies.update(policyId, {
+        roles: ['authenticated', 'service_role'],
+      })
+      expect(sql).toContain('TO')
+      expect(sql).toContain('authenticated')
+      expect(sql).toContain('service_role')
+    })
+
+    test('should wrap updates in a transaction', () => {
+      const { sql } = pgPolicies.update(policyId, {
+        name: 'renamed',
+        definition: 'true',
+      })
+      expect(sql).toContain('BEGIN;')
+      expect(sql).toContain('COMMIT;')
+    })
+
+    test('should put rename last in transaction', () => {
+      const { sql } = pgPolicies.update(policyId, {
+        name: 'renamed',
+        definition: 'true',
+      })
+      const renamePos = sql.indexOf('RENAME TO')
+      const usingPos = sql.indexOf('USING')
+      expect(usingPos).toBeLessThan(renamePos)
+    })
+  })
+
+  describe('remove', () => {
+    test('should generate drop policy SQL', () => {
+      const { sql } = pgPolicies.remove({
+        name: 'drop_policy',
+        schema: 'public',
+        table: 'users',
+      })
+      expect(sql).toContain('DROP POLICY')
+      expect(sql).toContain('drop_policy')
+      expect(sql).toContain('public')
+      expect(sql).toContain('users')
+    })
+  })
+
+  describe('zod schema', () => {
+    test('should validate a valid policy object', () => {
+      const result = pgPolicies.zod.safeParse({
+        id: 1,
+        schema: 'public',
+        table: 'users',
+        table_id: 100,
+        name: 'test_policy',
+        action: 'PERMISSIVE',
+        roles: ['public'],
+        command: 'SELECT',
+        definition: 'true',
+        check: null,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('should reject invalid action', () => {
+      const result = pgPolicies.zod.safeParse({
+        id: 1,
+        schema: 'public',
+        table: 'users',
+        table_id: 100,
+        name: 'test_policy',
+        action: 'INVALID',
+        roles: ['public'],
+        command: 'SELECT',
+        definition: 'true',
+        check: null,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('should reject invalid command', () => {
+      const result = pgPolicies.zod.safeParse({
+        id: 1,
+        schema: 'public',
+        table: 'users',
+        table_id: 100,
+        name: 'test_policy',
+        action: 'PERMISSIVE',
+        roles: ['public'],
+        command: 'UPSERT',
+        definition: 'true',
+        check: null,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('should allow null definition and check', () => {
+      const result = pgPolicies.zod.safeParse({
+        id: 1,
+        schema: 'public',
+        table: 'users',
+        table_id: 100,
+        name: 'test_policy',
+        action: 'PERMISSIVE',
+        roles: [],
+        command: 'ALL',
+        definition: null,
+        check: null,
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/packages/pg-meta/test/sql-generation/schemas.test.ts
+++ b/packages/pg-meta/test/sql-generation/schemas.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'vitest'
+
+import pgSchemas from '../../src/pg-meta-schemas'
+
+describe('pg-meta-schemas SQL generation', () => {
+  describe('list', () => {
+    test('should generate basic list query excluding system schemas', () => {
+      const { sql } = pgSchemas.list()
+      expect(sql).toContain('not (n.nspname in')
+    })
+
+    test('should include system schemas when requested', () => {
+      const { sql } = pgSchemas.list({ includeSystemSchemas: true })
+      expect(sql).not.toContain('NOT IN')
+    })
+
+    test('should apply limit', () => {
+      const { sql } = pgSchemas.list({ limit: 10 })
+      expect(sql).toContain('limit 10')
+    })
+
+    test('should apply offset', () => {
+      const { sql } = pgSchemas.list({ offset: 5 })
+      expect(sql).toContain('offset 5')
+    })
+  })
+
+  describe('retrieve', () => {
+    test('should retrieve by id', () => {
+      const { sql } = pgSchemas.retrieve({ id: 42 })
+      expect(sql).toContain('42')
+      expect(sql).toContain('n.oid')
+    })
+
+    test('should retrieve by name', () => {
+      const { sql } = pgSchemas.retrieve({ name: 'public' })
+      expect(sql).toContain("'public'")
+      expect(sql).toContain('n.nspname')
+    })
+  })
+
+  describe('create', () => {
+    test('should generate create schema SQL', () => {
+      const { sql } = pgSchemas.create({ name: 'new_schema' })
+      expect(sql).toContain('create schema')
+      expect(sql).toContain('new_schema')
+    })
+
+    test('should generate create schema with owner', () => {
+      const { sql } = pgSchemas.create({ name: 'owned_schema', owner: 'admin' })
+      expect(sql).toContain('create schema')
+      expect(sql).toContain('owned_schema')
+      expect(sql).toContain('authorization')
+      expect(sql).toContain('admin')
+    })
+
+    test('should not include authorization when owner is undefined', () => {
+      const { sql } = pgSchemas.create({ name: 'no_owner' })
+      expect(sql).not.toContain('authorization')
+    })
+  })
+
+  describe('update', () => {
+    test('should generate update schema name SQL by id', () => {
+      const { sql } = pgSchemas.update({ id: 1 }, { name: 'renamed' })
+      expect(sql).toContain('renamed')
+      expect(sql).toContain('rename to')
+    })
+
+    test('should generate update schema name SQL by name', () => {
+      const { sql } = pgSchemas.update({ name: 'old_name' }, { name: 'new_name' })
+      expect(sql).toContain("'old_name'")
+      expect(sql).toContain("'new_name'")
+    })
+
+    test('should generate update schema owner SQL', () => {
+      const { sql } = pgSchemas.update({ id: 1 }, { owner: 'new_owner' })
+      expect(sql).toContain('alter schema')
+      expect(sql).toContain('owner to')
+      expect(sql).toContain('new_owner')
+    })
+
+    test('should handle both name and owner update', () => {
+      const { sql } = pgSchemas.update({ id: 1 }, { name: 'new_name', owner: 'new_owner' })
+      expect(sql).toContain('rename to')
+      expect(sql).toContain('owner to')
+    })
+
+    test('should use regnamespace when looking up by name', () => {
+      const { sql } = pgSchemas.update({ name: 'my_schema' }, { name: 'renamed' })
+      expect(sql).toContain('regnamespace')
+    })
+
+    test('should use literal id when looking up by id', () => {
+      const { sql } = pgSchemas.update({ id: 42 }, { name: 'renamed' })
+      expect(sql).toContain('42')
+    })
+  })
+
+  describe('remove', () => {
+    test('should generate drop schema SQL by id', () => {
+      const { sql } = pgSchemas.remove({ id: 1 })
+      expect(sql).toContain('drop schema')
+      expect(sql).toContain('restrict')
+    })
+
+    test('should generate drop schema SQL by name', () => {
+      const { sql } = pgSchemas.remove({ name: 'temp_schema' })
+      expect(sql).toContain('drop schema')
+      expect(sql).toContain("'temp_schema'")
+    })
+
+    test('should generate drop schema SQL with cascade', () => {
+      const { sql } = pgSchemas.remove({ id: 1 }, { cascade: true })
+      expect(sql).toContain('cascade')
+    })
+
+    test('should default to restrict (no cascade)', () => {
+      const { sql } = pgSchemas.remove({ id: 1 })
+      expect(sql).toContain('restrict')
+    })
+  })
+
+  describe('zod schema', () => {
+    test('should validate a valid schema object', () => {
+      const result = pgSchemas.zod.safeParse({
+        id: 1,
+        name: 'public',
+        owner: 'postgres',
+        comment: 'Standard public schema',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('should allow null comment', () => {
+      const result = pgSchemas.zod.safeParse({
+        id: 1,
+        name: 'public',
+        owner: 'postgres',
+        comment: null,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('should reject missing required fields', () => {
+      const result = pgSchemas.zod.safeParse({
+        id: 1,
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/packages/pg-meta/test/sql-generation/triggers.test.ts
+++ b/packages/pg-meta/test/sql-generation/triggers.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from 'vitest'
+
+import * as pgTriggers from '../../src/pg-meta-triggers'
+
+describe('pg-meta-triggers SQL generation', () => {
+  describe('list', () => {
+    test('should generate basic list query', () => {
+      const { sql } = pgTriggers.list()
+      expect(sql).toContain('select * from triggers')
+    })
+
+    test('should exclude system schemas by default', () => {
+      const { sql } = pgTriggers.list()
+      expect(sql).toContain('where schema')
+      expect(sql).toContain('NOT IN')
+    })
+
+    test('should include system schemas when requested', () => {
+      const { sql } = pgTriggers.list({ includeSystemSchemas: true })
+      expect(sql).not.toContain('NOT IN')
+    })
+
+    test('should apply limit and offset', () => {
+      const { sql } = pgTriggers.list({ limit: 25, offset: 50 })
+      expect(sql).toContain('limit 25')
+      expect(sql).toContain('offset 50')
+    })
+
+    test('should filter by included schemas', () => {
+      const { sql } = pgTriggers.list({ includedSchemas: ['public', 'app'] })
+      expect(sql).toContain('IN')
+      expect(sql).toContain("'public'")
+      expect(sql).toContain("'app'")
+    })
+  })
+
+  describe('retrieve', () => {
+    test('should retrieve by id', () => {
+      const { sql } = pgTriggers.retrieve({ id: 99 })
+      expect(sql).toContain('99')
+    })
+
+    test('should retrieve by name, schema, and table', () => {
+      const { sql } = pgTriggers.retrieve({
+        name: 'my_trigger',
+        schema: 'public',
+        table: 'orders',
+      })
+      expect(sql).toContain("'my_trigger'")
+      expect(sql).toContain("'public'")
+      expect(sql).toContain("'orders'")
+    })
+  })
+
+  describe('create', () => {
+    test('should generate basic AFTER INSERT trigger', () => {
+      const { sql } = pgTriggers.create({
+        name: 'after_insert_trigger',
+        table: 'users',
+        function_name: 'notify_user',
+        activation: 'AFTER',
+        events: ['INSERT'],
+      })
+      expect(sql).toContain('create trigger')
+      expect(sql).toContain('after_insert_trigger')
+      expect(sql).toContain('AFTER')
+      expect(sql).toContain('INSERT')
+      expect(sql).toContain('public')
+      expect(sql).toContain('users')
+      expect(sql).toContain('notify_user')
+    })
+
+    test('should generate BEFORE UPDATE trigger with ROW orientation', () => {
+      const { sql } = pgTriggers.create({
+        name: 'before_update',
+        table: 'posts',
+        function_name: 'validate_post',
+        activation: 'BEFORE',
+        events: ['UPDATE'],
+        orientation: 'ROW',
+      })
+      expect(sql).toContain('BEFORE')
+      expect(sql).toContain('UPDATE')
+      expect(sql).toContain('for each ROW')
+    })
+
+    test('should generate trigger with STATEMENT orientation', () => {
+      const { sql } = pgTriggers.create({
+        name: 'statement_trigger',
+        table: 'logs',
+        function_name: 'audit_log',
+        activation: 'AFTER',
+        events: ['INSERT'],
+        orientation: 'STATEMENT',
+      })
+      expect(sql).toContain('for each STATEMENT')
+    })
+
+    test('should generate trigger with multiple events', () => {
+      const { sql } = pgTriggers.create({
+        name: 'multi_event',
+        table: 'items',
+        function_name: 'handle_change',
+        activation: 'AFTER',
+        events: ['INSERT', 'UPDATE', 'DELETE'],
+      })
+      expect(sql).toContain('INSERT or UPDATE or DELETE')
+    })
+
+    test('should generate trigger with condition', () => {
+      const { sql } = pgTriggers.create({
+        name: 'conditional_trigger',
+        table: 'orders',
+        function_name: 'process_order',
+        activation: 'AFTER',
+        events: ['UPDATE'],
+        condition: 'NEW.status = \'completed\'',
+      })
+      expect(sql).toContain("when (NEW.status = 'completed')")
+    })
+
+    test('should generate trigger with function args', () => {
+      const { sql } = pgTriggers.create({
+        name: 'args_trigger',
+        table: 'events',
+        function_name: 'process_event',
+        function_args: ['arg1', 'arg2'],
+        activation: 'AFTER',
+        events: ['INSERT'],
+      })
+      expect(sql).toContain("'arg1'")
+      expect(sql).toContain("'arg2'")
+    })
+
+    test('should generate trigger with custom function schema', () => {
+      const { sql } = pgTriggers.create({
+        name: 'custom_schema_trigger',
+        table: 'data',
+        function_schema: 'utils',
+        function_name: 'handle_data',
+        activation: 'BEFORE',
+        events: ['INSERT'],
+      })
+      expect(sql).toContain('utils')
+      expect(sql).toContain('handle_data')
+    })
+
+    test('should generate INSTEAD OF trigger', () => {
+      const { sql } = pgTriggers.create({
+        name: 'instead_trigger',
+        table: 'view_data',
+        function_name: 'handle_view_insert',
+        activation: 'INSTEAD OF',
+        events: ['INSERT'],
+      })
+      expect(sql).toContain('INSTEAD OF')
+    })
+  })
+
+  describe('update', () => {
+    const triggerId = { name: 'old_trigger', schema: 'public', table: 'users' }
+
+    test('should generate rename SQL', () => {
+      const { sql } = pgTriggers.update(triggerId, { name: 'new_trigger' })
+      expect(sql).toContain('rename to')
+      expect(sql).toContain('new_trigger')
+    })
+
+    test('should not generate rename SQL when name is the same', () => {
+      const { sql } = pgTriggers.update(triggerId, { name: 'old_trigger' })
+      expect(sql).not.toContain('rename to')
+    })
+
+    test('should generate enable trigger SQL for ORIGIN mode', () => {
+      const { sql } = pgTriggers.update(triggerId, { enabled_mode: 'ORIGIN' })
+      expect(sql).toContain('enable trigger')
+      expect(sql).toContain('old_trigger')
+    })
+
+    test('should generate disable trigger SQL', () => {
+      const { sql } = pgTriggers.update(triggerId, { enabled_mode: 'DISABLED' })
+      expect(sql).toContain('disable trigger')
+    })
+
+    test('should generate REPLICA mode SQL', () => {
+      const { sql } = pgTriggers.update(triggerId, { enabled_mode: 'REPLICA' })
+      expect(sql).toContain('enable REPLICA trigger')
+    })
+
+    test('should generate ALWAYS mode SQL', () => {
+      const { sql } = pgTriggers.update(triggerId, { enabled_mode: 'ALWAYS' })
+      expect(sql).toContain('enable ALWAYS trigger')
+    })
+
+    test('should wrap in transaction', () => {
+      const { sql } = pgTriggers.update(triggerId, { name: 'renamed' })
+      expect(sql).toContain('begin;')
+      expect(sql).toContain('commit;')
+    })
+  })
+
+  describe('remove', () => {
+    test('should generate drop trigger SQL', () => {
+      const { sql } = pgTriggers.remove({
+        name: 'drop_trigger',
+        schema: 'public',
+        table: 'users',
+      })
+      expect(sql).toContain('drop trigger')
+      expect(sql).toContain('drop_trigger')
+      expect(sql).toContain('public')
+      expect(sql).toContain('users')
+    })
+
+    test('should generate drop trigger SQL without cascade by default', () => {
+      const { sql } = pgTriggers.remove({
+        name: 'drop_trigger',
+        schema: 'public',
+        table: 'users',
+      })
+      expect(sql).not.toContain('cascade')
+    })
+
+    test('should generate drop trigger SQL with cascade', () => {
+      const { sql } = pgTriggers.remove(
+        { name: 'drop_trigger', schema: 'public', table: 'users' },
+        { cascade: true }
+      )
+      expect(sql).toContain('cascade')
+    })
+  })
+
+  describe('zod schemas', () => {
+    test('pgTriggerCreateZod should validate correct input', () => {
+      const result = pgTriggers.pgTriggerCreateZod.safeParse({
+        name: 'test_trigger',
+        table: 'users',
+        function_name: 'my_func',
+        activation: 'AFTER',
+        events: ['INSERT'],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('pgTriggerCreateZod should apply default schema', () => {
+      const result = pgTriggers.pgTriggerCreateZod.parse({
+        name: 'test_trigger',
+        table: 'users',
+        function_name: 'my_func',
+        activation: 'AFTER',
+        events: ['INSERT'],
+      })
+      expect(result.schema).toBe('public')
+      expect(result.function_schema).toBe('public')
+    })
+
+    test('pgTriggerCreateZod should reject invalid activation', () => {
+      const result = pgTriggers.pgTriggerCreateZod.safeParse({
+        name: 'test_trigger',
+        table: 'users',
+        function_name: 'my_func',
+        activation: 'DURING',
+        events: ['INSERT'],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('pgTriggerCreateZod should reject invalid orientation', () => {
+      const result = pgTriggers.pgTriggerCreateZod.safeParse({
+        name: 'test_trigger',
+        table: 'users',
+        function_name: 'my_func',
+        activation: 'AFTER',
+        events: ['INSERT'],
+        orientation: 'COLUMN',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('pgTriggerUpdateZod should validate name update', () => {
+      const result = pgTriggers.pgTriggerUpdateZod.safeParse({
+        name: 'new_name',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('pgTriggerUpdateZod should validate enabled_mode update', () => {
+      const result = pgTriggers.pgTriggerUpdateZod.safeParse({
+        enabled_mode: 'DISABLED',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('pgTriggerUpdateZod should reject invalid enabled_mode', () => {
+      const result = pgTriggers.pgTriggerUpdateZod.safeParse({
+        enabled_mode: 'SOMETIMES',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('pgTriggerZod should validate a complete trigger object', () => {
+      const result = pgTriggers.pgTriggerZod.safeParse({
+        id: 1,
+        table_id: 100,
+        enabled_mode: 'ORIGIN',
+        function_args: [],
+        name: 'test_trigger',
+        table: 'users',
+        schema: 'public',
+        condition: null,
+        orientation: 'ROW',
+        activation: 'AFTER',
+        events: ['INSERT', 'UPDATE'],
+        function_name: 'my_func',
+        function_schema: 'public',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Tests for functions, triggers, policies, schemas, and helpers SQL generation.