### PR TITLE
fix: order recently impersonated users in descending order on the SQL

### DIFF
--- a/apps/studio/components/interfaces/RoleImpersonationSelector/UserImpersonationSelector.tsx
+++ b/apps/studio/components/interfaces/RoleImpersonationSelector/UserImpersonationSelector.tsx
@@ -96,10 +96,10 @@ const UserImpersonationSelector = () => {
     setPreviousSearches((prev) => {
       // Remove if already present
       const filtered = prev.filter((u) => u.id !== user.id)
-      // Add new user to the end
-      const updated = [...filtered, user]
+      // Add new user to the start of the list (last used first)
+      const updated = [user, ...filtered]
       // Keep only the last 6
-      return updated.slice(-6)
+      return updated.slice(0, 5)
     })
 
     if (customAccessTokenHookDetails?.type === 'https') {


### PR DESCRIPTION
## Problem

When testing things in SQL Editor, you often have to impersonate the same user many times. It's cumbersome to look for them. We have a _Recents_ list but its order is not practical.

## Solution

Invert the order of the _Recents_ list so that the last impersonated user is the first one

## How to test

- Create multiple users
- Open the SQL Editor
- Impersonate different users
- Check the order of the list