### PR TITLE
fix: add cursor-pointer class to changelog menu item

### DIFF
--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -97,7 +97,7 @@ export function UserDropdown() {
                 <FlaskConical size={14} strokeWidth={1.5} className="text-foreground-lighter" />
                 Feature previews
               </DropdownMenuItem>
-              <DropdownMenuItem className="flex gap-2" asChild>
+              <DropdownMenuItem className="flex gap-2 cursor-pointer" asChild>
                 <Link
                   href="https://supabase.com/changelog"
                   target="_blank"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / UI Polish

## What is the current behavior?

Interactive menu item "Changelog" is currently missing the cursor-pointer class. This change was supposed to be in #42361, but i forgot to add the cursor-pointer class to the Changelog menu item.

## What is the new behavior?

Cursor-pointer present for the "Changelog" menu item.

## Additional context

Before:
<img width="272" height="336" alt="image" src="https://github.com/user-attachments/assets/f853b43e-2457-4417-82c2-a072fdd6295f" />

After:
<img width="272" height="336" alt="image" src="https://github.com/user-attachments/assets/5de9c368-5c7d-409a-a8af-3f0bf1634168" />

References #42360 