### PR TITLE
fix(docs): use pnpm exec for redocly instead of npx

### DIFF
--- a/apps/docs/spec/Makefile
+++ b/apps/docs/spec/Makefile
@@ -53,16 +53,16 @@ download.analytics.v0:
 transform: dereference.api.v1  dereference.auth.v1 dereference.storage.v0 dereference.tsdoc.v2 combine.tsdoc.v2
 
 dereference.api.v1:
-	npx @redocly/cli bundle --dereferenced -o $(REPO_DIR)/transforms/api_v1_openapi_deparsed.json $(REPO_DIR)/api_v1_openapi.json
+	cd $(GENERATOR_DIR) && pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/api_v1_openapi_deparsed.json $(REPO_DIR)/api_v1_openapi.json
 
 dereference.auth.v1:
-	npx @redocly/cli bundle --dereferenced -o $(REPO_DIR)/transforms/auth_v1_openapi_deparsed.json $(REPO_DIR)/auth_v1_openapi.json
+	cd $(GENERATOR_DIR) && pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/auth_v1_openapi_deparsed.json $(REPO_DIR)/auth_v1_openapi.json
 
 dereference.storage.v0:
-	npx @redocly/cli bundle --dereferenced -o $(REPO_DIR)/transforms/storage_v0_openapi_deparsed.json $(REPO_DIR)/storage_v0_openapi.json
+	cd $(GENERATOR_DIR) && pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/storage_v0_openapi_deparsed.json $(REPO_DIR)/storage_v0_openapi.json
 
 dereference.analytics.v0:
-	npx @redocly/cli bundle --dereferenced -o $(REPO_DIR)/transforms/analytics_v0_openapi_deparsed.json $(REPO_DIR)/analytics_v0_openapi.json
+	cd $(GENERATOR_DIR) && pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/analytics_v0_openapi_deparsed.json $(REPO_DIR)/analytics_v0_openapi.json
 
 # No longer updated
 # dereference.tsdoc.v1:
@@ -74,12 +74,12 @@ dereference.analytics.v0:
 # 	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:supabase:v1
 
 dereference.tsdoc.v2:
-	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:functions:v2
-	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:gotrue:v2
-	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:postgrest:v2
-	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:realtime:v2
-	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:storage:v2
-	cd $(GENERATOR_DIR) && npm run tsdoc:dereference:supabase:v2
+	cd $(GENERATOR_DIR) && pnpm run tsdoc:dereference:functions:v2
+	cd $(GENERATOR_DIR) && pnpm run tsdoc:dereference:gotrue:v2
+	cd $(GENERATOR_DIR) && pnpm run tsdoc:dereference:postgrest:v2
+	cd $(GENERATOR_DIR) && pnpm run tsdoc:dereference:realtime:v2
+	cd $(GENERATOR_DIR) && pnpm run tsdoc:dereference:storage:v2
+	cd $(GENERATOR_DIR) && pnpm run tsdoc:dereference:supabase:v2
 
 # No longer updated
 # combine.tsdoc.v1:
@@ -125,7 +125,7 @@ generate.sections.api.v1:
 ###############################################################################
 
 validate.analytics.v0:
-	npx @redocly/cli lint --extends=minimal $(REPO_DIR)/analytics_v0_openapi.json
+	cd $(GENERATOR_DIR) && pnpm exec redocly lint --extends=minimal $(REPO_DIR)/analytics_v0_openapi.json
 
 ###############################################################################
 # Format everything - easier for git to track changes.


### PR DESCRIPTION
## Problem                                                                                               
                                                                                                           
The [spec generation Makefile started failing](https://github.com/supabase/supabase/actions/runs/22142393017) with:                                                       

```text
  ReferenceError: React is not defined                                                                     
      at Object. (/Users/.../_npx/.../node_modules/styled-components/dist/styled-components.cjs.js:1:860)  
```

This occurred when `@redocly/cli@2.18.2` was released on Feb 16, 2026. The error happens because `npx @redocly/cli` installs the package in an isolated temporary cache without properly resolving peer dependencies (React is a peer dependency of styled-components).                                                                                                           

## Solution                                                                                              
                                                                                                           
Replace `npx @redocly/cli` with `pnpm exec redocly` to use the installed version from `packages/generator/package.json`. 

This ensures:                                                         

1. **Proper dependency resolution** - pnpm installs the full dependency tree including peer dependencies 
2. **Version control** - locked to the version in package.json instead of always fetching latest         
3. **Reproducible builds** - won't break when new versions are released                                  
                                                                                                           
## Changes                                                                                               
                                                                                                           
- Replace `npx @redocly/cli` → `cd $(GENERATOR_DIR) && pnpm exec redocly` (5 places)                     
- Replace `npm run` → `pnpm run` for consistency with project's package manager (6 places)               

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to execute documentation generation tasks from a centralized generator directory with unified package management, ensuring consistent handling of OpenAPI bundling, TypeScript documentation, and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->