### PR TITLE
chore(studio): remove physical backups disabled download button 

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -88,8 +88,9 @@ export const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupI
 
   return (
     <div
-      className={`flex h-12 items-center justify-between px-6 ${index ? 'border-t border-default' : ''
-        }`}
+      className={`flex h-12 items-center justify-between px-6 ${
+        index ? 'border-t border-default' : ''
+      }`}
     >
       <div className="flex items-center gap-x-2">
         <TimestampInfo

--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -7,7 +7,6 @@ import { InlineLink } from 'components/ui/InlineLink'
 import { useBackupDownloadMutation } from 'data/database/backup-download-mutation'
 import type { DatabaseBackup } from 'data/database/backups-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { DOCS_URL } from 'lib/constants'
 import { Badge, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { TimestampInfo } from 'ui-patterns'
 
@@ -59,38 +58,29 @@ export const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupI
           >
             Restore
           </ButtonTooltip>
-          <ButtonTooltip
-            type="default"
-            icon={<Download />}
-            loading={isDownloading}
-            disabled={!canTriggerScheduledBackups || isDownloading || backup.isPhysicalBackup}
-            onClick={() => {
-              if (!projectRef) return console.error('Project ref is required')
-              downloadBackup({ ref: projectRef, backup })
-            }}
-            tooltip={{
-              content: {
-                side: 'bottom',
-                className: backup.isPhysicalBackup ? 'w-64' : '',
-                text: backup.isPhysicalBackup ? (
-                  <>
-                    Physical backups cannot be downloaded through the dashboard. You can still
-                    download it via pgdump by following our guide{' '}
-                    <InlineLink
-                      href={`${DOCS_URL}/guides/troubleshooting/download-logical-backups`}
-                    >
-                      here
-                    </InlineLink>
-                    .
-                  </>
-                ) : !canTriggerScheduledBackups ? (
-                  'You need additional permissions to download backups'
-                ) : undefined,
-              },
-            }}
-          >
-            Download
-          </ButtonTooltip>
+
+          {!backup.isPhysicalBackup && (
+            <ButtonTooltip
+              type="default"
+              icon={<Download />}
+              loading={isDownloading}
+              disabled={!canTriggerScheduledBackups || isDownloading}
+              onClick={() => {
+                if (!projectRef) return console.error('Project ref is required')
+                downloadBackup({ ref: projectRef, backup })
+              }}
+              tooltip={{
+                content: {
+                  side: 'bottom',
+                  text: !canTriggerScheduledBackups
+                    ? 'You need additional permissions to download backups'
+                    : undefined,
+                },
+              }}
+            >
+              Download
+            </ButtonTooltip>
+          )}
         </div>
       )
     return <Badge variant="warning">Backup In Progress...</Badge>
@@ -98,9 +88,8 @@ export const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupI
 
   return (
     <div
-      className={`flex h-12 items-center justify-between px-6 ${
-        index ? 'border-t border-default' : ''
-      }`}
+      className={`flex h-12 items-center justify-between px-6 ${index ? 'border-t border-default' : ''
+        }`}
     >
       <div className="flex items-center gap-x-2">
         <TimestampInfo


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI update

## What is the current behavior?

- The vast majority of projects now have physical backups, not logical
- Physical backups are not downloadable
- But we show a disabled `Download` button for each physical backup
	- This button has confusing multi-step instructions about `pg_dump` that are [inaccurate](https://supabase.slack.com/archives/C02BJ2239GA/p1771979586829419?thread_ts=1771887878.203199&cid=C02BJ2239GA)

## What is the new behavior?

- We only show the (enabled) `Download` button for logical backups

| Before | After |
| --- | --- |
| <img width="1024" height="563" alt="AWS Healthy  Toolshed  Supabase-6FE7C23F-29D6-47B6-819A-84BC49927F3A" src="https://github.com/user-attachments/assets/167441bf-3ead-4c86-89df-60ab89ce8b98" /> | <img width="1024" height="563" alt="AWS Healthy  Toolshed  Supabase-C9E763B7-B447-468E-B928-BB9AD5ABC588" src="https://github.com/user-attachments/assets/3fccdf12-ba4e-424a-87ae-2294f1a3b7b1" /> |


## Additional context

Support believes removing the button entirely will have less of a burden than a better tooltip explanation.