### PR TITLE
Fix: SQL Editor browser back button navigation

### DIFF
--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -69,7 +69,7 @@ const SqlEditor: NextPageWithLayout = () => {
         snapV2.setSnippet(ref, data as unknown as SnippetWithContent)
       } else {
         setLastVisitedSnippet(undefined)
-        router.push(`/project/${ref}/sql/new`)
+        router.replace(`/project/${ref}/sql/new`)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -84,7 +84,7 @@ const SqlEditor: NextPageWithLayout = () => {
       content === undefined
     ) {
       const snippet = allSnippets.find((snippet) => snippet.id === history.sql)
-      if (snippet !== undefined) router.push(`/project/${ref}/sql/${history.sql}`)
+      if (snippet !== undefined) router.replace(`/project/${ref}/sql/${history.sql}`)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, allSnippets, content])

--- a/apps/studio/pages/project/[ref]/sql/index.tsx
+++ b/apps/studio/pages/project/[ref]/sql/index.tsx
@@ -23,14 +23,14 @@ const SQLEditorIndexPage: NextPageWithLayout = () => {
       const lastOpenedTab = history.sql
       const lastTabId = store.openTabs.find((id) => store.tabsMap[id]?.type === 'sql')
       if (lastOpenedTab !== undefined) {
-        router.push(`/project/${projectRef}/sql/${history.sql}`)
+        router.replace(`/project/${projectRef}/sql/${history.sql}`)
       } else if (lastTabId) {
         const lastTab = store.tabsMap[lastTabId]
         if (lastTab) {
-          router.push(`/project/${projectRef}/sql/${lastTab.id.replace('sql-', '')}`)
+          router.replace(`/project/${projectRef}/sql/${lastTab.id.replace('sql-', '')}`)
         }
       } else {
-        router.push(`/project/${projectRef}/sql/new`)
+        router.replace(`/project/${projectRef}/sql/new`)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problem
The SQL Editor had a browser navigation issue where pressing the back button would get stuck in a redirect loop between `/sql` and `/sql/new`, making it difficult to navigate away from the SQL Editor using standard browser controls.

## Solution
Changed automatic redirects from `router.push()` to `router.replace()` in the SQL Editor routing logic. 
This prevents adding unwanted history entries during automatic navigation, allowing the back button to work as expected.

## Related
- Closes https://github.com/supabase/supabase/issues/43035
