### PR TITLE
chore: github integration entitlement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -50,6 +50,7 @@ import { InlineLink } from 'components/ui/InlineLink'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
+import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 
 const GITHUB_ICON = (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 98 96" className="w-6">
@@ -79,8 +80,10 @@ const GitHubIntegrationConnectionForm = ({
   const [repoComboBoxOpen, setRepoComboboxOpen] = useState(false)
   const isParentProject = !selectedProject?.parent_project_ref
 
-  const isProPlanAndUp = selectedOrganization?.plan?.id !== 'free'
-  const promptProPlanUpgrade = IS_PLATFORM && !isProPlanAndUp
+  const { hasAccess: hasAccessToGitHubIntegration, isLoading: isLoadingEntitlements } =
+    useCheckEntitlements('integrations.github_connections')
+  const promptProPlanUpgrade =
+    IS_PLATFORM && !isLoadingEntitlements && !hasAccessToGitHubIntegration
 
   const { can: canUpdateGitHubConnection } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,
@@ -425,7 +428,8 @@ const GitHubIntegrationConnectionForm = ({
     )
   }
 
-  const isLoading = isCreatingConnection || isUpdatingConnection || isDeletingConnection
+  const isLoading =
+    isLoadingEntitlements || isCreatingConnection || isUpdatingConnection || isDeletingConnection
 
   return (
     <>


### PR DESCRIPTION
Adds the Github Integration entitlement to the GitHubIntegrationConnectionForm.


### Testing
- Head to `/project/_/settings/integrations` with an org on the Free Plan
- Assert that you see the upgrade prompt:
<img width="829" height="272" alt="image" src="https://github.com/user-attachments/assets/9b852595-b486-4ef9-99c8-3359463c9dc3" />

- Head to `/project/_/settings/integrations` with an org on the Pro Plan
- Assert that you don't see the upgrade prompt and you're able to enable and make changes to the Github Integration
