### PR TITLE
docs: migrate app.supabase.com URLs to /dashboard relative links

### DIFF
--- a/apps/docs/content/_partials/kotlin_project_setup.mdx
+++ b/apps/docs/content/_partials/kotlin_project_setup.mdx
@@ -4,7 +4,7 @@ Before we start building we're going to set up our Database and API. This is as 
 
 ### Create a project
 
-1. [Create a new project](https://app.supabase.com) in the Supabase Dashboard.
+1. [Create a new project](/dashboard) in the Supabase Dashboard.
 1. Enter your project details.
 1. Wait for the new database to launch.
 
@@ -21,7 +21,7 @@ Now we are going to set up the database schema. You can just copy/paste the SQL 
 >
 {/* <TabPanel id="dashboard" label="Dashboard">
 
-1. Go to the [SQL Editor](https://app.supabase.com/project/_/sql) page in the Dashboard.
+1. Go to the [SQL Editor](/dashboard/project/_/sql) page in the Dashboard.
 2. Click **Product Management**.
 3. Click **Run**.
 
@@ -42,4 +42,4 @@ From the [Google Console](https://console.developers.google.com/apis/library), c
 
 ![Create Google OAuth credentials](/docs/img/guides/kotlin/google-cloud-oauth-credentials-create.png)
 
-In your [Supabase Auth settings](https://app.supabase.com/project/_/auth/providers) enable Google as a provider and set the required credentials as outlined in the [auth docs](/docs/guides/auth/social-login/auth-google).
+In your [Supabase Auth settings](/dashboard/project/_/auth/providers) enable Google as a provider and set the required credentials as outlined in the [auth docs](/docs/guides/auth/social-login/auth-google).

--- a/apps/docs/content/guides/auth/social-login/auth-figma.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-figma.mdx
@@ -11,7 +11,7 @@ To enable Figma Auth for your project, you need to set up a Figma OAuth applicat
 Setting up Figma logins for your application consists of 3 parts:
 
 - Create and configure a Figma App on the [Figma Developers page](https://www.figma.com/developers/app).
-- Add your Figma `client_id` and `client_secret` to your [Supabase Project](https://app.supabase.com).
+- Add your Figma `client_id` and `client_secret` to your [Supabase Project](/dashboard).
 - Add the login code to your [Supabase JS Client App](https://github.com/supabase/supabase-js).
 
 ## Access the Figma Developers page

--- a/apps/docs/content/guides/functions/examples/amazon-bedrock-image-generator.mdx
+++ b/apps/docs/content/guides/functions/examples/amazon-bedrock-image-generator.mdx
@@ -28,7 +28,7 @@ AWS_CONFIG_FILE="./aws/config"
 ### Configure Storage
 
 - [locally] Run `supabase start`
-- Open Studio URL: [locally](http://127.0.0.1:54323/project/default/storage/buckets) | [hosted](https://app.supabase.com/project/_/storage/buckets)
+- Open Studio URL: [locally](http://127.0.0.1:54323/project/default/storage/buckets) | [hosted](/dashboard/project/_/storage/buckets)
 - Navigate to Storage
 - Click "New bucket"
 - Create a new public bucket called "images"

--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -108,7 +108,7 @@ Due to restrictions on the underlying cloud provider, disk expansions can occur 
 
 Free Plan projects enter [read-only](#read-only-mode) mode when you exceed the 500 MB limit. Once in read-only mode, you have these options:
 
-- [Upgrade to the Pro Plan](/dashboard/org/_/billing) to increase the limit to 8 GB. [Disable the Spend Cap](https://app.supabase.com/org/_/billing?panel=costControl) if you want your Pro instance to auto-scale beyond the 8 GB disk size limit.
+- [Upgrade to the Pro Plan](/dashboard/org/_/billing) to increase the limit to 8 GB. [Disable the Spend Cap](/dashboard/org/_/billing?panel=costControl) if you want your Pro instance to auto-scale beyond the 8 GB disk size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.
 
 ### Read-only mode

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -15,9 +15,9 @@ In this example we'll set up a database table, secure it with Row Level Security
   <StepHikeCompact.Step step={1}>
     <StepHikeCompact.Details title="Set up a Supabase project with a 'todos' table">
 
-    [Create a new project](https://app.supabase.com) in the Supabase Dashboard.
+    [Create a new project](/dashboard) in the Supabase Dashboard.
 
-    After your project is ready, create a table in your Supabase database. You can do this with either the Table interface or the [SQL Editor](https://app.supabase.com/project/_/sql).
+    After your project is ready, create a table in your Supabase database. You can do this with either the Table interface or the [SQL Editor](/dashboard/project/_/sql).
 
     </StepHikeCompact.Details>
 
@@ -1793,7 +1793,7 @@ We strongly encourage you to enable RLS and create policies for tables in privat
 
 You may choose to sign your own tokens to customize claims that can be checked in your RLS policies.
 
-Your project JWT secret is found with your [Project API keys](https://app.supabase.com/project/_/settings/api) in your dashboard.
+Your project JWT secret is found with your [Project API keys](/dashboard/project/_/settings/api) in your dashboard.
 
 <Admonition type="caution">
 

--- a/apps/docs/content/troubleshooting/all-about-supabase-egress-a_Sg_e.mdx
+++ b/apps/docs/content/troubleshooting/all-about-supabase-egress-a_Sg_e.mdx
@@ -19,8 +19,8 @@ You can read about Unified egress, included quota, and how to check the egress u
 
 While pointing out the exact cause for egress may not be straightforward, there are various steps you can take to determine the source of these issues:
 
-- Picking the "Top Paths" from the [log explorer](https://app.supabase.com/project/_/logs/explorer/templates) will help you identify heavily queried paths
-- By finding the most requested queries from Query performance report: https://app.supabase.com/project/_/advisors/query-performance
+- Picking the "Top Paths" from the [log explorer](/dashboard/project/_/logs/explorer/templates) will help you identify heavily queried paths
+- By finding the most requested queries from Query performance report: [Query Performance](/dashboard/project/_/advisors/query-performance)
 - Supavisor Egress is independent of client. There is no direct relation between a single query and Supavisor egress, it is harder to debug and identify. But you can make use of frequent queries from the link in above step that also displays average number of rows which will help to identify queries with a large number of rows returned. While this does not display Supavisor queries specifically, it will give an overview of queries with lots of rows that can help.
 - For Storage Egress, all outgoing traffic for storage-related requests to download/view your Storage items are considered as Storage egress. We have a "Storage Egress Requests" template in logs explorer that you can use to get the number of requests for each Storage object
 - If you pull 1mb of data out of the database using the Supavisor connection in your edge function, but only sends 100kb back to the user, you will have the Egress from the Supavisor to your Edge function plus from the edge function to your user

--- a/apps/docs/content/troubleshooting/canceling-statement-due-to-statement-timeout-581wFv.mdx
+++ b/apps/docs/content/troubleshooting/canceling-statement-due-to-statement-timeout-581wFv.mdx
@@ -13,6 +13,6 @@ You can run this query to check the current settings set for your roles: `SELECT
 
 To increase the `statement_timeout` for a specific role, you may follow the instructions [here](/docs/guides/database/timeouts#changing-the-default-timeout). Note that it may require a quick reboot for the changes to take effect.
 
-Additionally, to check how long a query is taking, you can check the Query Performance report which can give you more information on the query's performance: https://app.supabase.com/project/_/advisors/query-performance. You can use the [query plan analyzer](https://www.postgresql.org/docs/current/sql-explain.html) on any expensive queries that you have identified: `explain analyze <query-statement-here>;`. For supabase-js/ PostgREST queries you can use `.explain()`.
+Additionally, to check how long a query is taking, you can check the Query Performance report which can give you more information on the query's performance: [Query Performance](/dashboard/project/_/advisors/query-performance). You can use the [query plan analyzer](https://www.postgresql.org/docs/current/sql-explain.html) on any expensive queries that you have identified: `explain analyze <query-statement-here>;`. For supabase-js/ PostgREST queries you can use `.explain()`.
 
-You can also make use of Postgres logs that will give you useful information like when the query was executed: https://app.supabase.com/project/_/logs/postgres-logs.
+You can also make use of Postgres logs that will give you useful information like when the query was executed: [Postgres Logs](/dashboard/project/_/logs/postgres-logs).

--- a/apps/docs/content/troubleshooting/check-usage-for-monthly-active-users-mau-MwZaBs.mdx
+++ b/apps/docs/content/troubleshooting/check-usage-for-monthly-active-users-mau-MwZaBs.mdx
@@ -7,7 +7,7 @@ keywords = [ "MAU", "Monthly active users" ]
 database_id = "1759134d-a98d-4bfa-9501-71e06180700e"
 ---
 
-You can see the usage in your [projects usage page](https://app.supabase.com/project/_/settings/billing/usage).
+You can see the usage in your [projects usage page](/dashboard/project/_/settings/billing/usage).
 
 For MAU, we rely on the [Auth Server](https://github.com/supabase/auth) logs. MAU count is relative to your billing cycle and resets whenever your billing cycle resets. You can check your Auth logs in your [projects logs & analytics section](/dashboard/project/_/logs/auth-logs).
 

--- a/apps/docs/content/troubleshooting/database-error-saving-new-user-RU_EwB.mdx
+++ b/apps/docs/content/troubleshooting/database-error-saving-new-user-RU_EwB.mdx
@@ -22,7 +22,7 @@ This error is normally associated with a side effect of a database transaction.
 
 **Debugging this error:**
 
-- You can use the [Auth logs explorer](https://app.supabase.com/project/_/logs/auth-logs) to find the issue with more information
-- You can use the [Postgres logs explorer](https://app.supabase.com/project/_/logs/postgres-logs)
+- You can use the [Auth logs explorer](/dashboard/project/_/logs/auth-logs) to find the issue with more information
+- You can use the [Postgres logs explorer](/dashboard/project/_/logs/postgres-logs)
 
 https://user-images.githubusercontent.com/79497/225517698-b6e3ccaf-cd70-4acd-8124-ffbcee310d63.mp4

--- a/apps/docs/content/troubleshooting/edge-function-wall-clock-time-limit-reached-Nk38bW.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-wall-clock-time-limit-reached-Nk38bW.mdx
@@ -33,7 +33,7 @@ If you're facing the "wall clock time limit reached" error with a 546 error code
 
 - Divide Complex Tasks: For functions handling complex or extensive tasks, try breaking them down into smaller, discrete functions. This approach can help manage workloads more effectively and stay within time limits.
 
-- Monitor Execution Time: Use our logging or monitoring tools available to keep an eye on your function's performance. This can pinpoint where optimizations are necessary. To access logs visit: [Supabase Project Functions](https://app.supabase.com/project/_/functions) Select your function and click on Logs.
+- Monitor Execution Time: Use our logging or monitoring tools available to keep an eye on your function's performance. This can pinpoint where optimizations are necessary. To access logs visit: [Supabase Project Functions](/dashboard/project/_/functions) Select your function and click on Logs.
 
 - Check Our Guides: For more tips, refer to our debugging guide here: [Debugging Edge Functions](/docs/guides/functions/logging)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation URL migration.

## What is the current behavior?

Several docs content files still link to the deprecated `https://app.supabase.com` domain, which redirects to `supabase.com/dashboard`. This causes unnecessary redirects for users following these links.

## What is the new behavior?

All `https://app.supabase.com/*` URLs in docs content files are replaced with `/dashboard/*` relative links, which resolve correctly within the docs site and avoid redirects.

Additionally, two bare URLs that were displayed as raw text have been converted to proper markdown links for better readability and click targets.

## Files changed (10)

| File | Changes |
|------|---------|
| `_partials/kotlin_project_setup.mdx` | 3 URLs migrated |
| `guides/auth/social-login/auth-figma.mdx` | 1 URL migrated |
| `guides/platform/database-size.mdx` | 1 URL migrated |
| `guides/realtime/postgres-changes.mdx` | 3 URLs migrated |
| `troubleshooting/database-error-saving-new-user-*.mdx` | 2 URLs migrated |
| `troubleshooting/canceling-statement-*.mdx` | 2 URLs migrated + converted to markdown links |
| `troubleshooting/all-about-supabase-egress-*.mdx` | 2 URLs migrated + 1 converted to markdown link |
| `troubleshooting/check-usage-for-mau-*.mdx` | 1 URL migrated |
| `troubleshooting/edge-function-wall-clock-*.mdx` | 1 URL migrated |
| `guides/functions/examples/amazon-bedrock-*.mdx` | 1 URL migrated |