### PR TITLE
Fix table editor prefetch

### DIFF
--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -395,10 +395,13 @@ export const useTableRowsQuery = <TData = TableRowsData>(
 ) => {
   const queryClient = useQueryClient()
 
+  // [Joshen] Exclude preflightCheck from query key
+  const { preflightCheck, ...othersArgs } = args
+
   return useQuery<TableRowsData, TableRowsError, TData>({
     queryKey: tableRowKeys.tableRows(projectRef, {
       table: { id: tableId },
-      ...args,
+      ...othersArgs,
     }),
     queryFn: ({ signal }) =>
       getTableRows({ queryClient, projectRef, connectionString, tableId, ...args }, signal),


### PR DESCRIPTION
## Context

Noticed that the table editor prefetch wasn't working as intended as the table's rows were getting fetched again when opening the table.

Fix is that `preflightCheck` should've been excluded from the `table-rows` query key

## To test
Within the Table Editor
- [ ] Verify that `table-rows` is getting prefetched when hovering over a table in the side menu
- [ ] Verify that `table-rows` doesn't get fetched again when opening the table subsequently (There shouldn't be a UI loader too - rows should render immediately)