### PR TITLE
db: add column to incident_status_cache

### DIFF
--- a/supabase/migrations/20260307142538_origin_incident_id.sql
+++ b/supabase/migrations/20260307142538_origin_incident_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.incident_status_cache
+ADD COLUMN origin_incident_id text;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Database schema update

## What is the current behavior?

The incident_status_cache table does not have a column to track the ID of the originating incident.

## What is the new behavior?

Added origin_incident_id column to incident_status_cache to track the ID of the originating incident (which is different from the ID of the status page incident).

## Additional context