### PR TITLE
feat(design-system): responsive admonition

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -93,6 +93,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "admonition-responsive": {
+      name: "admonition-responsive",
+      type: "components:example",
+      registryDependencies: ["admonition"],
+      component: React.lazy(() => import("@/registry/default/example/admonition-responsive")),
+      source: "",
+      files: ["registry/default/example/admonition-responsive.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "admonition-button": {
       name: "admonition-button",
       type: "components:example",

--- a/apps/design-system/content/docs/fragments/admonition.mdx
+++ b/apps/design-system/content/docs/fragments/admonition.mdx
@@ -49,6 +49,18 @@ Only ever use the `primary` (green) button `type` on a `default` Admonition. Eve
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
+## Responsive
+
+{' '}
+<ComponentPreview
+  name="admonition-responsive"
+  className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
+/>
+
+Reize your browser to see the button(s) change `layout` based on the Admonition’s width.
+
+When `layout="responsive"`, the Alert root gets `@container` so the Admonition is the container-query context. The Admonition stays `vertical` when it’s narrow and switches to `horizontal` when its own width reaches the `@md` container breakpoint, independent of page width.
+
 ### Warning
 
 <ComponentPreview

--- a/apps/design-system/registry/default/example/admonition-responsive.tsx
+++ b/apps/design-system/registry/default/example/admonition-responsive.tsx
@@ -1,0 +1,14 @@
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
+
+export default function AdmonitionDemo() {
+  return (
+    <Admonition
+      type="default"
+      layout="responsive"
+      title="Disk management has moved"
+      description="Disk management is now handled alongside Project Compute on the Compute and Disk page."
+      actions={<Button type="default">Go to Compute and Disk</Button>}
+    />
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -14,6 +14,12 @@ export const examples: Registry = [
     files: ['example/admonition-demo.tsx'],
   },
   {
+    name: 'admonition-responsive',
+    type: 'components:example',
+    registryDependencies: ['admonition'],
+    files: ['example/admonition-responsive.tsx'],
+  },
+  {
     name: 'admonition-button',
     type: 'components:example',
     registryDependencies: ['admonition'],

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -27,6 +27,7 @@ export function DiskManagementPanelForm() {
       </PageSectionMeta>
       <PageSectionContent>
         <Admonition
+          type="default"
           layout="responsive"
           title="Disk Management has moved"
           description="Disk configuration is now managed alongside Project Compute on the new Compute and Disk page."

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import { useParams } from 'common'
 import { DOCS_URL } from 'lib/constants'
 import { Button } from 'ui'
-import { NoticeBar } from './ui/NoticeBar'
 import {
   PageSection,
   PageSectionContent,
@@ -12,6 +11,7 @@ import {
   PageSectionTitle,
 } from 'ui-patterns'
 import { DocsButton } from '../../ui/DocsButton'
+import { Admonition } from 'ui-patterns/admonition'
 
 // [Joshen] Only used for non AWS projects
 export function DiskManagementPanelForm() {
@@ -26,17 +26,13 @@ export function DiskManagementPanelForm() {
         <DocsButton href={`${DOCS_URL}/guides/platform/database-size#disk-management`} />
       </PageSectionMeta>
       <PageSectionContent>
-        <NoticeBar
-          visible={true}
-          type="default"
+        <Admonition
+          layout="responsive"
           title="Disk Management has moved"
           description="Disk configuration is now managed alongside Project Compute on the new Compute and Disk page."
           actions={
             <Button type="default" asChild>
-              <Link
-                href={`/project/${projectRef}/settings/compute-and-disk`}
-                className="!no-underline"
-              >
+              <Link href={`/project/${projectRef}/settings/compute-and-disk`}>
                 Go to Compute and Disk
               </Link>
             </Button>

--- a/packages/ui-patterns/src/admonition.tsx
+++ b/packages/ui-patterns/src/admonition.tsx
@@ -20,7 +20,7 @@ export interface AdmonitionProps {
     title?: ComponentProps<typeof AlertTitle_Shadcn_>
     description?: ComponentProps<typeof AlertDescription_Shadcn_>
   }
-  layout?: 'horizontal' | 'vertical'
+  layout?: 'horizontal' | 'vertical' | 'responsive'
   actions?: ReactNode
   icon?: ReactNode
   className?: string
@@ -111,6 +111,8 @@ export const Admonition = forwardRef<
         className={cn(
           // Handle occasional background elements
           'overflow-hidden',
+          // Container query context for responsive layout
+          layout === 'responsive' && '@container',
           // SVG icon
           admonitionSVG({ type: typeMapped }),
           props.className
@@ -126,9 +128,10 @@ export const Admonition = forwardRef<
         <div
           className={cn(
             'flex',
-            layout === 'vertical'
-              ? 'flex-col'
-              : 'flex-row items-center justify-between gap-x-6 lg:gap-x-8'
+            layout === 'vertical' && 'flex-col',
+            layout === 'horizontal' && 'flex-row items-center justify-between gap-x-6 lg:gap-x-8',
+            layout === 'responsive' &&
+              'flex-col @md:flex-row @md:items-center @md:justify-between @md:gap-x-6 @lg:gap-x-8'
           )}
         >
           {label || title ? (
@@ -167,7 +170,9 @@ export const Admonition = forwardRef<
             <div
               className={cn(
                 'flex flex-row gap-3',
-                layout === 'vertical' ? 'mt-3 items-start' : 'items-center'
+                layout === 'vertical' && 'mt-3 items-start',
+                layout === 'horizontal' && 'items-center',
+                layout === 'responsive' && 'mt-3 items-start @md:mt-0 @md:items-center'
               )}
             >
               {actions}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Component improvement

## What is the current behavior?

[Admonition](https://supabase.com/design-system/docs/fragments/admonition) often passes `actions`, often Button(s). These either are stacked via the `layout` prop `horizontal` or `vertical`. That binary choice often means, given layout flex, awkward text wrapping.

## What is the new behavior?

Admonition now has a `"responsive"` value for the `layout` prop. When `layout="responsive"`, the Alert root gets `@container` so the Admonition is the container-query context. The Admonition stays `vertical` when it’s narrow and switches to `horizontal` when its own width reaches the `@md` container breakpoint, independent of page width.

## Additional context

See the _Disk Management_ section of Database Settings to see the single in-situ example.

Video demo:

https://github.com/user-attachments/assets/318a4530-5ae4-43f3-99cf-b75967659ed3
