### PR TITLE
chore: restore to new project entitlement

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/BackupsList.tsx
@@ -1,6 +1,5 @@
 import Panel from 'components/ui/Panel'
 import { useCloneBackupsQuery } from 'data/projects/clone-query'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { Badge, Button } from 'ui'
 import { TimestampInfo } from 'ui-patterns'
@@ -9,17 +8,14 @@ import { BackupsEmpty } from '../BackupsEmpty'
 interface BackupsListProps {
   onSelectRestore: (id: number) => void
   disabled?: boolean
+  hasAccess?: boolean
 }
 
-export const BackupsList = ({ onSelectRestore, disabled }: BackupsListProps) => {
+export const BackupsList = ({ onSelectRestore, disabled, hasAccess }: BackupsListProps) => {
   const { data: project } = useSelectedProjectQuery()
-  const { data: organization } = useSelectedOrganizationQuery()
-
-  const isFreePlan = organization?.plan?.id === 'free'
-
   const { data: cloneBackups } = useCloneBackupsQuery(
     { projectRef: project?.ref },
-    { enabled: !isFreePlan }
+    { enabled: hasAccess }
   )
 
   return (

--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/CreateNewProjectDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/CreateNewProjectDialog.tsx
@@ -7,7 +7,6 @@ import { z } from 'zod'
 import { PasswordStrengthBar } from 'components/ui/PasswordStrengthBar'
 import { useProjectCloneMutation } from 'data/projects/clone-mutation'
 import { useCloneBackupsQuery } from 'data/projects/clone-query'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { passwordStrength, PasswordStrengthScore } from 'lib/password-strength'
 import { generateStrongPassword } from 'lib/project'
@@ -37,6 +36,7 @@ interface CreateNewProjectDialogProps {
   onOpenChange: (value: boolean) => void
   onCloneSuccess: () => void
   additionalMonthlySpend: NewProjectPrice
+  hasAccess?: boolean
 }
 
 export const CreateNewProjectDialog = ({
@@ -46,10 +46,9 @@ export const CreateNewProjectDialog = ({
   onOpenChange,
   onCloneSuccess,
   additionalMonthlySpend,
+  hasAccess,
 }: CreateNewProjectDialogProps) => {
   const { data: project } = useSelectedProjectQuery()
-  const { data: organization } = useSelectedOrganizationQuery()
-
   const [passwordStrengthScore, setPasswordStrengthScore] = useState(0)
   const [passwordStrengthMessage, setPasswordStrengthMessage] = useState('')
 
@@ -66,11 +65,9 @@ export const CreateNewProjectDialog = ({
     },
   })
 
-  const isFreePlan = organization?.plan?.id === 'free'
-
   const { data: cloneBackups } = useCloneBackupsQuery(
     { projectRef: project?.ref },
-    { enabled: !isFreePlan }
+    { enabled: hasAccess }
   )
   const hasPITREnabled = cloneBackups?.pitr_enabled
 

--- a/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
+++ b/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
@@ -18,6 +18,7 @@ import { UpgradeToPro } from 'components/ui/UpgradeToPro'
 import { useDiskAttributesQuery } from 'data/config/disk-attributes-query'
 import { useCloneBackupsQuery } from 'data/projects/clone-query'
 import { useCloneStatusQuery } from 'data/projects/clone-status-query'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import {
@@ -35,7 +36,8 @@ import { PreviousRestoreItem } from './PreviousRestoreItem'
 export const RestoreToNewProject = () => {
   const { data: project } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
-  const isFreePlan = organization?.plan?.id === 'free'
+  const { hasAccess: hasAccessToRestoreToNewProject, isLoading: isLoadingEntitlement } =
+    useCheckEntitlements('backup.restore_to_new_project')
   const isOrioleDb = useIsOrioleDb()
   const isAwsK8s = useIsAwsK8sCloudProvider()
 
@@ -50,7 +52,10 @@ export const RestoreToNewProject = () => {
     error,
     isPending: cloneBackupsLoading,
     isError,
-  } = useCloneBackupsQuery({ projectRef: project?.ref }, { enabled: !isFreePlan })
+  } = useCloneBackupsQuery(
+    { projectRef: project?.ref },
+    { enabled: hasAccessToRestoreToNewProject }
+  )
 
   const isActiveHealthy = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
@@ -102,7 +107,11 @@ export const RestoreToNewProject = () => {
   const isRestoring = previousClones?.some((c) => c.status === 'IN_PROGRESS')
   const restoringClone = previousClones?.find((c) => c.status === 'IN_PROGRESS')
 
-  if (isFreePlan) {
+  if (isLoadingEntitlement) {
+    return <GenericSkeletonLoader />
+  }
+
+  if (!hasAccessToRestoreToNewProject) {
     return (
       <UpgradeToPro
         buttonText="Upgrade"
@@ -256,6 +265,7 @@ export const RestoreToNewProject = () => {
         selectedBackupId={selectedBackupId}
         recoveryTimeTarget={recoveryTimeTarget}
         additionalMonthlySpend={additionalMonthlySpend}
+        hasAccess={hasAccessToRestoreToNewProject}
         onOpenChange={setShowNewProjectDialog}
         onCloneSuccess={() => {
           refetchCloneStatus()
@@ -307,6 +317,7 @@ export const RestoreToNewProject = () => {
       ) : (
         <BackupsList
           disabled={isRestoring}
+          hasAccess={hasAccessToRestoreToNewProject}
           onSelectRestore={(id) => {
             setSelectedBackupId(id)
             setShowConfirmationDialog(true)


### PR DESCRIPTION
Adds an entitlement check to prompt upgrades for restoring backups to new projects

### Testing
- Head to `/project/_/database/backups/restore-to-new-project` with a Free Project
- Assert that the upgrade prompt is shown
<img width="1271" height="309" alt="image" src="https://github.com/user-attachments/assets/ca1cf071-db2f-4398-ab6f-ef0cf7ccc714" />

- Head to `/project/_/database/backups/restore-to-new-project` with a Pro Project or above
- Assert that the restore backups UI is shown

<img width="1271" height="685" alt="image" src="https://github.com/user-attachments/assets/43d0be5a-370c-4827-bb39-c0ab9e7b74e7" />

