### PR TITLE
chore: add copy button to project reference custom domain flow, add n…

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
@@ -72,15 +72,6 @@ export const CustomDomainsConfigureHostname = () => {
 
   const domain = form.watch('domain')
   const trimmedDomain = domain.trim()
-  const subdomainLabel = (() => {
-    if (trimmedDomain.length === 0) return undefined
-
-    const labels = trimmedDomain.split('.').filter(Boolean)
-    if (labels.length === 0) return undefined
-    if (labels.length <= 2) return labels[0]
-
-    return labels.slice(0, -2).join('.')
-  })()
   const isSubmitting = isCheckingRecord || isCreating
 
   return (
@@ -138,17 +129,18 @@ export const CustomDomainsConfigureHostname = () => {
               with as low a TTL as possible. If you're using Cloudflare as your DNS provider,
               disable the proxy option.
               <br />
-              Some DNS providers expect only the subdomain label{' '}
-              {subdomainLabel !== undefined && (
+              {trimmedDomain.includes('.') ? (
                 <>
-                  <code className="text-code-inline">{subdomainLabel}</code>{' '}
+                  Some DNS providers expect only the subdomain label{' '}
+                  <code className="text-code-inline">
+                    {trimmedDomain.split('.')[0]}
+                  </code>
+                  , while others accept the full hostname{' '}
+                  <code className="text-code-inline">{trimmedDomain}</code>.
                 </>
+              ) : (
+                'Some DNS providers expect only the subdomain label, while others accept the full hostname.'
               )}
-              while others accept the full hostname{' '}
-              {trimmedDomain.length > 0 && (
-                <code className="text-code-inline">{trimmedDomain}</code>
-              )}
-              .
             </p>
           </CardContent>
 

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
+import CopyButton from 'components/ui/CopyButton'
 import { DocsButton } from 'components/ui/DocsButton'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCheckCNAMERecordMutation } from 'data/custom-domains/check-cname-mutation'
@@ -70,6 +71,15 @@ export const CustomDomainsConfigureHostname = () => {
   }
 
   const domain = form.watch('domain')
+  const trimmedDomain = domain.trim()
+  const subdomainLabel = (() => {
+    if (trimmedDomain.length === 0) return undefined
+
+    const labels = trimmedDomain.split('.').filter(Boolean)
+    if (labels.length <= 2) return labels[0] ?? 'api'
+
+    return labels.slice(0, -2).join('.')
+  })()
   const isSubmitting = isCheckingRecord || isCreating
 
   return (
@@ -112,12 +122,25 @@ export const CustomDomainsConfigureHostname = () => {
               {domain ? <code className="text-code-inline">{domain}</code> : 'your custom domain'}{' '}
               resolving to{' '}
               {endpoint ? (
-                <code className="text-code-inline">{endpoint}</code>
+                <span className="inline-flex items-center gap-x-1">
+                  <code className="text-code-inline">{endpoint}</code>
+                  <CopyButton iconOnly type="default" className="px-1" text={endpoint} />
+                </span>
               ) : (
                 "your project's API URL"
               )}{' '}
               with as low a TTL as possible. If you're using Cloudflare as your DNS provider,
-              disable the proxy option.
+              disable the proxy option. Some DNS providers expect only the subdomain label{' '}
+              {subdomainLabel !== undefined && (
+                <>
+                  <code className="text-code-inline">{subdomainLabel}</code>{' '}
+                </>
+              )}
+              while others accept the full hostname{' '}
+              {trimmedDomain.length > 0 && (
+                <code className="text-code-inline">{trimmedDomain}</code>
+              )}
+              .
             </p>
           </CardContent>
 

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
@@ -132,11 +132,9 @@ export const CustomDomainsConfigureHostname = () => {
               {trimmedDomain.includes('.') ? (
                 <>
                   Some DNS providers expect only the subdomain label{' '}
-                  <code className="text-code-inline">
-                    {trimmedDomain.split('.')[0]}
-                  </code>
-                  , while others accept the full hostname{' '}
-                  <code className="text-code-inline">{trimmedDomain}</code>.
+                  <code className="text-code-inline">{trimmedDomain.split('.')[0]}</code>, while
+                  others accept the full hostname{' '}
+                  <code className="text-code-inline whitespace-nowrap">{trimmedDomain}</code>.
                 </>
               ) : (
                 'Some DNS providers expect only the subdomain label, while others accept the full hostname.'

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
@@ -76,7 +76,8 @@ export const CustomDomainsConfigureHostname = () => {
     if (trimmedDomain.length === 0) return undefined
 
     const labels = trimmedDomain.split('.').filter(Boolean)
-    if (labels.length <= 2) return labels[0] ?? 'api'
+    if (labels.length === 0) return undefined
+    if (labels.length <= 2) return labels[0]
 
     return labels.slice(0, -2).join('.')
   })()
@@ -124,13 +125,20 @@ export const CustomDomainsConfigureHostname = () => {
               {endpoint ? (
                 <span className="inline-flex items-center gap-x-1">
                   <code className="text-code-inline">{endpoint}</code>
-                  <CopyButton iconOnly type="default" className="px-1" text={endpoint} />
+                  <CopyButton
+                    iconOnly
+                    type="text"
+                    className="h-5 w-5 min-w-0 p-0 [&_svg]:h-3 [&_svg]:w-3"
+                    text={endpoint}
+                  />
                 </span>
               ) : (
                 "your project's API URL"
               )}{' '}
               with as low a TTL as possible. If you're using Cloudflare as your DNS provider,
-              disable the proxy option. Some DNS providers expect only the subdomain label{' '}
+              disable the proxy option.
+              <br />
+              Some DNS providers expect only the subdomain label{' '}
               {subdomainLabel !== undefined && (
                 <>
                   <code className="text-code-inline">{subdomainLabel}</code>{' '}


### PR DESCRIPTION
…ote on subdomain

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature 

## What is the current behavior?

<img width="697" height="305" alt="CleanShot 2026-03-10 at 09 59 59" src="https://github.com/user-attachments/assets/7105c136-bffc-49e3-afaf-e6f49a2d4f12" />

## What is the new behavior?
- The endpoint value in the CNAME setup instructions can now be copied with a single click. 
- Also adds a note clarifying that some DNS providers expect only the subdomain label while others accept the full hostname.


https://github.com/user-attachments/assets/8e80ad33-b100-4313-9375-7c43b43c6254

