### PR TITLE
Remove org slug and project ref filter for GET notifications request

### DIFF
--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
@@ -1,15 +1,45 @@
-import { Lightbulb } from 'lucide-react'
+import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useProjectLintsQuery } from 'data/lint/lint-query'
+import { Lightbulb } from 'lucide-react'
+import { useMemo } from 'react'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
-import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { cn } from 'ui'
+
+import { useNotificationsV2Query } from '@/data/notifications/notifications-v2-query'
+import { useAdvisorStateSnapshot } from '@/state/advisor-state'
 
 export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
   const { toggleSidebar, activeSidebar } = useSidebarManagerSnapshot()
-  const { data: lints } = useProjectLintsQuery({ projectRef })
+  const { notificationFilterStatuses, notificationFilterPriorities } = useAdvisorStateSnapshot()
 
+  const notificationStatus = useMemo(() => {
+    if (notificationFilterStatuses.includes('archived')) {
+      return 'archived'
+    }
+    if (notificationFilterStatuses.includes('unread')) {
+      return 'new'
+    }
+    return undefined
+  }, [notificationFilterStatuses])
+
+  const notificationFilters = useMemo(
+    () => ({ priority: notificationFilterPriorities }),
+    [notificationFilterPriorities]
+  )
+
+  const { data: lints } = useProjectLintsQuery({ projectRef })
   const hasCriticalIssues = Array.isArray(lints) && lints.some((lint) => lint.level === 'ERROR')
+
+  const { data: notificationsData } = useNotificationsV2Query({
+    status: notificationStatus,
+    filters: notificationFilters,
+    limit: 20,
+  })
+  const notifications = useMemo(() => {
+    return notificationsData?.pages.flatMap((page) => page) ?? []
+  }, [notificationsData?.pages])
+  const hasUnreadNotifications = notifications.some((x) => x.status === 'new')
 
   const isOpen = activeSidebar?.id === SIDEBAR_KEYS.ADVISOR_PANEL
 
@@ -43,9 +73,11 @@ export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
           )}
         />
       </ButtonTooltip>
-      {hasCriticalIssues && (
+      {hasCriticalIssues ? (
         <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-destructive" />
-      )}
+      ) : hasUnreadNotifications ? (
+        <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-brand" />
+      ) : null}
     </div>
   )
 }

--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
@@ -7,33 +7,16 @@ import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { cn } from 'ui'
 
 import { useNotificationsV2Query } from '@/data/notifications/notifications-v2-query'
-import { useAdvisorStateSnapshot } from '@/state/advisor-state'
 
 export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
   const { toggleSidebar, activeSidebar } = useSidebarManagerSnapshot()
