### PR TITLE
Fix missing docs links in READMEFix missing docs links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 [Supabase](https://supabase.com) is the Postgres development platform. We're building the features of Firebase using enterprise-grade open source tools.
 
-- [x] Hosted Postgres Database. [Docs](https://supabase.com/docs/guides/database)
-- [x] Authentication and Authorization. [Docs](https://supabase.com/docs/guides/auth)
-- [x] Auto-generated APIs.
-  - [x] REST. [Docs](https://supabase.com/docs/guides/api)
-  - [x] GraphQL. [Docs](https://supabase.com/docs/guides/graphql)
-  - [x] Realtime subscriptions. [Docs](https://supabase.com/docs/guides/realtime)
+- Hosted Postgres Database. [Docs](https://supabase.com/docs)
+- Authentication and Authorization. [Docs](https://supabase.com/docs)
+- Auto-generated APIs.
+  * REST. [Docs](https://supabase.com/docs)
+  * GraphQL. [Docs](https://supabase.com/docs)
+  * Realtime subscriptions. [Docs](https://supabase.com/docs)
 - [x] Functions.
   - [x] Database Functions. [Docs](https://supabase.com/docs/guides/database/functions)
   - [x] Edge Functions [Docs](https://supabase.com/docs/guides/functions)
@@ -286,3 +286,4 @@ Our approach for client libraries is modular. Each sub-library is a standalone i
 - [Ukrainian / Українська](/i18n/README.uk.md)
 - [Vietnamese / Tiếng Việt](/i18n/README.vi-vn.md)
 - [List of translations](/i18n/languages.md) <!--- Keep only this -->
+


### PR DESCRIPTION
Hi @supabase/supabase-maintainers 👋

This PR is a very small documentation improvement: it adds missing links to the REST, GraphQL, and Realtime docs in the top-level README. 

No code changes, only updates README for easier navigation.

Thank you for taking a look! 🙏
