### PR TITLE
feat(assistant): send user feedback to Braintrust traces

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -224,6 +224,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           projectRef: project.ref,
           orgSlug: selectedOrganization.slug,
           reason,
+          spanId: state.messageSpanIds[messageId],
         })
 
         sendEvent({

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -248,7 +248,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
         })
       }
     },
-    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, sendEvent]
+    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, sendEvent, state]
   )
 
   const isContextExceededError =

--- a/apps/studio/data/ai/rate-message-mutation.ts
+++ b/apps/studio/data/ai/rate-message-mutation.ts
@@ -13,6 +13,7 @@ export type RateMessageVariables = {
   projectRef: string
   orgSlug?: string
   reason?: string
+  spanId?: string
 }
 
 export async function rateMessage({
@@ -22,6 +23,7 @@ export async function rateMessage({
   projectRef,
   orgSlug,
   reason,
+  spanId,
 }: RateMessageVariables) {
   const url = `${BASE_PATH}/api/ai/feedback/rate`
 
@@ -29,7 +31,7 @@ export async function rateMessage({
   const response = await fetchHandler(url, {
     headers,
     method: 'POST',
-    body: JSON.stringify({ rating, messages, messageId, projectRef, orgSlug, reason }),
+    body: JSON.stringify({ rating, messages, messageId, projectRef, orgSlug, reason, spanId }),
   })
 
   let body: any

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -42,6 +42,7 @@ export async function generateAssistantResponse({
   promptProviderOptions,
   providerOptions,
   abortSignal,
+  onSpanCreated,
 }: {
   messages: UIMessage[]
   model: LanguageModel
@@ -58,10 +59,15 @@ export async function generateAssistantResponse({
   promptProviderOptions?: Record<string, any>
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal
+  onSpanCreated?: (spanId: string) => void
 }) {
   const shouldTrace = IS_TRACING_ENABLED && !isHipaaEnabled
 
   const run = async (span?: Span) => {
+    if (span) {
+      onSpanCreated?.(span.id)
+    }
+
     // Only returns last 7 messages
     // Filters out tools with invalid states
     // Filters out tool outputs based on opt-in level using renderingToolOutputParser

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -41,6 +41,7 @@ export async function generateAssistantResponse({
   planId,
   promptProviderOptions,
   providerOptions,
+  requestedModel,
   abortSignal,
   onSpanCreated,
 }: {
@@ -56,6 +57,7 @@ export async function generateAssistantResponse({
   userId?: string
   orgId?: number
   planId?: string
+  requestedModel?: string
   promptProviderOptions?: Record<string, any>
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal
@@ -177,6 +179,7 @@ export async function generateAssistantResponse({
         userId,
         orgId,
         planId,
+        requestedModel,
         gitBranch: process.env.VERCEL_GIT_COMMIT_REF,
         environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
       },

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -1,14 +1,16 @@
 import { generateObject } from 'ai'
+import { currentLogger } from 'braintrust'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { z } from 'zod'
 
 import { IS_PLATFORM } from 'common'
+import { rateMessageResponseSchema } from 'components/ui/AIAssistantPanel/Message.utils'
 import type { AiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
+import { IS_TRACING_ENABLED } from 'lib/ai/braintrust-logger'
 import { getModel } from 'lib/ai/model'
 import { getOrgAIDetails } from 'lib/ai/org-ai-details'
 import { sanitizeMessagePart } from 'lib/ai/tools/tool-sanitizer'
 import apiWrapper from 'lib/api/apiWrapper'
-import { rateMessageResponseSchema } from 'components/ui/AIAssistantPanel/Message.utils'
 
 export const maxDuration = 30
 
@@ -31,6 +33,7 @@ const requestBodySchema = z.object({
   projectRef: z.string(),
   orgSlug: z.string().optional(),
   reason: z.string().optional(),
+  spanId: z.string().optional(),
 })
 
 export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
@@ -48,7 +51,7 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.status(400).json({ error: 'Invalid request body', issues: parseError.issues })
   }
 
-  const { rating, messages: rawMessages, projectRef, orgSlug, reason } = data
+  const { rating, messages: rawMessages, projectRef, orgSlug, reason, spanId } = data
 
   let aiOptInLevel: AiOptInLevel = 'disabled'
 
@@ -125,6 +128,22 @@ Instructions:
    - other: Anything else
 `,
     })
+
+    // Log feedback to Braintrust if tracing is enabled and span ID is available
+    if (IS_TRACING_ENABLED && spanId) {
+      try {
+        const logger = currentLogger()
+        logger?.logFeedback({
+          id: spanId,
+          scores: { user_rating: rating === 'positive' ? 1 : 0 },
+          comment: reason,
+          metadata: { category: object.category },
+          source: 'external',
+        })
+      } catch (error) {
+        console.error('Failed to log feedback to Braintrust:', error)
+      }
+    }
 
     return res.json({
       category: object.category,

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -135,7 +135,7 @@ Instructions:
         const logger = currentLogger()
         logger?.logFeedback({
           id: spanId,
-          scores: { user_rating: rating === 'positive' ? 1 : 0 },
+          scores: { 'User Rating': rating === 'positive' ? 1 : 0 },
           comment: reason,
           metadata: { category: object.category },
           source: 'external',

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -141,7 +141,7 @@ Instructions:
           comment: reason,
           source: 'external',
         })
-        logger?.log({
+        logger?.updateSpan({
           id: spanId,
           metadata: { feedbackCategory: object.category },
         })

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -54,6 +54,7 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   const { rating, messages: rawMessages, projectRef, orgSlug, reason, spanId } = data
 
   let aiOptInLevel: AiOptInLevel = 'disabled'
+  let isHipaaEnabled = false
 
   if (!IS_PLATFORM) {
     aiOptInLevel = 'schema'
@@ -62,13 +63,17 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   if (IS_PLATFORM && orgSlug && authorization && projectRef) {
     try {
       // Get organizations and compute opt in level server-side
-      const { aiOptInLevel: orgAIOptInLevel, isLimited: orgAILimited } = await getOrgAIDetails({
+      const {
+        aiOptInLevel: orgAIOptInLevel,
+        isHipaaEnabled: orgIsHipaaEnabled,
+      } = await getOrgAIDetails({
         orgSlug,
         authorization,
         projectRef,
       })
 
       aiOptInLevel = orgAIOptInLevel
+      isHipaaEnabled = orgIsHipaaEnabled
     } catch (error) {
       return res.status(400).json({
         error: 'There was an error fetching your organization details',
@@ -130,7 +135,7 @@ Instructions:
     })
 
     // Log feedback to Braintrust if tracing is enabled and span ID is available
-    if (IS_TRACING_ENABLED && spanId) {
+    if (IS_TRACING_ENABLED && !isHipaaEnabled && spanId) {
       try {
         const logger = currentLogger()
         logger?.logFeedback({

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -142,8 +142,11 @@ Instructions:
           id: spanId,
           scores: { 'User Rating': rating === 'positive' ? 1 : 0 },
           comment: reason,
-          metadata: { category: object.category },
           source: 'external',
+        })
+        logger?.log({
+          id: spanId,
+          metadata: { feedbackCategory: object.category },
         })
       } catch (error) {
         console.error('Failed to log feedback to Braintrust:', error)

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -1,8 +1,5 @@
 import { generateObject } from 'ai'
 import { currentLogger } from 'braintrust'
-import { NextApiRequest, NextApiResponse } from 'next'
-import { z } from 'zod'
-
 import { IS_PLATFORM } from 'common'
 import { rateMessageResponseSchema } from 'components/ui/AIAssistantPanel/Message.utils'
 import type { AiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
@@ -11,6 +8,8 @@ import { getModel } from 'lib/ai/model'
 import { getOrgAIDetails } from 'lib/ai/org-ai-details'
 import { sanitizeMessagePart } from 'lib/ai/tools/tool-sanitizer'
 import apiWrapper from 'lib/api/apiWrapper'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { z } from 'zod'
 
 export const maxDuration = 30
 
@@ -63,14 +62,12 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   if (IS_PLATFORM && orgSlug && authorization && projectRef) {
     try {
       // Get organizations and compute opt in level server-side
-      const {
-        aiOptInLevel: orgAIOptInLevel,
-        isHipaaEnabled: orgIsHipaaEnabled,
-      } = await getOrgAIDetails({
-        orgSlug,
-        authorization,
-        projectRef,
-      })
+      const { aiOptInLevel: orgAIOptInLevel, isHipaaEnabled: orgIsHipaaEnabled } =
+        await getOrgAIDetails({
+          orgSlug,
+          authorization,
+          projectRef,
+        })
 
       aiOptInLevel = orgAIOptInLevel
       isHipaaEnabled = orgIsHipaaEnabled

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -200,7 +200,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       providerOptions,
       abortSignal: abortController.signal,
       onSpanCreated: (spanId) => {
-        res.setHeader('x-bt-span-id', spanId)
+        res.setHeader('x-braintrust-span-id', spanId)
       },
     })
 

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -1,19 +1,18 @@
 import pgMeta from '@supabase/pg-meta'
-import { safeValidateUIMessages } from 'ai'
 import type { JwtPayload } from '@supabase/supabase-js'
-import type { NextApiRequest, NextApiResponse } from 'next'
-import z from 'zod'
-
+import { safeValidateUIMessages } from 'ai'
 import { IS_PLATFORM } from 'common'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { AiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
+import { generateAssistantResponse } from 'lib/ai/generate-assistant-response'
 import { getModel } from 'lib/ai/model'
 import { getOrgAIDetails } from 'lib/ai/org-ai-details'
-import { generateAssistantResponse } from 'lib/ai/generate-assistant-response'
 import { getTools } from 'lib/ai/tools'
-import { getURL } from 'lib/helpers'
 import apiWrapper from 'lib/api/apiWrapper'
 import { executeQuery } from 'lib/api/self-hosted/query'
+import { getURL } from 'lib/helpers'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import z from 'zod'
 
 export const maxDuration = 120
 
@@ -196,6 +195,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       userId,
       orgId,
       planId,
+      requestedModel,
       promptProviderOptions,
       providerOptions,
       abortSignal: abortController.signal,

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -199,6 +199,9 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       promptProviderOptions,
       providerOptions,
       abortSignal: abortController.signal,
+      onSpanCreated: (spanId) => {
+        res.setHeader('x-bt-span-id', spanId)
+      },
     })
 
     result.pipeUIMessageStreamToResponse(res, {

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -236,7 +236,7 @@ function createChatInstance(
       api: `${BASE_PATH}/api/ai/sql/generate-v4`,
       fetch: async (url, init) => {
         const response = await globalThis.fetch(url as RequestInfo, init)
-        const spanId = response.headers.get('x-bt-span-id')
+        const spanId = response.headers.get('x-braintrust-span-id')
         if (spanId) {
           state.pendingSpanIds[options.id] = spanId
         }

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -234,6 +234,14 @@ function createChatInstance(
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     transport: new DefaultChatTransport({
       api: `${BASE_PATH}/api/ai/sql/generate-v4`,
+      fetch: async (url, init) => {
+        const response = await globalThis.fetch(url as RequestInfo, init)
+        const spanId = response.headers.get('x-bt-span-id')
+        if (spanId) {
+          state.pendingSpanIds[options.id] = spanId
+        }
+        return response
+      },
       async prepareSendMessagesRequest({ messages, ...opts }) {
         const cleanedMessages = prepareMessagesForAPI(messages)
         const headerData = await constructHeaders()
@@ -282,6 +290,16 @@ function createChatInstance(
           chat.messages = messages as AssistantMessageType[]
           chat.updatedAt = new Date()
         }
+
+        // Associate pending span ID with the last assistant message
+        const pendingSpanId = state.pendingSpanIds[options.id]
+        if (pendingSpanId) {
+          const lastAssistantMsg = [...messages].reverse().find((m) => m.role === 'assistant')
+          if (lastAssistantMsg) {
+            state.messageSpanIds[lastAssistantMsg.id] = pendingSpanId
+          }
+          delete state.pendingSpanIds[options.id]
+        }
       }
     },
   })
@@ -294,6 +312,8 @@ export const createAiAssistantState = (): AiAssistantState => {
   const state: AiAssistantState = proxy({
     ...initialState, // Spread initial values directly
     chatInstances: {},
+    pendingSpanIds: {},
+    messageSpanIds: {},
 
     setContext: (context: Partial<AiAssistantContext>) => {
       state.context = { ...state.context, ...context }
@@ -511,6 +531,8 @@ export type AiAssistantState = AiAssistantData & {
   resetAiAssistantPanel: () => void
   activeChat: ChatSession | undefined
   chatInstances: Record<string, Chat<MessageType>>
+  pendingSpanIds: Record<string, string>
+  messageSpanIds: Record<string, string>
   setContext: (context: Partial<AiAssistantContext>) => void
   setModel: (model: AssistantModel) => void
   newChat: (


### PR DESCRIPTION
- Expose Braintrust span ID to client via `x-braintrust-span-id` response header, captured in chat transport
- On feedback submission, call `logFeedback()` with `scores["User Rating"]` (1/0), `comment`, and on the root span assign `metadata.feedbackCategory`
- Silently skipped when tracing is disabled (HIPAA, missing env vars)
- Log `requestedModel` in trace metadata so we can see what model the user selected vs what was actually used after throttling

Example traces:

- [Thumbs up](https://www.braintrust.dev/app/supabase.io/p/Assistant/trace?object_type=project_logs&object_id=5a8d02e5-b3b6-40cc-ba76-ecee286478f4&r=0bb71680-784c-45c1-a234-cba0242562d6&s=0bb71680-784c-45c1-a234-cba0242562d6)
- [Thumbs down + negative feedback](https://www.braintrust.dev/app/supabase.io/p/Assistant/trace?object_type=project_logs&object_id=5a8d02e5-b3b6-40cc-ba76-ecee286478f4&r=d5a78084-6c9a-4230-8615-1e864bb9bac7&s=d5a78084-6c9a-4230-8615-1e864bb9bac7)

<img width="645" height="173" alt="CleanShot 2026-02-19 at 13 30 25@2x" src="https://github.com/user-attachments/assets/6c463e83-27c6-4afb-a8d0-a329ed61270a" />

Closes AI-442