### PR TITLE
fix(studio): update support email domain from supabase.io to supabase.com

### DIFF
--- a/apps/studio/lib/auth.tsx
+++ b/apps/studio/lib/auth.tsx
@@ -20,7 +20,7 @@ const AuthErrorToaster = ({ children }: PropsWithChildren) => {
       // Check for unverified GitHub users after a GitHub sign in
       if (error.message === GOTRUE_ERRORS.UNVERIFIED_GITHUB_USER) {
         toast.error(
-          'Please verify your email on GitHub first, then reach out to us at support@supabase.io to log into the dashboard'
+          'Please verify your email on GitHub first, then reach out to us at support@supabase.com to log into the dashboard'
         )
         return
       }

--- a/apps/studio/pages/maintenance.tsx
+++ b/apps/studio/pages/maintenance.tsx
@@ -35,10 +35,10 @@ const MaintenancePage: NextPageWithLayout = () => {
         <p className="text-sm text-foreground-lighter max-w-xs mx-auto">
           If you need support while the dashboard is inaccessible, you can email us at{' '}
           <a
-            href="mailto:support+maintenance@supabase.io"
+            href="mailto:support+maintenance@supabase.com"
             className="text-foreground-light underline hover:text-foreground"
           >
-            support+maintenance@supabase.io
+            support+maintenance@supabase.com
           </a>
         </p>
         <div className="flex flex-col items-center gap-2 mt-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix — outdated email domain in user-facing messages.

## What is the current behavior?

Two files in Studio reference the old `supabase.io` domain for support email addresses:

1. `apps/studio/lib/auth.tsx` (line 23): Error toast tells users to contact `support@supabase.io`
2. `apps/studio/pages/maintenance.tsx` (lines 38, 41): Maintenance page links to `support+maintenance@supabase.io`

The official Supabase support email uses the `supabase.com` domain (as confirmed by `apps/studio/components/interfaces/Support/SupportFormPage.tsx` which uses `support@supabase.com`).

## What is the new behavior?

Both files now use the correct `supabase.com` domain:
- `support@supabase.io` -> `support@supabase.com`
- `support+maintenance@supabase.io` -> `support+maintenance@supabase.com`

## Additional context

Other `@supabase.io` references in Studio are in test/mock data (`pages/api/platform/profile/index.ts`, `lib/upload.test.ts`, `tests/components/Auth/Auth.constants.test.ts`) and were intentionally left unchanged.