### PR TITLE
fix(studio): parse SQL parameters safely around casts and literals

### DIFF
--- a/apps/studio/lib/sql-parameters.test.ts
+++ b/apps/studio/lib/sql-parameters.test.ts
@@ -40,6 +40,39 @@ describe('parseParameters', () => {
     const userIdParam = result.find((p) => p.name === 'userId')
     expect(userIdParam?.occurrences).toBe(2)
   })
+
+  it('ignores casts and placeholders inside quoted/commented SQL', () => {
+    const result = parseParameters(`
+      -- :ignored_comment
+      SELECT
+        metadata::jsonb AS payload,
+        ':ignored_string' AS literal
+      FROM logs
+      WHERE user_id = :userId
+      /* :ignored_block_comment */
+    `)
+
+    expect(result).toEqual([
+      {
+        name: 'userId',
+        value: '',
+        defaultValue: undefined,
+        type: undefined,
+        possibleValues: undefined,
+        occurrences: 1,
+      },
+    ])
+  })
+
+  it('ignores placeholders inside dollar-quoted strings', () => {
+    const result = parseParameters(`
+      SELECT $$:ignored$$ AS body, :userId AS user_id
+    `)
+
+    const userIdParam = result.find((p) => p.name === 'userId')
+    expect(userIdParam?.occurrences).toBe(1)
+    expect(result.map((p) => p.name)).not.toContain('ignored')
+  })
 })
 
 describe('processParameterizedSql', () => {
@@ -73,5 +106,32 @@ describe('processParameterizedSql', () => {
     const result = processParameterizedSql(sql, {})
     expect(result).toBe('SELECT * FROM items WHERE status = open')
     expect(result).not.toContain('@set')
+  })
+
+  it('does not treat postgres casts or quoted/commented values as parameters', () => {
+    const sql = `
+      @set userId:int = 123
+      SELECT
+        metadata::jsonb AS payload,
+        ':ignored_string' AS literal
+      FROM logs
+      WHERE user_id = :userId
+      -- :ignored_comment
+      /* :ignored_block_comment */
+    `
+
+    const result = processParameterizedSql(sql, {})
+
+    expect(result).toContain('metadata::jsonb')
+    expect(result).toContain("':ignored_string' AS literal")
+    expect(result).toContain('WHERE user_id = 123')
+    expect(result).not.toContain('@set')
+  })
+
+  it('throws only for true missing placeholders when casts are present', () => {
+    const sql = 'SELECT 1::int, :userId'
+    expect(() => processParameterizedSql(sql, {})).toThrowError(
+      'Missing value for parameter: userId'
+    )
   })
 })

--- a/apps/studio/lib/sql-parameters.ts
+++ b/apps/studio/lib/sql-parameters.ts
@@ -7,108 +7,306 @@ export interface Parameter {
   occurrences: number
 }
 
