### PR TITLE
fix: accept inconsistent casing in incident regions

### DIFF
--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.test.ts
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.test.ts
@@ -145,6 +145,21 @@ describe('shouldShowBanner', () => {
       ).toBe(true)
     })
 
+    it('shows when affected region has inconsistent casing (AI-generated cache)', () => {
+      expect(
+        shouldShowBanner({
+          incidents: [
+            {
+              id: 'test',
+              cache: { affected_regions: ['US-East-1'], affects_project_creation: false },
+            },
+          ],
+          hasProjects: true,
+          userRegions: new Set(['us-east-1']),
+        })
+      ).toBe(true)
+    })
+
     it('does not show when user has no databases in any affected region', () => {
       expect(
         shouldShowBanner({
@@ -278,6 +293,21 @@ describe('getRelevantIncidentIds', () => {
         userRegions: new Set(['eu-west-1', 'ap-southeast-1']),
       })
     ).toEqual(expect.arrayContaining(['ap-southeast-1-only', 'eu-west-1-only']))
+  })
+
+  it('returns the ID of a relevant incident when affected_regions has inconsistent casing', () => {
+    expect(
+      getRelevantIncidentIds({
+        incidents: [
+          {
+            id: 'mixed-case-region',
+            cache: { affected_regions: ['US-East-1'], affects_project_creation: false },
+          },
+        ],
+        hasProjects: true,
+        userRegions: new Set(['us-east-1']),
+      })
+    ).toEqual(['mixed-case-region'])
   })
 
   it('excludes incidents irrelevant to the user from the result', () => {

--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.ts
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.utils.ts
@@ -40,7 +40,7 @@ export function shouldShowBanner({
     if (hasUnknownRegions) return true
 
     // Region restriction: only show if the user has a database in an affected region
-    return affectedRegions.some((region) => userRegions.has(region))
+    return affectedRegions.some((region) => userRegions.has(region.toLowerCase()))
   })
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `affected_regions` generated by the AI sometimes have inconsistent casing, causing validation to fail.

## What is the new behavior?

The system now accepts `affected_regions` that match case-insensitively, allowing for variations in casing.

## Additional context