### PR TITLE
chore: auth sessions entitlement

### DIFF
--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -11,8 +11,8 @@ import NoPermission from 'components/ui/NoPermission'
 import { UpgradeToPro } from 'components/ui/UpgradeToPro'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { IS_PLATFORM } from 'lib/constants'
 import {
   Button,
@@ -83,9 +83,9 @@ export const SessionsAuthSettingsForm = () => {
     'custom_config_gotrue'
   )
 
-  const { data: organization } = useSelectedOrganizationQuery()
-  const isProPlanAndUp = organization?.plan?.id !== 'free'
-  const promptProPlanUpgrade = IS_PLATFORM && !isProPlanAndUp
+  const { hasAccess: hasUserSessionsEntitlement, isLoading: isLoadingEntitlements } =
+    useCheckEntitlements('auth.user_sessions')
+  const promptProPlanUpgrade = IS_PLATFORM && !hasUserSessionsEntitlement
 
   const refreshTokenForm = useForm<z.infer<typeof RefreshTokenSchema>>({
     resolver: zodResolver(RefreshTokenSchema),
@@ -182,7 +182,7 @@ export const SessionsAuthSettingsForm = () => {
     )
   }
 
-  if (isLoading) {
+  if (isLoading || isLoadingEntitlements) {
     return (
       <PageSection>
         <PageSectionContent>
@@ -304,7 +304,7 @@ export const SessionsAuthSettingsForm = () => {
                           <Switch
                             checked={field.value}
                             onCheckedChange={field.onChange}
-                            disabled={!canUpdateConfig || !isProPlanAndUp}
+                            disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
                           />
                         </FormControl_Shadcn_>
                       </FormItemLayout>
@@ -328,7 +328,7 @@ export const SessionsAuthSettingsForm = () => {
                               type="number"
                               min={0}
                               {...field}
-                              disabled={!canUpdateConfig || !isProPlanAndUp}
+                              disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
                             />
                           </PrePostTab>
                         </FormControl_Shadcn_>
@@ -353,7 +353,7 @@ export const SessionsAuthSettingsForm = () => {
                               type="number"
                               {...field}
                               className="flex-1"
-                              disabled={!canUpdateConfig || !isProPlanAndUp}
+                              disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
                             />
                           </PrePostTab>
                         </FormControl_Shadcn_>


### PR DESCRIPTION
This PR adds the entitlement check for configuring auth user sessions.

### Testing
- Head to `/project/_/auth/sessions` with an org on the Free Plan 
- Assert that the upgrade prompt is shown and that u:
<img width="1203" height="449" alt="image" src="https://github.com/user-attachments/assets/44aa1b64-e06b-491e-8d30-587cfe1ff65e" />


- Head to `/project/_/auth/sessions` with an org on the Pro Plan or above
- Assert that you're able to configure the User Sessions section
<img width="1203" height="381" alt="image" src="https://github.com/user-attachments/assets/b566dc49-6367-41cc-98fe-25d5e7bdaf87" />


