### PR TITLE
Update Kakao API key handling and validation messages

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -965,14 +965,8 @@ const EXTERNAL_PROVIDER_KAKAO = {
     },
     // [TODO] Update docs
     EXTERNAL_KAKAO_CLIENT_ID: {
-      title: 'REST API Key',
+      title: 'Native App Key',
       type: 'string',
-    },
-    // [TODO] Update docs
-    EXTERNAL_KAKAO_SECRET: {
-      title: 'Client Secret Code',
-      type: 'string',
-      isSecret: true,
     },
     EXTERNAL_KAKAO_EMAIL_OPTIONAL: {
       title: 'Allow users without an email',
@@ -985,12 +979,7 @@ const EXTERNAL_PROVIDER_KAKAO = {
     EXTERNAL_KAKAO_ENABLED: boolean().required(),
     EXTERNAL_KAKAO_CLIENT_ID: string().when('EXTERNAL_KAKAO_ENABLED', {
       is: true,
-      then: (schema) => schema.required('REST API Key is required'),
-      otherwise: (schema) => schema,
-    }),
-    EXTERNAL_KAKAO_SECRET: string().when('EXTERNAL_KAKAO_ENABLED', {
-      is: true,
-      then: (schema) => schema.required('Client Secret Code is required'),
+      then: (schema) => schema.required('Native App Key is required'),
       otherwise: (schema) => schema,
     }),
     EXTERNAL_KAKAO_EMAIL_OPTIONAL: boolean().optional(),

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/management-api-schema.d.ts
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/management-api-schema.d.ts
@@ -2385,7 +2385,6 @@ export interface components {
       external_google_skip_nonce_check: boolean | null
       external_kakao_client_id: string | null
       external_kakao_enabled: boolean | null
-      external_kakao_secret: string | null
       external_keycloak_client_id: string | null
       external_keycloak_enabled: boolean | null
       external_keycloak_secret: string | null
@@ -2670,7 +2669,6 @@ export interface components {
       external_google_skip_nonce_check?: boolean | null
       external_kakao_enabled?: boolean | null
       external_kakao_client_id?: string | null
-      external_kakao_secret?: string | null
       external_keycloak_enabled?: boolean | null
       external_keycloak_client_id?: string | null
       external_keycloak_secret?: string | null

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -2142,7 +2142,6 @@ export interface components {
       external_kakao_client_id: string | null
       external_kakao_email_optional: boolean | null
       external_kakao_enabled: boolean | null
-      external_kakao_secret: string | null
       external_keycloak_client_id: string | null
       external_keycloak_email_optional: boolean | null
       external_keycloak_enabled: boolean | null
@@ -3887,7 +3886,6 @@ export interface components {
       external_kakao_client_id?: string | null
       external_kakao_email_optional?: boolean | null
       external_kakao_enabled?: boolean | null
-      external_kakao_secret?: string | null
       external_keycloak_client_id?: string | null
       external_keycloak_email_optional?: boolean | null
       external_keycloak_enabled?: boolean | null


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug Fixes

## What is the current behavior?

Currently Supabase Requests REST API Key

## What is the new behavior?

Now Supabase Requests Native App Key

## Additional context

<img width="623" height="884" alt="native_app_page" src="https://github.com/user-attachments/assets/5f557f75-5042-4181-9478-128cd0da4e3e" />

## Ref

https://github.com/supabase/auth/issues/1755

https://github.com/supabase/supabase/blame/master/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx#L956-L1003

https://github.com/supabase/auth/pull/834