### PR TITLE
feat(studio): page titles (all)

### DIFF
--- a/apps/design-system/content/docs/ui-patterns/navigation.mdx
+++ b/apps/design-system/content/docs/ui-patterns/navigation.mdx
@@ -12,3 +12,22 @@ Supabase has a necessarily complex navigation system to handle multiple products
 A horizontal list of related views within a consistent PageLayout context, allowing for clearer page-level organisation. Activating a NavMenu item should trigger a URL change.
 
 [NavMenu component guidelines](../components/nav-menu)
+
+## Page titles
+
+Browser page titles should follow a consistent most-specific-first structure so tabs and browser history are easier to scan:
+
+`Entity | Section | Surface | Project | Org | Supabase`
+
+Examples:
+
+- `users | Table Editor | My Project | My Org | Supabase`
+- `Backups | Database | My Project | My Org | Supabase`
+
+Implementation notes (Studio):
+
+- Use the shared title formatter in `apps/studio/lib/page-title.ts`
+- Prefer `ProjectLayout` for project-scoped pages
+- Treat `title` as the section label and `product` as the surface label
+- Use `browserTitle.entity` for the most specific resource (table/function/query) when available
+- Avoid assembling `document.title` ad hoc in individual pages/layouts

--- a/apps/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/apps/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -8,12 +8,21 @@ import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { withAuth } from 'hooks/misc/withAuth'
 import { IS_PLATFORM } from 'lib/constants'
