### PR TITLE
feat: byoc early access page

### DIFF
--- a/apps/www/_go/index.tsx
+++ b/apps/www/_go/index.tsx
@@ -1,5 +1,6 @@
 import type { GoPageInput } from 'marketing'
 
+import byocEarlyAccess from './pre-release/byoc-early-access'
 import exampleLeadGen from './lead-gen/example-lead-gen'
 import exampleLegal from './legal/example-legal'
 import exampleThankYou from './thank-you/example-thank-you'
@@ -7,6 +8,7 @@ import boltWebinar from './webinar/bolt-webinar'
 import boltWebinarThankYou from './webinar/bolt-webinar-thank-you'
 
 const pages: GoPageInput[] = [
+  byocEarlyAccess,
   exampleLeadGen,
   exampleThankYou,
   exampleLegal,

--- a/apps/www/_go/pre-release/byoc-early-access.tsx
+++ b/apps/www/_go/pre-release/byoc-early-access.tsx
@@ -26,8 +26,7 @@ const page: GoPageInput = {
     {
       type: 'feature-grid',
       title: 'Your cloud, operated by Supabase',
-      description:
-        'Get the full power of Supabase deployed inside your own infrastructure.',
+      description: 'Get the full power of Supabase deployed inside your own infrastructure.',
       items: [
         {
           title: 'Control where your data goes',

--- a/apps/www/_go/pre-release/byoc-early-access.tsx
+++ b/apps/www/_go/pre-release/byoc-early-access.tsx
@@ -1,0 +1,128 @@
+import type { GoPageInput } from 'marketing'
+
+const page: GoPageInput = {
+  template: 'lead-gen',
+  slug: 'byoc-early-access',
+  metadata: {
+    title: 'Bring Your Own Cloud (BYOC) for Supabase — Early Access',
+    description:
+      'Deploy Supabase in your own AWS account. Meet strict data residency and compliance requirements while Supabase handles operations, upgrades and monitoring.',
+    ogImage: '/images/landing-pages/byoc-early-access/og.png',
+  },
+  hero: {
+    title: 'Bring Your Own Cloud (BYOC) for Supabase',
+    subtitle: 'Early Access',
+    description:
+      'Deploy Supabase in your own AWS account. Meet strict data residency and compliance requirements while Supabase handles operations, upgrades and monitoring.',
+    ctas: [
+      {
+        label: 'Request Early Access',
+        href: '#form',
+        variant: 'primary',
+      },
+    ],
+  },
+  sections: [
+    {
+      type: 'feature-grid',
+      title: 'Your cloud, operated by Supabase',
+      description:
+        'Get the full power of Supabase deployed inside your own infrastructure.',
+      items: [
+        {
+          title: 'Control where your data goes',
+          description:
+            'Meet data residency and compliance requirements. Your data stays in your infrastructure and in your region.',
+        },
+        {
+          title: 'Deploy the infrastructure you want',
+          description:
+            'Choose instance sizes and volumes for your use case. No project size constraints.',
+        },
+        {
+          title: 'Leverage your cloud costs',
+          description:
+            'Apply pre-negotiated discounts and cloud credits to your Supabase deployment.',
+        },
+        {
+          title: 'Let Supabase manage operations',
+          description:
+            'Supabase handles deployments, upgrades, monitoring and support. No Ops overhead.',
+        },
+      ],
+    },
+    {
+      type: 'form',
+      id: 'form',
+      title: 'Early Access Request Form',
+      description:
+        "If you are interested in participating in BYOC early access when it becomes available later in 2026, please fill out the form below. A member of the Supabase team will reach out if you've been selected.",
+      fields: [
+        {
+          type: 'text',
+          name: 'first_name',
+          label: 'First Name',
+          placeholder: 'First Name',
+          required: true,
+          half: true,
+        },
+        {
+          type: 'text',
+          name: 'last_name',
+          label: 'Last Name',
+          placeholder: 'Last Name',
+          required: true,
+          half: true,
+        },
+        {
+          type: 'email',
+          name: 'email',
+          label: 'Email Address',
+          placeholder: 'Work email',
+          required: true,
+        },
+        {
+          type: 'text',
+          name: 'company_name',
+          label: 'Company Name',
+          placeholder: 'Company name',
+          required: true,
+        },
+        {
+          type: 'text',
+          name: 'supabase_org_name',
+          label: 'Supabase Organization Name',
+          placeholder: 'Organization name (if applicable)',
+          required: false,
+        },
+      ],
+      submitLabel: 'Request Early Access',
+      disclaimer:
+        'By submitting this form, I confirm that I have read and understood the [Privacy Policy](https://supabase.com/privacy).',
+      crm: {
+        hubspot: {
+          formGuid: 'c09ead14-e1b7-4031-9f77-ba6b2ad96364',
+          fieldMap: {
+            first_name: 'firstname',
+            last_name: 'lastname',
+            email: 'email',
+            company_name: 'company',
+            supabase_org_name: 'what_is_your_supabase_org_slug',
+          },
+          consent:
+            'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
+        },
+        customerio: {
+          event: 'early_access_requested',
+          profileMap: {
+            email: 'email',
+            first_name: 'first_name',
+            last_name: 'last_name',
+          },
+        },
+      },
+    },
+  ],
+}
+
+export default page


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a dedicated landing page for BYOC Early Access

## What is the current behavior?



## What is the new behavior?

Adds /go/byoc-early-access using the _go lead gen page system. The page includes:
  - Hero section with "Request Early Access" CTA
  - Feature grid with the 4 BYOC value props (data residency, custom infrastructure, cloud cost optimization, managed operations)
  - Early access request form with First Name, Last Name, Email, Company Name, and Supabase Organization Name fields
  - Dual CRM integration: HubSpot and Customer.io

## Additional context

<img width="2477" height="1182" alt="Screenshot 2026-03-02 at 5 00 18 PM" src="https://github.com/user-attachments/assets/483abc67-465f-49c6-88c1-1f53c3edafef" />
<img width="2460" height="1183" alt="Screenshot 2026-03-02 at 5 00 30 PM" src="https://github.com/user-attachments/assets/de764bcf-2158-44b9-a95a-9d7ace06bf78" />


