### PR TITLE
fix: correct typos in variable names, error messages, and docs

### DIFF
--- a/apps/docs/content/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM.mdx
+++ b/apps/docs/content/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM.mdx
@@ -1,5 +1,5 @@
 ---
-title = "Increase vector lookup speeds by applying an HSNW index"
+title = "Increase vector lookup speeds by applying an HNSW index"
 github_url = "https://github.com/orgs/supabase/discussions/21379"
 date_created = "2024-02-20T05:32:05+00:00"
 topics = [ "database", "ai", "platform" ]
@@ -11,7 +11,7 @@ database_id = "7d755701-747f-4c3a-b8be-236c5518e4eb"
 
 > Building an index without the `CONCURRENTLY` modifier will lock the table, but it will also increase build times. For general advice about indexes, check out this [guide](https://github.com/orgs/supabase/discussions/22449).
 
-### **To speed up queries, it is ideal to create an HSNW index on your embedded column**
+### **To speed up queries, it is ideal to create an HNSW index on your embedded column**
 
 The general structure for creating an HNSW index follows this pattern:
 
@@ -58,7 +58,7 @@ If an address is returned, you should use your direct connection string found on
 
 **3. Increase memory for index creation (optional)**
 
-The `maintance_work_mem` variable limits the maximum amount of memory that can be used by maintenance operations, such as vacuuming, altering, and indexing tables. In your session you should try to set it to a reasonably high value:
+The `maintenance_work_mem` variable limits the maximum amount of memory that can be used by maintenance operations, such as vacuuming, altering, and indexing tables. In your session you should try to set it to a reasonably high value:
 
 ```sql
 set maintenance_work_mem to <several Gb's>; -- '#GB'

--- a/apps/docs/lib/docs.ts
+++ b/apps/docs/lib/docs.ts
@@ -43,7 +43,7 @@ export function isValidGuideFrontmatter(obj: object): obj is GuideFrontmatter {
     )
   }
   if ('subtitle' in obj && typeof obj.subtitle !== 'string') {
-    throw Error(`Invalid guide frontmatter: Subtitle must be a sring. Received: ${obj.subtitle}`)
+    throw Error(`Invalid guide frontmatter: Subtitle must be a string. Received: ${obj.subtitle}`)
   }
   if ('description' in obj && typeof obj.description !== 'string') {
     throw Error(

--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -207,11 +207,11 @@ const getLayoutedElementsViaLocalStorage = (
   // [Joshen] Potentially look into auto fitting new nodes?
   // https://github.com/xyflow/xyflow/issues/1113
 
-  const nodesWithNoSavedPositons = nodes.filter((n) => !(n.id in positions))
+  const nodesWithNoSavedPositions = nodes.filter((n) => !(n.id in positions))
   let newNodeCount = 0
   let basePosition = {
     x: 0,
-    y: -(NODE_SEP + TABLE_NODE_ROW_HEIGHT + nodesWithNoSavedPositons.length * 10),
+    y: -(NODE_SEP + TABLE_NODE_ROW_HEIGHT + nodesWithNoSavedPositions.length * 10),
   }
 
   nodes.forEach((node) => {

--- a/apps/www/lib/changelog.utils.ts
+++ b/apps/www/lib/changelog.utils.ts
@@ -1,5 +1,5 @@
 // hackery to fix Terry accidentally deleting
-// a bunch of releases and their associted discussions in Dec 2023
+// a bunch of releases and their associated discussions in Dec 2023
 // checks if titles match and grabs this original createdAt timestamp
 export const deletedDiscussions = [
   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (typo corrections)

## What is the current behavior?

Several typos across the codebase:

- `nodesWithNoSavedPositons` variable name misspelled in Schema visualizer utils
- Error message says "must be a sring" instead of "must be a string" in docs frontmatter validation
- HNSW (Hierarchical Navigable Small World) algorithm name misspelled as "HSNW" in vector index troubleshooting guide title and heading
- `maintance_work_mem` misspelled in troubleshooting docs (should be `maintenance_work_mem`)
- "associted" misspelled in changelog utils comment

## What is the new behavior?

All typos are corrected:

- `nodesWithNoSavedPositions` (correct spelling)
- "must be a string" (correct error message)
- "HNSW" (correct algorithm acronym)
- `maintenance_work_mem` (correct Postgres parameter name)
- "associated" (correct spelling)

## Additional context

These are straightforward typo fixes with no behavioral changes. The HNSW and maintenance_work_mem fixes are particularly important as they appear in user-facing documentation.