### PR TITLE
[FE-2738] fix(studio): use read replica identifier in table rows keys

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.utils.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.utils.tsx
@@ -38,20 +38,21 @@ export function useOnRowsChange(rows: SupaRow[]) {
       const previousRowsQueries = queryClient.getQueriesData<TableRowsData>({ queryKey })
 
       queryClient.setQueriesData<TableRowsData>({ queryKey }, (old) => {
-        return {
-          rows:
-            old?.rows.map((row) => {
-              // match primary keys
-              if (
-                Object.entries(row)
-                  .filter(([key]) => primaryKeyColumns.has(key))
-                  .every(([key, value]) => value === configuration.identifiers[key])
-              ) {
-                return { ...row, ...payload }
-              }
+        if (!old) return old
 
-              return row
-            }) ?? [],
+        return {
+          rows: old.rows.map((row) => {
+            // match primary keys
+            if (
+              Object.entries(row)
+                .filter(([key]) => primaryKeyColumns.has(key))
+                .every(([key, value]) => value === configuration.identifiers[key])
+            ) {
+              return { ...row, ...payload }
+            }
+
+            return row
+          }),
         }
       })
 

--- a/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
@@ -22,6 +22,7 @@ interface PrefetchEditorTablePageArgs {
   queryClient: QueryClient
   projectRef: string
   connectionString?: string | null
+  readReplicaIdentifier?: string
   id: number
   sorts?: Sort[]
   filters?: Filter[]
@@ -32,6 +33,7 @@ export function prefetchEditorTablePage({
   queryClient,
   projectRef,
   connectionString,
+  readReplicaIdentifier,
   id,
   sorts,
   filters,
@@ -51,6 +53,7 @@ export function prefetchEditorTablePage({
       prefetchTableRows(queryClient, {
         projectRef,
         connectionString,
+        readReplicaIdentifier,
         tableId: id,
         sorts: sorts ?? formatSortURLParams(supaTable.name, localSorts),
         filters: filters ?? formatFilterURLParams(localFilters),
@@ -66,7 +69,7 @@ export function usePrefetchEditorTablePage() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const { data: project } = useSelectedProjectQuery()
-  const { connectionString } = useConnectionStringForReadOps()
+  const { connectionString, identifier: readReplicaIdentifier } = useConnectionStringForReadOps()
   const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
   return useCallback(
@@ -82,6 +85,7 @@ export function usePrefetchEditorTablePage() {
         queryClient,
         projectRef: project.ref,
         connectionString,
+        readReplicaIdentifier,
         id,
         sorts,
         filters,
@@ -90,7 +94,7 @@ export function usePrefetchEditorTablePage() {
         // eat prefetching errors as they are not critical
       })
     },
-    [connectionString, project, queryClient, roleImpersonationState, router]
+    [connectionString, readReplicaIdentifier, project, queryClient, roleImpersonationState, router]
   )
 }
 

--- a/apps/studio/data/table-rows/table-rows-count-query.ts
+++ b/apps/studio/data/table-rows/table-rows-count-query.ts
@@ -82,23 +82,25 @@ export async function getTableRowsCount(
 export const useTableRowsCountQuery = <TData = TableRowsCountData>(
   {
     projectRef,
-    connectionString: connectionStringOverride,
     tableId,
     ...args
-  }: Omit<TableRowsCountVariables, 'queryClient'>,
+  }: Omit<TableRowsCountVariables, 'queryClient' | 'connectionString'>,
   {
     enabled = true,
     ...options
   }: UseCustomQueryOptions<TableRowsCountData, TableRowsCountError, TData> = {}
 ) => {
   const queryClient = useQueryClient()
-  const { connectionString: connectionStringReadOps, type } = useConnectionStringForReadOps()
-  const connectionString = connectionStringOverride || connectionStringReadOps
+  const {
+    connectionString,
+    identifier: readReplicaIdentifier,
+    type,
+  } = useConnectionStringForReadOps()
 
   return useQuery<TableRowsCountData, TableRowsCountError, TData>({
     queryKey: tableRowKeys.tableRowsCount(projectRef, {
       table: { id: tableId },
-      connectionString,
+      readReplicaIdentifier,
       ...args,
     }),
     queryFn: ({ signal }) =>

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -391,17 +391,11 @@ async function getTableRows(
 }
 
 export const useTableRowsQuery = <TData = TableRowsData>(
-  {
-    projectRef,
-    connectionString: connectionStringOverride,
-    tableId,
-    ...args
-  }: Omit<TableRowsVariables, 'queryClient'>,
+  { projectRef, tableId, ...args }: Omit<TableRowsVariables, 'queryClient' | 'connectionString'>,
   { enabled = true, ...options }: UseCustomQueryOptions<TableRowsData, TableRowsError, TData> = {}
 ) => {
   const queryClient = useQueryClient()
-  const { connectionString: connectionStringReadOps } = useConnectionStringForReadOps()
-  const connectionString = connectionStringOverride || connectionStringReadOps
+  const { connectionString, identifier: readReplicaIdentifier } = useConnectionStringForReadOps()
 
   // [Joshen] Exclude preflightCheck from query key
   const { preflightCheck, ...othersArgs } = args
@@ -409,7 +403,7 @@ export const useTableRowsQuery = <TData = TableRowsData>(
   return useQuery<TableRowsData, TableRowsError, TData>({
     queryKey: tableRowKeys.tableRows(projectRef, {
       table: { id: tableId },
-      connectionString,
+      readReplicaIdentifier,
       ...othersArgs,
     }),
     queryFn: ({ signal }) =>
@@ -423,14 +417,25 @@ export const useTableRowsQuery = <TData = TableRowsData>(
   })
 }
 
+type PrefetchTableRowsVariables = Omit<TableRowsVariables, 'queryClient'> & {
+  readReplicaIdentifier?: string
+}
+
 export function prefetchTableRows(
   client: QueryClient,
-  { projectRef, connectionString, tableId, ...args }: Omit<TableRowsVariables, 'queryClient'>
+  {
+    projectRef,
+    connectionString,
+    tableId,
+    readReplicaIdentifier,
+    ...args
+  }: PrefetchTableRowsVariables
 ) {
   return client.fetchQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- readReplicaIdentifier is used as a stable version of connectionString
     queryKey: tableRowKeys.tableRows(projectRef, {
       table: { id: tableId },
-      connectionString,
+      readReplicaIdentifier,
       ...args,
     }),
     queryFn: ({ signal }) =>


### PR DESCRIPTION
Previously `connectionString` was passed into the query key for `table-rows`. Since `connectionString` is unstable, it would cause the query key to change randomly, often making the user experience brief random "no rows found" states while data loaded for the new key.

This PR uses `readReplicaIdentifier` as a stable version of `connectionString`, maintaining the existing functionality while avoiding the unnecessary data reloads.

Note that there are still quite a few places where `connectionString` is passed into the query key. We'll fix these as follow up PRs.

I'm opting to also include the fix from https://github.com/supabase/supabase/pull/43572 in here for consistency.

**To test:**
- Ensure table editor functions normally
- Use the table editor with a read replica selected