### PR TITLE
docs(refine): use getClaims instead of getSession in auth check

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,15 +233,17 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const {
+        data: { claims },
+        error,
+      } = await supabaseClient.auth.getClaims()
 
-      if (!session) {
+      if (error || !claims) {
         return {
           authenticated: false,
-          error: {
+          error: error || {
             message: 'Check failed',
-            name: 'Session not found',
+            name: 'Claims not found',
           },
           logout: true,
           redirectTo: '/login',


### PR DESCRIPTION
## Summary
Updates the Refine getting-started tutorial auth provider check flow to use `getClaims()` instead of `getSession()`.

## Why
This aligns the docs with the recommended approach tracked in #42193.

## Changes
- In `apps/docs/content/guides/getting-started/tutorials/with-refine.mdx`:
  - replaced `getSession()` with `getClaims()` in the auth provider `check` example
  - switched from `session` existence checks to `claims`/`error` handling
  - updated fallback error name from `Session not found` to `Claims not found`

Closes #42193.
