### PR TITLE
docs: update outdated app.supabase.io URL in local development guide

### DIFF
--- a/apps/docs/content/guides/local-development/overview.mdx
+++ b/apps/docs/content/guides/local-development/overview.mdx
@@ -7,7 +7,7 @@ video: 'https://www.youtube-nocookie.com/v/vyHyYpvjaks'
 tocVideo: 'vyHyYpvjaks'
 ---
 
-Supabase is a flexible platform that lets you decide how you want to build your projects. You can use the Dashboard directly to get up and running quickly, or use a proper local setup. We suggest you work locally and deploy your changes to a linked project on the [Supabase Platform](https://app.supabase.io/).
+Supabase is a flexible platform that lets you decide how you want to build your projects. You can use the Dashboard directly to get up and running quickly, or use a proper local setup. We suggest you work locally and deploy your changes to a linked project on the [Supabase Platform](https://supabase.com/dashboard).
 
 Develop locally using the CLI to run a local Supabase stack. You can use the integrated Studio Dashboard to make changes, then capture your changes in schema migration files, which can be saved in version control.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

The local development overview doc (`apps/docs/content/guides/local-development/overview.mdx`) contains a link to the "Supabase Platform" pointing to `https://app.supabase.io/`, which is the old domain.

## What is the new behavior?

Updated the URL to `https://supabase.com/dashboard`, which is the current correct URL for the Supabase dashboard. The same document already uses `supabase.com/dashboard` elsewhere (line 238).

## Additional context

The old `app.supabase.io` domain redirects to `supabase.com/dashboard`, so links still work but it's better to point directly to the canonical URL.