### PR TITLE
chore: add telemetry standards skill for CodeRabbit

### DIFF
--- a/.claude/skills/telemetry-standards/SKILL.md
+++ b/.claude/skills/telemetry-standards/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: telemetry-standards
+description: PostHog event tracking standards for Supabase Studio. Use when reviewing
+  PRs for telemetry compliance or implementing new event tracking. Covers event naming,
+  property conventions, approved patterns, and implementation workflow.
+---
+
+# Telemetry Standards for Supabase Studio
+
+Standards and workflows for PostHog event tracking in `apps/studio/`. Use this
+when reviewing PRs for tracking compliance or implementing new tracking.
+
+## Event Naming
+
+**Format:** `[object]_[verb]` in snake_case
+
+**Approved verbs only:**
+opened, clicked, submitted, created, removed, updated, retrieved, intended, evaluated, added
+
+**Flag these mistakes:**
+- New unapproved verbs (saved, viewed, seen, pressed, etc.)
+- Wrong order: `click_product_card` should be `product_card_clicked`
+- Wrong casing: `productCardClicked` or `Product_Card_Clicked` should be `product_card_clicked`
+
+**Good examples:**
+- `product_card_clicked`
+- `sql_query_executed` — note: `executed` is not in the approved list, prefer `submitted`
+- `assistant_suggestion_accepted` — note: `accepted` is not in the approved list, prefer `clicked`
+- `backup_button_clicked`
+
+## Property Standards
+
+**Casing:** camelCase always
+
+**Names must be self-explanatory:**
+- `{ productType: 'database', planTier: 'pro' }`
+- `{ assistantType: 'sql', suggestionType: 'optimization' }`
+
+**Flag these:**
+- Generic names: `label`, `value`, `type`, `name`, `data`
+- snake_case or PascalCase properties
+- Inconsistent names across similar events (e.g., `assistantType` in one event, `aiType` in a related event)
+
+## What NOT to Track
+
+- Passive views/renders on page load (`dashboard_viewed`, `sidebar_appeared`, `page_loaded`)
+- Component appearances without user interaction
+- Generic "viewed" or "seen" events — these are already captured by pageview events
+
+**DO track:**
+- User clicks
+- Form submissions
+- Explicit opens/closes by user
+- User-initiated actions
+
+## Implementation Pattern
+
+**Required hook:** `useTrack` from `lib/telemetry/track`
+
+```typescript
+import { useTrack } from 'common/lib/telemetry'
+
+const MyComponent = () => {
+  const track = useTrack()
+
+  const handleClick = () => {
+    track('product_card_clicked', {
+      productType: 'database',
+      planTier: 'pro',
+      source: 'dashboard',
+    })
+  }
+
+  return <button onClick={handleClick}>Click me</button>
+}
+```
+
+**Deprecated — flag any usage:**
+```typescript
+// NEVER use useSendEventMutation
+const { mutate: sendEvent } = useSendEventMutation()
+```
+
+## Event Definitions
+
+All events must be defined in `packages/common/telemetry-constants.ts` with accurate JSDoc:
+
+```typescript
+/**
+ * [Event description]
+ * @page [accurate page/location where this fires]
+ * @source [what triggers this event]
+ */
+export const EVENT_NAME = '[object]_[verb]' as const
+```
+
+## Review Workflow
+
+Use when reviewing a PR for telemetry compliance.
+
+### Step 1: Fetch PR Details
+
+```bash
+gh pr view [PR_NUMBER] --json files,diff,title,body
+gh pr diff [PR_NUMBER]
+```
+
+Focus on:
+- `packages/common/telemetry-constants.ts`
+- Any files using `useTrack`, `track()`, or `useSendEventMutation`
+
+### Step 2: Check telemetry-constants.ts
+
+If modified, check every new or changed event for:
+- Event name follows `[object]_[verb]` snake_case format
+- Verb is from the approved list
+- Properties use camelCase and are self-explanatory
+- `@page` and `@source` descriptions are accurate
+- Property names are consistent with similar existing events
+
+### Step 3: Check Implementation Files
+
+For files using tracking functions:
+- No `useSendEventMutation` usage (must use `useTrack`)
+- No unnecessary view tracking (passive renders on page load)
+- Properties consistent with similar events in telemetry-constants.ts
+
+### Step 4: Check for Missing Tracking
+
+If the PR adds user-facing interactions (buttons, forms, toggles, modals, dialogs) without tracking:
+- Flag it as a suggestion: "This adds a user interaction that may benefit from tracking. Consider adding a `useTrack()` call."
+- Propose the event name following `[object]_[verb]` convention
+- Propose the `useTrack()` call with suggested properties
+
+### Step 5: Present Issues
+
+Format each issue as:
+
+```
+**File:** [filename]
+**Line:** [approximate line number from diff]
+**Issue:** [specific problem]
+**Suggestion:** [exact fix needed]
+**Severity:** Request Changes (for violations) or Suggestion (for missing tracking)
+```
+
+Present all issues and wait for user approval before posting.
+
+### Step 6: Post Comments (After Approval)
+
+```bash
+gh pr comment [PR_NUMBER] --body "[formatted comment]"
+```
+
+## Implementation Workflow
+
+Use when adding new event tracking.
+
+### Step 1: Design the Event
+
+Given the user action to track:
+1. Name: `[object]_[verb]` using approved verbs only
+2. Properties: camelCase, self-explanatory names
+3. Search `packages/common/telemetry-constants.ts` for similar events and match their property names
+
+Present the design:
+
+```
+Event Name: [object]_[verb]
+Properties:
+  - propertyName: type (description)
+@page: [where this fires]
+@source: [what triggers it]
+Similar Events: [list any related events found]
+```
+
+Wait for approval.
+
+### Step 2: Add to telemetry-constants.ts
+
+Add the event definition with JSDoc to `packages/common/telemetry-constants.ts`.
+
+### Step 3: Implement in Component
+
+1. Import: `import { useTrack } from 'common/lib/telemetry'`
+2. Initialize: `const track = useTrack()`
+3. Call: `track('object_verb', { propertyName: value })`
+
+### Step 4: Verify
+
+- [ ] Event added to telemetry-constants.ts with accurate @page/@source
+- [ ] Event name follows [object]_[verb] pattern with approved verb
+- [ ] Event name is snake_case
+- [ ] Properties are camelCase and self-explanatory
+- [ ] Using useTrack hook (not useSendEventMutation)
+- [ ] Not tracking passive views/appearances
+- [ ] Consistent with similar events

