### PR TITLE
chore: remove steal fallback from debuggableNavigatorLock

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -147,32 +147,10 @@ async function debuggableNavigatorLock<R>(
       }
 
       console.error(
-        `Waited for over 10s to acquire an Auth client lock, will steal the lock to unblock`,
+        `Waited for over 10s to acquire an Auth client lock`,
         await navigator.locks.query(),
         stackException
       )
-
-      // quickly steal the lock and release it so that others can acquire it,
-      // while leaving the code that was holding it to continue running
-      navigator.locks
-        .request(
-          name,
-          {
-            steal: true,
-          },
-          async () => {
-            await new Promise((accept) => {
-              setTimeout(accept, 0)
-            })
-
-            console.error('Lock was stolen and now released', stackException)
-          }
-        )
-        .catch((e: any) => {
-          if (captureException) {
-            captureException(e)
-          }
-        })
     })()
   }, 10000)
 


### PR DESCRIPTION
The SDK now handles orphaned lock recovery via steal internally (supabase-js#2106). Keep the BroadcastChannel observability wrapper for Sentry signals. The steal-based orphaned lock recovery in `debuggableNavigatorLock` (packages/common/gotrue.ts) (introduced in https://github.com/supabase/supabase/pull/39868) is now redundant, supabase-js#2106 handles this natively in the SDK.

Removes the `navigator.locks.request({ steal: true })` block while keeping the BroadcastChannel wrapper that sends lock-holder stack traces to Sentry.

Related: supabase/supabase-js#2106, supabase/supabase-js#2125