### PR TITLE
fix: correct Vue.js capitalization and "a IPv4" grammar

### DIFF
--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -12,7 +12,7 @@ If you can't find the Network Restrictions section at the bottom of your [Databa
 
 Each Supabase project comes with configurable restrictions on the IP ranges that are allowed to connect to Postgres and its pooler ("your database"). These restrictions are enforced before traffic reaches your database. If a connection is not restricted by IP, it still needs to authenticate successfully with valid database credentials.
 
-If direct connections to your database [resolve to a IPv6 address](/dashboard/project/_/database/settings), you need to add both IPv4 and IPv6 CIDRs to the list of allowed CIDRs. Network Restrictions will be applied to all database connection routes, whether pooled or direct. You will need to add both the IPv4 and IPv6 networks you want to allow. There are two exceptions: If you have been granted an extension on the IPv6 migration OR if you have purchased the [IPv4 add-on](/dashboard/project/_/settings/addons), you need only add IPv4 CIDRs.
+If direct connections to your database [resolve to an IPv6 address](/dashboard/project/_/database/settings), you need to add both IPv4 and IPv6 CIDRs to the list of allowed CIDRs. Network Restrictions will be applied to all database connection routes, whether pooled or direct. You will need to add both the IPv4 and IPv6 networks you want to allow. There are two exceptions: If you have been granted an extension on the IPv6 migration OR if you have purchased the [IPv4 add-on](/dashboard/project/_/settings/addons), you need only add IPv4 CIDRs.
 
 ## To get started via the Dashboard:
 

--- a/apps/studio/components/interfaces/Connect/Connect.constants.ts
+++ b/apps/studio/components/interfaces/Connect/Connect.constants.ts
@@ -170,7 +170,7 @@ export const FRAMEWORKS: ConnectionType[] = [
   },
   {
     key: 'vuejs',
-    label: 'Vue.JS',
+    label: 'Vue.js',
     icon: 'vuejs',
     guideLink: `${DOCS_URL}/guides/getting-started/quickstarts/vue`,
     children: [
@@ -383,7 +383,7 @@ export const CONNECTION_TYPES = [
 ]
 
 export const PGBOUNCER_ENABLED_BUT_NO_IPV4_ADDON_TEXT =
-  'Purchase IPv4 add-on or use Shared Pooler if on a IPv4 network'
+  'Purchase IPv4 add-on or use Shared Pooler if on an IPv4 network'
 export const IPV4_ADDON_TEXT = 'Connections are IPv4 proxied with IPv4 add-on'
 
 export type ConnectionStringMethod = 'direct' | 'transaction' | 'session'

--- a/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
@@ -225,7 +225,7 @@ export const ConnectionPanel = ({
                 <WarningIcon />
               </div>
               <div className="flex flex-col">
-                <span className="text-xs text-foreground">Only use on a IPv4 network</span>
+                <span className="text-xs text-foreground">Only use on an IPv4 network</span>
                 <div className="flex flex-col text-xs text-foreground-lighter">
                   <p>Session pooler connections are IPv4 proxied for free.</p>
                   <p>Use Direct Connection if connecting via an IPv6 network.</p>
@@ -280,7 +280,7 @@ export const ConnectionPanel = ({
                     You may also use the{' '}
                     <span className="text-foreground-light">Session Pooler</span> or{' '}
                     <span className="text-foreground-light">Transaction Pooler</span> if you are on
-                    a IPv4 network.
+                    an IPv4 network.
                   </p>
                 </div>
               </CollapsibleContent_Shadcn_>

--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -422,7 +422,7 @@ export const DatabaseConnectionString = () => {
                       !sharedPoolerPreferred && !ipv4Addon
                         ? PGBOUNCER_ENABLED_BUT_NO_IPV4_ADDON_TEXT
                         : sharedPoolerPreferred
-                          ? 'Use Session Pooler if on a IPv4 network or purchase IPv4 add-on'
+                          ? 'Use Session Pooler if on an IPv4 network or purchase IPv4 add-on'
                           : IPV4_ADDON_TEXT,
                     links: buttonLinks,
                   }}

--- a/apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts
@@ -170,7 +170,7 @@ export const FRAMEWORKS: ConnectionType[] = [
   },
   {
     key: 'vuejs',
-    label: 'Vue.JS',
+    label: 'Vue.js',
     icon: 'vuejs',
     guideLink: `${DOCS_URL}/guides/getting-started/quickstarts/vue`,
     children: [
@@ -382,7 +382,7 @@ export const CONNECTION_TYPES = [
 ]
 
 export const PGBOUNCER_ENABLED_BUT_NO_IPV4_ADDON_TEXT =
-  'Purchase IPv4 add-on or use Shared Pooler if on a IPv4 network'
+  'Purchase IPv4 add-on or use Shared Pooler if on an IPv4 network'
 export const IPV4_ADDON_TEXT = 'Connections are IPv4 proxied with IPv4 add-on'
 
 export type ConnectionStringMethod = 'direct' | 'transaction' | 'session'

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -131,7 +131,7 @@ const IPv4SidePanel = () => {
           <p className="text-sm">
             Direct connections to the database only work if your client is able to resolve IPv6
             addresses. Enabling the dedicated IPv4 add-on allows you to directly connect to your
-            database via a IPv4 address.
+            database via an IPv4 address.
           </p>
 
           {!isAws && (
@@ -252,7 +252,7 @@ const IPv4SidePanel = () => {
 
           {!hasAccessToIPv4 && (
             <Admonition type="note" title="IPv4 add-on is unavailable on the Free Plan">
-              <p>Upgrade your plan to enable a IPv4 address for your project</p>
+              <p>Upgrade your plan to enable an IPv4 address for your project</p>
               <Button asChild type="default">
                 <Link
                   href={`/org/${organization?.slug}/billing?panel=subscriptionPlan&source=ipv4SidePanel`}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (user-facing text corrections)

## What is the current behavior?

1. **Vue.JS**: The framework label in Connect constants shows "Vue.JS" instead of the official "Vue.js" branding
2. **"a IPv4/IPv6"**: Several user-facing strings incorrectly use "a IPv4" instead of "an IPv4" (since "IPv4" is pronounced starting with a vowel sound "eye")

## What is the new behavior?

1. Framework label corrected to "Vue.js" (matches [vuejs.org](https://vuejs.org) official branding)
2. All "a IPv4/IPv6" instances corrected to "an IPv4/IPv6" for proper grammar

## Files changed

- `apps/studio/components/interfaces/Connect/Connect.constants.ts` - Vue.js + an IPv4
- `apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts` - Vue.js + an IPv4
- `apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx` - an IPv4
- `apps/studio/components/interfaces/Connect/ConnectionPanel.tsx` - an IPv4 (2 places)
- `apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx` - an IPv4 (2 places)
- `apps/docs/content/guides/platform/network-restrictions.mdx` - an IPv6

## Additional context

These are user-facing text corrections with no behavioral changes.