### PR TITLE
feat: Fetch the google scripts only if consent is accepted

### DIFF
--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import { useLatest } from 'react-use'
 
 import { useUser } from './auth'
-import { hasConsented } from './consent-state'
+import { hasConsented, useConsentState } from './consent-state'
 import { IS_PLATFORM, IS_PROD, LOCAL_STORAGE_KEYS } from './constants'
 import { useFeatureFlags } from './feature-flags'
 import { post } from './fetchWrappers'
@@ -30,11 +30,14 @@ const { TELEMETRY_DATA } = LOCAL_STORAGE_KEYS
 
 // Reexports GoogleTagManager with the right API key set
 export const TelemetryTagManager = () => {
-  const isGTMEnabled = Boolean(IS_PLATFORM && process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID)
+  // useConsentState is used here to trigger a re-render when consent state changes
+  const { hasAccepted } = useConsentState()
 
-  if (!isGTMEnabled) {
-    return
-  }
+  const isGTMEnabled = Boolean(
+    IS_PLATFORM && process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID && hasAccepted
+  )
+
+  if (!isGTMEnabled) return null
 
   return (
     <Script

--- a/packages/ui-patterns/src/consent.tsx
+++ b/packages/ui-patterns/src/consent.tsx
@@ -28,6 +28,12 @@ export const useConsentToast = () => {
     snap.denyAll()
     clearTelemetryDataCookie()
 
+    // Clear GA4 and sGTM tracking cookies
+    const trackingCookies = ['_ga', '_ga_XW18KGKGNR', 'FPID', 'FPAU', 'FPLC']
+    trackingCookies.forEach((name) => {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=.supabase.com`
+    })
+
     if (consentToastId.current) {
       toast.dismiss(consentToastId.current)
     }


### PR DESCRIPTION
This pull request improves how user consent is handled for telemetry and tracking, ensuring that analytics scripts and cookies are only active when the user has provided consent. The changes both enforce stricter checks before enabling Google Tag Manager and ensure that tracking cookies are cleared when consent is denied.