### PR TITLE
fix(www): add missing rel="noreferrer" to Link components with target="_blank"

### DIFF
--- a/apps/www/components/OpenSource/Sponsorships.tsx
+++ b/apps/www/components/OpenSource/Sponsorships.tsx
@@ -17,7 +17,7 @@ const Sponsorships = ({ sponsorships }: { sponsorships: any[] }) => {
       </div>
       <div className="relative w-full h-fit grid md:grid-cols-2 lg:grid-cols-3 gap-4">
         {sponsorships.map((link) => (
-          <Link href={link.url} key={link.name} target="_blank">
+          <Link href={link.url} key={link.name} target="_blank" rel="noreferrer">
             <Panel
               innerClassName={cn(
                 'relative group flex flex-col gap-2 p-4 ',

--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -97,7 +97,7 @@ export const pricingTooltips: PricingTooltips = {
       <span className="prose text-xs">
         AWS PrivateLink enables private connectivity between your AWS VPC and Supabase, keeping
         traffic within the AWS network. Read more in our{' '}
-        <Link href="/docs/guides/platform/privatelink" target="_blank">
+        <Link href="/docs/guides/platform/privatelink" target="_blank" rel="noreferrer">
           docs
         </Link>
         .
@@ -110,7 +110,7 @@ export const pricingTooltips: PricingTooltips = {
       <span className="prose text-xs">
         Supabase provides granular access controls to manage permissions across your organizations
         and projects. Read more in our{' '}
-        <Link href="/docs/guides/platform/access-control" target="_blank">
+        <Link href="/docs/guides/platform/access-control" target="_blank" rel="noreferrer">
           docs
         </Link>
         .
@@ -129,7 +129,7 @@ export const pricingTooltips: PricingTooltips = {
         automatically captured for all authentication events and help you monitor user
         authentication activities, detect suspicious behavior, and maintain compliance with security
         requirements. Read more in our{' '}
-        <Link href="/docs/guides/auth/audit-logs" target="_blank">
+        <Link href="/docs/guides/auth/audit-logs" target="_blank" rel="noreferrer">
           docs
         </Link>
         .
@@ -143,7 +143,7 @@ export const pricingTooltips: PricingTooltips = {
         Any Platform API/Dashboard actions performed by organization members are logged
         automatically for auditing and security purposes. Includes actions such as creating a new
         project, inviting members or changing project settings. Read more in our{' '}
-        <Link href="/docs/guides/security/platform-audit-logs" target="_blank">
+        <Link href="/docs/guides/security/platform-audit-logs" target="_blank" rel="noreferrer">
           docs
         </Link>
         .

--- a/apps/www/components/Sections/UseCasesSection.tsx
+++ b/apps/www/components/Sections/UseCasesSection.tsx
@@ -88,7 +88,7 @@ const UseCase = ({
               </Button>
             ) : (
               <Button asChild size="tiny" type="default" iconRight={<ArrowUpRight />}>
-                <Link href={useCase.cta.link} target="_blank">
+                <Link href={useCase.cta.link} target="_blank" rel="noreferrer">
                   {useCase.cta.label ?? 'View example'}
                 </Link>
               </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (security hardening)

## What is the current behavior?

Six Next.js `<Link target="_blank">` components in the www app are missing `rel="noreferrer"`:

- `PricingTableRow.tsx` — 4 instances (pricing page tooltip doc links for PrivateLink, Access Roles, Auth Audit Logs, Platform Audit Logs)
- `Sponsorships.tsx` — 1 instance (open source sponsored project links)
- `UseCasesSection.tsx` — 1 instance (use case example CTA links)

Next.js `<Link>` does **not** automatically add `rel="noreferrer"` for `target="_blank"`, unlike some other frameworks.

## What is the new behavior?

All six Link components now include `rel="noreferrer"`, consistent with the established codebase pattern.

## Additional context

Companion to #42925 (Studio Link components) and #42927 (native `<a>` tags).