### PR TITLE
fix(studio): correct 'accouncement' typo in PanelNotice fallback text

### DIFF
--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -137,7 +137,7 @@ const PanelNotice = forwardRef<
         {href && (
           <Button size="tiny" type="default" className="text-xs" asChild>
             <a href={href} target="_blank" rel="noreferrer noopener">
-              {buttonText ?? 'Read the accouncement'}
+              {buttonText ?? 'Read the announcement'}
             </a>
           </Button>
         )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (typo in user-facing text)

## What is the current behavior?

The `PanelNotice` component's fallback button text reads "Read the accouncement" (missing the 'n' in announcement).

File: `apps/studio/components/ui/Panel.tsx`, line 140

## What is the new behavior?

The fallback text now correctly reads "Read the announcement".

## Additional context

Single character fix in a user-facing string. The `buttonText` prop can override this, but when no custom text is provided, the fallback should be spelled correctly.