### PR TITLE
fix(studio): support enum creation in custom schemas (#30632)

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -73,6 +73,10 @@ const ColumnType = ({
   const listboxId = useId()
   const availableTypes = POSTGRES_DATA_TYPES.concat(
     enumTypes.map((type) => type.format.replaceAll('"', ''))
+  ).concat(
+    enumTypes.map((option) =>
+      option.schema === 'public' ? option.name : `"${option.schema}"."${option.name}"`
+    )
   )
   const isAvailableType = value ? availableTypes.includes(value) : true
   const recommendation = RECOMMENDED_ALTERNATIVE_DATA_TYPE[value]
@@ -85,7 +89,16 @@ const ColumnType = ({
     if (pgOption) return pgOption
 
     // handle custom enums
-    const enumType = enumTypes.find((type) => type.format === name)
+    const enumType = enumTypes.find((option) => {
+      const typeString =
+        option.schema === 'public' ? option.name : `"${option.schema}"."${option.name}"`
+      return (
+        typeString === name ||
+        option.format === name ||
+        option.name === name ||
+        option.format.replaceAll('"', '') === name
+      )
+    })
     return enumType ? { ...enumType, type: 'enum' } : undefined
   }
 
@@ -232,46 +245,52 @@ const ColumnType = ({
                   <>
                     <CommandSeparator_Shadcn_ />
                     <CommandGroup_Shadcn_ heading="Other types">
-                      {enumTypes.map((option) => (
-                        <CommandItem_Shadcn_
-                          key={option.id}
-                          value={option.format}
-                          className={cn(
-                            'relative',
-                            option.format === value ? 'bg-surface-200' : ''
-                          )}
-                          onSelect={(value: string) => {
-                            // [Joshen] For camel case types specifically, format property includes escaped double quotes
-                            // which will cause the POST columns call to error out. So we strip it specifically in this context
-                            onOptionSelect(
-                              option.schema === 'public' ? value.replaceAll('"', '') : value
-                            )
-                            setOpen(false)
-                          }}
-                        >
-                          <div className="flex items-center gap-2">
-                            <div>
-                              <ListPlus size={16} className="text-foreground" strokeWidth={1.5} />
+                      {enumTypes.map((option) => {
+                        const typeString =
+                          option.schema === 'public'
+                            ? option.name
+                            : `"${option.schema}"."${option.name}"`
+                        const isSelected =
+                          option.format === value ||
+                          typeString === value ||
+                          option.format.replaceAll('"', '') === value
+
+                        return (
+                          <CommandItem_Shadcn_
+                            key={option.id}
+                            value={typeString}
+                            className={cn('relative', isSelected ? 'bg-surface-200' : '')}
+                            onSelect={() => {
+                              onOptionSelect(typeString)
+                              setOpen(false)
+                            }}
+                          >
+                            <div className="flex items-center gap-2">
+                              <div>
+                                <ListPlus size={16} className="text-foreground" strokeWidth={1.5} />
+                              </div>
+                              <span className="text-foreground">
+                                {option.schema === 'public'
+                                  ? option.name
+                                  : `${option.schema}.${option.name}`}
+                              </span>
+                              {option.comment !== undefined && (
+                                <span
+                                  title={option.comment ?? ''}
+                                  className="text-foreground-lighter"
+                                >
+                                  {option.comment}
+                                </span>
+                              )}
+                              {isSelected && (
+                                <span className="absolute right-3 top-2">
+                                  <Check className="text-brand" size={14} />
+                                </span>
+                              )}
                             </div>
-                            <span className="text-foreground">
-                              {option.format.replaceAll('"', '')}
-                            </span>
-                            {option.comment !== undefined && (
-                              <span
-                                title={option.comment ?? ''}
-                                className="text-foreground-lighter"
-                              >
-                                {option.comment}
-                              </span>
-                            )}
-                            {option.format === value && (
-                              <span className="absolute right-3 top-2">
-                                <Check className="text-brand" size={14} />
-                              </span>
-                            )}
-                          </div>
-                        </CommandItem_Shadcn_>
-                      ))}
+                          </CommandItem_Shadcn_>
+                        )
+                      })}
                     </CommandGroup_Shadcn_>
                   </>
                 )}

--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -234,15 +234,15 @@ function update(
     name === undefined || name === old.name
       ? ''
       : `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} RENAME COLUMN ${ident(
-        old.name
-      )} TO ${ident(name)};`
+          old.name
+        )} TO ${ident(name)};`
   // We use USING to allow implicit conversion of incompatible types (e.g. int4 -> text).
   const typeSql =
     type === undefined
       ? ''
       : `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(
-        old.name
-      )} SET DATA TYPE ${typeIdent(type)} USING ${ident(old.name)}::${typeIdent(type)};`
+          old.name
+        )} SET DATA TYPE ${typeIdent(type)} USING ${ident(old.name)}::${typeIdent(type)};`
 
   let defaultValueSql: string
   if (drop_default) {
@@ -288,11 +288,11 @@ function update(
   } else {
     isNullableSql = is_nullable
       ? `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(
-        old.name
-      )} DROP NOT NULL;`
+          old.name
+        )} DROP NOT NULL;`
       : `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(
-        old.name
-      )} SET NOT NULL;`
+          old.name
+        )} SET NOT NULL;`
   }
   let isUniqueSql = ''
   if (old.is_unique === true && is_unique === false) {
@@ -324,8 +324,8 @@ $$;
     comment === undefined
       ? ''
       : `COMMENT ON COLUMN ${ident(old.schema)}.${ident(old.table)}.${ident(
-        old.name
-      )} IS ${literal(comment)};`
+          old.name
+        )} IS ${literal(comment)};`
 
   const checkSql =
     check === undefined
@@ -346,28 +346,29 @@ BEGIN
 
   IF v_conname IS NOT NULL THEN
     EXECUTE format('ALTER TABLE ${ident(old.schema)}.${ident(
-        old.table
-      )} DROP CONSTRAINT %I', v_conname);
+      old.table
+    )} DROP CONSTRAINT %I', v_conname);
   END IF;
 
-  ${check !== null
-        ? `
+  ${
+    check !== null
+      ? `
   ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ADD CONSTRAINT ${ident(
-          `${old.table}_${old.name}_check`
-        )} CHECK (${check});
+    `${old.table}_${old.name}_check`
+  )} CHECK (${check});
 
   SELECT conkey into v_conkey FROM pg_constraint WHERE conname = ${literal(
-          `${old.table}_${old.name}_check`
-        )};
+    `${old.table}_${old.name}_check`
+  )};
 
   ASSERT v_conkey IS NOT NULL, 'error creating column constraint: check condition must refer to this column';
   ASSERT cardinality(v_conkey) = 1, 'error creating column constraint: check condition cannot refer to multiple columns';
   ASSERT v_conkey[1] = ${literal(
-          old.ordinal_position
-        )}, 'error creating column constraint: check condition cannot refer to other columns';
+    old.ordinal_position
+  )}, 'error creating column constraint: check condition cannot refer to other columns';
 `
-        : ''
-      }
+      : ''
+  }
 END
 $$;
 `

--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -179,11 +179,24 @@ COMMIT;`
 }
 
 const typeIdent = (type: string) => {
-  if (type.endsWith('[]')) {
-    const baseType = type.slice(0, -2)
-    return baseType.includes('.') ? `${baseType}[]` : `${ident(baseType)}[]`
+  const isArray = type.endsWith('[]')
+  const baseType = isArray ? type.slice(0, -2) : type
+  const suffix = isArray ? '[]' : ''
+
+  const quotedQualified = /^"([^"]+)"\."([^"]+)"$/.exec(baseType)
+  if (quotedQualified) {
+    return `${ident(quotedQualified[1])}.${ident(quotedQualified[2])}${suffix}`
   }
-  return type.includes('.') ? type : ident(type)
+
+  if (baseType.includes('.')) {
+    const parts = baseType.split('.')
+    if (parts.length !== 2 || parts.some((part) => part.length === 0)) {
+      throw new Error(`Invalid type identifier: ${type}`)
+    }
+    return `${ident(parts[0])}.${ident(parts[1])}${suffix}`
+  }
+
+  return `${ident(baseType)}${suffix}`
 }
 
 function update(
@@ -221,15 +234,15 @@ function update(
     name === undefined || name === old.name
       ? ''
       : `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} RENAME COLUMN ${ident(
-          old.name
-        )} TO ${ident(name)};`
+        old.name
+      )} TO ${ident(name)};`
   // We use USING to allow implicit conversion of incompatible types (e.g. int4 -> text).
   const typeSql =
     type === undefined
       ? ''
       : `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(
-          old.name
-        )} SET DATA TYPE ${typeIdent(type)} USING ${ident(old.name)}::${typeIdent(type)};`
+        old.name
+      )} SET DATA TYPE ${typeIdent(type)} USING ${ident(old.name)}::${typeIdent(type)};`
 
   let defaultValueSql: string
   if (drop_default) {
@@ -275,11 +288,11 @@ function update(
   } else {
     isNullableSql = is_nullable
       ? `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(
-          old.name
-        )} DROP NOT NULL;`
+        old.name
+      )} DROP NOT NULL;`
       : `ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ALTER COLUMN ${ident(
-          old.name
-        )} SET NOT NULL;`
+        old.name
+      )} SET NOT NULL;`
   }
   let isUniqueSql = ''
   if (old.is_unique === true && is_unique === false) {
@@ -311,8 +324,8 @@ $$;
     comment === undefined
       ? ''
       : `COMMENT ON COLUMN ${ident(old.schema)}.${ident(old.table)}.${ident(
-          old.name
-        )} IS ${literal(comment)};`
+        old.name
+      )} IS ${literal(comment)};`
 
   const checkSql =
     check === undefined
@@ -333,29 +346,28 @@ BEGIN
 
   IF v_conname IS NOT NULL THEN
     EXECUTE format('ALTER TABLE ${ident(old.schema)}.${ident(
-      old.table
-    )} DROP CONSTRAINT %I', v_conname);
+        old.table
+      )} DROP CONSTRAINT %I', v_conname);
   END IF;
 
-  ${
-    check !== null
-      ? `
+  ${check !== null
+        ? `
   ALTER TABLE ${ident(old.schema)}.${ident(old.table)} ADD CONSTRAINT ${ident(
-    `${old.table}_${old.name}_check`
-  )} CHECK (${check});
+          `${old.table}_${old.name}_check`
+        )} CHECK (${check});
 
   SELECT conkey into v_conkey FROM pg_constraint WHERE conname = ${literal(
-    `${old.table}_${old.name}_check`
-  )};
+          `${old.table}_${old.name}_check`
+        )};
 
   ASSERT v_conkey IS NOT NULL, 'error creating column constraint: check condition must refer to this column';
   ASSERT cardinality(v_conkey) = 1, 'error creating column constraint: check condition cannot refer to multiple columns';
   ASSERT v_conkey[1] = ${literal(
-    old.ordinal_position
-  )}, 'error creating column constraint: check condition cannot refer to other columns';
+          old.ordinal_position
+        )}, 'error creating column constraint: check condition cannot refer to other columns';
 `
-      : ''
-  }
+        : ''
+      }
 END
 $$;
 `

--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -178,13 +178,12 @@ COMMIT;`
   return { sql }
 }
 
