### PR TITLE
Fix spacing and schema prefix inconsistency in Table Editor

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/HeaderTitle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/HeaderTitle.tsx
@@ -10,8 +10,8 @@ const HeaderTitle: React.FC<Props> = ({ table, column }) => {
   if (!column) {
     return (
       <>
-        Add new column to{' '}
-        <code>{table.name}</code>
+        <span>Add new column to</span>
+        <code className="ml-1">{table.name}</code>
       </>
     )
   }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/HeaderTitle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/HeaderTitle.tsx
@@ -10,7 +10,8 @@ const HeaderTitle: React.FC<Props> = ({ table, column }) => {
   if (!column) {
     return (
       <>
-        Add new column to <code>{table.name}</code>
+        Add new column to{' '}
+        <code>{table.name}</code>
       </>
     )
   }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -195,10 +195,7 @@ export const SpreadsheetImport = ({
       header={
         selectedTable !== undefined ? (
           <>
-            Add data to{' '}
-            <code className="text-sm">
-              {selectedTable.schema}.{selectedTable.name}
-            </code>
+            Add data to <code className="text-sm">{selectedTable.name}</code>
           </>
         ) : (
           'Add content to new table'

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -195,7 +195,7 @@ export const SpreadsheetImport = ({
       header={
         selectedTable !== undefined ? (
           <>
-            Add data to <code className="text-sm">{selectedTable.name}</code>
+            Add data to <code className="text-sm ml-1">{selectedTable.name}</code>
           </>
         ) : (
           'Add content to new table'


### PR DESCRIPTION
Fixes this [Linear issue](https://linear.app/supabase/issue/FE-2732/table-editor-header-spacing-and-schema-prefix-inconsistency.). 

# Before

<img width="320" height="200" alt="image" src="https://github.com/user-attachments/assets/45dc3a08-50df-4a03-b7ee-1b107c60059e" />
<img width="320" height="150" alt="image" src="https://github.com/user-attachments/assets/c5cca6d5-a294-4137-8cf6-20e56678ebe6" />
<img width="320" height="150" alt="image" src="https://github.com/user-attachments/assets/be54093b-8ff0-4c71-9934-574baac13039" />


# After

<img width="320" height="150" alt="CleanShot 2026-03-08 at 13 05 48@2x" src="https://github.com/user-attachments/assets/4ed9817d-5ae7-45c2-9da7-6d1aec023975" />
<img width="320" height="150" alt="CleanShot 2026-03-08 at 13 06 06@2x" src="https://github.com/user-attachments/assets/7ae0920e-0b5b-4eb3-993c-180d51ffd942" />

