### PR TITLE
fix: removed deprecated mutable object ref

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/RLSCodeEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/RLSCodeEditor.tsx
@@ -1,7 +1,7 @@
 import Editor, { Monaco, OnChange, OnMount, useMonaco } from '@monaco-editor/react'
 import { noop } from 'lodash'
 import type { editor } from 'monaco-editor'
-import { MutableRefObject, useEffect, useRef } from 'react'
+import { RefObject, useEffect, useRef } from 'react'
 import { cn } from 'ui'
 
 import { Markdown } from 'components/interfaces/Markdown'
@@ -26,8 +26,8 @@ interface RLSCodeEditorProps {
   onChange?: () => void
   onMount?: () => void
 
-  editorRef: MutableRefObject<editor.IStandaloneCodeEditor | null>
-  monacoRef?: MutableRefObject<Monaco>
+  editorRef: RefObject<editor.IStandaloneCodeEditor | null>
+  monacoRef?: RefObject<Monaco>
 }
 
 export const RLSCodeEditor = ({

--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -1,6 +1,6 @@
 import Editor, { Monaco, OnMount } from '@monaco-editor/react'
 import { useRouter } from 'next/router'
-import { MutableRefObject, useEffect, useRef, useState } from 'react'
+import { RefObject, useEffect, useRef, useState } from 'react'
 
 import { useDebounce } from '@uidotdev/usehooks'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
@@ -21,8 +21,8 @@ export type MonacoEditorProps = {
   id: string
   snippetName: string
   className?: string
-  editorRef: MutableRefObject<IStandaloneCodeEditor | null>
-  monacoRef: MutableRefObject<Monaco | null>
+  editorRef: RefObject<IStandaloneCodeEditor | null>
+  monacoRef: RefObject<Monaco | null>
   autoFocus?: boolean
   executeQuery: () => void
   onHasSelection: (value: boolean) => void

--- a/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
+++ b/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
@@ -1,7 +1,7 @@
 import Editor, { EditorProps, Monaco, OnChange, OnMount, useMonaco } from '@monaco-editor/react'
 import { merge, noop } from 'lodash'
 import type { editor } from 'monaco-editor'
-import { MutableRefObject, useEffect, useRef, useState } from 'react'
+import { RefObject, useEffect, useRef, useState } from 'react'
 
 import { Markdown } from 'components/interfaces/Markdown'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
@@ -39,7 +39,7 @@ interface CodeEditorProps {
     explainCode: CodeEditorActions
     closeAssistant: CodeEditorActions
   }>
-  editorRef?: MutableRefObject<editor.IStandaloneCodeEditor | undefined>
+  editorRef?: RefObject<editor.IStandaloneCodeEditor | undefined>
   onInputChange?: (value?: string) => void
 }
 

--- a/apps/studio/components/ui/DataTable/hooks/useComposedRefs.ts
+++ b/apps/studio/components/ui/DataTable/hooks/useComposedRefs.ts
@@ -1,4 +1,4 @@
-import { Ref, useCallback } from 'react'
+import { Ref, RefObject, useCallback } from 'react'
 
 type PossibleRef<T> = Ref<T> | undefined
 
@@ -10,7 +10,7 @@ function setRef<T>(ref: PossibleRef<T>, value: T) {
   if (typeof ref === 'function') {
     ref(value)
   } else if (ref !== null && ref !== undefined) {
-    ;(ref as React.MutableRefObject<T>).current = value
+    ;(ref as RefObject<T>).current = value
   }
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Components in the studio were using a deprecated mutable object ref pattern which could lead to stale or unexpected ref behavior across editor components and hooks.

## What is the new behavior?

The commit removes the deprecated mutable object ref usage and standardizes ref handling via a composed/ref-forwarding approach (updates in `useComposedRefs`). This stabilizes refs for the various editor components and the DataTable hook.

[View GitHub issue here](https://github.com/supabase/supabase/issues/43637)