-// TODO: make this more robust - use type_id or type_schema + type_name instead of just type.
 const typeIdent = (type: string) => {
-  return type.endsWith('[]')
-    ? `${ident(type.slice(0, -2))}[]`
-    : type.includes('.')
-      ? type
-      : ident(type)
+  if (type.endsWith('[]')) {
+    const baseType = type.slice(0, -2)
+    return baseType.includes('.') ? `${baseType}[]` : `${ident(baseType)}[]`
+  }
+  return type.includes('.') ? type : ident(type)
 }
 
 function update(


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, if a user creates an enumerated type (enum) in a custom (non-`public`) schema, the Studio UI successfully retrieves and lists the type in the column creation dropdown. However, when the user selects it and clicks save, the UI silently strips the schema prefix and downcases the value (due to Shadcn's internal combobox filtering logic). The API call attempts to create the column using the unqualified enum string, resulting in the Postgres error `type "my_enum" does not exist` (as it assumes the `public` schema).

Furthermore, in `pg-meta`, if a user attempts to define a column as an array of a custom enumerated type (`"custom_schema"."my_enum"[]`), the `typeIdent` logic strips the `[]` but incorrectly double-escapes the already-qualified string, mangling it into `"""custom_schema"".""my_enum"""[]` and causing an immediate crash.

Resolves #30632

## What is the new behavior?

1. **Studio (`ColumnType.tsx`)**: Reconstructed the enum option mappers and selectors to strictly build and pass the correctly quoted, fully-qualified identifier (e.g. `"custom_schema"."my_enum"`) when the selected option belongs to a non-public schema. This completely shields the payload from Shadcn's format-stripping UI bugs.
2. **pg-meta (`pg-meta-columns.ts`)**: Patched `typeIdent` to safely recognize schema-qualified (period-containing) array formats without redundantly triggering `ident()`, guaranteeing seamless compatibility with `custom_schema.my_enum[]` declarations.

## Additional context

This follows a strict first-principles approach. By addressing the root formatting mismatches directly at the component bounds (`ColumnType.tsx`) and the SQL schema stringifier (`pg-meta-columns.ts`), it requires zero architectural changes and introduces no regressions to the default `public` schema workflows.