--- a/.claude/skills/telemetry-standards/SKILL.md
+++ b/.claude/skills/telemetry-standards/SKILL.md
@@ -15,7 +15,8 @@ reviewing PRs that touch tracking or when implementing new tracking.
 **Format:** `[object]_[verb]` in snake_case
 
 **Approved verbs only:**
-opened, clicked, submitted, created, removed, updated, retrieved, intended, evaluated, added
+opened, clicked, submitted, created, removed, updated, retrieved, intended, evaluated, added,
+enabled, disabled, copied, exposed, failed, converted
 
 **Flag these:**
 - Unapproved verbs (saved, viewed, seen, pressed, etc.)
@@ -35,16 +36,17 @@ opened, clicked, submitted, created, removed, updated, retrieved, intended, eval
 
 ## Property Standards
 
-**Casing:** camelCase always
+**Casing:** camelCase preferred for new events. The codebase has existing snake_case properties (e.g., `schema_name`, `table_name`) — when adding properties to an existing event, match its established convention.
 
 **Names must be self-explanatory:**
 - `{ productType: 'database', planTier: 'pro' }`
 - `{ assistantType: 'sql', suggestionType: 'optimization' }`
 
 **Flag these:**
-- Generic names: `label`, `value`, `type`, `name`, `data`
-- snake_case or PascalCase properties
+- Generic names: `label`, `value`, `name`, `data`
+- PascalCase properties
 - Inconsistent names across similar events (e.g., `assistantType` in one event, `aiType` in a related event)
+- Mixing camelCase and snake_case within the same event
 
 ## What NOT to Track
 
