### PR TITLE
feat(studio): add /api/status-override endpoint for status page banner override

### DIFF
--- a/apps/studio/pages/api/status-override.ts
+++ b/apps/studio/pages/api/status-override.ts
@@ -1,0 +1,19 @@
+import { IS_PLATFORM } from 'common'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+type ResponseData = { enabled: boolean }
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
+  if (!IS_PLATFORM) {
+    return res.status(404).end()
+  }
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).end()
+  }
+
+  return res.status(200).json({
+    enabled: process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true',
+  })
+}

--- a/apps/studio/proxy.ts
+++ b/apps/studio/proxy.ts
@@ -25,6 +25,7 @@ const HOSTED_SUPPORTED_API_URLS = [
   '/edge-functions/body',
   '/generate-attachment-url',
   '/incident-status',
+  '/status-override',
   '/api/integrations/stripe-sync',
   '/content/graphql',
 ]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

New feature — adds a platform-only API endpoint to Studio.

## What is the current behavior?

`NEXT_PUBLIC_ONGOING_INCIDENT` is not exposed outside of the dashboard.

## What is the new behavior?

`GET /api/status-override` returns `{ enabled: boolean }` indicating whether `NEXT_PUBLIC_ONGOING_INCIDENT` is set to `"true"`. The endpoint returns 404 on self-hosted and is added to the proxy allowlist for hosted platform access.

This is so that the incident banner bot can detect whether an override is in place.

## Additional context