### PR TITLE
fix(studio): allow newlines in SMS OTP template for WebOTP API

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -12,7 +12,7 @@ export interface Provider {
   properties: {
     [x: string]: {
       title: string
-      type: 'boolean' | 'string' | 'select' | 'number'
+      type: 'boolean' | 'string' | 'multiline-string' | 'select' | 'number' | 'datetime'
       enum: Enum[]
       show: {
         key: string

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -150,7 +150,6 @@ const FormField = ({
           id={name}
           name={name}
           disabled={disabled}
-          type={hidden ? 'password' : 'text'}
           label={properties.title}
           labelOptional={
             properties.descriptionOptional ? (

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -87,11 +87,17 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
           initialValues[key] = !(config as any)[key]
         } else {
           const configValue = (config as any)[key]
-          initialValues[key] = configValue
+          let value: string | boolean = configValue
             ? configValue
             : provider.properties[key].type === 'boolean'
               ? false
               : ''
+          // Convert literal \n escape sequences to actual newlines so the textarea
+          // displays them correctly (supports WebOTP API formatting requirements).
+          if (key === 'SMS_TEMPLATE' && typeof value === 'string') {
+            value = value.replace(/\\n/g, '\n')
+          }
+          initialValues[key] = value
         }
       }
     })


### PR DESCRIPTION
This pull request introduces enhancements to the authentication provider forms, primarily to support new field types and improve handling of multiline text values. The main changes include extending the provider property types, updating form field rendering, and converting literal newline escape sequences for SMS templates.

**Provider property type enhancements:**

* Added support for `multiline-string` and `datetime` types in the `Provider` interface, allowing more flexible form fields for authentication provider configuration.

**Form field rendering improvements:**

* Removed the explicit `type` prop from the form field input, enabling better handling of different field types.

**Multiline text handling:**

* In `ProviderForm`, added logic to convert literal `\n` escape sequences to actual newlines for the `SMS_TEMPLATE` field, improving textarea display and compatibility with WebOTP API formatting requirements.