### PR TITLE
chore(studio): refocus editor after Run button tap

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -118,6 +118,7 @@ export const SQLEditor = () => {
   const monacoRef = useRef<Monaco | null>(null)
   const diffEditorRef = useRef<IStandaloneDiffEditor | null>(null)
   const scrollTopRef = useRef<number>(0)
+  const shouldRefocusAfterRunRef = useRef(false)
 
   const [hasSelection, setHasSelection] = useState<boolean>(false)
   const [lineHighlights, setLineHighlights] = useState<string[]>([])
@@ -127,6 +128,23 @@ export const SQLEditor = () => {
   const [queryHasUpdateWithoutWhere, setQueryHasUpdateWithoutWhere] = useState(false)
   const [showWidget, setShowWidget] = useState(false)
   const [activeUtilityTab, setActiveUtilityTab] = useState<string>('results')
+
+  const refocusEditor = useCallback(() => {
+    requestAnimationFrame(() => {
+      setTimeout(() => editorRef.current?.focus(), 0)
+    })
+  }, [])
+
+  const clearPendingRunRefocus = useCallback(() => {
+    shouldRefocusAfterRunRef.current = false
+  }, [])
+
+  const refocusEditorAfterRunIfNeeded = useCallback(() => {
+    if (!shouldRefocusAfterRunRef.current) return
+
+    shouldRefocusAfterRunRef.current = false
+    refocusEditor()
+  }, [refocusEditor])
 
   // generate a new snippet title and an id to be used for new snippets. The dependency on urlId is to avoid a bug which
   // shows up when clicking on the SQL Editor while being in the SQL editor on a random snippet.
@@ -173,6 +191,7 @@ export const SQLEditor = () => {
 
       // revalidate lint query
       queryClient.invalidateQueries({ queryKey: lintKeys.lint(ref) })
+      refocusEditorAfterRunIfNeeded()
     },
     onError(error: any, vars) {
       if (id) {
@@ -209,6 +228,8 @@ export const SQLEditor = () => {
 
         snapV2.addResultError(id, error, vars.autoLimit)
       }
+
+      refocusEditorAfterRunIfNeeded()
     },
   })
 
@@ -273,87 +294,95 @@ export const SQLEditor = () => {
 
   const executeQuery = useCallback(
     async (force: boolean = false) => {
-      if (isDiffOpen) return
+      if (isDiffOpen) {
+        clearPendingRunRefocus()
+        return
+      }
 
       // use the latest state
       const state = getSqlEditorV2StateSnapshot()
       const snippet = state.snippets[id]
 
-      if (editorRef.current !== null && !isExecuting && project !== undefined) {
-        const editor = editorRef.current
-        const selection = editor.getSelection()
-        const selectedValue = selection ? editor.getModel()?.getValueInRange(selection) : undefined
-
-        const sql = snippet
-          ? (selectedValue || editorRef.current?.getValue()) ?? snippet.snippet.content?.sql
-          : selectedValue || editorRef.current?.getValue()
-
-        let queryHasIssues = false
-
-        const destructiveOperations = checkDestructiveQuery(sql)
-        if (!force && destructiveOperations) {
-          setShowPotentialIssuesModal(true)
-          setQueryHasDestructiveOperations(true)
-          queryHasIssues = true
-        }
-
-        const updateWithoutWhereClause = isUpdateWithoutWhere(sql)
-        if (!force && updateWithoutWhereClause) {
-          setShowPotentialIssuesModal(true)
-          setQueryHasUpdateWithoutWhere(true)
-          queryHasIssues = true
-        }
-
-        if (queryHasIssues) {
-          return
-        }
-
-        if (
-          !isHipaaProjectDisallowed &&
-          snippet?.snippet.name.startsWith(untitledSnippetTitle) &&
-          IS_PLATFORM
-        ) {
-          // Intentionally don't await title gen (lazy)
-          setAiTitle(id, sql)
-        }
-
-        if (lineHighlights.length > 0) {
-          editor?.deltaDecorations(lineHighlights, [])
-          setLineHighlights([])
-        }
-
-        const impersonatedRoleState = getImpersonatedRoleState()
-        const connectionString = databases?.find(
-          (db) => db.identifier === databaseSelectorState.selectedDatabaseId
-        )?.connectionString
-        if (!isValidConnString(connectionString)) {
-          return toast.error('Unable to run query: Connection string is missing')
-        }
-
-        const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
-        const formattedSql = suffixWithLimit(sql, limit)
-
-        execute({
-          projectRef: project.ref,
-          connectionString: connectionString,
-          sql: wrapWithRoleImpersonation(formattedSql, impersonatedRoleState),
-          autoLimit: appendAutoLimit ? limit : undefined,
-          isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRoleState.role),
-          isStatementTimeoutDisabled: true,
-          contextualInvalidation: true,
-          handleError: (error) => {
-            throw error
-          },
-        })
-
-        sendEvent({
-          action: 'sql_editor_query_run_button_clicked',
-          groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
-        })
+      if (editorRef.current === null || isExecuting || project === undefined) {
+        clearPendingRunRefocus()
+        return
       }
+
+      const editor = editorRef.current
+      const selection = editor.getSelection()
+      const selectedValue = selection ? editor.getModel()?.getValueInRange(selection) : undefined
+
+      const sql = snippet
+        ? (selectedValue || editorRef.current?.getValue()) ?? snippet.snippet.content?.sql
+        : selectedValue || editorRef.current?.getValue()
+
+      let queryHasIssues = false
+
+      const destructiveOperations = checkDestructiveQuery(sql)
+      if (!force && destructiveOperations) {
+        setShowPotentialIssuesModal(true)
+        setQueryHasDestructiveOperations(true)
+        queryHasIssues = true
+      }
+
+      const updateWithoutWhereClause = isUpdateWithoutWhere(sql)
+      if (!force && updateWithoutWhereClause) {
+        setShowPotentialIssuesModal(true)
+        setQueryHasUpdateWithoutWhere(true)
+        queryHasIssues = true
+      }
+
+      if (queryHasIssues) {
+        return
+      }
+
+      if (
+        !isHipaaProjectDisallowed &&
+        snippet?.snippet.name.startsWith(untitledSnippetTitle) &&
+        IS_PLATFORM
+      ) {
+        // Intentionally don't await title gen (lazy)
+        setAiTitle(id, sql)
+      }
+
+      if (lineHighlights.length > 0) {
+        editor?.deltaDecorations(lineHighlights, [])
+        setLineHighlights([])
+      }
+
+      const impersonatedRoleState = getImpersonatedRoleState()
+      const connectionString = databases?.find(
+        (db) => db.identifier === databaseSelectorState.selectedDatabaseId
+      )?.connectionString
+      if (!isValidConnString(connectionString)) {
+        clearPendingRunRefocus()
+        return toast.error('Unable to run query: Connection string is missing')
+      }
+
+      const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+      const formattedSql = suffixWithLimit(sql, limit)
+
+      execute({
+        projectRef: project.ref,
+        connectionString: connectionString,
+        sql: wrapWithRoleImpersonation(formattedSql, impersonatedRoleState),
+        autoLimit: appendAutoLimit ? limit : undefined,
+        isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRoleState.role),
+        isStatementTimeoutDisabled: true,
+        contextualInvalidation: true,
+        handleError: (error) => {
+          throw error
+        },
+      })
+
+      sendEvent({
+        action: 'sql_editor_query_run_button_clicked',
+        groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+      })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
+      clearPendingRunRefocus,
       isDiffOpen,
       id,
       isExecuting,
@@ -367,6 +396,11 @@ export const SQLEditor = () => {
       limit,
     ]
   )
+
+  const executeQueryFromButton = useCallback(() => {
+    shouldRefocusAfterRunRef.current = true
+    void executeQuery()
+  }, [executeQuery])
 
   const executeExplainQuery = useCallback(async () => {
     if (isDiffOpen) return
@@ -770,14 +804,18 @@ export const SQLEditor = () => {
         hasDestructiveOperations={queryHasDestructiveOperations}
         hasUpdateWithoutWhere={queryHasUpdateWithoutWhere}
         onCancel={() => {
+          clearPendingRunRefocus()
           setShowPotentialIssuesModal(false)
           setQueryHasDestructiveOperations(false)
           setQueryHasUpdateWithoutWhere(false)
-          setTimeout(() => editorRef.current?.focus(), 100)
+          refocusEditor()
         }}
         onConfirm={() => {
+          shouldRefocusAfterRunRef.current = true
           setShowPotentialIssuesModal(false)
-          executeQuery(true)
+          setQueryHasDestructiveOperations(false)
+          setQueryHasUpdateWithoutWhere(false)
+          void executeQuery(true)
         }}
       />
 
@@ -911,7 +949,7 @@ export const SQLEditor = () => {
                 isDisabled={isDiffOpen}
                 hasSelection={hasSelection}
                 prettifyQuery={prettifyQuery}
-                executeQuery={executeQuery}
+                executeQuery={executeQueryFromButton}
                 executeExplainQuery={executeExplainQuery}
                 onDebug={onDebug}
                 buildDebugPrompt={buildDebugPrompt}

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -399,8 +399,9 @@ export const SQLEditor = () => {
 
   const executeQueryFromButton = useCallback(() => {
     shouldRefocusAfterRunRef.current = true
+    refocusEditor()
     void executeQuery()
-  }, [executeQuery])
+  }, [executeQuery, refocusEditor])
 
   const executeExplainQuery = useCallback(async () => {
     if (isDiffOpen) return
@@ -815,6 +816,7 @@ export const SQLEditor = () => {
           setShowPotentialIssuesModal(false)
           setQueryHasDestructiveOperations(false)
           setQueryHasUpdateWithoutWhere(false)
+          refocusEditor()
           void executeQuery(true)
         }}
       />

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -260,6 +260,7 @@ export const EditorPanel = () => {
   const onExecuteSqlFromButton = () => {
     shouldRefocusAfterRunRef.current = true
     onExecuteSql()
+    refocusEditor()
   }
 
   const handleClosePanel = () => {
@@ -553,6 +554,7 @@ export const EditorPanel = () => {
               shouldRefocusAfterRunRef.current = true
               setShowWarning(undefined)
               onExecuteSql(true)
+              refocusEditor()
             }}
           />
         )}

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -32,6 +32,7 @@ import {
   PlusIcon,
   X,
 } from 'lucide-react'
+import type { editor as MonacoEditor } from 'monaco-editor'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
 import { editorPanelState, useEditorPanelStateSnapshot } from 'state/editor-panel-state'
@@ -89,6 +90,8 @@ export const EditorPanel = () => {
   const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [titleInput, setTitleInput] = useState('')
   const titleInputRef = useRef<HTMLInputElement>(null)
+  const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null)
+  const shouldRefocusAfterRunRef = useRef(false)
   const [monaco, setMonaco] = useState<Monaco | null>(null)
 
   useAddDefinitions('', monaco)
@@ -126,6 +129,23 @@ export const EditorPanel = () => {
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle')
   const saveStatusTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const originalSnippetRef = useRef<{ sql: string; name: string } | null>(null)
+
+  const refocusEditor = () => {
+    requestAnimationFrame(() => {
+      setTimeout(() => editorRef.current?.focus(), 0)
+    })
+  }
+
+  const clearPendingRunRefocus = () => {
+    shouldRefocusAfterRunRef.current = false
+  }
+
+  const refocusEditorAfterRunIfNeeded = () => {
+    if (!shouldRefocusAfterRunRef.current) return
+
+    shouldRefocusAfterRunRef.current = false
+    refocusEditor()
+  }
 
   const showSaveSuccess = () => {
     setSaveStatus('success')
@@ -184,10 +204,12 @@ export const EditorPanel = () => {
     onSuccess: async (res) => {
       setResults(res.result)
       setError(undefined)
+      refocusEditorAfterRunIfNeeded()
     },
     onError: (mutationError) => {
       setError(mutationError)
       setResults([])
+      refocusEditorAfterRunIfNeeded()
     },
   })
 
@@ -196,7 +218,10 @@ export const EditorPanel = () => {
     setShowWarning(undefined)
     setResults(undefined)
 
-    if (currentValue.length === 0) return
+    if (currentValue.length === 0) {
+      clearPendingRunRefocus()
+      return
+    }
 
     if (!skipValidation) {
       const isReadOnlySelectSQL = isReadOnlySelect(currentValue)
@@ -232,7 +257,13 @@ export const EditorPanel = () => {
     setIsTemplatesOpen(false)
   }
 
+  const onExecuteSqlFromButton = () => {
+    shouldRefocusAfterRunRef.current = true
+    onExecuteSql()
+  }
+
   const handleClosePanel = () => {
+    clearPendingRunRefocus()
     closeSidebar(SIDEBAR_KEYS.EDITOR_PANEL)
     setTemplates([])
     setError(undefined)
@@ -458,7 +489,10 @@ export const EditorPanel = () => {
             language="pgsql"
             value={currentValue}
             onChange={handleChange}
-            onMount={(_, m) => setMonaco(m)}
+            onMount={(editor, m) => {
+              editorRef.current = editor
+              setMonaco(m)
+            }}
             aiEndpoint={`${BASE_PATH}/api/ai/code/complete`}
             aiMetadata={{
               projectRef: project?.ref,
@@ -510,8 +544,13 @@ export const EditorPanel = () => {
           <SqlWarningAdmonition
             className="border-t"
             warningType={showWarning}
-            onCancel={() => setShowWarning(undefined)}
+            onCancel={() => {
+              clearPendingRunRefocus()
+              setShowWarning(undefined)
+              refocusEditor()
+            }}
             onConfirm={() => {
+              shouldRefocusAfterRunRef.current = true
               setShowWarning(undefined)
               onExecuteSql(true)
             }}
@@ -615,7 +654,11 @@ export const EditorPanel = () => {
           >
             {activeSnippet ? 'Update snippet' : 'Save as snippet'}
           </Button>
-          <SqlRunButton isDisabled={isExecuting} isExecuting={isExecuting} onClick={onExecuteSql} />
+          <SqlRunButton
+            isDisabled={isExecuting}
+            isExecuting={isExecuting}
+            onClick={onExecuteSqlFromButton}
+          />
         </div>
       </div>
       <SaveSnippetDialog


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resolves FDBK-40065

## What is the current behavior?

Using the _Run_ button on either inline or “full” SQL Editor removes focus from the Monaco editor.

## What is the new behavior?

The text caret remains in the Monaco editor even after button press.

## To test

Try running a few queries both with keyboard (⌘ enter) and mouse click on the _Run_ button:

```sql
-- 1) Create a mock table + seed data
drop table if exists public.test;

create table public.test (
  id bigserial primary key,
  name text not null,
  created_at timestamptz not null default now()
);

insert into public.test (name)
values
  ('alpha'),
  ('beta'),
  ('gamma'),
  ('delta');

select * from public.test order by id;
```

```sql
-- 2) Deletion query that should trigger the warning modal (destructive op)
delete from public.test where id <= 2;

-- Verify remaining rows
select * from public.test order by id;
```

## Additional context

- [ ] This was FDBK-40065 that we should reply to
