### PR TITLE
chore: split tests running from coveralls upload

### DIFF
--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -56,6 +56,12 @@ jobs:
         run: pnpm run test:ci
         working-directory: ./apps/studio
 
+  upload-coverage:
+    needs: test
+    if: ${{ always() && needs.test.result == 'success' }}
+    continue-on-error: true
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
@@ -67,8 +73,9 @@ jobs:
           fail-on-error: false
 
   finish:
-    needs: test
+    needs: [test, upload-coverage]
     if: ${{ always() }}
+    continue-on-error: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Coveralls Finished

--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -55,31 +55,29 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=3072'
         run: pnpm run test:ci
         working-directory: ./apps/studio
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: studio-coverage
+          path: ./apps/studio/coverage/lcov.info
+          retention-days: 1
 
-  upload-coverage:
+  coveralls:
     needs: test
     if: ${{ always() && needs.test.result == 'success' }}
     continue-on-error: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: studio-coverage
+          path: ./coverage
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
-          parallel: true
           flag-name: studio-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./apps/studio/coverage/lcov.info
+          path-to-lcov: ./coverage/lcov.info
           base-path: './apps/studio'
           fail-on-error: false
-
-  finish:
-    needs: [test, upload-coverage]
-    if: ${{ always() }}
-    continue-on-error: true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        with:
-          parallel-finished: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -45,6 +45,12 @@ jobs:
         run: pnpm run test:ci
         working-directory: ./packages/ui
 
+  upload-coverage:
+    needs: test
+    if: ${{ always() && needs.test.result == 'success' }}
+    continue-on-error: true
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
@@ -53,10 +59,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/ui/coverage/lcov.info
           base-path: './packages/ui'
+          fail-on-error: false
 
   finish:
-    needs: test
+    needs: [test, upload-coverage]
     if: ${{ always() }}
+    continue-on-error: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Coveralls Finished

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -44,31 +44,29 @@ jobs:
       - name: Run tests
         run: pnpm run test:ci
         working-directory: ./packages/ui
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ui-coverage
+          path: ./packages/ui/coverage/lcov.info
+          retention-days: 1
 
-  upload-coverage:
+  coveralls:
     needs: test
     if: ${{ always() && needs.test.result == 'success' }}
     continue-on-error: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ui-coverage
+          path: ./coverage
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
-          parallel: true
           flag-name: ui-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./packages/ui/coverage/lcov.info
+          path-to-lcov: ./coverage/lcov.info
           base-path: './packages/ui'
           fail-on-error: false
-
-  finish:
-    needs: [test, upload-coverage]
-    if: ${{ always() }}
-    continue-on-error: true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        with:
-          parallel-finished: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/studio/components/interfaces/Reports/Reports.utils.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.test.ts
@@ -1,3 +1,4 @@
+// @see studio-unit-tests.yml
 import { describe, it, expect } from 'vitest'
 import { formatTimestamp } from './Reports.utils'
 import dayjs from 'dayjs'


### PR DESCRIPTION
this is so we can easily tell when tests failed vs when coveralls failed in the PR checks / github action breakdown.

<img width="1510" height="316" alt="CleanShot 2026-02-25 at 11 28 00@2x" src="https://github.com/user-attachments/assets/ed119654-0341-4554-a2a1-e95f4c7a0995" />
