### PR TITLE
fix(query-performance): optimize pg_stat_statements query DEBUG-28

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -1,6 +1,6 @@
+import { PlanId } from 'data/subscriptions/types'
 import dayjs from 'dayjs'
 
-import { PlanId } from 'data/subscriptions/types'
 import type { DatetimeHelper } from '../Settings/Logs/Logs.types'
 import { PresetConfig, Presets, ReportFilterItem } from './Reports.types'
 

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -400,11 +400,11 @@ select
     -- mean_time,
     coalesce(statements.rows::numeric / nullif(statements.calls, 0), 0) as avg_rows,
     statements.rows as rows_read,
-    case 
-      when (statements.shared_blks_hit + statements.shared_blks_read) > 0 
+    case
+      when (statements.shared_blks_hit + statements.shared_blks_read) > 0
       then round(
-        (statements.shared_blks_hit * 100.0) / 
-        (statements.shared_blks_hit + statements.shared_blks_read), 
+        (statements.shared_blks_hit * 100.0) /
+        (statements.shared_blks_hit + statements.shared_blks_read),
         2
       )
       else 0
@@ -430,7 +430,7 @@ select
     }
   from pg_stat_statements as statements
     inner join pg_authid as auth on statements.userid = auth.oid
-  ${where || ''}
+  WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
   ${orderBy || 'order by statements.calls desc'}
   limit 20`,
       },
@@ -440,6 +440,10 @@ select
         -- reports-query-performance-most-time-consuming
 set search_path to public, extensions;
 
+with grand_total as (
+  select coalesce(nullif(sum(total_exec_time + total_plan_time), 0), 1) as v
+  from pg_stat_statements where calls > 0
+)
 select
     auth.rolname,
     statements.query,
@@ -448,7 +452,7 @@ select
     statements.mean_exec_time + statements.mean_plan_time as mean_time,
     coalesce(
       ((statements.total_exec_time + statements.total_plan_time) /
-        nullif(sum(statements.total_exec_time + statements.total_plan_time) OVER(), 0)) *
+        (select v from grand_total)) *
         100,
       0
     ) as prop_total_time${
@@ -473,7 +477,7 @@ select
     }
   from pg_stat_statements as statements
     inner join pg_authid as auth on statements.userid = auth.oid
-  ${where || ''}
+  WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
   ${orderBy || 'order by total_time desc'}
   limit 20`,
       },
@@ -519,7 +523,7 @@ select
     }
   from pg_stat_statements as statements
     inner join pg_authid as auth on statements.userid = auth.oid
-  ${where || ''}
+  WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
   ${orderBy || 'order by max_time desc'}
   limit 20`,
       },
@@ -543,7 +547,11 @@ select
         -- reports-query-performance-unified
         set search_path to public, extensions;
 
-        with base as (
+        with grand_total as (
+          select coalesce(nullif(sum(total_exec_time + total_plan_time), 0), 1) as v
+          from pg_stat_statements where calls > 0
+        ),
+        base as (
           select
             auth.rolname,
             statements.query,
@@ -564,13 +572,13 @@ select
             end as cache_hit_rate,
             coalesce(
               ((statements.total_exec_time + statements.total_plan_time) /
-                nullif(sum(statements.total_exec_time + statements.total_plan_time) OVER(), 0)) *
+                (select v from grand_total)) *
                 100,
               0
             ) as prop_total_time
           from pg_stat_statements as statements
             inner join pg_authid as auth on statements.userid = auth.oid
-          ${where || ''}
+          WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
           ${orderBy || 'order by total_time desc'}
           limit 50
         ),
@@ -615,28 +623,27 @@ select
 
         -- Count of slow queries (> 1 second average)
         SELECT count(*) as slow_queries_count
-        FROM pg_stat_statements 
-        WHERE statements.mean_exec_time > 1000;`,
+        FROM pg_stat_statements as statements
+        WHERE statements.calls > 0 AND statements.mean_exec_time > 1000;`,
       },
       queryMetrics: {
         queryType: 'db',
         sql: (_params, where, orderBy, runIndexAdvisor = false, filterIndexAdvisor = false) => `
         -- reports-query-performance-metrics
         set search_path to public, extensions;
