### PR TITLE
Fix auth hooks, enabled state in panel doesnt match hook state if disabled

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -1,10 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import randomBytes from 'randombytes'
-import { useEffect, useMemo } from 'react'
-import { SubmitHandler, useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import * as z from 'zod'
-
 import { useParams } from 'common'
 import { convertArgumentTypes } from 'components/interfaces/Database/Functions/Functions.utils'
 import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
@@ -16,11 +10,15 @@ import { useAuthHooksUpdateMutation } from 'data/auth/auth-hooks-update-mutation
 import { executeSql } from 'data/sql/execute-sql-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
+import randomBytes from 'randombytes'
+import { useEffect, useMemo } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import {
   Button,
+  Form_Shadcn_,
   FormControl_Shadcn_,
   FormField_Shadcn_,
-  Form_Shadcn_,
   Input_Shadcn_,
   RadioGroupStacked,
   RadioGroupStackedItem,
@@ -35,7 +33,9 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
-import { HOOKS_DEFINITIONS, HOOK_DEFINITION_TITLE, Hook } from './hooks.constants'
+import * as z from 'zod'
+
+import { Hook, HOOK_DEFINITION_TITLE, HOOKS_DEFINITIONS } from './hooks.constants'
 import { extractMethod, getRevokePermissionStatements, isValidHook } from './hooks.utils'
 
 interface CreateHookSheetProps {
@@ -239,7 +239,7 @@ export const CreateHookSheet = ({
 
         form.reset({
           hookType: definition.title,
-          enabled: authConfig?.[definition.enabledKey] || true,
+          enabled: isCreating ? true : authConfig?.[definition.enabledKey],
           selectedType: values.type,
           httpsValues: {
             url: (values.type === 'https' && values.url) || '',


### PR DESCRIPTION
## Context

If an auth hook is disabled, clicking "Configure hook" will incorrectly show the enable toggle as true

<img width="1095" height="265" alt="image" src="https://github.com/user-attachments/assets/72b4104c-658d-44fd-baca-1102aefc3fb3" />

<img width="737" height="216" alt="image" src="https://github.com/user-attachments/assets/73e4e8cb-7c03-440e-8f36-a7431b0ea051" />


Was due to the `enabled` value being default to `true` in the `useEffect`

## To test
- Just verify that the enable toggle in the panel matches the auth hook's enabled state
