### PR TITLE
Fix #42937: Data API max rows stuck at 77

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -44,7 +44,10 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 const formSchema = z.object({
   dbSchema: z.array(z.string()),
   dbExtraSearchPath: z.array(z.string()),
-  maxRows: z.number().max(1000000, "Can't be more than 1,000,000"),
+  maxRows: z
+    .number()
+    .min(0, "Can't be negative")
+    .max(1000000, "Can't be more than 1,000,000"),
   dbPool: z
     .number()
     .min(0, 'Must be more than 0')
@@ -318,7 +321,7 @@ export const PostgrestConfig = () => {
                           <FormItemLayout
                             layout="flex-row-reverse"
                             label="Max rows"
-                            description="The maximum number of rows returned from a view, table, or stored procedure. Limits payload size for accidental or malicious requests."
+                            description="The maximum number of rows returned from a view, table, or stored procedure. Limits payload size for accidental or malicious requests. Set to 0 for no limit."
                           >
                             <FormControl_Shadcn_>
                               <PrePostTab postTab="rows">
@@ -327,7 +330,12 @@ export const PostgrestConfig = () => {
                                   disabled={!canUpdatePostgrestConfig}
                                   {...field}
                                   type="number"
-                                  onChange={(e) => field.onChange(Number(e.target.value))}
+                                  value={field.value ?? ''}
+                                  onChange={(e) =>
+                                    field.onChange(
+                                      e.target.value === '' ? undefined : Number(e.target.value)
+                                    )
+                                  }
                                 />
                               </PrePostTab>
                             </FormControl_Shadcn_>


### PR DESCRIPTION
Fixes #42937

## Summary
This PR fixes: Data API max rows stuck at 77

## Changes
```
.../components/interfaces/Settings/API/PostgrestConfig.tsx | 14 +++++++++++---
 1 file changed, 11 insertions(+), 3 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).