### PR TITLE
ci: set explicit empty permissions for tokenless workflows

### DIFF
--- a/.github/workflows/trigger-nimbus-sync.yml
+++ b/.github/workflows/trigger-nimbus-sync.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   workflow_dispatch: # Allow manual triggering
 
+permissions: {}
+
 jobs:
   trigger-nimbus-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, ready_for_review]
 
+permissions: {}
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary\n- add explicit `permissions: {}` to workflows that do not require default `GITHUB_TOKEN` scopes\n\n### Updated workflows\n- `.github/workflows/trigger-nimbus-sync.yml`\n- `.github/workflows/validate-pr.yml`\n\n## Why\nBoth workflows rely on either custom token inputs or purely local checks. Explicitly setting empty permissions avoids unnecessary default token scopes and documents intent.\n\n## Notes\n- configuration-only changes\n- left `publish_image.yml` untouched because it chains into a reusable publish workflow with broader scope requirements\n