### PR TITLE
ci: restrict token permissions in validation and dispatch workflows

### DIFF
--- a/.github/workflows/trigger-nimbus-sync.yml
+++ b/.github/workflows/trigger-nimbus-sync.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   workflow_dispatch: # Allow manual triggering
 
+permissions: {}
+
 jobs:
   trigger-nimbus-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, ready_for_review]
 
+permissions: {}
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add `permissions: {}` to `.github/workflows/validate-pr.yml`
- add `permissions: {}` to `.github/workflows/trigger-nimbus-sync.yml`

## Why
Both workflows run without needing `GITHUB_TOKEN` API access:
- `validate-pr.yml` only executes local shell checks
- `trigger-nimbus-sync.yml` dispatches to another repo using `NIMBUS_SYNC_TOKEN` (a dedicated secret token)

Declaring empty default permissions makes that explicit and avoids granting unnecessary implicit token scopes.

## Validation
- reviewed workflow steps and confirmed no repository read/write operations require `GITHUB_TOKEN`
- confirmed dispatch workflow uses dedicated secret token input