-      
-        SELECT 
+
+        SELECT
           COALESCE(ROUND(AVG(statements.rows::numeric / NULLIF(statements.calls, 0)), 1), 0) as avg_rows_per_call,
           COUNT(*) FILTER (WHERE statements.total_exec_time + statements.total_plan_time > 1000) as slow_queries,
           COALESCE(
             ROUND(
-              SUM(statements.shared_blks_hit) * 100.0 / 
-              NULLIF(SUM(statements.shared_blks_hit + statements.shared_blks_read), 0), 
+              SUM(statements.shared_blks_hit) * 100.0 /
+              NULLIF(SUM(statements.shared_blks_hit + statements.shared_blks_read), 0),
               2
             ), 0
           ) || '%' as cache_hit_rate
         FROM pg_stat_statements as statements
-        WHERE statements.calls > 0
-        ${where || ''}
+        WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
         ${orderBy || ''}`,
       },
     },

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -430,6 +430,7 @@ select
     }
   from pg_stat_statements as statements
     inner join pg_authid as auth on statements.userid = auth.oid
+  -- skip queries that were never actually executed
   WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
   ${orderBy || 'order by statements.calls desc'}
   limit 20`,
@@ -440,6 +441,7 @@ select
         -- reports-query-performance-most-time-consuming
 set search_path to public, extensions;
 
+-- compute total time once up front so we don't need a window function over all rows
 with grand_total as (
   select coalesce(nullif(sum(total_exec_time + total_plan_time), 0), 1) as v
   from pg_stat_statements where calls > 0
@@ -477,6 +479,7 @@ select
     }
   from pg_stat_statements as statements
     inner join pg_authid as auth on statements.userid = auth.oid
+  -- skip queries that were never actually executed
   WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
   ${orderBy || 'order by total_time desc'}
   limit 20`,
@@ -523,6 +526,7 @@ select
     }
   from pg_stat_statements as statements
     inner join pg_authid as auth on statements.userid = auth.oid
+  -- skip queries that were never actually executed
   WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
   ${orderBy || 'order by max_time desc'}
   limit 20`,
@@ -547,6 +551,7 @@ select
         -- reports-query-performance-unified
         set search_path to public, extensions;
 
+        -- compute total time once up front so we don't need a window function over all rows
         with grand_total as (
           select coalesce(nullif(sum(total_exec_time + total_plan_time), 0), 1) as v
           from pg_stat_statements where calls > 0
@@ -578,6 +583,7 @@ select
             ) as prop_total_time
           from pg_stat_statements as statements
             inner join pg_authid as auth on statements.userid = auth.oid
+          -- skip queries that were never actually executed
           WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
           ${orderBy || 'order by total_time desc'}
           limit 50
@@ -623,7 +629,9 @@ select
 
         -- Count of slow queries (> 1 second average)
         SELECT count(*) as slow_queries_count
+        -- alias needed to reference columns in WHERE
         FROM pg_stat_statements as statements
+        -- skip never-executed queries; mean_exec_time > 1000ms = avg over 1 second
         WHERE statements.calls > 0 AND statements.mean_exec_time > 1000;`,
       },
       queryMetrics: {
@@ -643,6 +651,7 @@ select
             ), 0
           ) || '%' as cache_hit_rate
         FROM pg_stat_statements as statements
+        -- skip queries that were never actually executed
         WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
         ${orderBy || ''}`,
       },

