### PR TITLE
fix(docs): authenticate GitHub API calls in lint-warnings-guide

### DIFF
--- a/apps/docs/scripts/search/sources/lint-warnings-guide.ts
+++ b/apps/docs/scripts/search/sources/lint-warnings-guide.ts
@@ -24,12 +24,16 @@ export class LintWarningsGuideLoader extends BaseLoader {
   }
 
   async load() {
+    if (!appId || !installationId || !privateKey) {
+      throw new Error('Missing DOCS_GITHUB_APP_* environment variables')
+    }
+
     const octokit = new Octokit({
       authStrategy: createAppAuth,
       auth: {
         appId,
         installationId,
-        privateKey: crypto.createPrivateKey(privateKey!).export({ type: 'pkcs8', format: 'pem' }),
+        privateKey: crypto.createPrivateKey(privateKey).export({ type: 'pkcs8', format: 'pem' }),
       },
     })
 

--- a/apps/docs/scripts/search/sources/lint-warnings-guide.ts
+++ b/apps/docs/scripts/search/sources/lint-warnings-guide.ts
@@ -1,6 +1,11 @@
+import { createAppAuth } from '@octokit/auth-app'
 import { Octokit } from '@octokit/core'
+import crypto, { createHash } from 'node:crypto'
 import { BaseLoader, BaseSource } from './base.js'
-import { createHash } from 'node:crypto'
+
+const appId = process.env.DOCS_GITHUB_APP_ID
+const installationId = process.env.DOCS_GITHUB_APP_INSTALLATION_ID
+const privateKey = process.env.DOCS_GITHUB_APP_PRIVATE_KEY
 
 const getBasename = (path: string) => path.split('/').at(-1)!.replace(/\.md$/, '')
 
@@ -19,7 +24,14 @@ export class LintWarningsGuideLoader extends BaseLoader {
   }
 
   async load() {
-    const octokit = new Octokit()
+    const octokit = new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId,
+        installationId,
+        privateKey: crypto.createPrivateKey(privateKey!).export({ type: 'pkcs8', format: 'pem' }),
+      },
+    })
 
     const response = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
       owner: this.org,


### PR DESCRIPTION
- `LintWarningsGuideLoader` was making unauthenticated GitHub API calls (60 req/hr per IP), causing flaky failures on shared CI runners
- Uses the same GitHub App auth already in [github-discussion.ts](https://github.com/supabase/supabase/blob/9237db51f8db12e744e68500a4e3f42c43746734/apps/docs/scripts/search/sources/github-discussion.ts#L36) — no new env vars or deps needed

Fixes https://github.com/supabase/supabase/actions/runs/22184533189/job/64154440387