### PR TITLE
docs: replace deprecated getSession with getClaims in Refine tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,10 +233,10 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const { data } = await supabaseClient.auth.getClaims()
+      const { claims } = data
 
-      if (!session) {
+      if (!claims) {
         return {
           authenticated: false,
           error: {


### PR DESCRIPTION
Fixes #42193

Replaces the deprecated `getSession` call with `getClaims` in the Refine tutorial documentation (`with-refine.mdx`).

Changes:
- `supabaseClient.auth.getSession()` → `supabaseClient.auth.getClaims()`
- `data.session` → `data.claims`

This follows the recommended migration pattern per the Supabase auth docs.