### PR TITLE
feat: filter incidents with impact none out of banner

### DIFF
--- a/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
+++ b/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
@@ -19,7 +19,8 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
     useFlag('ongoingIncident') || process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true'
 
   const { data: allStatusPageEvents } = useIncidentStatusQuery()
-  const { incidents = [] } = allStatusPageEvents ?? {}
+  const { incidents: allIncidents = [] } = allStatusPageEvents ?? {}
+  const incidents = allIncidents.filter((i) => i.impact !== 'none')
 
   const hasActiveIncidents = incidents.length > 0
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Enhancement

## What is the current behavior?

Incidents are displayed regardless of impact.

## What is the new behavior?

Filters out incidents with impact = none

## Additional context

Resolves FE-2649
