### PR TITLE
chore: disk size config entitlement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -1,3 +1,4 @@
+import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { Markdown } from 'components/interfaces/Markdown'
@@ -62,6 +63,10 @@ export const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfiguratio
       setShowIncreaseDiskSizeModal(false)
     },
   })
+
+  const { hasAccess: hasAccessToDiskSizeConfig } = useCheckEntitlements(
+    'instances.disk_modifications'
+  )
 
   const currentDiskSize = project?.volumeSizeGb ?? 0
 
@@ -172,12 +177,12 @@ Read more about [disk management](${DOCS_URL}/guides/platform/database-size#disk
             <Alert_Shadcn_>
               <InfoIcon />
               <AlertTitle_Shadcn_>
-                {organization?.plan?.id === 'free'
+                {hasAccessToDiskSizeConfig === false
                   ? 'Disk size configuration is not available for projects on the Free Plan'
                   : 'Disk size configuration is only available when the spend cap has been disabled'}
               </AlertTitle_Shadcn_>
               <AlertDescription_Shadcn_>
-                {organization?.plan?.id === 'free' ? (
+                {hasAccessToDiskSizeConfig === false ? (
                   <p>
                     If you are intending to use more than 500MB of disk space, then you will need to
                     upgrade to at least the Pro Plan.
@@ -191,11 +196,11 @@ Read more about [disk management](${DOCS_URL}/guides/platform/database-size#disk
                 <Button asChild type="default" className="mt-3">
                   <Link
                     href={`/org/${organization?.slug}/billing?panel=${
-                      organization?.plan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
+                      hasAccessToDiskSizeConfig === false ? 'subscriptionPlan' : 'costControl'
                     }`}
                     target="_blank"
                   >
-                    {organization?.plan?.id === 'free'
+                    {hasAccessToDiskSizeConfig === false
                       ? 'Upgrade subscription'
                       : 'Disable spend cap'}
                   </Link>

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -195,7 +195,7 @@ const DiskSizeConfigurationModal = ({
               : 'Disk size configuration is only available when the spend cap has been disabled'}
           </AlertTitle_Shadcn_>
           <AlertDescription_Shadcn_>
-            {hasAccessToDiskModifications === false ?(
+            {hasAccessToDiskModifications === false ? (
               <p>
                 If you are intending to use more than 500MB of disk space, then you will need to
                 upgrade to at least the Pro Plan.

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -9,6 +9,7 @@ import { number, object } from 'yup'
 import { useParams } from 'common'
 import { SupportLink } from 'components/interfaces/Support/SupportLink'
 import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mutation'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -45,7 +46,10 @@ const DiskSizeConfigurationModal = ({
   const { data: projectSubscriptionData, isPending: isLoadingSubscription } =
     useOrgSubscriptionQuery({ orgSlug: organization?.slug }, { enabled: visible })
 
-  const isLoading = isLoadingProject || isLoadingSubscription
+  const { hasAccess: hasAccessToDiskModifications, isLoading: isLoadingDiskEntitlement } =
+    useCheckEntitlements('instances.disk_modifications')
+
+  const isLoading = isLoadingProject || isLoadingDiskEntitlement
 
   const timeTillNextAvailableDatabaseResize =
     lastDatabaseResizeAt === null ? 0 : 6 * 60 - dayjs().diff(lastDatabaseResizeAt, 'minutes')
@@ -101,7 +105,7 @@ const DiskSizeConfigurationModal = ({
           <ShimmeringLoader />
           <ShimmeringLoader />
         </div>
-      ) : projectSubscriptionData?.usage_billing_enabled === true ? (
+      ) : hasAccessToDiskModifications ? (
         <Form
           name="disk-resize-form"
           initialValues={INITIAL_VALUES}
@@ -186,12 +190,12 @@ const DiskSizeConfigurationModal = ({
         <Alert_Shadcn_ className="border-none">
           <InfoIcon />
           <AlertTitle_Shadcn_>
-            {projectSubscriptionData?.plan?.id === 'free'
+            {hasAccessToDiskModifications === false
               ? 'Disk size configuration is not available for projects on the Free Plan'
               : 'Disk size configuration is only available when the spend cap has been disabled'}
           </AlertTitle_Shadcn_>
           <AlertDescription_Shadcn_>
-            {projectSubscriptionData?.plan?.id === 'free' ? (
+            {hasAccessToDiskModifications === false ?(
               <p>
                 If you are intending to use more than 500MB of disk space, then you will need to
                 upgrade to at least the Pro Plan.
@@ -205,11 +209,11 @@ const DiskSizeConfigurationModal = ({
             <Button asChild type="default" className="mt-3">
               <Link
                 href={`/org/${organization?.slug}/billing?panel=${
-                  projectSubscriptionData?.plan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
+                  hasAccessToDiskModifications === false ? 'subscriptionPlan' : 'costControl'
                 }`}
                 target="_blank"
               >
-                {projectSubscriptionData?.plan?.id === 'free'
+                {hasAccessToDiskModifications === false
                   ? 'Upgrade subscription'
                   : 'Disable spend cap'}
               </Link>

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -105,7 +105,8 @@ const DiskSizeConfigurationModal = ({
           <ShimmeringLoader />
           <ShimmeringLoader />
         </div>
-      ) : projectSubscriptionData?.usage_billing_enabled === true && hasAccessToDiskModifications ? (
+      ) : projectSubscriptionData?.usage_billing_enabled === true &&
+        hasAccessToDiskModifications ? (
         <Form
           name="disk-resize-form"
           initialValues={INITIAL_VALUES}

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -49,7 +49,7 @@ const DiskSizeConfigurationModal = ({
   const { hasAccess: hasAccessToDiskModifications, isLoading: isLoadingDiskEntitlement } =
     useCheckEntitlements('instances.disk_modifications')
 
-  const isLoading = isLoadingProject || isLoadingDiskEntitlement
+  const isLoading = isLoadingProject || isLoadingSubscription || isLoadingDiskEntitlement
 
   const timeTillNextAvailableDatabaseResize =
     lastDatabaseResizeAt === null ? 0 : 6 * 60 - dayjs().diff(lastDatabaseResizeAt, 'minutes')
@@ -105,7 +105,7 @@ const DiskSizeConfigurationModal = ({
           <ShimmeringLoader />
           <ShimmeringLoader />
         </div>
-      ) : hasAccessToDiskModifications ? (
+      ) : projectSubscriptionData?.usage_billing_enabled === true ? (
         <Form
           name="disk-resize-form"
           initialValues={INITIAL_VALUES}

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -105,7 +105,7 @@ const DiskSizeConfigurationModal = ({
           <ShimmeringLoader />
           <ShimmeringLoader />
         </div>
-      ) : projectSubscriptionData?.usage_billing_enabled === true ? (
+      ) : projectSubscriptionData?.usage_billing_enabled === true && hasAccessToDiskModifications ? (
         <Form
           name="disk-resize-form"
           initialValues={INITIAL_VALUES}


### PR DESCRIPTION
Adds entitlements check to the `DiskSizeConfiguration` and `DiskSizeConfigurationModal` components

## Testing

### Database Settings
- You'll need an Org in the Pro Plan with spend cap disabled, and a Project with Fly as the cloud provider.
- Head to `/project/_/database/settings`
- Assert that the Disk Size configuration section is visible:
<img width="707" height="459" alt="image" src="https://github.com/user-attachments/assets/ce98ed20-cab7-44db-a118-b84d9f9f935c" />

- With a Free Project with Fly as the cloud provider, assert that the Disk Size configuration is gated:
<img width="707" height="260" alt="image" src="https://github.com/user-attachments/assets/23374b03-7981-42cd-b928-0e8808d128b1" />


### Observability > Database

- You'll need an Org in the Pro Plan with spend cap disabled, and a Project with Fly as the cloud provider.
- Head to `project/_/observability/database`, and scroll to the `Database Size` section
- Assert that clicking the `Increase disk size` button shows this modal:
<img width="829" height="469" alt="image" src="https://github.com/user-attachments/assets/ae121e3f-a68b-4de6-803d-aff8462e0c7c" />

- With a Free Project with Fly as the cloud provider, assert that the increase size modal doesn't allow you to increase the size
<img width="707" height="398" alt="image" src="https://github.com/user-attachments/assets/3e97ce27-4ecd-4152-80a0-d5e0d141f44b" />



