### PR TITLE
fix(growth): reduce group identify event volume with persistent dedupe

### DIFF
--- a/packages/common/groupIdentifyDedupe.test.ts
+++ b/packages/common/groupIdentifyDedupe.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { hasGroupContextBeenSent, markGroupContextSent } from './groupIdentifyDedupe'
+
+describe('groupIdentifyDedupe', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('hasGroupContextBeenSent', () => {
+    it('returns false for an unseen key', () => {
+      expect(hasGroupContextBeenSent('uid|org1|proj1')).toBe(false)
+    })
+
+    it('returns true after the key has been marked as sent', () => {
+      markGroupContextSent('uid|org1|proj1')
+      expect(hasGroupContextBeenSent('uid|org1|proj1')).toBe(true)
+    })
+
+    it('returns false for a different key that has not been marked', () => {
+      markGroupContextSent('uid|org1|proj1')
+      expect(hasGroupContextBeenSent('uid|org2|proj2')).toBe(false)
+    })
+
+    it('returns false when sessionStorage contains corrupted JSON', () => {
+      sessionStorage.setItem('ph_group_identify_sent', 'not-valid-json')
+      expect(hasGroupContextBeenSent('uid|org1|proj1')).toBe(false)
+    })
+
+    it('returns false when sessionStorage contains valid JSON that is not an array', () => {
+      sessionStorage.setItem('ph_group_identify_sent', '"just a string"')
+      expect(hasGroupContextBeenSent('uid|org1|proj1')).toBe(false)
+    })
+
+    it('returns false when sessionStorage.getItem throws', () => {
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('SecurityError')
+      })
+      expect(hasGroupContextBeenSent('uid|org1|proj1')).toBe(false)
+    })
+  })
+
+  describe('markGroupContextSent', () => {
+    it('tracks multiple keys independently', () => {
+      markGroupContextSent('uid|org1|proj1')
+      markGroupContextSent('uid|org2|proj2')
+
+      expect(hasGroupContextBeenSent('uid|org1|proj1')).toBe(true)
+      expect(hasGroupContextBeenSent('uid|org2|proj2')).toBe(true)
+    })
+
+    it('does not duplicate keys when marked twice', () => {
+      markGroupContextSent('uid|org1|proj1')
+      markGroupContextSent('uid|org1|proj1')
+
+      const raw = sessionStorage.getItem('ph_group_identify_sent')
+      const sent: string[] = JSON.parse(raw!)
+      expect(sent.filter((k) => k === 'uid|org1|proj1')).toHaveLength(1)
+    })
+
+    it('does not throw when sessionStorage.setItem throws', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+      expect(() => markGroupContextSent('uid|org1|proj1')).not.toThrow()
+    })
+
+    it('does not throw when sessionStorage contains corrupted JSON', () => {
+      sessionStorage.setItem('ph_group_identify_sent', '{bad}')
+      expect(() => markGroupContextSent('uid|org1|proj1')).not.toThrow()
+    })
+  })
+})

--- a/packages/common/groupIdentifyDedupe.ts
+++ b/packages/common/groupIdentifyDedupe.ts
@@ -1,0 +1,39 @@
+const STORAGE_KEY = 'ph_group_identify_sent'
+
+/**
+ * Check if a group identify call has already been sent for this context key
+ * in the current browser session.
+ *
+ * Returns false (allowing the call through) if sessionStorage is unavailable.
+ */
+export function hasGroupContextBeenSent(contextKey: string): boolean {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return false
+    const sent: unknown = JSON.parse(raw)
+    if (!Array.isArray(sent)) return false
+    return sent.includes(contextKey)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Mark a group identify context key as sent for this session.
+ * Call this after a successful POST to /telemetry/identify.
+ *
+ * No-ops silently if sessionStorage is unavailable.
+ */
+export function markGroupContextSent(contextKey: string): void {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    const parsed: unknown = raw ? JSON.parse(raw) : []
+    const sent: string[] = Array.isArray(parsed) ? parsed : []
+    if (!sent.includes(contextKey)) {
+      sent.push(contextKey)
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(sent))
+    }
+  } catch {
+    // sessionStorage unavailable — no-op
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the React `useRef`-based dedupe in `ensureGroupContext()` with a `sessionStorage`-backed set that tracks all previously-sent context keys per tab session
- Prevents redundant `POST /telemetry/identify` calls on page refresh, tab refocus, and repeated org/project navigation (A→B→A now fires 2 calls instead of 3)
- Expected ~90% reduction in group identify event volume without changing flag evaluation behavior

## Context

Investigation from [GROWTH-650](https://linear.app/supabase/issue/GROWTH-650) identified that `ensureGroupContext()` fires `Posthog.groupIdentify()` more often than necessary. The group identify calls are required (introduced in PR #42123 / GROWTH-593 to fix org/project-scoped flag evaluation), but the dedupe used a React ref that:
1. Reset on component remounts
2. Only stored the **last** sent key (so A→B→A fired 3 calls)
3. Did not survive page refresh

The new `sessionStorage`-based approach follows the existing `fireExposureIfNew` pattern in `posthog-client.ts`.

## What changed

| File | Change |
|------|--------|
| `packages/common/groupIdentifyDedupe.ts` | **New** — `sessionStorage`-backed dedupe utility with `hasGroupContextBeenSent()` / `markGroupContextSent()` |
| `packages/common/groupIdentifyDedupe.test.ts` | **New** — 10 unit tests covering happy path, multi-key tracking, corrupted JSON, and `sessionStorage` unavailability |
| `packages/common/feature-flags.tsx` | **Modified** — Remove `useRef`, import and use dedupe utility |

## How to verify

1. Deploy and monitor group identify event volume in PostHog (from GROWTH-650 investigation)
2. Navigate between orgs/projects in Studio — verify identify fires once per unique combo
3. Refresh page — verify dedupe persists (no re-fire for same context)
4. Open new tab — verify re-identification occurs (correct, new session)

## Test results

```
✓ groupIdentifyDedupe.test.ts (10 tests) 5ms
Test Files  1 passed (1)
Tests       10 passed (10)
```

Resolves [GROWTH-652](https://linear.app/supabase/issue/GROWTH-652/reduce-group-identify-event-volume-with-persistent-dedupe)