### PR TITLE
fix(common): resolve double-encoding in first-referrer cookie serialization

### DIFF
--- a/packages/common/first-referrer-cookie.test.ts
+++ b/packages/common/first-referrer-cookie.test.ts
@@ -111,6 +111,20 @@ describe('first-referrer-cookie', () => {
       expect(parseFirstReferrerCookie(`${FIRST_REFERRER_COOKIE_NAME}=${encoded}`)).toBeNull()
     })
 
+    it('parses double-encoded cookies (legacy format before serializer fix)', () => {
+      const input = buildFirstReferrerData({
+        referrer: 'https://www.google.com/',
+        landingUrl: 'https://supabase.com/pricing?utm_source=google',
+      })
+
+      // Simulate the old double-encoding: encodeURIComponent(JSON.stringify(data))
+      // followed by Next.js cookies.set() encoding it again.
+      const doubleEncoded = encodeURIComponent(encodeURIComponent(JSON.stringify(input)))
+      const parsed = parseFirstReferrerCookie(`${FIRST_REFERRER_COOKIE_NAME}=${doubleEncoded}`)
+
+      expect(parsed).toEqual(input)
+    })
+
     it('drops non-string values in utms/click_ids', () => {
       const encoded = encodeURIComponent(
         JSON.stringify({

--- a/packages/common/first-referrer-cookie.ts
+++ b/packages/common/first-referrer-cookie.ts
@@ -174,7 +174,7 @@ export function buildFirstReferrerData({
 // ---------------------------------------------------------------------------
 
 export function serializeFirstReferrerCookie(data: FirstReferrerData): string {
-  return encodeURIComponent(JSON.stringify(data))
+  return JSON.stringify(data)
 }
 
 // ---------------------------------------------------------------------------
@@ -319,7 +319,18 @@ export function parseFirstReferrerCookie(cookieHeader: string): FirstReferrerDat
     if (!match) return null
 
     const value = match.slice(`${FIRST_REFERRER_COOKIE_NAME}=`.length)
-    const parsed = JSON.parse(decodeURIComponent(value)) as unknown
+    const decoded = decodeURIComponent(value)
+    // Handle double-encoded cookies from before the serializer fix.
+    // Next.js cookies.set() encodes automatically, but serializeFirstReferrerCookie
+    // previously called encodeURIComponent too, producing double-encoded values.
+    let jsonString: string
+    try {
+      JSON.parse(decoded)
+      jsonString = decoded
+    } catch {
+      jsonString = decodeURIComponent(decoded)
+    }
+    const parsed = JSON.parse(jsonString) as unknown
 
     if (!parsed || typeof parsed !== 'object') return null
 


### PR DESCRIPTION
## Problem

While working on the phased PostHog Attribution rollout (GROWTH-625 / GROWTH-668) — specifically the initial referrer handoff across the app boundary — we discovered that `parseFirstReferrerCookie` was returning `null` even when the cookie was visibly present in the browser.

The root cause: `serializeFirstReferrerCookie` calls `encodeURIComponent(JSON.stringify(data))`, but Next.js `cookies.set()` encodes the value again, producing a double-encoded cookie. On the read side, `parseFirstReferrerCookie` only decodes once, so `JSON.parse` receives a still-encoded string and fails. The `try/catch` swallows the error and returns `null`.

Confirmed in production: the raw cookie value starts with `%257B%2522` (double-encoded `%` characters). A single `decodeURIComponent` produces `%7B%22referrer%22...` — still URL-encoded, not valid JSON. This was blocking the cross-app attribution handoff that GROWTH-625 depends on.

## Changes

- **Serializer**: Removed `encodeURIComponent` from `serializeFirstReferrerCookie` — Next.js `cookies.set()` already handles encoding
- **Parser**: Made `parseFirstReferrerCookie` resilient to both encodings — tries single decode first, falls back to double decode for existing cookies in the wild (365-day TTL means legacy cookies persist up to a year)
- **Test**: Added unit test for the double-encoded legacy cookie format

## Testing

- 35/35 common unit tests pass, 12/12 www middleware tests pass
- Verified locally: Google → www (localhost:3000) → Studio (localhost:8082). Console logs confirmed `parseFirstReferrerCookie` returned the full data object instead of null
- Confirmed in production that existing cookies are double-encoded and the fix correctly handles them

Ref: GROWTH-625 / GROWTH-668