### PR TITLE
chore: Bump vulnerable dependencies

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 .expo
 .next
 node_modules
-package-lock.json
+pnpm-lock.yaml
 docker*
 apps/**/out
 # prettier-plugin-sql-cst only supports sqlite syntax

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -83,7 +83,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
     "shared-data": "workspace:*",
-    "swiper": "^11.0.7",
+    "swiper": "^12.1.2",
     "typed.js": "^2.0.16",
     "typescript": "catalog:",
     "ui": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prettier-plugin-sql-cst": "^0.11.0",
     "rimraf": "^6.0.0",
     "sass": "^1.72.0",
-    "supabase": "^2.65.6",
+    "supabase": "^2.76.10",
     "supports-color": "^8.0.0",
     "tailwindcss": "catalog:",
     "tsx": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,7 +1379,7 @@ importers:
         version: 5.83.0(react@18.3.1)
       axios:
         specifier: ^1.12.0
-        version: 1.12.2
+        version: 1.13.5
       class-variance-authority:
         specifier: '*'
         version: 0.6.1
@@ -9751,8 +9751,8 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -11939,8 +11939,8 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -11968,6 +11968,10 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -24766,7 +24770,7 @@ snapshots:
       concat-stream: 2.0.0
       cookie: 0.7.2
       dotenv: 16.4.5
-      form-data: 4.0.4
+      form-data: 4.0.5
       jest-diff: 29.7.0
       jest-matcher-utils: 29.7.0
       js-yaml: 4.1.1
@@ -26374,7 +26378,7 @@ snapshots:
   '@types/node-fetch@2.6.6':
     dependencies:
       '@types/node': 22.13.14
-      form-data: 4.0.4
+      form-data: 4.0.5
 
   '@types/node@18.18.13':
     dependencies:
@@ -27456,10 +27460,10 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@1.12.2:
+  axios@1.13.5:
     dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -29933,7 +29937,7 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
     dependencies:
@@ -29951,6 +29955,14 @@ snapshots:
   form-data-encoder@1.7.2: {}
 
   form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -31395,7 +31407,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.4
