### PR TITLE
docs: remove duplicate paragraph in Realtime concepts

### DIFF
--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -31,8 +31,6 @@ If you have a private channel and a public channel with the same topic name, Rea
 
 ## Database resources
 
-Realtime uses several database connections to perform several operations. As a user, you are able to tune some of them using [Realtime Settings](/docs/guides/realtime/settings).
-
 ### Database connections
 
 Realtime uses several database connections to perform various operations. You can configure some of these connections through [Realtime Settings](/docs/guides/realtime/settings).


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update 

## What is the current behavior?

A paragraph describing Realtime database connections appears immediately before the "Database connections" section header, then again immediately after it 

## What is the new behavior?

Removed the first (pre-header) instance of the paragraph, so the description appears only once, in its natural place beneath the section header.

## Additional context

No visual changes, just a clarity/deduplication fix.