### PR TITLE
fix: rename misspelled variable reccomendedComputeSize

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/fields/IOPSField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/IOPSField.tsx
@@ -48,7 +48,7 @@ export function IOPSField({ form, disableInput }: IOPSFieldProps) {
       control={control}
       name="provisionedIOPS"
       render={({ field }) => {
-        const reccomendedComputeSize = calculateComputeSizeRequiredForIops(watchedIOPS)
+        const recommendedComputeSize = calculateComputeSizeRequiredForIops(watchedIOPS)
         return (
           <FormItemLayout
             layout="horizontal"
@@ -63,11 +63,11 @@ export function IOPSField({ form, disableInput }: IOPSFieldProps) {
                     <Button
                       type="default"
                       onClick={() => {
-                        setValue('computeSize', reccomendedComputeSize ?? 'ci_nano')
+                        setValue('computeSize', recommendedComputeSize ?? 'ci_nano')
                         trigger('provisionedIOPS')
                       }}
                     >
-                      Update to {mapAddOnVariantIdToComputeSize(reccomendedComputeSize)}
+                      Update to {mapAddOnVariantIdToComputeSize(recommendedComputeSize)}
                     </Button>
                   }
                 />


### PR DESCRIPTION
## Summary
- Rename `reccomendedComputeSize` → `recommendedComputeSize` in `apps/studio/components/interfaces/DiskManagement/fields/IOPSField.tsx`
- Fixes misspelling across all 3 occurrences of the variable

## Test plan
- [x] Variable rename only — no logic change
- [x] All 3 references updated consistently