### PR TITLE
fix(ui): Make heading anchors focusable

### DIFF
--- a/packages/ui/src/components/CustomHTMLElements/Heading.tsx
+++ b/packages/ui/src/components/CustomHTMLElements/Heading.tsx
@@ -58,10 +58,9 @@ const Heading = forwardRef(
         {anchor && (
           <a
             href={link}
-            aria-hidden="true"
-            className="ml-2 opacity-0 group-hover:opacity-100 transition"
+            className="ml-2 opacity-0 focus:opacity-100 group-hover:opacity-100 transition"
           >
-            <span aria-hidden="true">#</span>
+            #
           </a>
         )}
       </HeadingTag>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes heading anchors focusable via keyboard.

## What is the current behavior?

Heading anchords cannot be focused because of wrong aria attributes.

## What is the new behavior?

Pressing tab makes heading anchors visible.

## Additional context

--