@@ -54,14 +56,16 @@ opened, clicked, submitted, created, removed, updated, retrieved, intended, eval
 
 **DO track:** user clicks, form submissions, explicit opens/closes, user-initiated actions.
 
+**Exception:** `_exposed` events for A/B experiment exposure tracking are valid even though they fire on render.
+
 **Never track PII** (emails, names, IPs, etc.) in event properties.
 
 ## Required Pattern
 
-Use `useTrack` from `lib/telemetry/track`. Never use `useSendEventMutation` (deprecated).
+Import `useTrack` from `lib/telemetry/track` (within `apps/studio/`). Never use `useSendEventMutation` (deprecated).
 
 ```typescript
-import { useTrack } from 'common/lib/telemetry'
+import { useTrack } from 'lib/telemetry/track'
 
 const MyComponent = () => {
   const track = useTrack()
@@ -80,18 +84,27 @@ const MyComponent = () => {
 
 ## Event Definitions
 
-All events must be defined in `packages/common/telemetry-constants.ts` with JSDoc:
+All events must be defined as TypeScript interfaces in `packages/common/telemetry-constants.ts`:
 
 ```typescript
 /**
  * [Event description]
- * @page [page/location where this fires]
+ *
+ * @group Events
  * @source [what triggers this event]
  */
-export const EVENT_NAME = '[object]_[verb]' as const
+export interface MyFeatureClickedEvent {
+  action: 'my_feature_clicked'
+  properties: {
+    /** Description of property */
+    featureType: string
+  }
+  groups: TelemetryGroups
+}
 ```
 
-`@page` and `@source` must accurately describe where and how the event fires.
+Add the new interface to the `TelemetryEvent` union type so `useTrack` picks it up.
+`@group Events` and `@source` must be accurate.
 
 ## Review Rules
 
@@ -112,26 +125,27 @@ When checking property consistency, search `packages/common/telemetry-constants.
 
 ## Well-Formed Event Examples
 
+From the actual codebase:
+
 ```typescript
-track('sql_query_submitted', {
-  queryType: 'select',
-  executionTime: 1234,
-  rowCount: 50,
+// User copies a connection string
+track('connection_string_copied', {
+  connectionType: 'psql',
+  connectionMethod: 'transaction_pooler',
+  connectionTab: 'Connection String',
 })
 
-track('assistant_suggestion_clicked', {
-  assistantType: 'sql',
-  suggestionType: 'optimization',
+// User enables a feature preview
+track('feature_preview_enabled', {
+  feature: 'realtime_inspector',
 })
 
-track('database_connection_clicked', {
-  connectionType: 'direct',
-  source: 'settings_page',
-})
+// User clicks a banner CTA
+track('index_advisor_banner_dismiss_button_clicked')
 
-track('backup_button_clicked', {
-  backupType: 'manual',
-  databaseSize: 'large',
+// Experiment exposure (fires on render — valid exception)
+track('home_new_experiment_exposed', {
+  variant: 'treatment',
 })
 ```
 
