### PR TITLE
fix(studio): add missing alt text on logo images and fix double space in toast

### DIFF
--- a/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -124,7 +124,7 @@ const SecondStep = ({
   const { mutate: unenroll } = useMfaUnenrollMutation({ onSuccess: () => onClose() })
   const { mutate: challengeAndVerify, isPending: isVerifying } = useMfaChallengeAndVerifyMutation({
     onError: (error) => {
-      toast.error(`Failed to add a second factor authentication:  ${error?.message}`)
+      toast.error(`Failed to add a second factor authentication: ${error?.message}`)
     },
     onSuccess: async () => {
       if (lastVisitedOrganization) {

--- a/apps/studio/components/layouts/SignInLayout/ForgotPasswordLayout.tsx
+++ b/apps/studio/components/layouts/SignInLayout/ForgotPasswordLayout.tsx
@@ -41,7 +41,7 @@ const ForgotPasswordLayout = ({
                       ? `${BASE_PATH}/img/supabase-dark.svg`
                       : `${BASE_PATH}/img/supabase-light.svg`
                   }
-                  alt=""
+                  alt="Supabase Logo"
                   height={24}
                   width={120}
                 />

--- a/apps/studio/pages/404.tsx
+++ b/apps/studio/pages/404.tsx
@@ -29,7 +29,7 @@ const Error404: NextPage = ({}) => {
                       ? `${BASE_PATH}/img/supabase-dark.svg`
                       : `${BASE_PATH}/img/supabase-light.svg`
                   }
-                  alt="supabase"
+                  alt="Supabase Logo"
                   height={24}
                   width={120}
                 />

--- a/apps/studio/pages/500.tsx
+++ b/apps/studio/pages/500.tsx
@@ -39,7 +39,7 @@ const Error500: NextPage = () => {
                       ? `${router.basePath}/img/supabase-dark.svg`
                       : `${router.basePath}/img/supabase-light.svg`
                   }
-                  alt=""
+                  alt="Supabase Logo"
                   height={24}
                   width={120}
                 />

--- a/apps/studio/pages/sign-in-fly-tos.tsx
+++ b/apps/studio/pages/sign-in-fly-tos.tsx
@@ -81,7 +81,7 @@ const SignInFlyTos = () => {
                         ? `${BASE_PATH}/img/supabase-dark.svg`
                         : `${BASE_PATH}/img/supabase-light.svg`
                     }
-                    alt=""
+                    alt="Supabase Logo"
                     height={24}
                     width={120}
                   />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (accessibility + UX)

## What is the current behavior?

Several Studio pages render the Supabase logo with empty or inconsistent `alt` attributes:

- `pages/sign-in-fly-tos.tsx`: `alt=""`
- `pages/500.tsx`: `alt=""`
- `pages/404.tsx`: `alt="supabase"` (inconsistent casing)
- `components/layouts/SignInLayout/ForgotPasswordLayout.tsx`: `alt=""`

Other layouts like `SignInLayout.tsx`, `RedeemCreditsLayout.tsx`, and `APIAuthorizationLayout.tsx` already use `alt="Supabase Logo"`.

Additionally, the MFA enrollment error toast in `AddNewFactorModal.tsx` has a double space before the error message interpolation.

## What is the new behavior?

- All Supabase logo images now consistently use `alt="Supabase Logo"`, improving screen reader accessibility
- The MFA error toast now displays with a single space: `"Failed to add a second factor authentication: {error}"` instead of two spaces

## Additional context

The alt text change matches the existing convention used in `SignInLayout.tsx` (line 127), `RedeemCreditsLayout.tsx` (line 34), `APIAuthorizationLayout.tsx` (line 32), and `LinkAwsMarketplaceLayout.tsx` (line 36).