### PR TITLE
fix(studio): table padding on auth overview tables

### DIFF
--- a/apps/studio/components/interfaces/Auth/Overview/OverviewMetrics.tsx
+++ b/apps/studio/components/interfaces/Auth/Overview/OverviewMetrics.tsx
@@ -289,7 +289,7 @@ export const OverviewMetrics = ({ metrics, isLoading, error }: OverviewMetricsPr
                   <ChartTitle>Auth API Errors</ChartTitle>
                 </ChartHeader>
                 <ChartContent
-                  className="p-0"
+                  className="!p-0"
                   isEmpty={responseErrors.length === 0}
                   emptyState={
                     <div className="p-6">
@@ -372,7 +372,7 @@ export const OverviewMetrics = ({ metrics, isLoading, error }: OverviewMetricsPr
                   <ChartActions actions={errorCodesActions} />
                 </ChartHeader>
                 <ChartContent
-                  className="p-0"
+                  className="!p-0"
                   isEmpty={errorCodes.length === 0}
                   emptyState={
                     <div className="p-6">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Very smol fix. Think a recent fix to chart/card padding bodged it, easy fix for now.

| Before | After |
|--------|--------|
| <img width="888" height="313" alt="Screenshot 2026-02-25 at 14 08 33" src="https://github.com/user-attachments/assets/875e3c5e-74c8-414d-a636-8ce4c67dea20" /> | <img width="875" height="260" alt="Screenshot 2026-02-25 at 14 08 55" src="https://github.com/user-attachments/assets/6e2e1214-d91f-4364-9fcf-a7cc5deb390d" /> |


