### PR TITLE
fix(studio): circle centering

### DIFF
--- a/packages/ui/src/components/shadcn/ui/radio-group.tsx
+++ b/packages/ui/src/components/shadcn/ui/radio-group.tsx
@@ -22,13 +22,13 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        'aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        'relative aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      <RadioGroupPrimitive.Indicator className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+        <Circle size={10} strokeWidth={0} className="fill-current text-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI fix

## What is the current behavior?

Radio button circles are off-center in Safari.

## What is the new behavior?

Radio button circles are centered in Safari. Extraneous stroke on the Lucide Circle icon also removed.

| Before | After |
| --- | --- |
| <img width="1502" height="864" alt="General  Supabase" src="https://github.com/user-attachments/assets/7fea0cc5-d62f-4c29-b341-494e66b91c38" /> | <img width="1502" height="864" alt="General  Supabase" src="https://github.com/user-attachments/assets/296cbb72-ced2-44f7-8c73-d2c758a66507" /> |

It’s hard to see the before-after via screenshots. Go to org settings on `master` in Safari to see the difference.

## Additional context

We already applied this fix in `radio-group-stacked`.