### PR TITLE
Ensure logs pages are accessible irregardless of project's status

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -10,6 +10,7 @@ import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
 import { Blocks, FileText, Lightbulb, List, Settings, Telescope } from 'lucide-react'
 
 export const generateToolRoutes = (ref?: string, project?: Project, features?: {}): Route[] => {
+  const isProjectActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
   const isProjectBuilding = project?.status === PROJECT_STATUS.COMING_UP
   const buildingUrl = `/project/${ref}`
 
@@ -17,6 +18,7 @@ export const generateToolRoutes = (ref?: string, project?: Project, features?: {
     {
       key: 'editor',
       label: 'Table Editor',
+      disabled: !isProjectActive,
       icon: <TableEditor size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/editor`),
       linkElement: <EditorIndexPageLink projectRef={ref} />,
@@ -24,6 +26,7 @@ export const generateToolRoutes = (ref?: string, project?: Project, features?: {
     {
       key: 'sql',
       label: 'SQL Editor',
+      disabled: !isProjectActive,
       icon: <SqlEditor size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/sql`),
     },
@@ -58,6 +61,7 @@ export const generateProductRoutes = (
     {
       key: 'database',
       label: 'Database',
+      disabled: !isProjectActive,
       icon: <Database size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link:
         ref &&
@@ -73,6 +77,7 @@ export const generateProductRoutes = (
           {
             key: 'auth',
             label: 'Authentication',
+            disabled: !isProjectActive,
             icon: <Auth size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link:
               ref &&
@@ -90,6 +95,7 @@ export const generateProductRoutes = (
           {
             key: 'storage',
             label: 'Storage',
+            disabled: !isProjectActive,
             icon: <Storage size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/storage/files`),
           },
@@ -100,6 +106,7 @@ export const generateProductRoutes = (
           {
             key: 'functions',
             label: 'Edge Functions',
+            disabled: false,
             icon: <EdgeFunctions size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && `/project/${ref}/functions`,
           },
@@ -110,6 +117,7 @@ export const generateProductRoutes = (
           {
             key: 'realtime',
             label: 'Realtime',
+            disabled: !isProjectActive,
             icon: <Realtime size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/realtime/inspector`),
           },
@@ -123,6 +131,7 @@ export const generateOtherRoutes = (
   project?: Project,
   features?: { unifiedLogs?: boolean; showReports?: boolean; apiDocsSidePanel?: boolean }
 ): Route[] => {
+  const isProjectActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
   const isProjectBuilding = project?.status === PROJECT_STATUS.COMING_UP
   const buildingUrl = `/project/${ref}`
 
@@ -135,6 +144,7 @@ export const generateOtherRoutes = (
     {
       key: 'advisors',
       label: 'Advisors',
+      disabled: !isProjectActive,
       icon: <Lightbulb size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/advisors/security`),
     },
@@ -143,6 +153,7 @@ export const generateOtherRoutes = (
           {
             key: 'observability',
             label: 'Observability',
+            disabled: !isProjectActive,
             icon: <Telescope size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/observability`),
           },
@@ -151,20 +162,16 @@ export const generateOtherRoutes = (
     {
       key: 'logs',
       label: 'Logs',
+      disabled: false,
       icon: <List size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-      link:
-        ref &&
-        (isProjectBuilding
-          ? buildingUrl
-          : unifiedLogsEnabled
-            ? `/project/${ref}/logs`
-            : `/project/${ref}/logs/explorer`),
+      link: ref && (unifiedLogsEnabled ? `/project/${ref}/logs` : `/project/${ref}/logs/explorer`),
     },
     ...(apiDocsSidePanelEnabled
       ? [
           {
             key: 'api',
             label: 'API Docs',
+            disabled: !isProjectActive,
             icon: <FileText size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link:
               ref &&
@@ -175,6 +182,7 @@ export const generateOtherRoutes = (
     {
       key: 'integrations',
       label: 'Integrations',
+      disabled: !isProjectActive,
       icon: <Blocks size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/integrations`),
     },
@@ -192,6 +200,7 @@ export const generateSettingsRoutes = (ref?: string, project?: Project): Route[]
         ref &&
         (IS_PLATFORM ? `/project/${ref}/settings/general` : `/project/${ref}/settings/log-drains`),
       items: settingsMenu,
+      disabled: false,
     },
   ]
 }

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -1,7 +1,3 @@
-import Head from 'next/head'
-import { useRouter } from 'next/router'
-import { forwardRef, Fragment, PropsWithChildren, ReactNode, useEffect } from 'react'
-
 import { mergeRefs, useParams } from 'common'
 import { CreateBranchModal } from 'components/interfaces/BranchManagement/CreateBranchModal'
 import { ProjectAPIDocs } from 'components/interfaces/ProjectAPIDocs/ProjectAPIDocs'
@@ -13,10 +9,14 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { withAuth } from 'hooks/misc/withAuth'
 import { usePHFlag } from 'hooks/ui/useFlag'
 import { PROJECT_STATUS } from 'lib/constants'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { forwardRef, Fragment, PropsWithChildren, ReactNode, useEffect } from 'react'
 import { useAppStateSnapshot } from 'state/app-state'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { cn, LogoLoader, ResizableHandle, ResizablePanel, ResizablePanelGroup } from 'ui'
 import MobileSheetNav from 'ui-patterns/MobileSheetNav/MobileSheetNav'
+
 import { useEditorType } from '../editors/EditorsLayout.hooks'
 import { useSetMainScrollContainer } from '../MainScrollContainerContext'
 import BuildingState from './BuildingState'
@@ -35,27 +35,27 @@ import { UpgradingState } from './UpgradingState'
 // [Joshen] This is temporary while we unblock users from managing their project
 // if their project is not responding well for any reason. Eventually needs a bit of an overhaul
 const routesToIgnoreProjectDetailsRequest = [
+  '/project/[ref]/settings/infrastructure',
+  '/project/[ref]/settings/addons',
   '/project/[ref]/settings/general',
   '/project/[ref]/database/settings',
   '/project/[ref]/storage/settings',
-  '/project/[ref]/settings/infrastructure',
-  '/project/[ref]/settings/addons',
 ]
 
 const routesToIgnoreDBConnection = [
   '/project/[ref]/branches',
-  '/project/[ref]/database/backups/scheduled',
-  '/project/[ref]/database/backups/pitr',
-  '/project/[ref]/settings/addons',
+  '/project/[ref]/database/backups',
+  '/project/[ref]/settings',
   '/project/[ref]/functions',
+  '/project/[ref]/logs',
 ]
 
 const routesToIgnorePostgrestConnection = [
-  '/project/[ref]/reports',
   '/project/[ref]/settings/general',
-  '/project/[ref]/database/settings',
   '/project/[ref]/settings/infrastructure',
   '/project/[ref]/settings/addons',
+  '/project/[ref]/database/settings',
+  '/project/[ref]/reports',
 ]
 
 export interface ProjectLayoutProps {
@@ -108,7 +108,8 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
     const ignorePausedState =
       router.pathname === '/project/[ref]' ||
       router.pathname.includes('/project/[ref]/settings') ||
-      router.pathname.includes('/project/[ref]/functions')
+      router.pathname.includes('/project/[ref]/functions') ||
+      router.pathname.includes('/project/[ref]/logs')
     const showPausedState = isPaused && !ignorePausedState
 
     const sidebarMinSizePercentage = 1
@@ -132,7 +133,6 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
           <meta name="description" content="Supabase Studio" />
         </Head>
         <div className="flex flex-row h-full w-full">
-          {/*  autoSaveId="project-layout" */}
           <ResizablePanelGroup direction="horizontal">
             {productMenu && (
               <ResizablePanel
@@ -275,18 +275,10 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
   const { data: selectedProject } = useSelectedProjectQuery()
   const isHomeNew = usePHFlag('homeNew') === 'new-home'
 
-  const isBranchesPage = router.pathname.includes('/project/[ref]/branches')
-  const isSettingsPages = router.pathname.includes('/project/[ref]/settings')
-  const isEdgeFunctionPages = router.pathname.includes('/project/[ref]/functions')
-  const isVaultPage = router.pathname === '/project/[ref]/settings/vault'
   const isBackupsPage = router.pathname.includes('/project/[ref]/database/backups')
   const isHomePage = router.pathname === '/project/[ref]'
 
-  const requiresDbConnection: boolean =
-    (!isEdgeFunctionPages &&
-      !isSettingsPages &&
-      !routesToIgnoreDBConnection.includes(router.pathname)) ||
-    isVaultPage
+  const requiresDbConnection = !routesToIgnoreDBConnection.some((x) => router.pathname.includes(x))
   const requiresPostgrestConnection = !routesToIgnorePostgrestConnection.includes(router.pathname)
   const requiresProjectDetails = !routesToIgnoreProjectDetailsRequest.includes(router.pathname)
 
@@ -302,19 +294,9 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
   const isProjectPauseFailed = selectedProject?.status === PROJECT_STATUS.PAUSE_FAILED
   const isProjectOffline = selectedProject?.postgrestStatus === 'OFFLINE'
 
-  // handle redirect to home for building state
-  const shouldRedirectToHomeForBuilding =
-    isHomeNew && requiresDbConnection && isProjectBuilding && !isBranchesPage && !isHomePage
-
   // We won't be showing the building state with the new home page
   const shouldShowBuildingState =
-    requiresDbConnection && isProjectBuilding && !isBranchesPage && !(isHomeNew && isHomePage)
-
-  useEffect(() => {
-    if (shouldRedirectToHomeForBuilding && ref) {
-      router.replace(`/project/${ref}`)
-    }
-  }, [shouldRedirectToHomeForBuilding, ref, router])
+    isProjectBuilding && requiresDbConnection && !(isHomeNew && isHomePage)
 
   useEffect(() => {
     if (ref) state.setSelectedDatabaseId(ref)
@@ -352,12 +334,8 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
     return <RestoringState />
   }
 
-  if (isProjectRestoreFailed && !isBackupsPage && !isEdgeFunctionPages) {
+  if (requiresDbConnection && isProjectRestoreFailed) {
     return <RestoreFailedState />
-  }
-
-  if (shouldRedirectToHomeForBuilding) {
-    return <LogoLoader />
   }
 
   if (shouldShowBuildingState) {

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -294,9 +294,19 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
   const isProjectPauseFailed = selectedProject?.status === PROJECT_STATUS.PAUSE_FAILED
   const isProjectOffline = selectedProject?.postgrestStatus === 'OFFLINE'
 
+  // handle redirect to home for building state
+  const shouldRedirectToHomeForBuilding =
+    isProjectBuilding && requiresDbConnection && isHomeNew && !isHomePage
+
   // We won't be showing the building state with the new home page
   const shouldShowBuildingState =
     isProjectBuilding && requiresDbConnection && !(isHomeNew && isHomePage)
+
+  useEffect(() => {
+    if (shouldRedirectToHomeForBuilding && ref) {
+      router.replace(`/project/${ref}`)
+    }
+  }, [shouldRedirectToHomeForBuilding, ref, router])
 
   useEffect(() => {
     if (ref) state.setSelectedDatabaseId(ref)
@@ -336,6 +346,10 @@ const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapp
 
   if (requiresDbConnection && isProjectRestoreFailed) {
     return <RestoreFailedState />
+  }
+
+  if (shouldRedirectToHomeForBuilding) {
+    return <LogoLoader />
   }
 
   if (shouldShowBuildingState) {

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -1,8 +1,7 @@
-import { ArrowUpRight } from 'lucide-react'
-
 import type { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
 import type { Project } from 'data/projects/project-detail-query'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
+import { ArrowUpRight } from 'lucide-react'
 import type { Organization } from 'types'
 
 export const generateSettingsMenu = (
@@ -37,13 +36,7 @@ export const generateSettingsMenu = (
   }
 
   const isProjectActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
-  const isProjectBuilding = project?.status === PROJECT_STATUS.COMING_UP
-  const buildingUrl = `/project/${ref}`
 
-  const authEnabled = features?.auth ?? true
-  const authProvidersEnabled = features?.authProviders ?? true
-  const edgeFunctionsEnabled = features?.edgeFunctions ?? true
-  const storageEnabled = features?.storage ?? true
   const legacyJwtKeysEnabled = features?.legacyJwtKeys ?? true
   const billingEnabled = features?.billing ?? true
 
@@ -67,7 +60,7 @@ export const generateSettingsMenu = (
         {
           name: 'Infrastructure',
           key: 'infrastructure',
-          url: isProjectBuilding ? buildingUrl : `/project/${ref}/settings/infrastructure`,
+          url: `/project/${ref}/settings/infrastructure`,
           items: [],
           disabled: !isProjectActive,
         },
@@ -118,14 +111,15 @@ export const generateSettingsMenu = (
         {
           name: 'Data API',
           key: 'api',
-          url: isProjectBuilding ? buildingUrl : `/project/${ref}/integrations/data_api/overview`,
+          url: `/project/${ref}/integrations/data_api/overview`,
           items: [],
           rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
+          disabled: !isProjectActive,
         },
         {
           name: 'Vault',
           key: 'vault',
-          url: isProjectBuilding ? buildingUrl : `/project/${ref}/integrations/vault/overview`,
+          url: `/project/${ref}/integrations/vault/overview`,
           items: [],
           rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
           label: 'Beta',


### PR DESCRIPTION
## Context

Ensure that project's logs pages are accessible irregardless of project's status, given that logs are mutually exclusive from the project's database and doesn't require the database to be online for it to be functional.

## Other changes
Mainly around simplifying some logic within ProjectLayout
- Remove `disabled` prop in `SideBarNavLink` component, given that `route` prop already has a `disabled` param
  - Define `disabled` within `NavigationBar.utils.tsx` -> just have one place to define the "configuration" of a route
- Minimize manually declaring specific routes to render specific UI (for Restore failed)
  - All of these can be grouped under `routesToIgnoreDBConnection`

## To test
- [ ] Verify that you can access the logs page while the project is coming up
- [ ] Verify that you can access the logs page on a paused project (and also use it)