### PR TITLE
docs: remove deprecated getSession() from SolidJS tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -261,7 +261,7 @@ Now that we have all the components in place, let's update `App.tsx`:
 <$CodeTabs>
 
 ```jsx name=src/App.tsx
-import { Component, createEffect, createSignal } from 'solid-js'
+import { Component, createEffect, createSignal, onCleanup } from 'solid-js'
 import { supabase } from './supabaseClient'
 import { AuthSession } from '@supabase/supabase-js'
 import Account from './Account'
@@ -271,13 +271,13 @@ const App: Component = () => {
   const [session, setSession] = createSignal<AuthSession | null>(null)
 
   createEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
     })
 
-    supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
-    })
+    onCleanup(() => subscription.unsubscribe())
   })
 
   return (


### PR DESCRIPTION
## What

Removes the deprecated `supabase.auth.getSession()` call from the SolidJS tutorial's `App.tsx`, replacing it with `onAuthStateChange` which now fires an `INITIAL_SESSION` event on setup.

## Why

`getSession()` reads from local storage without server-side JWT validation and is deprecated. Since `onAuthStateChange` now emits `INITIAL_SESSION` when the listener is registered, the separate `getSession()` call is redundant — `onAuthStateChange` handles both the initial session hydration and subsequent auth state changes.

This also adds proper subscription cleanup via SolidJS's `onCleanup`.

## Changes

In `App.tsx` code block:

```diff
-import { Component, createEffect, createSignal } from 'solid-js'
+import { Component, createEffect, createSignal, onCleanup } from 'solid-js'

  createEffect(() => {
-   supabase.auth.getSession().then(({ data: { session } }) => {
-     setSession(session)
-   })
-
-   supabase.auth.onAuthStateChange((_event, session) => {
+   const {
+     data: { subscription },
+   } = supabase.auth.onAuthStateChange((_event, session) => {
      setSession(session)
    })
+
+   onCleanup(() => subscription.unsubscribe())
  })
```

Fixes #42192