### PR TITLE
[FE-2635] fix: fail build if assets upload fails

### DIFF
--- a/scripts/upload-static-assets.sh
+++ b/scripts/upload-static-assets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 #######
 
@@ -82,13 +83,11 @@ aws s3 sync "$PUBLIC_DIR" "s3://$BUCKET_NAME/$SITE_NAME/${VERCEL_GIT_COMMIT_SHA:
     --region auto \
     --only-show-errors
 
-if [ $? -eq 0 ]; then
-    echo -e "${GREEN}Upload completed successfully!${NC}"
-    
-    # Clean up local static files so we prevent a double upload
-    echo -e "${YELLOW}Cleaning up local static files...${NC}"
-    rm -rf "$STATIC_DIR"/*
-    echo -e "${GREEN}Local static files cleaned up${NC}"
+echo -e "${GREEN}Upload completed successfully!${NC}"
 
-    # We still keep the public dir, as Next.js does not officially support serving the public files via CDN
-fi
+# Clean up local static files so we prevent a double upload
+echo -e "${YELLOW}Cleaning up local static files...${NC}"
+rm -rf "$STATIC_DIR"/*
+echo -e "${GREEN}Local static files cleaned up${NC}"
+
+# We still keep the public dir, as Next.js does not officially support serving the public files via CDN


### PR DESCRIPTION
Adds `set -eo pipefail` so any failed upload immediately exits the script with a non-zero code, failing the Vercel build.