### PR TITLE
fix(billing): remove duplicate tax ID entry for New Zealand

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/TaxID.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/TaxID.constants.ts
@@ -722,13 +722,6 @@ export const TAX_IDS: TaxId[] = [
     countryIso2: 'MK',
   },
   {
-    name: 'nz_gst',
-    type: 'nz_gst',
-    country: 'New Zealand',
-    placeholder: '123456789',
-    countryIso2: 'NZ',
-  },
-  {
     name: 'NO VAT',
     type: 'no_vat',
     country: 'Norway',


### PR DESCRIPTION
This PR removes a duplicate `nz_gst` entry from the tax ID types list.

**Testing**

<img width="1217" height="614" alt="Screenshot 2026-03-06 at 5 25 38 PM" src="https://github.com/user-attachments/assets/2895ddbd-d124-4ee3-9135-2c08d6f1b0b3" />
