### PR TITLE
fix: correct article usage for acronyms (an MFA, an SMS, an OTP)

### DIFF
--- a/apps/docs/content/guides/platform/multi-factor-authentication.mdx
+++ b/apps/docs/content/guides/platform/multi-factor-authentication.mdx
@@ -40,7 +40,7 @@ If you are an organization owner and on the Pro, Team or Enterprise plan, you ca
 
 ## Disable MFA
 
-You can disable MFA for your user account under your [Supabase account settings](/dashboard/account/security). On subsequent login attempts, you will not be prompted to enter a MFA code.
+You can disable MFA for your user account under your [Supabase account settings](/dashboard/account/security). On subsequent login attempts, you will not be prompted to enter an MFA code.
 
 <Admonition type="caution">
 

--- a/apps/docs/docs/ref/dart/v0/upgrade-guide.mdx
+++ b/apps/docs/docs/ref/dart/v0/upgrade-guide.mdx
@@ -353,7 +353,7 @@ await supabase.auth.signInWithOtp(
   phone: phone,
 );
 
-// After receiving a SMS with a OTP.
+// After receiving an SMS with an OTP.
 await supabase.auth.verifyOTP(
   type: OtpType.sms,
   token: token,

--- a/apps/docs/docs/ref/javascript/v1/upgrade-guide.mdx
+++ b/apps/docs/docs/ref/javascript/v1/upgrade-guide.mdx
@@ -250,7 +250,7 @@ const { data, error } = await supabase
   .auth
   .signInWithOtp({ phone })
 
-// After receiving a SMS with a OTP.
+// After receiving an SMS with an OTP.
 const { data, error } = await supabase
 .auth
 .verifyOtp({ phone, token })

--- a/apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts
+++ b/apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts
@@ -40,7 +40,7 @@ export const useMfaChallengeAndVerifyMutation = ({
       return mfaChallengeAndVerify(params)
     },
     async onSuccess(data, variables, context) {
-      // when a MFA is added, the aaLevel is bumped up
+      // when an MFA is added, the aaLevel is bumped up
       const refreshFactors = variables.refreshFactors ?? true
 
       await Promise.all([


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation / text fix (grammar)

## What is the current behavior?

Several places in the codebase use "a" before acronyms that start with vowel sounds, which is grammatically incorrect:

- "enter a MFA code" (MFA is pronounced "em-eff-ay", starting with a vowel sound)
- "a SMS with a OTP" (SMS = "ess-em-ess", OTP = "oh-tee-pee")

## What is the new behavior?

Corrected to use "an" before acronyms with vowel sounds:

- "enter an MFA code"
- "an SMS with an OTP"

## Files changed

- `apps/studio/data/profile/mfa-challenge-and-verify-mutation.ts` - comment fix
- `apps/docs/content/guides/platform/multi-factor-authentication.mdx` - user-facing docs
- `apps/docs/docs/ref/javascript/v1/upgrade-guide.mdx` - code comment in example
- `apps/docs/docs/ref/dart/v0/upgrade-guide.mdx` - code comment in example

## Additional context

The rule: use "an" before acronyms pronounced with an initial vowel sound, regardless of the first letter. "MFA" starts with "em" (vowel sound), "SMS" starts with "ess" (vowel sound), "OTP" starts with "oh" (vowel sound).