### PR TITLE
Add .mdx raw API and copy-as-markdown feature

### DIFF
--- a/apps/docs/app/api/guides/raw/[[...slug]]/route.ts
+++ b/apps/docs/app/api/guides/raw/[[...slug]]/route.ts
@@ -1,0 +1,49 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { mdxToMarkdown } from '~/features/docs/GuidesMdx.mdxToMarkdown'
+import { getGuidesMarkdown } from '~/features/docs/GuidesMdx.utils'
+
+/**
+ * Returns the preprocessed Markdown source for a guide page.
+ *
+ * Accessed by appending `.mdx` to any guide URL:
+ *   /docs/guides/auth/users  →  /docs/guides/auth/users.mdx
+ *
+ * The rewrite in next.config.mjs maps:
+ *   /guides/:path*.mdx  →  /api/guides/raw/:path*
+ *
+ * The content returned is the same preprocessed Markdown that the page
+ * renders from: partials are expanded, GitHub code samples are inlined,
+ * and directives are resolved — but it has NOT been compiled to HTML.
+ * This makes it useful for LLMs and "copy as Markdown" tooling.
+ *
+ * All access control checks (published sections, disabled pages) are
+ * enforced by `getGuidesMarkdown`, which calls `notFound()` for any
+ * path that should not be publicly accessible.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug?: string[] }> }
+) {
+  const { slug } = await params
+
+  if (!slug?.length) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  // Reuses all existing security + navigation checks.
+  // Calls notFound() (→ 404) for invalid paths, unpublished sections,
+  // and disabled pages.
+  const data = await getGuidesMarkdown(slug)
+  const rawContent = data.meta.title
+    ? `# ${data.meta.title}\n\n${data.content}`
+    : data.content
+  const body = mdxToMarkdown(rawContent)
+
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  })
+}

--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { usePathname } from 'next/navigation'
 import { isFeatureEnabled } from 'common'
 import { cn } from 'ui'
@@ -15,7 +16,15 @@ interface TOCHeader {
   level: number
 }
 
-const GuidesTableOfContents = ({ className, video }: { className?: string; video?: string }) => {
+const GuidesTableOfContents = ({
+  className,
+  video,
+  children,
+}: {
+  className?: string
+  video?: string
+  children?: React.ReactNode
+}) => {
   const pathname = usePathname()
   const { toc } = useTocAnchors()
 
@@ -46,6 +55,7 @@ const GuidesTableOfContents = ({ className, video }: { className?: string; video
             </TOCScrollArea>
           </Toc>
         )}
+        {children && <div className="pl-5">{children}</div>}
       </div>
     </div>
   )

--- a/apps/docs/features/docs/CopyMarkdownButton.client.tsx
+++ b/apps/docs/features/docs/CopyMarkdownButton.client.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+
+import { cn } from 'ui'
+
+type CopyState = 'idle' | 'fetching' | 'copied' | 'error'
+
+interface CopyMarkdownButtonProps {
+  /**
+   * The URL that serves the raw Markdown for this page.
+   * Constructed by the server as `${BASE_PATH}${pathname}.mdx`.
+   * Kept as a prop so the server component controls the URL and the
+   * client component stays a pure, testable function of its inputs.
+   */
+  markdownUrl: string
+}
+
+/**
+ * Fetches a page's Markdown from `markdownUrl` and copies it to the
+ * clipboard. The URL is the `.mdx` variant of the current guide page,
+ * so the button and the URL feature share exactly one code path.
+ */
+export function CopyMarkdownButton({ markdownUrl }: CopyMarkdownButtonProps) {
+  const [state, setState] = useState<CopyState>('idle')
+
+  async function handleCopy() {
+    if (state === 'fetching') return
+
+    setState('fetching')
+
+    try {
+      const res = await fetch(markdownUrl)
+      if (!res.ok) throw new Error(`Unexpected status ${res.status}`)
+
+      const text = await res.text()
+      await navigator.clipboard.writeText(text)
+
+      setState('copied')
+      setTimeout(() => setState('idle'), 2000)
+    } catch {
+      setState('error')
+      setTimeout(() => setState('idle'), 2000)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      disabled={state === 'fetching'}
+      aria-label="Copy page as markdown"
+      className={cn(
+        'flex items-center gap-1.5',
+        'text-sm text-scale-1000 hover:text-scale-1200',
+        'transition-colors',
+        'disabled:opacity-50 disabled:cursor-wait'
+      )}
+    >
+      {state === 'copied' ? (
+        <>
+          <Check size={14} strokeWidth={1.5} />
+          Copied!
+        </>
+      ) : state === 'error' ? (
+        <>
+          <Copy size={14} strokeWidth={1.5} />
+          Failed to copy
+        </>
+      ) : (
+        <>
+          <Copy size={14} strokeWidth={1.5} />
+          Copy page
+        </>
+      )}
+    </button>
+  )
+}

--- a/apps/docs/features/docs/GuidesMdx.mdxToMarkdown.ts
+++ b/apps/docs/features/docs/GuidesMdx.mdxToMarkdown.ts
@@ -1,0 +1,122 @@
+/**
+ * Transforms MDX-specific JSX into plain Markdown suitable for LLMs and
+ * copy-as-markdown tooling.
+ */
+
+const ADMONITION_TYPE_MAP: Record<string, string> = {
+  note: 'NOTE',
+  tip: 'TIP',
+  info: 'NOTE',
+  caution: 'CAUTION',
+  warning: 'WARNING',
+  danger: 'WARNING',
+  deprecation: 'WARNING',
+}
+
+/** Strip {/* ... *\/} MDX expression comments */
+function stripMdxComments(content: string): string {
+  return content.replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+}
+
+/**
+ * <Admonition type="note" title="Optional title">
+ *   body
+ * </Admonition>
+ *
+ * → GitHub-style blockquote admonition:
+ *
+ * > [!NOTE]
+ * > **Optional title**
+ * >
+ * > body
+ */
+function transformAdmonitions(content: string): string {
+  return content.replace(
+    /<Admonition\b([^>]*)>([\s\S]*?)<\/Admonition>/g,
+    (_, attrs: string, body: string) => {
+      const typeMatch = attrs.match(/type="(\w+)"/)
+      const titleMatch = attrs.match(/title="([^"]*)"/)
+      const type = typeMatch?.[1] ?? 'note'
+      const ghType = ADMONITION_TYPE_MAP[type] ?? 'NOTE'
+      const title = titleMatch?.[1]
+
+      const bodyLines = body
+        .trim()
+        .split('\n')
+        .map((line) => `> ${line}`)
+        .join('\n')
+
+      const header = title
+        ? `> [!${ghType}]\n> **${title}**\n>\n${bodyLines}`
+        : `> [!${ghType}]\n${bodyLines}`
+
+      return header
+    }
+  )
+}
+
+function extractAttr(attrs: string, name: string): string | undefined {
+  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`, ''))
+  return match?.[1]
+}
+
+function extractSrc(attrs: string): string | undefined {
+  // Simple string: src="/path/to/img.png"
+  const simple = attrs.match(/\bsrc="([^"]+)"/)
+  if (simple) return simple[1]
+
+  // Object literal: src={{ light: '/...', dark: '/...' }} — prefer light
+  const light = attrs.match(/light:\s*['"]([^'"]+)['"]/)
+  if (light) return light[1]
+
+  const dark = attrs.match(/dark:\s*['"]([^'"]+)['"]/)
+  if (dark) return dark[1]
+
+  return undefined
+}
+
+/**
+ * <Image alt="..." src="/path" caption="..." />
+ * <Image alt="..." src={{ light: '/...', dark: '/...' }} />
+ *
+ * → ![alt](src "caption")
+ */
+function transformImages(content: string): string {
+  return content.replace(/<Image\b([\s\S]*?)\/>/g, (_, attrs: string) => {
+    const alt = extractAttr(attrs, 'alt') ?? ''
+    const src = extractSrc(attrs)
+    const caption = extractAttr(attrs, 'caption')
+
+    if (!src) return ''
+    return caption ? `![${alt}](${src} "${caption}")` : `![${alt}](${src})`
+  })
+}
+
+/**
+ * For any remaining JSX block-level components (e.g. <Tabs>, <TabPanel>,
+ * <StepHikeCompact>), strip the opening and closing tags but keep the inner
+ * text content so prose is not lost.
+ *
+ * Self-closing tags with no useful text content are removed entirely.
+ */
+function stripRemainingJsx(content: string): string {
+  // Remove self-closing tags that don't carry text (e.g. <IconCheck />)
+  content = content.replace(/<[A-Z][A-Za-z.]*\b[^>]*\/>/g, '')
+  // Strip opening and closing tags, keeping inner content
+  content = content.replace(/<\/?[A-Z][A-Za-z.]*\b[^>]*>/g, '')
+  return content
+}
+
+/** Collapse runs of 3+ blank lines down to two (one blank line between blocks) */
+function normalizeBlankLines(content: string): string {
+  return content.replace(/\n{3,}/g, '\n\n')
+}
+
+export function mdxToMarkdown(content: string): string {
+  content = stripMdxComments(content)
+  content = transformAdmonitions(content)
+  content = transformImages(content)
+  content = stripRemainingJsx(content)
+  content = normalizeBlankLines(content)
+  return content.trim()
+}

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -60,6 +60,7 @@ const nextConfig = {
   ],
   outputFileTracingIncludes: {
     '/api/crawlers': ['./features/docs/generated/**/*', './docs/ref/**/*'],
+    '/api/guides/raw/**': ['./content/guides/**/*', './content/_partials/**/*', './examples/**/*'],
     '/guides/**/*': ['./content/guides/**/*', './content/troubleshooting/**/*', './examples/**/*'],
     '/reference/**/*': ['./features/docs/generated/**/*', './docs/ref/**/*'],
   },
@@ -115,6 +116,17 @@ const nextConfig = {
       {
         source: '/favicon/:slug*',
         headers: [{ key: 'cache-control', value: 'public, max-age=86400' }],
+      },
+    ]
+  },
+
+  async rewrites() {
+    return [
+      {
+        // Appending .mdx to any guide URL returns the preprocessed markdown source.
+        // e.g. /guides/auth/users.mdx → /api/guides/raw/auth/users
+        source: '/guides/:path*.mdx',
+        destination: '/api/guides/raw/:path*',
       },
     ]
   },

--- a/apps/docs/scripts/test-mdx-to-markdown.ts
+++ b/apps/docs/scripts/test-mdx-to-markdown.ts
@@ -1,0 +1,142 @@
+/**
+ * Scans all guide MDX files, runs them through mdxToMarkdown, then reports
+ * anything in the output that still looks like unhandled JSX or MDX
+ * expressions — so we know what the transform missed.
+ *
+ * Usage:
+ *   pnpm tsx scripts/test-mdx-to-markdown.ts
+ *   pnpm tsx scripts/test-mdx-to-markdown.ts --verbose   # show matched lines
+ */
+
+import { readdir, readFile } from 'node:fs/promises'
+import { extname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mdxToMarkdown } from '../features/docs/GuidesMdx.mdxToMarkdown.js'
+
+const GUIDES_DIR = fileURLToPath(new URL('../content/guides', import.meta.url))
+const VERBOSE = process.argv.includes('--verbose')
+
+// ── Patterns we want to be absent from the output ───────────────────────────
+
+const CHECKS: Array<{ name: string; pattern: RegExp }> = [
+  {
+    name: 'JSX opening/closing tag',
+    pattern: /<\/?[A-Z][A-Za-z.]*\b[^>]*>/,
+  },
+  {
+    name: 'JSX self-closing tag',
+    pattern: /<[A-Z][A-Za-z.]*\b[^>]*\/>/,
+  },
+  {
+    name: 'MDX expression block',
+    // Catches {someVar}, {/* comment */}, etc. — but not standard markdown
+    // things like {id} inside code fences.
+    pattern: /(?<!`)\{(?!\s*\/\*)(?:[^`}]{1,80})\}(?!`)/,
+  },
+  {
+    name: 'MDX import/export',
+    pattern: /^(import|export)\s+/m,
+  },
+]
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+interface Hit {
+  file: string
+  line: number
+  text: string
+  check: string
+}
+
+async function getAllMdxFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { recursive: true })
+  return entries
+    .filter((f) => extname(f) === '.mdx' && !f.split('/').at(-1)?.startsWith('_'))
+    .map((f) => join(dir, f))
+}
+
+function findHits(transformed: string, filePath: string): Hit[] {
+  const hits: Hit[] = []
+  const lines = transformed.split('\n')
+  let inFence = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Skip content inside fenced code blocks — JSX there is intentional
+    if (/^```/.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+
+    for (const check of CHECKS) {
+      if (check.pattern.test(line)) {
+        hits.push({
+          file: relative(GUIDES_DIR, filePath),
+          line: i + 1,
+          text: line.trim(),
+          check: check.name,
+        })
+        break // one hit per line is enough
+      }
+    }
+  }
+
+  return hits
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const files = await getAllMdxFiles(GUIDES_DIR)
+console.log(`Scanning ${files.length} guide files...\n`)
+
+const allHits: Hit[] = []
+let errorCount = 0
+
+for (const file of files) {
+  try {
+    const raw = await readFile(file, 'utf-8')
+    const transformed = mdxToMarkdown(raw)
+    const hits = findHits(transformed, file)
+    allHits.push(...hits)
+  } catch (err) {
+    console.error(`  ERROR processing ${relative(GUIDES_DIR, file)}: ${err}`)
+    errorCount++
+  }
+}
+
+if (allHits.length === 0) {
+  console.log('✓ No unhandled JSX or MDX expressions found.')
+} else {
+  // Group by check name so it's easy to see what categories need fixing
+  const byCheck = Map.groupBy(allHits, (h) => h.check)
+
+  for (const [checkName, hits] of byCheck) {
+    console.log(`\n── ${checkName} (${hits.length} hits) ──`)
+
+    // Group by file within each check
+    const byFile = Map.groupBy(hits, (h) => h.file)
+    for (const [file, fileHits] of byFile) {
+      if (VERBOSE) {
+        for (const h of fileHits) {
+          console.log(`  ${file}:${h.line}`)
+          console.log(`    ${h.text}`)
+        }
+      } else {
+        console.log(`  ${file} (${fileHits.length})`)
+      }
+    }
+  }
+}
+
+console.log(`
+── Summary ──────────────────────────────
+  Files scanned : ${files.length}
+  Files with hits: ${new Set(allHits.map((h) => h.file)).size}
+  Total hits    : ${allHits.length}
+  Errors        : ${errorCount}
+`)
+
+process.exit(allHits.length > 0 || errorCount > 0 ? 1 : 0)


### PR DESCRIPTION
Introduce an API endpoint that serves preprocessed Markdown for guide pages (.mdx) and a client "Copy as Markdown" button. Adds mdxToMarkdown transformer to convert MDX/JSX (admonitions, Image, other components) into plain Markdown, a test script to scan guides for unhandled JSX, and a CopyMarkdownButton client component. Integrates the copy button into GuidesMdx template and GuidesTableOfContents (TOC now accepts children), updates next.config.mjs with rewrites and outputFileTracingIncludes for the new API, and adds a navigation types reference in next-env.d.ts. The API enforces existing access checks via getGuidesMarkdown and returns Markdown with caching headers.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
