### PR TITLE
sentry: lower sampling

### DIFF
--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -103,7 +103,7 @@ Sentry.init({
   debug: false,
 
   // Enable performance monitoring - Next.js routes and API calls are automatically instrumented
-  tracesSampleRate: 0.1, // Capture 10% of transactions for performance monitoring
+  tracesSampleRate: 0.03, // Capture 3% of transactions for performance monitoring
 
   // [Ali] Filter out browser extensions and user scripts (FE-2094)
   // Using denyUrls to block known third-party script patterns

--- a/apps/studio/sentry.edge.config.ts
+++ b/apps/studio/sentry.edge.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   debug: false,
 
   // Enable performance monitoring
-  tracesSampleRate: 0.1, // Capture 10% of transactions for performance monitoring
+  tracesSampleRate: 0.03, // Capture 3% of transactions for performance monitoring
 })

--- a/apps/studio/sentry.server.config.ts
+++ b/apps/studio/sentry.server.config.ts
@@ -13,7 +13,7 @@ Sentry.init({
   debug: false,
 
   // Enable performance monitoring
-  tracesSampleRate: 0.1, // Capture 10% of transactions for performance monitoring
+  tracesSampleRate: 0.03, // Capture 3% of transactions for performance monitoring
   ignoreErrors: [
     // Used exclusively in Monaco Editor.
     'ResizeObserver',


### PR DESCRIPTION
lowers to 3%