+      form-data: 4.0.5
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0(supports-color@8.1.1)
       https-proxy-agent: 5.0.1(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13723,8 +13723,8 @@ packages:
     resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
     hasBin: true
 
-  markdown-it@14.1.0:
-    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
   markdown-link@0.1.1:
@@ -20424,7 +20424,7 @@ snapshots:
       get-value: 3.0.1
       graphql: 16.11.0
       graphql-language-service: 5.3.1(graphql@16.11.0)
-      markdown-it: 14.1.0
+      markdown-it: 14.1.1
       react: 18.3.1
       react-compiler-runtime: 19.1.0-rc.1(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -31920,7 +31920,7 @@ snapshots:
       mdurl: 1.0.1
       uc.micro: 1.0.6
 
-  markdown-it@14.1.0:
+  markdown-it@14.1.1:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,7 +796,7 @@ importers:
         version: 0.10.1
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76)
+        version: 1.27.0(supports-color@8.1.1)(zod@3.25.76)
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.6.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -832,10 +832,10 @@ importers:
         version: 2.98.0
       '@supabase/mcp-server-supabase':
         specifier: ^0.6.3
-        version: 0.6.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)
+        version: 0.6.3(@modelcontextprotocol/sdk@1.27.0(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)
       '@supabase/mcp-utils':
         specifier: ^0.3.2
-        version: 0.3.2(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)
+        version: 0.3.2(@modelcontextprotocol/sdk@1.27.0(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)
       '@supabase/pg-meta':
         specifier: workspace:*
         version: link:../../packages/pg-meta
@@ -4606,8 +4606,8 @@ packages:
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
-  '@modelcontextprotocol/sdk@1.25.3':
-    resolution: {integrity: sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==}
+  '@modelcontextprotocol/sdk@1.27.0':
+    resolution: {integrity: sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -11729,18 +11729,18 @@ packages:
   exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
 
-  express-rate-limit@7.5.0:
-    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
     engines: {node: '>= 16'}
     peerDependencies:
-      express: ^4.11 || 5 || ^5.0.0-beta.1
+      express: '>= 4.11'
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   exsolve@1.0.7:
@@ -12789,6 +12789,10 @@ packages:
   ioredis@5.7.0:
     resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -18679,6 +18683,11 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -21496,7 +21505,7 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.17.1
@@ -21506,16 +21515,16 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.1.0(supports-color@8.1.1)
-      express-rate-limit: 7.5.0(express@5.1.0(supports-color@8.1.1))
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.2.1(express@5.2.1(supports-color@8.1.1))
+      hono: 4.11.7
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.0(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
-      - hono
       - supports-color
 
   '@monaco-editor/loader@1.4.0(monaco-editor@0.52.2)':
@@ -25550,20 +25559,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/mcp-server-supabase@0.6.3(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)':
+  '@supabase/mcp-server-supabase@0.6.3(@modelcontextprotocol/sdk@1.27.0(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@mjackson/multipart-parser': 0.10.1
-      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76)
-      '@supabase/mcp-utils': 0.3.2(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.0(supports-color@8.1.1)(zod@3.25.76)
+      '@supabase/mcp-utils': 0.3.2(@modelcontextprotocol/sdk@1.27.0(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)
       common-tags: 1.8.2
       gqlmin: 0.3.1
       graphql: 16.11.0
       openapi-fetch: 0.13.8
       zod: 3.25.76
 
-  '@supabase/mcp-utils@0.3.2(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)':
+  '@supabase/mcp-utils@0.3.2(@modelcontextprotocol/sdk@1.27.0(supports-color@8.1.1)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.0(supports-color@8.1.1)(zod@3.25.76)
       zod: 3.25.76
 
   '@supabase/postgres-meta@0.64.6(encoding@0.1.13)(supports-color@8.1.1)':
@@ -29644,9 +29653,10 @@ snapshots:
 
   exponential-backoff@3.1.1: {}
 
-  express-rate-limit@7.5.0(express@5.1.0(supports-color@8.1.1)):
+  express-rate-limit@8.2.1(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.1.0(supports-color@8.1.1)
+      express: 5.2.1(supports-color@8.1.1)
+      ip-address: 10.0.1
 
   express@4.22.1(supports-color@8.1.1):
     dependencies:
@@ -29684,7 +29694,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.1.0(supports-color@8.1.1):
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.1(supports-color@8.1.1)
@@ -29693,6 +29703,7 @@ snapshots:
       cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -30960,6 +30971,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.0.1: {}
 
   ip-address@9.0.5:
     dependencies:
@@ -36058,7 +36071,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@dotenvx/dotenvx': 1.51.0
-      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.7)(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.0(supports-color@8.1.1)(zod@3.25.76)
       browserslist: 4.26.2
       commander: 14.0.1
       cosmiconfig: 9.0.0(typescript@5.9.2)
@@ -36086,7 +36099,6 @@ snapshots:
       - '@cfworker/json-schema'
       - '@types/node'
       - babel-plugin-macros
-      - hono
       - supports-color
       - typescript
 
@@ -38312,6 +38324,10 @@ snapshots:
       zod: 3.25.76
 
   zod-to-json-schema@3.25.0(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
         version: 1.2.0
       remark-gfm:
         specifier: ^4.0.0
-        version: 4.0.0(supports-color@8.1.1)
+        version: 4.0.1(supports-color@8.1.1)
       sonner:
         specifier: ^1.5.0
         version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -471,7 +471,7 @@ importers:
         version: 17.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-katex:
         specifier: ^7.0.0
-        version: 7.0.0
+        version: 7.0.1
       rehype-slug:
         specifier: ^5.1.0
         version: 5.1.0
@@ -1464,7 +1464,7 @@ importers:
         version: 1.2.0
       remark-gfm:
         specifier: ^4.0.0
-        version: 4.0.0(supports-color@8.1.1)
+        version: 4.0.1(supports-color@8.1.1)
       sonner:
         specifier: ^1.5.0
         version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1979,7 +1979,7 @@ importers:
         version: 15.2.0(encoding@0.1.13)(supports-color@8.1.1)
       mdast-util-from-markdown:
         specifier: ^2.0.0
-        version: 2.0.0(supports-color@8.1.1)
+        version: 2.0.2(supports-color@8.1.1)
       sql-formatter:
         specifier: ^15.0.0
         version: 15.4.9
@@ -2679,7 +2679,7 @@ importers:
         version: 15.0.1(supports-color@8.1.1)
       remark-gfm:
         specifier: ^4.0.0
-        version: 4.0.0(supports-color@8.1.1)
+        version: 4.0.1(supports-color@8.1.1)
       scroll-into-view-if-needed:
         specifier: ^3.1.0
         version: 3.1.0
@@ -12480,9 +12480,6 @@ packages:
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
-  hast-util-to-jsx-runtime@2.3.0:
-    resolution: {integrity: sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==}
-
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -13768,9 +13765,6 @@ packages:
 
   mdast-util-from-markdown@1.3.1:
     resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
-
-  mdast-util-from-markdown@2.0.0:
-    resolution: {integrity: sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==}
 
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
@@ -15106,9 +15100,6 @@ packages:
   parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
 
-  parse5@7.2.1:
-    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
-
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -16285,9 +16276,6 @@ packages:
   rehype-harden@1.1.2:
     resolution: {integrity: sha512-58RSgd3BAYW/hULy6qvrLBIRe8qe5PElwEpRjrLilvhJ3N+Y6ptKAmy1CLIIyoMz7CMI30GqENhNXksJd5hGDg==}
 
-  rehype-katex@7.0.0:
-    resolution: {integrity: sha512-h8FPkGE00r2XKU+/acgqwWUlyzve1IiOKwsEkg4pDL3k48PiE0Pt+/uLtVHDVkN1yA4iurZN6UES8ivHVEQV6Q==}
-
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
 
@@ -16325,9 +16313,6 @@ packages:
 
   remark-gfm@3.0.1:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
-
-  remark-gfm@4.0.0:
-    resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -30511,7 +30496,7 @@ snapshots:
       '@types/hast': 3.0.4
       devlop: 1.1.0
       hast-util-from-parse5: 8.0.1
-      parse5: 7.2.1
+      parse5: 7.3.0
       vfile: 6.0.3
       vfile-message: 4.0.2
 
@@ -30555,7 +30540,7 @@ snapshots:
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.1
-      parse5: 7.2.1
+      parse5: 7.3.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
@@ -30596,26 +30581,6 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.3
       zwitch: 2.0.4
-
-  hast-util-to-jsx-runtime@2.3.0(supports-color@8.1.1):
-    dependencies:
-      '@types/estree': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      estree-util-is-identifier-name: 3.0.0
-      hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.0(supports-color@8.1.1)
-      mdast-util-mdx-jsx: 3.1.3(supports-color@8.1.1)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
-      property-information: 6.3.0
-      space-separated-tokens: 2.0.2
-      style-to-object: 1.0.8
-      unist-util-position: 5.0.0
-      vfile-message: 4.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
@@ -31990,23 +31955,6 @@ snapshots:
       micromark-util-types: 1.1.0
       unist-util-stringify-position: 3.0.3
       uvu: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-from-markdown@2.0.0(supports-color@8.1.1):
-    dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      decode-named-character-reference: 1.0.2
-      devlop: 1.1.0
-      mdast-util-to-string: 4.0.0
-      micromark: 4.0.0(supports-color@8.1.1)
-      micromark-util-decode-numeric-character-reference: 2.0.1
-      micromark-util-decode-string: 2.0.0
-      micromark-util-normalize-identifier: 2.0.0
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.0
-      unist-util-stringify-position: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -34218,10 +34166,6 @@ snapshots:
     dependencies:
       entities: 4.5.0
 
-  parse5@7.2.1:
-    dependencies:
-      entities: 4.5.0
-
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -35100,7 +35044,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/react': 18.3.3
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.0(supports-color@8.1.1)
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       html-url-attributes: 3.0.0
       mdast-util-to-hast: 13.2.1
       react: 18.3.1
@@ -35481,16 +35425,6 @@ snapshots:
 
   rehype-harden@1.1.2: {}
 
-  rehype-katex@7.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/katex': 0.16.7
-      hast-util-from-html-isomorphic: 2.0.0
-      hast-util-to-text: 4.0.0
-      katex: 0.16.21
-      unist-util-visit-parents: 6.0.1
-      vfile: 6.0.3
-
   rehype-katex@7.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -35573,17 +35507,6 @@ snapshots:
       mdast-util-gfm: 2.0.2(supports-color@8.1.1)
       micromark-extension-gfm: 2.0.3
       unified: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-gfm@4.0.0(supports-color@8.1.1):
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.0.0(supports-color@8.1.1)
-      micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@8.1.1)
-      remark-stringify: 11.0.0
-      unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4441,8 +4441,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -21267,7 +21267,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -32962,7 +32962,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,8 @@ overrides:
   node-gyp>tar: ^7.5.8
   '@mapbox/node-pre-gyp>tar': ^7.5.8
   tmp: ^0.2.4
+  '@aws-sdk/core>fast-xml-parser': ^5.3.5
+  openapi-sampler>fast-xml-parser: ^5.3.5
 
 importers:
 
@@ -11815,12 +11817,8 @@ packages:
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
-  fast-xml-parser@4.4.1:
-    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
-    hasBin: true
-
-  fast-xml-parser@4.5.3:
-    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+  fast-xml-parser@5.3.6:
+    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
     hasBin: true
 
   fastest-stable-stringify@2.0.2:
@@ -17179,8 +17177,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   structured-clone-es@1.0.0:
     resolution: {integrity: sha512-FL8EeKFFyNQv5cMnXI31CIMCsFarSVI2bF0U0ImeNE3g/F1IvJQyqzOXxPBRXiwQfyBTlbNe88jh1jFW0O/jiQ==}
@@ -19064,7 +19062,7 @@ snapshots:
       '@smithy/util-body-length-browser': 4.0.0
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-utf8': 4.0.0
-      fast-xml-parser: 4.4.1
+      fast-xml-parser: 5.3.6
       tslib: 2.8.1
 
   '@aws-sdk/core@3.826.0':
@@ -19082,7 +19080,7 @@ snapshots:
       '@smithy/util-body-length-browser': 4.0.0
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-utf8': 4.0.0
-      fast-xml-parser: 4.4.1
+      fast-xml-parser: 5.3.6
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-cognito-identity@3.830.0':
@@ -29804,13 +29802,9 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
-  fast-xml-parser@4.4.1:
+  fast-xml-parser@5.3.6:
     dependencies:
-      strnum: 1.1.2
-
-  fast-xml-parser@4.5.3:
-    dependencies:
-      strnum: 1.1.2
+      strnum: 2.1.2
 
   fastest-stable-stringify@2.0.2: {}
 
@@ -33976,7 +33970,7 @@ snapshots:
   openapi-sampler@1.6.1:
     dependencies:
       '@types/json-schema': 7.0.15
-      fast-xml-parser: 4.5.3
+      fast-xml-parser: 5.3.6
       json-pointer: 0.6.2
 
   openapi-types@10.0.0: {}
@@ -36690,7 +36684,7 @@ snapshots:
       '@types/node': 22.13.14
       qs: 6.15.0
 
-  strnum@1.1.2: {}
+  strnum@2.1.2: {}
 
   structured-clone-es@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^1.72.0
         version: 1.72.0
       supabase:
-        specifier: ^2.65.6
-        version: 2.67.1(supports-color@8.1.1)
+        specifier: ^2.76.10
+        version: 2.76.14(supports-color@8.1.1)
       supports-color:
         specifier: ^8.0.0
         version: 8.1.1
@@ -17242,8 +17242,8 @@ packages:
     resolution: {integrity: sha512-TDQg6Nh7e2DaLmMjqpJt7Wwh2Au5loVPH2gwKMkD89e3pb5F/zMQGWt22asEXme031jEmhjazixFH0lwMgbRJA==}
     engines: {node: '>=18.0.0'}
 
-  supabase@2.67.1:
-    resolution: {integrity: sha512-d/trGytTjB/Hi625zHh2RFFttjLOkSdRTsY/N1pjxoAfG0blDiHKqPwu12VJYitg4nzgjfhjnD3pLyfU0ko5vg==}
+  supabase@2.76.14:
+    resolution: {integrity: sha512-2XmYs8+A4WXd+w/OND9u9qbSTnGdLCuddnii01H1LkmgwcZ9krXwxElE+YYmzhsEKCUHv5wVjAf5HTUwQ4PnVA==}
     engines: {npm: '>=8'}
     hasBin: true
 
@@ -17338,11 +17338,6 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  tar@7.5.2:
-    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
@@ -36768,12 +36763,12 @@ snapshots:
     dependencies:
       openapi-fetch: 0.6.2
 
-  supabase@2.67.1(supports-color@8.1.1):
+  supabase@2.76.14(supports-color@8.1.1):
     dependencies:
       bin-links: 6.0.0
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 3.3.2
-      tar: 7.5.2
+      tar: 7.5.9
     transitivePeerDependencies:
       - supports-color
 
@@ -36899,14 +36894,6 @@ snapshots:
       b4a: 1.6.7
       fast-fifo: 1.3.2
       streamx: 2.22.0
-
-  tar@7.5.2:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.9:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1750,8 +1750,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-data
       swiper:
-        specifier: ^11.0.7
-        version: 11.0.7
+        specifier: ^12.1.2
+        version: 12.1.2
       typed.js:
         specifier: ^2.0.16
         version: 2.0.16
@@ -17294,8 +17294,8 @@ packages:
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
-  swiper@11.0.7:
-    resolution: {integrity: sha512-cDfglW1B6uSmB6eB6pNmzDTNLmZtu5bWWa1vak0RU7fOI9qHjMzl7gVBvYSl34b0RU2N11HxxETJqQ5LeqI1cA==}
+  swiper@12.1.2:
+    resolution: {integrity: sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==}
     engines: {node: '>= 4.7.0'}
 
   swr@2.2.5:
@@ -36837,7 +36837,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  swiper@11.0.7: {}
+  swiper@12.1.2: {}
 
   swr@2.2.5(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15793,8 +15793,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -27562,7 +27566,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.14.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -27577,7 +27581,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.0
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.0
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -29686,7 +29690,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.14.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0(supports-color@8.1.1)
@@ -29721,7 +29725,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.0
       range-parser: 1.2.1
       router: 2.2.0(supports-color@8.1.1)
       send: 1.2.0(supports-color@8.1.1)
@@ -34848,7 +34852,11 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
@@ -36680,7 +36688,7 @@ snapshots:
   stripe@17.7.0:
     dependencies:
       '@types/node': 22.13.14
-      qs: 6.14.1
+      qs: 6.15.0
 
   strnum@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,9 @@ overrides:
   lodash: ^4.17.23
   payload>undici: ^7.18.2
   refractor>prismjs: ^1.30.0
-  tar: ^7.5.7
+  cacache>tar: ^7.5.8
+  node-gyp>tar: ^7.5.8
+  '@mapbox/node-pre-gyp>tar': ^7.5.8
   tmp: ^0.2.4
 
 importers:
@@ -17337,10 +17339,14 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.9:
+    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+    engines: {node: '>=18'}
 
   termi-link@1.1.0:
     resolution: {integrity: sha512-2qSN6TnomHgVLtk+htSWbaYs4Rd2MH/RU7VpHTy6MBstyNyWbM4yKd1DCYpE3fDg8dmGWojXCngNi/MHCzGuAA==}
@@ -21418,7 +21424,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -21431,7 +21437,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.1.0
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -27710,7 +27716,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 7.5.7
+      tar: 7.5.9
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -27727,7 +27733,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 4.0.0
       ssri: 10.0.6
-      tar: 7.5.7
+      tar: 7.5.9
       unique-filename: 3.0.0
 
   call-bind-apply-helpers@1.0.2:
@@ -33483,7 +33489,7 @@ snapshots:
       nopt: 7.2.1
       proc-log: 3.0.0
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -33498,7 +33504,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -36767,7 +36773,7 @@ snapshots:
       bin-links: 6.0.0
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 3.3.2
-      tar: 7.5.7
+      tar: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -36894,7 +36900,15 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.22.0
 
-  tar@7.5.7:
+  tar@7.5.2:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.9:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,3 +78,5 @@ overrides:
   node-gyp>tar: ^7.5.8
   '@mapbox/node-pre-gyp>tar': ^7.5.8
   tmp: ^0.2.4
+  '@aws-sdk/core>fast-xml-parser': ^5.3.5
+  openapi-sampler>fast-xml-parser: ^5.3.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,5 +73,7 @@ overrides:
   lodash: 'catalog:'
   payload>undici: ^7.18.2
   refractor>prismjs: ^1.30.0
-  tar: ^7.5.7
+  cacache>tar: ^7.5.8
+  node-gyp>tar: ^7.5.8
+  '@mapbox/node-pre-gyp>tar': ^7.5.8
   tmp: ^0.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,7 @@ minimumReleaseAgeExclude:
   - lodash
   - next-mdx-remote
   - react-resizable-panels
+  - swiper@12.1.2
 
 onlyBuiltDependencies:
   - node-pty

--- a/scripts/fix-audit-vulnerability.ts
+++ b/scripts/fix-audit-vulnerability.ts
@@ -1,0 +1,299 @@
+import { execSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as readline from 'node:readline'
+
+interface Advisory {
+  id: number
+  module_name: string
+  severity: string
+  title: string
+  vulnerable_versions: string
+  patched_versions: string
+  findings: Array<{
+    version: string
+    paths: string[]
+  }>
+}
+
+interface AuditOutput {
+  advisories: Record<string, Advisory>
+  metadata: {
+    vulnerabilities: Record<string, number>
+    dependencies: number
+    totalDependencies: number
+  }
+}
+
+interface VulnerableModule {
+  module_name: string
+  advisories: Advisory[]
+  highestSeverity: string
+  overrideVersion: string
+  allPaths: string[]
+}
+
+const WORKSPACE_YAML_PATH = path.join(process.cwd(), 'pnpm-workspace.yaml')
+const LOCKFILE_PATH = path.join(process.cwd(), 'pnpm-lock.yaml')
+
+const SEVERITY_ORDER = ['critical', 'high', 'moderate', 'low']
+
+function runAudit(): AuditOutput {
+  try {
+    const stdout = execSync('pnpm audit --json', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024,
+    })
+    return JSON.parse(stdout)
+  } catch (error: any) {
+    // pnpm audit exits with code 1 when vulnerabilities exist
+    if (error.stdout) {
+      return JSON.parse(error.stdout)
+    }
+    throw error
+  }
+}
+
+function parseMinVersion(patchedVersions: string): string | null {
+  const match = patchedVersions.match(/>=(\d+\.\d+\.\d+)/)
+  return match ? match[1] : null
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  }
+  return 0
+}
+
+function groupAdvisories(advisories: Record<string, Advisory>): VulnerableModule[] {
+  const byModule = new Map<string, Advisory[]>()
+
+  for (const adv of Object.values(advisories)) {
+    if (adv.patched_versions === '<0.0.0') continue
+
+    const existing = byModule.get(adv.module_name) ?? []
+    existing.push(adv)
+    byModule.set(adv.module_name, existing)
+  }
+
+  const result: VulnerableModule[] = []
+
+  for (const [module_name, advs] of byModule) {
+    const allPaths = [...new Set(advs.flatMap((a) => a.findings.flatMap((f) => f.paths)))]
+
+    const versions = advs
+      .map((a) => parseMinVersion(a.patched_versions))
+      .filter(Boolean) as string[]
+    const highestVersion = versions.sort(compareSemver).pop()!
+    const overrideVersion = `^${highestVersion}`
+
+    const highestSeverity = advs
+      .map((a) => a.severity)
+      .sort((a, b) => SEVERITY_ORDER.indexOf(a) - SEVERITY_ORDER.indexOf(b))
+      .at(0)!
+
+    result.push({
+      module_name,
+      advisories: advs,
+      highestSeverity,
+      overrideVersion,
+      allPaths,
+    })
+  }
+
+  result.sort((a, b) => {
+    const sevDiff =
+      SEVERITY_ORDER.indexOf(a.highestSeverity) - SEVERITY_ORDER.indexOf(b.highestSeverity)
+    if (sevDiff !== 0) return sevDiff
+    return a.module_name.localeCompare(b.module_name)
+  })
+
+  return result
+}
+
+function displayVulnerabilities(modules: VulnerableModule[]): void {
+  console.log('\nVulnerable dependencies (patchable):\n')
+
+  const severityColors: Record<string, string> = {
+    critical: '\x1b[31m',
+    high: '\x1b[33m',
+    moderate: '\x1b[36m',
+    low: '\x1b[37m',
+  }
+  const reset = '\x1b[0m'
+
+  for (let i = 0; i < modules.length; i++) {
+    const m = modules[i]
+    const color = severityColors[m.highestSeverity] ?? reset
+
+    console.log(
+      `  ${String(i + 1).padStart(2)}. ${color}[${m.highestSeverity.toUpperCase()}]${reset} ` +
+        `${m.module_name} -> ${m.overrideVersion}`
+    )
+
+    const maxPaths = 3
+    const paths = m.allPaths.slice(0, maxPaths)
+    for (const p of paths) {
+      console.log(`      via ${p.replace(/__/g, '/')}`)
+    }
+    if (m.allPaths.length > maxPaths) {
+      console.log(`      ... and ${m.allPaths.length - maxPaths} more`)
+    }
+  }
+
+  console.log('')
+}
+
+function promptSelection(modules: VulnerableModule[]): Promise<VulnerableModule> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise((resolve, reject) => {
+    rl.question(`Select vulnerability to fix (1-${modules.length}): `, (answer) => {
+      rl.close()
+      const num = parseInt(answer, 10)
+      if (isNaN(num) || num < 1 || num > modules.length) {
+        reject(new Error(`Invalid selection: ${answer}`))
+        return
+      }
+      resolve(modules[num - 1])
+    })
+  })
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function formatOverrideLine(moduleName: string, version: string): string {
+  const key = moduleName.includes('@') ? `'${moduleName}'` : moduleName
+  return `  ${key}: ${version}`
+}
+
+function addOverride(yamlContent: string, moduleName: string, version: string): string {
+  const lines = yamlContent.split('\n')
+
+  const overridesIdx = lines.findIndex((line) => /^overrides:\s*$/.test(line))
+  if (overridesIdx === -1) {
+    throw new Error('Could not find "overrides:" section in pnpm-workspace.yaml')
+  }
+
+  // Find the end of the overrides block (next non-indented, non-empty line)
+  let blockEnd = overridesIdx + 1
+  while (blockEnd < lines.length) {
+    const line = lines[blockEnd]
+    if (line === '' || /^\s+/.test(line)) {
+      blockEnd++
+    } else {
+      break
+    }
+  }
+
+  // Check if this module already has an override
+  const existingPattern = new RegExp(`^\\s+['"]?${escapeRegex(moduleName)}['"]?\\s*:`)
+  const existingIdx = lines.findIndex(
+    (line, idx) => idx > overridesIdx && idx < blockEnd && existingPattern.test(line)
+  )
+
+  if (existingIdx !== -1) {
+    console.log(`\nWARNING: Override for "${moduleName}" already exists:`)
+    console.log(`  ${lines[existingIdx].trim()}`)
+    console.log(`  Replacing with: ${moduleName}: ${version}`)
+    lines[existingIdx] = formatOverrideLine(moduleName, version)
+    return lines.join('\n')
+  }
+
+  // Insert new override at the end of the overrides block
+  const newLine = formatOverrideLine(moduleName, version)
+  lines.splice(blockEnd, 0, newLine)
+  return lines.join('\n')
+}
+
+async function main(): Promise<void> {
+  console.log('Running pnpm audit...')
+  const auditResult = runAudit()
+
+  const modules = groupAdvisories(auditResult.advisories)
+
+  if (modules.length === 0) {
+    console.log('No patchable vulnerabilities found.')
+    process.exit(0)
+  }
+
+  displayVulnerabilities(modules)
+
+  const selected = await promptSelection(modules)
+
+  // Snapshot original files for revert on failure
+  const originalYaml = fs.readFileSync(WORKSPACE_YAML_PATH, 'utf-8')
+  const originalLockfile = fs.readFileSync(LOCKFILE_PATH, 'utf-8')
+
+  function revert(): void {
+    console.log('\nReverting pnpm-workspace.yaml and pnpm-lock.yaml...')
+    fs.writeFileSync(WORKSPACE_YAML_PATH, originalYaml, 'utf-8')
+    fs.writeFileSync(LOCKFILE_PATH, originalLockfile, 'utf-8')
+    console.log('Reverted to original state.')
+  }
+
+  console.log(`\nAdding override: ${selected.module_name}: ${selected.overrideVersion}`)
+  const updatedYaml = addOverride(originalYaml, selected.module_name, selected.overrideVersion)
+  fs.writeFileSync(WORKSPACE_YAML_PATH, updatedYaml, 'utf-8')
+  console.log('Updated pnpm-workspace.yaml')
+
+  console.log('\nRunning pnpm install (with override)...')
+  try {
+    execSync('pnpm install', {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    })
+  } catch (error: any) {
+    const output = (error.stdout ?? '') + (error.stderr ?? '')
+    if (output.includes('ERR_PNPM_NO_MATCHING_VERSION')) {
+      console.error(
+        `\nNo matching version found for "${selected.module_name}@${selected.overrideVersion}", the minimumReleaseAge option forbids it from installing.`
+      )
+      revert()
+      process.exit(1)
+    }
+    throw error
+  }
+
+  // Remove the override and re-install to see if the lockfile update alone fixes it
+  console.log('\nRemoving override and running pnpm install again...')
+  fs.writeFileSync(WORKSPACE_YAML_PATH, originalYaml, 'utf-8')
+  execSync('pnpm install --silent', {
+    stdio: 'pipe',
+    encoding: 'utf-8',
+  })
+
+  console.log('\nRunning pnpm audit to verify fix without override...')
+  const verifyResult = runAudit()
+
+  const stillVulnerable = Object.values(verifyResult.advisories).some(
+    (adv) => adv.module_name === selected.module_name
+  )
+
+  if (stillVulnerable) {
+    revert()
+    console.error(
+      `\nERROR: Vulnerability for "${selected.module_name}" still present even with override.`
+    )
+    console.error('Consider using scoped overrides or updating the parent dependency.')
+    process.exit(1)
+  }
+
+  console.log(
+    `\nSUCCESS: Vulnerability for "${selected.module_name}" resolved without needing a permanent override.`
+  )
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
This pull request primarily updates dependencies across the project to their latest versions, improving compatibility, security, and performance. It also modifies configuration files to align with the current package management setup.

Dependency upgrades (core libraries and tools):
Bumps dependencies to solve the following issues:
- https://github.com/supabase/supabase/security/dependabot/2855
- https://github.com/supabase/supabase/security/dependabot/2844
- https://github.com/supabase/supabase/security/dependabot/2860
- https://github.com/supabase/supabase/security/dependabot/2815
- https://github.com/supabase/supabase/security/dependabot/2774
- https://github.com/supabase/supabase/security/dependabot/2836
- https://github.com/supabase/supabase/security/dependabot/2816
- https://github.com/supabase/supabase/security/dependabot/2778
- https://github.com/supabase/supabase/security/dependabot/2790
- https://github.com/supabase/supabase/security/dependabot/2793

Configuration and lock file updates:

* Changed `.prettierignore` to ignore `pnpm-lock.yaml` instead of `package-lock.json`, reflecting the switch to pnpm as the package manager.
* Updated dependency overrides in `pnpm-lock.yaml` for `tar` and `fast-xml-parser` to ensure consistent versions across the workspace.

These updates collectively ensure the project stays current with its dependencies, reduces potential vulnerabilities, and improves overall stability and maintainability.