@@ -140,9 +154,9 @@ track('backup_button_clicked', {
 To add tracking for a user action:
 
 1. **Name the event** — `[object]_[verb]` using approved verbs only
-2. **Choose properties** — camelCase, self-explanatory; check `packages/common/telemetry-constants.ts` for similar events and match their property names
-3. **Add to telemetry-constants.ts** — with `@page` and `@source` JSDoc
-4. **Add to component** — import `useTrack`, call `track('event_name', { properties })`
+2. **Choose properties** — camelCase preferred for new events; check `packages/common/telemetry-constants.ts` for similar events and match their property names and casing
+3. **Add interface to telemetry-constants.ts** — with `@group Events` and `@source` JSDoc, add to the `TelemetryEvent` union type
+4. **Add to component** — `import { useTrack } from 'lib/telemetry/track'`, call `track('event_name', { properties })`
 
 ### Verification checklist
 

--- a/.claude/skills/telemetry-standards/SKILL.md
+++ b/.claude/skills/telemetry-standards/SKILL.md
@@ -27,6 +27,12 @@ opened, clicked, submitted, created, removed, updated, retrieved, intended, eval
 - `backup_button_clicked`
 - `sql_query_submitted`
 
+**Common mistakes with corrections:**
+- `database_saved` → `save_button_clicked` or `database_updated` (unapproved verb)
+- `click_backup_button` → `backup_button_clicked` (wrong order)
+- `dashboardViewed` → don't track passive views on page load
+- `component_rendered` → don't track — no user interaction
+
 ## Property Standards
 
 **Casing:** camelCase always
@@ -47,6 +53,8 @@ opened, clicked, submitted, created, removed, updated, retrieved, intended, eval
 - Generic "viewed" or "seen" events — already captured by pageview events
 
 **DO track:** user clicks, form submissions, explicit opens/closes, user-initiated actions.
+
+**Never track PII** (emails, names, IPs, etc.) in event properties.
 
 ## Required Pattern
 
@@ -102,6 +110,31 @@ When a PR adds user-facing interactions (buttons, forms, toggles, modals) **with
 
 When checking property consistency, search `packages/common/telemetry-constants.ts` for similar events and verify property names match.
 
+## Well-Formed Event Examples
+
+```typescript
+track('sql_query_submitted', {
+  queryType: 'select',
+  executionTime: 1234,
+  rowCount: 50,
+})
+
+track('assistant_suggestion_clicked', {
+  assistantType: 'sql',
+  suggestionType: 'optimization',
+})
+
+track('database_connection_clicked', {
+  connectionType: 'direct',
+  source: 'settings_page',
+})
+
+track('backup_button_clicked', {
+  backupType: 'manual',
+  databaseSize: 'large',
+})
+```
+
 ## Implementing New Tracking
 
 To add tracking for a user action:
@@ -119,4 +152,5 @@ To add tracking for a user action:
 - [ ] Event defined in telemetry-constants.ts with accurate `@page`/`@source`
 - [ ] Using `useTrack` hook (not `useSendEventMutation`)
 - [ ] Not tracking passive views/appearances
+- [ ] No PII in event properties (emails, names, IPs, etc.)
 - [ ] Property names consistent with similar events

--- a/.claude/skills/telemetry-standards/SKILL.md
+++ b/.claude/skills/telemetry-standards/SKILL.md
@@ -2,13 +2,13 @@
 name: telemetry-standards
 description: PostHog event tracking standards for Supabase Studio. Use when reviewing
   PRs for telemetry compliance or implementing new event tracking. Covers event naming,
-  property conventions, approved patterns, and implementation workflow.
+  property conventions, approved patterns, and implementation guide.
 ---
 
 # Telemetry Standards for Supabase Studio
 
-Standards and workflows for PostHog event tracking in `apps/studio/`. Use this
-when reviewing PRs for tracking compliance or implementing new tracking.
+Standards for PostHog event tracking in `apps/studio/`. Apply these when
+reviewing PRs that touch tracking or when implementing new tracking.
 
 ## Event Naming
 
@@ -17,16 +17,15 @@ when reviewing PRs for tracking compliance or implementing new tracking.
 **Approved verbs only:**
 opened, clicked, submitted, created, removed, updated, retrieved, intended, evaluated, added
 
-**Flag these mistakes:**
-- New unapproved verbs (saved, viewed, seen, pressed, etc.)
-- Wrong order: `click_product_card` should be `product_card_clicked`
-- Wrong casing: `productCardClicked` or `Product_Card_Clicked` should be `product_card_clicked`
+**Flag these:**
+- Unapproved verbs (saved, viewed, seen, pressed, etc.)
+- Wrong order: `click_product_card` → should be `product_card_clicked`
+- Wrong casing: `productCardClicked` → should be `product_card_clicked`
 
 **Good examples:**
 - `product_card_clicked`
-- `sql_query_executed` — note: `executed` is not in the approved list, prefer `submitted`
-- `assistant_suggestion_accepted` — note: `accepted` is not in the approved list, prefer `clicked`
 - `backup_button_clicked`
+- `sql_query_submitted`
 
 ## Property Standards
 
@@ -45,17 +44,13 @@ opened, clicked, submitted, created, removed, updated, retrieved, intended, eval
 
 - Passive views/renders on page load (`dashboard_viewed`, `sidebar_appeared`, `page_loaded`)
 - Component appearances without user interaction
-- Generic "viewed" or "seen" events — these are already captured by pageview events
+- Generic "viewed" or "seen" events — already captured by pageview events
 
-**DO track:**
-- User clicks
-- Form submissions
-- Explicit opens/closes by user
-- User-initiated actions
+**DO track:** user clicks, form submissions, explicit opens/closes, user-initiated actions.
 
-## Implementation Pattern
+## Required Pattern
 
-**Required hook:** `useTrack` from `lib/telemetry/track`
+Use `useTrack` from `lib/telemetry/track`. Never use `useSendEventMutation` (deprecated).
 
 ```typescript
 import { useTrack } from 'common/lib/telemetry'
@@ -75,123 +70,53 @@ const MyComponent = () => {
 }
 ```
 
-**Deprecated — flag any usage:**
-```typescript
-// NEVER use useSendEventMutation
-const { mutate: sendEvent } = useSendEventMutation()
-```
-
 ## Event Definitions
 
-All events must be defined in `packages/common/telemetry-constants.ts` with accurate JSDoc:
+All events must be defined in `packages/common/telemetry-constants.ts` with JSDoc:
 
 ```typescript
 /**
  * [Event description]
- * @page [accurate page/location where this fires]
+ * @page [page/location where this fires]
  * @source [what triggers this event]
  */
 export const EVENT_NAME = '[object]_[verb]' as const
 ```
 
-## Review Workflow
+`@page` and `@source` must accurately describe where and how the event fires.
 
-Use when reviewing a PR for telemetry compliance.
+## Review Rules
 
-### Step 1: Fetch PR Details
+When reviewing a PR, flag these as **required changes:**
 
-```bash
-gh pr view [PR_NUMBER] --json files,diff,title,body
-gh pr diff [PR_NUMBER]
-```
+1. **Naming violations** — event not following `[object]_[verb]` snake_case, or using an unapproved verb
+2. **Property violations** — not camelCase, generic names, or inconsistent with similar events
+3. **Deprecated hook** — any usage of `useSendEventMutation` instead of `useTrack`
+4. **Unnecessary view tracking** — events that fire on page load without user interaction
+5. **Inaccurate docs** — `@page`/`@source` descriptions that don't match the actual implementation
 
-Focus on:
-- `packages/common/telemetry-constants.ts`
-- Any files using `useTrack`, `track()`, or `useSendEventMutation`
-
-### Step 2: Check telemetry-constants.ts
-
-If modified, check every new or changed event for:
-- Event name follows `[object]_[verb]` snake_case format
-- Verb is from the approved list
-- Properties use camelCase and are self-explanatory
-- `@page` and `@source` descriptions are accurate
-- Property names are consistent with similar existing events
-
-### Step 3: Check Implementation Files
-
-For files using tracking functions:
-- No `useSendEventMutation` usage (must use `useTrack`)
-- No unnecessary view tracking (passive renders on page load)
-- Properties consistent with similar events in telemetry-constants.ts
-
-### Step 4: Check for Missing Tracking
-
-If the PR adds user-facing interactions (buttons, forms, toggles, modals, dialogs) without tracking:
-- Flag it as a suggestion: "This adds a user interaction that may benefit from tracking. Consider adding a `useTrack()` call."
+When a PR adds user-facing interactions (buttons, forms, toggles, modals) **without** tracking, suggest:
+- "This adds a user interaction that may benefit from tracking."
 - Propose the event name following `[object]_[verb]` convention
 - Propose the `useTrack()` call with suggested properties
 
-### Step 5: Present Issues
+When checking property consistency, search `packages/common/telemetry-constants.ts` for similar events and verify property names match.
 
-Format each issue as:
+## Implementing New Tracking
 
-```
-**File:** [filename]
-**Line:** [approximate line number from diff]
-**Issue:** [specific problem]
-**Suggestion:** [exact fix needed]
-**Severity:** Request Changes (for violations) or Suggestion (for missing tracking)
-```
+To add tracking for a user action:
 
-Present all issues and wait for user approval before posting.
+1. **Name the event** — `[object]_[verb]` using approved verbs only
+2. **Choose properties** — camelCase, self-explanatory; check `packages/common/telemetry-constants.ts` for similar events and match their property names
+3. **Add to telemetry-constants.ts** — with `@page` and `@source` JSDoc
+4. **Add to component** — import `useTrack`, call `track('event_name', { properties })`
 
-### Step 6: Post Comments (After Approval)
+### Verification checklist
 
-```bash
-gh pr comment [PR_NUMBER] --body "[formatted comment]"
-```
-
-## Implementation Workflow
-
-Use when adding new event tracking.
-
-### Step 1: Design the Event
-
-Given the user action to track:
-1. Name: `[object]_[verb]` using approved verbs only
-2. Properties: camelCase, self-explanatory names
-3. Search `packages/common/telemetry-constants.ts` for similar events and match their property names
-
-Present the design:
-
-```
-Event Name: [object]_[verb]
-Properties:
-  - propertyName: type (description)
-@page: [where this fires]
-@source: [what triggers it]
-Similar Events: [list any related events found]
-```
-
-Wait for approval.
-
-### Step 2: Add to telemetry-constants.ts
-
-Add the event definition with JSDoc to `packages/common/telemetry-constants.ts`.
-
-### Step 3: Implement in Component
-
-1. Import: `import { useTrack } from 'common/lib/telemetry'`
-2. Initialize: `const track = useTrack()`
-3. Call: `track('object_verb', { propertyName: value })`
-
-### Step 4: Verify
-
-- [ ] Event added to telemetry-constants.ts with accurate @page/@source
-- [ ] Event name follows [object]_[verb] pattern with approved verb
+- [ ] Event name follows `[object]_[verb]` with approved verb
 - [ ] Event name is snake_case
 - [ ] Properties are camelCase and self-explanatory
-- [ ] Using useTrack hook (not useSendEventMutation)
+- [ ] Event defined in telemetry-constants.ts with accurate `@page`/`@source`
+- [ ] Using `useTrack` hook (not `useSendEventMutation`)
 - [ ] Not tracking passive views/appearances
-- [ ] Consistent with similar events
+- [ ] Property names consistent with similar events


### PR DESCRIPTION
## Summary

- Adds a combined telemetry standards skill (`.claude/skills/telemetry-standards/SKILL.md`) that covers PostHog event naming conventions, property standards, review rules, and implementation guide
- Intended to be imported as CodeRabbit learnings after merge so CodeRabbit can flag missing/incorrect tracking in PRs
- Consolidates standards from existing `review-telemetry` and `implement-tracking` Claude commands into a single source of truth

## Post-merge steps

### 1. Import as CodeRabbit learnings (one-time)

Comment on any PR in the repo:
```
@coderabbitai add a learning using .claude/skills/telemetry-standards/SKILL.md
```

This teaches CodeRabbit the telemetry standards. It will then:
- Flag naming/property violations when `telemetry-constants.ts` is changed
- Suggest adding `useTrack()` tracking when PRs add user-facing interactions without it
- Propose event names following `[object]_[verb]` convention

### 2. Add path instructions in CodeRabbit web UI (optional, recommended)

Go to CodeRabbit settings > Review > Path Instructions and add:

- **Path:** `packages/common/telemetry-constants.ts`
- **Instructions:** "Strictly enforce event naming: [object]_[verb] in snake_case. Only approved verbs: opened, clicked, submitted, created, removed, updated, retrieved, intended, evaluated, added. Properties must be camelCase and self-explanatory. Flag any usage of useSendEventMutation."

### 3. Remove old Claude commands (after verifying skill works)

Delete `.claude/commands/review-telemetry.md` and `.claude/commands/implement-tracking.md` — this skill replaces both.

Closes GROWTH-661