### PR TITLE
chore: pg-meta quotes

### DIFF
--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -1,5 +1,7 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import type { User } from 'data/auth/users-infinite-query'
 import { RoleImpersonationState as ValtioRoleImpersonationState } from 'state/role-impersonation-state'
+
 import { uuidv4 } from './helpers'
 
 type PostgrestImpersonationRole =
@@ -99,8 +101,8 @@ function getPostgrestRoleImpersonationSql(
   const unexpiredClaims = { ...claims, exp: getExp1HourFromNow() }
 
   return `
-select set_config('role', '${role.role}', true),
-set_config('request.jwt.claims', '${JSON.stringify(unexpiredClaims).replaceAll("'", "''")}', true),
+select set_config('role', ${literal(role.role)}, true),
+set_config('request.jwt.claims', ${literal(JSON.stringify(unexpiredClaims))}, true),
 set_config('request.method', 'POST', true),
 set_config('request.path', '/impersonation-example-request-path', true),
 set_config('request.headers', '{"accept": "*/*"}', true);
@@ -113,7 +115,7 @@ export const ROLE_IMPERSONATION_NO_RESULTS = 'ROLE_IMPERSONATION_NO_RESULTS'
 
 function getCustomRoleImpersonationSql(roleName: string) {
   return /* SQL */ `
-    set local role '${roleName}';
+    set local role ${literal(roleName)};
   `.trim()
 }
 


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Manual replacement of quotes

## What is the new behavior?

Uses defined SQL literal function

## Additional context

No security risk, but builds better sql strings following best practice and avoids potential issues with frontend mis-escaping something