### PR TITLE
feat(assistant): add overflow menu with Copy chat ID action

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -1,6 +1,15 @@
-import { Plus, Settings, X } from 'lucide-react'
+import { Clipboard, Ellipsis, Plus, Settings, X } from 'lucide-react'
 import { useState } from 'react'
-import { AiIconAnimation, Button } from 'ui'
+import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
+import {
+  AiIconAnimation,
+  Button,
+  copyToClipboard,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'ui'
 import { Admonition } from 'ui-patterns'
 
 import { ButtonTooltip } from '../ButtonTooltip'
@@ -26,6 +35,7 @@ export const AIAssistantHeader = ({
   isHipaaProjectDisallowed,
   aiOptInLevel,
 }: AIAssistantHeaderProps) => {
+  const snap = useAiAssistantStateSnapshot()
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
   return (
     <div className="z-30 sticky top-0">
@@ -70,6 +80,26 @@ export const AIAssistantHeader = ({
                 content: { side: 'bottom', text: 'Permission settings' },
               }}
             />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <ButtonTooltip
+                  type="text"
+                  size="tiny"
+                  icon={<Ellipsis strokeWidth={1.5} />}
+                  className="h-7 w-7 p-0"
+                  tooltip={{ content: { side: 'bottom', text: 'More options' } }}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="gap-x-2"
+                  onClick={() => copyToClipboard(snap.activeChatId ?? '')}
+                >
+                  <Clipboard size={14} strokeWidth={1.5} />
+                  <span>Copy chat ID</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
             <ButtonTooltip
               type="text"
               className="w-7 h-7"


### PR DESCRIPTION
Adds an overflow `…` menu to the AI assistant header with a **Copy chat ID** action. Clicking it copies the active chat's UUID to the clipboard, useful for reproduction/debugging.

<img width="810" height="233" alt="CleanShot 2026-03-02 at 14 55 31@2x" src="https://github.com/user-attachments/assets/f3571978-6ca0-4f99-8b5d-625742f290e6" />

This facilitates filtering Logs like so:

<img width="727" height="321" alt="CleanShot 2026-03-02 at 14 57 01@2x" src="https://github.com/user-attachments/assets/ec259f2d-58f9-4087-beca-351f62ac5059" />

Closes AI-441