### PR TITLE
[FE-2553] chore(studio): only show replication moved CTA if replication is enabled

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -25,8 +25,15 @@ export const InfrastructureInfo = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
-  const { projectAuthAll: authEnabled, projectSettingsDatabaseUpgrades: showDatabaseUpgrades } =
-    useIsFeatureEnabled(['project_auth:all', 'project_settings:database_upgrades'])
+  const {
+    projectAuthAll: authEnabled,
+    projectSettingsDatabaseUpgrades: showDatabaseUpgrades,
+    databaseReplication: showReplication,
+  } = useIsFeatureEnabled([
+    'project_auth:all',
+    'project_settings:database_upgrades',
+    'database:replication',
+  ])
 
   const {
     data,
@@ -71,7 +78,7 @@ export const InfrastructureInfo = () => {
     <>
       <ScaffoldDivider />
 
-      {project?.cloud_provider !== 'FLY' && (
+      {project?.cloud_provider !== 'FLY' && showReplication && (
         <ScaffoldContainer>
           <ScaffoldSection isFullWidth>
             <NoticeBar


### PR DESCRIPTION
The "Management of read replicas has moved" banner in Settings > Infrastructure linked to /database/replication, which returns a 404-like page for users who don't have the database:replication feature enabled. The notice is now only shown when the feature is enabled.