### PR TITLE
feat(growth): expand www middleware to /dashboard and /docs (Phase 1 - instrumentation only)

### DIFF
--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it } from 'vitest'
+
+import { FIRST_REFERRER_COOKIE_NAME } from 'common/first-referrer-cookie'
+
+import { middleware } from './middleware'
+
+function makeRequest(
+  url: string,
+  { referer, hasCookie }: { referer?: string; hasCookie?: boolean } = {}
+): NextRequest {
+  const req = new NextRequest(new URL(url, 'https://supabase.com'), {
+    headers: referer ? { referer } : {},
+  })
+  if (hasCookie) {
+    req.cookies.set(FIRST_REFERRER_COOKIE_NAME, 'existing')
+  }
+  return req
+}
+
+describe('www middleware', () => {
+  describe('cookie stamping on normal paths', () => {
+    it('stamps cookie for external referrer on www path', () => {
+      const req = makeRequest('/pricing', { referer: 'https://google.com' })
+      const res = middleware(req)
+
+      expect(res.cookies.get(FIRST_REFERRER_COOKIE_NAME)).toBeDefined()
+    })
+
+    it('does not stamp cookie for internal referrer', () => {
+      const req = makeRequest('/pricing', { referer: 'https://supabase.com/docs' })
+      const res = middleware(req)
+
+      expect(res.cookies.get(FIRST_REFERRER_COOKIE_NAME)).toBeUndefined()
+    })
+  })
+
+  describe('dashboard/docs instrumentation guard', () => {
+    it('sets x-sb-mw-hit header on /dashboard paths', () => {
+      const req = makeRequest('/dashboard/project/123', { referer: 'https://google.com' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-sb-mw-hit')).toBe('1')
+    })
+
+    it('sets x-sb-mw-hit header on /docs paths', () => {
+      const req = makeRequest('/docs/guides/auth', { referer: 'https://google.com' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-sb-mw-hit')).toBe('1')
+    })
+
+    it('does NOT stamp cookie on /dashboard paths', () => {
+      const req = makeRequest('/dashboard/project/123', { referer: 'https://google.com' })
+      const res = middleware(req)
+
+      expect(res.cookies.get(FIRST_REFERRER_COOKIE_NAME)).toBeUndefined()
+    })
+
+    it('does NOT stamp cookie on /docs paths', () => {
+      const req = makeRequest('/docs/guides/auth', { referer: 'https://google.com' })
+      const res = middleware(req)
+
+      expect(res.cookies.get(FIRST_REFERRER_COOKIE_NAME)).toBeUndefined()
+    })
+
+    it('does NOT set x-sb-mw-hit header on normal www paths', () => {
+      const req = makeRequest('/pricing', { referer: 'https://google.com' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-sb-mw-hit')).toBeNull()
+    })
+  })
+})

--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 import { describe, expect, it } from 'vitest'
 
-import { FIRST_REFERRER_COOKIE_NAME } from 'common/first-referrer-cookie'
+import { FIRST_REFERRER_COOKIE_NAME, MW_DIAG_COOKIE_NAME } from 'common/first-referrer-cookie'
 
 import { middleware } from './middleware'
 
@@ -16,6 +16,15 @@ function makeRequest(
     req.cookies.set(FIRST_REFERRER_COOKIE_NAME, 'existing')
   }
   return req
+}
+
+function parseDiagCookie(value: string) {
+  const params = new URLSearchParams(value)
+  return {
+    hit: params.get('hit') === '1',
+    would_stamp: params.get('would_stamp') === '1',
+    has_cookie: params.get('has_cookie') === '1',
+  }
 }
 
 describe('www middleware', () => {
@@ -35,40 +44,92 @@ describe('www middleware', () => {
     })
   })
 
-  describe('dashboard/docs instrumentation guard', () => {
-    it('sets x-sb-mw-hit header on /dashboard paths', () => {
+  describe('dashboard/docs diagnostic guard', () => {
+    it('sets diagnostic cookie on /dashboard paths', () => {
       const req = makeRequest('/dashboard/project/123', { referer: 'https://google.com' })
       const res = middleware(req)
 
-      expect(res.headers.get('x-sb-mw-hit')).toBe('1')
+      expect(res.cookies.get(MW_DIAG_COOKIE_NAME)).toBeDefined()
     })
 
-    it('sets x-sb-mw-hit header on /docs paths', () => {
+    it('sets diagnostic cookie on /docs paths', () => {
       const req = makeRequest('/docs/guides/auth', { referer: 'https://google.com' })
       const res = middleware(req)
 
-      expect(res.headers.get('x-sb-mw-hit')).toBe('1')
+      expect(res.cookies.get(MW_DIAG_COOKIE_NAME)).toBeDefined()
     })
 
-    it('does NOT stamp cookie on /dashboard paths', () => {
+    it('encodes hit=1 in diagnostic cookie', () => {
+      const req = makeRequest('/dashboard/project/123', { referer: 'https://google.com' })
+      const res = middleware(req)
+      const raw = res.cookies.get(MW_DIAG_COOKIE_NAME)?.value ?? ''
+      const diag = parseDiagCookie(raw)
+
+      expect(diag.hit).toBe(true)
+    })
+
+    it('encodes would_stamp=1 for external referrer with no existing cookie', () => {
+      const req = makeRequest('/dashboard/project/123', { referer: 'https://google.com' })
+      const res = middleware(req)
+      const raw = res.cookies.get(MW_DIAG_COOKIE_NAME)?.value ?? ''
+      const diag = parseDiagCookie(raw)
+
+      expect(diag.would_stamp).toBe(true)
+      expect(diag.has_cookie).toBe(false)
+    })
+
+    it('encodes would_stamp=0 for direct navigation (no referrer)', () => {
+      const req = makeRequest('/dashboard/project/123')
+      const res = middleware(req)
+      const raw = res.cookies.get(MW_DIAG_COOKIE_NAME)?.value ?? ''
+      const diag = parseDiagCookie(raw)
+
+      expect(diag.would_stamp).toBe(false)
+      expect(diag.has_cookie).toBe(false)
+    })
+
+    it('encodes would_stamp=0 for internal referrer', () => {
+      const req = makeRequest('/dashboard/project/123', {
+        referer: 'https://supabase.com/pricing',
+      })
+      const res = middleware(req)
+      const raw = res.cookies.get(MW_DIAG_COOKIE_NAME)?.value ?? ''
+      const diag = parseDiagCookie(raw)
+
+      expect(diag.would_stamp).toBe(false)
+    })
+
+    it('encodes has_cookie=1 when first-referrer cookie is already present', () => {
+      const req = makeRequest('/dashboard/project/123', {
+        referer: 'https://google.com',
+        hasCookie: true,
+      })
+      const res = middleware(req)
+      const raw = res.cookies.get(MW_DIAG_COOKIE_NAME)?.value ?? ''
+      const diag = parseDiagCookie(raw)
+
+      expect(diag.has_cookie).toBe(true)
+    })
+
+    it('does NOT stamp first-referrer cookie on /dashboard paths', () => {
       const req = makeRequest('/dashboard/project/123', { referer: 'https://google.com' })
       const res = middleware(req)
 
       expect(res.cookies.get(FIRST_REFERRER_COOKIE_NAME)).toBeUndefined()
     })
 
-    it('does NOT stamp cookie on /docs paths', () => {
+    it('does NOT stamp first-referrer cookie on /docs paths', () => {
       const req = makeRequest('/docs/guides/auth', { referer: 'https://google.com' })
       const res = middleware(req)
 
       expect(res.cookies.get(FIRST_REFERRER_COOKIE_NAME)).toBeUndefined()
     })
 
-    it('does NOT set x-sb-mw-hit header on normal www paths', () => {
+    it('does NOT set diagnostic cookie on normal www paths', () => {
       const req = makeRequest('/pricing', { referer: 'https://google.com' })
       const res = middleware(req)
 
-      expect(res.headers.get('x-sb-mw-hit')).toBeNull()
+      expect(res.cookies.get(MW_DIAG_COOKIE_NAME)).toBeUndefined()
     })
   })
 })

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -3,16 +3,23 @@ import { NextResponse, type NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
   const response = NextResponse.next()
+
+  const pathname = request.nextUrl.pathname
+  const isDashboardOrDocs = pathname.startsWith('/dashboard') || pathname.startsWith('/docs')
+
+  if (isDashboardOrDocs) {
+    response.headers.set('x-sb-mw-hit', '1')
+    return response
+  }
+
   stampFirstReferrerCookie(request, response)
   return response
 }
 
 export const config = {
   matcher: [
-    // Match all paths except Next.js internals, static files, and proxied app paths.
-    // - _next/data: client-side navigation JSON fetches (MUST exclude to prevent full page reloads)
-    // - dashboard: Studio app (proxied via multi-zone, has its own cookie stamping in proxy.ts)
-    // - docs: Docs app (proxied via multi-zone in prod, has its own middleware for cookie stamping)
-    '/((?!api|_next/static|_next/image|_next/data|dashboard|docs|favicon.ico|__nextjs).*)',
+    // Match all paths except Next.js internals and static files.
+    // MUST exclude _next/data to prevent full page reloads in multi-zone apps.
+    '/((?!api|_next/static|_next/image|_next/data|favicon.ico|__nextjs).*)',
   ],
 }

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -1,4 +1,9 @@
-import { stampFirstReferrerCookie } from 'common/first-referrer-cookie'
+import {
+  FIRST_REFERRER_COOKIE_NAME,
+  MW_DIAG_COOKIE_NAME,
+  shouldRefreshCookie,
+  stampFirstReferrerCookie,
+} from 'common/first-referrer-cookie'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
@@ -8,7 +13,19 @@ export function middleware(request: NextRequest) {
   const isDashboardOrDocs = pathname.startsWith('/dashboard') || pathname.startsWith('/docs')
 
   if (isDashboardOrDocs) {
-    response.headers.set('x-sb-mw-hit', '1')
+    // Phase 1: diagnostic only — no permanent cookie mutations.
+    // Compute what Phase 2 would do and encode it in a short-lived cookie
+    // readable by client-side telemetry so we get PostHog-visible data.
+    // This also tests the Set-Cookie mutation path that Phase 2 will use.
+    const referrer = request.headers.get('referer') ?? ''
+    const hasCookie = request.cookies.has(FIRST_REFERRER_COOKIE_NAME)
+    const { stamp: wouldStamp } = shouldRefreshCookie(hasCookie, { referrer, url: request.url })
+
+    response.cookies.set(
+      MW_DIAG_COOKIE_NAME,
+      `hit=1&would_stamp=${wouldStamp ? '1' : '0'}&has_cookie=${hasCookie ? '1' : '0'}`,
+      { path: '/', sameSite: 'lax', maxAge: 60 }
+    )
     return response
   }
 

--- a/packages/common/first-referrer-cookie.test.ts
+++ b/packages/common/first-referrer-cookie.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest'
 import {
   buildFirstReferrerData,
   FIRST_REFERRER_COOKIE_NAME,
+  MW_DIAG_COOKIE_NAME,
   hasPaidSignals,
   isExternalReferrer,
   parseFirstReferrerCookie,
+  parseMwDiagCookie,
   serializeFirstReferrerCookie,
   shouldRefreshCookie,
 } from './first-referrer-cookie'
@@ -164,6 +166,71 @@ describe('first-referrer-cookie', () => {
       expect(hasPaidSignals(new URL('https://supabase.com/?utm_source=google'))).toBe(false)
       expect(hasPaidSignals(new URL('https://supabase.com/?utm_medium=email'))).toBe(false)
       expect(hasPaidSignals(new URL('https://supabase.com/?utm_medium=organic'))).toBe(false)
+    })
+  })
+
+  describe('parseMwDiagCookie', () => {
+    it('parses well-formed value with would_stamp=1 and has_cookie=0', () => {
+      const header = `${MW_DIAG_COOKIE_NAME}=hit=1&would_stamp=1&has_cookie=0`
+      expect(parseMwDiagCookie(header)).toEqual({
+        hit: true,
+        would_stamp: true,
+        has_existing_cookie: false,
+      })
+    })
+
+    it('parses well-formed value with would_stamp=0 and has_cookie=1', () => {
+      const header = `${MW_DIAG_COOKIE_NAME}=hit=1&would_stamp=0&has_cookie=1`
+      expect(parseMwDiagCookie(header)).toEqual({
+        hit: true,
+        would_stamp: false,
+        has_existing_cookie: true,
+      })
+    })
+
+    it('returns null when hit=0', () => {
+      const header = `${MW_DIAG_COOKIE_NAME}=hit=0&would_stamp=1&has_cookie=1`
+      expect(parseMwDiagCookie(header)).toBeNull()
+    })
+
+    it('returns object with would_stamp: false when would_stamp key is missing', () => {
+      const header = `${MW_DIAG_COOKIE_NAME}=hit=1&has_cookie=1`
+      expect(parseMwDiagCookie(header)).toEqual({
+        hit: true,
+        would_stamp: false,
+        has_existing_cookie: true,
+      })
+    })
+
+    it('returns object with has_existing_cookie: false when has_cookie key is missing', () => {
+      const header = `${MW_DIAG_COOKIE_NAME}=hit=1&would_stamp=1`
+      expect(parseMwDiagCookie(header)).toEqual({
+        hit: true,
+        would_stamp: true,
+        has_existing_cookie: false,
+      })
+    })
+
+    it('returns null for empty string input', () => {
+      expect(parseMwDiagCookie('')).toBeNull()
+    })
+
+    it('returns null when cookie is not present in header', () => {
+      expect(parseMwDiagCookie('session=abc123; theme=dark')).toBeNull()
+    })
+
+    it('returns null for garbage value', () => {
+      const header = `${MW_DIAG_COOKIE_NAME}=not-a-valid-query-string`
+      expect(parseMwDiagCookie(header)).toBeNull()
+    })
+
+    it('parses correct cookie from header with multiple cookies', () => {
+      const header = `session=abc123; ${MW_DIAG_COOKIE_NAME}=hit=1&would_stamp=1&has_cookie=0; theme=dark`
+      expect(parseMwDiagCookie(header)).toEqual({
+        hit: true,
+        would_stamp: true,
+        has_existing_cookie: false,
+      })
     })
   })
 

--- a/packages/common/first-referrer-cookie.ts
+++ b/packages/common/first-referrer-cookie.ts
@@ -47,6 +47,13 @@ interface MiddlewareResponse {
 
 export const FIRST_REFERRER_COOKIE_NAME = '_sb_first_referrer'
 
+/**
+ * Short-lived (60s) diagnostic cookie written by www middleware on /dashboard and /docs paths.
+ * Encodes: hit=1&would_stamp={0|1}&has_cookie={0|1}
+ * Read by Studio telemetry to report middleware reach and attribution signals to PostHog.
+ */
+export const MW_DIAG_COOKIE_NAME = '_sb_mw_diag'
+
 /** 365 days in seconds */
 export const FIRST_REFERRER_COOKIE_MAX_AGE = 365 * 24 * 60 * 60
 
@@ -260,6 +267,44 @@ export function stampFirstReferrerCookie(
       : {}),
     maxAge: FIRST_REFERRER_COOKIE_MAX_AGE,
   })
+}
+
+// ---------------------------------------------------------------------------
+// Middleware diagnostic cookie — parse (client-side)
+// ---------------------------------------------------------------------------
+
+export interface MwDiagData {
+  hit: boolean
+  would_stamp: boolean
+  has_existing_cookie: boolean
+}
+
+/**
+ * Parse the short-lived middleware diagnostic cookie written by www middleware
+ * on /dashboard and /docs paths. Returns null if the cookie is absent or malformed.
+ */
+export function parseMwDiagCookie(cookieHeader: string): MwDiagData | null {
+  try {
+    const cookies = cookieHeader.split(';')
+    const match = cookies
+      .map((c) => c.trim())
+      .find((c) => c.startsWith(`${MW_DIAG_COOKIE_NAME}=`))
+
+    if (!match) return null
+
+    const value = match.slice(`${MW_DIAG_COOKIE_NAME}=`.length)
+    const params = new URLSearchParams(value)
+
+    if (params.get('hit') !== '1') return null
+
+    return {
+      hit: true,
+      would_stamp: params.get('would_stamp') === '1',
+      has_existing_cookie: params.get('has_cookie') === '1',
+    }
+  } catch {
+    return null
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -12,8 +12,8 @@ import { hasConsented, useConsentState } from './consent-state'
 import { IS_PLATFORM, IS_PROD, LOCAL_STORAGE_KEYS } from './constants'
 import { useFeatureFlags } from './feature-flags'
 import { post } from './fetchWrappers'
-import type { FirstReferrerData } from './first-referrer-cookie'
-import { isExternalReferrer, parseFirstReferrerCookie } from './first-referrer-cookie'
+import type { FirstReferrerData, MwDiagData } from './first-referrer-cookie'
+import { isExternalReferrer, parseFirstReferrerCookie, parseMwDiagCookie } from './first-referrer-cookie'
 import { ensurePlatformSuffix, isBrowser } from './helpers'
 import { useParams, useTelemetryCookie } from './hooks'
 import { posthogClient, type ClientTelemetryEvent } from './posthog-client'
@@ -109,6 +109,7 @@ interface HandlePageTelemetryOptions {
   ref?: string
   telemetryDataOverride?: SharedTelemetryData
   firstReferrerData?: FirstReferrerData | null
+  mwDiagData?: MwDiagData | null
 }
 
 function handlePageTelemetry({
@@ -119,6 +120,7 @@ function handlePageTelemetry({
   ref,
   telemetryDataOverride,
   firstReferrerData,
+  mwDiagData,
 }: HandlePageTelemetryOptions) {
   // Send to PostHog client-side (only in browser)
   if (typeof window !== 'undefined') {
@@ -222,6 +224,13 @@ function handlePageTelemetry({
       ...(firstReferrerData !== undefined && {
         first_referrer_cookie_present: firstReferrerCookiePresent,
         first_referrer_cookie_consumed: firstReferrerCookieConsumed,
+      }),
+      // Phase 1 middleware diagnostic: present only when _sb_mw_diag cookie was found
+      // (i.e., the request was routed through www middleware on /dashboard or /docs)
+      ...(mwDiagData && {
+        mw_diag_hit: mwDiagData.hit,
+        mw_diag_would_stamp: mwDiagData.would_stamp,
+        mw_diag_has_existing_cookie: mwDiagData.has_existing_cookie,
       }),
     })
   }
@@ -336,10 +345,12 @@ export const PageTelemetry = ({
       hasAcceptedConsent &&
       !hasSentInitialPageTelemetryRef.current
     ) {
-      // Read the edge-set first-referrer cookie (cross-app handoff)
-      const firstReferrerData = parseFirstReferrerCookie(document.cookie)
+      // Read the edge-set cookies (cross-app handoff)
+      const cookieHeader = document.cookie
+      const firstReferrerData = parseFirstReferrerCookie(cookieHeader)
+      const mwDiagData = parseMwDiagCookie(cookieHeader)
 
-      const cookies = document.cookie.split(';')
+      const cookies = cookieHeader.split(';')
       const telemetryCookieValue = cookies
         .map((cookie) => cookie.trim())
         .find((cookie) => cookie.startsWith(`${TELEMETRY_DATA}=`))
@@ -358,6 +369,7 @@ export const PageTelemetry = ({
             ref,
             telemetryDataOverride: telemetryData,
             firstReferrerData,
+            mwDiagData,
           })
         } catch (error) {
           if (!IS_PROD) {
@@ -370,6 +382,7 @@ export const PageTelemetry = ({
             slug,
             ref,
             firstReferrerData,
+            mwDiagData,
           })
         } finally {
           clearTelemetryDataCookie()
@@ -382,6 +395,7 @@ export const PageTelemetry = ({
           slug,
           ref,
           firstReferrerData,
+          mwDiagData,
         })
       }
 


### PR DESCRIPTION
## Problem

The `_sb_first_referrer` cookie isn't working. The www middleware matcher explicitly excludes `/dashboard` and `/docs`, so the cookie never gets stamped for Studio or Docs traffic. PostHog confirmed: only 1 event with `first_referrer_cookie_present=true` out of ~46.5M Studio pageviews in the last 7 days.

## Background: what the matcher does

In Next.js, the `matcher` config controls which incoming requests the middleware function even runs on. If a path doesn't match, the middleware is skipped entirely — the request passes through untouched. If it matches, the middleware runs and can mutate the response (set cookies, headers, etc.).

This matters because Studio's SPA navigation works via silent `/_next/data/` JSON fetches. If middleware runs on those requests and returns `NextResponse.next()` with any mutations, it breaks those fetches and causes full page reloads instead of client-side transitions.

## What we tried before

| PR | www runs on `/dashboard`? | Studio `proxy.ts` runs on all routes? | Result |
|---|---|---|---|
| **#42768** (Attempt 1) | ✅ Yes — and also intercepts `_next/data` | ✅ Yes — `matcher` config removed, stamps cookie everywhere | Full page reloads in Studio |
| **#43129** (Full revert) | ❌ No — www middleware deleted entirely | ❌ No — restored to `matcher: '/api/*'` only | Back to baseline, no cookie stamping anywhere |
| **#43153** (Attempt 2) | ❌ No — `/dashboard` explicitly excluded | ✅ Yes — `matcher` config removed again, stamps cookie everywhere | Full page reloads in Studio again |
| **#43189** (Attempt 3) | ❌ No — same as #43153 | ✅ Yes — `matcher` config still removed, cookie stamping made conditional | Still broken |
| **#43190** (Ivan's fix) | ❌ No — `/dashboard` still excluded | ❌ No — restored to `matcher: '/api/*'` only | Works — but cookie never stamps for `/dashboard` traffic |
| **#43413** (this PR) | ✅ Yes — sets diagnostic cookie only, no attribution stamping yet | ❌ No — unchanged, still `matcher: '/api/*'` only | ❓ Untested in prod |

The common factor in every failure: Studio's `proxy.ts` ran on all routes (including `_next/data` requests), which broke SPA navigation. This PR is the first one that runs www middleware on `/dashboard` while Studio's `proxy.ts` stays in its original narrow `/api/*` scope.

## What changed

This is Phase 1 of a two-phase rollout. We remove `dashboard|docs` from the matcher's negative lookahead so www middleware runs on those paths — but instead of stamping cookies, we set a short-lived (60s) diagnostic cookie `_sb_mw_diag` on `/dashboard` and `/docs` requests.

The diagnostic cookie encodes `hit=1&would_stamp={0|1}&has_cookie={0|1}`, which Studio telemetry reads on the initial pageview and reports to PostHog as `mw_diag_hit`, `mw_diag_would_stamp`, and `mw_diag_has_existing_cookie` properties.

A cookie rather than a header because response headers aren't readable by JS. It also tests the actual Set-Cookie mutation path that Phase 2 will use (which is what Next.js issue #41885 is specifically about).

Phase 1 answers two key questions before we commit to Phase 2:
1. Does expanding the matcher break Studio SPA navigation?
2. What % of /dashboard arrivals would get a first-referrer cookie stamped in Phase 2?

## Phase 2 readiness criteria

**Important caveat**: `mw_diag_*` data reflects consented users only and may under-represent first-visit anonymous traffic. The Phase 2 decision should account for this — the actual middleware execution rate is likely higher than what PostHog reports.

### PostHog query spec

**Middleware execution rate**: Of all Studio initial pageviews on `/dashboard` or `/docs` paths, what percentage have `mw_diag_hit = true`? Expected: >= 90%. Below 70% warrants investigation (could indicate edge caching bypassing middleware, or a matcher configuration issue).

```
Filter: event = "$pageview" AND (current_url contains "/dashboard" OR current_url contains "/docs")
Breakdown: mw_diag_hit (true vs null/missing)
Metric:    count(mw_diag_hit = true) / count(all) * 100
```

**Would-stamp rate**: Of events with `mw_diag_hit = true`, what percentage have `mw_diag_would_stamp = true`? This tells us what percentage of Phase 2 traffic would actually get a cookie stamped. No hard threshold — unexpected values (< 5% or > 95%) suggest a logic bug worth investigating before Phase 2.

```
Filter: event = "$pageview" AND mw_diag_hit = true
Breakdown: mw_diag_would_stamp (true vs false)
Metric:    count(mw_diag_would_stamp = true) / count(all) * 100
```

**Existing cookie rate**: Of events with `mw_diag_hit = true`, what percentage have `mw_diag_has_existing_cookie = true`? This tells us how many users already have the cookie from a prior www visit.

```
Filter: event = "$pageview" AND mw_diag_hit = true
Breakdown: mw_diag_has_existing_cookie (true vs false)
Metric:    count(mw_diag_has_existing_cookie = true) / count(all) * 100
```

### Go / no-go threshold table

| Signal | Go | Investigate | No-Go |
|---|---|---|---|
| `mw_diag_hit` rate (% of /dashboard+/docs pageviews) | >= 90% | 70-90% | < 70% |
| SPA navigation errors (Sentry / Vercel logs) | No increase | < 0.1% increase | > 0.5% increase |
| Middleware p99 latency (Vercel function logs) | < 50ms added | 50-100ms | > 100ms |
| Sample volume in first 24h | > 1,000 events | 100-1,000 (extend window) | < 100 (insufficient data) |

## Changes

- `apps/www/middleware.ts`: Removed `dashboard|docs` from matcher; added `isDashboardOrDocs` guard that sets `_sb_mw_diag` diagnostic cookie instead of stamping attribution
- `apps/www/middleware.test.ts`: 12 tests covering cookie stamping on www paths, diagnostic cookie encoding for all scenarios (external referrer, direct nav, internal referrer, existing cookie)
- `packages/common/first-referrer-cookie.ts`: Exported `MW_DIAG_COOKIE_NAME`, `MwDiagData` type, and `parseMwDiagCookie()` helper
- `packages/common/telemetry.tsx`: Reads `_sb_mw_diag` on initial Studio pageview; reports `mw_diag_*` properties to PostHog

## Testing

Unit tests pass (13/13 www, 31/31 first-referrer-cookie). Production validation needed:

- [ ] Studio SPA navigation works (tab changes, SQL editor, no full page reloads)
- [ ] PostHog shows `mw_diag_hit = true` on Studio initial pageviews
- [ ] `mw_diag_would_stamp` distribution looks reasonable before enabling Phase 2
- [ ] Monitor 24h before Phase 2

Ref: GROWTH-625 / GROWTH-668