### PR TITLE
docs: clarify free plan database size vs disk size

### DIFF
--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -106,7 +106,11 @@ Due to restrictions on the underlying cloud provider, disk expansions can occur 
 
 ### Free Plan behavior
 
-Free Plan projects enter [read-only](#read-only-mode) mode when you exceed the 500 MB limit. Once in read-only mode, you have these options:
+Free Plan projects include **500 MB of database size per project**.
+
+If the database size exceeds this limit, the project may enter read-only mode until the database size is reduced or the project is upgraded.
+
+Note that this limit refers to **database size**, not the total disk size allocated to the project. Once in read-only mode, you have these options:
 
 - [Upgrade to the Pro Plan](/dashboard/org/_/billing) to increase the limit to 8 GB. [Disable the Spend Cap](https://app.supabase.com/org/_/billing?panel=costControl) if you want your Pro instance to auto-scale beyond the 8 GB disk size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.


### PR DESCRIPTION
Fixes #43487

Updated the "Free Plan behavior" section in the documentation to clarify that the 500 MB limit refers to database size rather than total disk size.
