### PR TITLE
fix: custom report gets stuck block after deleting sql snippet

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -63,8 +63,8 @@ export const ReportBlock = ({
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchIntervalInBackground: false,
-      retry: (failureCount: number) => {
-        if (failureCount >= 2) return false
+      retry: (failureCount: number, error) => {
+        if (error.code === 404 || failureCount >= 2) return false
         return true
       },
     }

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -151,7 +151,7 @@ export const ReportBlock = ({
                 ? String(executeSqlError)
                 : undefined
           }
-          isExecuting={executeSqlLoading}
+          isExecuting={!contentError && executeSqlLoading}
           isWriteQuery={isWriteQuery}
           actions={
             <ButtonTooltip

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -154,15 +154,13 @@ export const ReportBlock = ({
           isExecuting={executeSqlLoading}
           isWriteQuery={isWriteQuery}
           actions={
-            !isLoadingContent && (
-              <ButtonTooltip
-                type="text"
-                icon={<X />}
-                className="w-7 h-7"
-                onClick={() => onRemoveChart({ metric: { key: item.attribute } })}
-                tooltip={{ content: { side: 'bottom', text: 'Remove chart' } }}
-              />
-            )
+            <ButtonTooltip
+              type="text"
+              icon={<X />}
+              className="w-7 h-7"
+              onClick={() => onRemoveChart({ metric: { key: item.attribute } })}
+              tooltip={{ content: { side: 'bottom', text: 'Remove chart' } }}
+            />
           }
           onExecute={(queryType) => {
             refetch()

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -167,7 +167,8 @@ export const QueryBlock = ({
                   chartConfig={chartSettings}
                   columns={Object.keys(results?.[0] ?? {})}
                   changeView={(nextView) => {
-                    if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: { view: nextView } })
+                    if (onUpdateChartConfig)
+                      onUpdateChartConfig({ chartConfig: { view: nextView } })
                     setChartSettings({ ...chartSettings, view: nextView })
                   }}
                   updateChartConfig={(config) => {

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -146,59 +146,61 @@ export const QueryBlock = ({
       label={label}
       badge={isWriteQuery && <Badge variant="warning">Write</Badge>}
       actions={
-        disabled ? null : (
-          <>
-            <ButtonTooltip
-              type="text"
-              size="tiny"
-              className="w-7 h-7"
-              icon={<Code size={14} strokeWidth={1.5} />}
-              onClick={() => setShowSql(!showSql)}
-              tooltip={{
-                content: { side: 'bottom', text: showSql ? 'Hide query' : 'Show query' },
-              }}
-            />
-            {hasResults && (
-              <BlockViewConfiguration
-                view={view}
-                isChart={view === 'chart'}
-                lockColumns={false}
-                chartConfig={chartSettings}
-                columns={Object.keys(results?.[0] ?? {})}
-                changeView={(nextView) => {
-                  if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: { view: nextView } })
-                  setChartSettings({ ...chartSettings, view: nextView })
-                }}
-                updateChartConfig={(config) => {
-                  if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: config })
-                  setChartSettings(config)
+        <>
+          {!disabled && (
+            <>
+              <ButtonTooltip
+                type="text"
+                size="tiny"
+                className="w-7 h-7"
+                icon={<Code size={14} strokeWidth={1.5} />}
+                onClick={() => setShowSql(!showSql)}
+                tooltip={{
+                  content: { side: 'bottom', text: showSql ? 'Hide query' : 'Show query' },
                 }}
               />
-            )}
+              {hasResults && (
+                <BlockViewConfiguration
+                  view={view}
+                  isChart={view === 'chart'}
+                  lockColumns={false}
+                  chartConfig={chartSettings}
+                  columns={Object.keys(results?.[0] ?? {})}
+                  changeView={(nextView) => {
+                    if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: { view: nextView } })
+                    setChartSettings({ ...chartSettings, view: nextView })
+                  }}
+                  updateChartConfig={(config) => {
+                    if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: config })
+                    setChartSettings(config)
+                  }}
+                />
+              )}
 
-            <EditQueryButton id={id} title={label} sql={sql} />
-            <ButtonTooltip
-              type="text"
-              size="tiny"
-              className="w-7 h-7"
-              icon={<Play size={14} strokeWidth={1.5} />}
-              loading={isExecuting}
-              disabled={isExecuting || disabled || !sql}
-              onClick={runSelect}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  className: 'max-w-56 text-center',
-                  text: isExecuting
-                    ? 'Query is running. Check the SQL Editor to manage running queries.'
-                    : 'Run query',
-                },
-              }}
-            />
+              <EditQueryButton id={id} title={label} sql={sql} />
+              <ButtonTooltip
+                type="text"
+                size="tiny"
+                className="w-7 h-7"
+                icon={<Play size={14} strokeWidth={1.5} />}
+                loading={isExecuting}
+                disabled={isExecuting || disabled || !sql}
+                onClick={runSelect}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    className: 'max-w-56 text-center',
+                    text: isExecuting
+                      ? 'Query is running. Check the SQL Editor to manage running queries.'
+                      : 'Run query',
+                  },
+                }}
+              />
+            </>
+          )}
 
-            {actions}
-          </>
-        )
+          {actions}
+        </>
       }
     >
       {!!showWarning && !blockWriteQueries && (


### PR DESCRIPTION
- Deleted SQL Snippets leave a hanging block that loads forever in custom reports, and its not possible to delete them. 
- Now you can delete blocks if they get stuck loading
- Also shows correct error state when a block couldn't load because the sql snippet was removed
## before
- stuck forever 
<img width="1296" height="936" alt="CleanShot 2026-02-26 at 13 23 25@2x" src="https://github.com/user-attachments/assets/bb65cc5f-c2a4-4027-876e-db9682ec6f3c" />

## after
- show error state
- allow user to delete snippet
<img width="1388" height="862" alt="CleanShot 2026-02-26 at 13 23 45@2x" src="https://github.com/user-attachments/assets/c5d6c114-071b-4e4d-a913-25b3c788db95" />
