### PR TITLE
docs(auth): clarify ip_address is not included in audit logs

### DIFF
--- a/apps/docs/content/guides/auth/audit-logs.mdx
+++ b/apps/docs/content/guides/auth/audit-logs.mdx
@@ -47,13 +47,16 @@ Audit logs contain detailed information about each authentication event:
   "timestamp": "2025-08-01T10:30:00Z",
   "user_id": "uuid",
   "action": "user_signedup",
-  "ip_address": "192.168.1.1",
   "user_agent": "Mozilla/5.0...",
   "metadata": {
     "provider": "email"
   }
 }
 ```
+> **Note**
+>
+> The `ip_address` field is not currently included in Auth audit logs.
+> Client IP addresses are available in `auth.sessions`, but are not logged for each authentication event in the audit logs.
 
 ### Log actions reference
 


### PR DESCRIPTION
Fixes #42997

Removed `ip_address` from the audit log example and clarified that client IP addresses are stored in `auth.sessions`, but are not currently included in Auth audit logs.

This aligns the documentation with the current behavior.

---

## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The documentation example includes `ip_address` in Auth audit logs, but this field is not actually present in the audit logs.

## What is the new behavior?

The example no longer includes `ip_address`, and a note clarifies that IP addresses are stored in `auth.sessions`, but not included in audit logs.

## Additional context

N/A
