### PR TITLE
fix: add missing rel="noreferrer" to anchor tags with target="_blank"

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/EnterpriseCard.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/EnterpriseCard.tsx
@@ -56,7 +56,7 @@ export const EnterpriseCard = ({ plan, isCurrentPlan }: EnterpriseCardProps) => 
             })
           }
         >
-          <a href={plan.href} className="hidden md:block" target="_blank">
+          <a href={plan.href} className="hidden md:block" target="_blank" rel="noreferrer">
             {plan.cta}
           </a>
         </Button>
@@ -93,7 +93,7 @@ export const EnterpriseCard = ({ plan, isCurrentPlan }: EnterpriseCardProps) => 
             })
           }
         >
-          <a href={plan.href} className="visible md:hidden mt-8" target="_blank">
+          <a href={plan.href} className="visible md:hidden mt-8" target="_blank" rel="noreferrer">
             {plan.cta}
           </a>
         </Button>

--- a/apps/www/components/Nav/GitHubButton.tsx
+++ b/apps/www/components/Nav/GitHubButton.tsx
@@ -30,7 +30,12 @@ const GitHubButton = () => {
       asChild
       onClick={() => sendTelemetryEvent({ action: 'homepage_github_button_clicked' })}
     >
-      <a type={undefined} href="https://github.com/supabase/supabase" target="_blank">
+      <a
+        type={undefined}
+        href="https://github.com/supabase/supabase"
+        target="_blank"
+        rel="noreferrer"
+      >
         <span className="flex items-center gap-1">
           <svg
             className="w-6 h-6"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (security hardening)

## What is the current behavior?

Three `<a target="_blank">` tags are missing the `rel="noreferrer"` attribute:

- `apps/studio/components/interfaces/Organization/BillingSettings/Subscription/EnterpriseCard.tsx` (2 instances — desktop and mobile CTA links)
- `apps/www/components/Nav/GitHubButton.tsx` (1 instance — global navigation GitHub star button)

Without `rel="noreferrer"`, the browser sends the `Referer` header to the target site when opening links in a new tab.

## What is the new behavior?

All three anchor tags now include `rel="noreferrer"`, consistent with the existing pattern used across the codebase (113+ instances already use `rel="noreferrer"`).

## Additional context

This follows the same pattern as #42925 which addressed missing `rel="noreferrer"` on Next.js `<Link>` components in Studio. These are native `<a>` tags that were missed in that pass.