### PR TITLE
docs: fix grammar, spelling, and capitalization across docs and studio

### DIFF
--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -293,7 +293,7 @@ You can use the Supabase client libraries to send Broadcast messages.
 
 
     /**
-     * Sending a message after subscribing will use Websockets
+     * Sending a message after subscribing will use WebSockets
      */
     myChannel.subscribe((status) => {
       if (status !== 'SUBSCRIBED') {
@@ -325,7 +325,7 @@ You can use the Supabase client libraries to send Broadcast messages.
     );
     print(res);
 
-    // Sending a message after subscribing will use Websockets
+    // Sending a message after subscribing will use WebSockets
     myChannel.subscribe((status, error) {
       if (status != RealtimeSubscribeStatus.subscribed) {
         return;
@@ -352,7 +352,7 @@ You can use the Supabase client libraries to send Broadcast messages.
     // Sending a message before subscribing will use HTTP
     await myChannel.broadcast(event: "shout", message: ["message": "HI"])
 
-    // Sending a message after subscribing will use Websockets
+    // Sending a message after subscribing will use WebSockets
     await myChannel.subscribe()
     try await myChannel.broadcast(
         event: "shout",
@@ -376,7 +376,7 @@ You can use the Supabase client libraries to send Broadcast messages.
       put("message", "Hi")
     })
 
-    // Sending a message after subscribing will use Websockets
+    // Sending a message after subscribing will use WebSockets
     myChannel.subscribe(blockUntilSubscribed = true)
     channelB.broadcast(
       event = "shout",
@@ -401,7 +401,7 @@ You can use the Supabase client libraries to send Broadcast messages.
     ```python
     my_channel = supabase.channel('test-channel')
 
-    # Sending a message after subscribing will use Websockets
+    # Sending a message after subscribing will use WebSockets
     def on_subscribe(status, err):
       if status != RealtimeSubscribeStates.SUBSCRIBED:
         return

--- a/apps/docs/content/troubleshooting/prisma-error-management-Cm5P_o.mdx
+++ b/apps/docs/content/troubleshooting/prisma-error-management-Cm5P_o.mdx
@@ -63,7 +63,7 @@ Add pgbouncer=true to the connection string.
 
 ## `Max client connections reached`
 
-Checkout this [guide](https://github.com/orgs/supabase/discussions/22305) for managing this error
+Check out this [guide](https://github.com/orgs/supabase/discussions/22305) for managing this error
 
 ## `Server has closed the connection`
 

--- a/apps/docs/docs/ref/javascript/v1/upgrade-guide.mdx
+++ b/apps/docs/docs/ref/javascript/v1/upgrade-guide.mdx
@@ -6,7 +6,7 @@ description: 'Learn how to upgrade to supabase-js v2.'
 
 supabase-js v2 focuses on "quality-of-life" improvements for developers and addresses some of the largest pain points in v1. v2 includes type support, a rebuilt Auth library with async methods, improved errors, and more.
 
-No new features will be added to supabase-js v1 , but we'll continuing merging security fixes to v1, with maintenance patches for the next 3 months.
+No new features will be added to supabase-js v1, but we'll continue merging security fixes to v1, with maintenance patches for the next 3 months.
 
 ## Upgrade the client library
 
@@ -462,7 +462,7 @@ The cookie-related methods like `setAuthCookie` and `getUserByCookie` have been 
 For Next.js you can use the [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs) to help you manage cookies.
 If you can't use the Auth Helpers, you can use [server-side rendering](https://supabase.com/docs/guides/auth/server-side-rendering).
 
-Some the [PR](https://github.com/supabase/gotrue-js/pull/340) for additional background information.
+See the [PR](https://github.com/supabase/gotrue-js/pull/340) for additional background information.
 
 ### Data methods
 

--- a/apps/docs/docs/ref/kotlin/installing.mdx
+++ b/apps/docs/docs/ref/kotlin/installing.mdx
@@ -28,7 +28,7 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
         - [**postgrest-kt**](https://github.com/supabase-community/supabase-kt/tree/master/Postgrest)
         - Other plugins also available [here](https://github.com/supabase-community/supabase-kt/tree/master/plugins)
 
-        Checkout the different READMEs for information about supported Kotlin targets.
+        Check out the different READMEs for information about supported Kotlin targets.
 
         *Note that the minimum Android SDK version is 26. For lower versions, you need to enable [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).*
 
@@ -96,7 +96,7 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
     <RefSubLayout.Details>
 
         You can find a list of engines [here](https://ktor.io/docs/http-client-engines.html)
-        - Note that not all Ktor engines support Websockets. So if you plan to use the Realtime module, make sure to use an engine that supports Websockets. Checkout the [engine limitations](https://ktor.io/docs/client-engines.html#limitations) for more information.
+        - Note that not all Ktor engines support WebSockets. So if you plan to use the Realtime module, make sure to use an engine that supports WebSockets. Check out the [engine limitations](https://ktor.io/docs/client-engines.html#limitations) for more information.
         - If using `supabase-kt` 3.0.0 and above, you need to use Ktor version 3.0.0-rc-1 or later.
 
     </RefSubLayout.Details>

--- a/apps/docs/docs/ref/kotlin/v2/installing.mdx
+++ b/apps/docs/docs/ref/kotlin/v2/installing.mdx
@@ -92,7 +92,7 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
     <RefSubLayout.Details>
 
         You can find a list of engines [here](https://ktor.io/docs/http-client-engines.html)
-        Note that not all Ktor engines support Websockets. So if you plan to use the Realtime module, make sure to use an engine that supports Websockets. Checkout the [engine limitations](https://ktor.io/docs/client-engines.html#limitations) for more information.
+        Note that not all Ktor engines support WebSockets. So if you plan to use the Realtime module, make sure to use an engine that supports WebSockets. Check out the [engine limitations](https://ktor.io/docs/client-engines.html#limitations) for more information.
 
     </RefSubLayout.Details>
     <RefSubLayout.Examples>

--- a/apps/docs/docs/ref/realtime/realtime.mdx
+++ b/apps/docs/docs/ref/realtime/realtime.mdx
@@ -19,7 +19,7 @@ There are two versions of this server: `Realtime` and `Realtime RLS`.
 `Realtime RLS` server works by:
 
 1. polling PostgreSQL's replication functionality (using PostgreSQL's logical decoding and [wal2json](https://github.com/eulerto/wal2json) output plugin)
-2. passing database changes to a [Write Ahead Log Realtime Unified Security (WALRUS)](https://github.com/supabase/walrus) PostgresSQL function and receiving a list of authorized subscribers depending on Row Level Security (RLS) policies
+2. passing database changes to a [Write Ahead Log Realtime Unified Security (WALRUS)](https://github.com/supabase/walrus) PostgreSQL function and receiving a list of authorized subscribers depending on Row Level Security (RLS) policies
 3. converting the changes into JSON
 4. broadcasting to authorized subscribers over WebSockets
 

--- a/apps/docs/docs/ref/self-hosting-realtime/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-realtime/introduction.mdx
@@ -26,7 +26,7 @@ hideTitle: true
     `Realtime RLS` server works by:
 
     1. Polling PostgreSQL's replication functionality (using PostgreSQL's logical decoding and [wal2json](https://github.com/eulerto/wal2json) output plugin)
-    2. Passing database changes to a [Write Ahead Log Realtime Unified Security (WALRUS)](https://github.com/supabase/walrus) PostgresSQL function and receiving a list of authorized subscribers depending on Row Level Security (RLS) policies
+    2. Passing database changes to a [Write Ahead Log Realtime Unified Security (WALRUS)](https://github.com/supabase/walrus) PostgreSQL function and receiving a list of authorized subscribers depending on Row Level Security (RLS) policies
     3. Converting the changes into JSON
     4. Broadcasting to authorized subscribers over WebSockets
 

--- a/apps/studio/components/interfaces/Functions/Functions.templates.ts
+++ b/apps/studio/components/interfaces/Functions/Functions.templates.ts
@@ -407,7 +407,7 @@ Deno.serve(async (req) => {
   },
   {
     value: 'websocket-server',
-    name: 'Websocket Server Example',
+    name: 'WebSocket Server Example',
     description: 'Create a real-time WebSocket server',
     content: `// Setup type definitions for built-in Supabase Runtime APIs
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation and copy corrections.

## What is the current behavior?

Several docs and one Studio file contain grammar, spelling, and capitalization issues:

- JS v1 upgrade guide: "we'll continuing" (should be "we'll continue"), "Some the [PR]" (should be "See the [PR]"), extra space before comma
- Realtime docs: "PostgresSQL" (should be "PostgreSQL") in 2 files
- Kotlin SDK installing docs: "Websockets" (should be "WebSockets"), "Checkout the" (should be "Check out the")
- Broadcast guide: "Websockets" (should be "WebSockets") in code comments (5 occurrences)
- Prisma troubleshooting: "Checkout this" (should be "Check out this")
- Edge function template: "Websocket Server Example" (should be "WebSocket Server Example")

## What is the new behavior?

All grammar, spelling, and capitalization issues are corrected:

- **Grammar**: "we'll continue" (verb tense), "See the [PR]" (correct word), removed extra space
- **Spelling**: "PostgreSQL" (correct product name)
- **Capitalization**: "WebSocket" / "WebSockets" follows the official W3C/IETF naming convention
- **Word splitting**: "Check out" as a phrasal verb (two words), vs "checkout" the noun

## Files changed (8)

- `apps/docs/docs/ref/javascript/v1/upgrade-guide.mdx` — grammar fixes (3 issues)
- `apps/docs/docs/ref/self-hosting-realtime/introduction.mdx` — PostgresSQL -> PostgreSQL
- `apps/docs/docs/ref/realtime/realtime.mdx` — PostgresSQL -> PostgreSQL
- `apps/docs/docs/ref/kotlin/v2/installing.mdx` — WebSockets + Check out
- `apps/docs/docs/ref/kotlin/installing.mdx` — WebSockets + Check out (2 occurrences)
- `apps/docs/content/guides/realtime/broadcast.mdx` — Websockets -> WebSockets (5 occurrences)
- `apps/docs/content/troubleshooting/prisma-error-management-Cm5P_o.mdx` — Check out
- `apps/studio/components/interfaces/Functions/Functions.templates.ts` — WebSocket template name