### PR TITLE
docs: replace getSession with getUser in SolidJS tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -271,8 +271,12 @@ const App: Component = () => {
   const [session, setSession] = createSignal<AuthSession | null>(null)
 
   createEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session)
+    supabase.auth.getUser().then(({ data, error }) => {
+      if (!error && data?.user) {
+        supabase.auth.getSession().then(({ data: { session } }) => {
+          setSession(session)
+        })
+      }
     })
 
     supabase.auth.onAuthStateChange((_event, session) => {


### PR DESCRIPTION
## Description

This PR updates the SolidJS tutorial to replace the deprecated `getSession()` method with `getUser()` for the initial authentication check, following the same pattern as the Refine tutorial update in PR #43136.

## Changes

- Updated `App.tsx` code example to use `getUser()` instead of `getSession()` for initial user authentication
- Added proper error handling for the authentication check
- Maintains backward compatibility by still using `getSession()` to get the session object after user verification

## Related Issue

Fixes #42192

## Testing

- [x] Verified the code follows the same pattern as the Refine tutorial fix
- [x] Ensured proper error handling is in place
- [x] Maintained consistency with Supabase auth best practices

## Checklist

- [x] Documentation updated
- [x] Follows existing code style
- [x] References the related issue