+import { buildStudioPageTitle } from 'lib/page-title'
 import { useAppStateSnapshot } from 'state/app-state'
 import { cn } from 'ui'
 import { WithSidebar } from './WithSidebar'
 
 export interface AccountLayoutProps {
   title: string
+}
+
+const ACCOUNT_ROUTE_TITLES: Record<string, string> = {
+  '/account/me': 'Preferences',
+  '/account/tokens': 'Access Tokens',
+  '/account/tokens/scoped': 'Scoped Access Tokens',
+  '/account/security': 'Security',
+  '/account/audit': 'Audit Logs',
 }
 
 const AccountLayout = ({ children, title }: PropsWithChildren<AccountLayoutProps>) => {
@@ -23,7 +32,7 @@ const AccountLayout = ({ children, title }: PropsWithChildren<AccountLayoutProps
   const showSecuritySettings = useIsFeatureEnabled('account:show_security_settings')
 
   const { appTitle } = useCustomContent(['app:title'])
-  const titleSuffix = appTitle || 'Supabase'
+  const brandTitle = appTitle || 'Supabase'
 
   const [lastVisitedOrganization] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.LAST_VISITED_ORGANIZATION,
@@ -38,6 +47,12 @@ const AccountLayout = ({ children, title }: PropsWithChildren<AccountLayoutProps
         : '/organizations'
 
   const currentPath = router.pathname
+  const sectionTitle = ACCOUNT_ROUTE_TITLES[currentPath] ?? title
+  const pageTitle = buildStudioPageTitle({
+    section: sectionTitle,
+    surface: 'Account',
+    brand: brandTitle,
+  })
 
   useEffect(() => {
     if (!IS_PLATFORM) {
@@ -48,7 +63,7 @@ const AccountLayout = ({ children, title }: PropsWithChildren<AccountLayoutProps
   return (
     <>
       <Head>
-        <title>{title ? `${title} | ${titleSuffix}` : titleSuffix}</title>
+        <title>{pageTitle}</title>
         <meta name="description" content="Supabase Studio" />
       </Head>
       <div className={cn('flex flex-col w-screen h-[calc(100vh-48px)]')}>

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.tsx
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.tsx
@@ -65,12 +65,7 @@ const AuthProductMenu = () => {
     authenticationPerformance,
   })
 
-  return (
-    <ProductMenu
-      page={page}
-      menu={menu}
-    />
-  )
+  return <ProductMenu page={page} menu={menu} />
 }
 
 const AuthLayout = ({ children }: PropsWithChildren<{}>) => {

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.tsx
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.tsx
@@ -9,6 +9,26 @@ import { withAuth } from 'hooks/misc/withAuth'
 import { ProjectLayout } from '../ProjectLayout'
 import { generateAuthMenu } from './AuthLayout.utils'
 
+const AUTH_SECTION_TITLE_BY_PAGE: Record<string, string> = {
+  overview: 'Overview',
+  users: 'Users',
+  'oauth-apps': 'OAuth Apps',
+  policies: 'Policies',
+  providers: 'Sign In / Providers',
+  'third-party': 'Sign In / Providers',
+  'oauth-server': 'OAuth Server',
+  sessions: 'Sessions',
+  'rate-limits': 'Rate Limits',
+  mfa: 'Multi-Factor',
+  'url-configuration': 'URL Configuration',
+  protection: 'Attack Protection',
+  hooks: 'Auth Hooks',
+  'audit-logs': 'Audit Logs',
+  performance: 'Performance',
+  templates: 'Email',
+  smtp: 'Email',
+}
+
 const AuthProductMenu = () => {
   const router = useRouter()
   const { ref: projectRef = 'default' } = useParams()
@@ -34,28 +54,33 @@ const AuthProductMenu = () => {
 
   useAuthConfigPrefetch({ projectRef })
   const page = router.pathname.split('/')[4]
+  const menu = generateAuthMenu(projectRef, {
+    authenticationSignInProviders,
+    authenticationRateLimits,
+    authenticationEmails,
+    authenticationMultiFactor,
+    authenticationAttackProtection,
+    authenticationShowOverview,
+    authenticationOauth21,
+    authenticationPerformance,
+  })
 
   return (
     <ProductMenu
       page={page}
-      menu={generateAuthMenu(projectRef, {
-        authenticationSignInProviders,
-        authenticationRateLimits,
-        authenticationEmails,
-        authenticationMultiFactor,
-        authenticationAttackProtection,
-        authenticationShowOverview,
-        authenticationOauth21,
-        authenticationPerformance,
-      })}
+      menu={menu}
     />
   )
 }
 
 const AuthLayout = ({ children }: PropsWithChildren<{}>) => {
+  const router = useRouter()
+  const page = router.pathname.split('/')[4]
+  const sectionTitle = page !== undefined ? AUTH_SECTION_TITLE_BY_PAGE[page] : undefined
+
   return (
     <ProjectLayout
-      title="Authentication"
+      title={sectionTitle}
       product="Authentication"
       productMenu={<AuthProductMenu />}
       isBlocking={false}

--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
@@ -78,8 +78,7 @@ const DatabaseLayout = ({ children, title }: PropsWithChildren<DatabaseLayoutPro
   const router = useRouter()
   const page = router.pathname.split('/')[4]
   const routeSectionTitle = page !== undefined ? DATABASE_SECTION_TITLE_BY_ROUTE[page] : undefined
-  const resolvedTitle =
-    title && title !== 'Database' ? title : routeSectionTitle ?? title
+  const resolvedTitle = title && title !== 'Database' ? title : routeSectionTitle ?? title
 
   return (
     <ProjectLayout

--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
@@ -16,6 +16,23 @@ export interface DatabaseLayoutProps {
   title?: string
 }
 
+const DATABASE_SECTION_TITLE_BY_ROUTE: Record<string, string> = {
+  schemas: 'Schema Visualizer',
+  tables: 'Tables',
+  functions: 'Functions',
+  triggers: 'Triggers',
+  types: 'Enumerated Types',
+  extensions: 'Extensions',
+  indexes: 'Indexes',
+  publications: 'Publications',
+  roles: 'Roles',
+  'column-privileges': 'Column Privileges',
+  settings: 'Settings',
+  replication: 'Replication',
+  backups: 'Backups',
+  migrations: 'Migrations',
+}
+
 const DatabaseProductMenu = () => {
   const { data: project } = useSelectedProjectQuery()
 
@@ -57,9 +74,20 @@ const DatabaseProductMenu = () => {
   )
 }
 
-const DatabaseLayout = ({ children }: PropsWithChildren<DatabaseLayoutProps>) => {
+const DatabaseLayout = ({ children, title }: PropsWithChildren<DatabaseLayoutProps>) => {
+  const router = useRouter()
+  const page = router.pathname.split('/')[4]
+  const routeSectionTitle = page !== undefined ? DATABASE_SECTION_TITLE_BY_ROUTE[page] : undefined
+  const resolvedTitle =
+    title && title !== 'Database' ? title : routeSectionTitle ?? title
+
   return (
-    <ProjectLayout product="Database" productMenu={<DatabaseProductMenu />} isBlocking={false}>
+    <ProjectLayout
+      title={resolvedTitle}
+      product="Database"
+      productMenu={<DatabaseProductMenu />}
+      isBlocking={false}
+    >
       {children}
     </ProjectLayout>
   )

--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
@@ -49,6 +49,14 @@ interface EdgeFunctionDetailsLayoutProps {
   title?: string
 }
 
+const getEdgeFunctionDetailsSectionTitle = (pathname: string) => {
+  if (pathname.endsWith('/invocations')) return 'Invocations'
+  if (pathname.endsWith('/logs')) return 'Logs'
+  if (pathname.endsWith('/details')) return 'Details'
+  if (pathname.endsWith('/code')) return 'Code'
+  return 'Overview'
+}
+
 const EdgeFunctionDetailsLayout = ({
   title,
   children,
@@ -91,6 +99,10 @@ const EdgeFunctionDetailsLayout = ({
     )
 
   const name = selectedFunction?.name || ''
+  const browserTitle = {
+    entity: functionSlug ? name || functionSlug : undefined,
+    section: title || getEdgeFunctionDetailsSectionTitle(router.pathname),
+  }
 
   const breadcrumbItems = [
     {
@@ -215,14 +227,18 @@ const EdgeFunctionDetailsLayout = ({
 
   if (!isLoading && !canReadFunctions) {
     return (
-      <ProjectLayout title={title || 'Edge Functions'} product="Edge Functions">
+      <ProjectLayout
+        title={title || 'Edge Functions'}
+        product="Edge Functions"
+        browserTitle={browserTitle}
+      >
         <NoPermission isFullPage resourceText="access your project's edge functions" />
       </ProjectLayout>
     )
   }
 
   return (
-    <EdgeFunctionsLayout>
+    <EdgeFunctionsLayout browserTitle={browserTitle}>
       <div className="w-full min-h-full flex flex-col items-stretch">
         <PageHeader size="full" className="sticky top-0 z-10 bg-background">
           {breadcrumbItems.length > 0 && (

--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { PropsWithChildren } from 'react'
+import { ComponentProps, PropsWithChildren } from 'react'
 
 import { useParams } from 'common'
 import { ProductMenu } from 'components/ui/ProductMenu'
@@ -35,11 +35,21 @@ const EdgeFunctionsProductMenu = () => {
   return <ProductMenu page={page} menu={menuItems} />
 }
 
-const EdgeFunctionsLayout = ({ children }: PropsWithChildren<{}>) => {
+interface EdgeFunctionsLayoutProps {
+  title?: string
+  browserTitle?: ComponentProps<typeof ProjectLayout>['browserTitle']
+}
+
+const EdgeFunctionsLayout = ({
+  children,
+  title = 'Edge Functions',
+  browserTitle,
+}: PropsWithChildren<EdgeFunctionsLayoutProps>) => {
   return (
     <ProjectLayout
-      title="Edge Functions"
+      title={title}
       product="Edge Functions"
+      browserTitle={browserTitle}
       productMenu={<EdgeFunctionsProductMenu />}
       isBlocking={false}
     >

--- a/apps/studio/components/layouts/LogsLayout/LogsLayout.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsLayout.tsx
@@ -30,7 +30,9 @@ const LogsLayout = ({ title, children }: PropsWithChildren<LogsLayoutProps>) => 
 
   if (!canUseLogsExplorer) {
     if (isLoading) {
-      return <ProjectLayout isLoading title={resolvedTitle} product="Logs & Analytics"></ProjectLayout>
+      return (
+        <ProjectLayout isLoading title={resolvedTitle} product="Logs & Analytics"></ProjectLayout>
+      )
     }
 
     if (!isLoading && !canUseLogsExplorer) {

--- a/apps/studio/components/layouts/LogsLayout/LogsLayout.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsLayout.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 import { PropsWithChildren } from 'react'
+import { useRouter } from 'next/router'
 
 import NoPermission from 'components/ui/NoPermission'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -12,20 +13,29 @@ interface LogsLayoutProps {
   title?: string
 }
 
+const LOGS_SECTION_TITLE_BY_ROUTE: Record<string, string> = {
+  '/project/[ref]/logs/explorer': 'Explorer',
+  '/project/[ref]/logs/explorer/recent': 'Recent',
+  '/project/[ref]/logs/explorer/saved': 'Saved',
+  '/project/[ref]/logs/explorer/templates': 'Templates',
+}
+
 const LogsLayout = ({ title, children }: PropsWithChildren<LogsLayoutProps>) => {
+  const router = useRouter()
   const { isLoading, can: canUseLogsExplorer } = useAsyncCheckPermissions(
     PermissionAction.ANALYTICS_READ,
     'logflare'
   )
+  const resolvedTitle = title ?? LOGS_SECTION_TITLE_BY_ROUTE[router.pathname]
 
   if (!canUseLogsExplorer) {
     if (isLoading) {
-      return <ProjectLayout isLoading></ProjectLayout>
+      return <ProjectLayout isLoading title={resolvedTitle} product="Logs & Analytics"></ProjectLayout>
     }
 
     if (!isLoading && !canUseLogsExplorer) {
       return (
-        <ProjectLayout>
+        <ProjectLayout title={resolvedTitle} product="Logs & Analytics">
           <NoPermission isFullPage resourceText="access your project's logs" />
         </ProjectLayout>
       )
@@ -33,7 +43,11 @@ const LogsLayout = ({ title, children }: PropsWithChildren<LogsLayoutProps>) => 
   }
 
   return (
-    <ProjectLayout title={title} product="Logs & Analytics" productMenu={<LogsSidebarMenuV2 />}>
+    <ProjectLayout
+      title={resolvedTitle}
+      product="Logs & Analytics"
+      productMenu={<LogsSidebarMenuV2 />}
+    >
       {children}
     </ProjectLayout>
   )

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
@@ -17,6 +17,29 @@ interface ObservabilityLayoutProps {
   title?: string
 }
 
+const OBSERVABILITY_SECTION_TITLE_BY_ROUTE: Record<string, string> = {
+  'api-overview': 'API Gateway',
+  auth: 'Auth',
+  database: 'Database',
+  'edge-functions': 'Edge Functions',
+  postgrest: 'PostgREST',
+  'query-performance': 'Query Performance',
+  realtime: 'Realtime',
+  storage: 'Storage',
+}
+
+const getObservabilitySectionTitle = (pathname: string | null, title?: string) => {
+  if (title !== undefined) return title
+  if (!pathname) return undefined
+
+  const segments = pathname.split('/').filter(Boolean)
+  const page = segments[3]
+
+  if (page === undefined) return 'Overview'
+
+  return OBSERVABILITY_SECTION_TITLE_BY_ROUTE[page] ?? 'Report'
+}
+
 const ObservabilityLayoutContent = ({
   title,
   children,
@@ -81,11 +104,12 @@ const ObservabilityLayoutContent = ({
   ])
 
   const { reportsAll } = useIsFeatureEnabled(['reports:all'])
+  const resolvedTitle = getObservabilitySectionTitle(pathname, title)
 
   if (reportsAll) {
     return (
       <ProjectLayout
-        title={title}
+        title={resolvedTitle}
         product="Observability"
         productMenu={<ObservabilityMenu />}
         isBlocking={false}

--- a/apps/studio/components/layouts/ProjectLayout/index.test.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.test.tsx
@@ -4,11 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { STUDIO_PAGE_TITLE_SEPARATOR } from '@/lib/page-title'
 
-const {
-  mockRouter,
-  mockSetSelectedDatabaseId,
-  mockSetMobileMenuOpen,
-} = vi.hoisted(() => ({
+const { mockRouter, mockSetSelectedDatabaseId, mockSetMobileMenuOpen } = vi.hoisted(() => ({
   mockRouter: {
     pathname: '/project/[ref]/observability/query-performance',
     asPath: '/project/default/observability/query-performance',

--- a/apps/studio/components/layouts/ProjectLayout/index.test.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.test.tsx
@@ -1,0 +1,199 @@
+import { render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { STUDIO_PAGE_TITLE_SEPARATOR } from '@/lib/page-title'
+
+const {
+  mockRouter,
+  mockSetSelectedDatabaseId,
+  mockSetMobileMenuOpen,
+} = vi.hoisted(() => ({
+  mockRouter: {
+    pathname: '/project/[ref]/observability/query-performance',
+    asPath: '/project/default/observability/query-performance',
+    push: vi.fn(),
+    replace: vi.fn(),
+  },
+  mockSetSelectedDatabaseId: vi.fn(),
+  mockSetMobileMenuOpen: vi.fn(),
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => mockRouter,
+}))
+
+vi.mock('next/head', async () => {
+  const React = await import('react')
+
+  const Head = ({ children }: { children?: ReactNode }) => {
+    React.useEffect(() => {
+      const titleElement = React.Children.toArray(children).find(
+        (child) => React.isValidElement(child) && child.type === 'title'
+      )
+
+      if (!React.isValidElement(titleElement)) return
+
+      const titleText = React.Children.toArray(titleElement.props.children).join('')
+      document.title = titleText
+    }, [children])
+
+    return null
+  }
+
+  return { default: Head }
+})
+
+vi.mock('common', () => ({
+  useParams: () => ({ ref: 'default' }),
+  mergeRefs:
+    (..._refs: any[]) =>
+    (_value: unknown) => {},
+}))
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}))
+
+vi.mock('ui', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
+  LogoLoader: () => <div data-testid="logo-loader" />,
+  ResizableHandle: (props: any) => <div {...props} />,
+  ResizablePanel: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  ResizablePanelGroup: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  useIsMobile: () => false,
+  usePanelRef: () => undefined,
+}))
+
+vi.mock('ui-patterns/MobileSheetNav/MobileSheetNav', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../editors/EditorsLayout.hooks', () => ({
+  useEditorType: () => undefined,
+}))
+
+vi.mock('../MainScrollContainerContext', () => ({
+  useSetMainScrollContainer: () => () => {},
+}))
+
+vi.mock('./BuildingState', () => ({ default: () => null }))
+vi.mock('./ConnectingState', () => ({ default: () => null }))
+vi.mock('./LoadingState', () => ({ LoadingState: () => null }))
+vi.mock('./PausedState/ProjectPausedState', () => ({ ProjectPausedState: () => null }))
+vi.mock('./PauseFailedState', () => ({ default: () => null }))
+vi.mock('./PausingState', () => ({ default: () => null }))
+vi.mock('./ProductMenuBar', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+vi.mock('./ResizingState', () => ({ default: () => null }))
+vi.mock('./RestartingState', () => ({ default: () => null }))
+vi.mock('./RestoreFailedState', () => ({ default: () => null }))
+vi.mock('./RestoringState', () => ({ default: () => null }))
+vi.mock('./UpgradingState', () => ({ UpgradingState: () => null }))
+
+vi.mock('@/components/interfaces/BranchManagement/CreateBranchModal', () => ({
+  CreateBranchModal: () => null,
+}))
+vi.mock('@/components/interfaces/ProjectAPIDocs/ProjectAPIDocs', () => ({
+  ProjectAPIDocs: () => null,
+}))
+vi.mock('@/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner', () => ({
+  ResourceExhaustionWarningBanner: () => null,
+}))
+
+vi.mock('@/hooks/custom-content/useCustomContent', () => ({
+  useCustomContent: () => ({ appTitle: 'Supabase' }),
+}))
+
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: () => ({
+    data: { name: 'Organization 1', slug: 'org-1' },
+  }),
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({
+    data: {
+      ref: 'default',
+      name: 'Project 1',
+      status: 'ACTIVE_HEALTHY',
+      postgrestStatus: 'ONLINE',
+    },
+  }),
+}))
+
+vi.mock('@/hooks/misc/withAuth', () => ({
+  withAuth: (Component: any) => Component,
+}))
+
+vi.mock('@/hooks/ui/useFlag', () => ({
+  usePHFlag: () => undefined,
+}))
+
+vi.mock('@/state/app-state', () => ({
+  useAppStateSnapshot: () => ({
+    mobileMenuOpen: false,
+    showSidebar: false,
+    setMobileMenuOpen: mockSetMobileMenuOpen,
+  }),
+}))
+
+vi.mock('@/state/database-selector', () => ({
+  useDatabaseSelectorStateSnapshot: () => ({
+    setSelectedDatabaseId: mockSetSelectedDatabaseId,
+  }),
+}))
+
+import { ProjectLayout } from './index'
+
+describe('ProjectLayout title', () => {
+  beforeEach(() => {
+    mockRouter.pathname = '/project/[ref]/observability/query-performance'
+    mockRouter.asPath = '/project/default/observability/query-performance'
+    document.title = ''
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    document.title = ''
+  })
+
+  it('sets a composed document title and deduplicates identical section/surface labels', async () => {
+    render(
+      <ProjectLayout title="Settings" product="Settings" isBlocking={false}>
+        <div>Page Content</div>
+      </ProjectLayout>
+    )
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        ['Settings', 'Project 1', 'Organization 1', 'Supabase'].join(STUDIO_PAGE_TITLE_SEPARATOR)
+      )
+    })
+  })
+
+  it('prefers entity-first browserTitle metadata when provided', async () => {
+    render(
+      <ProjectLayout
+        title="Database"
+        product="Database"
+        browserTitle={{ entity: 'users', section: 'Tables' }}
+        isBlocking={false}
+      >
+        <div>Page Content</div>
+      </ProjectLayout>
+    )
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        ['users', 'Tables', 'Database', 'Project 1', 'Organization 1', 'Supabase'].join(
+          STUDIO_PAGE_TITLE_SEPARATOR
+        )
+      )
+    })
+  })
+})

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -37,6 +37,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { withAuth } from '@/hooks/misc/withAuth'
 import { usePHFlag } from '@/hooks/ui/useFlag'
 import { PROJECT_STATUS } from '@/lib/constants'
+import { buildStudioPageTitle } from '@/lib/page-title'
 import { useAppStateSnapshot } from '@/state/app-state'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
@@ -72,6 +73,13 @@ export interface ProjectLayoutProps {
   isBlocking?: boolean
   product?: string
   productMenu?: ReactNode
+  browserTitle?: {
+    entity?: string
+    section?: string
+    surface?: string
+    override?: string
+  }
+  // Deprecated: use browserTitle.entity instead. Kept for backwards compatibility.
   selectedTable?: string
   resizableSidebar?: boolean
   productMenuClassName?: string
@@ -85,6 +93,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
       isBlocking = true,
       product = '',
       productMenu,
+      browserTitle,
       children,
       selectedTable,
       resizableSidebar = false,
@@ -102,7 +111,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
     const combinedRef = mergeRefs(ref, setMainScrollContainer)
 
     const { appTitle } = useCustomContent(['app:title'])
-    const titleSuffix = appTitle || 'Supabase'
+    const brandTitle = appTitle || 'Supabase'
 
     const isMobile = useIsMobile()
 
@@ -114,6 +123,17 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
 
     const projectName = selectedProject?.name
     const organizationName = selectedOrganization?.name
+    const pageTitle =
+      browserTitle?.override ||
+      buildStudioPageTitle({
+        entity: browserTitle?.entity ?? selectedTable,
+        section: browserTitle?.section ?? title,
+        surface: browserTitle?.surface ?? product,
+        project: projectName,
+        org: organizationName,
+        brand: brandTitle,
+      }) ||
+      brandTitle
 
     const isPaused = selectedProject?.status === PROJECT_STATUS.INACTIVE
 
@@ -127,17 +147,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
     return (
       <>
         <Head>
-          <title>
-            {title
-              ? `${title} | ${titleSuffix}`
-              : selectedTable
-                ? `${selectedTable} | ${projectName} | ${organizationName} | ${titleSuffix}`
-                : projectName
-                  ? `${projectName} | ${organizationName} | ${titleSuffix}`
-                  : organizationName
-                    ? `${organizationName} | ${titleSuffix}`
-                    : titleSuffix}
-          </title>
+          <title>{pageTitle}</title>
           <meta name="description" content="Supabase Studio" />
         </Head>
         <div className="flex flex-row h-full w-full">

--- a/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
+++ b/apps/studio/components/layouts/editors/EditorBaseLayout.tsx
@@ -22,6 +22,7 @@ export const EditorBaseLayout = ({
   product,
   productMenuClassName,
   productMenu,
+  browserTitle,
 }: ExplorerLayoutProps) => {
   const { ref } = useParams()
   const pathname = usePathname()
@@ -33,11 +34,31 @@ export const EditorBaseLayout = ({
   const hideTabs =
     pathname === `/project/${ref}/editor` || pathname === `/project/${ref}/sql` || hasNoOpenTabs
 
+  const activeEditorTab = tabs.activeTab ? tabs.tabsMap[tabs.activeTab] : undefined
+  const activeEditorTabEntity =
+    activeEditorTab === undefined
+      ? undefined
+      : editor === 'sql'
+        ? activeEditorTab.type === 'sql'
+          ? activeEditorTab.metadata?.name || activeEditorTab.label
+          : undefined
+        : editor === 'table'
+          ? activeEditorTab.type !== 'sql'
+            ? activeEditorTab.metadata?.name || activeEditorTab.label
+            : undefined
+          : undefined
+
+  const mergedBrowserTitle = {
+    ...browserTitle,
+    entity: browserTitle?.entity ?? activeEditorTabEntity,
+  }
+
   return (
     <ProjectLayoutWithAuth
       resizableSidebar
       title={title}
       product={product}
+      browserTitle={mergedBrowserTitle}
       productMenuClassName={productMenuClassName}
       productMenu={productMenu}
     >

--- a/apps/studio/lib/page-title.test.ts
+++ b/apps/studio/lib/page-title.test.ts
@@ -11,7 +11,9 @@ describe('buildStudioPageTitle', () => {
         org: 'Acme Org',
         brand: 'Supabase',
       })
-    ).toBe(`Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+    ).toBe(
+      `Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`
+    )
   })
 
   it('includes entity and section when provided', () => {
@@ -36,7 +38,9 @@ describe('buildStudioPageTitle', () => {
         project: 'Acme Project',
         brand: 'Supabase',
       })
-    ).toBe(`Authentication${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+    ).toBe(
+      `Authentication${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`
+    )
   })
 
   it('deduplicates adjacent segments case-insensitively', () => {
@@ -48,7 +52,9 @@ describe('buildStudioPageTitle', () => {
         org: 'Acme Org',
         brand: 'Supabase',
       })
-    ).toBe(`Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+    ).toBe(
+      `Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`
+    )
   })
 
   it('normalizes whitespace in each segment', () => {
@@ -58,7 +64,9 @@ describe('buildStudioPageTitle', () => {
         surface: '  Edge    Functions ',
         brand: ' Supabase ',
       })
-    ).toBe(`hello world${STUDIO_PAGE_TITLE_SEPARATOR}Edge Functions${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+    ).toBe(
+      `hello world${STUDIO_PAGE_TITLE_SEPARATOR}Edge Functions${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`
+    )
   })
 
   it('truncates very long segments', () => {
@@ -84,4 +92,3 @@ describe('buildStudioPageTitle', () => {
     ).toBe(`Settings${STUDIO_PAGE_TITLE_SEPARATOR}Supabase Studio`)
   })
 })
-

--- a/apps/studio/lib/page-title.test.ts
+++ b/apps/studio/lib/page-title.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildStudioPageTitle, STUDIO_PAGE_TITLE_SEPARATOR } from './page-title'
+
+describe('buildStudioPageTitle', () => {
+  it('builds a project-scoped title in most-specific-first order', () => {
+    expect(
+      buildStudioPageTitle({
+        surface: 'Database',
+        project: 'Acme Project',
+        org: 'Acme Org',
+        brand: 'Supabase',
+      })
+    ).toBe(`Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+  })
+
+  it('includes entity and section when provided', () => {
+    expect(
+      buildStudioPageTitle({
+        entity: 'users',
+        section: 'Tables',
+        surface: 'Database',
+        project: 'Acme Project',
+        org: 'Acme Org',
+        brand: 'Supabase',
+      })
+    ).toBe(
+      `users${STUDIO_PAGE_TITLE_SEPARATOR}Tables${STUDIO_PAGE_TITLE_SEPARATOR}Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`
+    )
+  })
+
+  it('omits missing segments', () => {
+    expect(
+      buildStudioPageTitle({
+        section: 'Authentication',
+        project: 'Acme Project',
+        brand: 'Supabase',
+      })
+    ).toBe(`Authentication${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+  })
+
+  it('deduplicates adjacent segments case-insensitively', () => {
+    expect(
+      buildStudioPageTitle({
+        section: 'Database',
+        surface: 'database',
+        project: 'Acme Project',
+        org: 'Acme Org',
+        brand: 'Supabase',
+      })
+    ).toBe(`Database${STUDIO_PAGE_TITLE_SEPARATOR}Acme Project${STUDIO_PAGE_TITLE_SEPARATOR}Acme Org${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+  })
+
+  it('normalizes whitespace in each segment', () => {
+    expect(
+      buildStudioPageTitle({
+        entity: '  hello   world  ',
+        surface: '  Edge    Functions ',
+        brand: ' Supabase ',
+      })
+    ).toBe(`hello world${STUDIO_PAGE_TITLE_SEPARATOR}Edge Functions${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`)
+  })
+
+  it('truncates very long segments', () => {
+    const longName = 'x'.repeat(80)
+
+    expect(
+      buildStudioPageTitle({
+        entity: longName,
+        surface: 'Table Editor',
+        brand: 'Supabase',
+      })
+    ).toBe(
+      `${'x'.repeat(59)}…${STUDIO_PAGE_TITLE_SEPARATOR}Table Editor${STUDIO_PAGE_TITLE_SEPARATOR}Supabase`
+    )
+  })
+
+  it('supports custom brand titles', () => {
+    expect(
+      buildStudioPageTitle({
+        surface: 'Settings',
+        brand: 'Supabase Studio',
+      })
+    ).toBe(`Settings${STUDIO_PAGE_TITLE_SEPARATOR}Supabase Studio`)
+  })
+})
+

--- a/apps/studio/lib/page-title.ts
+++ b/apps/studio/lib/page-title.ts
@@ -21,7 +21,14 @@ const normalizeTitleSegment = (value?: string) => {
 }
 
 export const buildStudioPageTitle = (parts: StudioPageTitleParts) => {
-  const orderedParts = [parts.entity, parts.section, parts.surface, parts.project, parts.org, parts.brand]
+  const orderedParts = [
+    parts.entity,
+    parts.section,
+    parts.surface,
+    parts.project,
+    parts.org,
+    parts.brand,
+  ]
 
   const segments: string[] = []
 
@@ -37,4 +44,3 @@ export const buildStudioPageTitle = (parts: StudioPageTitleParts) => {
 
   return segments.join(STUDIO_PAGE_TITLE_SEPARATOR)
 }
-

--- a/apps/studio/lib/page-title.ts
+++ b/apps/studio/lib/page-title.ts
@@ -1,0 +1,40 @@
+export interface StudioPageTitleParts {
+  entity?: string
+  section?: string
+  surface?: string
+  project?: string
+  org?: string
+  brand?: string
+}
+
+export const STUDIO_PAGE_TITLE_SEPARATOR = ' | '
+const MAX_SEGMENT_LENGTH = 60
+
+const normalizeTitleSegment = (value?: string) => {
+  if (value === undefined) return undefined
+
+  const normalized = value.trim().replace(/\s+/g, ' ')
+  if (normalized.length === 0) return undefined
+
+  if (normalized.length <= MAX_SEGMENT_LENGTH) return normalized
+  return `${normalized.slice(0, MAX_SEGMENT_LENGTH - 1).trimEnd()}…`
+}
+
+export const buildStudioPageTitle = (parts: StudioPageTitleParts) => {
+  const orderedParts = [parts.entity, parts.section, parts.surface, parts.project, parts.org, parts.brand]
+
+  const segments: string[] = []
+
+  orderedParts.forEach((part) => {
+    const segment = normalizeTitleSegment(part)
+    if (!segment) return
+
+    const lastSegment = segments[segments.length - 1]
+    if (lastSegment !== undefined && lastSegment.toLowerCase() === segment.toLowerCase()) return
+
+    segments.push(segment)
+  })
+
+  return segments.join(STUDIO_PAGE_TITLE_SEPARATOR)
+}
+

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -416,157 +416,157 @@ const Wizard: NextPageWithLayout = () => {
       <Form_Shadcn_ {...form}>
         <form onSubmit={form.handleSubmit(onSubmitWithComputeCostsConfirmation)}>
           <Panel
-          loading={!isOrganizationsSuccess}
-          title={
-            <div key="panel-title">
-              <h3>Create a new project</h3>
-              <p className="text-sm text-foreground-lighter text-balance">
-                Your project will have its own dedicated instance and full Postgres database. An API
-                will be set up so you can easily interact with your new database.
-              </p>
-            </div>
-          }
-          footer={
-            <ProjectCreationFooter
-              form={form}
-              canCreateProject={canCreateProject}
-              instanceSize={instanceSize}
-              organizationProjects={organizationProjects}
-              isCreatingNewProject={isCreatingNewProject}
-              isSuccessNewProject={isSuccessNewProject}
-            />
-          }
-        >
-          <>
-            {projectCreationDisabled ? (
-              <DisabledWarningDueToIncident title="Project creation is currently disabled" />
-            ) : (
-              <div className="divide-y divide-border-muted">
-                <OrganizationSelector form={form} />
+            loading={!isOrganizationsSuccess}
+            title={
+              <div key="panel-title">
+                <h3>Create a new project</h3>
+                <p className="text-sm text-foreground-lighter text-balance">
+                  Your project will have its own dedicated instance and full Postgres database. An
+                  API will be set up so you can easily interact with your new database.
+                </p>
+              </div>
+            }
+            footer={
+              <ProjectCreationFooter
+                form={form}
+                canCreateProject={canCreateProject}
+                instanceSize={instanceSize}
+                organizationProjects={organizationProjects}
+                isCreatingNewProject={isCreatingNewProject}
+                isSuccessNewProject={isSuccessNewProject}
+              />
+            }
+          >
+            <>
+              {projectCreationDisabled ? (
+                <DisabledWarningDueToIncident title="Project creation is currently disabled" />
+              ) : (
+                <div className="divide-y divide-border-muted">
+                  <OrganizationSelector form={form} />
 
-                {canCreateProject && (
-                  <>
-                    <ProjectNameInput form={form} />
+                  {canCreateProject && (
+                    <>
+                      <ProjectNameInput form={form} />
 
-                    {cloudProviderEnabled && showNonProdFields && (
-                      <CloudProviderSelector form={form} />
-                    )}
+                      {cloudProviderEnabled && showNonProdFields && (
+                        <CloudProviderSelector form={form} />
+                      )}
 
-                    {canChooseInstanceSize && <ComputeSizeSelector form={form} />}
+                      {canChooseInstanceSize && <ComputeSizeSelector form={form} />}
 
-                    <DatabasePasswordInput form={form} />
+                      <DatabasePasswordInput form={form} />
 
-                    <RegionSelector
-                      form={form}
-                      instanceSize={instanceSize as DesiredInstanceSize}
-                    />
+                      <RegionSelector
+                        form={form}
+                        instanceSize={instanceSize as DesiredInstanceSize}
+                      />
 
-                    {showPostgresVersionSelector && (
-                      <Panel.Content>
-                        <FormField_Shadcn_
-                          control={form.control}
-                          name="postgresVersionSelection"
-                          render={({ field }) => (
-                            <PostgresVersionSelector
-                              field={field}
-                              form={form}
-                              cloudProvider={form.getValues('cloudProvider') as CloudProvider}
-                              organizationSlug={slug}
-                              dbRegion={form.getValues('dbRegion')}
-                            />
-                          )}
+                      {showPostgresVersionSelector && (
+                        <Panel.Content>
+                          <FormField_Shadcn_
+                            control={form.control}
+                            name="postgresVersionSelection"
+                            render={({ field }) => (
+                              <PostgresVersionSelector
+                                field={field}
+                                form={form}
+                                cloudProvider={form.getValues('cloudProvider') as CloudProvider}
+                                organizationSlug={slug}
+                                dbRegion={form.getValues('dbRegion')}
+                              />
+                            )}
+                          />
+                        </Panel.Content>
+                      )}
+
+                      {showNonProdFields && <CustomPostgresVersionInput form={form} />}
+
+                      <SecurityOptions form={form} />
+                      {showAdvancedConfig && !!availableOrioleVersion && (
+                        <AdvancedConfiguration form={form} />
+                      )}
+
+                      {shouldShowFreeProjectInfo ? (
+                        <Admonition
+                          className="rounded-none border-0 border-t"
+                          type="note"
+                          title="Need a free project?"
+                          description={
+                            <p>
+                              You can have up to 2 free projects across all organizations.{' '}
+                              <Link className="underline text-foreground" href="/new">
+                                Create a free organization
+                              </Link>{' '}
+                              to use them.
+                            </p>
+                          }
                         />
-                      </Panel.Content>
-                    )}
+                      ) : null}
+                    </>
+                  )}
 
-                    {showNonProdFields && <CustomPostgresVersionInput form={form} />}
-
-                    <SecurityOptions form={form} />
-                    {showAdvancedConfig && !!availableOrioleVersion && (
-                      <AdvancedConfiguration form={form} />
-                    )}
-
-                    {shouldShowFreeProjectInfo ? (
+                  {freePlanWithExceedingLimits ? (
+                    isAdmin &&
+                    slug && (
+                      <FreeProjectLimitWarning membersExceededLimit={membersExceededLimit || []} />
+                    )
+                  ) : hasOutstandingInvoices ? (
+                    <Panel.Content>
                       <Admonition
-                        className="rounded-none border-0 border-t"
-                        type="note"
-                        title="Need a free project?"
+                        type="default"
+                        title="Your organization has overdue invoices"
                         description={
-                          <p>
-                            You can have up to 2 free projects across all organizations.{' '}
-                            <Link className="underline text-foreground" href="/new">
-                              Create a free organization
-                            </Link>{' '}
-                            to use them.
-                          </p>
+                          <div className="space-y-3">
+                            <p className="text-sm leading-normal">
+                              Please resolve all outstanding invoices first before creating a new
+                              project
+                            </p>
+
+                            <div>
+                              <Button asChild type="default">
+                                <Link href={`/org/${slug}/billing#invoices`}>View invoices</Link>
+                              </Button>
+                            </div>
+                          </div>
                         }
                       />
-                    ) : null}
-                  </>
-                )}
+                    </Panel.Content>
+                  ) : null}
+                </div>
+              )}
+            </>
+          </Panel>
 
-                {freePlanWithExceedingLimits ? (
-                  isAdmin &&
-                  slug && (
-                    <FreeProjectLimitWarning membersExceededLimit={membersExceededLimit || []} />
-                  )
-                ) : hasOutstandingInvoices ? (
-                  <Panel.Content>
-                    <Admonition
-                      type="default"
-                      title="Your organization has overdue invoices"
-                      description={
-                        <div className="space-y-3">
-                          <p className="text-sm leading-normal">
-                            Please resolve all outstanding invoices first before creating a new
-                            project
-                          </p>
-
-                          <div>
-                            <Button asChild type="default">
-                              <Link href={`/org/${slug}/billing#invoices`}>View invoices</Link>
-                            </Button>
-                          </div>
-                        </div>
-                      }
-                    />
-                  </Panel.Content>
-                ) : null}
-              </div>
-            )}
-          </>
-        </Panel>
-
-        <ConfirmationModal
-          size="large"
-          loading={false}
-          visible={isComputeCostsConfirmationModalVisible}
-          title="Confirm compute costs"
-          confirmLabel="I understand"
-          onCancel={() => setIsComputeCostsConfirmationModalVisible(false)}
-          onConfirm={async () => {
-            const values = form.getValues()
-            await onSubmit(values)
-            setIsComputeCostsConfirmationModalVisible(false)
-          }}
-          variant={'warning'}
-        >
-          <div className="text-sm text-foreground-light space-y-1">
-            <p>
-              Launching a project on compute size "{instanceLabel(instanceSize)}" increases your
-              monthly costs by ${additionalMonthlySpend}, independent of how actively you use it. By
-              clicking "I understand", you agree to the additional costs.{' '}
-              <Link
-                href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
-                target="_blank"
-                className="underline"
-              >
-                Compute Costs
-              </Link>{' '}
-              are non-refundable.
-            </p>
-          </div>
-        </ConfirmationModal>
+          <ConfirmationModal
+            size="large"
+            loading={false}
+            visible={isComputeCostsConfirmationModalVisible}
+            title="Confirm compute costs"
+            confirmLabel="I understand"
+            onCancel={() => setIsComputeCostsConfirmationModalVisible(false)}
+            onConfirm={async () => {
+              const values = form.getValues()
+              await onSubmit(values)
+              setIsComputeCostsConfirmationModalVisible(false)
+            }}
+            variant={'warning'}
+          >
+            <div className="text-sm text-foreground-light space-y-1">
+              <p>
+                Launching a project on compute size "{instanceLabel(instanceSize)}" increases your
+                monthly costs by ${additionalMonthlySpend}, independent of how actively you use it.
+                By clicking "I understand", you agree to the additional costs.{' '}
+                <Link
+                  href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
+                  target="_blank"
+                  className="underline"
+                >
+                  Compute Costs
+                </Link>{' '}
+                are non-refundable.
+              </p>
+            </div>
+          </ConfirmationModal>
         </form>
       </Form_Shadcn_>
     </>

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -41,6 +41,7 @@ import {
   useProjectCreateMutation,
 } from 'data/projects/project-create-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -48,9 +49,11 @@ import { useTrackExperimentExposure } from 'hooks/misc/useTrackExperimentExposur
 import { withAuth } from 'hooks/misc/withAuth'
 import { usePHFlag } from 'hooks/ui/useFlag'
 import { DOCS_URL, PROJECT_STATUS, PROVIDERS, useDefaultProvider } from 'lib/constants'
+import { buildStudioPageTitle } from 'lib/page-title'
 import { useProfile } from 'lib/profile'
 import { useTrack } from 'lib/telemetry/track'
 import Link from 'next/link'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -68,8 +71,13 @@ const Wizard: NextPageWithLayout = () => {
   const track = useTrack()
   const router = useRouter()
   const { slug, projectName } = useParams()
+  const { appTitle } = useCustomContent(['app:title'])
   const defaultProvider = useDefaultProvider()
   const { profile } = useProfile()
+  const pageTitle = buildStudioPageTitle({
+    section: 'New Project',
+    brand: appTitle || 'Supabase',
+  })
 
   const { data: currentOrg } = useSelectedOrganizationQuery()
   const rlsExperimentVariant = usePHFlag<'control' | 'test' | false | undefined>(
@@ -399,9 +407,15 @@ const Wizard: NextPageWithLayout = () => {
   )
 
   return (
-    <Form_Shadcn_ {...form}>
-      <form onSubmit={form.handleSubmit(onSubmitWithComputeCostsConfirmation)}>
-        <Panel
+    <>
+      {/* Wizard layouts set the visual header but not the browser tab title. */}
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content="Supabase Studio" />
+      </Head>
+      <Form_Shadcn_ {...form}>
+        <form onSubmit={form.handleSubmit(onSubmitWithComputeCostsConfirmation)}>
+          <Panel
           loading={!isOrganizationsSuccess}
           title={
             <div key="panel-title">
@@ -553,8 +567,9 @@ const Wizard: NextPageWithLayout = () => {
             </p>
           </div>
         </ConfirmationModal>
-      </form>
-    </Form_Shadcn_>
+        </form>
+      </Form_Shadcn_>
+    </>
   )
 }
 

--- a/apps/studio/pages/new/index.tsx
+++ b/apps/studio/pages/new/index.tsx
@@ -1,4 +1,5 @@
 import HCaptcha from '@hcaptcha/react-hcaptcha'
+import Head from 'next/head'
 import { useCallback, useEffect, useState } from 'react'
 
 import { NewOrgForm } from 'components/interfaces/Organization/NewOrg/NewOrgForm'
@@ -6,6 +7,8 @@ import AppLayout from 'components/layouts/AppLayout/AppLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import WizardLayout from 'components/layouts/WizardLayout'
 import { SetupIntentResponse, useSetupIntent } from 'data/stripe/setup-intent-mutation'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
+import { buildStudioPageTitle } from 'lib/page-title'
 import type { NextPageWithLayout } from 'types'
 
 /**
@@ -13,6 +16,11 @@ import type { NextPageWithLayout } from 'types'
  */
 const Wizard: NextPageWithLayout = () => {
   const [intent, setIntent] = useState<SetupIntentResponse>()
+  const { appTitle } = useCustomContent(['app:title'])
+  const pageTitle = buildStudioPageTitle({
+    section: 'New Organization',
+    brand: appTitle || 'Supabase',
+  })
 
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [captchaRef, setCaptchaRef] = useState<HCaptcha | null>(null)
@@ -75,6 +83,11 @@ const Wizard: NextPageWithLayout = () => {
 
   return (
     <>
+      {/* Wizard layouts set the visual header but not the browser tab title. */}
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content="Supabase Studio" />
+      </Head>
       <HCaptcha
         ref={captchaRefCallback}
         sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}

--- a/apps/studio/pages/org/_/[[...routeSlug]].tsx
+++ b/apps/studio/pages/org/_/[[...routeSlug]].tsx
@@ -7,8 +7,11 @@ import { buildOrgUrl } from 'components/interfaces/Organization/Organization.uti
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { withAuth } from 'hooks/misc/withAuth'
+import { buildStudioPageTitle } from 'lib/page-title'
 import { NextPage } from 'next'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { cn } from 'ui'
 
@@ -16,6 +19,7 @@ import { OrganizationCard } from '@/components/interfaces/Organization/Organizat
 
 const GenericOrganizationPage: NextPage = () => {
   const router = useRouter()
+  const { appTitle } = useCustomContent(['app:title'])
   const { routeSlug, ...queryParams } = router.query
   const queryString =
     Object.keys(queryParams).length > 0
@@ -23,9 +27,18 @@ const GenericOrganizationPage: NextPage = () => {
       : ''
 
   const { data: organizations, isPending: isLoading } = useOrganizationsQuery()
+  const pageTitle = buildStudioPageTitle({
+    section: 'Select an organization',
+    surface: 'Organizations',
+    brand: appTitle || 'Supabase',
+  })
 
   return (
     <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content="Supabase Studio" />
+      </Head>
       <Header />
       <PageLayout className="flex-grow min-h-0" title="Select an organization to continue">
         <ScaffoldContainer>

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -1,5 +1,6 @@
 import { Plus, Search } from 'lucide-react'
 import Link from 'next/link'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
@@ -13,8 +14,10 @@ import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import AlertError from 'components/ui/AlertError'
 import { NoSearchResults } from 'components/ui/NoSearchResults'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { withAuth } from 'hooks/misc/withAuth'
+import { buildStudioPageTitle } from 'lib/page-title'
 import type { NextPageWithLayout } from 'types'
 import { Button, Skeleton } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
@@ -22,9 +25,14 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 
 const OrganizationsPage: NextPageWithLayout = () => {
   const router = useRouter()
+  const { appTitle } = useCustomContent(['app:title'])
   const [search, setSearch] = useState('')
   const { error: orgNotFoundError, org: orgSlug } = useParams()
   const orgNotFound = orgNotFoundError === 'org_not_found'
+  const pageTitle = buildStudioPageTitle({
+    section: 'Your Organizations',
+    brand: appTitle || 'Supabase',
+  })
 
   const {
     data: organizations = [],
@@ -51,63 +59,69 @@ const OrganizationsPage: NextPageWithLayout = () => {
   }, [isSuccess, organizations])
 
   return (
-    <ScaffoldContainer>
-      <ScaffoldSection isFullWidth className="flex flex-col gap-y-4">
-        {orgNotFound && (
-          <Admonition
-            type="destructive"
-            title="Organization not found"
-            description={
-              <>
-                The organization <code className="text-code-inline">{orgSlug}</code> does not exist
-                or you do not have permission to access to it. Contact the the owner if you believe
-                this is a mistake.
-              </>
-            }
-          />
-        )}
-
-        {organizations.length > 0 && (
-          <div className="flex items-center justify-between gap-x-2 md:gap-x-3">
-            <Input
-              size="tiny"
-              placeholder="Search for an organization"
-              icon={<Search />}
-              className="w-full flex-1 md:w-64"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content="Supabase Studio" />
+      </Head>
+      <ScaffoldContainer>
+        <ScaffoldSection isFullWidth className="flex flex-col gap-y-4">
+          {orgNotFound && (
+            <Admonition
+              type="destructive"
+              title="Organization not found"
+              description={
+                <>
+                  The organization <code className="text-code-inline">{orgSlug}</code> does not
+                  exist or you do not have permission to access to it. Contact the the owner if you
+                  believe this is a mistake.
+                </>
+              }
             />
-
-            {organizationCreationEnabled && (
-              <Button asChild icon={<Plus />} type="primary" className="w-min">
-                <Link href={`/new`}>New organization</Link>
-              </Button>
-            )}
-          </div>
-        )}
-
-        {isSuccess && organizations.length === 0 && !isError && <NoOrganizationsState />}
-
-        {search.length > 0 && filteredOrganizations.length === 0 && (
-          <NoSearchResults searchString={search} />
-        )}
-
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {isLoading && (
-            <>
-              <Skeleton className="h-[70px] rounded-md" />
-              <Skeleton className="h-[70px] rounded-md" />
-              <Skeleton className="h-[70px] rounded-md" />
-            </>
           )}
-          {isError && <AlertError error={error} subject="Failed to load organizations" />}
-          {isSuccess &&
-            filteredOrganizations.map((org) => (
-              <OrganizationCard key={org.id} organization={org} />
-            ))}
-        </div>
-      </ScaffoldSection>
-    </ScaffoldContainer>
+
+          {organizations.length > 0 && (
+            <div className="flex items-center justify-between gap-x-2 md:gap-x-3">
+              <Input
+                size="tiny"
+                placeholder="Search for an organization"
+                icon={<Search />}
+                className="w-full flex-1 md:w-64"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+              />
+
+              {organizationCreationEnabled && (
+                <Button asChild icon={<Plus />} type="primary" className="w-min">
+                  <Link href={`/new`}>New organization</Link>
+                </Button>
+              )}
+            </div>
+          )}
+
+          {isSuccess && organizations.length === 0 && !isError && <NoOrganizationsState />}
+
+          {search.length > 0 && filteredOrganizations.length === 0 && (
+            <NoSearchResults searchString={search} />
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {isLoading && (
+              <>
+                <Skeleton className="h-[70px] rounded-md" />
+                <Skeleton className="h-[70px] rounded-md" />
+                <Skeleton className="h-[70px] rounded-md" />
+              </>
+            )}
+            {isError && <AlertError error={error} subject="Failed to load organizations" />}
+            {isSuccess &&
+              filteredOrganizations.map((org) => (
+                <OrganizationCard key={org.id} organization={org} />
+              ))}
+          </div>
+        </ScaffoldSection>
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/logs/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/index.tsx
@@ -24,7 +24,7 @@ export const LogPage: NextPageWithLayout = () => {
   if (isUnifiedLogsEnabled) {
     return (
       <DefaultLayout>
-        <ProjectLayout>
+        <ProjectLayout title="Unified Logs" product="Logs & Analytics">
           <UnifiedLogs />
         </ProjectLayout>
       </DefaultLayout>

--- a/apps/studio/pages/project/[ref]/logs/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/index.tsx
@@ -24,7 +24,8 @@ export const LogPage: NextPageWithLayout = () => {
   if (isUnifiedLogsEnabled) {
     return (
       <DefaultLayout>
-        <ProjectLayout title="Unified Logs" product="Logs & Analytics">
+        {/* Omit the generic product segment here; project/org context already makes the route clear. */}
+        <ProjectLayout title="Unified Logs">
           <UnifiedLogs />
         </ProjectLayout>
       </DefaultLayout>

--- a/apps/studio/pages/project/[ref]/logs/pg-upgrade-logs.tsx
+++ b/apps/studio/pages/project/[ref]/logs/pg-upgrade-logs.tsx
@@ -11,7 +11,7 @@ export const LogPage: NextPageWithLayout = () => {
 
 LogPage.getLayout = (page) => (
   <DefaultLayout>
-    <LogsLayout title="Database">{page}</LogsLayout>
+    <LogsLayout title="Postgres Version Upgrade">{page}</LogsLayout>
   </DefaultLayout>
 )
 

--- a/apps/studio/pages/project/[ref]/observability/query-performance.tsx
+++ b/apps/studio/pages/project/[ref]/observability/query-performance.tsx
@@ -127,7 +127,7 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
 
 QueryPerformanceReport.getLayout = (page) => (
   <DefaultLayout>
-    <ObservabilityLayout title="Query performance">{page}</ObservabilityLayout>
+    <ObservabilityLayout title="Query Performance">{page}</ObservabilityLayout>
   </DefaultLayout>
 )
 


### PR DESCRIPTION
_Closed in favour of stacked PRs starting with #43538._

---

## What is the current behavior?

Page titles between surfaces are inconsistent and vague. Sometimes they say the product name:

```
My Project | My Org | Supabase
```

...even when on a specific surface like Database > Tables.

Other times they show the entity name but skip over the project or org name :

```
Edge Functions | Supabase
```

## What is the new behavior?

Page titles all follow the same format:
```
users | Table Editor | My Project | My Org | Supabase
hello-world | Logs | Edge Functions | My Project | My Org | Supabase
Backups | Database | My Project | My Org | Supabase
Authentication | My Project | My Org | Supabase
```

That format is:

entity, section, surface, project, org, brand