### PR TITLE
fix: improve table editor truncated texts display

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -177,11 +177,12 @@ const ColumnType = ({
             aria-controls={listboxId}
             className={cn('w-full justify-between', !value && 'text-foreground-lighter')}
             iconRight={<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />}
+            title={value && value.replaceAll('"', '')}
           >
             {value ? (
               <div className="flex gap-2 items-center">
                 <span>{inferIcon(getOptionByName(value)?.type ?? '')}</span>
-                {value.replaceAll('"', '')}
+                <span className="block truncate">{value.replaceAll('"', '')}</span>
               </div>
             ) : (
               'Choose a column type...'

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -92,6 +92,7 @@ const InputWithSuggestions = ({
         inputClassName="pr-10"
         type="text"
         value={value}
+        title={value}
         onChange={onInputChange}
         data-testid={dataTestId}
         actions={

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -337,7 +337,7 @@ export const TableEditor = ({
   return (
     <SidePanel
       data-testid="table-editor-side-panel"
-      size="large"
+      size="xlarge"
       key="TableEditor"
       visible={visible}
       header={<HeaderTitle schema={selectedSchema} table={table} isDuplicating={isDuplicating} />}


### PR DESCRIPTION
Fixes #41579
Supersedes #42342 and #41580

## Problem

In the table editor, when the column type is long, it is truncated which makes it hard to disambiguate `timestamp` from `timestampz` for instance.

<img width="1310" height="360" alt="image" src="https://github.com/user-attachments/assets/668b4022-944e-4d10-90b6-8b5173ec45e3" />

## Solution

- make the table editor a bit larger
- add a tooltip on the column type input
- I also added a tooltip on the default value input which suffers from the same issue

Note: the column name already have a tooltip

<img width="623" height="418" alt="image" src="https://github.com/user-attachments/assets/9aa5bc10-d627-42ee-b91a-1f8d83911ee0" />

<img width="640" height="357" alt="image" src="https://github.com/user-attachments/assets/c6af4780-8308-4073-bf5c-937ff5822884" />
