### PR TITLE
fix(studio): Trim whitespace from SMTP_HOST on form submission

### DIFF
--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -149,6 +149,21 @@ export const SmtpForm = () => {
 
   const onSubmit = (values: SmtpFormValues) => {
     const { ENABLE_SMTP, ...rest } = values
+
+    // Trim whitespace from string fields to prevent DNS lookup failures
+    if (rest.SMTP_HOST) {
+      rest.SMTP_HOST = rest.SMTP_HOST.trim()
+    }
+    if (rest.SMTP_USER) {
+      rest.SMTP_USER = rest.SMTP_USER.trim()
+    }
+    if (rest.SMTP_ADMIN_EMAIL) {
+      rest.SMTP_ADMIN_EMAIL = rest.SMTP_ADMIN_EMAIL.trim()
+    }
+    if (rest.SMTP_SENDER_NAME) {
+      rest.SMTP_SENDER_NAME = rest.SMTP_SENDER_NAME.trim()
+    }
+
     const basePayload = ENABLE_SMTP ? rest : defaultDisabledSmtpFormValues
 
     // When enabling SMTP, set RATE_LIMIT_EMAIL_SENT to 30

--- a/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -151,20 +151,15 @@ export const SmtpForm = () => {
     const { ENABLE_SMTP, ...rest } = values
 
     // Trim whitespace from string fields to prevent DNS lookup failures
-    if (rest.SMTP_HOST) {
-      rest.SMTP_HOST = rest.SMTP_HOST.trim()
-    }
-    if (rest.SMTP_USER) {
-      rest.SMTP_USER = rest.SMTP_USER.trim()
-    }
-    if (rest.SMTP_ADMIN_EMAIL) {
-      rest.SMTP_ADMIN_EMAIL = rest.SMTP_ADMIN_EMAIL.trim()
-    }
-    if (rest.SMTP_SENDER_NAME) {
-      rest.SMTP_SENDER_NAME = rest.SMTP_SENDER_NAME.trim()
+    const normalizedRest = {
+      ...rest,
+      ...(rest.SMTP_HOST && { SMTP_HOST: rest.SMTP_HOST.trim() }),
+      ...(rest.SMTP_USER && { SMTP_USER: rest.SMTP_USER.trim() }),
+      ...(rest.SMTP_ADMIN_EMAIL && { SMTP_ADMIN_EMAIL: rest.SMTP_ADMIN_EMAIL.trim() }),
+      ...(rest.SMTP_SENDER_NAME && { SMTP_SENDER_NAME: rest.SMTP_SENDER_NAME.trim() }),
     }
 
-    const basePayload = ENABLE_SMTP ? rest : defaultDisabledSmtpFormValues
+    const basePayload = ENABLE_SMTP ? normalizedRest : defaultDisabledSmtpFormValues
 
     // When enabling SMTP, set RATE_LIMIT_EMAIL_SENT to 30
     // When disabling, backend will handle resetting to default


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Addresses issue #43529

## What is the current behavior?

When users enter an SMTP_HOST value with leading or trailing whitespace (e.g., `smtp.gmail.com ` or ` smtp.gmail.com`), the whitespace is preserved. This causes SMTP connection failures since the host lookup fails with invalid characters.

## What is the new behavior?

String fields (`SMTP_HOST`, `SMTP_SENDER_NAME`, `SMTP_ADMIN_EMAIL`) are now trimmed of whitespace before being submitted to the API. This prevents configuration errors from accidental whitespace.

## Additional context

Closes #43529

The fix trims string values in the `onSubmit` handler within the SmtpForm component before making the API call.