### PR TITLE
fix(docs): update getSession to getUser in Refine tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-refine.mdx
@@ -233,15 +233,15 @@ const authProvider: AuthProvider = {
   },
   check: async () => {
     try {
-      const { data } = await supabaseClient.auth.getSession()
-      const { session } = data
+      const { data } = await supabaseClient.auth.getUser()
+      const { user } = data
 
-      if (!session) {
+      if (!user) {
         return {
           authenticated: false,
           error: {
             message: 'Check failed',
-            name: 'Session not found',
+            name: 'User not found',
           },
           logout: true,
           redirectTo: '/login',


### PR DESCRIPTION
## What kind of change does this PR make?

Docs update

## What does this PR do?

Replaces deprecated `supabase.auth.getSession()` with `supabase.auth.getUser()` 
in the Refine user management tutorial and example code.

### Why?

`getSession()` reads from local storage and isn't guaranteed to return an 
authenticated session. `getUser()` sends a request to the Supabase Auth server, 
validating the session server-side for improved security.

### Files changed:

- `apps/docs/content/guides/getting-started/tutorials/with-refine.mdx`
- `apps/docs/examples/user-management/refine-user-management/src/providers/auth-provider.ts`
- `apps/docs/examples/examples/user-management/refine-user-management/src/providers/auth-provider.ts`

Closes #42193