### PR TITLE
fix(studio): prevent self-hosted log drains settings crash

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -224,6 +224,7 @@ export function LogDrainDestinationSheetForm({
   const { data: logDrains } = useLogDrainsQuery({
     ref,
   })
+  const normalizedLogDrains = Array.isArray(logDrains) ? logDrains : []
 
   const [newCustomHeader, setNewCustomHeader] = useState({ name: '', value: '' })
   const track = useTrack()
@@ -315,7 +316,8 @@ export function LogDrainDestinationSheetForm({
                 // Temp check to make sure the name is unique
                 const logDrainName = form.getValues('name')
                 const logDrainExists =
-                  !!logDrains?.length && logDrains?.find((drain) => drain.name === logDrainName)
+                  normalizedLogDrains.length > 0 &&
+                  normalizedLogDrains.find((drain) => drain.name === logDrainName)
                 if (logDrainExists && mode === 'create') {
                   toast.error('Log drain name already exists')
                   return

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -60,7 +60,8 @@ export function LogDrains({
   const axiomEnabled = useFlag('axiomLogDrain')
   const otlpEnabled = useFlag('otlpLogDrain')
   const last9Enabled = useFlag('Last9LogDrain')
-  const hasLogDrains = !!logDrains?.length
+  const normalizedLogDrains = Array.isArray(logDrains) ? logDrains : []
+  const hasLogDrains = normalizedLogDrains.length > 0
 
   const { mutate: deleteLogDrain } = useDeleteLogDrainMutation({
     onSuccess: () => {
@@ -134,8 +135,8 @@ export function LogDrains({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {logDrains
-              ?.slice()
+            {normalizedLogDrains
+              .slice()
               .sort((a, b) => b.id - a.id)
               .map((drain) => (
                 <TableRow key={drain.id}>

--- a/apps/studio/data/log-drains/log-drains-query.test.ts
+++ b/apps/studio/data/log-drains/log-drains-query.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeLogDrainsData } from './log-drains-query'
+
+describe('normalizeLogDrainsData', () => {
+  it('returns array as-is for valid payloads', () => {
+    const payload = [{ id: 1, name: 'drain-a' }, { id: 2, name: 'drain-b' }]
+    expect(normalizeLogDrainsData(payload)).toEqual(payload)
+  })
+
+  it('returns empty array for non-array payloads', () => {
+    expect(normalizeLogDrainsData(undefined)).toEqual([])
+    expect(normalizeLogDrainsData(null)).toEqual([])
+    expect(normalizeLogDrainsData({ error: { message: 'no table' } })).toEqual([])
+    expect(normalizeLogDrainsData('invalid')).toEqual([])
+  })
+})

--- a/apps/studio/data/log-drains/log-drains-query.ts
+++ b/apps/studio/data/log-drains/log-drains-query.ts
@@ -8,6 +8,9 @@ export type LogDrainsVariables = {
   ref?: string
 }
 
+export const normalizeLogDrainsData = (data: unknown): LogDrainsData =>
+  Array.isArray(data) ? (data as LogDrainsData) : []
+
 export async function getLogDrains({ ref }: LogDrainsVariables, signal?: AbortSignal) {
   if (!ref) {
     throw new Error('ref is required')
@@ -22,7 +25,7 @@ export async function getLogDrains({ ref }: LogDrainsVariables, signal?: AbortSi
     handleError(error)
   }
 
-  return data
+  return normalizeLogDrainsData(data)
 }
 
 export type LogDrainsData = Awaited<ReturnType<typeof getLogDrains>>

--- a/apps/studio/pages/project/[ref]/settings/log-drains.tsx
+++ b/apps/studio/pages/project/[ref]/settings/log-drains.tsx
@@ -59,6 +59,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
     { ref },
     { enabled: !isLoadingEntitlement && hasAccessToLogDrains }
   )
+  const hasLogDrains = Array.isArray(logDrains) && logDrains.length > 0
 
   const { mutate: createLogDrain, isPending: createLoading } = useCreateLogDrainMutation({
     onSuccess: () => {
@@ -192,7 +193,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
         subtitle="Send your project logs to third party destinations"
         primaryActions={
           <>
-            {!(logDrains?.length === 0) && (
+            {hasLogDrains && (
               <div className="flex items-center">
                 <Button
                   disabled={!hasAccessToLogDrains || !canManageLogDrains}


### PR DESCRIPTION
Fixes #41585

## Summary

This PR fixes a self-hosted Studio crash on Project Settings / Log Drains caused by non-array log drains payloads.

## What changed

- Added defensive normalization in `getLogDrains()`:
  - `normalizeLogDrainsData(data)` returns `[]` when payload is not an array.
- Updated Log Drains UI to always operate on normalized arrays before `.slice()/.sort()/.find()` calls:
  - `apps/studio/components/interfaces/LogDrains/LogDrains.tsx`
  - `apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx`
  - `apps/studio/pages/project/[ref]/settings/log-drains.tsx`
- Added regression test:
  - `apps/studio/data/log-drains/log-drains-query.test.ts`

## Why

In self-hosted environments without cloud Log Drains support, upstream responses can be non-array/shape-mismatched. The previous UI path could call array methods on non-array values, triggering runtime crash (`v?.slice(...).sort is not a function`).

This patch makes data handling shape-safe and degrades gracefully to empty state instead of crashing.

## Tests

Added unit tests covering:
- pass-through for valid arrays,
- fallback to empty array for undefined/null/object/string payloads.

## Validation

Could not execute Studio test/lint commands in this WSL shell due missing Linux Node/pnpm runtime.
The patch is small, typed, and includes regression tests for CI.
