### PR TITLE
fix(Docs): Use internal Tooltip, prevent hydration issues on homepage

### DIFF
--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -141,11 +141,7 @@ const HomePageCover = (props) => {
 
                 return (
                   <Link key={i} href={framework.href} passHref className="no-underline">
-                    <IconPanel
-                      iconSize={iconSize}
-                      tooltip={framework.tooltip}
-                      icon={iconToUse}
-                    />
+                    <IconPanel iconSize={iconSize} tooltip={framework.tooltip} icon={iconToUse} />
                   </Link>
                 )
               })}

--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -143,7 +143,6 @@ const HomePageCover = (props) => {
                   <Link key={i} href={framework.href} passHref className="no-underline">
                     <IconPanel
                       iconSize={iconSize}
-                      hideArrow
                       tooltip={framework.tooltip}
                       icon={iconToUse}
                     />

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -668,7 +668,6 @@
     "react-intersection-observer": "^9.8.2",
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.6.6",
-    "react-tooltip": "*",
     "react-use": "^17.5.0",
     "recharts": "catalog:",
     "remark": "^15.0.1",

--- a/packages/ui-patterns/src/IconPanel/index.tsx
+++ b/packages/ui-patterns/src/IconPanel/index.tsx
@@ -3,7 +3,7 @@
 import { ChevronRight } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import * as React from 'react'
-import ReactTooltip from 'react-tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 interface Props {
   title?: string
@@ -18,7 +18,6 @@ interface Props {
   hasLightIcon?: boolean
 
   showLink?: boolean
-  hideArrow?: boolean
 }
 
 export const IconPanel = ({
@@ -30,7 +29,6 @@ export const IconPanel = ({
   background = true,
   hasLightIcon,
   showLink = false,
-  hideArrow = false,
 }: Props) => {
   const { theme } = useTheme()
 
@@ -57,70 +55,61 @@ export const IconPanel = ({
   }
 
   return (
-    <>
-      <div className={['relative', 'group'].join(' ')} data-tip={tooltip}>
-        <div className={['peer relative', 'flex flex-col', icon ? 'gap-6' : 'gap-2'].join(' ')}>
-          <div
-            className={[
-              'flex',
-              children ? 'items-start' : 'items-center',
-              (title || !hideArrow || showLink) && 'gap-3',
-            ].join(' ')}
-          >
-            {typeof icon === 'string' ? (
-              <IconContainer>
-                <img
-                  className={iconSize === 'lg' ? 'w-8' : 'w-5'}
-                  src={`${icon}${hasLightIcon && theme !== 'dark' ? '-light' : ''}.svg`}
-                  alt={
-                    title !== undefined
-                      ? `${title} Icon`
-                      : tooltip !== undefined
-                        ? `${tooltip} Icon`
-                        : 'Icon'
-                  }
-                />
-              </IconContainer>
-            ) : (
-              <IconContainer>{icon}</IconContainer>
-            )}
-            <div className="flex flex-col gap-1">
-              <div className="flex items-center gap-3">
-                {title && <h5 className="text-base text-foreground m-0">{title}</h5>}
-                {!hideArrow && (
-                  <div
-                    className="
-                transition-all ease-out -ml-1 opacity-0
-                text-foreground-muted
-                group-hover:opacity-100
-                group-hover:ml-0"
-                  >
-                    <ChevronRight strokeWidth={2} size={14} />
-                  </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={['relative', 'group'].join(' ')} data-tip={tooltip}>
+          <div className={['peer relative', 'flex flex-col', icon ? 'gap-6' : 'gap-2'].join(' ')}>
+            <div
+              className={[
+                'flex',
+                children ? 'items-start' : 'items-center',
+                (title || showLink) && 'gap-3',
+              ].join(' ')}
+            >
+              {typeof icon === 'string' ? (
+                <IconContainer>
+                  <img
+                    className={iconSize === 'lg' ? 'w-8' : 'w-5'}
+                    src={`${icon}${hasLightIcon && theme !== 'dark' ? '-light' : ''}.svg`}
+                    alt={
+                      title !== undefined
+                        ? `${title} Icon`
+                        : tooltip !== undefined
+                          ? `${tooltip} Icon`
+                          : 'Icon'
+                    }
+                  />
+                </IconContainer>
+              ) : (
+                <IconContainer>{icon}</IconContainer>
+              )}
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-3">
+                  {title && <h5 className="text-base text-foreground m-0">{title}</h5>}
+                </div>
+                {children && (
+                  <span className="text-sm text-foreground-light not-prose">{children}</span>
+                )}
+                {showLink && (
+                  <span className="text-brand-link justify-end text-sm">Learn more</span>
                 )}
               </div>
-              {children && (
-                <span className="text-sm text-foreground-light not-prose">{children}</span>
-              )}
-              {showLink && <span className="text-brand-link justify-end text-sm">Learn more</span>}
             </div>
           </div>
-        </div>
-        <div
-          className="
+          <div
+            className="
         absolute transition-all ease-in
         -z-10 -inset-3 rounded-2xl
         bg-surface-100 opacity-0 peer-hover:opacity-100"
-        ></div>
-      </div>
+          ></div>
+        </div>
+      </TooltipTrigger>
+
       {tooltip && (
-        <ReactTooltip
-          effect="solid"
-          backgroundColor="hsl(var(--background-alternative-default))"
-          textColor="hsl(var(--foreground-light))"
-          className="!py-2 !px-4"
-        />
+        <TooltipContent side="top" className="">
+          {tooltip}
+        </TooltipContent>
       )}
-    </>
+    </Tooltip>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2680,9 +2680,6 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.6
         version: 15.6.6(react@18.3.1)
-      react-tooltip:
-        specifier: '*'
-        version: 4.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use:
         specifier: ^17.5.0
         version: 17.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16185,13 +16182,6 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
-  react-tooltip@4.5.1:
-    resolution: {integrity: sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==}
-    engines: {npm: '>=6.13'}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -18131,10 +18121,6 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     hasBin: true
 
   uuid@9.0.1:
@@ -35248,13 +35234,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
 
-  react-tooltip@4.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      uuid: 7.0.3
-
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.26.10
@@ -37627,8 +37606,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
-
-  uuid@7.0.3: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a bug fix on the Docs homepage. Current in production we can see a flicker that shows black bars under `IconPanel` components.

<img width="1501" height="863" alt="Screenshot 2026-03-06 at 15 30 24" src="https://github.com/user-attachments/assets/69fd967c-1c48-478d-a096-c0bd8f0ad5f8" />

In development, this actually stays since we rely on server rendering instead of static generation, this stays until the dev refreshes and the cache prevents this broken look.

## What is the new behavior?

The problem is within the `react-tooltip`, a package we only use in here, that seems to not support RSC situations in modern-ish React.

The solution: Use the `Tooltip` family of components we already have in our `'ui'` package. This eliminates the issue plus shows a _tooltip_ that it's actually aligned with our current visuals. The former tooltip in this icon component was quite broken.

_Current tooltip (if you wanna call that a tooltip)_
<img width="481" height="364" alt="Screenshot 2026-03-11 at 17 17 14" src="https://github.com/user-attachments/assets/517d83b6-3262-4b0f-8b0d-51351802b977" />

_Tooltip after this PR_
<img width="483" height="355" alt="Screenshot 2026-03-11 at 17 17 08" src="https://github.com/user-attachments/assets/88294657-cdfb-4678-8c37-9b2196f4155f" />
