### PR TITLE
chore: add entitlement check to observability log retention

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -17,7 +17,7 @@ import { Auth, Database, Realtime, Storage } from 'icons'
 import sumBy from 'lodash/sumBy'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Loading } from 'ui'
 
 type ChartIntervalKey = ProjectLogStatsVariables['interval']
@@ -39,6 +39,10 @@ const ProjectUsage = () => {
     retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day'
 
   const [interval, setInterval] = useState<ChartIntervalKey>(DEFAULT_INTERVAL)
+
+  useEffect(() => {
+    setInterval(retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day')
+  }, [retentionDays])
 
   const { data, isPending: isLoading } = useProjectLogStatsQuery({ projectRef, interval })
 

--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -10,7 +10,7 @@ import {
 } from 'data/analytics/project-log-stats-query'
 import dayjs from 'dayjs'
 import { useFillTimeseriesSorted } from 'hooks/analytics/useFillTimeseriesSorted'
-import { useCurrentOrgPlan } from 'hooks/misc/useCurrentOrgPlan'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { Auth, Database, Realtime, Storage } from 'icons'
@@ -32,9 +32,11 @@ const ProjectUsage = () => {
     'project_storage:all',
   ])
 
-  const { plan } = useCurrentOrgPlan()
+  const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
+  const retentionDays = getEntitlementMax()
 
-  const DEFAULT_INTERVAL: ChartIntervalKey = plan?.id === 'free' ? '1hr' : '1day'
+  const DEFAULT_INTERVAL: ChartIntervalKey =
+    retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day'
 
   const [interval, setInterval] = useState<ChartIntervalKey>(DEFAULT_INTERVAL)
 
@@ -94,8 +96,6 @@ const ProjectUsage = () => {
         <ChartIntervalDropdown
           value={interval || '1day'}
           onChange={(interval) => setInterval(interval as ProjectLogStatsVariables['interval'])}
-          planId={plan?.id}
-          planName={plan?.name}
           organizationSlug={organization?.slug}
           dropdownAlign="start"
           tooltipSide="right"

--- a/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
@@ -15,7 +15,7 @@ import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle, Loading } from 'ui'
 import { Row } from 'ui-patterns'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
@@ -61,6 +61,10 @@ export const ProjectUsageSection = () => {
   const DEFAULT_INTERVAL: ChartIntervalKey =
     retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day'
   const [interval, setInterval] = useState<ChartIntervalKey>(DEFAULT_INTERVAL)
+
+  useEffect(() => {
+    setInterval(retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day')
+  }, [retentionDays])
 
   const selectedInterval = CHART_INTERVALS.find((i) => i.key === interval) || CHART_INTERVALS[1]
 

--- a/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/HomeNew/ProjectUsageSection.tsx
@@ -10,7 +10,7 @@ import {
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import dayjs from 'dayjs'
 import { useFillTimeseriesSorted } from 'hooks/analytics/useFillTimeseriesSorted'
-import { useCurrentOrgPlan } from 'hooks/misc/useCurrentOrgPlan'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import Link from 'next/link'
@@ -55,9 +55,11 @@ export const ProjectUsageSection = () => {
     'project_auth:all',
     'project_storage:all',
   ])
-  const { plan } = useCurrentOrgPlan()
+  const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
+  const retentionDays = getEntitlementMax()
 
-  const DEFAULT_INTERVAL: ChartIntervalKey = plan?.id === 'free' ? '1hr' : '1day'
+  const DEFAULT_INTERVAL: ChartIntervalKey =
+    retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day'
   const [interval, setInterval] = useState<ChartIntervalKey>(DEFAULT_INTERVAL)
 
   const selectedInterval = CHART_INTERVALS.find((i) => i.key === interval) || CHART_INTERVALS[1]
@@ -208,8 +210,6 @@ export const ProjectUsageSection = () => {
         <ChartIntervalDropdown
           value={interval}
           onChange={(interval) => setInterval(interval as ChartIntervalKey)}
-          planId={plan?.id}
-          planName={plan?.name}
           organizationSlug={organization?.slug}
           dropdownAlign="end"
           tooltipSide="left"

--- a/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
+++ b/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
@@ -5,7 +5,6 @@ import ReportPadding from 'components/interfaces/Reports/ReportPadding'
 import { ChartIntervalDropdown } from 'components/ui/Logs/ChartIntervalDropdown'
 import { CHART_INTERVALS } from 'components/ui/Logs/logs.utils'
 import dayjs from 'dayjs'
-import { useCurrentOrgPlan } from 'hooks/misc/useCurrentOrgPlan'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { RefreshCw } from 'lucide-react'
@@ -25,7 +24,6 @@ export const ObservabilityOverview = () => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const { data: organization } = useSelectedOrganizationQuery()
-  const { plan } = useCurrentOrgPlan()
   const queryClient = useQueryClient()
 
   const { projectStorageAll: storageSupported } = useIsFeatureEnabled(['project_storage:all'])
@@ -156,8 +154,6 @@ export const ObservabilityOverview = () => {
           <ChartIntervalDropdown
             value={interval}
             onChange={(interval) => setInterval(interval as ChartIntervalKey)}
-            planId={plan?.id}
-            planName={plan?.name}
             organizationSlug={organization?.slug}
             dropdownAlign="end"
             tooltipSide="left"

--- a/apps/studio/components/ui/Logs/ChartIntervalDropdown.tsx
+++ b/apps/studio/components/ui/Logs/ChartIntervalDropdown.tsx
@@ -1,4 +1,5 @@
 import { InlineLink } from 'components/ui/InlineLink'
+import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { ChevronDown } from 'lucide-react'
 import {
   Button,
@@ -12,15 +13,17 @@ import {
   TooltipTrigger,
 } from 'ui'
 
-import { CHART_INTERVALS, LOG_RETENTION } from './logs.utils'
+import { CHART_INTERVALS } from './logs.utils'
 
-type PlanId = keyof typeof LOG_RETENTION
+function getDaysRequired(startValue: number, startUnit: string): number {
+  if (startUnit === 'day') return startValue
+  if (startUnit === 'hour') return startValue / 24
+  return 0
+}
 
 interface ChartIntervalDropdownProps {
   value: string
   onChange: (value: string) => void
-  planId?: string
-  planName?: string
   organizationSlug?: string
   dropdownAlign?: 'start' | 'center' | 'end'
   tooltipSide?: 'left' | 'right' | 'top' | 'bottom'
@@ -29,14 +32,14 @@ interface ChartIntervalDropdownProps {
 export const ChartIntervalDropdown = ({
   value,
   onChange,
-  planId = 'free',
-  planName,
   organizationSlug,
   dropdownAlign = 'start',
   tooltipSide = 'right',
 }: ChartIntervalDropdownProps) => {
   const selectedInterval = CHART_INTERVALS.find((i) => i.key === value) || CHART_INTERVALS[1]
-  const normalizedPlanId = (planId && planId in LOG_RETENTION ? planId : 'free') as PlanId
+
+  const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
+  const retentionDays = getEntitlementMax()
 
   return (
     <DropdownMenu>
@@ -48,10 +51,10 @@ export const ChartIntervalDropdown = ({
       <DropdownMenuContent side="bottom" align={dropdownAlign} className="w-40">
         <DropdownMenuRadioGroup value={value} onValueChange={onChange}>
           {CHART_INTERVALS.map((i) => {
-            const disabled = !i.availableIn?.includes(normalizedPlanId)
+            const daysRequired = getDaysRequired(i.startValue, i.startUnit)
+            const disabled = retentionDays !== undefined && daysRequired > retentionDays
 
             if (disabled) {
-              const retentionDuration = LOG_RETENTION[normalizedPlanId]
               return (
                 <Tooltip key={i.key}>
                   <TooltipTrigger asChild>
@@ -61,8 +64,8 @@ export const ChartIntervalDropdown = ({
                   </TooltipTrigger>
                   <TooltipContent side={tooltipSide}>
                     <p>
-                      {planName} plan only includes up to {retentionDuration} day
-                      {retentionDuration > 1 ? 's' : ''} of log retention
+                      Your plan only includes up to {retentionDays} day
+                      {retentionDays !== undefined && retentionDays > 1 ? 's' : ''} of log retention
                     </p>
                     <p className="text-foreground-light">
                       {organizationSlug ? (

--- a/apps/studio/components/ui/Logs/logs.utils.ts
+++ b/apps/studio/components/ui/Logs/logs.utils.ts
@@ -1,13 +1,5 @@
 import type { ChartIntervals } from 'types'
 
-export const LOG_RETENTION = {
-  free: 1,
-  pro: 7,
-  team: 28,
-  enterprise: 90,
-  platform: 1,
-}
-
 export const CHART_INTERVALS: ChartIntervals[] = [
   {
     key: '1hr',
@@ -15,7 +7,6 @@ export const CHART_INTERVALS: ChartIntervals[] = [
     startValue: 1,
     startUnit: 'hour',
     format: 'MMM D, h:mma',
-    availableIn: ['free', 'pro', 'team', 'enterprise', 'platform'],
   },
   {
     key: '1day',
@@ -23,7 +14,6 @@ export const CHART_INTERVALS: ChartIntervals[] = [
     startValue: 24,
     startUnit: 'hour',
     format: 'MMM D, ha',
-    availableIn: ['free', 'pro', 'team', 'enterprise', 'platform'],
   },
   {
     key: '7day',
@@ -31,6 +21,5 @@ export const CHART_INTERVALS: ChartIntervals[] = [
     startValue: 7,
     startUnit: 'day',
     format: 'MMM D',
-    availableIn: ['pro', 'team', 'enterprise'],
   },
 ]

--- a/apps/studio/types/ui.ts
+++ b/apps/studio/types/ui.ts
@@ -1,6 +1,5 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
 import { ProjectLogStatsVariables } from 'data/analytics/project-log-stats-query'
-import { PlanId } from 'data/subscriptions/types'
 
 export interface Notification {
   category: 'info' | 'error' | 'success' | 'loading'
@@ -23,7 +22,6 @@ export interface ChartIntervals {
   startValue: number
   startUnit: 'minute' | 'hour' | 'day'
   format?: 'MMM D, h:mm:ssa' | 'MMM D, h:mma' | 'MMM D, ha' | 'MMM D'
-  availableIn?: PlanId[]
 }
 
 export interface VaultSecret {


### PR DESCRIPTION
### Changes
- Replace plan-based checks (`LOG_RETENTION`, `availableIn`) with `useCheckEntitlements('log.retention_days')` in the chart interval dropdown
- `ChartIntervalDropdown` now calls the entitlements hook internally instead of receiving plan props
- Remove `LOG_RETENTION` constant and `availableIn` from `CHART_INTERVALS`
- Update consumer components (`ProjectUsage`, `ProjectUsageSection`, `ObservabilityOverview`) to remove plan prop passing

### Testing
- Head to `/project/_/observability` with a Free plan org.
- Click on the time selector "Last 7 days" is disabled, default is "Last 60 minutes", tooltip shows retention limit and upgrade link

<img width="827" height="151" alt="image" src="https://github.com/user-attachments/assets/20988398-8f0a-46b6-be3d-af4e9d530f81" />

- With a Pro Org and above the "Last 7 days" option should be enabled

