### PR TITLE
Adjust header + project list for wildcard routes

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/EmptyStates.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/EmptyStates.tsx
@@ -1,9 +1,7 @@
+import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { BoxPlus } from 'icons'
 import { Plus } from 'lucide-react'
 import Link from 'next/link'
-
-import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
-import { BASE_PATH } from 'lib/constants'
 import {
   Button,
   Card,
@@ -16,21 +14,14 @@ import {
   TableRow,
 } from 'ui'
 import { EmptyStatePresentational } from 'ui-patterns'
+
 import { ShimmeringCard } from './ShimmeringCard'
+import { HomeIcon } from '@/components/layouts/ProjectLayout/LayoutHeader/HomeIcon'
 
 export const Header = () => {
   return (
-    <div className="border-default border-b p-3">
-      <div className="flex items-center space-x-2">
-        <Link href="/projects">
-          <img
-            src={`${BASE_PATH}/img/supabase-logo.svg`}
-            alt="Supabase"
-            className="border-default rounded border p-1 hover:border-white"
-            style={{ height: 24 }}
-          />
-        </Link>
-      </div>
+    <div className="flex items-center border-default border-b px-4 py-3.5">
+      <HomeIcon />
     </div>
   )
 }

--- a/apps/studio/pages/org/[slug]/index.tsx
+++ b/apps/studio/pages/org/[slug]/index.tsx
@@ -19,7 +19,7 @@ const ProjectsPage: NextPageWithLayout = () => {
 
   return (
     <ScaffoldContainer className="flex-grow flex">
-      <ScaffoldSection isFullWidth className="flex-grow pb-0">
+      <ScaffoldSection isFullWidth className="pb-0">
         {disableAccessMfa ? (
           <Admonition
             type="note"

--- a/apps/studio/pages/project/_/[[...routeSlug]].tsx
+++ b/apps/studio/pages/project/_/[[...routeSlug]].tsx
@@ -25,6 +25,7 @@ import {
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
 } from 'ui'
+import { ShimmeringLoader } from 'ui-patterns'
 
 // [Joshen] I'd say we don't do route validation here, this page will act more
 // like a proxy to the project specific pages, and we let those pages handle
@@ -84,10 +85,12 @@ const GenericProjectPage: NextPage = () => {
     <div className="h-screen flex flex-col">
       <Header />
       <PageLayout className="flex-grow min-h-0" title="Select a project to continue">
-        <ScaffoldContainer className="flex-grow flex flex-col">
-          {organizations.length > 0 && (
-            <ScaffoldSection isFullWidth>
-              <div className="flex items-center gap-x-2">
+        <ScaffoldContainer className="flex-grow flex flex-col gap-y-4">
+          <ScaffoldSection isFullWidth className="py-0">
+            <div className="flex items-center gap-x-2">
+              {isLoadingOrganizations ? (
+                <ShimmeringLoader className="w-60 py-0 h-[26px]" />
+              ) : (
                 <Select_Shadcn_ value={selectedSlug} onValueChange={setSlug}>
                   <SelectTrigger_Shadcn_ size="tiny" className="w-60 truncate">
                     <div className="flex items-center gap-x-2">
@@ -103,11 +106,11 @@ const GenericProjectPage: NextPage = () => {
                     ))}
                   </SelectContent_Shadcn_>
                 </Select_Shadcn_>
-                <HomePageActions hideNewProject />
-              </div>
-            </ScaffoldSection>
-          )}
-          <ScaffoldSection isFullWidth className="flex-grow pt-0 flex flex-col gap-y-4 h-px">
+              )}
+              <HomePageActions hideNewProject />
+            </div>
+          </ScaffoldSection>
+          <ScaffoldSection isFullWidth className="py-0">
             {isLoadingOrganizations ? (
               <LoadingCardView />
             ) : isErrorOrganizations ? (


### PR DESCRIPTION
## Context

Small adjustments to wildcard routes

- Header logo to be consistent with other layouts
  - Before:
    <img width="463" height="172" alt="image" src="https://github.com/user-attachments/assets/217bb9d8-d4f9-4482-8c40-5f0c49afeee6" />
  - After:
    <img width="523" height="229" alt="image" src="https://github.com/user-attachments/assets/707dd541-f0ab-4023-ba25-e244eb7c3e7a" />
- Project wildcard route list view to be consistent with org/[slug] page - project list shouldn't take full height if there's no need to, scroll behaviour should be on the page
  - Before:
    <img width="1224" height="868" alt="image" src="https://github.com/user-attachments/assets/6ff9f8a3-9f68-40a0-9a0b-e60fbef603cd" />
  - After:
    <img width="1230" height="477" alt="image" src="https://github.com/user-attachments/assets/91d65969-9457-49f9-9ce2-d3befc4576ad" />

