### PR TITLE
fix: use console.error for error logging in useLocalStorage hooks

### DIFF
--- a/apps/learn/components/use-local-storage.tsx
+++ b/apps/learn/components/use-local-storage.tsx
@@ -17,7 +17,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
       return item ? JSON.parse(item) : initialValue
     } catch (error) {
       // If error also return initialValue
-      console.log(error)
+      console.error(error)
       return initialValue
     }
   })
@@ -37,7 +37,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
         }
       } catch (error) {
         // A more advanced implementation would handle the error case
-        console.log(error)
+        console.error(error)
       }
     },
     [key, storedValue]

--- a/apps/ui-library/components/use-local-storage.tsx
+++ b/apps/ui-library/components/use-local-storage.tsx
@@ -16,7 +16,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
       return item ? JSON.parse(item) : initialValue
     } catch (error) {
       // If error also return initialValue
-      console.log(error)
+      console.error(error)
       return initialValue
     }
   })
@@ -36,7 +36,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
         }
       } catch (error) {
         // A more advanced implementation would handle the error case
-        console.log(error)
+        console.error(error)
       }
     },
     [key, storedValue]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (logging severity)

## What is the current behavior?

The `useLocalStorage` hook in both `apps/learn` and `apps/ui-library` uses `console.log()` to log errors from localStorage operations (JSON parsing failures, quota exceeded errors, etc.). This makes real errors indistinguishable from informational logs.

## What is the new behavior?

Both error catch blocks now use `console.error()` instead of `console.log()`, ensuring localStorage failures are logged at the correct severity level and are easier to identify during debugging.

## Additional context

Files changed:
- `apps/learn/components/use-local-storage.tsx` (2 occurrences)
- `apps/ui-library/components/use-local-storage.tsx` (2 occurrences)

This is consistent with the same fix previously applied to the Studio app's `useLocalStorage` hook.