### PR TITLE
feat: add tooltip displaying active incidents to banner

### DIFF
--- a/apps/studio/components/interfaces/Organization/HeaderBanner.tsx
+++ b/apps/studio/components/interfaces/Organization/HeaderBanner.tsx
@@ -1,9 +1,9 @@
 import { AnimatePresence, motion } from 'framer-motion'
+import { InfoIcon, XIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
+import { Button, cn, CriticalIcon, Tooltip, TooltipContent, TooltipTrigger, WarningIcon } from 'ui'
 
-import { useOrganizationRestrictions } from 'hooks/misc/useOrganizationRestrictions'
-import { XIcon } from 'lucide-react'
-import { Button, cn, CriticalIcon, WarningIcon } from 'ui'
+import { useOrganizationRestrictions } from '@/hooks/misc/useOrganizationRestrictions'
 
 const bannerMotionProps = {
   initial: { height: 0, opacity: 0 },
@@ -32,6 +32,7 @@ interface HeaderBannerProps {
   title: string
   description: string | ReactNode
   onDismiss?: () => void
+  titleTooltip?: ReactNode
 }
 const variantStyles = {
   danger: {
@@ -48,7 +49,13 @@ const variantStyles = {
   },
 } as const
 
-export const HeaderBanner = ({ variant, title, description, onDismiss }: HeaderBannerProps) => {
+export const HeaderBanner = ({
+  variant,
+  title,
+  description,
+  onDismiss,
+  titleTooltip,
+}: HeaderBannerProps) => {
   const { banner: bannerStyles, icon: iconStyles } = variantStyles[variant]
   const Icon = variant === 'danger' ? CriticalIcon : WarningIcon
 
@@ -91,7 +98,24 @@ export const HeaderBanner = ({ variant, title, description, onDismiss }: HeaderB
             )}
           >
             {/* Title */}
-            <p className="text-sm text-foreground font-medium md:truncate">{title}</p>
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm text-foreground font-medium md:truncate">{title}</p>
+              {titleTooltip && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      className="flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity"
+                      aria-label="View incident details"
+                    >
+                      <InfoIcon size={14} className="text-foreground" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="max-w-xs">
+                    {titleTooltip}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
             {/* Description */}
             <div className="flex flex-row items-center gap-1.5 min-w-0 md:flex-nowrap text-sm">
               <span className="hidden md:inline text-foreground-muted">·</span>

--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.tsx
@@ -16,12 +16,27 @@ export const StatusPageBanner = () => {
 
   if (!banner) return null
 
+  const incidentTooltip =
+    banner.incidents && banner.incidents.length > 0 ? (
+      <div className="flex flex-col gap-1.5">
+        <p className="font-medium">Active incidents</p>
+        <ul className="space-y-0.5">
+          {banner.incidents.map((incident) => (
+            <li key={incident.id} className="text-foreground-light">
+              {incident.name}
+            </li>
+          ))}
+        </ul>
+      </div>
+    ) : undefined
+
   return (
     <HeaderBanner
       variant="warning"
       title={banner.title}
       description={BANNER_DESCRIPTION}
       onDismiss={banner.dismiss}
+      titleTooltip={incidentTooltip}
     />
   )
 }

--- a/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
+++ b/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
@@ -12,7 +12,11 @@ import {
 } from '@/data/projects/org-projects-infinite-query'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
-export type StatusPageBannerData = { title: string; dismiss?: () => void }
+export type StatusPageBannerData = {
+  title: string
+  dismiss?: () => void
+  incidents?: Array<{ id: string; name: string }>
+}
 
 export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
   const showIncidentBannerOverride =
@@ -70,6 +74,7 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
     ])
   }, [incidents, hasProjects, userRegions, hasUnknownRegions, setDismissedIds])
 
+  // Override path: no dismiss or incident list, since there is no incident ID to dismiss against
   if (showIncidentBannerOverride) return { title: 'We are investigating a technical issue' }
 
   if (!hasActiveIncidents || !isProjectsFetched) return null
@@ -97,8 +102,15 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
     ? 'We are investigating a technical issue'
     : 'Project creation may be impacted in some regions'
 
+  const relevantIncidents = undismissedIncidents
+    .filter((i) =>
+      shouldShowBanner({ incidents: [i], hasProjects, userRegions, hasUnknownRegions })
+    )
+    .map((i) => ({ id: i.id, name: i.name }))
+
   return {
     title,
     dismiss,
+    incidents: relevantIncidents,
   }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The incident banner exists but does not display active incidents.

## What is the new behavior?

The incident banner now displays a tooltip showing active incidents.

## Additional context

Test on local, with the latest env vars from platform it should have an active incident banner

<img width="1166" height="234" alt="CleanShot 2026-03-02 at 13 34 15@2x" src="https://github.com/user-attachments/assets/5bb3b865-e1cf-4c75-8c75-dc6dfdb5a6db" />

Resolves FE-2651
(the onDismiss issue from that incident already works, just addressing the listing incidents part)