### PR TITLE
fix(studio): apply role impersonation to CSV bulk imports

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -255,10 +255,10 @@ export const SidePanelEditor = ({
   })
   const { mutateAsync: createPublication } = useDatabasePublicationCreateMutation()
   const { mutateAsync: updatePublication } = useDatabasePublicationUpdateMutation({
-    onError: () => { },
+    onError: () => {},
   })
   const { mutateAsync: updateApiPrivileges } = useTableApiAccessPrivilegesMutation({
-    onError: () => { }, // Errors handled inline
+    onError: () => {}, // Errors handled inline
   })
 
   const isDuplicating = snap.sidePanel?.type === 'table' && snap.sidePanel.mode === 'duplicate'
@@ -407,7 +407,7 @@ export const SidePanelEditor = ({
 
     if (payload !== undefined && configuration !== undefined) {
       try {
-        await saveRow(payload, isNewRecord, configuration, () => { })
+        await saveRow(payload, isNewRecord, configuration, () => {})
       } catch (error) {
         // [Joshen] No error handler required as error is handled within saveRow
       } finally {
@@ -432,8 +432,8 @@ export const SidePanelEditor = ({
       const isNewRecord = false
       const configuration = { identifiers, rowIdx: row.idx }
 
-      saveRow(value, isNewRecord, configuration, () => { })
-    } catch (error) { }
+      saveRow(value, isNewRecord, configuration, () => {})
+    } catch (error) {}
   }
 
   const saveColumn = async (
@@ -457,23 +457,23 @@ export const SidePanelEditor = ({
 
     const response = isNewRecord
       ? await createColumn({
-        projectRef: project?.ref!,
-        connectionString: project?.connectionString,
-        payload: payload as CreateColumnPayload,
-        selectedTable,
-        primaryKey,
-        foreignKeyRelations,
-      })
+          projectRef: project?.ref!,
+          connectionString: project?.connectionString,
+          payload: payload as CreateColumnPayload,
+          selectedTable,
+          primaryKey,
+          foreignKeyRelations,
+        })
       : await updateColumn({
-        projectRef: project?.ref!,
-        connectionString: project?.connectionString,
-        originalColumn: selectedColumnToEdit as PostgresColumn,
-        payload: payload as UpdateColumnPayload,
-        selectedTable,
-        primaryKey,
-        foreignKeyRelations,
-        existingForeignKeyRelations,
-      })
+          projectRef: project?.ref!,
+          connectionString: project?.connectionString,
+          originalColumn: selectedColumnToEdit as PostgresColumn,
+          payload: payload as UpdateColumnPayload,
+          selectedTable,
+          primaryKey,
+          foreignKeyRelations,
+          existingForeignKeyRelations,
+        })
 
     if (response?.error) {
       toast.error(response.error.message)
@@ -597,14 +597,14 @@ export const SidePanelEditor = ({
       const realtimeTables =
         isAlreadyEnabled && !enabled
           ? // Toggle realtime off
-          realtimePublication.tables
-            .filter((t) => t.id !== table.id)
-            .map((t) => `${t.schema}.${t.name}`)
+            realtimePublication.tables
+              .filter((t) => t.id !== table.id)
+              .map((t) => `${t.schema}.${t.name}`)
           : !isAlreadyEnabled && enabled
             ? // Toggle realtime on
-            realtimePublication.tables
-              .map((t) => `${t.schema}.${t.name}`)
-              .concat([`${table.schema}.${table.name}`])
+              realtimePublication.tables
+                .map((t) => `${t.schema}.${t.name}`)
+                .concat([`${table.schema}.${table.name}`])
             : null
       if (realtimeTables === null) return
       await updatePublication({
@@ -891,8 +891,9 @@ export const SidePanelEditor = ({
           toast.loading(
             <SonnerProgress
               progress={progress}
-              message={`Adding ${importContent.rows.length.toLocaleString()} rows to ${selectedTable.name
-                }`}
+              message={`Adding ${importContent.rows.length.toLocaleString()} rows to ${
+                selectedTable.name
+              }`}
             />,
             { id: toastId }
           )
@@ -947,7 +948,7 @@ export const SidePanelEditor = ({
       <TableEditor
         table={
           snap.sidePanel?.type === 'table' &&
-            (snap.sidePanel.mode === 'edit' || snap.sidePanel.mode === 'duplicate')
+          (snap.sidePanel.mode === 'edit' || snap.sidePanel.mode === 'duplicate')
             ? selectedTable
             : undefined
         }
@@ -955,11 +956,11 @@ export const SidePanelEditor = ({
         templateData={
           snap.sidePanel?.type === 'table' && snap.sidePanel.templateData
             ? {
-              ...snap.sidePanel.templateData,
-              columns: snap.sidePanel.templateData.columns
-                ? [...snap.sidePanel.templateData.columns]
-                : undefined,
-            }
+                ...snap.sidePanel.templateData,
+                columns: snap.sidePanel.templateData.columns
+                  ? [...snap.sidePanel.templateData.columns]
+                  : undefined,
+              }
             : undefined
         }
         visible={snap.sidePanel?.type === 'table'}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -255,10 +255,10 @@ export const SidePanelEditor = ({
   })
   const { mutateAsync: createPublication } = useDatabasePublicationCreateMutation()
   const { mutateAsync: updatePublication } = useDatabasePublicationUpdateMutation({
-    onError: () => {},
+    onError: () => { },
   })
   const { mutateAsync: updateApiPrivileges } = useTableApiAccessPrivilegesMutation({
-    onError: () => {}, // Errors handled inline
+    onError: () => { }, // Errors handled inline
   })
 
   const isDuplicating = snap.sidePanel?.type === 'table' && snap.sidePanel.mode === 'duplicate'
@@ -407,7 +407,7 @@ export const SidePanelEditor = ({
 
     if (payload !== undefined && configuration !== undefined) {
       try {
-        await saveRow(payload, isNewRecord, configuration, () => {})
+        await saveRow(payload, isNewRecord, configuration, () => { })
       } catch (error) {
         // [Joshen] No error handler required as error is handled within saveRow
       } finally {
@@ -432,8 +432,8 @@ export const SidePanelEditor = ({
       const isNewRecord = false
       const configuration = { identifiers, rowIdx: row.idx }
 
-      saveRow(value, isNewRecord, configuration, () => {})
-    } catch (error) {}
+      saveRow(value, isNewRecord, configuration, () => { })
+    } catch (error) { }
   }
 
   const saveColumn = async (
@@ -457,23 +457,23 @@ export const SidePanelEditor = ({
 
     const response = isNewRecord
       ? await createColumn({
-          projectRef: project?.ref!,
-          connectionString: project?.connectionString,
-          payload: payload as CreateColumnPayload,
-          selectedTable,
-          primaryKey,
-          foreignKeyRelations,
-        })
+        projectRef: project?.ref!,
+        connectionString: project?.connectionString,
+        payload: payload as CreateColumnPayload,
+        selectedTable,
+        primaryKey,
+        foreignKeyRelations,
+      })
       : await updateColumn({
-          projectRef: project?.ref!,
-          connectionString: project?.connectionString,
-          originalColumn: selectedColumnToEdit as PostgresColumn,
-          payload: payload as UpdateColumnPayload,
-          selectedTable,
-          primaryKey,
-          foreignKeyRelations,
-          existingForeignKeyRelations,
-        })
+        projectRef: project?.ref!,
+        connectionString: project?.connectionString,
+        originalColumn: selectedColumnToEdit as PostgresColumn,
+        payload: payload as UpdateColumnPayload,
+        selectedTable,
+        primaryKey,
+        foreignKeyRelations,
+        existingForeignKeyRelations,
+      })
 
     if (response?.error) {
       toast.error(response.error.message)
@@ -597,14 +597,14 @@ export const SidePanelEditor = ({
       const realtimeTables =
         isAlreadyEnabled && !enabled
           ? // Toggle realtime off
-            realtimePublication.tables
-              .filter((t) => t.id !== table.id)
-              .map((t) => `${t.schema}.${t.name}`)
+          realtimePublication.tables
+            .filter((t) => t.id !== table.id)
+            .map((t) => `${t.schema}.${t.name}`)
           : !isAlreadyEnabled && enabled
             ? // Toggle realtime on
-              realtimePublication.tables
-                .map((t) => `${t.schema}.${t.name}`)
-                .concat([`${table.schema}.${table.name}`])
+            realtimePublication.tables
+              .map((t) => `${t.schema}.${t.name}`)
+              .concat([`${table.schema}.${table.name}`])
             : null
       if (realtimeTables === null) return
       await updatePublication({
@@ -694,6 +694,7 @@ export const SidePanelEditor = ({
           organizationSlug: org?.slug,
           generatedPolicies,
           onCreatePoliciesSuccess: () => track('rls_generated_policies_created'),
+          roleImpersonationState: getImpersonatedRoleState(),
         })
 
         if (isRealtimeEnabled) await updateTableRealtime(table, true)
@@ -890,9 +891,8 @@ export const SidePanelEditor = ({
           toast.loading(
             <SonnerProgress
               progress={progress}
-              message={`Adding ${importContent.rows.length.toLocaleString()} rows to ${
-                selectedTable.name
-              }`}
+              message={`Adding ${importContent.rows.length.toLocaleString()} rows to ${selectedTable.name
+                }`}
             />,
             { id: toastId }
           )
@@ -947,7 +947,7 @@ export const SidePanelEditor = ({
       <TableEditor
         table={
           snap.sidePanel?.type === 'table' &&
-          (snap.sidePanel.mode === 'edit' || snap.sidePanel.mode === 'duplicate')
+            (snap.sidePanel.mode === 'edit' || snap.sidePanel.mode === 'duplicate')
             ? selectedTable
             : undefined
         }
@@ -955,11 +955,11 @@ export const SidePanelEditor = ({
         templateData={
           snap.sidePanel?.type === 'table' && snap.sidePanel.templateData
             ? {
-                ...snap.sidePanel.templateData,
-                columns: snap.sidePanel.templateData.columns
-                  ? [...snap.sidePanel.templateData.columns]
-                  : undefined,
-              }
+              ...snap.sidePanel.templateData,
+              columns: snap.sidePanel.templateData.columns
+                ? [...snap.sidePanel.templateData.columns]
+                : undefined,
+            }
             : undefined
         }
         visible={snap.sidePanel?.type === 'table'}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -871,7 +871,8 @@ export const SidePanelEditor = ({
             />,
             { id: toastId }
           )
-        }
+        },
+        getImpersonatedRoleState()
       )
       if (res.error) {
         toast.error(`Failed to import data: ${res.error.message}`, { id: toastId })
@@ -895,7 +896,8 @@ export const SidePanelEditor = ({
             />,
             { id: toastId }
           )
-        }
+        },
+        getImpersonatedRoleState()
       )
       if (res.error) {
         toast.error(`Failed to import data: ${res.error.message}`, { id: toastId })

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -548,6 +548,7 @@ export const createTable = async ({
   organizationSlug?: string
   generatedPolicies?: GeneratedPolicy[]
   onCreatePoliciesSuccess?: () => void
+  roleImpersonationState?: RoleImpersonationState
 }) => {
   const queryClient = getQueryClient()
 
@@ -727,7 +728,8 @@ export const createTable = async ({
             </div>,
             { id: toastId }
           )
-        }
+        },
+        roleImpersonationState
       )
 
       if (error !== undefined) {
@@ -759,7 +761,8 @@ export const createTable = async ({
             </div>,
             { id: toastId }
           )
-        }
+        },
+        roleImpersonationState
       )
     }
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -1,4 +1,6 @@
 import pgMeta from '@supabase/pg-meta'
+import { RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
+import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
 import { Query } from '@supabase/pg-meta/src/query'
 import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
 import type { SupaRow } from 'components/grid/types'
@@ -1045,7 +1047,8 @@ export const insertRowsViaSpreadsheet = async (
   file: any,
   table: RetrieveTableResult,
   selectedHeaders: string[],
-  onProgressUpdate: (progress: number) => void
+  onProgressUpdate: (progress: number) => void,
+  roleImpersonationState?: RoleImpersonationState
 ) => {
   let chunkNumber = 0
   let insertError: any = undefined
@@ -1068,9 +1071,15 @@ export const insertRowsViaSpreadsheet = async (
         })
 
         const insertQuery = new Query().from(table.name, table.schema).insert(formattedData).toSql()
+        const sql = wrapWithRoleImpersonation(insertQuery, roleImpersonationState)
         try {
           await executeWithRetry(() =>
-            executeSql({ projectRef, connectionString, sql: insertQuery })
+            executeSql({
+              projectRef,
+              connectionString,
+              sql,
+              isRoleImpersonationEnabled: isRoleImpersonationEnabled(roleImpersonationState?.role),
+            })
           )
         } catch (error) {
           console.warn(error)
@@ -1099,7 +1108,8 @@ export const insertTableRows = async (
   table: RetrieveTableResult,
   rows: any,
   selectedHeaders: string[],
-  onProgressUpdate: (progress: number) => void
+  onProgressUpdate: (progress: number) => void,
+  roleImpersonationState?: RoleImpersonationState
 ) => {
   let insertError = undefined
   let insertProgress = 0
@@ -1116,8 +1126,14 @@ export const insertTableRows = async (
       return Promise.race([
         new Promise(async (resolve, reject) => {
           const insertQuery = new Query().from(table.name, table.schema).insert(batch).toSql()
+          const sql = wrapWithRoleImpersonation(insertQuery, roleImpersonationState)
           try {
-            await executeSql({ projectRef, connectionString, sql: insertQuery })
+            await executeSql({
+              projectRef,
+              connectionString,
+              sql,
+              isRoleImpersonationEnabled: isRoleImpersonationEnabled(roleImpersonationState?.role),
+            })
           } catch (error) {
             insertError = error
             reject(error)

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -1,5 +1,5 @@
 import pgMeta from '@supabase/pg-meta'
-import { RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
+import { type RoleImpersonationState, wrapWithRoleImpersonation } from 'lib/role-impersonation'
 import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
 import { Query } from '@supabase/pg-meta/src/query'
 import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
@@ -532,6 +532,7 @@ export const createTable = async ({
   organizationSlug,
   generatedPolicies = [],
   onCreatePoliciesSuccess,
+  roleImpersonationState,
 }: {
   projectRef: string
   connectionString?: string | null


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

CSV bulk imports currently bypass the `set_config('request.jwt.claim.sub', ...)` transaction wrapper used when interacting with the Data Grid. As a result, when importing data into a table with Row-Level Security (RLS) policies relying on `auth.uid()`, the constraints either fail or the `uid` isn't set correctly.

Closes #28820

## What is the new behavior?

This PR modifies the CSV import handlers to wrap the Postgres `INSERT` commands within the same role-impersonating transactions used for individual cell edits.

Specifically:
- Appended an optional `roleImpersonationState` argument to `insertRowsViaSpreadsheet` and `insertTableRows`.
- Wrapped the generated `insertQuery` inside `wrapWithRoleImpersonation(insertQuery, roleImpersonationState)` and supplied the `isRoleImpersonationEnabled(...)` flag directly to `executeSql()`.
- Retrieved the impersonation state via the existing `getImpersonatedRoleState()` hook and passed it down to the handlers during a CSV upload or Text Paste.

This mirrors exactly how Supabase executes regular data operations during cell edits.

## Additional context

Tested locally with `npm run typecheck` and `pnpm run format` aligned.
