### PR TITLE
Speed CI e2e tests by avoiding reseting the database

### DIFF
--- a/apps/studio/.env
+++ b/apps/studio/.env
@@ -28,4 +28,3 @@ DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 
 # Required to manage edge-functions via dashboard on Self-Hosting
 # EDGE_FUNCTIONS_MANAGEMENT_FOLDER=/path-where-edge-functions-are-mounted
-#

--- a/apps/studio/.env
+++ b/apps/studio/.env
@@ -28,3 +28,4 @@ DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 
 # Required to manage edge-functions via dashboard on Self-Hosting
 # EDGE_FUNCTIONS_MANAGEMENT_FOLDER=/path-where-edge-functions-are-mounted
+#

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:ui-patterns": "turbo run test --filter=ui-patterns",
     "test:studio": "turbo run test --filter=studio",
     "test:studio:watch": "turbo run test --filter=studio -- watch",
-    "e2e:setup:cli": "supabase stop --all --no-backup ; supabase start --exclude studio && supabase db reset && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
+    "e2e:setup:cli": "supabase stop --all --no-backup ; supabase start --exclude studio && if [ -z \"${CI}\" ]; then supabase db reset; fi && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
     "e2e:setup:selfhosted": "SKIP_ASSET_UPLOAD=1 pnpm e2e:setup:cli && NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm run build:studio && NODE_ENV=test pnpm --prefix ./apps/studio start",
     "e2e:setup:platform": "SKIP_ASSET_UPLOAD=1 NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm run build:studio && pnpm --prefix ./apps/studio start",
     "e2e": "pnpm --prefix e2e/studio run e2e",
@@ -65,6 +65,13 @@
     "pnpm": "10.24",
     "node": ">=22"
   },
-  "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
+  "keywords": [
+    "postgres",
+    "firebase",
+    "storage",
+    "functions",
+    "database",
+    "auth"
+  ],
   "packageManager": "pnpm@10.24.0"
 }


### PR DESCRIPTION
## Problem

We currently initialise a local Supabase instance first (which apply migrations) and then reset it. Although that makes sense in a local development environment, it doesn't for CI as the instance will be completely new.

## Solution

Add a condition to avoid reseting the database when the `CI` environment variable isn't set.

## How to test

### Locally

Run the following command on your machine:
```
pnpm run e2e:setup:cli
```

You should see the migrations being applied twice if the local instance wasn't running yet.

### In CI

The _Selfhosted Studio E2E Tests_ job in this PR checks should only apply the migrations once