### PR TITLE
chore(studio): move organization settings nav to sidebar layout

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -163,7 +163,7 @@ export const AuditLogs = () => {
 
   if (isLogsNotAvailableBasedOnPlan) {
     return (
-      <ScaffoldContainer>
+      <ScaffoldContainer className="px-6 xl:px-10">
         <ScaffoldSection isFullWidth>
           <UpgradeToPro
             plan="Team"
@@ -179,7 +179,7 @@ export const AuditLogs = () => {
 
   return (
     <>
-      <ScaffoldContainer>
+      <ScaffoldContainer className="px-6 xl:px-10">
         <ScaffoldSection isFullWidth>
           <div className="space-y-4 flex flex-col">
             {showFilters && (

--- a/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
@@ -1,10 +1,12 @@
 import { NoProjectsOnPaidOrgInfo } from 'components/interfaces/Billing/NoProjectsOnPaidOrgInfo'
-import {
-  ScaffoldContainer,
-  ScaffoldSection,
-  ScaffoldSectionTitle,
-} from 'components/layouts/Scaffold'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import {
+  PageSection,
+  PageSectionContent,
+  PageSectionMeta,
+  PageSectionSummary,
+  PageSectionTitle,
+} from 'ui-patterns/PageSection'
 import { OrganizationDeletePanel } from './OrganizationDeletePanel'
 
 import { DataPrivacyForm } from './DataPrivacyForm'
@@ -14,20 +16,43 @@ export const GeneralSettings = () => {
   const organizationDeletionEnabled = useIsFeatureEnabled('organizations:delete')
 
   return (
-    <ScaffoldContainer>
+    <>
       <NoProjectsOnPaidOrgInfo />
 
-      <ScaffoldSection isFullWidth>
-        <ScaffoldSectionTitle className="mb-4">Organization Details</ScaffoldSectionTitle>
-        <OrganizationDetailsForm />
-      </ScaffoldSection>
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Organization details</PageSectionTitle>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent>
+          <OrganizationDetailsForm />
+        </PageSectionContent>
+      </PageSection>
 
-      <ScaffoldSection isFullWidth>
-        <ScaffoldSectionTitle className="mb-4">Data Privacy</ScaffoldSectionTitle>
-        <DataPrivacyForm />
-      </ScaffoldSection>
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Data privacy</PageSectionTitle>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent>
+          <DataPrivacyForm />
+        </PageSectionContent>
+      </PageSection>
 
-      {organizationDeletionEnabled && <OrganizationDeletePanel />}
-    </ScaffoldContainer>
+      {organizationDeletionEnabled && (
+        <PageSection>
+          <PageSectionMeta>
+            <PageSectionSummary>
+              <PageSectionTitle>Danger zone</PageSectionTitle>
+            </PageSectionSummary>
+          </PageSectionMeta>
+          <PageSectionContent>
+            <OrganizationDeletePanel />
+          </PageSectionContent>
+        </PageSection>
+      )}
+    </>
   )
 }

--- a/apps/studio/components/interfaces/Organization/GeneralSettings/OrganizationDeletePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/OrganizationDeletePanel.tsx
@@ -1,4 +1,3 @@
-import { ScaffoldSection, ScaffoldSectionTitle } from 'components/layouts/Scaffold'
 import PartnerManagedResource from 'components/ui/PartnerManagedResource'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { MANAGED_BY } from 'lib/constants/infrastructure'
@@ -8,28 +7,23 @@ import { DeleteOrganizationButton } from './DeleteOrganizationButton'
 export const OrganizationDeletePanel = () => {
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
 
-  return (
-    <ScaffoldSection isFullWidth>
-      <ScaffoldSectionTitle className="mb-4">Danger Zone</ScaffoldSectionTitle>
-      {selectedOrganization?.managed_by !== 'vercel-marketplace' ? (
-        <Admonition
-          type="destructive"
-          title="Deleting this organization will also remove its projects"
-          description="Make sure you have made a backup of your projects if you want to keep your data"
-        >
-          <DeleteOrganizationButton />
-        </Admonition>
-      ) : (
-        <PartnerManagedResource
-          managedBy={MANAGED_BY.VERCEL_MARKETPLACE}
-          resource="Organizations"
-          cta={{
-            installationId: selectedOrganization?.partner_id,
-            path: '/settings',
-            message: 'Delete organization in Vercel Marketplace',
-          }}
-        />
-      )}
-    </ScaffoldSection>
+  return selectedOrganization?.managed_by !== 'vercel-marketplace' ? (
+    <Admonition
+      type="destructive"
+      title="Deleting this organization will also remove its projects"
+      description="Make sure you have made a backup of your projects if you want to keep your data"
+    >
+      <DeleteOrganizationButton />
+    </Admonition>
+  ) : (
+    <PartnerManagedResource
+      managedBy={MANAGED_BY.VERCEL_MARKETPLACE}
+      resource="Organizations"
+      cta={{
+        installationId: selectedOrganization?.partner_id,
+        path: '/settings',
+        message: 'Delete organization in Vercel Marketplace',
+      }}
+    />
   )
 }

--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
@@ -68,7 +68,7 @@ export const OAuthApps = () => {
 
   return (
     <>
-      <ScaffoldContainer>
+      <ScaffoldContainer className="px-6 xl:px-10">
         <ScaffoldSection isFullWidth className="flex flex-col gap-y-8">
           <div className="space-y-4">
             <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-2">

--- a/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
@@ -153,7 +153,7 @@ export const SSOConfig = () => {
   }, [ssoConfig, form])
 
   return (
-    <ScaffoldContainer>
+    <ScaffoldContainer size="small">
       <ScaffoldSection isFullWidth>
         {isLoadingEntitlement || (hasAccessToSso && isLoadingSSOConfig) ? (
           <Card>

--- a/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
@@ -153,7 +153,7 @@ export const SSOConfig = () => {
   }, [ssoConfig, form])
 
   return (
-    <ScaffoldContainer size="small">
+    <ScaffoldContainer size="small" className="px-6 xl:px-10">
       <ScaffoldSection isFullWidth>
         {isLoadingEntitlement || (hasAccessToSso && isLoadingSSOConfig) ? (
           <Card>

--- a/apps/studio/components/interfaces/Organization/SecuritySettings.tsx
+++ b/apps/studio/components/interfaces/Organization/SecuritySettings.tsx
@@ -105,7 +105,7 @@ export const SecuritySettings = () => {
   }
 
   return (
-    <ScaffoldContainer size="small">
+    <ScaffoldContainer size="small" className="px-6 xl:px-10">
       <ScaffoldSection isFullWidth>
         {!isPaidPlan ? (
           <UpgradeToPro

--- a/apps/studio/components/interfaces/Organization/SecuritySettings.tsx
+++ b/apps/studio/components/interfaces/Organization/SecuritySettings.tsx
@@ -105,7 +105,7 @@ export const SecuritySettings = () => {
   }
 
   return (
-    <ScaffoldContainer>
+    <ScaffoldContainer size="small">
       <ScaffoldSection isFullWidth>
         {!isPaidPlan ? (
           <UpgradeToPro

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -372,6 +372,14 @@ const OrganizationLinks = () => {
   const showBilling = useIsFeatureEnabled('billing:all')
 
   const activeRoute = router.pathname.split('/')[3]
+  const organizationSettingsRoutes = new Set([
+    'general',
+    'security',
+    'sso',
+    'apps',
+    'audit',
+    'documents',
+  ])
 
   const navMenuItems = [
     {
@@ -428,11 +436,7 @@ const OrganizationLinks = () => {
               i === 0
                 ? activeRoute === undefined
                 : item.key === 'settings'
-                  ? router.pathname.includes('/general') ||
-                    router.pathname.includes('/apps') ||
-                    router.pathname.includes('/audit') ||
-                    router.pathname.includes('/documents') ||
-                    router.pathname.includes('/security')
+                  ? organizationSettingsRoutes.has(activeRoute ?? '')
                   : activeRoute === item.key
             }
             route={{

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -409,7 +409,7 @@ const OrganizationLinks = () => {
         ]
       : []),
     {
-      label: 'Organization settings',
+      label: 'Organization Settings',
       href: `/org/${organizationSlug}/general`,
       key: 'settings',
       icon: <Settings size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.test.ts
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   generateOrganizationSettingsSections,
+  getOrganizationSettingsDocumentTitle,
   normalizeOrganizationSettingsPath,
 } from './OrganizationSettingsLayout'
 
@@ -36,11 +37,7 @@ describe('OrganizationSettingsLayout helpers', () => {
       showLegalDocuments: false,
     })
 
-    expect(section.links.map((item) => item.label)).toEqual([
-      'General',
-      'OAuth Apps',
-      'Audit Logs',
-    ])
+    expect(section.links.map((item) => item.label)).toEqual(['General', 'OAuth Apps', 'Audit Logs'])
   })
 
   it('normalizes hash paths for active state checks', () => {
@@ -54,5 +51,13 @@ describe('OrganizationSettingsLayout helpers', () => {
     })
 
     expect(section.links.find((item) => item.label === 'Security')?.isActive).toBe(true)
+  })
+
+  it('uses settings as default document title when page title is not provided', () => {
+    expect(getOrganizationSettingsDocumentTitle(undefined, 'Supabase')).toBe('Settings | Supabase')
+  })
+
+  it('uses page title for document title when provided', () => {
+    expect(getOrganizationSettingsDocumentTitle('General', 'Supabase')).toBe('General | Supabase')
   })
 })

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.test.ts
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.test.ts
@@ -7,8 +7,8 @@ import {
 } from './OrganizationSettingsLayout'
 
 describe('OrganizationSettingsLayout helpers', () => {
-  it('returns expected organization settings links', () => {
-    const [section] = generateOrganizationSettingsSections({
+  it('returns expected organization settings sections and links', () => {
+    const sections = generateOrganizationSettingsSections({
       slug: 'my-org',
       currentPath: '/org/my-org/general',
       showSecuritySettings: true,
@@ -16,20 +16,27 @@ describe('OrganizationSettingsLayout helpers', () => {
       showLegalDocuments: true,
     })
 
-    expect(section.heading).toBe('Organization Settings')
-    expect(section.links.map((item) => item.label)).toEqual([
+    expect(sections.map((section) => section.heading)).toEqual([
+      'Configuration',
+      'Connections',
+      'Compliance',
+    ])
+    expect(sections.flatMap((section) => section.links.map((item) => item.label))).toEqual([
       'General',
       'Security',
-      'OAuth Apps',
       'SSO',
+      'OAuth Apps',
       'Audit Logs',
       'Legal Documents',
     ])
-    expect(section.links.find((item) => item.label === 'General')?.isActive).toBe(true)
+    expect(
+      sections.flatMap((section) => section.links).find((item) => item.label === 'General')
+        ?.isActive
+    ).toBe(true)
   })
 
   it('hides feature-flagged items when flags are disabled', () => {
-    const [section] = generateOrganizationSettingsSections({
+    const sections = generateOrganizationSettingsSections({
       slug: 'my-org',
       currentPath: '/org/my-org/general',
       showSecuritySettings: false,
@@ -37,12 +44,21 @@ describe('OrganizationSettingsLayout helpers', () => {
       showLegalDocuments: false,
     })
 
-    expect(section.links.map((item) => item.label)).toEqual(['General', 'OAuth Apps', 'Audit Logs'])
+    expect(sections.map((section) => section.heading)).toEqual([
+      'Configuration',
+      'Connections',
+      'Compliance',
+    ])
+    expect(sections.flatMap((section) => section.links.map((item) => item.label))).toEqual([
+      'General',
+      'OAuth Apps',
+      'Audit Logs',
+    ])
   })
 
   it('normalizes hash paths for active state checks', () => {
     const currentPath = normalizeOrganizationSettingsPath('/org/my-org/security#sso')
-    const [section] = generateOrganizationSettingsSections({
+    const sections = generateOrganizationSettingsSections({
       slug: 'my-org',
       currentPath,
       showSecuritySettings: true,
@@ -50,7 +66,10 @@ describe('OrganizationSettingsLayout helpers', () => {
       showLegalDocuments: true,
     })
 
-    expect(section.links.find((item) => item.label === 'Security')?.isActive).toBe(true)
+    expect(
+      sections.flatMap((section) => section.links).find((item) => item.label === 'Security')
+        ?.isActive
+    ).toBe(true)
   })
 
   it('uses settings as default document title when page title is not provided', () => {

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.test.ts
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  generateOrganizationSettingsSections,
+  normalizeOrganizationSettingsPath,
+} from './OrganizationSettingsLayout'
+
+describe('OrganizationSettingsLayout helpers', () => {
+  it('returns expected organization settings links', () => {
+    const [section] = generateOrganizationSettingsSections({
+      slug: 'my-org',
+      currentPath: '/org/my-org/general',
+      showSecuritySettings: true,
+      showSsoSettings: true,
+      showLegalDocuments: true,
+    })
+
+    expect(section.heading).toBe('Organization Settings')
+    expect(section.links.map((item) => item.label)).toEqual([
+      'General',
+      'Security',
+      'OAuth Apps',
+      'SSO',
+      'Audit Logs',
+      'Legal Documents',
+    ])
+    expect(section.links.find((item) => item.label === 'General')?.isActive).toBe(true)
+  })
+
+  it('hides feature-flagged items when flags are disabled', () => {
+    const [section] = generateOrganizationSettingsSections({
+      slug: 'my-org',
+      currentPath: '/org/my-org/general',
+      showSecuritySettings: false,
+      showSsoSettings: false,
+      showLegalDocuments: false,
+    })
+
+    expect(section.links.map((item) => item.label)).toEqual([
+      'General',
+      'OAuth Apps',
+      'Audit Logs',
+    ])
+  })
+
+  it('normalizes hash paths for active state checks', () => {
+    const currentPath = normalizeOrganizationSettingsPath('/org/my-org/security#sso')
+    const [section] = generateOrganizationSettingsSections({
+      slug: 'my-org',
+      currentPath,
+      showSecuritySettings: true,
+      showSsoSettings: true,
+      showLegalDocuments: true,
+    })
+
+    expect(section.links.find((item) => item.label === 'Security')?.isActive).toBe(true)
+  })
+})

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
@@ -34,7 +34,7 @@ export const generateOrganizationSettingsSections = ({
   showSsoSettings = true,
   showLegalDocuments = true,
 }: OrganizationSettingsSectionsProps): SidebarSection[] => {
-  const links = [
+  const configurationLinks = [
     {
       key: 'general',
       label: 'General',
@@ -49,11 +49,6 @@ export const generateOrganizationSettingsSections = ({
           },
         ]
       : []),
-    {
-      key: 'apps',
-      label: 'OAuth Apps',
-      href: `/org/${slug}/apps`,
-    },
     ...(showSsoSettings
       ? [
           {
@@ -63,6 +58,17 @@ export const generateOrganizationSettingsSections = ({
           },
         ]
       : []),
+  ]
+
+  const connectionsLinks = [
+    {
+      key: 'apps',
+      label: 'OAuth Apps',
+      href: `/org/${slug}/apps`,
+    },
+  ]
+
+  const complianceLinks = [
     {
       key: 'audit',
       label: 'Audit Logs',
@@ -81,9 +87,25 @@ export const generateOrganizationSettingsSections = ({
 
   return [
     {
-      key: 'organization-settings',
-      heading: 'Organization Settings',
-      links: links.map((item) => ({
+      key: 'configuration',
+      heading: 'Configuration',
+      links: configurationLinks.map((item) => ({
+        ...item,
+        isActive: currentPath === item.href,
+      })),
+    },
+    {
+      key: 'connections',
+      heading: 'Connections',
+      links: connectionsLinks.map((item) => ({
+        ...item,
+        isActive: currentPath === item.href,
+      })),
+    },
+    {
+      key: 'compliance',
+      heading: 'Compliance',
+      links: complianceLinks.map((item) => ({
         ...item,
         isActive: currentPath === item.href,
       })),

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
@@ -1,8 +1,10 @@
+import Head from 'next/head'
 import { PropsWithChildren } from 'react'
 
 import { useParams } from 'common'
 import type { SidebarSection } from 'components/layouts/AccountLayout/AccountLayout.types'
 import { WithSidebar } from 'components/layouts/AccountLayout/WithSidebar'
+import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { useCurrentPath } from 'hooks/misc/useCurrentPath'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 
@@ -14,7 +16,16 @@ interface OrganizationSettingsSectionsProps {
   showLegalDocuments?: boolean
 }
 
+interface OrganizationSettingsLayoutProps {
+  pageTitle?: string
+}
+
 export const normalizeOrganizationSettingsPath = (path: string) => path.split('#')[0]
+export const getOrganizationSettingsPageTitle = (pageTitle?: string) => pageTitle ?? 'Settings'
+export const getOrganizationSettingsDocumentTitle = (
+  pageTitle: string | undefined,
+  title: string
+) => `${getOrganizationSettingsPageTitle(pageTitle)} | ${title}`
 
 export const generateOrganizationSettingsSections = ({
   slug,
@@ -80,10 +91,15 @@ export const generateOrganizationSettingsSections = ({
   ]
 }
 
-function OrganizationSettingsLayout({ children }: PropsWithChildren) {
+function OrganizationSettingsLayout({
+  children,
+  pageTitle,
+}: PropsWithChildren<OrganizationSettingsLayoutProps>) {
   const { slug } = useParams()
   const fullCurrentPath = useCurrentPath()
   const currentPath = normalizeOrganizationSettingsPath(fullCurrentPath)
+  const { appTitle } = useCustomContent(['app:title'])
+  const titleSuffix = appTitle || 'Supabase'
 
   const {
     organizationShowSsoSettings: showSsoSettings,
@@ -104,9 +120,24 @@ function OrganizationSettingsLayout({ children }: PropsWithChildren) {
   })
 
   return (
-    <WithSidebar title="Organization Settings" breadcrumbs={[]} sections={sections}>
-      {children}
-    </WithSidebar>
+    <>
+      <Head>
+        <title>{getOrganizationSettingsDocumentTitle(pageTitle, titleSuffix)}</title>
+        <meta name="description" content="Supabase Studio" />
+      </Head>
+      <WithSidebar
+        title="Organization Settings"
+        breadcrumbs={[]}
+        sections={sections}
+        header={
+          <div className="border-default flex min-h-[var(--header-height)] items-center border-b px-6">
+            <h4 className="text-lg">Settings</h4>
+          </div>
+        }
+      >
+        {children}
+      </WithSidebar>
+    </>
   )
 }
 

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
@@ -1,17 +1,89 @@
-import Link from 'next/link'
 import { PropsWithChildren } from 'react'
 
 import { useParams } from 'common'
+import type { SidebarSection } from 'components/layouts/AccountLayout/AccountLayout.types'
+import { WithSidebar } from 'components/layouts/AccountLayout/WithSidebar'
 import { useCurrentPath } from 'hooks/misc/useCurrentPath'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { NavMenu, NavMenuItem } from 'ui'
-import { ScaffoldContainerLegacy, ScaffoldTitle } from '../Scaffold'
+
+interface OrganizationSettingsSectionsProps {
+  slug?: string
+  currentPath: string
+  showSecuritySettings?: boolean
+  showSsoSettings?: boolean
+  showLegalDocuments?: boolean
+}
+
+export const normalizeOrganizationSettingsPath = (path: string) => path.split('#')[0]
+
+export const generateOrganizationSettingsSections = ({
+  slug,
+  currentPath,
+  showSecuritySettings = true,
+  showSsoSettings = true,
+  showLegalDocuments = true,
+}: OrganizationSettingsSectionsProps): SidebarSection[] => {
+  const links = [
+    {
+      key: 'general',
+      label: 'General',
+      href: `/org/${slug}/general`,
+    },
+    ...(showSecuritySettings
+      ? [
+          {
+            key: 'security',
+            label: 'Security',
+            href: `/org/${slug}/security`,
+          },
+        ]
+      : []),
+    {
+      key: 'apps',
+      label: 'OAuth Apps',
+      href: `/org/${slug}/apps`,
+    },
+    ...(showSsoSettings
+      ? [
+          {
+            key: 'sso',
+            label: 'SSO',
+            href: `/org/${slug}/sso`,
+          },
+        ]
+      : []),
+    {
+      key: 'audit',
+      label: 'Audit Logs',
+      href: `/org/${slug}/audit`,
+    },
+    ...(showLegalDocuments
+      ? [
+          {
+            key: 'documents',
+            label: 'Legal Documents',
+            href: `/org/${slug}/documents`,
+          },
+        ]
+      : []),
+  ]
+
+  return [
+    {
+      key: 'organization-settings',
+      heading: 'Organization Settings',
+      links: links.map((item) => ({
+        ...item,
+        isActive: currentPath === item.href,
+      })),
+    },
+  ]
+}
 
 function OrganizationSettingsLayout({ children }: PropsWithChildren) {
   const { slug } = useParams()
-  // Get the path without any hash values
   const fullCurrentPath = useCurrentPath()
-  const [currentPath] = fullCurrentPath.split('#')
+  const currentPath = normalizeOrganizationSettingsPath(fullCurrentPath)
 
   const {
     organizationShowSsoSettings: showSsoSettings,
@@ -23,60 +95,18 @@ function OrganizationSettingsLayout({ children }: PropsWithChildren) {
     'organization:show_legal_documents',
   ])
 
-  const navMenuItems = [
-    {
-      label: 'General',
-      href: `/org/${slug}/general`,
-    },
-    ...(showSecuritySettings
-      ? [
-          {
-            label: 'Security',
-            href: `/org/${slug}/security`,
-          },
-        ]
-      : []),
-    {
-      label: 'OAuth Apps',
-      href: `/org/${slug}/apps`,
-    },
-    ...(showSsoSettings
-      ? [
-          {
-            label: 'SSO',
-            href: `/org/${slug}/sso`,
-          },
-        ]
-      : []),
-
-    {
-      label: 'Audit Logs',
-      href: `/org/${slug}/audit`,
-    },
-    ...(showLegalDocuments
-      ? [
-          {
-            label: 'Legal Documents',
-            href: `/org/${slug}/documents`,
-          },
-        ]
-      : []),
-  ]
+  const sections = generateOrganizationSettingsSections({
+    slug,
+    currentPath,
+    showSecuritySettings,
+    showSsoSettings,
+    showLegalDocuments,
+  })
 
   return (
-    <>
-      <ScaffoldContainerLegacy className="mb-0">
-        <ScaffoldTitle>Organization Settings</ScaffoldTitle>
-        <NavMenu className="overflow-x-auto" aria-label="Organization menu navigation">
-          {(navMenuItems.filter(Boolean) as { label: string; href: string }[]).map((item) => (
-            <NavMenuItem key={item.label} active={currentPath === item.href}>
-              <Link href={item.href}>{item.label}</Link>
-            </NavMenuItem>
-          ))}
-        </NavMenu>
-      </ScaffoldContainerLegacy>
-      <div className="h-full w-full overflow-y-auto">{children}</div>
-    </>
+    <WithSidebar title="Organization Settings" breadcrumbs={[]} sections={sections}>
+      {children}
+    </WithSidebar>
   )
 }
 

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -132,14 +132,14 @@ export const generateSettingsMenu = (
       items: [
         ...(billingEnabled
           ? [
-            {
-              name: 'Subscription',
-              key: 'subscription',
-              url: `/org/${organization?.slug}/billing`,
-              items: [],
-              rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
-            },
-          ]
+              {
+                name: 'Subscription',
+                key: 'subscription',
+                url: `/org/${organization?.slug}/billing`,
+                items: [],
+                rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
+              },
+            ]
           : []),
         {
           name: 'Usage',

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -22,7 +22,7 @@ export const generateSettingsMenu = (
   if (!IS_PLATFORM) {
     return [
       {
-        title: 'Project Settings',
+        title: 'Configuration',
         items: [
           {
             name: `Log Drains`,
@@ -42,7 +42,7 @@ export const generateSettingsMenu = (
 
   return [
     {
-      title: 'Project Settings',
+      title: 'Configuration',
       items: [
         {
           name: 'General',
@@ -106,7 +106,7 @@ export const generateSettingsMenu = (
       ],
     },
     {
-      title: 'Configuration',
+      title: 'Integrations',
       items: [
         {
           name: 'Data API',
@@ -132,14 +132,14 @@ export const generateSettingsMenu = (
       items: [
         ...(billingEnabled
           ? [
-              {
-                name: 'Subscription',
-                key: 'subscription',
-                url: `/org/${organization?.slug}/billing`,
-                items: [],
-                rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
-              },
-            ]
+            {
+              name: 'Subscription',
+              key: 'subscription',
+              url: `/org/${organization?.slug}/billing`,
+              items: [],
+              rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
+            },
+          ]
           : []),
         {
           name: 'Usage',

--- a/apps/studio/pages/org/[slug]/apps.tsx
+++ b/apps/studio/pages/org/[slug]/apps.tsx
@@ -11,7 +11,7 @@ const OrgOAuthApps: NextPageWithLayout = () => {
 OrgOAuthApps.getLayout = (page) => (
   <DefaultLayout>
     <OrganizationLayout>
-      <OrganizationSettingsLayout>{page}</OrganizationSettingsLayout>
+      <OrganizationSettingsLayout pageTitle="OAuth Apps">{page}</OrganizationSettingsLayout>
     </OrganizationLayout>
   </DefaultLayout>
 )

--- a/apps/studio/pages/org/[slug]/apps.tsx
+++ b/apps/studio/pages/org/[slug]/apps.tsx
@@ -3,7 +3,6 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import type { NextPageWithLayout } from 'types'
-import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
   PageHeaderDescription,
@@ -25,9 +24,7 @@ const OrgOAuthApps: NextPageWithLayout = () => {
           </PageHeaderSummary>
         </PageHeaderMeta>
       </PageHeader>
-      <PageContainer size="default">
-        <OAuthApps />
-      </PageContainer>
+      <OAuthApps />
     </>
   )
 }

--- a/apps/studio/pages/org/[slug]/apps.tsx
+++ b/apps/studio/pages/org/[slug]/apps.tsx
@@ -3,9 +3,33 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
 
 const OrgOAuthApps: NextPageWithLayout = () => {
-  return <OAuthApps />
+  return (
+    <>
+      <PageHeader size="default">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>OAuth Apps</PageHeaderTitle>
+            <PageHeaderDescription>
+              Published and authorized OAuth applications
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="default">
+        <OAuthApps />
+      </PageContainer>
+    </>
+  )
 }
 
 OrgOAuthApps.getLayout = (page) => (

--- a/apps/studio/pages/org/[slug]/audit.tsx
+++ b/apps/studio/pages/org/[slug]/audit.tsx
@@ -5,6 +5,14 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
 import { LogoLoader } from 'ui'
 
 const OrgAuditLogs: NextPageWithLayout = () => {
@@ -13,7 +21,23 @@ const OrgAuditLogs: NextPageWithLayout = () => {
 
   return (
     <>
-      {selectedOrganization === undefined && isLoadingPermissions ? <LogoLoader /> : <AuditLogs />}
+      <PageHeader size="default">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>Audit Logs</PageHeaderTitle>
+            <PageHeaderDescription>
+              Organization-level activity history and security event records
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="default">
+        {selectedOrganization === undefined && isLoadingPermissions ? (
+          <LogoLoader />
+        ) : (
+          <AuditLogs />
+        )}
+      </PageContainer>
     </>
   )
 }

--- a/apps/studio/pages/org/[slug]/audit.tsx
+++ b/apps/studio/pages/org/[slug]/audit.tsx
@@ -21,7 +21,7 @@ const OrgAuditLogs: NextPageWithLayout = () => {
 OrgAuditLogs.getLayout = (page) => (
   <DefaultLayout>
     <OrganizationLayout>
-      <OrganizationSettingsLayout>{page}</OrganizationSettingsLayout>
+      <OrganizationSettingsLayout pageTitle="Audit Logs">{page}</OrganizationSettingsLayout>
     </OrganizationLayout>
   </DefaultLayout>
 )

--- a/apps/studio/pages/org/[slug]/audit.tsx
+++ b/apps/studio/pages/org/[slug]/audit.tsx
@@ -5,7 +5,6 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import type { NextPageWithLayout } from 'types'
-import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
   PageHeaderDescription,
@@ -31,13 +30,7 @@ const OrgAuditLogs: NextPageWithLayout = () => {
           </PageHeaderSummary>
         </PageHeaderMeta>
       </PageHeader>
-      <PageContainer size="default">
-        {selectedOrganization === undefined && isLoadingPermissions ? (
-          <LogoLoader />
-        ) : (
-          <AuditLogs />
-        )}
-      </PageContainer>
+      {selectedOrganization === undefined && isLoadingPermissions ? <LogoLoader /> : <AuditLogs />}
     </>
   )
 }

--- a/apps/studio/pages/org/[slug]/documents.tsx
+++ b/apps/studio/pages/org/[slug]/documents.tsx
@@ -22,7 +22,7 @@ const OrgDocuments: NextPageWithLayout = () => {
 OrgDocuments.getLayout = (page) => (
   <DefaultLayout>
     <OrganizationLayout>
-      <OrganizationSettingsLayout>{page}</OrganizationSettingsLayout>
+      <OrganizationSettingsLayout pageTitle="Legal Documents">{page}</OrganizationSettingsLayout>
     </OrganizationLayout>
   </DefaultLayout>
 )

--- a/apps/studio/pages/org/[slug]/documents.tsx
+++ b/apps/studio/pages/org/[slug]/documents.tsx
@@ -6,6 +6,14 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
 
 const OrgDocuments: NextPageWithLayout = () => {
   const { slug } = useParams()
@@ -16,7 +24,23 @@ const OrgDocuments: NextPageWithLayout = () => {
     return <UnknownInterface urlBack={`/org/${slug}`} />
   }
 
-  return <Documents />
+  return (
+    <>
+      <PageHeader size="default">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>Legal Documents</PageHeaderTitle>
+            <PageHeaderDescription>
+              Compliance documentation and legal agreements
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="default">
+        <Documents />
+      </PageContainer>
+    </>
+  )
 }
 
 OrgDocuments.getLayout = (page) => (

--- a/apps/studio/pages/org/[slug]/documents.tsx
+++ b/apps/studio/pages/org/[slug]/documents.tsx
@@ -3,17 +3,15 @@ import { Documents } from 'components/interfaces/Organization/Documents/Document
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
-import { PageContainer } from 'ui-patterns/PageContainer'
-import {
-  PageHeader,
-  PageHeaderDescription,
-  PageHeaderMeta,
-  PageHeaderSummary,
-  PageHeaderTitle,
-} from 'ui-patterns/PageHeader'
 
 const OrgDocuments: NextPageWithLayout = () => {
   const { slug } = useParams()
@@ -26,19 +24,13 @@ const OrgDocuments: NextPageWithLayout = () => {
 
   return (
     <>
-      <PageHeader size="default">
-        <PageHeaderMeta>
-          <PageHeaderSummary>
-            <PageHeaderTitle>Legal Documents</PageHeaderTitle>
-            <PageHeaderDescription>
-              Compliance documentation and legal agreements
-            </PageHeaderDescription>
-          </PageHeaderSummary>
-        </PageHeaderMeta>
-      </PageHeader>
-      <PageContainer size="default">
-        <Documents />
-      </PageContainer>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Legal documents</ScaffoldTitle>
+          <ScaffoldDescription>Compliance documentation and legal agreements</ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <Documents />
     </>
   )
 }

--- a/apps/studio/pages/org/[slug]/documents.tsx
+++ b/apps/studio/pages/org/[slug]/documents.tsx
@@ -6,6 +6,7 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import {
   ScaffoldContainer,
   ScaffoldDescription,
+  ScaffoldDivider,
   ScaffoldHeader,
   ScaffoldTitle,
 } from 'components/layouts/Scaffold'
@@ -30,6 +31,7 @@ const OrgDocuments: NextPageWithLayout = () => {
           <ScaffoldDescription>Compliance documentation and legal agreements</ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
+      <ScaffoldDivider />
       <Documents />
     </>
   )

--- a/apps/studio/pages/org/[slug]/general.tsx
+++ b/apps/studio/pages/org/[slug]/general.tsx
@@ -5,6 +5,14 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
 import { LogoLoader } from 'ui'
 
 const OrgGeneralSettings: NextPageWithLayout = () => {
@@ -13,11 +21,23 @@ const OrgGeneralSettings: NextPageWithLayout = () => {
 
   return (
     <>
-      {selectedOrganization === undefined && isLoadingPermissions ? (
-        <LogoLoader />
-      ) : (
-        <GeneralSettings />
-      )}
+      <PageHeader size="default">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>Organization Settings</PageHeaderTitle>
+            <PageHeaderDescription>
+              General configuration, privacy, and lifecycle controls
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="default">
+        {selectedOrganization === undefined && isLoadingPermissions ? (
+          <LogoLoader />
+        ) : (
+          <GeneralSettings />
+        )}
+      </PageContainer>
     </>
   )
 }
@@ -25,7 +45,7 @@ const OrgGeneralSettings: NextPageWithLayout = () => {
 OrgGeneralSettings.getLayout = (page) => (
   <DefaultLayout>
     <OrganizationLayout>
-      <OrganizationSettingsLayout>{page}</OrganizationSettingsLayout>
+      <OrganizationSettingsLayout pageTitle="General">{page}</OrganizationSettingsLayout>
     </OrganizationLayout>
   </DefaultLayout>
 )

--- a/apps/studio/pages/org/[slug]/security.tsx
+++ b/apps/studio/pages/org/[slug]/security.tsx
@@ -21,7 +21,7 @@ const OrgSecuritySettings: NextPageWithLayout = () => {
 OrgSecuritySettings.getLayout = (page) => (
   <DefaultLayout>
     <OrganizationLayout>
-      <OrganizationSettingsLayout>{page}</OrganizationSettingsLayout>
+      <OrganizationSettingsLayout pageTitle="Security">{page}</OrganizationSettingsLayout>
     </OrganizationLayout>
   </DefaultLayout>
 )

--- a/apps/studio/pages/org/[slug]/security.tsx
+++ b/apps/studio/pages/org/[slug]/security.tsx
@@ -6,6 +6,14 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
 
 const OrgSecuritySettings: NextPageWithLayout = () => {
   const { slug } = useParams()
@@ -15,7 +23,23 @@ const OrgSecuritySettings: NextPageWithLayout = () => {
     return <UnknownInterface urlBack={`/org/${slug}`} />
   }
 
-  return <SecuritySettings />
+  return (
+    <>
+      <PageHeader size="default">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>Security</PageHeaderTitle>
+            <PageHeaderDescription>
+              Organization-wide security controls and MFA enforcement
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="default">
+        <SecuritySettings />
+      </PageContainer>
+    </>
+  )
 }
 
 OrgSecuritySettings.getLayout = (page) => (

--- a/apps/studio/pages/org/[slug]/security.tsx
+++ b/apps/studio/pages/org/[slug]/security.tsx
@@ -6,7 +6,6 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
-import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
   PageHeaderDescription,
@@ -25,7 +24,7 @@ const OrgSecuritySettings: NextPageWithLayout = () => {
 
   return (
     <>
-      <PageHeader size="default">
+      <PageHeader size="small">
         <PageHeaderMeta>
           <PageHeaderSummary>
             <PageHeaderTitle>Security</PageHeaderTitle>
@@ -35,9 +34,7 @@ const OrgSecuritySettings: NextPageWithLayout = () => {
           </PageHeaderSummary>
         </PageHeaderMeta>
       </PageHeader>
-      <PageContainer size="default">
-        <SecuritySettings />
-      </PageContainer>
+      <SecuritySettings />
     </>
   )
 }

--- a/apps/studio/pages/org/[slug]/sso.tsx
+++ b/apps/studio/pages/org/[slug]/sso.tsx
@@ -6,6 +6,14 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
 
 const OrgSSO: NextPageWithLayout = () => {
   const { slug } = useParams()
@@ -15,7 +23,23 @@ const OrgSSO: NextPageWithLayout = () => {
     return <UnknownInterface urlBack={`/org/${slug}/general`} />
   }
 
-  return <SSOConfig />
+  return (
+    <>
+      <PageHeader size="default">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>Single Sign-On</PageHeaderTitle>
+            <PageHeaderDescription>
+              SAML SSO configuration and domain access controls
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+        </PageHeaderMeta>
+      </PageHeader>
+      <PageContainer size="default">
+        <SSOConfig />
+      </PageContainer>
+    </>
+  )
 }
 
 OrgSSO.getLayout = (page) => (

--- a/apps/studio/pages/org/[slug]/sso.tsx
+++ b/apps/studio/pages/org/[slug]/sso.tsx
@@ -21,7 +21,7 @@ const OrgSSO: NextPageWithLayout = () => {
 OrgSSO.getLayout = (page) => (
   <DefaultLayout>
     <OrganizationLayout>
-      <OrganizationSettingsLayout>{page}</OrganizationSettingsLayout>
+      <OrganizationSettingsLayout pageTitle="SSO">{page}</OrganizationSettingsLayout>
     </OrganizationLayout>
   </DefaultLayout>
 )

--- a/apps/studio/pages/org/[slug]/sso.tsx
+++ b/apps/studio/pages/org/[slug]/sso.tsx
@@ -6,7 +6,6 @@ import OrganizationSettingsLayout from 'components/layouts/ProjectLayout/Organiz
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from 'types'
-import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
   PageHeaderDescription,
@@ -25,7 +24,7 @@ const OrgSSO: NextPageWithLayout = () => {
 
   return (
     <>
-      <PageHeader size="default">
+      <PageHeader size="small">
         <PageHeaderMeta>
           <PageHeaderSummary>
             <PageHeaderTitle>Single Sign-On</PageHeaderTitle>
@@ -35,9 +34,7 @@ const OrgSSO: NextPageWithLayout = () => {
           </PageHeaderSummary>
         </PageHeaderMeta>
       </PageHeader>
-      <PageContainer size="default">
-        <SSOConfig />
-      </PageContainer>
+      <SSOConfig />
     </>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI change

## What is the current behavior?

Organization settings are currently spread across a NavMenu. This is getting unweildy as the amount of children within Organization settings grows.

## What is the new behavior?

Organization settings are now on a sidebar, just like Project Settings and most other surfaces.

| Before | After |
| --- | --- |
| <img width="1024" height="563" alt="Supabase" src="https://github.com/user-attachments/assets/3889858c-157a-4deb-8714-71fe9cf002e6" /> | <img width="1024" height="563" alt="General  Supabase" src="https://github.com/user-attachments/assets/1b4eb2c3-a67c-4eda-ab3c-e6610dd5ccf4" /> |

## Additional context

@fsansalvadore and the design team have have other efforts going on to reduce interface clutter, e.g. nested sidebars.
