### PR TITLE
Render email in UserDropdown if username is empty

### DIFF
--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -54,7 +54,7 @@ export function UserDropdown() {
         {IS_PLATFORM && (
           <>
             <div className="px-2 py-1 flex flex-col gap-0 text-sm">
-              {!!username && (
+              {!!username ? (
                 <>
                   <span title={username} className="w-full text-left text-foreground truncate">
                     {username}
@@ -68,6 +68,10 @@ export function UserDropdown() {
                     </span>
                   )}
                 </>
+              ) : (
+                <span title={primaryEmail} className="w-full text-left text-foreground truncate">
+                  {primaryEmail}
+                </span>
               )}
             </div>
             <DropdownMenuSeparator />


### PR DESCRIPTION
## Context

Just a tiny fix - the user dropdown doesn't show any user info if there's no username set, opting to show the email minimally

### Before
<img width="274" height="120" alt="image" src="https://github.com/user-attachments/assets/985ef1d2-3720-402a-b0fc-6b728029a0a8" />

### After
<img width="286" height="155" alt="image" src="https://github.com/user-attachments/assets/e6264aa4-841b-44c9-bd92-c9d67153f0dd" />
