### PR TITLE
fix(studio): skip empty SQL execution when saving Data API settings

### DIFF
--- a/apps/studio/data/privileges/update-exposed-entities-mutation.ts
+++ b/apps/studio/data/privileges/update-exposed-entities-mutation.ts
@@ -41,6 +41,8 @@ export async function updateExposedEntities({
     sqlParts.push(buildFunctionPrivilegesSql(functionNamesToRemove, 'revoke'))
   }
 
+  if (sqlParts.length === 0) return
+
   await executeSql({
     projectRef,
     connectionString,


### PR DESCRIPTION
When saving Data API settings with only max rows changes (no table/function privilege changes), updateExposedEntities sent an empty string to pg-meta/query which failed server-side validation with 'String must contain at least 1 character(s)'. Early return when there are no SQL parts to execute.

