### PR TITLE
chore: prevention of used leaked passwords entitlement

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -1,3 +1,5 @@
+import type { FeatureKey } from 'data/entitlements/entitlements-query'
+
 export interface Enum {
   label: string
   value: string
@@ -22,7 +24,7 @@ export interface Provider {
       descriptionOptional?: string
       units?: string
       isSecret?: boolean
-      isPaid?: boolean
+      entitlementKey?: FeatureKey
       link?: string
     }
   }

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -7,6 +7,7 @@ import { ResourceItem } from 'components/ui/Resource/ResourceItem'
 import type { components } from 'data/api'
 import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useHasEntitlementAccess } from 'hooks/misc/useCheckEntitlements'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { BASE_PATH } from 'lib/constants'
 import { Check } from 'lucide-react'
@@ -67,7 +68,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
     )
   }
 
-  const isFreePlan = organization?.plan.id === 'free'
+  const hasEntitlementAccess = useHasEntitlementAccess()
 
   const INITIAL_VALUES = (() => {
     const initialValues: { [x: string]: string | boolean } = {}
@@ -201,18 +202,17 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
                           )
                         }
 
+                        const { entitlementKey } = provider.properties[x]
+                        const hasAccess =
+                          entitlementKey == null || hasEntitlementAccess(entitlementKey)
                         const properties = {
                           ...provider.properties[x],
-                          description:
-                            provider.properties[x].isPaid && isFreePlan
-                              ? `${description} Only available on [Pro plan](/org/${organization.slug}/billing?panel=subscriptionPlan) and above.`
-                              : description,
+                          description: hasAccess
+                            ? description
+                            : `${description} Only available on [Pro plan](/org/${organization?.slug}/billing?panel=subscriptionPlan) and above.`,
                         }
-                        const isDisabledDueToPlan = properties.isPaid && isFreePlan
                         const shouldDisable =
-                          properties.type === 'boolean'
-                            ? isDisabledDueToPlan && !values[x]
-                            : isDisabledDueToPlan
+                          properties.type === 'boolean' ? !hasAccess && !values[x] : !hasAccess
 
                         return (
                           <FormField

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -38,7 +38,7 @@ const PROVIDER_EMAIL = {
         'Rejects the use of known or easy to guess passwords on sign up or password change. Powered by the HaveIBeenPwned.org Pwned Passwords API.',
       type: 'boolean',
       link: `${DOCS_URL}/guides/auth/password-security#password-strength-and-leaked-password-protection`,
-      isPaid: true,
+      entitlementKey: 'password_hibp',
     },
     PASSWORD_MIN_LENGTH: {
       title: 'Minimum password length',

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -38,7 +38,7 @@ const PROVIDER_EMAIL = {
         'Rejects the use of known or easy to guess passwords on sign up or password change. Powered by the HaveIBeenPwned.org Pwned Passwords API.',
       type: 'boolean',
       link: `${DOCS_URL}/guides/auth/password-security#password-strength-and-leaked-password-protection`,
-      entitlementKey: 'password_hibp',
+      entitlementKey: 'auth.password_hibp',
     },
     PASSWORD_MIN_LENGTH: {
       title: 'Minimum password length',

--- a/apps/studio/hooks/misc/useCheckEntitlements.ts
+++ b/apps/studio/hooks/misc/useCheckEntitlements.ts
@@ -6,7 +6,7 @@ import type {
 } from 'data/entitlements/entitlements-query'
 import { useEntitlementsQuery } from 'data/entitlements/entitlements-query'
 import { IS_PLATFORM } from 'lib/constants'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useSelectedOrganizationQuery } from './useSelectedOrganization'
 
 function isNumericConfig(
@@ -59,6 +59,26 @@ function getEntitlementMax(entitlement: Entitlement | null): number | undefined 
   return isEntitlementUnlimited(entitlement)
     ? Number.MAX_SAFE_INTEGER
     : getEntitlementNumericValue(entitlement)
+}
+
+export function useHasEntitlementAccess(organizationSlug?: string) {
+  const shouldGetSelectedOrg = !organizationSlug
+  const { data: selectedOrg } = useSelectedOrganizationQuery({
+    enabled: shouldGetSelectedOrg,
+  })
+
+  const finalOrgSlug = organizationSlug || selectedOrg?.slug
+  const enabled = IS_PLATFORM && !!finalOrgSlug
+
+  const { data: entitlementsData } = useEntitlementsQuery({ slug: finalOrgSlug! }, { enabled })
+
+  return useCallback(
+    (key: string) =>
+      IS_PLATFORM
+        ? entitlementsData?.entitlements.find((e) => e.feature.key === key)?.hasAccess ?? false
+        : true,
+    [entitlementsData]
+  )
 }
 
 export function useCheckEntitlements(


### PR DESCRIPTION
### Changes
- Replaces the isPaid plan-based check on the "Prevent use of leaked passwords" (PASSWORD_HIBP_ENABLED) setting with a proper entitlement check using the `password_hibp` entitlement key
- Adds a new `useHasEntitlementAccess` hook that returns a reusable checker function for any entitlement key, backed by the same cached entitlements query


### Testing
- Head to `/project/_/auth/providers?provider=Email` with an Org on the Free Plan
- Assert that the "Prevent use of leaked passwords" toggle is disabled.
- Head to `/project/_/auth/providers?provider=Email` with an Org on the Pro Plan
- Assert that the "Prevent use of leaked passwords" toggle is enabled and can be toggled and saved.

<img width="612" height="496" alt="image" src="https://github.com/user-attachments/assets/fc1ccc79-016c-4265-96ac-bdb458d2a8de" />
