### PR TITLE
feat: add description to schema visualizer

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -1,9 +1,8 @@
 import { buildTableEditorUrl } from 'components/grid/SupabaseGrid.utils'
-import { DiamondIcon, ExternalLink, Fingerprint, Hash, Key, Table2 } from 'lucide-react'
+import { DiamondIcon, ExternalLink, Fingerprint, Hash, InfoIcon, Key, Table2 } from 'lucide-react'
 import Link from 'next/link'
 import { Handle, NodeProps } from 'reactflow'
-
-import { Button, cn } from 'ui'
+import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 // ReactFlow is scaling everything by the factor of 2
 export const TABLE_NODE_WIDTH = 320
@@ -15,6 +14,7 @@ export type TableNodeData = {
   name: string
   ref?: string
   isForeign: boolean
+  description: string
   columns: {
     id: string
     isPrimary: boolean
@@ -67,19 +67,30 @@ export const TableNode = ({
               <Table2 strokeWidth={1} size={12} className="text-light" />
               {data.name}
             </div>
-            {!placeholder && (
-              <Button asChild type="text" className="px-0 w-[16px] h-[16px] rounded">
-                <Link
-                  href={buildTableEditorUrl({
-                    projectRef: data.ref,
-                    tableId: data.id,
-                    schema: data.schema,
-                  })}
-                >
-                  <ExternalLink size={10} className="text-foreground-light" />
-                </Link>
-              </Button>
-            )}
+            <div className="flex items-center gap-2">
+              {data.description && (
+                <Tooltip>
+                  <TooltipTrigger asChild className="cursor-default ">
+                    <InfoIcon size={10} className="text-light" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top">{data.description}</TooltipContent>
+                </Tooltip>
+              )}
+
+              {!placeholder && (
+                <Button asChild type="text" className="px-0 w-[16px] h-[16px] rounded">
+                  <Link
+                    href={buildTableEditorUrl({
+                      projectRef: data.ref,
+                      tableId: data.id,
+                      schema: data.schema,
+                    })}
+                  >
+                    <ExternalLink size={10} className="text-foreground-light" />
+                  </Link>
+                </Button>
+              )}
+            </div>
           </header>
 
           {data.columns.map((column) => (

--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -2,10 +2,12 @@ import dagre from '@dagrejs/dagre'
 import type { PostgresSchema, PostgresTable } from '@supabase/postgres-meta'
 import { uniqBy } from 'lodash'
 import { Edge, Node, Position } from 'reactflow'
+
 import 'reactflow/dist/style.css'
 
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { tryParseJson } from 'lib/helpers'
+
 import { TABLE_NODE_ROW_HEIGHT, TABLE_NODE_WIDTH, TableNodeData } from './SchemaTableNode'
 
 const NODE_SEP = 25
@@ -41,6 +43,7 @@ export async function getGraphDataFromTables(
       ref,
       id: table.id,
       name: table.name,
+      description: table.comment ?? '',
       schema: table.schema,
       isForeign: false,
       columns,
@@ -78,6 +81,7 @@ export async function getGraphDataFromTables(
           ref: ref!,
           schema: rel.target_table_schema,
           name: targetId,
+          description: '',
           isForeign: true,
           columns: [],
         }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Studio > Database > Schema Visualizer

## What is the current behavior?

If a table has a description value then the value does not show on the visualizer

## What is the new behavior?

<img width="393" height="243" alt="Screenshot 2026-03-04 at 19 09 47" src="https://github.com/user-attachments/assets/fcd61ecb-c1b8-4408-b753-62cc1d136c69" />


## Additional context

Closes #36072 
