### PR TITLE
Fix #42584: [Studio] Policy Command buttons (SELECT/INSERT/UPDATE/DELETE

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyAllowedOperation.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyAllowedOperation.tsx
@@ -11,28 +11,31 @@ const PolicyAllowedOperation = ({
   onSelectOperation = noop,
 }: PolicyAllowedOperationProps) => {
   return (
-    <div className="flex justify-between space-x-12">
-      <div className="flex w-1/3 flex-col space-y-2">
+    <div className="flex flex-wrap justify-between gap-y-4">
+      <div className="flex w-1/3 min-w-[180px] flex-col space-y-2">
         <label className="text-base text-foreground-light" htmlFor="allowed-operation">
           Allowed operation
         </label>
         <p className="text-sm text-foreground-lighter">Select an operation for this policy</p>
       </div>
-      <div className="w-2/3">
-        <div className="flex items-center space-x-8">
-          <Radio.Group type="small-cards" size="tiny" id="allowed-operation">
-            {['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'ALL'].map((op) => (
-              <Radio
-                key={op}
-                name="allowed-operation"
-                label={op}
-                value={op}
-                checked={operation === op}
-                onChange={(e) => onSelectOperation(e.target.value)}
-              />
-            ))}
-          </Radio.Group>
-        </div>
+      <div className="flex-1">
+        <Radio.Group
+          type="small-cards"
+          size="tiny"
+          id="allowed-operation"
+          groupClassName="flex flex-row flex-wrap gap-3"
+        >
+          {['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'ALL'].map((op) => (
+            <Radio
+              key={op}
+              name="allowed-operation"
+              label={op}
+              value={op}
+              checked={operation === op}
+              onChange={(e) => onSelectOperation(e.target.value)}
+            />
+          ))}
+        </Radio.Group>
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes #42584

## Summary
This PR fixes: [Studio] Policy Command buttons (SELECT/INSERT/UPDATE/DELETE/ALL) overflow at lower screen resolutions

## Changes
```
.../PolicyEditor/PolicyAllowedOperation.tsx        | 37 ++++++++++++----------
 1 file changed, 20 insertions(+), 17 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).