### PR TITLE
feat(studio): enable functions counter on Home for self-hosted environments

### DIFF
--- a/apps/studio/components/interfaces/Home/Home.tsx
+++ b/apps/studio/components/interfaces/Home/Home.tsx
@@ -167,7 +167,6 @@ export const Home = () => {
                     )}
                   </div>
 
-                  {IS_PLATFORM && (
                     <div className="flex flex-col gap-y-1">
                       <Link
                         href={`/project/${ref}/functions`}
@@ -181,7 +180,6 @@ export const Home = () => {
                         <p className="text-2xl tabular-nums">{functionsCount}</p>
                       )}
                     </div>
-                  )}
 
                   {IS_PLATFORM && (
                     <div className="flex flex-col gap-y-1">

--- a/apps/studio/components/interfaces/Home/Home.tsx
+++ b/apps/studio/components/interfaces/Home/Home.tsx
@@ -167,19 +167,19 @@ export const Home = () => {
                     )}
                   </div>
 
-                    <div className="flex flex-col gap-y-1">
-                      <Link
-                        href={`/project/${ref}/functions`}
-                        className="transition text-foreground-light hover:text-foreground text-sm"
-                      >
-                        Functions
-                      </Link>
-                      {isLoadingFunctions ? (
-                        <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
-                      ) : (
-                        <p className="text-2xl tabular-nums">{functionsCount}</p>
-                      )}
-                    </div>
+                  <div className="flex flex-col gap-y-1">
+                    <Link
+                      href={`/project/${ref}/functions`}
+                      className="transition text-foreground-light hover:text-foreground text-sm"
+                    >
+                      Functions
+                    </Link>
+                    {isLoadingFunctions ? (
+                      <ShimmeringLoader className="w-full h-[32px] w-6 p-0" />
+                    ) : (
+                      <p className="text-2xl tabular-nums">{functionsCount}</p>
+                    )}
+                  </div>
 
                   {IS_PLATFORM && (
                     <div className="flex flex-col gap-y-1">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The Functions counter on the Home page is only displayed in platform environments.  
In self-hosted setups, the counter is hidden due to a platform guard, even though Functions may be available.

## What is the new behavior?

The Functions counter is now also displayed in self-hosted environments.

This is now possible thanks to the following PRs:

- #40690  
- #42322  
- #42349  
- #42350  

These PRs introduce and enable the API required for listing Functions in Studio, making it feasible to show the Functions count outside of the platform environment.

## Additional context

Related issues: #36285

This change removes the platform-only restriction around the Functions card in the Home interface, allowing feature parity between platform and self-hosted deployments where the Functions API is available.

<img width="1684" height="675" alt="image" src="https://github.com/user-attachments/assets/9d225249-c8ed-4390-aeb4-b9381d078184" />
