### PR TITLE
chore(studio): add Billing nav command

### DIFF
--- a/apps/studio/components/layouts/BillingLayout/Billing.Commands.tsx
+++ b/apps/studio/components/layouts/BillingLayout/Billing.Commands.tsx
@@ -1,3 +1,4 @@
+import { IS_PLATFORM } from 'common'
 import { COMMAND_MENU_SECTIONS } from 'components/interfaces/App/CommandMenu/CommandMenu.utils'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -11,7 +12,7 @@ export function useBillingGotoCommands(options?: CommandOptions) {
 
   useRegisterCommands(
     COMMAND_MENU_SECTIONS.NAVIGATE,
-    billingEnabled
+    IS_PLATFORM && billingEnabled
       ? [
           {
             id: 'nav-billing',

--- a/apps/studio/components/layouts/BillingLayout/Billing.Commands.tsx
+++ b/apps/studio/components/layouts/BillingLayout/Billing.Commands.tsx
@@ -1,0 +1,26 @@
+import { COMMAND_MENU_SECTIONS } from 'components/interfaces/App/CommandMenu/CommandMenu.utils'
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import type { CommandOptions } from 'ui-patterns/CommandMenu'
+import { useRegisterCommands } from 'ui-patterns/CommandMenu'
+
+export function useBillingGotoCommands(options?: CommandOptions) {
+  const { data: organization } = useSelectedOrganizationQuery()
+  const billingEnabled = useIsFeatureEnabled('billing:all')
+  const slug = organization?.slug ?? '_'
+
+  useRegisterCommands(
+    COMMAND_MENU_SECTIONS.NAVIGATE,
+    billingEnabled
+      ? [
+          {
+            id: 'nav-billing',
+            name: 'Billing',
+            route: `/org/${slug}/billing`,
+            defaultHidden: true,
+          },
+        ]
+      : [],
+    { ...options, deps: [slug] }
+  )
+}

--- a/apps/studio/components/layouts/useLayoutNavCommands.ts
+++ b/apps/studio/components/layouts/useLayoutNavCommands.ts
@@ -2,6 +2,7 @@ import { useIsLoggedIn } from 'common'
 import { useApiDocsGotoCommands } from 'components/interfaces/ProjectAPIDocs/ProjectAPIDocs.Commands'
 import { useAdvisorsGoToCommands } from './AdvisorsLayout/Advisors.Commands'
 import { useAuthGotoCommands } from './AuthLayout/Auth.Commands'
+import { useBillingGotoCommands } from './BillingLayout/Billing.Commands'
 import { useDatabaseGotoCommands } from './DatabaseLayout/Database.Commands'
 import { useFunctionsGotoCommands } from './EdgeFunctionsLayout/EdgeFunctions.Commands'
 import { useIntegrationsGotoCommands } from './IntegrationsLayout/Integrations.Commands'
@@ -27,4 +28,5 @@ export function useLayoutNavCommands() {
   useApiDocsGotoCommands({ enabled: isLoggedIn })
   useProjectSettingsGotoCommands({ enabled: isLoggedIn })
   useIntegrationsGotoCommands({ enabled: isLoggedIn })
+  useBillingGotoCommands({ enabled: isLoggedIn })
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add new "Billing" navigation entry in the command menu.

## What is the current behavior?

![screenshot-2026-02-16-at-17 28 35](https://github.com/user-attachments/assets/d267e0c1-7f07-41dc-9b1f-08a974cd9478)

## What is the new behavior?

<img width="695" height="567" alt="Screenshot 2026-02-17 at 18 24 49" src="https://github.com/user-attachments/assets/d60f7ba2-1c7a-4c2e-9205-8bd64629db63" />
