### PR TITLE
fix(studio): rename initalSelectedTable to initialSelectedTable in TriggerSheet

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx
@@ -165,13 +165,13 @@ export const TriggerSheet = ({
       form.clearErrors()
 
       if (isDuplicatingTrigger && selectedTrigger) {
-        const initalSelectedTable = tables.find((t) => t.name === selectedTrigger.table)
+        const initialSelectedTable = tables.find((t) => t.name === selectedTrigger.table)
 
         form.reset({
           ...selectedTrigger,
-          tableId: initalSelectedTable?.id.toString(),
-          table: initalSelectedTable?.name,
-          schema: initalSelectedTable?.schema,
+          tableId: initialSelectedTable?.id.toString(),
+          table: initialSelectedTable?.name,
+          schema: initialSelectedTable?.schema,
         })
       } else if (isEditing) {
         form.reset(selectedTrigger)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (variable name typo)

## What is the current behavior?

In `TriggerSheet.tsx`, the local variable is named `initalSelectedTable` (missing the second 'i' in "initial").

## What is the new behavior?

The variable is renamed to `initialSelectedTable` across all 4 occurrences in the file. This is a purely local variable, so the change has no external API impact.

## Additional context

File: `apps/studio/components/interfaces/Database/Triggers/TriggerSheet.tsx`

All 4 references are within the same `useEffect` block (lines 168-174), so this is a safe rename with no risk of breaking other code.