### PR TITLE
fix(www): correct "Postrges" typo in solutions data

### DIFF
--- a/apps/www/data/solutions/postgres-developers.tsx
+++ b/apps/www/data/solutions/postgres-developers.tsx
@@ -113,7 +113,7 @@ const data: () => {
       label: '',
       heading: (
         <>
-          Why <span className="text-foreground">Postrges developers</span> choose Supabase
+          Why <span className="text-foreground">Postgres developers</span> choose Supabase
         </>
       ),
       subheading:


### PR DESCRIPTION
## Fix typo in solutions data ("Postrges" → "Postgres")

### Context

Noticed a spelling issue in the website solutions data where **"Postrges"** was incorrectly written instead of **"Postgres"**.

This PR corrects the typo to ensure accurate naming and consistency across the site.

### Changes

- Updated `"Postrges"` → `"Postgres"` in `apps/www/data/solutions`