### PR TITLE
Joshen/fe 2573 table editor allow users to run query with cost warning

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -49,6 +49,7 @@ export const SupabaseGrid = ({
   const { data: project } = useSelectedProjectQuery()
   const tableEditorSnap = useTableEditorStateSnapshot()
   const snap = useTableEditorTableStateSnapshot()
+  const preflightCheck = !tableEditorSnap.tablesToIgnorePreflightCheck.includes(tableId ?? -1)
 
   const gridRef = useRef<DataGridHandle>(null)
   const [mounted, setMounted] = useState(false)
@@ -81,6 +82,7 @@ export const SupabaseGrid = ({
       sorts,
       filters,
       page: snap.page,
+      preflightCheck,
       limit: tableEditorSnap.rowsPerPage,
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },

--- a/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -1,7 +1,4 @@
 import { THRESHOLD_COUNT } from '@supabase/pg-meta/src/sql/studio/get-count-estimate'
-import { ArrowLeft, ArrowRight, HelpCircle, Loader2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
-
 import { keepPreviousData } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { useTableFilter } from 'components/grid/hooks/useTableFilter'
@@ -12,12 +9,15 @@ import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
 import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { RoleImpersonationState } from 'lib/role-impersonation'
+import { ArrowLeft, ArrowRight, HelpCircle, Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
 import { DropdownControl } from '../../common/DropdownControl'
 import { formatEstimatedCount } from './Pagination.utils'
 
@@ -106,6 +106,8 @@ export const Pagination = ({ enableForeignRowsQuery = true }: PaginationProps) =
   const maxPages = Math.ceil(count / tableEditorSnap.rowsPerPage)
   const totalPages = count > 0 ? maxPages : 1
 
+  const preflightCheck = !tableEditorSnap.tablesToIgnorePreflightCheck.includes(id ?? -1)
+
   // [Joshen] This is only applicable for foreign tables, as we use the number of rows on the page to determine
   // if we've reached the last page (and hence disable the next button)
   const { data: rowsData, isPending: isLoadingRows } = useTableRowsQuery(
@@ -116,6 +118,7 @@ export const Pagination = ({ enableForeignRowsQuery = true }: PaginationProps) =
       sorts,
       filters,
       page: snap.page,
+      preflightCheck,
       limit: tableEditorSnap.rowsPerPage,
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },

--- a/apps/studio/components/grid/components/grid/GridError.tsx
+++ b/apps/studio/components/grid/components/grid/GridError.tsx
@@ -11,12 +11,18 @@ import { Admonition } from 'ui-patterns'
 
 import { HighCostError } from '@/components/ui/HighQueryCost'
 import { COST_THRESHOLD_ERROR } from '@/data/sql/execute-sql-query'
+import { useTableEditorStateSnapshot } from '@/state/table-editor'
 import { ResponseError } from '@/types'
 
 export const GridError = ({ error }: { error?: ResponseError | null }) => {
+  const { id: _id } = useParams()
+  const tableId = _id ? Number(_id) : undefined
+
   const { filters } = useTableFilter()
   const { sorts } = useTableSort()
+
   const snap = useTableEditorTableStateSnapshot()
+  const tableEditorSnap = useTableEditorStateSnapshot()
 
   if (!error) return null
 
@@ -42,6 +48,9 @@ export const GridError = ({ error }: { error?: ResponseError | null }) => {
           'Remove any sorts or filters on unindexed columns, or',
           'Create indexes for columns that you want to filter or sort on',
         ]}
+        onSelectLoadData={() => {
+          if (!!tableId) tableEditorSnap.setTableToIgnorePreflightCheck(tableId)
+        }}
       />
     )
   } else if (isForeignTableMissingVaultKeyError) {

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -31,18 +31,18 @@ import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import {
   Button,
+  cn,
+  copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   Separator,
-  cn,
-  copyToClipboard,
 } from 'ui'
 
 import { ExportDialog } from './ExportDialog'
-import { formatRowsForCSV } from './Header.utils'
 import { FilterPopover } from './filter/FilterPopover'
+import { formatRowsForCSV } from './Header.utils'
 import { SortPopover } from './sort/SortPopover'
 
 export type HeaderProps = {
@@ -222,6 +222,9 @@ type RowHeaderProps = {
 }
 
 const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
+  const { id: _id } = useParams()
+  const tableId = _id ? Number(_id) : undefined
+
   const queryClient = useQueryClient()
   const { data: project } = useSelectedProjectQuery()
   const tableEditorSnap = useTableEditorStateSnapshot()
@@ -237,6 +240,8 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   const [isExporting, setIsExporting] = useState(false)
   const [showExportModal, setShowExportModal] = useState(false)
 
+  const preflightCheck = !tableEditorSnap.tablesToIgnorePreflightCheck.includes(tableId ?? -1)
+
   const { data } = useTableRowsQuery(
     {
       projectRef: project?.ref,
@@ -245,6 +250,7 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
       sorts,
       filters,
       page: snap.page,
+      preflightCheck,
       limit: tableEditorSnap.rowsPerPage,
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },

--- a/apps/studio/components/grid/components/header/HeaderNew.tsx
+++ b/apps/studio/components/grid/components/header/HeaderNew.tsx
@@ -223,6 +223,9 @@ type RowHeaderProps = {
 }
 
 const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
+  const { id: _id } = useParams()
+  const tableId = _id ? Number(_id) : undefined
+
   const queryClient = useQueryClient()
   const { data: project } = useSelectedProjectQuery()
   const tableEditorSnap = useTableEditorStateSnapshot()
@@ -238,6 +241,8 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   const [isExporting, setIsExporting] = useState(false)
   const [showExportModal, setShowExportModal] = useState(false)
 
+  const preflightCheck = !tableEditorSnap.tablesToIgnorePreflightCheck.includes(tableId ?? -1)
+
   const { data } = useTableRowsQuery(
     {
       projectRef: project?.ref,
@@ -246,6 +251,7 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
       sorts,
       filters,
       page: snap.page,
+      preflightCheck,
       limit: tableEditorSnap.rowsPerPage,
       roleImpersonationState: roleImpersonationState as RoleImpersonationState,
     },

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.CleanupNotice.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.CleanupNotice.tsx
@@ -16,6 +16,9 @@ import {
   SelectItem_Shadcn_,
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
@@ -24,15 +27,15 @@ import {
   useCronJobsCleanupActions,
   type BatchDeletionProgress,
 } from './CronJobsTab.useCleanupActions'
+import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 interface CronJobRunDetailsOverflowNoticeV2Props {
+  queryCost?: number
   refetchJobs: () => void
 }
 
-export const CronJobRunDetailsOverflowNoticeV2 = (
-  props: CronJobRunDetailsOverflowNoticeV2Props
-) => {
+export const CronJobRunDetailsOverflowNotice = (props: CronJobRunDetailsOverflowNoticeV2Props) => {
   return (
     <Admonition
       type="note"
@@ -46,6 +49,7 @@ export const CronJobRunDetailsOverflowNoticeV2 = (
 }
 
 const CronJobRunDetailsOverflowDialog = ({
+  queryCost,
   refetchJobs,
 }: CronJobRunDetailsOverflowNoticeV2Props) => {
   const { data: project } = useSelectedProjectQuery()
@@ -75,7 +79,10 @@ const CronJobRunDetailsOverflowDialog = ({
       <DialogTrigger asChild>
         <Button type="default">Learn more</Button>
       </DialogTrigger>
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent
+        aria-describedby={undefined}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Last run for cron jobs omitted for overview</DialogTitle>
         </DialogHeader>
@@ -89,8 +96,17 @@ const CronJobRunDetailsOverflowDialog = ({
           </p>
 
           <p className="text-sm">
-            However, the join was skipped as the estimated query cost exceeds safety thresholds,
-            likely due to the size of{' '}
+            However, the join was skipped as the{' '}
+            <Tooltip>
+              <TooltipTrigger className={InlineLinkClassName}>estimated query cost</TooltipTrigger>
+              <TooltipContent side="bottom" className="flex flex-col gap-y-1">
+                <p>Estimated cost: {queryCost?.toLocaleString()}</p>
+                <p className="text-foreground-light">
+                  Determined via the <code className="text-code-inline">EXPLAIN</code> command
+                </p>
+              </TooltipContent>
+            </Tooltip>{' '}
+            exceeds safety thresholds, likely due to the size of{' '}
             <code className="text-code-inline !break-keep">cron.job_run_details</code> table.
           </p>
         </DialogSection>

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
@@ -18,7 +18,7 @@ import { LoadingLine, Sheet, SheetContent } from 'ui'
 import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { formatCronJobColumns } from './CronJobs.utils'
-import { CronJobRunDetailsOverflowNoticeV2 } from './CronJobsTab.CleanupNotice'
+import { CronJobRunDetailsOverflowNotice } from './CronJobsTab.CleanupNotice'
 import { CronJobsTabDataGrid } from './CronJobsTab.DataGrid'
 import { CronJobsTabHeader } from './CronJobsTab.Header'
 import { useCronJobsData } from './CronJobsTab.useCronJobsData'
@@ -171,7 +171,12 @@ export const CronjobsTab = () => {
             onCreateJob={onOpenCreateJobSheet}
           />
           <LoadingLine loading={grid.isLoading || grid.isRefetching || grid.isFetchingNextPage} />
-          {grid.isMinimal && <CronJobRunDetailsOverflowNoticeV2 refetchJobs={grid.refetch} />}
+          {grid.isMinimal && (
+            <CronJobRunDetailsOverflowNotice
+              queryCost={grid.queryCost}
+              refetchJobs={grid.refetch}
+            />
+          )}
           <CronJobsTabDataGrid
             columns={columns}
             rows={grid.rows}

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.useCronJobsData.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.useCronJobsData.ts
@@ -27,6 +27,7 @@ type UseCronJobsDataParams = ConnectionVars & {
 
 interface CronJobsGridState {
   rows: Array<CronJob>
+  queryCost?: number
   isSuccess: boolean
   isLoading: boolean
   error: ResponseError | null
@@ -130,6 +131,7 @@ export function useCronJobsData({
   return {
     grid: {
       rows: cronJobs,
+      queryCost: cronJobsError?.metadata?.cost,
       error: useMinimalQuery ? cronJobsMinimalError : cronJobsError,
       isSuccess: useMinimalQuery ? isCronJobsMinimalSuccess : isCronJobsSuccess,
       isLoading: useMinimalQuery ? isCronJobsMinimalLoading : isCronJobsLoading,

--- a/apps/studio/components/ui/HighQueryCost.tsx
+++ b/apps/studio/components/ui/HighQueryCost.tsx
@@ -24,17 +24,26 @@ import { ResponseError } from '@/types'
 interface HighQueryCostErrorProps {
   error: ResponseError
   suggestions?: string[]
+  onSelectLoadData?: () => void
 }
 
-export const HighCostError = ({ error, suggestions }: HighQueryCostErrorProps) => {
-  // [Joshen] The CTA could be to use a read replica to query or something?
+export const HighCostError = ({
+  error,
+  suggestions,
+  onSelectLoadData,
+}: HighQueryCostErrorProps) => {
   return (
     <Admonition
       type="default"
       title="Data not loaded to protect database performance"
       description="The query to retrieve the data was not run as it could place heavy load on the database and impact performance"
     >
-      <HighQueryCostDialog error={error} suggestions={suggestions} />
+      <div className="mt-2 flex items-center gap-x-2 items-center">
+        <Button type="default" onClick={() => onSelectLoadData?.()}>
+          Load data
+        </Button>
+        <HighQueryCostDialog error={error} suggestions={suggestions} />
+      </div>
     </Admonition>
   )
 }
@@ -45,9 +54,7 @@ const HighQueryCostDialog = ({ error, suggestions = [] }: HighQueryCostErrorProp
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button type="default" className="mt-2">
-          Learn more
-        </Button>
+        <Button type="outline">Learn more</Button>
       </DialogTrigger>
       <DialogContent onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>

--- a/apps/studio/components/ui/HighQueryCost.tsx
+++ b/apps/studio/components/ui/HighQueryCost.tsx
@@ -83,17 +83,30 @@ const HighQueryCostDialog = ({ error, suggestions = [] }: HighQueryCostErrorProp
             is high and could place significant load on the database with high disk I/O or CPU
             usage.
           </p>
-          {suggestions.length > 0 && (
-            <div className="flex flex-col gap-y-1">
-              <p>You may check the following to lower the cost of the query</p>
-              <ul className="list-disc pl-6">
-                {suggestions.map((x) => (
-                  <li key={x}>{x}</li>
-                ))}
-              </ul>
-            </div>
-          )}
         </DialogSection>
+
+        {suggestions.length > 0 && (
+          <>
+            <DialogSectionSeparator />
+            <DialogSection className="flex flex-col gap-y-4 text-sm">
+              <p className="font-mono text-foreground-lighter uppercase tracking-tight text-sm">
+                Suggested steps
+              </p>
+
+              {suggestions.length > 0 && (
+                <div className="flex flex-col gap-y-1">
+                  <p>You may check the following to lower the cost of the query</p>
+                  <ul className="list-disc pl-6">
+                    {suggestions.map((x) => (
+                      <li key={x}>{x}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </DialogSection>
+          </>
+        )}
+
         <DialogFooter>
           <DocsButton
             href={`${DOCS_URL}/guides/troubleshooting/understanding-postgresql-explain-output-Un9dqX`}

--- a/apps/studio/components/ui/HighQueryCost.tsx
+++ b/apps/studio/components/ui/HighQueryCost.tsx
@@ -39,9 +39,9 @@ export const HighCostError = ({
       description="The query to retrieve the data was not run as it could place heavy load on the database and impact performance"
     >
       <div className="mt-2 flex items-center gap-x-2 items-center">
-        <Button type="default" onClick={() => onSelectLoadData?.()}>
-          Load data
-        </Button>
+        {!!onSelectLoadData && (
+          <LoadDataWarningDialog error={error} onSelectLoadData={onSelectLoadData} />
+        )}
         <HighQueryCostDialog error={error} suggestions={suggestions} />
       </div>
     </Admonition>
@@ -80,11 +80,12 @@ const HighQueryCostDialog = ({ error, suggestions = [] }: HighQueryCostErrorProp
                 </p>
               </TooltipContent>
             </Tooltip>{' '}
-            is high and could place significant load on the database.
+            is high and could place significant load on the database with high disk I/O or CPU
+            usage.
           </p>
           {suggestions.length > 0 && (
             <div className="flex flex-col gap-y-1">
-              <p>You may check the following to ensure that the query cost is lower</p>
+              <p>You may check the following to lower the cost of the query</p>
               <ul className="list-disc pl-6">
                 {suggestions.map((x) => (
                   <li key={x}>{x}</li>
@@ -102,6 +103,64 @@ const HighQueryCostDialog = ({ error, suggestions = [] }: HighQueryCostErrorProp
               Understood
             </Button>
           </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const LoadDataWarningDialog = ({
+  error,
+  onSelectLoadData,
+}: {
+  error: ResponseError
+  onSelectLoadData: () => void
+}) => {
+  const metadata = error.metadata
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="default">Load data</Button>
+      </DialogTrigger>
+      <DialogContent onOpenAutoFocus={(event) => event.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Confirm to proceed loading data</DialogTitle>
+          <DialogDescription>
+            Preventive measure to mitigate impacting the database
+          </DialogDescription>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection className="flex flex-col gap-y-2 text-sm">
+          <p>
+            The query to load your table's data was initially skipped as its{' '}
+            <Tooltip>
+              <TooltipTrigger className={InlineLinkClassName}>estimated cost</TooltipTrigger>
+              <TooltipContent side="bottom" className="flex flex-col gap-y-1">
+                <p>Estimated cost: {metadata?.cost.toLocaleString()}</p>
+                <p className="text-foreground-light">
+                  Determined via the <code className="text-code-inline">EXPLAIN</code> command
+                </p>
+              </TooltipContent>
+            </Tooltip>{' '}
+            is high and could place significant load on the database with high disk I/O or CPU
+            usage.
+          </p>
+
+          <p>
+            You may proceed to run the query, and we'll suppress this warning for this table for the
+            rest of this browser session.
+          </p>
+        </DialogSection>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="default" className="opacity-100">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="warning" onClick={() => onSelectLoadData()}>
+            I understand, proceed
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -21,7 +21,7 @@ import {
  * Reckon we ensure that the dashboard just caps query costs at "heavy", so that it doesn't impact the DB for other queries
  * (e.g from the user's application)
  */
-const COST_THRESHOLD = 100_000
+const COST_THRESHOLD = 200_000
 export const COST_THRESHOLD_ERROR = 'Query cost exceeds threshold'
 
 export type ExecuteSqlVariables = {

--- a/apps/studio/state/table-editor-table.tsx
+++ b/apps/studio/state/table-editor-table.tsx
@@ -1,15 +1,15 @@
 import { useFlag } from 'common'
+import { TableIndexAdvisorProvider } from 'components/grid/context/TableIndexAdvisorContext'
 import {
   loadTableEditorStateFromLocalStorage,
   parseSupaTable,
   saveTableEditorStateToLocalStorageDebounced,
 } from 'components/grid/SupabaseGrid.utils'
-import { TableIndexAdvisorProvider } from 'components/grid/context/TableIndexAdvisorContext'
 import { Filter, SupaRow } from 'components/grid/types'
 import { getInitialGridColumns } from 'components/grid/utils/column'
 import { getGridColumns } from 'components/grid/utils/gridColumns'
 import { Entity } from 'data/table-editor/table-editor-types'
-import { PropsWithChildren, createContext, useContext, useEffect, useRef } from 'react'
+import { createContext, PropsWithChildren, useContext, useEffect, useRef } from 'react'
 import { CalculatedColumn } from 'react-data-grid'
 import { proxy, ref, subscribe, useSnapshot } from 'valtio'
 import { proxySet } from 'valtio/utils'
@@ -20,6 +20,7 @@ export const createTableEditorTableState = ({
   projectRef,
   table: originalTable,
   editable = true,
+  preflightCheck = true,
   onAddColumn,
   onExpandJSONEditor,
   onExpandTextEditor,
@@ -28,6 +29,7 @@ export const createTableEditorTableState = ({
   table: Entity
   /** If set to true, render an additional "+" column to support adding a new column in the grid editor */
   editable?: boolean
+  preflightCheck?: boolean
   onAddColumn: () => void
   onExpandJSONEditor: (column: string, row: SupaRow) => void
   onExpandTextEditor: (column: string, row: SupaRow) => void
@@ -171,6 +173,9 @@ export const createTableEditorTableState = ({
     clearFilters: () => {
       state.filters = []
     },
+
+    preflightCheck,
+    setPreflightCheck: (value: boolean) => (state.preflightCheck = value),
   })
 
   return state

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -10,15 +10,15 @@ import { generateTableChangeKey } from 'components/grid/utils/queueOperationUtil
 import { ForeignKey } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
 import type { EditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
 import type { TableField } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
-import { PropsWithChildren, createContext, useContext } from 'react'
+import { createContext, PropsWithChildren, useContext } from 'react'
 import type { Dictionary } from 'types'
 import { proxy, useSnapshot } from 'valtio'
 
 import {
   NewQueuedOperation,
+  QueuedOperationType,
   type OperationQueueState,
   type QueueStatus,
-  QueuedOperationType,
 } from './table-editor-operation-queue.types'
 
 export const TABLE_EDITOR_DEFAULT_ROWS_PER_PAGE = 100
@@ -330,6 +330,16 @@ export const createTableEditorState = () => {
         },
       })
       return state.operationQueue.operations.some((op) => op.id === key)
+    },
+
+    /**
+     * Toggle the preflight check behaviour for each table
+     */
+    tablesToIgnorePreflightCheck: [] as number[],
+    setTableToIgnorePreflightCheck: (id: number) => {
+      const set = new Set<number>(state.tablesToIgnorePreflightCheck)
+      set.add(id)
+      state.tablesToIgnorePreflightCheck = [...set]
     },
   })
 


### PR DESCRIPTION
## Context

Related to this previous PR [here](https://github.com/supabase/supabase/pull/42321)

Table Editor: Adding a CTA to the `HighQueryCost` UI to allow users to proceed with fetching data despite the high query cost warning, to prevent completely blocking the users from their workflows (realised that certain heavy queries are required and this safeguard shouldn't be creating dead-ends for users)

<img width="1159" height="264" alt="image" src="https://github.com/user-attachments/assets/5fa01f7f-4442-4349-91f2-f4275e177f89" />

Clicking "Load more" will open a confirmation dialog, in which proceeding to load the data will thereafter suppress this preflight check for the table, for the rest of the browser session

<img width="450" height="305" alt="image" src="https://github.com/user-attachments/assets/d3197a5d-a861-47a8-95da-e157972ce092" />

## Other changes

- Also bumped the query cost threshold from 100,000 to 200,000 - the former might have been too aggressive 😓 
- (Unrelated) Added query cost tooltip for cron jobs high query cost warning
  <img width="450" height="230" alt="image" src="https://github.com/user-attachments/assets/d2c66972-7c4c-4f99-818c-e90a0991c2f5" />
