### PR TITLE
chore: entitlement checks for infra warnings

### DIFF
--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/CPUWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/CPUWarnings.tsx
@@ -6,12 +6,16 @@ import { DOCS_URL } from 'lib/constants'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
 interface CPUWarningsProps {
-  canChangeComputeSize: boolean
+  hasAccessToComputeSizes: boolean
   upgradeUrl: string
   severity?: 'warning' | 'critical' | null
 }
 
-export const CPUWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: CPUWarningsProps) => {
+export const CPUWarnings = ({
+  hasAccessToComputeSizes,
+  upgradeUrl,
+  severity,
+}: CPUWarningsProps) => {
   if (severity === 'warning') {
     return (
       <Alert_Shadcn_ variant="warning">
@@ -28,7 +32,7 @@ export const CPUWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: CPUW
           </Button>
           <Button asChild type="warning">
             <Link href={upgradeUrl}>
-              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+              {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>
@@ -52,7 +56,7 @@ export const CPUWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: CPUW
           </Button>
           <Button asChild type="danger">
             <Link href={upgradeUrl}>
-              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+              {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/CPUWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/CPUWarnings.tsx
@@ -6,12 +6,12 @@ import { DOCS_URL } from 'lib/constants'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
 interface CPUWarningsProps {
-  isFreePlan: boolean
+  canChangeComputeSize: boolean
   upgradeUrl: string
   severity?: 'warning' | 'critical' | null
 }
 
-export const CPUWarnings = ({ isFreePlan, upgradeUrl, severity }: CPUWarningsProps) => {
+export const CPUWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: CPUWarningsProps) => {
   if (severity === 'warning') {
     return (
       <Alert_Shadcn_ variant="warning">
@@ -28,7 +28,7 @@ export const CPUWarnings = ({ isFreePlan, upgradeUrl, severity }: CPUWarningsPro
           </Button>
           <Button asChild type="warning">
             <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>
@@ -52,7 +52,7 @@ export const CPUWarnings = ({ isFreePlan, upgradeUrl, severity }: CPUWarningsPro
           </Button>
           <Button asChild type="danger">
             <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
@@ -4,7 +4,7 @@ import { Admonition } from 'ui-patterns'
 
 // [Joshen] In the future, conditionals should be from resource exhaustion endpoint as single source of truth
 interface DiskIOBandwidthWarningsProps {
-  canChangeComputeSize: boolean
+  hasAccessToComputeSizes: boolean
   hasLatest: boolean
   upgradeUrl: string
   currentBillingCycleSelected: boolean
@@ -13,7 +13,7 @@ interface DiskIOBandwidthWarningsProps {
 }
 
 export const DiskIOBandwidthWarnings = ({
-  canChangeComputeSize,
+  hasAccessToComputeSizes,
   hasLatest,
   currentBillingCycleSelected,
   upgradeUrl,
@@ -34,7 +34,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="danger">
               <Link href={upgradeUrl}>
-                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+                {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>
@@ -58,7 +58,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="danger">
               <Link href={upgradeUrl}>
-                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+                {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>
@@ -81,7 +81,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="warning">
               <Link href={upgradeUrl}>
-                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+                {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>
@@ -105,7 +105,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="warning">
               <Link href={upgradeUrl}>
-                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+                {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
@@ -4,7 +4,7 @@ import { Admonition } from 'ui-patterns'
 
 // [Joshen] In the future, conditionals should be from resource exhaustion endpoint as single source of truth
 interface DiskIOBandwidthWarningsProps {
-  isFreePlan: boolean
+  canChangeComputeSize: boolean
   hasLatest: boolean
   upgradeUrl: string
   currentBillingCycleSelected: boolean
@@ -13,7 +13,7 @@ interface DiskIOBandwidthWarningsProps {
 }
 
 export const DiskIOBandwidthWarnings = ({
-  isFreePlan,
+  canChangeComputeSize,
   hasLatest,
   currentBillingCycleSelected,
   upgradeUrl,
@@ -34,7 +34,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="danger">
               <Link href={upgradeUrl}>
-                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>
@@ -58,7 +58,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="danger">
               <Link href={upgradeUrl}>
-                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>
@@ -81,7 +81,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="warning">
               <Link href={upgradeUrl}>
-                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>
@@ -105,7 +105,7 @@ export const DiskIOBandwidthWarnings = ({
             </p>
             <Button asChild type="warning">
               <Link href={upgradeUrl}>
-                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+                {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
               </Link>
             </Button>
           </>

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/RAMWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/RAMWarnings.tsx
@@ -6,12 +6,16 @@ import { DOCS_URL } from 'lib/constants'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
 interface RAMWarningsProps {
-  canChangeComputeSize: boolean
+  hasAccessToComputeSizes: boolean
   upgradeUrl: string
   severity?: 'warning' | 'critical' | null
 }
 
-export const RAMWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: RAMWarningsProps) => {
+export const RAMWarnings = ({
+  hasAccessToComputeSizes,
+  upgradeUrl,
+  severity,
+}: RAMWarningsProps) => {
   if (severity === 'warning') {
     return (
       <Alert_Shadcn_ variant="warning">
@@ -28,7 +32,7 @@ export const RAMWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: RAMW
           </Button>
           <Button asChild type="warning">
             <Link href={upgradeUrl}>
-              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+              {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>
@@ -52,7 +56,7 @@ export const RAMWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: RAMW
           </Button>
           <Button asChild type="danger">
             <Link href={upgradeUrl}>
-              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
+              {hasAccessToComputeSizes ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/RAMWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/RAMWarnings.tsx
@@ -6,12 +6,12 @@ import { DOCS_URL } from 'lib/constants'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
 interface RAMWarningsProps {
-  isFreePlan: boolean
+  canChangeComputeSize: boolean
   upgradeUrl: string
   severity?: 'warning' | 'critical' | null
 }
 
-export const RAMWarnings = ({ isFreePlan, upgradeUrl, severity }: RAMWarningsProps) => {
+export const RAMWarnings = ({ canChangeComputeSize, upgradeUrl, severity }: RAMWarningsProps) => {
   if (severity === 'warning') {
     return (
       <Alert_Shadcn_ variant="warning">
@@ -28,7 +28,7 @@ export const RAMWarnings = ({ isFreePlan, upgradeUrl, severity }: RAMWarningsPro
           </Button>
           <Button asChild type="warning">
             <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>
@@ -52,7 +52,7 @@ export const RAMWarnings = ({ isFreePlan, upgradeUrl, severity }: RAMWarningsPro
           </Button>
           <Button asChild type="danger">
             <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              {canChangeComputeSize ? 'Change compute add-on' : 'Upgrade project'}
             </Link>
           </Button>
         </div>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -25,6 +25,7 @@ import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-que
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useResourceWarningsQuery } from 'data/usage/resource-warnings-query'
 import dayjs from 'dayjs'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL, INSTANCE_MICRO_SPECS, INSTANCE_NANO_SPECS, InstanceSpecs } from 'lib/constants'
@@ -64,7 +65,9 @@ export const InfrastructureActivity = () => {
   const { data: subscription, isPending: isLoadingSubscription } = useOrgSubscriptionQuery({
     orgSlug: organization?.slug,
   })
-  const isFreePlan = organization?.plan?.id === 'free'
+  const { hasAccess: canChangeComputeSize } = useCheckEntitlements(
+    'instances.compute_update_available_sizes'
+  )
 
   const { data: resourceWarnings } = useResourceWarningsQuery({ ref: projectRef })
   // [Joshen Cleanup] JFYI this client side filtering can be cleaned up once BE changes are live which will only return the warnings based on the provided ref
@@ -269,7 +272,7 @@ export const InfrastructureActivity = () => {
                     <>
                       <DiskIOBandwidthWarnings
                         upgradeUrl={upgradeUrl}
-                        isFreePlan={isFreePlan}
+                        canChangeComputeSize={canChangeComputeSize}
                         hasLatest={hasLatest}
                         currentBillingCycleSelected={currentBillingCycleSelected}
                         latestIoBudgetConsumption={latestIoBudgetConsumption}
@@ -329,15 +332,15 @@ export const InfrastructureActivity = () => {
                   )}
                   {attribute.key === 'max_cpu_usage' && (
                     <CPUWarnings
-                      isFreePlan={isFreePlan}
                       upgradeUrl={upgradeUrl}
+                      canChangeComputeSize={canChangeComputeSize}
                       severity={projectResourceWarnings?.cpu_exhaustion}
                     />
                   )}
                   {attribute.key === 'ram_usage' && (
                     <RAMWarnings
-                      isFreePlan={isFreePlan}
                       upgradeUrl={upgradeUrl}
+                      canChangeComputeSize={canChangeComputeSize}
                       severity={projectResourceWarnings?.memory_and_swap_exhaustion}
                     />
                   )}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -65,7 +65,7 @@ export const InfrastructureActivity = () => {
   const { data: subscription, isPending: isLoadingSubscription } = useOrgSubscriptionQuery({
     orgSlug: organization?.slug,
   })
-  const { hasAccess: canChangeComputeSize } = useCheckEntitlements(
+  const { hasAccess: hasAccessToComputeSizes } = useCheckEntitlements(
     'instances.compute_update_available_sizes'
   )
 
@@ -108,7 +108,7 @@ export const InfrastructureActivity = () => {
   const upgradeUrl =
     organization === undefined
       ? `/`
-      : organization.plan.id === 'free'
+      : hasAccessToComputeSizes
         ? `/org/${organization?.slug ?? '[slug]'}/billing#subscription`
         : `/project/${projectRef}/settings/addons`
 
@@ -272,7 +272,7 @@ export const InfrastructureActivity = () => {
                     <>
                       <DiskIOBandwidthWarnings
                         upgradeUrl={upgradeUrl}
-                        canChangeComputeSize={canChangeComputeSize}
+                        hasAccessToComputeSizes={hasAccessToComputeSizes}
                         hasLatest={hasLatest}
                         currentBillingCycleSelected={currentBillingCycleSelected}
                         latestIoBudgetConsumption={latestIoBudgetConsumption}
@@ -333,14 +333,14 @@ export const InfrastructureActivity = () => {
                   {attribute.key === 'max_cpu_usage' && (
                     <CPUWarnings
                       upgradeUrl={upgradeUrl}
-                      canChangeComputeSize={canChangeComputeSize}
+                      hasAccessToComputeSizes={hasAccessToComputeSizes}
                       severity={projectResourceWarnings?.cpu_exhaustion}
                     />
                   )}
                   {attribute.key === 'ram_usage' && (
                     <RAMWarnings
                       upgradeUrl={upgradeUrl}
-                      canChangeComputeSize={canChangeComputeSize}
+                      hasAccessToComputeSizes={hasAccessToComputeSizes}
                       severity={projectResourceWarnings?.memory_and_swap_exhaustion}
                     />
                   )}


### PR DESCRIPTION
### Changes
- Replace `isFreePlan` with entitlement-based check in infrastructure warnings: `CPUWarnings`, `RAMWarnings`, and `DiskIOBandwidthWarnings` previously derived their button label ("Upgrade project" vs "Change compute add-on") from checking the org's plan. This is now driven by the `instances.compute_update_available_sizes` entitlement.