-  const { notificationFilterStatuses, notificationFilterPriorities } = useAdvisorStateSnapshot()
-
-  const notificationStatus = useMemo(() => {
-    if (notificationFilterStatuses.includes('archived')) {
-      return 'archived'
-    }
-    if (notificationFilterStatuses.includes('unread')) {
-      return 'new'
-    }
-    return undefined
-  }, [notificationFilterStatuses])
-
-  const notificationFilters = useMemo(
-    () => ({ priority: notificationFilterPriorities }),
-    [notificationFilterPriorities]
-  )
 
   const { data: lints } = useProjectLintsQuery({ projectRef })
   const hasCriticalIssues = Array.isArray(lints) && lints.some((lint) => lint.level === 'ERROR')
 
   const { data: notificationsData } = useNotificationsV2Query({
-    status: notificationStatus,
-    filters: notificationFilters,
+    status: 'new',
+    filters: {},
     limit: 20,
   })
   const notifications = useMemo(() => {

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
@@ -1,6 +1,3 @@
-import dayjs from 'dayjs'
-import { useMemo, useRef } from 'react'
-
 import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { Lint, useProjectLintsQuery } from 'data/lint/lint-query'
 import {
@@ -9,12 +6,15 @@ import {
   useNotificationsV2Query,
 } from 'data/notifications/notifications-v2-query'
 import { useNotificationsV2UpdateMutation } from 'data/notifications/notifications-v2-update-mutation'
+import dayjs from 'dayjs'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from 'lib/constants'
 import { useTrack } from 'lib/telemetry/track'
+import { useMemo, useRef } from 'react'
 import { AdvisorSeverity, AdvisorTab, useAdvisorStateSnapshot } from 'state/advisor-state'
 import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
+
 import { AdvisorDetail } from './AdvisorDetail'
 import { AdvisorFilters } from './AdvisorFilters'
 import type { AdvisorItem } from './AdvisorPanel.types'
@@ -98,12 +98,8 @@ export const AdvisorPanel = () => {
   // Memoize filters to prevent query key changes on every render
   // Use selected organization and project if they exist
   const notificationFilters = useMemo(
-    () => ({
-      priority: notificationFilterPriorities,
-      organizations: selectedOrganization?.slug ? [selectedOrganization.slug] : [],
-      projects: project?.ref ? [project.ref] : [],
-    }),
-    [notificationFilterPriorities, selectedOrganization?.slug, project?.ref]
+    () => ({ priority: notificationFilterPriorities }),
+    [notificationFilterPriorities]
   )
 
   const {

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
@@ -7,7 +7,6 @@ import {
 } from 'data/notifications/notifications-v2-query'
 import { useNotificationsV2UpdateMutation } from 'data/notifications/notifications-v2-update-mutation'
 import dayjs from 'dayjs'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from 'lib/constants'
 import { useTrack } from 'lib/telemetry/track'
@@ -66,7 +65,6 @@ export const AdvisorPanel = () => {
     resetNotificationFilters,
   } = useAdvisorStateSnapshot()
   const { data: project } = useSelectedProjectQuery()
-  const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const { activeSidebar, closeSidebar } = useSidebarManagerSnapshot()
 
   const isSidebarOpen = activeSidebar?.id === SIDEBAR_KEYS.ADVISOR_PANEL

--- a/apps/studio/data/notifications/notifications-v2-query.ts
+++ b/apps/studio/data/notifications/notifications-v2-query.ts
@@ -1,8 +1,8 @@
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
-import { get, handleError } from 'data/fetchers'
-
 import type { components } from 'data/api'
+import { get, handleError } from 'data/fetchers'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
+
 import { notificationKeys } from './keys'
 
 const NOTIFICATIONS_PAGE_LIMIT = 10
@@ -12,9 +12,9 @@ export type NotificationVariables = {
   limit?: number
   status?: 'new' | 'seen' | 'archived'
   filters: {
-    priority: readonly string[]
-    organizations: readonly string[]
-    projects: readonly string[]
+    priority?: readonly string[]
+    organizations?: readonly string[]
+    projects?: readonly string[]
   }
 }
 
@@ -37,16 +37,17 @@ export type NotificationData = {
 
 export async function getNotifications(options: NotificationVariables, signal?: AbortSignal) {
   const { status, filters, page = 0, limit = NOTIFICATIONS_PAGE_LIMIT } = options
+  const { priority = [], organizations = [], projects = [] } = filters
+
   const { data, error } = await get('/platform/notifications', {
     params: {
       query: {
         offset: page * limit,
         limit,
-        // [Alaister]: 'as any' is needed because the API types don't reflect an array of strings
-        ...(status !== undefined ? { status } : { status: ['new', 'seen'].join(',') as any }),
-        ...(filters.priority.length > 0 ? { priority: filters.priority.join(',') as any } : {}),
-        ...(filters.organizations.length > 0 ? { org_slug: filters.organizations.join(',') } : {}),
-        ...(filters.projects.length > 0 ? { project_ref: filters.projects.join(',') } : {}),
+        ...(status !== undefined ? { status } : { status: ['new', 'seen'].join(',') }),
+        ...(priority.length > 0 ? { priority: priority.join(',') } : {}),
+        ...(organizations.length > 0 ? { org_slug: organizations.join(',') } : {}),
+        ...(projects.length > 0 ? { project_ref: projects.join(',') } : {}),
       },
     },
     headers: { Version: '2' },


### PR DESCRIPTION
## Context

Since moving notifications to the Advisors Panel, we've been sending `org_slug` and `project_ref` to the GET notifications endpoint, which resulted in certain notifications not being returned such as those that are user specific (no org slug nor project ref)

Am opting to remove both slug and ref filters for the notifications as the notifications should be on a user level (irregardless if you're within a project or not) - the Advisor's Panel's button in the layout header would also suggest that notifications in there are not tied to an org or project

## To test

This one's a bit tricky to test unless you have notifications on staging, but i've double checked on prod with a curl command that removing the org slug and project ref filters returns the correct notifications