### PR TITLE
add success redirect on go pages forms

### DIFF
--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -184,6 +184,8 @@ export const formSectionSchema = z.object({
   disclaimer: z.string().optional(),
   /** Message shown after a successful submission. Defaults to a generic thank-you message. */
   successMessage: z.string().optional(),
+  /** URL to redirect the user to after a successful submission. When set, overrides successMessage. */
+  successRedirect: z.string().optional(),
   /** CRM integration config. When provided, form submissions are sent to the configured providers. */
   crm: formCrmConfigSchema.optional(),
 })

--- a/packages/marketing/src/go/sections/FormSection.tsx
+++ b/packages/marketing/src/go/sections/FormSection.tsx
@@ -102,7 +102,11 @@ export default function FormSection({ section }: { section: GoFormSection }) {
       const result = await submitFormAction(section.crm, values, { pageUri, pageName })
 
       if (result.success) {
-        setSubmitState('success')
+        if (section.successRedirect) {
+          window.location.href = section.successRedirect
+        } else {
+          setSubmitState('success')
+        }
       } else {
         setSubmitState('error')
         setErrorMessages(result.errors)


### PR DESCRIPTION
Usage in a page definition:

```ts
{
  type: 'form',
  // ...fields, crm, etc.
  submitLabel: 'Request a demo',
  successRedirect: '/thank-you',   // <-- redirect after submit
}
```