### PR TITLE
Fix #42819: Supabase Dashboard issues invalid ORDER BY syntax when query

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/hooks/useIndexInvalidation.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/hooks/useIndexInvalidation.ts
@@ -34,7 +34,10 @@ export function useIndexInvalidation() {
   const { invalidate: invalidateTableIndexAdvisor } = useTableIndexAdvisor()
 
   const preset = QUERY_PERFORMANCE_PRESET_MAP[urlPreset as QUERY_PERFORMANCE_REPORT_TYPES]
-  const orderBy = !!sort ? ({ column: sort, order } as QueryPerformanceSort) : undefined
+  const orderBy =
+    sort && order && ['asc', 'desc'].includes(order)
+      ? ({ column: sort, order } as QueryPerformanceSort)
+      : undefined
   const roles = router?.query?.roles ?? []
 
   const queryPerformanceQuery = useQueryPerformanceQuery({

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -615,7 +615,7 @@ select
 
         -- Count of slow queries (> 1 second average)
         SELECT count(*) as slow_queries_count
-        FROM pg_stat_statements 
+        FROM pg_stat_statements as statements
         WHERE statements.mean_exec_time > 1000;`,
       },
       queryMetrics: {


### PR DESCRIPTION
Fixes #42819

## Summary
This PR fixes: Supabase Dashboard issues invalid ORDER BY syntax when querying pg_stat_statements (ORDER BY created_at:asc null)

## Changes
```
.../interfaces/QueryPerformance/hooks/useIndexInvalidation.ts        | 5 ++++-
 apps/studio/components/interfaces/Reports/Reports.constants.ts       | 2 +-
 2 files changed, 5 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).