### PR TITLE
fix: remove entitlement checks from realtime settings

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -20,7 +20,6 @@ import {
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import {
   Button,
   Card,
@@ -90,38 +89,15 @@ export const RealtimeSettings = () => {
       },
     })
 
-  const { getEntitlementMax: getEntitledMaxPayloadSize } = useCheckEntitlements(
-    'realtime.max_payload_size_in_kb'
-  )
-  const entitledMaxPayloadSize = getEntitledMaxPayloadSize() ?? 3000
-
-  const { getEntitlementMax: getEntitledMaxConcurrentUsers } = useCheckEntitlements(
-    'realtime.max_concurrent_users'
-  )
-  const entitledMaxConcurrentUsers = getEntitledMaxConcurrentUsers() ?? 50000
-
-  const { getEntitlementMax: getEntitledMaxEventsPerSecond } = useCheckEntitlements(
-    'realtime.max_events_per_second'
-  )
-  const entitledMaxEventsPerSecond = getEntitledMaxEventsPerSecond() ?? 10000
-
-  const { getEntitlementMax: getEntitledMaxPresenceEventsPerSecond } = useCheckEntitlements(
-    'realtime.max_presence_events_per_second'
-  )
-  const entitledMaxPresenceEventsPerSecond = getEntitledMaxPresenceEventsPerSecond() ?? 10000
-
   const FormSchema = z.object({
     connection_pool: z.coerce
       .number()
       .min(1)
       .max(maxConn?.maxConnections ?? 100),
-    max_concurrent_users: z.coerce.number().min(1).max(entitledMaxConcurrentUsers),
-    max_events_per_second: z.coerce.number().min(1).max(entitledMaxEventsPerSecond),
-    max_presence_events_per_second: z.coerce
-      .number()
-      .min(1)
-      .max(entitledMaxPresenceEventsPerSecond),
-    max_payload_size_in_kb: z.coerce.number().min(1).max(entitledMaxPayloadSize),
+    max_concurrent_users: z.coerce.number().min(1).max(50000),
+    max_events_per_second: z.coerce.number().min(1).max(10000),
+    max_presence_events_per_second: z.coerce.number().min(1).max(10000),
+    max_payload_size_in_kb: z.coerce.number().min(1).max(3000),
     suspend: z.boolean(),
     // [Joshen] These fields are temporarily hidden from the UI
     // max_bytes_per_second: z.coerce.number().min(1).max(10000000),


### PR DESCRIPTION
The Realtime configurable values are not hard limits, so we shouldn't model them as entitlements in the Realtime Settings.