### PR TITLE
fix: correct indefinite article usage for acronyms (an HTTP, an API, an RLS)

### DIFF
--- a/apps/docs/content/guides/ai/integrations/roboflow.mdx
+++ b/apps/docs/content/guides/ai/integrations/roboflow.mdx
@@ -111,7 +111,7 @@ data=[{'predictions': {'time': 0.08492901099998562, 'image': {'width': 640, 'hei
 
 You can use the Supabase vector database functionality to store and query CLIP embeddings.
 
-Roboflow Inference provides a HTTP interface through which you can calculate image and text embeddings using CLIP.
+Roboflow Inference provides an HTTP interface through which you can calculate image and text embeddings using CLIP.
 
 ### Step 1: Install and start Roboflow Inference
 

--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -99,7 +99,7 @@ notify pgrst, 'reload config';
 
 <$Partial path="db_pre_request_warning.mdx" />
 
-Inside the function you can perform any additional checks on the request headers or JWT and raise an exception to prevent the request from completing. For example, this exception raises a HTTP 402 Payment Required response with a `hint` and additional `X-Powered-By` header:
+Inside the function you can perform any additional checks on the request headers or JWT and raise an exception to prevent the request from completing. For example, this exception raises an HTTP 402 Payment Required response with a `hint` and additional `X-Powered-By` header:
 
 ```sql
 raise sqlstate 'PGRST' using
@@ -186,7 +186,7 @@ You can only rate-limit `POST`, `PUT`, `PATCH` and `DELETE` requests. This is be
 Outline:
 
 - A new row is added to a `private.rate_limits` table each time a modifying action is done to the database containing the IP address and the timestamp of the action.
-- If there are over 100 requests from the same IP address in the last 5 minutes, the request is rejected with a HTTP 420 code.
+- If there are over 100 requests from the same IP address in the last 5 minutes, the request is rejected with an HTTP 420 code.
 
 Create the table:
 

--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -42,7 +42,7 @@ A [Postgres function](/docs/guides/database/functions) can be configured as a ho
 </TabPanel>
 <TabPanel id="http" label="HTTP Endpoint">
 
-A HTTP Hook is an endpoint which takes in a JSON event payload and returns a JSON response. You can use any HTTP endpoint as a Hook, including an endpoint in your application. The easiest way to create a HTTP hook is to create a [Supabase Edge Function](/docs/guides/functions/quickstart).
+An HTTP Hook is an endpoint which takes in a JSON event payload and returns a JSON response. You can use any HTTP endpoint as a Hook, including an endpoint in your application. The easiest way to create an HTTP hook is to create a [Supabase Edge Function](/docs/guides/functions/quickstart).
 
 </TabPanel>
 </Tabs>
@@ -97,7 +97,7 @@ HTTP Hooks in Supabase follow the [Standard Webhooks Specification](https://www.
 
 When the request is made to the HTTP hook, you should use the [Standard Webhooks libraries](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries) to verify these headers.
 
-When a HTTP hook is created, the secret generated should be of the `v1,whsec_<base64-secret>` format:
+When an HTTP hook is created, the secret generated should be of the `v1,whsec_<base64-secret>` format:
 
 - `v1` denotes the version of the hook
 - `whsec_` signifies that the secret is symmetric
@@ -303,7 +303,7 @@ Here's an example:
 }
 ```
 
-Errors returned from a Postgres Hook are not retry-able. When an error is returned, the error is propagated from the hook to Supabase Auth and translated into a HTTP error which is returned to your application. Supabase Auth will only take into account the error and disregard the rest of the payload.
+Errors returned from a Postgres Hook are not retry-able. When an error is returned, the error is propagated from the hook to Supabase Auth and translated into an HTTP error which is returned to your application. Supabase Auth will only take into account the error and disregard the rest of the payload.
 
 </TabPanel>
 

--- a/apps/docs/content/guides/auth/auth-hooks/before-user-created-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/before-user-created-hook.mdx
@@ -173,7 +173,7 @@ This response will block the user creation and return the error message to the c
 
 ## Examples
 
-Each of the following examples shows how to use the `before-user-created` hook to control signup behavior. Each use case includes both a HTTP implementation (e.g. using an Edge Function) and a SQL implementation (Postgres function).
+Each of the following examples shows how to use the `before-user-created` hook to control signup behavior. Each use case includes both an HTTP implementation (e.g. using an Edge Function) and a SQL implementation (Postgres function).
 
 <Tabs
   scrollable

--- a/apps/docs/content/guides/auth/auth-hooks/password-verification-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/password-verification-hook.mdx
@@ -161,7 +161,7 @@ revoke all
 </TabPanel>
 <TabPanel id="sql-send-email-on-failed-password-attempt" label="Send email notification on failed password attempts">
 
-You can notify a user via email instead of blocking the user. To do so, make use of [Supabase Vault](/docs/guides/database/vault) to store the API Key of our mail provider and use [`pg_net`](/docs/guides/database/extensions/pg_net) to send a HTTP request to our email provider to send the email. Ensure that you have configured a sender signature for the email account which you are sending emails from.
+You can notify a user via email instead of blocking the user. To do so, make use of [Supabase Vault](/docs/guides/database/vault) to store the API Key of our mail provider and use [`pg_net`](/docs/guides/database/extensions/pg_net) to send an HTTP request to our email provider to send the email. Ensure that you have configured a sender signature for the email account which you are sending emails from.
 
 First, create a table to track sign in attempts.
 

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -282,7 +282,7 @@ However, encountering a different AAL level on the server may not actually be a 
 3. User has lost their authenticator device and is confused about the next
    steps.
 
-We thus recommend you redirect users to a page where they can authenticate using their additional factor, instead of rendering a HTTP 401 Unauthorized or HTTP 403 Forbidden content.
+We thus recommend you redirect users to a page where they can authenticate using their additional factor, instead of rendering an HTTP 401 Unauthorized or HTTP 403 Forbidden content.
 
 ### APIs
 

--- a/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
+++ b/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
@@ -36,7 +36,7 @@ const supabase = createClient(
 )
 ```
 
-Make sure the all users in your application have the `role: 'authenticated'` [custom claim](https://firebase.google.com/docs/auth/admin/custom-claims) set. If you're using the `onCreate` Cloud Function to add this custom claim to newly signed up users, you will need to call `getIdToken(/* forceRefresh */ true)` immediately after sign up as the `onCreate` function does not run synchronously.
+Make sure all users in your application have the `role: 'authenticated'` [custom claim](https://firebase.google.com/docs/auth/admin/custom-claims) set. If you're using the `onCreate` Cloud Function to add this custom claim to newly signed up users, you will need to call `getIdToken(/* forceRefresh */ true)` immediately after sign up as the `onCreate` function does not run synchronously.
 
 </TabPanel>
 
@@ -58,7 +58,7 @@ await Supabase.initialize(
 );
 ```
 
-Make sure the all users in your application have the `role: 'authenticated'` [custom claim](https://firebase.google.com/docs/auth/admin/custom-claims) set. If you're using the `onCreate` Cloud Function to add this custom claim to newly signed up users, you will need to call `getIdToken(/* forceRefresh */ true)` immediately after sign up as the `onCreate` function does not run synchronously.
+Make sure all users in your application have the `role: 'authenticated'` [custom claim](https://firebase.google.com/docs/auth/admin/custom-claims) set. If you're using the `onCreate` Cloud Function to add this custom claim to newly signed up users, you will need to call `getIdToken(/* forceRefresh */ true)` immediately after sign up as the `onCreate` function does not run synchronously.
 
 </TabPanel>
 </$Show>

--- a/apps/docs/content/guides/local-development/testing/pgtap-extended.mdx
+++ b/apps/docs/content/guides/local-development/testing/pgtap-extended.mdx
@@ -345,7 +345,7 @@ Now to setup the RLS policies for each tables:
 
 ```sql
 -- Create a private schema to store all security definer functions utils
--- As such functions should never be in a API exposed schema
+-- As such functions should never be in an API exposed schema
 create schema if not exists private;
 -- Helper function for role checks
 create or replace function private.get_user_org_role(org_id bigint, user_id uuid)

--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -909,7 +909,7 @@ SELECT realtime.send (
 
 #### Setup realtime authorization
 
-Realtime Authorization is required and enabled by default. To allow your users to listen to messages from topics, create a RLS (Row Level Security) policy:
+Realtime Authorization is required and enabled by default. To allow your users to listen to messages from topics, create an RLS (Row Level Security) policy:
 
 ```sql
 CREATE POLICY "authenticated can receive broadcasts"

--- a/apps/docs/content/guides/storage/debugging/error-codes.mdx
+++ b/apps/docs/content/guides/storage/debugging/error-codes.mdx
@@ -126,7 +126,7 @@ Here's a list of the most common error codes and their potential resolutions:
 Indicates that the resource is not found or you don't have the correct permission to access it
 **Resolution:**
 
-- Add a RLS policy to grant permission to the resource. See our [Access Control docs](/docs/guides/storage/security/access-control) for more information.
+- Add an RLS policy to grant permission to the resource. See our [Access Control docs](/docs/guides/storage/security/access-control) for more information.
 - Ensure you include the user `Authorization` header
 - Verify the object exists
 

--- a/apps/docs/content/guides/telemetry/log-drains.mdx
+++ b/apps/docs/content/guides/telemetry/log-drains.mdx
@@ -81,7 +81,7 @@ This will create an infinite loop, as we are generating an additional log event 
 
 2. Configure the HTTP Drain
 
-Create a HTTP drain under the [Project Settings > Log Drains](/dashboard/project/_/settings/log-drains).
+Create an HTTP drain under the [Project Settings > Log Drains](/dashboard/project/_/settings/log-drains).
 
 - Disable the Gzip, as we want to receive the payload without compression.
 - Under URL, set it to your edge function URL `https://[PROJECT REF].supabase.co/functions/v1/hello-world`

--- a/apps/docs/content/troubleshooting/scan-error-on-column-confirmation_token-converting-null-to-string-is-unsupported-during-auth-login-a0c686.mdx
+++ b/apps/docs/content/troubleshooting/scan-error-on-column-confirmation_token-converting-null-to-string-is-unsupported-during-auth-login-a0c686.mdx
@@ -8,7 +8,7 @@ message = "error finding user: sql: Scan error on column 'confirmation_token': c
 
 ---
 
-If you encounter a HTTP 500 error during authentication with the message `error finding user: sql: Scan error on column "confirmation_token": converting NULL to string is unsupported`, this typically indicates that the GoTrue Auth service found a `NULL` value in the `auth.users.confirmation_token` column, where a non-nullable string is expected.
+If you encounter an HTTP 500 error during authentication with the message `error finding user: sql: Scan error on column "confirmation_token": converting NULL to string is unsupported`, this typically indicates that the GoTrue Auth service found a `NULL` value in the `auth.users.confirmation_token` column, where a non-nullable string is expected.
 
 To resolve this, update the `confirmation_token` to an empty string where it is `NULL`. You can execute the following SQL query in the [SQL Editor](/dashboard/project/_/sql/new):
 

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -85,7 +85,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it("should return a HTTP request config when there's a query parameter or hash in the URL (also handles edge function)", () => {
+  it("should return an HTTP request config when there's a query parameter or hash in the URL (also handles edge function)", () => {
     const command = `select net.http_post( url:='https://random_project_ref.supabase.co/functions/v1/_?first=1#second=2', headers:=jsonb_build_object('Authorization', 'Bearer something'), timeout_milliseconds:=5000 )`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://random_project_ref.supabase.co/functions/v1/_?first=1#second=2',
@@ -103,7 +103,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config when the command posts to another supabase.co project', () => {
+  it('should return an HTTP request config when the command posts to another supabase.co project', () => {
     const command = `select net.http_post( url:='https://another_project_ref.supabase.co/functions/v1/_', headers:=jsonb_build_object(), body:='', timeout_milliseconds:=5000 );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://another_project_ref.supabase.co/functions/v1/_',
@@ -116,7 +116,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config with POST method, empty headers and a body as string', () => {
+  it('should return an HTTP request config with POST method, empty headers and a body as string', () => {
     const command = `select net.http_post( url:='https://example.com/api/endpoint', headers:=jsonb_build_object(), body:='hello', timeout_milliseconds:=5000 );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://example.com/api/endpoint',
@@ -129,7 +129,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config with POST method, some headers and empty body', () => {
+  it('should return an HTTP request config with POST method, some headers and empty body', () => {
     const command = `select net.http_post( url:='https://example.com/api/endpoint', headers:=jsonb_build_object('fst', '1', 'snd', '2'), body:='', timeout_milliseconds:=1000 );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://example.com/api/endpoint',
@@ -145,7 +145,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config with GET method and empty body', () => {
+  it('should return an HTTP request config with GET method and empty body', () => {
     const command = `select net.http_get( url:='https://example.com/api/endpoint', headers:=jsonb_build_object(), timeout_milliseconds:=5000 );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://example.com/api/endpoint',
@@ -158,7 +158,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config with POST method and a body as JSON object', () => {
+  it('should return an HTTP request config with POST method and a body as JSON object', () => {
     const command = `select net.http_post( url:='https://example.com/api/endpoint', headers:=jsonb_build_object(), body:='{"key": "value"}', timeout_milliseconds:=5000 );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://example.com/api/endpoint',
@@ -171,7 +171,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config with POST method, plain JSON headers and plain JSON body', () => {
+  it('should return an HTTP request config with POST method, plain JSON headers and plain JSON body', () => {
     const command = `select net.http_post( url:='https://example.com/api/endpoint', headers:='{"fst": "1", "snd": "2"}',body:='{"key": "value"}',timeout_milliseconds:=5000);`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://example.com/api/endpoint',
@@ -187,7 +187,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a HTTP request config with POST method, plain JSON headers and plain JSON body with ::jsonb typecasting', () => {
+  it('should return an HTTP request config with POST method, plain JSON headers and plain JSON body with ::jsonb typecasting', () => {
     const command = `select net.http_post( url:='https://example.com/api/endpoint', headers:='{"fst": "1", "snd": "2"}'::jsonb,body:='{"key": "value"}'::jsonb,timeout_milliseconds:=5000);`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       endpoint: 'https://example.com/api/endpoint',
@@ -203,7 +203,7 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return SQL snippet type if the command is a HTTP request that cannot be parsed properly due to positional notationa', () => {
+  it('should return SQL snippet type if the command is an HTTP request that cannot be parsed properly due to positional notation', () => {
     const command = `SELECT net.http_post( 'https://webhook.site/dacc2028-a588-462c-9597-c8968e61d0fa', '{"message":"Hello from Supabase"}'::jsonb, '{}'::jsonb, '{"Content-Type":"application/json"}'::jsonb );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       type: 'sql_snippet',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Grammar corrections across documentation and test descriptions.

## What is the current behavior?

Multiple docs and test files use "a" before acronyms that start with a vowel sound when pronounced:
- "a HTTP" (pronounced "aitch-tee-tee-pee") should be "an HTTP"
- "a API" (pronounced "ay-pee-eye") should be "an API"  
- "a RLS" (pronounced "arr-ell-ess") should be "an RLS"
- "the all users" is redundant (should be "all users")

## What is the new behavior?

All instances corrected to use proper English indefinite articles:

### Docs files (11 files):
- `firebase-auth.mdx` — "the all users" -> "all users" (2 occurrences)
- `log-drains.mdx` — "a HTTP drain" -> "an HTTP drain"
- `securing-your-api.mdx` — "a HTTP 402" and "a HTTP 420" -> "an HTTP"
- `scan-error-*.mdx` — "a HTTP 500" -> "an HTTP 500"
- `roboflow.mdx` — "a HTTP interface" -> "an HTTP interface"
- `auth-hooks.mdx` — "A HTTP Hook" -> "An HTTP Hook", "a HTTP hook" -> "an HTTP hook", "a HTTP error" -> "an HTTP error"
- `auth-mfa.mdx` — "a HTTP 401" -> "an HTTP 401"
- `password-verification-hook.mdx` — "a HTTP request" -> "an HTTP request"
- `before-user-created-hook.mdx` — "a HTTP implementation" -> "an HTTP implementation"
- `pgtap-extended.mdx` — "a API exposed schema" -> "an API exposed schema"
- `error-codes.mdx` — "a RLS policy" -> "an RLS policy"
- `broadcast.mdx` — "a RLS" -> "an RLS"

### Studio files (1 file):
- `CronJobs.utils.test.ts` — "a HTTP request" -> "an HTTP request" (9 test descriptions) + "notationa" typo -> "notation"

## Additional context

The rule: use "an" before acronyms pronounced with a leading vowel sound. "HTTP" starts with "aitch" (vowel sound), "API" starts with "ay" (vowel sound), and "RLS" starts with "arr" (vowel sound).