### PR TITLE
fix(studio): rename DiskMangement to DiskManagement in component names

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -50,7 +50,7 @@ import { FormFooterChangeBadge } from '../DataWarehouse/FormFooterChangeBadge'
 import { CreateDiskStorageSchema, DiskStorageSchemaType } from './DiskManagement.schema'
 import { DiskManagementMessage } from './DiskManagement.types'
 import { mapComputeSizeNameToAddonVariantId } from './DiskManagement.utils'
-import { DiskMangementRestartRequiredSection } from './DiskManagementRestartRequiredSection'
+import { DiskManagementRestartRequiredSection } from './DiskManagementRestartRequiredSection'
 import { DiskManagementReviewAndSubmitDialog } from './DiskManagementReviewAndSubmitDialog'
 import { AutoScaleFields } from './fields/AutoScaleFields'
 import { ComputeSizeField } from './fields/ComputeSizeField'
@@ -343,7 +343,7 @@ export function DiskManagementForm() {
           isProjectRequestingDiskChanges ||
           (isEntitlementsLoaded && !isPlanUpgradeRequired && noPermissions)) && (
           <div className="relative flex flex-col gap-10">
-            <DiskMangementRestartRequiredSection
+            <DiskManagementRestartRequiredSection
               visible={isProjectResizing}
               title="Your project will now automatically restart."
               description="Your project will be unavailable for up to 2 mins."

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementRestartRequiredSection.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementRestartRequiredSection.tsx
@@ -3,17 +3,17 @@ import { RotateCcw } from 'lucide-react'
 
 import { DialogSection, WarningIcon } from 'ui'
 
-interface DiskMangementRestartRequiredSectionProps {
+interface DiskManagementRestartRequiredSectionProps {
   visible: boolean
   title: string
   description: string
 }
 
-export const DiskMangementRestartRequiredSection = ({
+export const DiskManagementRestartRequiredSection = ({
   visible,
   title,
   description,
-}: DiskMangementRestartRequiredSectionProps) => {
+}: DiskManagementRestartRequiredSectionProps) => {
   return (
     <AnimatePresence>
       {visible && (

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx
@@ -42,10 +42,10 @@ import {
   getAvailableComputeOptions,
   mapAddOnVariantIdToComputeSize,
 } from './DiskManagement.utils'
-import { DiskMangementRestartRequiredSection } from './DiskManagementRestartRequiredSection'
+import { DiskManagementRestartRequiredSection } from './DiskManagementRestartRequiredSection'
 import { BillingChangeBadge } from './ui/BillingChangeBadge'
 import { DISK_AUTOSCALE_CONFIG_DEFAULTS, DiskType } from './ui/DiskManagement.constants'
-import { DiskMangementCoolDownSection } from './ui/DiskManagementCoolDownSection'
+import { DiskManagementCoolDownSection } from './ui/DiskManagementCoolDownSection'
 
 const TableHeaderRow = () => (
   <TableRow>
@@ -286,12 +286,12 @@ export const DiskManagementReviewAndSubmitDialog = ({
         {(hasComputeChanges || hasDiskConfigChanges) && (
           <>
             <div className="flex flex-col gap-2 p-5">
-              <DiskMangementRestartRequiredSection
+              <DiskManagementRestartRequiredSection
                 visible={hasComputeChanges}
                 title="Resizing your Compute will trigger a project restart"
                 description="Project will restart automatically on confirmation."
               />
-              <DiskMangementCoolDownSection visible={hasDiskConfigChanges} />
+              <DiskManagementCoolDownSection visible={hasDiskConfigChanges} />
             </div>
             <DialogSectionSeparator />
           </>

--- a/apps/studio/components/interfaces/DiskManagement/ui/DiskManagementCoolDownSection.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/DiskManagementCoolDownSection.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import CountdownTimerRadial from 'components/ui/CountdownTimer/CountdownTimerRadial'
 import { DialogSection } from 'ui'
 
-export const DiskMangementCoolDownSection = ({ visible }: { visible: boolean }) => {
+export const DiskManagementCoolDownSection = ({ visible }: { visible: boolean }) => {
   const [progress, setProgress] = useState(100)
   const [showCountdown, setShowCountdown] = useState(false)
   const [isJumping, setIsJumping] = useState(false)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo fix in component and interface names.

## What is the current behavior?

Several DiskManagement components have a typo in their exported names — `DiskMangement` (missing "a" in "Management"):
- `DiskMangementCoolDownSection` in `DiskManagementCoolDownSection.tsx`
- `DiskMangementRestartRequiredSection` and `DiskMangementRestartRequiredSectionProps` in `DiskManagementRestartRequiredSection.tsx`
- Corresponding imports in `DiskManagementReviewAndSubmitDialog.tsx` and `DiskManagementForm.tsx`

Note that the **file names** are already correctly spelled — only the exported identifiers have the typo.

## What is the new behavior?

All component names, interface names, and imports now use the correct spelling: `DiskManagement`.

## Additional context

Files changed:
- `apps/studio/components/interfaces/DiskManagement/ui/DiskManagementCoolDownSection.tsx`
- `apps/studio/components/interfaces/DiskManagement/DiskManagementRestartRequiredSection.tsx`
- `apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx`
- `apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx`

This is a safe rename — all references are internal to the DiskManagement feature directory, and no other files in the codebase reference the old names.