### PR TITLE
fix(studio): add missing rel="noreferrer" to target="_blank" links

### DIFF
--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -240,7 +240,11 @@ export function LogsSidebarMenuV2() {
           title="New logs"
           description="Get early access"
           actions={
-            <Link href="https://forms.supabase.com/unified-logs-signup" target="_blank">
+            <Link
+              href="https://forms.supabase.com/unified-logs-signup"
+              target="_blank"
+              rel="noreferrer"
+            >
               <Button type="default" size="tiny">
                 Early access
               </Button>

--- a/apps/studio/components/ui/BannerStack/Banners/BannerMetricsAPI.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerMetricsAPI.tsx
@@ -51,6 +51,7 @@ export const BannerMetricsAPI = () => {
             <Link
               href={`${DOCS_URL}/guides/telemetry/metrics`}
               target="_blank"
+              rel="noreferrer"
               onClick={() => track('metrics_api_banner_cta_button_clicked')}
             >
               Get started for free

--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -197,7 +197,7 @@ export const ChartHeader = ({
             },
           }}
         >
-          <Link href={docsUrl} target="_blank">
+          <Link href={docsUrl} target="_blank" rel="noreferrer">
             <InfoIcon className="w-4 h-4 text-foreground-lighter" />
           </Link>
         </ButtonTooltip>

--- a/apps/studio/components/ui/GrafanaPromoBanner.tsx
+++ b/apps/studio/components/ui/GrafanaPromoBanner.tsx
@@ -61,6 +61,7 @@ const GrafanaBannerActions = ({ className }: { className?: string }) => {
         <Link
           href={`${DOCS_URL}/guides/telemetry/metrics`}
           target="_blank"
+          rel="noreferrer"
           onClick={() =>
             sendEvent({
               action: 'reports_database_grafana_banner_clicked',
@@ -75,6 +76,7 @@ const GrafanaBannerActions = ({ className }: { className?: string }) => {
         <Link
           href="https://github.com/supabase/supabase-grafana"
           target="_blank"
+          rel="noreferrer"
           onClick={() =>
             sendEvent({
               action: 'reports_database_grafana_banner_clicked',

--- a/apps/studio/components/ui/ObservabilityLink.tsx
+++ b/apps/studio/components/ui/ObservabilityLink.tsx
@@ -10,6 +10,7 @@ export const ObservabilityLink = () => {
           href={`${DOCS_URL}/guides/telemetry/metrics`}
           className="text-foreground underline underline-offset-2 decoration-foreground-muted hover:decoration-foreground transition-all"
           target="_blank"
+          rel="noreferrer"
         >
           Get started for free!
         </Link>

--- a/apps/studio/pages/integrations/vercel/install.tsx
+++ b/apps/studio/pages/integrations/vercel/install.tsx
@@ -220,7 +220,7 @@ const VercelIntegration: NextPageWithLayout = () => {
                 <AlertDescription_Shadcn_ className="prose">
                   You will need to create a Supabase Organization before you can install the Vercel
                   Integration. You can create a new organization{' '}
-                  <Link href="https://supabase.com/dashboard/new" target="_blank">
+                  <Link href="https://supabase.com/dashboard/new" target="_blank" rel="noreferrer">
                     here
                   </Link>
                   .

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -545,6 +545,7 @@ const Wizard: NextPageWithLayout = () => {
               <Link
                 href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
                 target="_blank"
+                rel="noreferrer"
                 className="underline"
               >
                 Compute Costs

--- a/apps/studio/pages/project/[ref]/observability/storage.tsx
+++ b/apps/studio/pages/project/[ref]/observability/storage.tsx
@@ -173,7 +173,11 @@ export const StorageReport: NextPageWithLayout = () => {
                 The number of storage requests that are cached at the edge level. A higher number of
                 hits is better.{' '}
                 <span className="flex items-center gap-1 text-foreground-lighter">
-                  <Link href={`${DOCS_URL}/guides/storage/cdn/fundamentals`} target="_blank">
+                  <Link
+                    href={`${DOCS_URL}/guides/storage/cdn/fundamentals`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     Read More
                   </Link>
                   <ExternalLinkIcon className="w-3 h-3" />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Security/accessibility improvement

## What is the current behavior?

Several `<Link>` components with `target="_blank"` are missing the `rel="noreferrer"` attribute. Without it, the opened page receives the `Referer` header containing the current URL, which may leak sensitive information (e.g., project refs in dashboard URLs).

## What is the new behavior?

Added `rel="noreferrer"` to 9 link instances across 8 files, consistent with the existing pattern used in 113+ other `target="_blank"` links throughout Studio.

### Files changed:
- `apps/studio/components/ui/GrafanaPromoBanner.tsx` (2 links)
- `apps/studio/components/ui/BannerStack/Banners/BannerMetricsAPI.tsx`
- `apps/studio/components/ui/ObservabilityLink.tsx`
- `apps/studio/components/ui/Charts/ChartHeader.tsx`
- `apps/studio/pages/new/[slug].tsx`
- `apps/studio/pages/integrations/vercel/install.tsx`
- `apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx`
- `apps/studio/pages/project/[ref]/observability/storage.tsx`

## Additional context

The `rel="noreferrer"` pattern is already the standard in this codebase (113 existing instances). This PR brings the remaining outliers into alignment.