### PR TITLE
fix vector product link

### DIFF
--- a/apps/www/components/MagnifiedProducts.tsx
+++ b/apps/www/components/MagnifiedProducts.tsx
@@ -1,18 +1,15 @@
-import { useRef } from 'react'
-import Link from 'next/link'
+import { DEFAULT_TRANSITION } from '~/lib/animations'
+import { useBreakpoint } from 'common'
 import {
-  MotionValue,
   motion,
+  MotionValue,
   useInView,
   useMotionValue,
   useSpring,
   useTransform,
 } from 'framer-motion'
-import { useBreakpoint } from 'common'
-import { Products } from './Sections/ProductsCta'
-import { cn } from 'ui'
-
-import { DEFAULT_TRANSITION } from '~/lib/animations'
+import Link from 'next/link'
+import { useRef } from 'react'
 import {
   PRODUCT_MODULES,
   PRODUCT_MODULES_NAMES,
@@ -21,6 +18,9 @@ import {
   PRODUCT_SHORTNAMES,
   products as PRODUCTS,
 } from 'shared-data/products'
+import { cn } from 'ui'
+
+import { Products } from './Sections/ProductsCta'
 
 function MagnifiedProducts({ currentProduct }: { currentProduct: Products | string }) {
   let mouseX = useMotionValue(Infinity)
@@ -174,7 +174,7 @@ const products = {
     description: 'Integrate your favorite ML-models to store, index and search vector embeddings.',
     description_short: '',
     label: '',
-    url: '/vector',
+    url: '/modules/vector',
   },
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the Vector button on the bottom of https://supabase.com/edge-functions page has an href to a non existing route

## What is the new behavior?

changed the href from /vector to /modules/vector
