### PR TITLE
Update realtimeErrorCodes.toml | fixed typo

### DIFF
--- a/apps/docs/content/errorCodes/realtimeErrorCodes.toml
+++ b/apps/docs/content/errorCodes/realtimeErrorCodes.toml
@@ -179,7 +179,7 @@ description = "Unauthorized access to Realtime channel."
 description = "Realtime is currently restarting."
 
 [UnableToProcessListenPayload]
-description = "Payload sent in NOTIFY operation was JSON parsable."
+description = "Payload sent in NOTIFY operation was not JSON parsable."
 
 [UnableToListenToTenantDatabase]
 description = "Unable to LISTEN for notifications against the Tenant Database."


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

doc update

## What is the current behavior?

Error description states that realtime breaks when a message is JSON parsable. Should state when it is "not" JSON parsable

## What is the new behavior?

Added not key word to description:

```
Payload sent in NOTIFY operation was "NOT" JSON parsable.
```
