### PR TITLE
fix(studio): allow newlines in SMS OTP template for WebOTP API compatibility

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -100,6 +100,13 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       if (payload[x] === '') payload[x] = null
     })
 
+    // Convert \n escape sequences in SMS_TEMPLATE to real newline characters.
+    // This allows users to type \n in the template textarea to create actual line
+    // breaks in the sent SMS — required for WebOTP API compatibility (issue #6435).
+    if (typeof payload.SMS_TEMPLATE === 'string') {
+      payload.SMS_TEMPLATE = payload.SMS_TEMPLATE.replace(/\\n/g, '\n')
+    }
+
     // The backend uses empty string to represent no required characters in the password
     if (payload.PASSWORD_REQUIRED_CHARACTERS === NO_REQUIRED_CHARACTERS) {
       payload.PASSWORD_REQUIRED_CHARACTERS = ''

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -395,7 +395,8 @@ export const PROVIDER_PHONE = {
     SMS_TEMPLATE: {
       title: 'SMS Message',
       type: 'multiline-string',
-      description: 'To format the OTP code use `{{ .Code }}`',
+      description:
+        'To format the OTP code use `{{ .Code }}`. Use `\\n` to insert a newline — required for [WebOTP API](https://developer.chrome.com/docs/identity/web-otp/) compatibility.',
       show: {
         key: 'SMS_PROVIDER',
         matches: ['twilio', 'messagebird', 'textlocal', 'vonage'],


### PR DESCRIPTION
## What does this PR do?

Fixes #6435

Allows users to include newlines in the SMS OTP template by converting
`\n` escape sequences to actual newline characters before sending the
configuration to the API.

## Why?

The [WebOTP API](https://developer.chrome.com/docs/identity/web-otp/)
requires SMS messages to contain at least one newline to auto-fill OTP
codes on mobile browsers. Previously, typing `\n` in the SMS template
textarea was sent as a literal backslash-n (`\n`), not a real newline.

## Changes

- [ProviderForm.tsx](cci:7://file:///c:/Users/Saura/Desktop/code/supabase/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx:0:0-0:0): Convert `\n` escape sequences in `SMS_TEMPLATE` to real newlines on submit
- [AuthProvidersFormValidation.tsx](cci:7://file:///c:/Users/Saura/Desktop/code/supabase/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx:0:0-0:0): Update field description to document `\n` support and link to WebOTP API docs

## Testing

- Typed `Your OTP: {{ .Code }}\n\n@yourdomain.com` in SMS template field
- Verified the API payload contains actual newlines, not literal `\n` strings
