### PR TITLE
chore: logs entitlements badges

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -361,7 +361,9 @@ export const LogsDatePicker = ({
                   aria-disabled={helper.disabled}
                 ></RadioGroupItem>
                 {helper.text}
-                {showHelperBadge(helper) ? <Lock size={12} className="text-foreground-muted" /> : null}
+                {showHelperBadge(helper) ? (
+                  <Lock size={12} className="text-foreground-muted" />
+                ) : null}
               </Label>
             ))}
           </RadioGroup>

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -1,9 +1,8 @@
 import dayjs from 'dayjs'
-import { Clock, HistoryIcon } from 'lucide-react'
+import { Clock, HistoryIcon, Lock } from 'lucide-react'
 import type { PropsWithChildren } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { Badge } from '@ui/components/shadcn/ui/badge'
 import { Label } from '@ui/components/shadcn/ui/label'
 import { RadioGroup, RadioGroupItem } from '@ui/components/shadcn/ui/radio-group'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
@@ -22,8 +21,6 @@ import {
 } from 'ui'
 import { LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD } from './Logs.constants'
 import type { DatetimeHelper } from './Logs.types'
-import type { PlanId } from 'data/subscriptions/types'
-
 type Unit = 'minute' | 'hour' | 'day'
 
 export type ParsedCustomInput =
@@ -57,30 +54,11 @@ export const parseCustomInput = (input: string): ParsedCustomInput => {
   return { type: 'unit', value, unit: matchedUnit }
 }
 
-export const getAvailableInForDays = (days: number): PlanId[] => {
-  if (days <= 1) return ['free', 'pro', 'team', 'enterprise', 'platform']
-  if (days <= 7) return ['pro', 'team', 'enterprise', 'platform']
-  return ['team', 'enterprise', 'platform']
-}
-
-export const convertToDays = (value: number, unit: Unit): number => {
-  switch (unit) {
-    case 'minute':
-      return value / (60 * 24)
-    case 'hour':
-      return value / 24
-    case 'day':
-      return value
-  }
-}
-
 export const generateDynamicHelper = (value: number, unit: Unit): DatetimeHelper => {
-  const days = convertToDays(value, unit)
   return {
     text: `Last ${value} ${unit}${value === 1 ? '' : 's'}`,
     calcFrom: () => dayjs().subtract(value, unit).toISOString(),
     calcTo: () => dayjs().toISOString(),
-    availableIn: getAvailableInForDays(days),
   }
 }
 
@@ -330,7 +308,6 @@ export const LogsDatePicker = ({
 
   const showHelperBadge = (helper?: DatetimeHelper) => {
     if (!helper) return false
-    if (!helper.availableIn?.length) return false
     if (!entitledToAuditLogDays) return false
 
     const day = Math.abs(dayjs().diff(dayjs(helper.calcFrom()), 'day'))
@@ -384,7 +361,7 @@ export const LogsDatePicker = ({
                   aria-disabled={helper.disabled}
                 ></RadioGroupItem>
                 {helper.text}
-                {showHelperBadge(helper) ? <Badge>{helper.availableIn?.[0] || ''}</Badge> : null}
+                {showHelperBadge(helper) ? <Lock size={12} className="text-foreground-muted" /> : null}
               </Label>
             ))}
           </RadioGroup>

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,6 +1,5 @@
 import type { Datum } from 'components/ui/Charts/Charts.types'
 import React from 'react'
-import type { PlanId } from 'data/subscriptions/types'
 
 interface Metadata {
   [key: string]: string | number | Object | Object[] | any
@@ -143,5 +142,4 @@ export interface DatetimeHelper {
   calcFrom: () => string
   default?: boolean
   disabled?: boolean
-  availableIn?: PlanId[]
 }

--- a/apps/studio/tests/features/logs/Logs.Datepickers.test.tsx
+++ b/apps/studio/tests/features/logs/Logs.Datepickers.test.tsx
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event'
 import {
   LogsDatePicker,
   parseCustomInput,
-  convertToDays,
-  getAvailableInForDays,
   generateDynamicHelper,
   generateDynamicHelpers,
   generateHelpersFromInput,
@@ -70,39 +68,6 @@ describe('parseCustomInput', () => {
   })
 })
 
-describe('convertToDays', () => {
-  test('converts minutes to days', () => {
-    expect(convertToDays(1440, 'minute')).toBe(1)
-    expect(convertToDays(720, 'minute')).toBe(0.5)
-  })
-
-  test('converts hours to days', () => {
-    expect(convertToDays(24, 'hour')).toBe(1)
-    expect(convertToDays(48, 'hour')).toBe(2)
-  })
-
-  test('days remain unchanged', () => {
-    expect(convertToDays(7, 'day')).toBe(7)
-  })
-})
-
-describe('getAvailableInForDays', () => {
-  test('returns all plans for <= 1 day', () => {
-    expect(getAvailableInForDays(0.5)).toEqual(['free', 'pro', 'team', 'enterprise', 'platform'])
-    expect(getAvailableInForDays(1)).toEqual(['free', 'pro', 'team', 'enterprise', 'platform'])
-  })
-
-  test('returns pro+ for <= 7 days', () => {
-    expect(getAvailableInForDays(2)).toEqual(['pro', 'team', 'enterprise', 'platform'])
-    expect(getAvailableInForDays(7)).toEqual(['pro', 'team', 'enterprise', 'platform'])
-  })
-
-  test('returns team+ for > 7 days', () => {
-    expect(getAvailableInForDays(8)).toEqual(['team', 'enterprise', 'platform'])
-    expect(getAvailableInForDays(30)).toEqual(['team', 'enterprise', 'platform'])
-  })
-})
-
 describe('generateDynamicHelper', () => {
   test('generates helper with correct text', () => {
     const helper = generateDynamicHelper(5, 'hour')
@@ -119,14 +84,6 @@ describe('generateDynamicHelper', () => {
     expect(generateDynamicHelper(2, 'minute').text).toBe('Last 2 minutes')
     expect(generateDynamicHelper(2, 'hour').text).toBe('Last 2 hours')
     expect(generateDynamicHelper(2, 'day').text).toBe('Last 2 days')
-  })
-
-  test('generates helper with correct availableIn based on time range', () => {
-    const minuteHelper = generateDynamicHelper(30, 'minute')
-    expect(minuteHelper.availableIn).toEqual(['free', 'pro', 'team', 'enterprise', 'platform'])
-
-    const dayHelper = generateDynamicHelper(14, 'day')
-    expect(dayHelper.availableIn).toEqual(['team', 'enterprise', 'platform'])
   })
 
   test('calcFrom returns correct ISO string', () => {


### PR DESCRIPTION
### Changes
- Replace hardcoded plan-to-days mapping (`getAvailableInForDays`) with entitlement-driven checks.
- Show a lock icon on date picker helpers that exceed the user's entitled log retention, instead of a plan name badge.
- Remove availableIn from DatetimeHelper type — the entitlement API is now the single source of truth.

### Testing
- Head to `/project/_/logs` on a free plan project and verify lock icons appear on helpers beyond 1 day
- Verify clicking a locked helper still triggers the upgrade prompt
<img width="511" height="483" alt="image" src="https://github.com/user-attachments/assets/41dce8c0-205a-4d82-9c07-12f4bb6b0f4d" />
