### PR TITLE
Tiny fix for notifications red dot

### DIFF
--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
@@ -14,7 +14,6 @@ export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
   const { data: lints } = useProjectLintsQuery({ projectRef })
 
   const { data: notificationsData } = useNotificationsV2Query({
-    status: undefined,
     filters: {},
     limit: 20,
   })

--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
@@ -14,7 +14,7 @@ export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
   const { data: lints } = useProjectLintsQuery({ projectRef })
 
   const { data: notificationsData } = useNotificationsV2Query({
-    status: 'new',
+    status: undefined,
     filters: {},
     limit: 20,
   })


### PR DESCRIPTION
## Context

Should've removed the `status` prop when fetching notifications in `AdvisorButton` for a more accurate indication of `hasCriticalNotifications` as we should show that dot for read critical notifications too (not just new)