### PR TITLE
docs: comment out Kong ports key in reverse proxy HTTPS guide

### DIFF
--- a/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
@@ -38,9 +38,9 @@ Comment out Kong's host port mappings in `docker-compose.yml` so that it's not e
 ```yaml
 kong:
   # ...
-  ports:
-    # - ${KONG_HTTP_PORT}:8000/tcp
-    # - ${KONG_HTTPS_PORT}:8443/tcp
+  # ports:
+  #   - ${KONG_HTTP_PORT}:8000/tcp
+  #   - ${KONG_HTTPS_PORT}:8443/tcp
 ```
 
 Kong remains accessible to other containers on the internal Docker network.


### PR DESCRIPTION
## Summary
- Comment out the ports key itself in the reverse proxy guide snippet
- Keep port mapping lines commented under it

## Why
The existing snippet comments only the list entries but leaves ports active, which can produce:
services.kong.ports must be a array
when users follow the guide literally.

## Reference
- Closes #43567