### PR TITLE
feat(billing): tax id dismissible banner

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -2,6 +2,7 @@ import { useFlag } from 'common'
 import { ClockSkewBanner } from 'components/layouts/AppLayout/ClockSkewBanner'
 import { NoticeBanner } from 'components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from 'components/layouts/AppLayout/StatusPageBanner'
+import { TaxIdBanner } from 'components/layouts/AppLayout/TaxIdBanner'
 import { PropsWithChildren } from 'react'
 
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
@@ -16,6 +17,7 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
         <StatusPageBanner />
         {showNoticeBanner && <NoticeBanner />}
         <OrganizationResourceBanner />
+        <TaxIdBanner />
         {clockSkewBanner && <ClockSkewBanner />}
       </div>
       {children}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerData.tsx
@@ -1,4 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useQueryClient } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -15,6 +16,7 @@ import { useOrganizationCustomerProfileQuery } from 'data/organizations/organiza
 import { useOrganizationCustomerProfileUpdateMutation } from 'data/organizations/organization-customer-profile-update-mutation'
 import { useOrganizationTaxIdQuery } from 'data/organizations/organization-tax-id-query'
 import { useOrganizationTaxIdUpdateMutation } from 'data/organizations/organization-tax-id-update-mutation'
+import { organizationKeys } from 'data/organizations/keys'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { Button, Card, CardFooter, Form_Shadcn_ as Form } from 'ui'
@@ -28,6 +30,7 @@ import { useBillingCustomerDataForm } from './useBillingCustomerDataForm'
 
 export const BillingCustomerData = () => {
   const { slug } = useParams()
+  const queryClient = useQueryClient()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
 
   const { can: canReadBillingCustomerData, isSuccess: isPermissionsLoaded } =
@@ -91,6 +94,19 @@ export const BillingCustomerData = () => {
         await updateTaxId({ slug, taxId: data.tax_id })
 
         toast.success('Successfully updated billing data')
+
+        // Optimistically update organization_missing_tax_id in the cached organizations list
+        // so the TaxIdBanner hides immediately. The server responds 304 Not Modified for a
+        // while after the tax ID is saved, so invalidation/refetch won't work here.
+        queryClient.setQueriesData<any[]>(
+          { queryKey: organizationKeys.list(), exact: true },
+          (prev) => {
+            if (!prev) return prev
+            return prev.map((org) =>
+              org.slug === slug ? { ...org, organization_missing_tax_id: data.tax_id == null } : org
+            )
+          }
+        )
 
         setIsSubmitting(false)
       } catch (error: any) {

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -21,7 +21,11 @@ export const TaxIdBanner = () => {
   )
 
   const shouldFetch =
-    !!slug && org?.plan?.id !== 'free' && isDismissLoaded && !isDismissed && !!org?.organization_missing_tax_id
+    !!slug &&
+    org?.plan?.id !== 'free' &&
+    isDismissLoaded &&
+    !isDismissed &&
+    !!org?.organization_missing_tax_id
 
   const { data: customerProfile } = useOrganizationCustomerProfileQuery(
     { slug },

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -1,11 +1,14 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { useRouter } from 'next/router'
 
+import { TAX_IDS } from '@/components/interfaces/Organization/BillingSettings/BillingCustomerData/TaxID.constants'
 import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
-import { useOrganizationTaxIdQuery } from 'data/organizations/organization-tax-id-query'
+import { useOrganizationCustomerProfileQuery } from 'data/organizations/organization-customer-profile-query'
+
+const SUPPORTED_TAX_ID_COUNTRIES = new Set(TAX_IDS.map((t) => t.countryIso2))
 
 export const TaxIdBanner = () => {
   const router = useRouter()
@@ -17,22 +20,25 @@ export const TaxIdBanner = () => {
     false
   )
 
-  const { data: taxId, isSuccess: isTaxIdLoaded } = useOrganizationTaxIdQuery(
+  const shouldFetch =
+    !!slug && org?.plan?.id !== 'free' && isDismissLoaded && !isDismissed && !!org?.organization_missing_tax_id
+
+  const { data: customerProfile } = useOrganizationCustomerProfileQuery(
     { slug },
-    {
-      enabled: !!slug && org?.plan?.id !== 'free' && isDismissLoaded && !isDismissed,
-      staleTime: 1000 * 60 * 30,
-    }
+    { enabled: shouldFetch, staleTime: 1000 * 60 * 30 }
   )
+
+  const billingCountry = customerProfile?.address?.country
+  const hasSupportedTaxId = !!billingCountry && SUPPORTED_TAX_ID_COUNTRIES.has(billingCountry)
 
   if (
     router.pathname.includes('sign-in') ||
     !org ||
     org.plan?.id === 'free' ||
-    !isTaxIdLoaded ||
     !isDismissLoaded ||
-    taxId ||
-    isDismissed
+    isDismissed ||
+    !org.organization_missing_tax_id ||
+    !hasSupportedTaxId
   ) {
     return null
   }

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -1,0 +1,51 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useRouter } from 'next/router'
+
+import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
+import { InlineLink } from '@/components/ui/InlineLink'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useOrganizationTaxIdQuery } from 'data/organizations/organization-tax-id-query'
+
+export const TaxIdBanner = () => {
+  const router = useRouter()
+  const { data: org } = useSelectedOrganizationQuery()
+  const slug = org?.slug
+
+  const { data: taxId, isSuccess: isTaxIdLoaded } = useOrganizationTaxIdQuery(
+    { slug },
+    { enabled: !!slug && org?.plan?.id !== 'free', staleTime: 1000 * 60 * 30 }
+  )
+
+  const [isDismissed, setIsDismissed, { isSuccess: isDismissLoaded }] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.TAX_ID_BANNER_DISMISSED(slug ?? ''),
+    false
+  )
+
+  if (
+    router.pathname.includes('sign-in') ||
+    !org ||
+    org.plan?.id === 'free' ||
+    !isTaxIdLoaded ||
+    !isDismissLoaded ||
+    taxId ||
+    isDismissed
+  ) {
+    return null
+  }
+
+  return (
+    <HeaderBanner
+      variant="note"
+      title="Add a Tax ID to your organization"
+      description={
+        <>
+          If you are a registered business, please{' '}
+          <InlineLink href={`/org/${slug}/billing#address`}>add a Tax ID</InlineLink> to your billing
+          settings. Not applicable for individual users.
+        </>
+      }
+      onDismiss={() => setIsDismissed(true)}
+    />
+  )
+}

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -12,14 +12,17 @@ export const TaxIdBanner = () => {
   const { data: org } = useSelectedOrganizationQuery()
   const slug = org?.slug
 
-  const { data: taxId, isSuccess: isTaxIdLoaded } = useOrganizationTaxIdQuery(
-    { slug },
-    { enabled: !!slug && org?.plan?.id !== 'free', staleTime: 1000 * 60 * 30 }
-  )
-
   const [isDismissed, setIsDismissed, { isSuccess: isDismissLoaded }] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.TAX_ID_BANNER_DISMISSED(slug ?? ''),
     false
+  )
+
+  const { data: taxId, isSuccess: isTaxIdLoaded } = useOrganizationTaxIdQuery(
+    { slug },
+    {
+      enabled: !!slug && org?.plan?.id !== 'free' && !isDismissed,
+      staleTime: 1000 * 60 * 30,
+    }
   )
 
   if (

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -41,8 +41,8 @@ export const TaxIdBanner = () => {
       description={
         <>
           If you are a registered business, please{' '}
-          <InlineLink href={`/org/${slug}/billing#address`}>add a Tax ID</InlineLink> to your billing
-          settings. Not applicable for individual users.
+          <InlineLink href={`/org/${slug}/billing#address`}>add a Tax ID</InlineLink> to your
+          billing settings. Not applicable for individual users.
         </>
       }
       onDismiss={() => setIsDismissed(true)}

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -20,7 +20,7 @@ export const TaxIdBanner = () => {
   const { data: taxId, isSuccess: isTaxIdLoaded } = useOrganizationTaxIdQuery(
     { slug },
     {
-      enabled: !!slug && org?.plan?.id !== 'free' && !isDismissed,
+      enabled: !!slug && org?.plan?.id !== 'free' && isDismissLoaded && !isDismissed,
       staleTime: 1000 * 60 * 30,
     }
   )

--- a/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
@@ -71,8 +71,6 @@ export const useOrganizationTaxIdUpdateMutation = ({
 
       // We already have the data, no need to refetch
       queryClient.setQueryData(organizationKeys.taxId(slug), data.tax_id)
-      // Invalidate the organizations list so organization_missing_tax_id is refreshed
-      await invalidateOrganizationsQuery(queryClient)
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { del, handleError, put } from 'data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
 import { organizationKeys } from './keys'
+import { invalidateOrganizationsQuery } from './organizations-query'
 
 export type OrganizationTaxIdUpdateVariables = {
   slug?: string
@@ -70,6 +71,8 @@ export const useOrganizationTaxIdUpdateMutation = ({
 
       // We already have the data, no need to refetch
       queryClient.setQueryData(organizationKeys.taxId(slug), data.tax_id)
+      // Invalidate the organizations list so organization_missing_tax_id is refreshed
+      await invalidateOrganizationsQuery(queryClient)
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -103,6 +103,10 @@ export const LOCAL_STORAGE_KEYS = {
 
   // Observability banner dismissed
   OBSERVABILITY_BANNER_DISMISSED: (ref: string) => `observability-banner-dismissed-${ref}`,
+
+  // Tax ID banner dismissed
+  TAX_ID_BANNER_DISMISSED: (slug: string) => `tax-id-banner-dismissed-${slug}`,
+
   TABLE_EDITOR_NEW_FILTER_BANNER_DISMISSED: (ref: string) =>
     `table-editor-new-filter-banner-dismissed-${ref}`,
 


### PR DESCRIPTION
### Changes
- Adds a dismissible banner prompting paid org users to add a Tax ID to their billing settings
- Only shown to users with billing read permissions on orgs with a paid plan and no Tax ID set
- Dismissal is persisted per-org via localStorage; banner also auto-hides when a Tax ID is added

### Testing
- Log in as a user with no billing permissions into a Free Plan Org with no tax id: no banner is shown
- Log in as a user with billing permissions into a Free Plan Org with no tax id: no banner is shown
- Log in as a user with billing permissions into a Paid Plan Org with no tax id
- Assert banner appears at the top
- Head to `/org/_/billing` with a paid Org. Change your billing country to a not support one (like Paraguay) and click save. Assert that the banner disappears. Change it back to continue testing.
- Click dismiss: banner disappears and stays dismissed across navigation/refresh
- Log in as a user with billing permissions into a different Paid Plan Org with no tax id
- Add a Tax ID via billing settings, assert that the banner disappears immediately

<img width="1911" height="50" alt="image" src="https://github.com/user-attachments/assets/d6208d6d-0939-4ff6-9613-5c687e7c622e" />