### PR TITLE
fix(assistant): use extractTextOnly in conciseness scorer

### DIFF
--- a/apps/studio/evals/scorer.ts
+++ b/apps/studio/evals/scorer.ts
@@ -117,7 +117,7 @@ export const concisenessScorer: EvalScorer<
 > = async ({ input, output }) => {
   return await concisenessEvaluator({
     input: input.prompt,
-    output: serializeSteps(output.steps),
+    output: extractTextOnly(output.steps),
   })
 }
 


### PR DESCRIPTION
`concisenessScorer` was passing full serialized text + tool calls JSON to the LLM judge (SQL queries, GraphQL payloads, etc.). Switches to `extractTextOnly` so the judge only evaluates text the user actually sees.

Prerequisite for https://github.com/supabase/supabase/pull/43613 to set a fair conciseness baseline score.

Ref AI-402