### PR TITLE
db: add incident_status_cache table

### DIFF
--- a/supabase/migrations/20260218202528_status_cache.sql
+++ b/supabase/migrations/20260218202528_status_cache.sql
@@ -1,0 +1,35 @@
+create table if not exists public.incident_status_cache (
+	id bigint primary key generated always as identity,
+	incident_id text unique not null,
+	shortlink text unique not null,
+	updated_at timestamptz not null default now(),
+	affects_project_creation boolean not null default false,
+	affected_regions text[]
+);
+
+alter table public.incident_status_cache
+enable row level security;
+
+revoke all on public.incident_status_cache from anon;
+revoke all on public.incident_status_cache from authenticated;
+
+create index if not exists idx_incident_status_cache_incident_id
+on public.incident_status_cache (incident_id);
+
+create index if not exists idx_incident_status_cache_shortlink
+on public.incident_status_cache (shortlink);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+	new.updated_at = now();
+	return new;
+end;
+$$;
+
+create trigger set_incident_status_cache_updated_at
+before update on public.incident_status_cache
+for each row
+execute function public.set_updated_at();


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Database migration — adds a new table.

## What is the current behavior?

There is no table to cache AI-derived incident metadata.

## What is the new behavior?

Adds an `incident_status_cache` table for caching AI-derived incident metadata.

## Additional context