### PR TITLE
feat: restore ability to dismiss incident banners

### DIFF
--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.tsx
@@ -16,5 +16,12 @@ export const StatusPageBanner = () => {
 
   if (!banner) return null
 
-  return <HeaderBanner variant="warning" title={banner.title} description={BANNER_DESCRIPTION} />
+  return (
+    <HeaderBanner
+      variant="warning"
+      title={banner.title}
+      description={BANNER_DESCRIPTION}
+      onDismiss={banner.dismiss}
+    />
+  )
 }

--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.ts
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.ts
@@ -1,6 +1,6 @@
 import type { IncidentCache } from 'lib/api/incident-status'
 
-type BannerIncident = { cache?: IncidentCache | null }
+type BannerIncident = { id: string; cache?: IncidentCache | null }
 
 /**
  * Determines whether the incident status banner should be shown to a given user,
@@ -41,4 +41,28 @@ export function shouldShowBanner({
     // Region restriction: only show if the user has a database in an affected region
     return affectedRegions.some((region) => userRegions.has(region))
   })
+}
+
+/**
+ * Returns the IDs of incidents that are relevant to the given user.
+ *
+ * An incident is considered relevant if it would trigger banner visibility for
+ * the user, per the same logic as shouldShowBanner.
+ */
+export function getRelevantIncidentIds({
+  incidents,
+  hasProjects,
+  userRegions,
+  hasUnknownRegions = false,
+}: {
+  incidents: Array<BannerIncident>
+  hasProjects: boolean
+  userRegions: Set<string>
+  hasUnknownRegions?: boolean
+}): Array<string> {
+  return incidents
+    .filter((incident) =>
+      shouldShowBanner({ incidents: [incident], hasProjects, userRegions, hasUnknownRegions })
+    )
+    .map((incident) => incident.id)
 }

--- a/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
+++ b/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
@@ -1,7 +1,8 @@
 import { useQueries } from '@tanstack/react-query'
-import { useFlag } from 'common'
+import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
+import { useCallback, useMemo } from 'react'
 
-import { shouldShowBanner } from './StatusPageBanner.utils'
+import { getRelevantIncidentIds, shouldShowBanner } from './StatusPageBanner.utils'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useIncidentStatusQuery } from '@/data/platform/incident-status-query'
 import { projectKeys } from '@/data/projects/keys'
@@ -9,8 +10,9 @@ import {
   getOrganizationProjects,
   type OrgProject,
 } from '@/data/projects/org-projects-infinite-query'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
-export type StatusPageBannerData = { title: string }
+export type StatusPageBannerData = { title: string; dismiss?: () => void }
 
 export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
   const showIncidentBannerOverride =
@@ -40,22 +42,63 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
 
   const allProjects = orgProjectsQueries.flatMap((q) => q.data?.projects ?? [])
   const hasProjects = allProjects.length > 0
-  const userRegions = new Set(
-    allProjects.flatMap((project: OrgProject) => project.databases.map((db) => db.region))
+  const userRegions = useMemo(
+    () =>
+      new Set(
+        allProjects.flatMap((project: OrgProject) => project.databases.map((db) => db.region))
+      ),
+    [allProjects]
   )
   const hasUnknownRegions = orgProjectsQueries.some(
     (q) => q.isError || (q.data !== undefined && q.data.pagination.count > q.data.projects.length)
   )
 
+  const [dismissedIds, setDismissedIds, { isSuccess: isDismissedLoaded }] = useLocalStorageQuery<
+    Array<string>
+  >(LOCAL_STORAGE_KEYS.INCIDENT_BANNER_DISMISSED_IDS, [])
+
+  const dismiss = useCallback(() => {
+    const activeIncidentIds = new Set(incidents.map((i) => i.id))
+    const relevantIds = getRelevantIncidentIds({
+      incidents,
+      hasProjects,
+      userRegions,
+      hasUnknownRegions,
+    })
+    setDismissedIds((prev) => [
+      ...new Set([...prev.filter((id) => activeIncidentIds.has(id)), ...relevantIds]),
+    ])
+  }, [incidents, hasProjects, userRegions, hasUnknownRegions, setDismissedIds])
+
   if (showIncidentBannerOverride) return { title: 'We are investigating a technical issue' }
 
   if (!hasActiveIncidents || !isProjectsFetched) return null
 
-  if (!shouldShowBanner({ incidents, hasProjects, userRegions, hasUnknownRegions })) return null
+  // Filter out individually dismissed incidents. An incident stays dismissed as
+  // long as its ID remains in the stored set, regardless of whether other
+  // incidents are added or removed.
+  const dismissedIdSet = new Set(dismissedIds)
+  const undismissedIncidents = incidents.filter((i) => !dismissedIdSet.has(i.id))
+
+  // If dismissed state hasn't loaded yet, hide to prevent a flash of the banner.
+  // If all relevant incidents have been dismissed, hide the banner.
+  if (
+    !isDismissedLoaded ||
+    !shouldShowBanner({
+      incidents: undismissedIncidents,
+      hasProjects,
+      userRegions,
+      hasUnknownRegions,
+    })
+  )
+    return null
+
+  const title = hasProjects
+    ? 'We are investigating a technical issue'
+    : 'Project creation may be impacted in some regions'
 
   return {
-    title: hasProjects
-      ? 'We are investigating a technical issue'
-      : 'Project creation may be impacted in some regions',
+    title,
+    dismiss,
   }
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -11,7 +11,7 @@ export const LOCAL_STORAGE_KEYS = {
   PROJECTS_SORT: 'projects-sort',
   FEEDBACK_WIDGET_CONTENT: 'feedback-widget-content',
   FEEDBACK_WIDGET_SCREENSHOT: 'feedback-widget-screenshot',
-  INCIDENT_BANNER_DISMISSED: (id: string) => `incident-banner-dismissed-${id}`,
+  INCIDENT_BANNER_DISMISSED_IDS: 'incident-banner-dismissed-ids',
   MAINTENANCE_BANNER_DISMISSED: (id: string) => `maintenance-banner-dismissed-${id}`,
 
   UI_PREVIEW_API_SIDE_PANEL: 'supabase-ui-api-side-panel',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature restoration

## What is the current behavior?

Incident banners cannot be dismissed by users.

## What is the new behavior?

Users can dismiss incident banners again.

## Additional context