### PR TITLE
chore: Remove unused ShowUntil

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -12,14 +12,6 @@ This guide refers to upgrading the Postgres version of your Supabase Project. Fo
 
 You can upgrade your project using in-place upgrades or by pausing and restoring your project.
 
-<ShowUntil date="2024-12-17">
-<Admonition type="tip">
-
-The Migrating and Upgrading guide has been divided into two sections. To migrate between Supabase projects, see [Migrating within Supabase](/docs/guides/platform/migrating-within-supabase).
-
-</Admonition>
-</ShowUntil>
-
 ## In-place upgrades
 
 <Admonition type="note">

--- a/apps/docs/features/ui/ShowUntil.tsx
+++ b/apps/docs/features/ui/ShowUntil.tsx
@@ -7,6 +7,9 @@ export function ShowUntil({ children, date }: { children: ReactNode; date: strin
   if (isNaN(untilDate.getTime()) || currentDate < untilDate) {
     return <>{children}</>
   } else {
+    console.error(
+      `[docs/features/ui/ShowUntil]: Component for ${date} expired, please update remove this note.`
+    )
     return null
   }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes `ShowUntil` component and change its behavior.

## What is the current behavior?

Component stays in page without a signal in page that it needs to be removed.

## What is the new behavior?

When you visit a page in dev, you get an error that a component needs to be removed.

<img width="1114" height="547" alt="Screenshot 2026-03-09 at 11 48 31" src="https://github.com/user-attachments/assets/ce4469bb-adfe-4836-94dc-1bd07ed6aa7b" />

