### PR TITLE
fix: correct grammar in comments and user-facing copy

### DIFF
--- a/apps/docs/content/troubleshooting/customizing-emails-by-language-KZ_38Q.mdx
+++ b/apps/docs/content/troubleshooting/customizing-emails-by-language-KZ_38Q.mdx
@@ -38,7 +38,7 @@ It can be accessed in a project's [Email Templates](/dashboard/project/_/auth/te
 
 If you need to update a user's meta-data, you can do so with the [`updateUser`](/docs/reference/javascript/auth-updateuser?example=update-the-users-metadata) function.
 
-The meta-data can be used to store a users language preferences. You could then use "if statements" in the email template to set the response for a specific language:
+The meta-data can be used to store a user's language preferences. You could then use "if statements" in the email template to set the response for a specific language:
 
 ```html
 {{if eq .Data.language "en" }}

--- a/apps/docs/instrumentation-client.ts
+++ b/apps/docs/instrumentation-client.ts
@@ -1,5 +1,5 @@
 // This file configures the initialization of Sentry on the client.
-// The added config here will be used whenever a users loads a page in their browser.
+// The added config here will be used whenever a user loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -1,5 +1,5 @@
 // This file configures the initialization of Sentry on the client.
-// The config you add here will be used whenever a users loads a page in their browser.
+// The config you add here will be used whenever a user loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
@@ -216,7 +216,7 @@ Sentry.init({
     'NotFoundError: The object can not be found here.',
     // [Joshen] This one sprung up recently and I've no idea where this is coming from
     'r.default.setDefaultLevel is not a function',
-    // [Joshen] Safe to ignore, it an error from the copyToClipboard
+    // [Joshen] Safe to ignore, it's an error from the copyToClipboard
     'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
   ],
 })

--- a/apps/www/data/partners/index.tsx
+++ b/apps/www/data/partners/index.tsx
@@ -51,7 +51,7 @@ export default {
       },
       {
         title: 'Add OAuth2 Support',
-        text: 'Use the OAuth2 protocol to access a users organization or project',
+        text: "Use the OAuth2 protocol to access a user's organization or project",
       },
       {
         title: 'Receive Tokens',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Grammar corrections in comments and user-facing text.

## What is the current behavior?

Several files have minor grammar issues:

- Missing contraction: "it an error" (should be "it's an error")
- Subject-verb disagreement: "a users loads" (should be "a user loads")
- Missing possessive apostrophe: "a users organization" and "a users language" (should be "a user's")

## What is the new behavior?

All grammar issues are corrected:

- `apps/studio/instrumentation-client.ts` — "it's an error" + "a user loads"
- `apps/docs/instrumentation-client.ts` — "a user loads"
- `apps/www/data/partners/index.tsx` — "a user's organization"
- `apps/docs/content/troubleshooting/customizing-emails-by-language-KZ_38Q.mdx` — "a user's language"