### PR TITLE
docs(auth): fix typo in Google Auth scopes documentation

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -27,7 +27,7 @@ Supabase Auth needs a few scopes granting access to profile data of your end use
 
 - `openid` (add manually)
 - `.../auth/userinfo.email` (added by default)
-- `...auth/userinfo.profile` (added by default)
+- `.../auth/userinfo.profile` (added by default)
 
 If you add more scopes, especially those on the sensitive or restricted list your application might be subject to verification which may take a long time.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. Fix typo