### PR TITLE
add connect row

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
@@ -4,14 +4,20 @@ import { getKeys, useAPIKeysQuery } from 'data/api-keys/api-keys-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { cn, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from 'ui'
 
-import type { ProjectKeys } from './Connect.types'
+import type { ConnectMode, ProjectKeys } from './Connect.types'
 import { ConnectConfigSection, ModeSelector } from './ConnectConfigSection'
 import { ConnectStepsSection } from './ConnectStepsSection'
 import { useConnectState } from './useConnectState'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+
+const CONNECT_MODES = ['framework', 'direct', 'orm', 'mcp'] as const
+
+function isConnectMode(value: string): value is ConnectMode {
+  return CONNECT_MODES.some((mode) => mode === value)
+}
 
 export const ConnectSheet = () => {
   const {
@@ -28,7 +34,7 @@ export const ConnectSheet = () => {
     'showConnect',
     parseAsBoolean.withDefault(false)
   )
-  const [, setConnectTab] = useQueryState('connectTab', parseAsString)
+  const [connectTab, setConnectTab] = useQueryState('connectTab', parseAsString)
 
   const handleOpenChange = (sheetOpen: boolean) => {
     if (!sheetOpen) {
@@ -87,6 +93,17 @@ export const ConnectSheet = () => {
     [schema.modes, availableModeIds]
   )
 
+  useEffect(() => {
+    if (!showConnect || !connectTab || !isConnectMode(connectTab)) return
+    if (!availableModeIds.includes(connectTab) || state.mode === connectTab) return
+    setMode(connectTab)
+  }, [showConnect, connectTab, availableModeIds, state.mode, setMode])
+
+  const handleModeChange = (mode: ConnectMode) => {
+    setMode(mode)
+    setConnectTab(mode)
+  }
+
   return (
     <Sheet open={showConnect} onOpenChange={handleOpenChange}>
       <SheetContent size="lg" className="flex flex-col gap-0 p-0 space-y-0" tabIndex={undefined}>
@@ -97,7 +114,11 @@ export const ConnectSheet = () => {
 
         <div className="flex flex-1 flex-col overflow-y-auto divide-y">
           <div className="p-8">
-            <ModeSelector modes={availableModes} selected={state.mode} onChange={setMode} />
+            <ModeSelector
+              modes={availableModes}
+              selected={state.mode}
+              onChange={handleModeChange}
+            />
           </div>
 
           <div className="border-b p-8">

--- a/apps/studio/components/interfaces/HomeNew/GetConnectedSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/GetConnectedSection.tsx
@@ -1,0 +1,104 @@
+import { Box, Cable, Database, Sparkles } from 'lucide-react'
+import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
+import type { ReactNode } from 'react'
+
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { BASE_PATH, PROJECT_STATUS } from 'lib/constants'
+import { Card, CardContent, cn } from 'ui'
+
+import type { ConnectMode } from '../ConnectSheet/Connect.types'
+
+type ConnectAction = {
+  mode: ConnectMode
+  heading: string
+  subheading: string
+  icon: ReactNode
+}
+
+const CONNECT_ACTIONS: ConnectAction[] = [
+  {
+    mode: 'framework',
+    heading: 'Framework',
+    subheading: 'Use a client library',
+    icon: <Box size={16} strokeWidth={1.5} />,
+  },
+  {
+    mode: 'direct',
+    heading: 'Direct',
+    subheading: 'Connection string',
+    icon: <Database size={16} strokeWidth={1.5} />,
+  },
+  {
+    mode: 'orm',
+    heading: 'ORM',
+    subheading: 'Third-party library',
+    icon: <Cable size={16} strokeWidth={1.5} />,
+  },
+  {
+    mode: 'mcp',
+    heading: 'MCP',
+    subheading: 'Connect your agent',
+    icon: <Sparkles size={16} strokeWidth={1.5} />,
+  },
+]
+
+export const GetConnectedSection = () => {
+  const { data: selectedProject } = useSelectedProjectQuery()
+  const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
+  const [, setConnectTab] = useQueryState('connectTab', parseAsString)
+
+  const isActiveHealthy = selectedProject?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  const handleConnectClick = (mode: ConnectMode) => {
+    setConnectTab(mode)
+    setShowConnect(true)
+  }
+
+  return (
+    <section className="w-full">
+      <div className="mb-6">
+        <h3 className="heading-section">Get connected</h3>
+      </div>
+
+      <Card className="bg-background/25 border-dashed relative overflow-hidden">
+        <div className="absolute -inset-16 z-0 opacity-50">
+          <img
+            src={`${BASE_PATH}/img/reports/bg-grafana-dark.svg`}
+            alt="Supabase Grafana"
+            className="w-full h-full object-cover object-right hidden dark:block"
+          />
+          <img
+            src={`${BASE_PATH}/img/reports/bg-grafana-light.svg`}
+            alt="Supabase Grafana"
+            className="w-full h-full object-cover object-right dark:hidden"
+          />
+          <div className="absolute inset-0 bg-gradient-to-r from-background-alternative to-transparent" />
+        </div>
+
+        <CardContent className="relative z-10 p-0">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 divide-y md:divide-y-0 md:divide-x border-muted">
+            {CONNECT_ACTIONS.map((action) => (
+              <button
+                key={action.mode}
+                type="button"
+                disabled={!isActiveHealthy}
+                onClick={() => handleConnectClick(action.mode)}
+                className={cn(
+                  'group flex flex-col items-center justify-center gap-3 p-6 text-center transition-colors min-h-32',
+                  'hover:bg-surface-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+                  !isActiveHealthy && 'cursor-not-allowed opacity-50'
+                )}
+              >
+                <span className="text-foreground-light group-hover:text-foreground">{action.icon}</span>
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm">{action.heading}</p>
+                  <p className="text-sm text-foreground-lighter">{action.subheading}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/apps/studio/components/interfaces/HomeNew/GetConnectedSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/GetConnectedSection.tsx
@@ -1,9 +1,8 @@
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { BASE_PATH, PROJECT_STATUS } from 'lib/constants'
 import { Box, Cable, Database, Sparkles } from 'lucide-react'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import type { ReactNode } from 'react'
-
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { BASE_PATH, PROJECT_STATUS } from 'lib/constants'
 import { Card, CardContent, cn } from 'ui'
 
 import type { ConnectMode } from '../ConnectSheet/Connect.types'
@@ -89,7 +88,9 @@ export const GetConnectedSection = () => {
                   !isActiveHealthy && 'cursor-not-allowed opacity-50'
                 )}
               >
-                <span className="text-foreground-light group-hover:text-foreground">{action.icon}</span>
+                <span className="text-foreground-light group-hover:text-foreground">
+                  {action.icon}
+                </span>
                 <div className="flex flex-col gap-1">
                   <p className="text-sm">{action.heading}</p>
                   <p className="text-sm text-foreground-lighter">{action.subheading}</p>


### PR DESCRIPTION
<img width="3686" height="2240" alt="image" src="https://github.com/user-attachments/assets/8456ea66-80f3-44b0-b3ae-c6ccd802ed58" />

<img width="3076" height="2242" alt="image" src="https://github.com/user-attachments/assets/56c6e25b-d0b5-4b1a-a9ae-44c1dc0649fb" />


In our continued efforts to refine the dashboard homepage this replaces the getting started section with a simple connect row that takes the user to the new connect sheet with the right mode selected. 