### PR TITLE
feat(studio): Display region-specific incidents in RegionSelector

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -1,16 +1,11 @@
-import { UseFormReturn } from 'react-hook-form'
-
 import { useFlag, useParams } from 'common'
-import AlertError from 'components/ui/AlertError'
-import Panel from 'components/ui/Panel'
-import { useDefaultRegionQuery } from 'data/misc/get-default-region-query'
-import { useOrganizationAvailableRegionsQuery } from 'data/organizations/organization-available-regions-query'
-import type { DesiredInstanceSize } from 'data/projects/new-project.constants'
-import { BASE_PATH, PROVIDERS } from 'lib/constants'
+import { UseFormReturn } from 'react-hook-form'
 import type { CloudProvider } from 'shared-data'
 import {
   Badge,
+  cn,
   FormField_Shadcn_,
+  Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectGroup_Shadcn_,
   SelectItem_Shadcn_,
@@ -18,15 +13,23 @@ import {
   SelectSeparator_Shadcn_,
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
-  Select_Shadcn_,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  cn,
 } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { getAvailableRegions } from './ProjectCreation.utils'
+import AlertError from '@/components/ui/AlertError'
+import { InlineLink } from '@/components/ui/InlineLink'
+import Panel from '@/components/ui/Panel'
+import { useDefaultRegionQuery } from '@/data/misc/get-default-region-query'
+import { useOrganizationAvailableRegionsQuery } from '@/data/organizations/organization-available-regions-query'
+import { useIncidentStatusQuery } from '@/data/platform/incident-status-query'
+import type { DesiredInstanceSize } from '@/data/projects/new-project.constants'
+import { BASE_PATH, PROVIDERS } from '@/lib/constants'
 
 interface RegionSelectorProps {
   form: UseFormReturn<CreateProjectForm>
@@ -37,6 +40,18 @@ interface RegionSelectorProps {
 // [Joshen] Let's use a library to maintain the flag SVGs in the future
 // I tried using https://flagpack.xyz/docs/development/react/ but couldn't get it to render
 // ^ can try again next time
+
+// Maps smart region group codes to the specific-region code prefixes they contain.
+// Used to check whether an incident affecting specific regions also affects a smart region selection.
+const SMART_REGION_PREFIXES: Record<string, Array<string>> = {
+  americas: ['us-', 'ca-', 'sa-'],
+  emea: ['eu-', 'me-', 'af-'],
+  apac: ['ap-'],
+}
+
+function smartRegionMatchesSpecific(smartCode: string, specificCode: string): boolean {
+  return (SMART_REGION_PREFIXES[smartCode] ?? []).some((prefix) => specificCode.startsWith(prefix))
+}
 
 // Map backend region names to user-friendly display names
 const getDisplayNameForSmartRegion = (name: string): string => {
@@ -55,6 +70,9 @@ export const RegionSelector = ({
   const cloudProvider = form.getValues('cloudProvider') as CloudProvider
 
   const smartRegionEnabled = useFlag('enableSmartRegion')
+
+  const { data: statusData } = useIncidentStatusQuery()
+  const { incidents = [] } = statusData ?? {}
 
   const { isPending: isLoadingDefaultRegion } = useDefaultRegionQuery(
     { cloudProvider },
@@ -114,150 +132,183 @@ export const RegionSelector = ({
             return !!region.name && region.name === field.value
           })
 
+          const affectingIncidents = incidents.filter((incident) => {
+            const affectedRegions = incident.cache?.affected_regions ?? []
+            if (affectedRegions.length === 0 || selectedRegion?.code === undefined) return false
+
+            // Specific region: direct code match
+            if (affectedRegions.includes(selectedRegion.code)) return true
+
+            // Smart region: match if any affected region falls within the smart group
+            return affectedRegions.some((specificCode) =>
+              smartRegionMatchesSpecific(selectedRegion.code, specificCode)
+            )
+          })
+
           return (
-            <FormItemLayout
-              layout={layout}
-              label="Region"
-              description={
-                <>
-                  <p>Select the region closest to your users for the best performance.</p>
-                  {showNonProdFields && (
-                    <div className="mt-2 text-warning">
-                      <p>Only these regions are supported for local/staging projects:</p>
-                      <ul className="list-disc list-inside mt-1">
-                        <li>East US (North Virginia)</li>
-                        <li>Central EU (Frankfurt)</li>
-                        <li>Southeast Asia (Singapore)</li>
-                      </ul>
-                    </div>
-                  )}
-                </>
-              }
-            >
-              <Select_Shadcn_
-                value={field.value}
-                onValueChange={field.onChange}
-                disabled={isLoading}
-              >
-                <SelectTrigger_Shadcn_ className="[&>:nth-child(1)]:w-full [&>:nth-child(1)]:flex [&>:nth-child(1)]:items-start">
-                  <SelectValue_Shadcn_
-                    placeholder={
-                      isLoading
-                        ? 'Loading available regions...'
-                        : 'Select a region for your project..'
-                    }
-                  >
-                    {field.value !== undefined && (
-                      <div className="flex items-center gap-x-3">
-                        {selectedRegion?.code && (
-                          <img
-                            alt="region icon"
-                            className="w-5 rounded-sm"
-                            src={`${BASE_PATH}/img/regions/${selectedRegion.code}.svg`}
-                          />
-                        )}
-                        <span className="text-foreground">
-                          {selectedRegion?.name
-                            ? getDisplayNameForSmartRegion(selectedRegion.name)
-                            : field.value}
-                        </span>
+            <>
+              <FormItemLayout
+                layout={layout}
+                label="Region"
+                description={
+                  <>
+                    <p>Select the region closest to your users for the best performance.</p>
+                    {showNonProdFields && (
+                      <div className="mt-2 text-warning">
+                        <p>Only these regions are supported for local/staging projects:</p>
+                        <ul className="list-disc list-inside mt-1">
+                          <li>East US (North Virginia)</li>
+                          <li>Central EU (Frankfurt)</li>
+                          <li>Southeast Asia (Singapore)</li>
+                        </ul>
                       </div>
                     )}
-                  </SelectValue_Shadcn_>
-                </SelectTrigger_Shadcn_>
-                <SelectContent_Shadcn_>
-                  {smartRegionEnabled && (
-                    <>
-                      <SelectGroup_Shadcn_>
-                        <SelectLabel_Shadcn_>General regions</SelectLabel_Shadcn_>
-                        {smartRegions.map((value) => {
-                          return (
-                            <SelectItem_Shadcn_
-                              key={value.code}
-                              value={value.name}
-                              className="w-full [&>:nth-child(2)]:w-full"
-                            >
-                              <div className="flex flex-row items-center justify-between w-full">
-                                <div className="flex items-center gap-x-3">
-                                  <img
-                                    alt="region icon"
-                                    className="w-5 rounded-sm"
-                                    src={`${BASE_PATH}/img/regions/${value.code}.svg`}
-                                  />
-                                  <span className="text-foreground">
-                                    {getDisplayNameForSmartRegion(value.name)}
+                  </>
+                }
+              >
+                <Select_Shadcn_
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  disabled={isLoading}
+                >
+                  <SelectTrigger_Shadcn_ className="[&>:nth-child(1)]:w-full [&>:nth-child(1)]:flex [&>:nth-child(1)]:items-start">
+                    <SelectValue_Shadcn_
+                      placeholder={
+                        isLoading
+                          ? 'Loading available regions...'
+                          : 'Select a region for your project..'
+                      }
+                    >
+                      {field.value !== undefined && (
+                        <div className="flex items-center gap-x-3">
+                          {selectedRegion?.code && (
+                            <img
+                              alt="region icon"
+                              className="w-5 rounded-sm"
+                              src={`${BASE_PATH}/img/regions/${selectedRegion.code}.svg`}
+                            />
+                          )}
+                          <span className="text-foreground">
+                            {selectedRegion?.name
+                              ? getDisplayNameForSmartRegion(selectedRegion.name)
+                              : field.value}
+                          </span>
+                        </div>
+                      )}
+                    </SelectValue_Shadcn_>
+                  </SelectTrigger_Shadcn_>
+                  <SelectContent_Shadcn_>
+                    {smartRegionEnabled && (
+                      <>
+                        <SelectGroup_Shadcn_>
+                          <SelectLabel_Shadcn_>General regions</SelectLabel_Shadcn_>
+                          {smartRegions.map((value) => {
+                            return (
+                              <SelectItem_Shadcn_
+                                key={value.code}
+                                value={value.name}
+                                className="w-full [&>:nth-child(2)]:w-full"
+                              >
+                                <div className="flex flex-row items-center justify-between w-full">
+                                  <div className="flex items-center gap-x-3">
+                                    <img
+                                      alt="region icon"
+                                      className="w-5 rounded-sm"
+                                      src={`${BASE_PATH}/img/regions/${value.code}.svg`}
+                                    />
+                                    <span className="text-foreground">
+                                      {getDisplayNameForSmartRegion(value.name)}
+                                    </span>
+                                  </div>
+
+                                  <div>
+                                    {recommendedSmartRegions.has(value.code) && (
+                                      <Badge variant="success" className="mr-1">
+                                        Recommended
+                                      </Badge>
+                                    )}
+                                  </div>
+                                </div>
+                              </SelectItem_Shadcn_>
+                            )
+                          })}
+                        </SelectGroup_Shadcn_>
+                        <SelectSeparator_Shadcn_ />
+                      </>
+                    )}
+
+                    <SelectGroup_Shadcn_>
+                      <SelectLabel_Shadcn_>Specific regions</SelectLabel_Shadcn_>
+                      {regionOptions.map((value) => {
+                        return (
+                          <SelectItem_Shadcn_
+                            key={value.code}
+                            value={value.name}
+                            className={cn(
+                              'w-full [&>:nth-child(2)]:w-full',
+                              value.status !== undefined && '!pointer-events-auto'
+                            )}
+                            disabled={value.status !== undefined}
+                          >
+                            <div className="flex flex-row items-center justify-between w-full gap-x-2">
+                              <div className="flex items-center gap-x-3">
+                                <img
+                                  alt="region icon"
+                                  className="w-5 rounded-sm"
+                                  src={`${BASE_PATH}/img/regions/${value.code}.svg`}
+                                />
+                                <div className="flex items-center gap-x-2">
+                                  <span className="text-foreground">{value.name}</span>
+                                  <span className="text-xs text-foreground-lighter font-mono">
+                                    {value.code}
                                   </span>
                                 </div>
+                              </div>
 
-                                <div>
-                                  {recommendedSmartRegions.has(value.code) && (
-                                    <Badge variant="success" className="mr-1">
-                                      Recommended
+                              {recommendedSpecificRegions.has(value.code) && (
+                                <Badge variant="success" className="mr-1">
+                                  Recommended
+                                </Badge>
+                              )}
+                              {value.status !== undefined && value.status === 'capacity' && (
+                                <Tooltip>
+                                  <TooltipTrigger>
+                                    <Badge variant="warning" className="mr-1">
+                                      Unavailable
                                     </Badge>
-                                  )}
-                                </div>
-                              </div>
-                            </SelectItem_Shadcn_>
-                          )
-                        })}
-                      </SelectGroup_Shadcn_>
-                      <SelectSeparator_Shadcn_ />
-                    </>
-                  )}
-
-                  <SelectGroup_Shadcn_>
-                    <SelectLabel_Shadcn_>Specific regions</SelectLabel_Shadcn_>
-                    {regionOptions.map((value) => {
-                      return (
-                        <SelectItem_Shadcn_
-                          key={value.code}
-                          value={value.name}
-                          className={cn(
-                            'w-full [&>:nth-child(2)]:w-full',
-                            value.status !== undefined && '!pointer-events-auto'
-                          )}
-                          disabled={value.status !== undefined}
-                        >
-                          <div className="flex flex-row items-center justify-between w-full gap-x-2">
-                            <div className="flex items-center gap-x-3">
-                              <img
-                                alt="region icon"
-                                className="w-5 rounded-sm"
-                                src={`${BASE_PATH}/img/regions/${value.code}.svg`}
-                              />
-                              <div className="flex items-center gap-x-2">
-                                <span className="text-foreground">{value.name}</span>
-                                <span className="text-xs text-foreground-lighter font-mono">
-                                  {value.code}
-                                </span>
-                              </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    Temporarily unavailable due to this region being at capacity.
+                                  </TooltipContent>
+                                </Tooltip>
+                              )}
                             </div>
+                          </SelectItem_Shadcn_>
+                        )
+                      })}
+                    </SelectGroup_Shadcn_>
+                  </SelectContent_Shadcn_>
+                </Select_Shadcn_>
+              </FormItemLayout>
 
-                            {recommendedSpecificRegions.has(value.code) && (
-                              <Badge variant="success" className="mr-1">
-                                Recommended
-                              </Badge>
-                            )}
-                            {value.status !== undefined && value.status === 'capacity' && (
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  <Badge variant="warning" className="mr-1">
-                                    Unavailable
-                                  </Badge>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  Temporarily unavailable due to this region being at capacity.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                        </SelectItem_Shadcn_>
-                      )
-                    })}
-                  </SelectGroup_Shadcn_>
-                </SelectContent_Shadcn_>
-              </Select_Shadcn_>
-            </FormItemLayout>
+              {affectingIncidents.length > 0 && (
+                <Admonition
+                  type="warning"
+                  title="Incident in progress for this region"
+                  description={
+                    <>
+                      We're currently investigating an issue that may impact projects in this
+                      region. Follow updates on{' '}
+                      <InlineLink href="https://status.supabase.com">
+                        status.supabase.com
+                      </InlineLink>
+                      .
+                    </>
+                  }
+                  className="mt-3"
+                />
+              )}
+            </>
           )
         }}
       />

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -292,21 +292,23 @@ export const RegionSelector = ({
               </FormItemLayout>
 
               {affectingIncidents.length > 0 && (
-                <Admonition
-                  type="warning"
-                  title="Incident in progress for this region"
-                  description={
-                    <>
-                      We're currently investigating an issue that may impact projects in this
-                      region. Follow updates on{' '}
-                      <InlineLink href="https://status.supabase.com">
-                        status.supabase.com
-                      </InlineLink>
-                      .
-                    </>
-                  }
-                  className="mt-3"
-                />
+                <FormItemLayout layout="horizontal">
+                  <Admonition
+                    type="warning"
+                    title="Incident in progress for this region"
+                    description={
+                      <>
+                        We're currently investigating an issue that may impact projects in this
+                        region. Follow updates on{' '}
+                        <InlineLink href="https://status.supabase.com">
+                          status.supabase.com
+                        </InlineLink>
+                        .
+                      </>
+                    }
+                    className="mt-3"
+                  />
+                </FormItemLayout>
               )}
             </>
           )

--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.test.ts
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.test.ts
@@ -56,14 +56,14 @@ describe('shouldShowBanner', () => {
       ).toBe(true)
     })
 
-    it('shows when affects_project_creation is true even with a region restriction', () => {
+    it('does not show when affects_project_creation is true but there is a region restriction', () => {
       expect(
         shouldShowBanner({
           incidents: [usEast1AndCreation],
           hasProjects: false,
           userRegions: new Set(),
         })
-      ).toBe(true)
+      ).toBe(false)
     })
   })
 
@@ -221,7 +221,7 @@ describe('shouldShowBanner', () => {
       ).toBe(false)
     })
 
-    it('still shows for affects_project_creation with no projects even when regions are unknown', () => {
+    it('does not show for affects_project_creation with no projects when there is a region restriction, even when regions are unknown', () => {
       expect(
         shouldShowBanner({
           incidents: [usEast1AndCreation],
@@ -229,7 +229,7 @@ describe('shouldShowBanner', () => {
           userRegions: new Set(),
           hasUnknownRegions: true,
         })
-      ).toBe(true)
+      ).toBe(false)
     })
   })
 })

--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.ts
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.ts
@@ -30,7 +30,8 @@ export function shouldShowBanner({
     const affectsProjectCreation = incident.cache?.affects_project_creation ?? false
 
     // Users with no projects only see the banner if the incident affects project creation
-    if (!hasProjects) return affectsProjectCreation
+    // and has no specific region targeting (inline notice in RegionSelector handles region-specific incidents)
+    if (!hasProjects) return affectsProjectCreation && affectedRegions.length === 0
 
     // User has projects: if no region restriction, always show
     if (affectedRegions.length === 0) return true


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Region-specific incidents are only shown in the global StatusPageBanner, which doesn't clearly indicate that an incident only affects specific regions during project creation.

## What is the new behavior?

Region-specific incidents are now displayed inline in the RegionSelector with smart region matching to show which regions are affected. The StatusPageBanner logic is updated to avoid duplicate incident notices for region-specific incidents when creating projects.

## Additional context

<img width="1394" height="650" alt="CleanShot 2026-03-02 at 16 32 34@2x" src="https://github.com/user-attachments/assets/fd3734dc-8049-4c24-82d8-456bfbdbd4fd" />

Resolves FE-2652