### PR TITLE
chore(studio): remove extraneous double spaces in className strings

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyEditorPanelHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyEditorPanelHeader.tsx
@@ -53,7 +53,7 @@ export const PolicyEditorPanelHeader = ({
               open={showDetails}
               onOpenChange={setShowDetails}
             >
-              <CollapsibleTrigger_Shadcn_ className="group  font-normal p-0 [&[data-state=open]>div>svg]:!-rotate-180">
+              <CollapsibleTrigger_Shadcn_ className="group font-normal p-0 [&[data-state=open]>div>svg]:!-rotate-180">
                 <div className="flex items-center gap-x-2 w-full">
                   <p className="text-xs text-foreground-light group-hover:text-foreground transition">
                     View policy details

--- a/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserPanel.tsx
@@ -81,7 +81,7 @@ export const UserPanel = () => {
               <TabsList_Shadcn_ className="px-5 flex gap-x-4 min-h-[46px]">
                 <TabsTrigger_Shadcn_
                   value="overview"
-                  className="px-0 pb-0 h-full text-xs  data-[state=active]:bg-transparent !shadow-none"
+                  className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent !shadow-none"
                 >
                   Overview
                 </TabsTrigger_Shadcn_>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraphLegend.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraphLegend.tsx
@@ -3,7 +3,7 @@ import { DiamondIcon, Fingerprint, Hash, Key } from 'lucide-react'
 export const SchemaGraphLegend = () => {
   return (
     <div className="absolute bottom-0 left-0 border-t flex justify-center px-1 py-2 shadow-md bg-surface-100 w-full z-10">
-      <ul className="flex flex-wrap  items-center justify-center gap-4">
+      <ul className="flex flex-wrap items-center justify-center gap-4">
         <li className="flex items-center text-xs font-mono gap-1">
           <Key size={15} strokeWidth={1.5} className="flex-shrink-0 text-light" />
           Primary key

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsEmptyState.tsx
@@ -1,6 +1,6 @@
 export default function CronJobsEmptyState({ page }: { page: string }) {
   return (
-    <div className="  text-center h-full w-full items-center justify-center rounded-md px-4 py-12  ">
+    <div className="text-center h-full w-full items-center justify-center rounded-md px-4 py-12">
       <p className="text-sm text-foreground">
         {page === 'jobs' ? 'No cron jobs created yet' : 'No runs for this cron job yet'}
       </p>

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/MessageDetailsPanel.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/MessageDetailsPanel.tsx
@@ -101,7 +101,7 @@ export const MessageDetailsPanel = ({
         <TabsList_Shadcn_ className="px-5 flex gap-x-4 min-h-[46px]">
           <TabsTrigger_Shadcn_
             value="details"
-            className="px-0 pb-0 h-full text-xs  data-[state=active]:bg-transparent !shadow-none"
+            className="px-0 pb-0 h-full text-xs data-[state=active]:bg-transparent !shadow-none"
           >
             Overview
           </TabsTrigger_Shadcn_>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -260,7 +260,7 @@ export const CreateWrapperSheet = ({
                           label="Tables"
                           showIndicator={false}
                         >
-                          <div className="flex  gap-x-5">
+                          <div className="flex gap-x-5">
                             <div className="flex flex-col">
                               <p className="text-foreground-light text-left">
                                 Create foreign tables to query data from {wrapperMeta.label}.
@@ -285,7 +285,7 @@ export const CreateWrapperSheet = ({
                           label="Schema"
                           showIndicator={false}
                         >
-                          <div className="flex  gap-x-5">
+                          <div className="flex gap-x-5">
                             <div className="flex flex-col">
                               <p className="text-foreground-light text-left">
                                 Create all foreign tables from {wrapperMeta.label} in a specified

--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/StripeSyncSettingsPage.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/StripeSyncSettingsPage.tsx
@@ -102,7 +102,7 @@ export const StripeSyncSettingsPage = () => {
               <CardContent>
                 <div className="flex space-x-4 @container">
                   <Table2 className="w-5 h-5 shrink-0" />
-                  <div className="flex flex-col items-start @lg:flex-row @lg:items-center  gap-4">
+                  <div className="flex flex-col items-start @lg:flex-row @lg:items-center gap-4">
                     <div className="flex flex-col gap-1">
                       <h5 className="text-sm mb-1">Open Stripe schema in Table Editor</h5>
                       <p className="text-sm text-foreground-light">

--- a/apps/studio/components/interfaces/ProjectAPIDocs/FirstLevelNav.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/FirstLevelNav.tsx
@@ -75,7 +75,7 @@ export const FirstLevelNav = (): ReactNode => {
 
   return (
     <>
-      <nav aria-labelledby="api-docs-rest-categories" className="px-2 py-4  border-b">
+      <nav aria-labelledby="api-docs-rest-categories" className="px-2 py-4 border-b">
         <h2 id="api-docs-rest-categories" className="sr-only">
           REST API Docs
         </h2>

--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeFilterPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeFilterPopover/index.tsx
@@ -135,7 +135,7 @@ export const RealtimeFilterPopover = ({ config, onChangeConfig }: RealtimeFilter
                 }
               />
             </div>
-            <p className="text-xs  text-foreground-light pt-1">
+            <p className="text-xs text-foreground-light pt-1">
               Send any data to any client subscribed to the same channel
             </p>
           </div>

--- a/apps/studio/components/layouts/ProjectLayout/BuildingState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/BuildingState.tsx
@@ -133,7 +133,7 @@ const BuildingState = () => {
                 </ul>
               </div>
             </div>
-            <div className="col-span-12  lg:col-span-8 flex flex-col gap-8">
+            <div className="col-span-12 lg:col-span-8 flex flex-col gap-8">
               <APIKeys />
             </div>
           </div>

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -321,7 +321,7 @@ export const CustomLabel = ({
     return (
       <button
         key={entry.name}
-        className="flex md:flex-col gap-1 md:gap-0 w-fit text-foreground rounded-lg  hover:bg-background-overlay-hover"
+        className="flex md:flex-col gap-1 md:gap-0 w-fit text-foreground rounded-lg hover:bg-background-overlay-hover"
         onMouseOver={() => handleMouseEnter(entry.name)}
         onMouseOutCapture={handleMouseLeave}
         onClick={(e) => onToggleAttribute?.(entry.name, { exclusive: e.metaKey || e.ctrlKey })}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code cleanup — removes extraneous double spaces from `className` string literals across 11 Studio components.

## What is the current behavior?

Several components have double spaces (or leading/trailing spaces) in their `className` attributes. While CSS class application is whitespace-agnostic so this doesn't affect rendering, the extra spaces are unnecessary noise in the code.

## What is the new behavior?

All double spaces in `className` strings are normalized to single spaces. No visual or behavioral changes.

## Files changed

| File | Change |
|------|--------|
| `ComposedChart.utils.tsx` | `rounded-lg  hover:` -> `rounded-lg hover:` |
| `BuildingState.tsx` | `col-span-12  lg:col-span-8` -> `col-span-12 lg:col-span-8` |
| `UserPanel.tsx` | `text-xs  data-[state=active]` -> `text-xs data-[state=active]` |
| `CreateWrapperSheet.tsx` (x2) | `flex  gap-x-5` -> `flex gap-x-5` |
| `SchemaGraphLegend.tsx` | `flex-wrap  items-center` -> `flex-wrap items-center` |
| `StripeSyncSettingsPage.tsx` | `@lg:items-center  gap-4` -> `@lg:items-center gap-4` |
| `CronJobsEmptyState.tsx` | `"  text-center ... py-12  "` -> `"text-center ... py-12"` |
| `MessageDetailsPanel.tsx` | `text-xs  data-[state=active]` -> `text-xs data-[state=active]` |
| `PolicyEditorPanelHeader.tsx` | `group  font-normal` -> `group font-normal` |
| `FirstLevelNav.tsx` | `py-4  border-b` -> `py-4 border-b` |
| `RealtimeFilterPopover/index.tsx` | `text-xs  text-foreground-light` -> `text-xs text-foreground-light` |