### PR TITLE
fix(www): fix typos in Sponsorships component

### DIFF
--- a/apps/www/components/OpenSource/Sponsorships.tsx
+++ b/apps/www/components/OpenSource/Sponsorships.tsx
@@ -12,7 +12,7 @@ const Sponsorships = ({ sponsorships }: { sponsorships: any[] }) => {
           Sponsored Projects
         </h2>
         <p className="text-foreground-lighter mb-4 max-w-sm">
-          We don't just live and breath open-source, we also sponsor projects we love.
+          We don't just live and breathe open-source, we also sponsor projects we love.
         </p>
       </div>
       <div className="relative w-full h-fit grid md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -33,7 +33,7 @@ const Sponsorships = ({ sponsorships }: { sponsorships: any[] }) => {
                     viewBox="0 0 24 24"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
-                    className="fill-foreground-lighter grouopp-hover:fill-foreground"
+                    className="fill-foreground-lighter group-hover:fill-foreground"
                   >
                     <path
                       fillRule="evenodd"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (typo corrections)

## What is the current behavior?

In `apps/www/components/OpenSource/Sponsorships.tsx`:

1. The text reads "We don't just live and **breath** open-source" — should be "**breathe**" (verb form)
2. The Tailwind class `grouopp-hover:fill-foreground` is a typo of `group-hover:fill-foreground`, which means the GitHub icon SVG never changes color on hover as intended

## What is the new behavior?

- "breath" corrected to "breathe"
- `grouopp-hover` corrected to `group-hover`, restoring the hover color transition on the GitHub icon

## Additional context

The `group-hover` fix is a functional improvement — the broken class name was silently ignored by Tailwind, so the hover effect on the GitHub icon in the Sponsored Projects section was not working.