-// [Joshen TODO] We'll want tests for this to ensure that this runs properly
+type ParamDefault = {
+  value: string
+  type?: string
+  possibleValues?: string[]
+}
+
+type ParamToken = {
+  name: string
+  start: number
+  end: number
+}
+
+const PARAM_IDENTIFIER_START = /^[A-Za-z_]$/
+const PARAM_IDENTIFIER_CHAR = /^[A-Za-z0-9_]$/
+
+const isParamIdentifierStart = (value: string | undefined) =>
+  value !== undefined && PARAM_IDENTIFIER_START.test(value)
+
+const isParamIdentifierChar = (value: string | undefined) =>
+  value !== undefined && PARAM_IDENTIFIER_CHAR.test(value)
+
+const parseTypeInfo = (typeInfo?: string): Pick<ParamDefault, 'type' | 'possibleValues'> => {
+  const normalizedTypeInfo = typeInfo?.trim()
+
+  if (!normalizedTypeInfo) {
+    return {}
+  }
+
+  if (!normalizedTypeInfo.includes('|')) {
+    return { type: normalizedTypeInfo }
+  }
+
+  return {
+    type: 'enum',
+    possibleValues: normalizedTypeInfo
+      .split('|')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+  }
+}
+
+const parseSetDirective = (
+  line: string
+): { name: string; value: string; type?: string; possibleValues?: string[] } | null => {
+  const match = line.match(/^@set\s+([A-Za-z_][A-Za-z0-9_]*)(?::([^=]+))?\s*=\s*([^;\n]+)\s*;?$/)
+
+  if (!match) {
+    return null
+  }
+
+  const [, name, typeInfo, value] = match
+  const trimmedValue = value?.trim()
+  if (!trimmedValue) {
+    return null
+  }
+
+  return {
+    name,
+    value: trimmedValue,
+    ...parseTypeInfo(typeInfo),
+  }
+}
+
+const extractSetDirectives = (sql: string) => {
+  const defaults: Record<string, ParamDefault> = {}
+  const lines = sql.split(/\r?\n/)
+  const sqlWithoutSetDirectives: string[] = []
+
+  for (const line of lines) {
+    const directive = parseSetDirective(line.trimStart())
+    if (!directive) {
+      sqlWithoutSetDirectives.push(line)
+      continue
+    }
+
+    defaults[directive.name] = {
+      value: directive.value,
+      type: directive.type,
+      possibleValues: directive.possibleValues,
+    }
+  }
+
+  return {
+    defaults,
+    sqlWithoutSetDirectives: sqlWithoutSetDirectives.join('\n'),
+  }
+}
+
+const readDollarQuoteTag = (sql: string, startIndex: number) => {
+  if (sql[startIndex] !== '$') {
+    return null
+  }
+
+  let endIndex = startIndex + 1
+  while (isParamIdentifierChar(sql[endIndex])) {
+    endIndex += 1
+  }
+
+  if (sql[endIndex] !== '$') {
+    return null
+  }
+
+  return sql.slice(startIndex, endIndex + 1)
+}
+
+const findParamTokens = (sql: string) => {
+  const tokens: ParamToken[] = []
+
+  let index = 0
+  let state:
+    | 'normal'
+    | 'single-quote'
+    | 'double-quote'
+    | 'line-comment'
+    | 'block-comment'
+    | 'dollar-quote' = 'normal'
+  let blockCommentDepth = 0
+  let dollarQuoteTag: string | null = null
+
+  while (index < sql.length) {
+    const current = sql[index]
+
+    if (state === 'single-quote') {
+      if (current === "'" && sql[index + 1] === "'") {
+        index += 2
+        continue
+      }
+
+      if (current === '\\' && sql[index + 1] !== undefined) {
+        index += 2
+        continue
+      }
+
+      if (current === "'") {
+        state = 'normal'
+      }
+
+      index += 1
+      continue
+    }
+
+    if (state === 'double-quote') {
+      if (current === '"' && sql[index + 1] === '"') {
+        index += 2
+        continue
+      }
+
+      if (current === '"') {
+        state = 'normal'
+      }
+
+      index += 1
+      continue
+    }
+
+    if (state === 'line-comment') {
+      if (current === '\n' || current === '\r') {
+        state = 'normal'
+      }
+
+      index += 1
+      continue
+    }
+
+    if (state === 'block-comment') {
+      if (current === '/' && sql[index + 1] === '*') {
+        blockCommentDepth += 1
+        index += 2
+        continue
+      }
+
+      if (current === '*' && sql[index + 1] === '/') {
+        blockCommentDepth -= 1
+        index += 2
+        if (blockCommentDepth === 0) {
+          state = 'normal'
+        }
+        continue
+      }
+
+      index += 1
+      continue
+    }
+
+    if (state === 'dollar-quote') {
+      if (dollarQuoteTag && sql.startsWith(dollarQuoteTag, index)) {
+        index += dollarQuoteTag.length
+        dollarQuoteTag = null
+        state = 'normal'
+        continue
+      }
+
+      index += 1
+      continue
+    }
+
+    if (current === "'") {
+      state = 'single-quote'
+      index += 1
+      continue
+    }
+
+    if (current === '"') {
+      state = 'double-quote'
+      index += 1
+      continue
+    }
+
+    if (current === '-' && sql[index + 1] === '-') {
+      state = 'line-comment'
+      index += 2
+      continue
+    }
+
+    if (current === '/' && sql[index + 1] === '*') {
+      state = 'block-comment'
+      blockCommentDepth = 1
+      index += 2
+      continue
+    }
+
+    if (current === '$') {
+      const tag = readDollarQuoteTag(sql, index)
+      if (tag) {
+        state = 'dollar-quote'
+        dollarQuoteTag = tag
+        index += tag.length
+        continue
+      }
+    }
+
+    if (
+      current === ':' &&
+      sql[index - 1] !== ':' &&
+      sql[index + 1] !== ':' &&
+      isParamIdentifierStart(sql[index + 1])
+    ) {
+      let end = index + 2
+      while (isParamIdentifierChar(sql[end])) {
+        end += 1
+      }
+
+      tokens.push({
+        name: sql.slice(index + 1, end),
+        start: index,
+        end,
+      })
+      index = end
+      continue
+    }
+
+    index += 1
+  }
+
+  return tokens
+}
 
 export const parseParameters = (sql: string | undefined) => {
   if (!sql) return []
 
-  // Parse @set parameter defaults with optional type information
-  const setParamRegex = /@set\s+(\w+)(?::([^=]+))?\s*=\s*([^;\n]+)/g
-  const paramDefaults: Record<string, { value: string; type?: string; possibleValues?: string[] }> =
-    {}
-  let match
+  const { defaults, sqlWithoutSetDirectives } = extractSetDirectives(sql)
+  const paramOccurrences = new Map<string, number>()
 
-  while ((match = setParamRegex.exec(sql)) !== null) {
-    const [_, paramName, paramType, paramValue] = match
-    if (!paramName || !paramValue?.trim()) continue
-
-    const typeInfo = paramType?.trim()
-
-    let type: string | undefined
-    let possibleValues: string[] | undefined
-
-    if (typeInfo) {
-      // Handle union types (value1 | value2 | value3)
-      if (typeInfo.includes('|')) {
-        possibleValues = typeInfo.split('|').map((v) => v.trim())
-        type = 'enum'
-      } else {
-        type = typeInfo.trim()
-      }
-    }
-
-    paramDefaults[paramName] = {
-      value: paramValue.trim(),
-      type,
-      possibleValues,
-    }
+  for (const token of findParamTokens(sqlWithoutSetDirectives)) {
+    paramOccurrences.set(token.name, (paramOccurrences.get(token.name) ?? 0) + 1)
   }
 
-  // Find all :parameter occurrences and count them
-  const paramRegex = /:(\w+)/g
-  const paramOccurrences: Record<string, number> = {}
-  const uniqueParams = new Set<string>()
-
-  while ((match = paramRegex.exec(sql)) !== null) {
-    const [_, paramName] = match
-    paramOccurrences[paramName] = (paramOccurrences[paramName] || 0) + 1
-    uniqueParams.add(paramName)
-  }
-
-  // Create parameter objects for unique parameters
-  return Array.from(uniqueParams).map((paramName) => ({
+  return Array.from(paramOccurrences.entries()).map(([paramName, occurrences]) => ({
     name: paramName,
-    value: paramDefaults[paramName]?.value || '',
-    defaultValue: paramDefaults[paramName]?.value,
-    type: paramDefaults[paramName]?.type,
-    possibleValues: paramDefaults[paramName]?.possibleValues,
-    occurrences: paramOccurrences[paramName],
+    value: defaults[paramName]?.value ?? '',
+    defaultValue: defaults[paramName]?.value,
+    type: defaults[paramName]?.type,
+    possibleValues: defaults[paramName]?.possibleValues,
+    occurrences,
   }))
 }
 
 export const processParameterizedSql = (sql: string, parameters: Record<string, string>) => {
-  // Parse @set parameter defaults with type information from SQL
-  const setParamRegex = /@set\s+(\w+)(?::([^=]+))?\s*=\s*([^;\n]+)/g
-  const paramDefaults: Record<string, { value: string; type?: string; possibleValues?: string[] }> =
-    {}
-  let match
+  const { defaults, sqlWithoutSetDirectives } = extractSetDirectives(sql)
+  const tokens = findParamTokens(sqlWithoutSetDirectives)
 
-  while ((match = setParamRegex.exec(sql)) !== null) {
-    const [_, paramName, paramType, paramValue] = match
-    if (!paramName || !paramValue?.trim()) continue
-
-    const typeInfo = paramType?.trim()
-    let type: string | undefined
-    let possibleValues: string[] | undefined
-
-    if (typeInfo) {
-      if (typeInfo.includes('|')) {
-        possibleValues = typeInfo.split('|').map((v) => v.trim())
-        type = 'enum'
-      } else {
-        type = typeInfo.trim()
-      }
-    }
-
-    paramDefaults[paramName] = {
-      value: paramValue.trim(),
-      type,
-      possibleValues,
-    }
+  if (tokens.length === 0) {
+    return sqlWithoutSetDirectives
   }
 
-  // Remove @set lines from SQL
-  let processedSql = sql.replace(/@set\s+\w+(?:\s*:\s*[^=]+)?\s*=\s*[^;\n]+[\n;]*/g, '')
+  let cursor = 0
+  let processedSql = ''
 
-  // Replace :parameters with values
-  const paramRegex = /:(\w+)/g
-  processedSql = processedSql.replace(paramRegex, (match, paramName) => {
-    const value = parameters[paramName] ?? paramDefaults[paramName]?.value
+  for (const token of tokens) {
+    processedSql += sqlWithoutSetDirectives.slice(cursor, token.start)
+
+    const value = parameters[token.name] ?? defaults[token.name]?.value
     if (value === undefined) {
-      throw new Error(`Missing value for parameter: ${paramName}`)
+      throw new Error(`Missing value for parameter: ${token.name}`)
     }
-    return value
-  })
 
+    processedSql += value
+    cursor = token.end
+  }
+
+  processedSql += sqlWithoutSetDirectives.slice(cursor)
   return processedSql
 }


### PR DESCRIPTION
## Summary
  - Reworked SQL parameter parsing in `apps/studio/lib/sql-parameters.ts:115` from regex matching to a state-aware scanner.
  - Ignored false positives from PostgreSQL casts (`::type`), quoted strings, comments, and dollar-quoted blocks.
  - Centralized `@set` directive extraction and reused it in both `parseParameters` and `processParameterizedSql`.
  - Added regression coverage in `apps/studio/lib/sql-parameters.test.ts:44`, `apps/studio/lib/sql-parameters.test.ts:67`, `apps/studio/lib/sql-
  parameters.test.ts:111`, and `apps/studio/lib/sql-parameters.test.ts:131`.

  ## Why
  The previous `:(\w+)` approach could incorrectly treat non-parameter SQL syntax as placeholders, causing incorrect substitution and runtime errors in real
  queries.

  ## Testing
  - ✅ `corepack pnpm --filter studio exec vitest run lib/sql-parameters.test.ts` (13/13 passed)
  - ⚠️ `corepack pnpm --filter studio exec vitest run` has unrelated pre-existing failures (locale formatting expectations in `QueryBlock` / `Charts` tests,
  plus intermittent `SupportFormPage` behavior)