### PR TITLE
docs(auth): clarify ip_address is not included in audit logs

### DIFF
--- a/apps/docs/content/guides/auth/audit-logs.mdx
+++ b/apps/docs/content/guides/auth/audit-logs.mdx
@@ -47,13 +47,14 @@ Audit logs contain detailed information about each authentication event:
   "timestamp": "2025-08-01T10:30:00Z",
   "user_id": "uuid",
   "action": "user_signedup",
-  "ip_address": "192.168.1.1",
   "user_agent": "Mozilla/5.0...",
   "metadata": {
     "provider": "email"
   }
 }
 ```
+> Note: While IP address information may be available in session data,
+> it is not currently included in Auth audit log entries.
 
 ### Log actions reference
 


### PR DESCRIPTION
Fixes #42997

The documentation example previously showed `ip_address` as part of Auth audit log entries. However, IP address is not currently included in actual audit log records.

This change removes the misleading example and clarifies the behavior.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
