### PR TITLE
chore: add space between text title and docs link in addons panels

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -119,7 +119,7 @@ const CustomDomainSidePanel = () => {
             : undefined
       }
       header={
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <h4>Custom domains</h4>
           <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
             <Link

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -112,7 +112,7 @@ const IPv4SidePanel = () => {
             : undefined
       }
       header={
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <h4>Dedicated IPv4 address</h4>
           <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
             <Link

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -165,7 +165,7 @@ const PITRSidePanel = () => {
               : undefined
       }
       header={
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <h4>Point in Time Recovery</h4>
           <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
             <Link


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI improvement

## What is the current behavior?

<img width="568" height="128" alt="CleanShot 2026-03-03 at 11 35 46" src="https://github.com/user-attachments/assets/7682b69a-94f0-427e-9bcc-468c8b2d259c" />

## What is the new behavior?

<img width="424" height="65" alt="CleanShot 2026-03-03 at 11 52 36" src="https://github.com/user-attachments/assets/faf20475-da94-4f73-ae9f-cd9e9ad53540" />

Side panels:
- settings/addons?panel=ipv4
- settings/addons?panel=pitr
- settings/addons?panel=customDomain
