### PR TITLE
chore: rename configuration to how-to guides

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -2827,10 +2827,12 @@ export const self_hosting: NavMenuConstant = {
   items: [
     { name: 'Overview', url: '/guides/self-hosting' },
     { name: 'Self-Hosting with Docker', url: '/guides/self-hosting/docker' },
-    { name: 'Restore from Platform', url: '/guides/self-hosting/restore-from-platform' },
     {
-      name: 'Configuration',
-      items: [{ name: 'Enabling MCP server', url: '/guides/self-hosting/enable-mcp' }],
+      name: 'How-to Guides',
+      items: [
+        { name: 'Enabling MCP server', url: '/guides/self-hosting/enable-mcp' },
+        { name: 'Restore from Platform', url: '/guides/self-hosting/restore-from-platform' },
+      ],
     },
     {
       name: 'Auth Server',

--- a/apps/docs/content/guides/self-hosting/restore-from-platform.mdx
+++ b/apps/docs/content/guides/self-hosting/restore-from-platform.mdx
@@ -96,7 +96,7 @@ SELECT count(*) FROM auth.users;
 SELECT * FROM pg_extension;
 ```
 
-## What's included and what's not
+## What's included in the restore and what's not
 
 The database dump includes your schema, data, roles, RLS policies, database functions, triggers, and `auth.users`. However, several things require separate configuration on your self-hosted instance:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Rename "Configuration" under "Self-Hosting" to "How-to Guides" and a minor fix to the recent how-to.