--- a/apps/studio/components/interfaces/Reports/Reports.queryPerformance.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.queryPerformance.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { PRESET_CONFIG } from './Reports.constants'
+import { Presets } from './Reports.types'
+
+const queries = PRESET_CONFIG[Presets.QUERY_PERFORMANCE].queries as Record<
+  string,
+  { sql: (...args: any[]) => string }
+>
+
+const queryNames = [
+  'mostFrequentlyInvoked',
+  'mostTimeConsuming',
+  'slowestExecutionTime',
+  'unified',
+  'slowQueriesCount',
+  'queryMetrics',
+] as const
+
+describe('QUERY_PERFORMANCE SQL queries', () => {
+  describe('calls > 0 base filter', () => {
+    it.each(queryNames)('%s includes calls > 0 without user filters', (name) => {
+      const sql = queries[name].sql([], undefined, undefined)
+      expect(sql).toContain('calls > 0')
+    })
+
+    it.each(queryNames)('%s still includes calls > 0 when user filters are provided', (name) => {
+      const sql = queries[name].sql([], "WHERE auth.rolname in ('postgres')", undefined)
+      expect(sql).toContain('calls > 0')
+    })
+  })
+
+  describe('WHERE clause composition with user filters', () => {
+    const userWhere = "WHERE auth.rolname in ('postgres')"
+
+    it.each(['mostFrequentlyInvoked', 'mostTimeConsuming', 'slowestExecutionTime', 'unified'] as const)(
+      '%s: user filters appended with AND (no duplicate WHERE)',
+      (name) => {
+        const sql = queries[name].sql([], userWhere, undefined)
+        // Should not have two WHERE keywords in a row / duplicate WHERE
+        expect(sql).not.toMatch(/WHERE\s+.*WHERE/s)
+        // User filter condition should be present
+        expect(sql).toContain("auth.rolname in ('postgres')")
+        // Should use AND to join base filter and user filter
+        expect(sql).toMatch(/calls > 0\s+AND/)
+      }
+    )
+
+    it('queryMetrics: user filters appended with AND (no duplicate WHERE in FROM clause)', () => {
+      const sql = queries.queryMetrics.sql([], userWhere, undefined)
+      // queryMetrics uses COUNT(*) FILTER (WHERE ...) which is valid SQL and not a duplicate
+      // Just verify the base filter + user filter are correctly composed
+      expect(sql).toContain("auth.rolname in ('postgres')")
+      expect(sql).toMatch(/calls > 0\s+AND/)
+      // Should not have two WHERE keywords after the FROM keyword
+      expect(sql).not.toMatch(/FROM[\s\S]*WHERE[\s\S]*WHERE[\s\S]*WHERE/s)
+    })
+
+    it.each(['mostFrequentlyInvoked', 'mostTimeConsuming', 'slowestExecutionTime', 'unified', 'queryMetrics'] as const)(
+      '%s: no trailing junk when no user filters',
+      (name) => {
+        const sql = queries[name].sql([], undefined, undefined)
+        // Should not have a dangling undefined or 'WHERE' with nothing after the base filter
+        expect(sql).not.toContain('undefined')
+        expect(sql).not.toMatch(/calls > 0\s+AND\s+(ORDER|LIMIT|$)/im)
+      }
+    )
+  })
+
+  describe('slowQueriesCount bug fix', () => {
+    it('uses table alias "statements"', () => {
+      const sql = queries.slowQueriesCount.sql()
+      expect(sql).toContain('pg_stat_statements as statements')
+    })
+
+    it('filters by mean_exec_time using the alias', () => {
+      const sql = queries.slowQueriesCount.sql()
+      expect(sql).toContain('statements.mean_exec_time > 1000')
+    })
+  })
+
+  describe('window function elimination', () => {
+    it('unified uses grand_total CTE instead of OVER()', () => {
+      const sql = queries.unified.sql([], undefined, undefined)
+      expect(sql).toContain('grand_total')
+      expect(sql).not.toContain('OVER()')
+    })
+
+    it('mostTimeConsuming uses grand_total CTE instead of OVER()', () => {
+      const sql = queries.mostTimeConsuming.sql([], undefined, undefined)
+      expect(sql).toContain('grand_total')
+      expect(sql).not.toContain('OVER()')
+    })
+
+    it('grand_total CTE references calls > 0', () => {
+      const sql = queries.unified.sql([], undefined, undefined)
+      expect(sql).toMatch(/grand_total[\s\S]*calls > 0/)
+    })
+  })
+
+  describe('multiple user filters', () => {
+    it('handles multiple user filter conditions', () => {
+      const multiWhere = "WHERE auth.rolname in ('postgres') AND statements.calls >= 10"
+      const sql = queries.mostFrequentlyInvoked.sql([], multiWhere, undefined)
+      expect(sql).toContain('calls > 0')
+      expect(sql).toContain("auth.rolname in ('postgres')")
+      expect(sql).toContain('statements.calls >= 10')
+      expect(sql).not.toMatch(/WHERE\s+.*WHERE/s)
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Reports/Reports.queryPerformance.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.queryPerformance.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
 import { PRESET_CONFIG } from './Reports.constants'
 import { Presets } from './Reports.types'
 
@@ -32,18 +33,20 @@ describe('QUERY_PERFORMANCE SQL queries', () => {
   describe('WHERE clause composition with user filters', () => {
     const userWhere = "WHERE auth.rolname in ('postgres')"
 
-    it.each(['mostFrequentlyInvoked', 'mostTimeConsuming', 'slowestExecutionTime', 'unified'] as const)(
-      '%s: user filters appended with AND (no duplicate WHERE)',
-      (name) => {
-        const sql = queries[name].sql([], userWhere, undefined)
-        // Should not have two WHERE keywords in a row / duplicate WHERE
-        expect(sql).not.toMatch(/WHERE\s+.*WHERE/s)
-        // User filter condition should be present
-        expect(sql).toContain("auth.rolname in ('postgres')")
-        // Should use AND to join base filter and user filter
-        expect(sql).toMatch(/calls > 0\s+AND/)
-      }
-    )
+    it.each([
+      'mostFrequentlyInvoked',
+      'mostTimeConsuming',
+      'slowestExecutionTime',
+      'unified',
+    ] as const)('%s: user filters appended with AND (no duplicate WHERE)', (name) => {
+      const sql = queries[name].sql([], userWhere, undefined)
+      // Should not have two WHERE keywords in a row / duplicate WHERE
+      expect(sql).not.toMatch(/WHERE\s+.*WHERE/s)
+      // User filter condition should be present
+      expect(sql).toContain("auth.rolname in ('postgres')")
+      // Should use AND to join base filter and user filter
+      expect(sql).toMatch(/calls > 0\s+AND/)
+    })
 
     it('queryMetrics: user filters appended with AND (no duplicate WHERE in FROM clause)', () => {
       const sql = queries.queryMetrics.sql([], userWhere, undefined)
@@ -55,15 +58,18 @@ describe('QUERY_PERFORMANCE SQL queries', () => {
       expect(sql).not.toMatch(/FROM[\s\S]*WHERE[\s\S]*WHERE[\s\S]*WHERE/s)
     })
 
-    it.each(['mostFrequentlyInvoked', 'mostTimeConsuming', 'slowestExecutionTime', 'unified', 'queryMetrics'] as const)(
-      '%s: no trailing junk when no user filters',
-      (name) => {
-        const sql = queries[name].sql([], undefined, undefined)
-        // Should not have a dangling undefined or 'WHERE' with nothing after the base filter
-        expect(sql).not.toContain('undefined')
-        expect(sql).not.toMatch(/calls > 0\s+AND\s+(ORDER|LIMIT|$)/im)
-      }
-    )
+    it.each([
+      'mostFrequentlyInvoked',
+      'mostTimeConsuming',
+      'slowestExecutionTime',
+      'unified',
+      'queryMetrics',
+    ] as const)('%s: no trailing junk when no user filters', (name) => {
+      const sql = queries[name].sql([], undefined, undefined)
+      // Should not have a dangling undefined or 'WHERE' with nothing after the base filter
+      expect(sql).not.toContain('undefined')
+      expect(sql).not.toMatch(/calls > 0\s+AND\s+(ORDER|LIMIT|$)/im)
+    })
   })
 
   describe('slowQueriesCount bug fix', () => {


### PR DESCRIPTION
- Filter out never-run queries early: previously the queries didn't check if a statement had ever actually been executed, so PostgreSQL would process and return those useless rows. Adding WHERE calls > 0 skips
  them upfront.
- Replace window functions with a pre-computed total: two queries were using a SQL window function to calculate the "% of total time" column, which forces PostgreSQL to load every single row into memory before
  returning results. Replaced with a small CTE that computes the total once separately, so PostgreSQL can apply the row limit without buffering everything first. This was the main cause of page crashes on databases
   with a large query history.
 - slowQueriesCount bug fix: added missing as statements alias
 - queryMetrics WHERE clause fix: ${where} was producing WHERE ... WHERE ..., now uses .replace(/^WHERE/, 'AND')