### PR TITLE
docs: replace deprecated getSession() with getUser() in Refine tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,10 +233,9 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const { data, error } = await supabaseClient.auth.getUser()
 
-      if (!session) {
+      if (error || !data.user) {
         return {
           authenticated: false,
           error: {


### PR DESCRIPTION
## What

Replaces the deprecated `supabase.auth.getSession()` call with `supabase.auth.getUser()` in the Refine tutorial's `authProvider.check` method.

## Why

`getSession()` reads from local storage without validating the JWT against the Supabase Auth server. This was deprecated in favor of `getUser()`, which performs server-side validation — critical for authentication checks.

The `check` method in `authProvider` is specifically used to verify whether a user is authenticated, so it should use the validated `getUser()` approach.

## Changes

In `src/authProvider.ts` code block:

```diff
  check: async () => {
    try {
-     const { data } = await supabaseClient.auth.getSession()
-     const { session } = data
-
-     if (!session) {
+     const { data, error } = await supabaseClient.auth.getUser()
+
+     if (error || !data.user) {
```

Fixes #42193