### PR TITLE
Studio: generate documentation for dashboard SQL queries

### DIFF
--- a/apps/studio/generated/studio-sql-inventory.json
+++ b/apps/studio/generated/studio-sql-inventory.json
@@ -1,0 +1,323 @@
+[
+  {
+    "file": "data/database/database.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "getLiveTupleEstimate",
+        "sql": "SELECT n_live_tup AS live_tuple_estimate\nFROM pg_stat_user_tables\nWHERE schemaname = ${literal(schema)}\nAND relname = ${literal(table)};",
+        "analysis": {
+          "tables": [
+            "pg_stat_user_tables"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "The query getLiveTupleEstimate retrieves the current estimated number of live rows (tuples) in a specified user table within a given schema by querying PostgreSQL's statistics view pg_stat_user_tables. This helps estimate table size and activity without running a full count."
+      }
+    ]
+  },
+  {
+    "file": "data/database-cron-jobs/database-cron-jobs.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "getJobRunDetailsPageCountSql",
+        "sql": "SELECT pg_relation_size(oid) / current_setting('block_size')::int8 AS num_pages\nFROM pg_class\nWHERE relname = 'job_run_details'\n  AND relnamespace = 'cron'::regnamespace;",
+        "analysis": {
+          "tables": [
+            "pg_class"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This query retrieves the total number of disk pages used by the 'job_run_details' table within the 'cron' schema by dividing its size in bytes by the database block size. It's useful for understanding the physical storage size and page count of that specific table."
+      },
+      {
+        "name": "getDeleteOldCronJobRunDetailsByCtidSql",
+        "sql": "WITH deleted AS (\n  DELETE FROM cron.job_run_details\n  WHERE ctid >= ${safeCtidStart}::tid\n    AND ctid < ${safeCtidEnd}::tid\n    AND end_time < now() - interval ${literal(interval)}\n  RETURNING 1\n)\nSELECT count(*) as deleted_count FROM deleted;",
+        "analysis": {
+          "tables": [
+            "cron.job_run_details",
+            "deleted"
+          ],
+          "schemas": [
+            "cron"
+          ],
+          "type": "read"
+        },
+        "purpose": "This query deletes old records from the `cron.job_run_details` table within a specific CTID range where the job run has ended before a certain interval ago, and then returns the count of rows deleted. It is used to efficiently purge outdated cron job run details while tracking how many entries were removed."
+      },
+      {
+        "name": "getScheduleDeleteCronJobRunDetailsSql",
+        "sql": "SELECT cron.schedule(\n  ${literal(CRON_CLEANUP_SCHEDULE_NAME)},\n  ${literal(CRON_CLEANUP_SCHEDULE_EXPRESSION)},\n  $$DELETE FROM cron.job_run_details WHERE end_time < now() - interval ${literal(interval)}$$\n);",
+        "analysis": {
+          "tables": [
+            "cron.job_run_details"
+          ],
+          "schemas": [
+            "cron"
+          ],
+          "type": "read"
+        },
+        "purpose": "This query creates or updates a scheduled cron job named by CRON_CLEANUP_SCHEDULE_NAME that runs at the interval specified by CRON_CLEANUP_SCHEDULE_EXPRESSION to delete records from the cron.job_run_details table where the end_time is older than the given interval, helping to clean up old job run logs automatically."
+      },
+      {
+        "name": "getCronJobsMinimalSql",
+        "sql": "SELECT \n  job.jobid,\n  job.jobname,\n  job.schedule,\n  job.command,\n  job.active\nFROM \n  cron.job job\n${!!searchTerm ?",
+        "analysis": {
+          "tables": [
+            "cron.job"
+          ],
+          "schemas": [
+            "cron"
+          ],
+          "type": "read"
+        },
+        "purpose": "The `getCronJobsMinimalSql` query retrieves a minimal set of details (job ID, name, schedule, command, and active status) for cron jobs from the `cron.job` table, optionally filtering results based on a provided search term. It is used to quickly fetch essential information about scheduled jobs for display or management purposes in the dashboard."
+      },
+      {
+        "name": "getCronJobsSql",
+        "sql": "WITH latest_runs AS (\n  SELECT \n    jobid,\n    status,\n    MAX(start_time) AS latest_run\n  FROM cron.job_run_details\n  GROUP BY jobid, status\n), most_recent_runs AS (\n  SELECT \n    jobid, \n    status, \n    latest_run\n  FROM latest_runs lr1\n  WHERE latest_run = (\n    SELECT MAX(latest_run) \n    FROM latest_runs lr2 \n    WHERE lr2.jobid = lr1.jobid\n  )\n)\nSELECT \n  job.jobid,\n  job.jobname,\n  job.schedule,\n  job.command,\n  job.active,\n  mr.latest_run,\n  mr.status\nFROM \n  cron.job job\nLEFT JOIN most_recent_runs mr ON job.jobid = mr.jobid\n${!!searchTerm ?",
+        "analysis": {
+          "tables": [
+            "cron.job_run_details",
+            "latest_runs",
+            "cron.job",
+            "most_recent_runs"
+          ],
+          "schemas": [
+            "cron"
+          ],
+          "type": "read"
+        },
+        "purpose": "The getCronJobsSql query retrieves a list of all cron jobs along with their most recent run status and timestamp by joining the job metadata with the latest execution details from the job_run_details table. It helps developers and support engineers quickly see the current state and last execution time of each scheduled job for monitoring and troubleshooting purposes."
+      }
+    ]
+  },
+  {
+    "file": "data/database-extensions/database-extensions.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "getDatabaseExtensionDefaultSchemaSQL",
+        "sql": "select name, version, schema from pg_available_extension_versions where name = ${literal(extension)} limit 1;",
+        "analysis": {
+          "tables": [
+            "pg_available_extension_versions"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This query retrieves the name, version, and default schema of a specified database extension from the available extension versions in PostgreSQL. It helps identify the details of the given extension by filtering on its name and returning the first matching record."
+      }
+    ]
+  },
+  {
+    "file": "data/database-indexes/database-indexes.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "getIndexesSQL",
+        "sql": "SELECT\n  n.nspname        AS schema,\n  t.relname        AS \"table\",\n  i.relname        AS name,\n  pg_get_indexdef(idx.indexrelid) AS definition,\n  STRING_AGG(\n    COALESCE(a.attname, '(expression)'),\n    ', ' ORDER BY k.ord\n  ) AS columns\nFROM pg_index idx\nJOIN pg_class      t ON t.oid = idx.indrelid\nJOIN pg_class      i ON i.oid = idx.indexrelid\nJOIN pg_namespace  n ON n.oid = t.relnamespace\nJOIN LATERAL unnest(idx.indkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE\nLEFT JOIN pg_attribute a\n  ON a.attrelid = t.oid\n AND a.attnum   = k.attnum\nWHERE n.nspname = '${schema}'\nGROUP BY\n  n.nspname,\n  t.relname,\n  i.relname,\n  idx.indexrelid\nORDER BY\n  schema, \"table\", name;",
+        "analysis": {
+          "tables": [
+            "pg_index",
+            "pg_class",
+            "pg_namespace",
+            "LATERAL",
+            "pg_attribute"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This query retrieves detailed information about all indexes within a specified database schema, including the schema name, table name, index name, index definition, and the columns (or expressions) covered by each index. It helps developers or support engineers understand the indexing structure for performance tuning or troubleshooting."
+      }
+    ]
+  },
+  {
+    "file": "data/privileges/privileges.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": "table_privileges as (\n      select\n        c.oid::int as id,\n        n.nspname as schema_name,\n        c.relname as name,\n        c.relkind as kind,\n\n        -- Anon Privileges\n        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'SELECT') as anon_select,\n        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'INSERT') as anon_insert,\n        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'UPDATE') as anon_update,\n        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'DELETE') as anon_delete,\n\n        -- Authenticated Privileges\n        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'SELECT') as auth_select,\n        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'INSERT') as auth_insert,\n        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'UPDATE') as auth_update,\n        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'DELETE') as auth_delete,\n\n        -- Service Role Privileges\n        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'SELECT') as srv_select,\n        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'INSERT') as srv_insert,\n        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'UPDATE') as srv_update,\n        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'DELETE') as srv_delete\n\n      from pg_class c\n      join pg_namespace n\n        on n.oid = c.relnamespace\n      left join lateral aclexplode(coalesce(c.relacl, acldefault('r', c.relowner))) as acl\n        on true\n      left join pg_roles pr\n        on pr.oid = acl.grantee\n      where c.relkind in ('r', 'p', 'v', 'm', 'f')\n        and n.nspname not in (${IGNORED_SCHEMAS_LIST})\n        ${search ?",
+        "analysis": {
+          "tables": [
+            "pg_class",
+            "pg_namespace",
+            "lateral",
+            "pg_roles"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This query retrieves the access privileges (SELECT, INSERT, UPDATE, DELETE) for key roles (anon, authenticated, service_role) on database objects (tables, views, etc.) within schemas that are not in the ignored schemas list, enabling visibility into permission settings while excluding system or irrelevant schemas. It helps developers/support engineers audit and manage role-based access control for relevant database objects."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": "with ${getTableGrantsCTEs({ search })}\n    select\n      (select count(*)::int from table_grants) as total_count,\n      coalesce(\n        (\n          select jsonb_agg(\n            jsonb_build_object(\n              'id', tg.id,\n              'schema', tg.schema_name,\n              'name', tg.name,\n              'status', tg.status\n            )\n          )\n          from (\n            select *\n            from table_grants\n            order by schema_name, name\n            offset ${offset}\n            limit ${limit}\n          ) tg\n        ),\n        '[]'::jsonb\n      ) as tables;",
+        "analysis": {
+          "tables": [
+            "table_grants"
+          ],
+          "schemas": [],
+          "type": "read"
+        },
+        "purpose": "This query retrieves a paginated list of table grants, including their IDs, schema names, table names, and statuses, along with the total count of such grants, useful for displaying or managing ignored schemas in a dashboard. It supports filtering and pagination through the provided search, offset, and limit parameters."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": "with ${getTableGrantsCTEs()}\n    select\n      count(*)::int as total_count,\n      (count(*) filter (where status = 'granted' and schema_name in (${schemasList})))::int as grants_count\n    from table_grants",
+        "analysis": {
+          "tables": [
+            "table_grants"
+          ],
+          "schemas": [],
+          "type": "read"
+        },
+        "purpose": "The IGNORED_SCHEMAS query counts the total number of table grants and specifically counts how many of those grants have a status of 'granted' within the specified schemas. This helps identify the number of active grants versus total grants in the given schema list."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": "function_privileges as (\n      select\n        n.nspname as schema_name,\n        p.proname as name,\n\n        -- Aggregate EXECUTE across all overloads + all 3 roles\n        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'EXECUTE') as anon_execute,\n        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'EXECUTE') as auth_execute,\n        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'EXECUTE') as srv_execute\n\n      from pg_proc p\n      join pg_namespace n\n        on n.oid = p.pronamespace\n      left join lateral aclexplode(coalesce(p.proacl, acldefault('f', p.proowner))) as acl\n        on true\n      left join pg_roles pr\n        on pr.oid = acl.grantee\n      where p.prokind in ('f', 'w')\n        and n.nspname not in (${IGNORED_SCHEMAS_LIST})\n        ${search ?",
+        "analysis": {
+          "tables": [
+            "pg_proc",
+            "pg_namespace",
+            "lateral",
+            "pg_roles"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "The IGNORED_SCHEMAS query is designed to identify and aggregate EXECUTE privileges on functions within all schemas except those listed in IGNORED_SCHEMAS_LIST, specifically checking if the roles 'anon', 'authenticated', or 'service_role' have execution rights. This helps in monitoring or auditing function-level access permissions outside excluded schemas in the database."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": "with ${getFunctionGrantsCTEs({ search })}\n    select\n      (select count(*)::int from function_grants) as total_count,\n      coalesce(\n        (\n          select jsonb_agg(\n            jsonb_build_object(\n              'schema', fg.schema_name,\n              'name', fg.name,\n              'status', fg.status\n            )\n          )\n          from (\n            select *\n            from function_grants\n            order by schema_name, name\n            offset ${offset}\n            limit ${limit}\n          ) fg\n        ),\n        '[]'::jsonb\n      ) as functions;",
+        "analysis": {
+          "tables": [
+            "function_grants"
+          ],
+          "schemas": [],
+          "type": "read"
+        },
+        "purpose": "This query retrieves a paginated list of function grants along with their schema, name, and status, while also returning the total count of all function grants available. It's used to display and navigate through function grant records within the IGNORED_SCHEMAS context of the dashboard."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": "with ${getFunctionGrantsCTEs()}\n    select\n      count(*)::int as total_count,\n      (count(*) filter (where status = 'granted' and schema_name in (${schemasList})))::int as grants_count\n    from function_grants",
+        "analysis": {
+          "tables": [
+            "function_grants"
+          ],
+          "schemas": [],
+          "type": "read"
+        },
+        "purpose": "This query counts the total number of function grants and specifically how many of those granted are within a given list of schemas (`schemasList`). It helps to monitor and compare the total grants versus granted functions in ignored or specified schemas."
+      },
+      {
+        "name": "buildTablePrivilegesSql",
+        "sql": "do $$\n    declare\n      nspname name;\n      relname name;\n    begin\n      for nspname, relname in\n        select n.nspname, c.relname\n        from pg_class c\n        join pg_namespace n on n.oid = c.relnamespace\n        where c.oid in (${oids.join(', ')})\n      loop\n        execute format('${privilegeClause}', nspname, relname);\n      end loop;\n    end $$;",
+        "analysis": {
+          "tables": [
+            "pg_class",
+            "pg_namespace"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "The `buildTablePrivilegesSql` query dynamically retrieves the schema and table names for given table OIDs and then executes a formatted privilege-related SQL command on each identified table. It is used to apply or check specific table privileges programmatically within the database."
+      },
+      {
+        "name": "buildFunctionPrivilegesSql",
+        "sql": "do $$\n    declare\n      nspname name;\n      proname name;\n      arg_types text;\n    begin\n      for nspname, proname, arg_types in\n        select n.nspname, p.proname, pg_get_function_identity_arguments(p.oid)\n        from pg_proc p\n        join pg_namespace n on n.oid = p.pronamespace\n        where (n.nspname, p.proname) in (${tuples})\n      loop\n        execute format('${privilegeClause}', nspname, proname, arg_types);\n      end loop;\n    end $$;",
+        "analysis": {
+          "tables": [
+            "pg_proc",
+            "pg_namespace"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This query dynamically iterates over specified stored functions by their schema and name, then executes a privilege-related SQL command (defined by `${privilegeClause}`) on each function using its identity argument signature. It’s used to grant, revoke, or check privileges on database functions in a flexible, programmatic way."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": ": ''}\n      group by c.oid, n.nspname, c.relname, c.relkind\n    ),\n    table_grants as (\n      select\n        id,\n        schema_name,\n        name,\n        kind,\n        case\n          -- 1. Strict Granted: All 3 roles possess ALL 4 privileges\n          when (\n            anon_select and anon_insert and anon_update and anon_delete and\n            auth_select and auth_insert and auth_update and auth_delete and\n            srv_select and srv_insert and srv_update and srv_delete\n          ) then 'granted'\n\n          -- 2. Strict Revoked: NO role possesses ANY privilege\n          when not (\n            anon_select or anon_insert or anon_update or anon_delete or\n            auth_select or auth_insert or auth_update or auth_delete or\n            srv_select or srv_insert or srv_update or srv_delete\n          ) then 'revoked'\n\n          -- 3. Custom: Anything in between\n          else 'custom'\n        end as status\n      from table_privileges\n    )",
+        "analysis": {
+          "tables": [
+            "table_privileges"
+          ],
+          "schemas": [],
+          "type": "unknown"
+        },
+        "purpose": "This SQL query categorizes database tables' privilege statuses into three groups—'granted' when all three roles have all key privileges, 'revoked' when none of the roles have any privileges, and 'custom' for any other partial permission combinations—helping to identify schema access configurations efficiently."
+      },
+      {
+        "name": "IGNORED_SCHEMAS",
+        "sql": ": ''}\n      group by n.nspname, p.proname\n    ),\n    function_grants as (\n      select\n        schema_name,\n        name,\n        case\n          when anon_execute and auth_execute and srv_execute then 'granted'\n          when not (anon_execute or auth_execute or srv_execute) then 'revoked'\n          else 'custom'\n        end as status\n      from function_privileges\n    )",
+        "analysis": {
+          "tables": [
+            "function_privileges"
+          ],
+          "schemas": [],
+          "type": "unknown"
+        },
+        "purpose": "This query categorizes functions in each schema based on their execution privileges for anonymous, authenticated, and server roles, labeling them as 'granted', 'revoked', or 'custom' to help identify access levels in ignored schemas. It supports auditing and managing function-level permissions in the database."
+      }
+    ]
+  },
+  {
+    "file": "data/storage/storage.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "getLargestSizeLimitBucketsSqlUnoptimized",
+        "sql": "SELECT id, name, file_size_limit\nFROM storage.buckets\nWHERE file_size_limit IS NOT NULL\nORDER BY file_size_limit DESC\nLIMIT ${LARGEST_SIZE_LIMIT_BUCKETS_COUNT + 1};",
+        "analysis": {
+          "tables": [
+            "storage.buckets"
+          ],
+          "schemas": [
+            "storage"
+          ],
+          "type": "read"
+        },
+        "purpose": "This query retrieves the IDs, names, and file size limits of storage buckets that have a defined file size limit, sorting them from largest to smallest limit and returning the top results plus one extra based on a given count parameter. It is used to identify the buckets with the highest file size restrictions, likely for monitoring or management purposes."
+      }
+    ]
+  },
+  {
+    "file": "data/table-rows/table-rows.sql.ts",
+    "extractionStatus": "ok",
+    "queries": [
+      {
+        "name": "getTableRowsCountSql",
+        "sql": "with approximation as (\n    select reltuples as estimate\n    from pg_class\n    where oid = ${table.id}\n)\nselect \n  case \n    when estimate > ${THRESHOLD_COUNT} then (select -1)\n    else (${countBaseSql})\n  end as count,\n  estimate > ${THRESHOLD_COUNT} as is_estimate\nfrom approximation;",
+        "analysis": {
+          "tables": [
+            "pg_class",
+            "approximation"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This query retrieves the row count for a specific table by either returning an exact count using a supplied SQL (`countBaseSql`) if the estimated row count is below a threshold, or returning -1 to indicate an approximate count when the estimate exceeds that threshold, flagging whether the count is an estimate. This helps optimize performance by avoiding expensive exact counts on very large tables."
+      },
+      {
+        "name": "getTableRowsCountSql",
+        "sql": "${COUNT_ESTIMATE_SQL}\n\nwith approximation as (\n    select reltuples as estimate\n    from pg_class\n    where oid = ${table.id}\n)\nselect \n  case \n    when estimate > ${THRESHOLD_COUNT} then ${filters.length > 0 ?",
+        "analysis": {
+          "tables": [
+            "pg_class"
+          ],
+          "schemas": [],
+          "type": "metadata"
+        },
+        "purpose": "This SQL query estimates the row count of a specific database table using PostgreSQL's system catalog (pg_class) for a fast approximate count, and conditionally decides whether to rely on this estimate or perform a more precise count based on a threshold and applied filters. It helps optimize performance by avoiding expensive full table scans when dealing with large tables."
+      }
+    ]
+  }
+]

--- a/apps/studio/generated/studio-sql-inventory.md
+++ b/apps/studio/generated/studio-sql-inventory.md
@@ -1,0 +1,603 @@
+# Supabase Studio SQL Query Inventory
+
+Generated automatically from `apps/studio/data/**/*.sql.ts`.
+
+## data/database/database.sql.ts
+
+### getLiveTupleEstimate
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_stat_user_tables
+
+**Purpose:**
+The query getLiveTupleEstimate retrieves the current estimated number of live rows (tuples) in a specified user table within a given schema by querying PostgreSQL's statistics view pg_stat_user_tables. This helps estimate table size and activity without running a full count.
+
+```sql
+SELECT n_live_tup AS live_tuple_estimate
+FROM pg_stat_user_tables
+WHERE schemaname = ${literal(schema)}
+AND relname = ${literal(table)};
+```
+
+## data/database-cron-jobs/database-cron-jobs.sql.ts
+
+### getJobRunDetailsPageCountSql
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_class
+
+**Purpose:**
+This query retrieves the total number of disk pages used by the 'job_run_details' table within the 'cron' schema by dividing its size in bytes by the database block size. It's useful for understanding the physical storage size and page count of that specific table.
+
+```sql
+SELECT pg_relation_size(oid) / current_setting('block_size')::int8 AS num_pages
+FROM pg_class
+WHERE relname = 'job_run_details'
+  AND relnamespace = 'cron'::regnamespace;
+```
+
+### getDeleteOldCronJobRunDetailsByCtidSql
+
+**Type:** read
+
+**Tables touched:**
+- cron.job_run_details
+- deleted
+
+**Purpose:**
+This query deletes old records from the `cron.job_run_details` table within a specific CTID range where the job run has ended before a certain interval ago, and then returns the count of rows deleted. It is used to efficiently purge outdated cron job run details while tracking how many entries were removed.
+
+```sql
+WITH deleted AS (
+  DELETE FROM cron.job_run_details
+  WHERE ctid >= ${safeCtidStart}::tid
+    AND ctid < ${safeCtidEnd}::tid
+    AND end_time < now() - interval ${literal(interval)}
+  RETURNING 1
+)
+SELECT count(*) as deleted_count FROM deleted;
+```
+
+### getScheduleDeleteCronJobRunDetailsSql
+
+**Type:** read
+
+**Tables touched:**
+- cron.job_run_details
+
+**Purpose:**
+This query creates or updates a scheduled cron job named by CRON_CLEANUP_SCHEDULE_NAME that runs at the interval specified by CRON_CLEANUP_SCHEDULE_EXPRESSION to delete records from the cron.job_run_details table where the end_time is older than the given interval, helping to clean up old job run logs automatically.
+
+```sql
+SELECT cron.schedule(
+  ${literal(CRON_CLEANUP_SCHEDULE_NAME)},
+  ${literal(CRON_CLEANUP_SCHEDULE_EXPRESSION)},
+  $$DELETE FROM cron.job_run_details WHERE end_time < now() - interval ${literal(interval)}$$
+);
+```
+
+### getCronJobsMinimalSql
+
+**Type:** read
+
+**Tables touched:**
+- cron.job
+
+**Purpose:**
+The `getCronJobsMinimalSql` query retrieves a minimal set of details (job ID, name, schedule, command, and active status) for cron jobs from the `cron.job` table, optionally filtering results based on a provided search term. It is used to quickly fetch essential information about scheduled jobs for display or management purposes in the dashboard.
+
+```sql
+SELECT 
+  job.jobid,
+  job.jobname,
+  job.schedule,
+  job.command,
+  job.active
+FROM 
+  cron.job job
+${!!searchTerm ?
+```
+
+### getCronJobsSql
+
+**Type:** read
+
+**Tables touched:**
+- cron.job_run_details
+- latest_runs
+- cron.job
+- most_recent_runs
+
+**Purpose:**
+The getCronJobsSql query retrieves a list of all cron jobs along with their most recent run status and timestamp by joining the job metadata with the latest execution details from the job_run_details table. It helps developers and support engineers quickly see the current state and last execution time of each scheduled job for monitoring and troubleshooting purposes.
+
+```sql
+WITH latest_runs AS (
+  SELECT 
+    jobid,
+    status,
+    MAX(start_time) AS latest_run
+  FROM cron.job_run_details
+  GROUP BY jobid, status
+), most_recent_runs AS (
+  SELECT 
+    jobid, 
+    status, 
+    latest_run
+  FROM latest_runs lr1
+  WHERE latest_run = (
+    SELECT MAX(latest_run) 
+    FROM latest_runs lr2 
+    WHERE lr2.jobid = lr1.jobid
+  )
+)
+SELECT 
+  job.jobid,
+  job.jobname,
+  job.schedule,
+  job.command,
+  job.active,
+  mr.latest_run,
+  mr.status
+FROM 
+  cron.job job
+LEFT JOIN most_recent_runs mr ON job.jobid = mr.jobid
+${!!searchTerm ?
+```
+
+## data/database-extensions/database-extensions.sql.ts
+
+### getDatabaseExtensionDefaultSchemaSQL
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_available_extension_versions
+
+**Purpose:**
+This query retrieves the name, version, and default schema of a specified database extension from the available extension versions in PostgreSQL. It helps identify the details of the given extension by filtering on its name and returning the first matching record.
+
+```sql
+select name, version, schema from pg_available_extension_versions where name = ${literal(extension)} limit 1;
+```
+
+## data/database-indexes/database-indexes.sql.ts
+
+### getIndexesSQL
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_index
+- pg_class
+- pg_namespace
+- LATERAL
+- pg_attribute
+
+**Purpose:**
+This query retrieves detailed information about all indexes within a specified database schema, including the schema name, table name, index name, index definition, and the columns (or expressions) covered by each index. It helps developers or support engineers understand the indexing structure for performance tuning or troubleshooting.
+
+```sql
+SELECT
+  n.nspname        AS schema,
+  t.relname        AS "table",
+  i.relname        AS name,
+  pg_get_indexdef(idx.indexrelid) AS definition,
+  STRING_AGG(
+    COALESCE(a.attname, '(expression)'),
+    ', ' ORDER BY k.ord
+  ) AS columns
+FROM pg_index idx
+JOIN pg_class      t ON t.oid = idx.indrelid
+JOIN pg_class      i ON i.oid = idx.indexrelid
+JOIN pg_namespace  n ON n.oid = t.relnamespace
+JOIN LATERAL unnest(idx.indkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+LEFT JOIN pg_attribute a
+  ON a.attrelid = t.oid
+ AND a.attnum   = k.attnum
+WHERE n.nspname = '${schema}'
+GROUP BY
+  n.nspname,
+  t.relname,
+  i.relname,
+  idx.indexrelid
+ORDER BY
+  schema, "table", name;
+```
+
+## data/privileges/privileges.sql.ts
+
+### IGNORED_SCHEMAS
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_class
+- pg_namespace
+- lateral
+- pg_roles
+
+**Purpose:**
+This query retrieves the access privileges (SELECT, INSERT, UPDATE, DELETE) for key roles (anon, authenticated, service_role) on database objects (tables, views, etc.) within schemas that are not in the ignored schemas list, enabling visibility into permission settings while excluding system or irrelevant schemas. It helps developers/support engineers audit and manage role-based access control for relevant database objects.
+
+```sql
+table_privileges as (
+      select
+        c.oid::int as id,
+        n.nspname as schema_name,
+        c.relname as name,
+        c.relkind as kind,
+
+        -- Anon Privileges
+        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'SELECT') as anon_select,
+        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'INSERT') as anon_insert,
+        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'UPDATE') as anon_update,
+        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'DELETE') as anon_delete,
+
+        -- Authenticated Privileges
+        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'SELECT') as auth_select,
+        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'INSERT') as auth_insert,
+        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'UPDATE') as auth_update,
+        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'DELETE') as auth_delete,
+
+        -- Service Role Privileges
+        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'SELECT') as srv_select,
+        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'INSERT') as srv_insert,
+        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'UPDATE') as srv_update,
+        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'DELETE') as srv_delete
+
+      from pg_class c
+      join pg_namespace n
+        on n.oid = c.relnamespace
+      left join lateral aclexplode(coalesce(c.relacl, acldefault('r', c.relowner))) as acl
+        on true
+      left join pg_roles pr
+        on pr.oid = acl.grantee
+      where c.relkind in ('r', 'p', 'v', 'm', 'f')
+        and n.nspname not in (${IGNORED_SCHEMAS_LIST})
+        ${search ?
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** read
+
+**Tables touched:**
+- table_grants
+
+**Purpose:**
+This query retrieves a paginated list of table grants, including their IDs, schema names, table names, and statuses, along with the total count of such grants, useful for displaying or managing ignored schemas in a dashboard. It supports filtering and pagination through the provided search, offset, and limit parameters.
+
+```sql
+with ${getTableGrantsCTEs({ search })}
+    select
+      (select count(*)::int from table_grants) as total_count,
+      coalesce(
+        (
+          select jsonb_agg(
+            jsonb_build_object(
+              'id', tg.id,
+              'schema', tg.schema_name,
+              'name', tg.name,
+              'status', tg.status
+            )
+          )
+          from (
+            select *
+            from table_grants
+            order by schema_name, name
+            offset ${offset}
+            limit ${limit}
+          ) tg
+        ),
+        '[]'::jsonb
+      ) as tables;
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** read
+
+**Tables touched:**
+- table_grants
+
+**Purpose:**
+The IGNORED_SCHEMAS query counts the total number of table grants and specifically counts how many of those grants have a status of 'granted' within the specified schemas. This helps identify the number of active grants versus total grants in the given schema list.
+
+```sql
+with ${getTableGrantsCTEs()}
+    select
+      count(*)::int as total_count,
+      (count(*) filter (where status = 'granted' and schema_name in (${schemasList})))::int as grants_count
+    from table_grants
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_proc
+- pg_namespace
+- lateral
+- pg_roles
+
+**Purpose:**
+The IGNORED_SCHEMAS query is designed to identify and aggregate EXECUTE privileges on functions within all schemas except those listed in IGNORED_SCHEMAS_LIST, specifically checking if the roles 'anon', 'authenticated', or 'service_role' have execution rights. This helps in monitoring or auditing function-level access permissions outside excluded schemas in the database.
+
+```sql
+function_privileges as (
+      select
+        n.nspname as schema_name,
+        p.proname as name,
+
+        -- Aggregate EXECUTE across all overloads + all 3 roles
+        bool_or(pr.rolname = 'anon' and acl.privilege_type = 'EXECUTE') as anon_execute,
+        bool_or(pr.rolname = 'authenticated' and acl.privilege_type = 'EXECUTE') as auth_execute,
+        bool_or(pr.rolname = 'service_role' and acl.privilege_type = 'EXECUTE') as srv_execute
+
+      from pg_proc p
+      join pg_namespace n
+        on n.oid = p.pronamespace
+      left join lateral aclexplode(coalesce(p.proacl, acldefault('f', p.proowner))) as acl
+        on true
+      left join pg_roles pr
+        on pr.oid = acl.grantee
+      where p.prokind in ('f', 'w')
+        and n.nspname not in (${IGNORED_SCHEMAS_LIST})
+        ${search ?
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** read
+
+**Tables touched:**
+- function_grants
+
+**Purpose:**
+This query retrieves a paginated list of function grants along with their schema, name, and status, while also returning the total count of all function grants available. It's used to display and navigate through function grant records within the IGNORED_SCHEMAS context of the dashboard.
+
+```sql
+with ${getFunctionGrantsCTEs({ search })}
+    select
+      (select count(*)::int from function_grants) as total_count,
+      coalesce(
+        (
+          select jsonb_agg(
+            jsonb_build_object(
+              'schema', fg.schema_name,
+              'name', fg.name,
+              'status', fg.status
+            )
+          )
+          from (
+            select *
+            from function_grants
+            order by schema_name, name
+            offset ${offset}
+            limit ${limit}
+          ) fg
+        ),
+        '[]'::jsonb
+      ) as functions;
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** read
+
+**Tables touched:**
+- function_grants
+
+**Purpose:**
+This query counts the total number of function grants and specifically how many of those granted are within a given list of schemas (`schemasList`). It helps to monitor and compare the total grants versus granted functions in ignored or specified schemas.
+
+```sql
+with ${getFunctionGrantsCTEs()}
+    select
+      count(*)::int as total_count,
+      (count(*) filter (where status = 'granted' and schema_name in (${schemasList})))::int as grants_count
+    from function_grants
+```
+
+### buildTablePrivilegesSql
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_class
+- pg_namespace
+
+**Purpose:**
+The `buildTablePrivilegesSql` query dynamically retrieves the schema and table names for given table OIDs and then executes a formatted privilege-related SQL command on each identified table. It is used to apply or check specific table privileges programmatically within the database.
+
+```sql
+do $$
+    declare
+      nspname name;
+      relname name;
+    begin
+      for nspname, relname in
+        select n.nspname, c.relname
+        from pg_class c
+        join pg_namespace n on n.oid = c.relnamespace
+        where c.oid in (${oids.join(', ')})
+      loop
+        execute format('${privilegeClause}', nspname, relname);
+      end loop;
+    end $$;
+```
+
+### buildFunctionPrivilegesSql
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_proc
+- pg_namespace
+
+**Purpose:**
+This query dynamically iterates over specified stored functions by their schema and name, then executes a privilege-related SQL command (defined by `${privilegeClause}`) on each function using its identity argument signature. It’s used to grant, revoke, or check privileges on database functions in a flexible, programmatic way.
+
+```sql
+do $$
+    declare
+      nspname name;
+      proname name;
+      arg_types text;
+    begin
+      for nspname, proname, arg_types in
+        select n.nspname, p.proname, pg_get_function_identity_arguments(p.oid)
+        from pg_proc p
+        join pg_namespace n on n.oid = p.pronamespace
+        where (n.nspname, p.proname) in (${tuples})
+      loop
+        execute format('${privilegeClause}', nspname, proname, arg_types);
+      end loop;
+    end $$;
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** unknown
+
+**Tables touched:**
+- table_privileges
+
+**Purpose:**
+This SQL query categorizes database tables' privilege statuses into three groups—'granted' when all three roles have all key privileges, 'revoked' when none of the roles have any privileges, and 'custom' for any other partial permission combinations—helping to identify schema access configurations efficiently.
+
+```sql
+: ''}
+      group by c.oid, n.nspname, c.relname, c.relkind
+    ),
+    table_grants as (
+      select
+        id,
+        schema_name,
+        name,
+        kind,
+        case
+          -- 1. Strict Granted: All 3 roles possess ALL 4 privileges
+          when (
+            anon_select and anon_insert and anon_update and anon_delete and
+            auth_select and auth_insert and auth_update and auth_delete and
+            srv_select and srv_insert and srv_update and srv_delete
+          ) then 'granted'
+
+          -- 2. Strict Revoked: NO role possesses ANY privilege
+          when not (
+            anon_select or anon_insert or anon_update or anon_delete or
+            auth_select or auth_insert or auth_update or auth_delete or
+            srv_select or srv_insert or srv_update or srv_delete
+          ) then 'revoked'
+
+          -- 3. Custom: Anything in between
+          else 'custom'
+        end as status
+      from table_privileges
+    )
+```
+
+### IGNORED_SCHEMAS
+
+**Type:** unknown
+
+**Tables touched:**
+- function_privileges
+
+**Purpose:**
+This query categorizes functions in each schema based on their execution privileges for anonymous, authenticated, and server roles, labeling them as 'granted', 'revoked', or 'custom' to help identify access levels in ignored schemas. It supports auditing and managing function-level permissions in the database.
+
+```sql
+: ''}
+      group by n.nspname, p.proname
+    ),
+    function_grants as (
+      select
+        schema_name,
+        name,
+        case
+          when anon_execute and auth_execute and srv_execute then 'granted'
+          when not (anon_execute or auth_execute or srv_execute) then 'revoked'
+          else 'custom'
+        end as status
+      from function_privileges
+    )
+```
+
+## data/storage/storage.sql.ts
+
+### getLargestSizeLimitBucketsSqlUnoptimized
+
+**Type:** read
+
+**Tables touched:**
+- storage.buckets
+
+**Purpose:**
+This query retrieves the IDs, names, and file size limits of storage buckets that have a defined file size limit, sorting them from largest to smallest limit and returning the top results plus one extra based on a given count parameter. It is used to identify the buckets with the highest file size restrictions, likely for monitoring or management purposes.
+
+```sql
+SELECT id, name, file_size_limit
+FROM storage.buckets
+WHERE file_size_limit IS NOT NULL
+ORDER BY file_size_limit DESC
+LIMIT ${LARGEST_SIZE_LIMIT_BUCKETS_COUNT + 1};
+```
+
+## data/table-rows/table-rows.sql.ts
+
+### getTableRowsCountSql
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_class
+- approximation
+
+**Purpose:**
+This query retrieves the row count for a specific table by either returning an exact count using a supplied SQL (`countBaseSql`) if the estimated row count is below a threshold, or returning -1 to indicate an approximate count when the estimate exceeds that threshold, flagging whether the count is an estimate. This helps optimize performance by avoiding expensive exact counts on very large tables.
+
+```sql
+with approximation as (
+    select reltuples as estimate
+    from pg_class
+    where oid = ${table.id}
+)
+select 
+  case 
+    when estimate > ${THRESHOLD_COUNT} then (select -1)
+    else (${countBaseSql})
+  end as count,
+  estimate > ${THRESHOLD_COUNT} as is_estimate
+from approximation;
+```
+
+### getTableRowsCountSql
+
+**Type:** metadata
+
+**Tables touched:**
+- pg_class
+
+**Purpose:**
+This SQL query estimates the row count of a specific database table using PostgreSQL's system catalog (pg_class) for a fast approximate count, and conditionally decides whether to rely on this estimate or perform a more precise count based on a threshold and applied filters. It helps optimize performance by avoiding expensive full table scans when dealing with large tables.
+
+```sql
+${COUNT_ESTIMATE_SQL}
+
+with approximation as (
+    select reltuples as estimate
+    from pg_class
+    where oid = ${table.id}
+)
+select 
+  case 
+    when estimate > ${THRESHOLD_COUNT} then ${filters.length > 0 ?
+```

--- a/apps/studio/scripts/generate-studio-sql-docs.ts
+++ b/apps/studio/scripts/generate-studio-sql-docs.ts
@@ -1,0 +1,281 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  })
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const STUDIO_DIR = path.resolve(__dirname, '..')
+const DATA_DIR = path.join(STUDIO_DIR, 'data')
+const OUTPUT_DIR = path.join(STUDIO_DIR, 'generated')
+
+type QueryAnalysis = {
+  tables: string[]
+  schemas: string[]
+  type: 'read' | 'write' | 'metadata' | 'unknown'
+}
+
+type ExtractedQuery = {
+  name: string
+  sql: string
+  analysis?: QueryAnalysis
+  purpose?: string | null
+}
+
+function analyzeSql(sql: string): QueryAnalysis {
+  const tables = new Set<string>()
+  const schemas = new Set<string>()
+
+  const tableRegex =
+    /\b(from|join|update|into|delete\s+from)\s+([a-zA-Z0-9_."]+)/gi
+
+  for (const match of sql.matchAll(tableRegex)) {
+    const table = match[2].replace(/"/g, '')
+    tables.add(table)
+
+    if (table.includes('.')) {
+      schemas.add(table.split('.')[0])
+    }
+  }
+
+  let type: QueryAnalysis['type'] = 'unknown'
+  const lower = sql.toLowerCase()
+
+  if (lower.includes('pg_') || lower.includes('information_schema')) {
+    type = 'metadata'
+  } else if (lower.startsWith('select') || lower.startsWith('with')) {
+    type = 'read'
+  } else if (
+    lower.startsWith('insert') ||
+    lower.startsWith('update') ||
+    lower.startsWith('delete')
+  ) {
+    type = 'write'
+  }
+
+  return {
+    tables: [...tables],
+    schemas: [...schemas],
+    type,
+  }
+}
+
+function extractTaggedSql(content: string): ExtractedQuery[] {
+  const results: ExtractedQuery[] = []
+  const regex = /\/\*\s*SQL\s*\*\/\s*`([\s\S]*?)`/g
+
+  for (const match of content.matchAll(regex)) {
+    const sql = match[1].trim()
+
+    const before = content.slice(0, match.index)
+    const exportMatch = before.match(/export\s+const\s+(\w+)/g)?.pop()
+
+    let name = 'unknown'
+    if (exportMatch) {
+      const m = exportMatch.match(/export\s+const\s+(\w+)/)
+      if (m) name = m[1]
+    }
+
+    results.push({ name, sql })
+  }
+
+  return results
+}
+
+function extractTemplateSql(content: string): ExtractedQuery[] {
+  const results: ExtractedQuery[] = []
+  const templateRegex = /`([\s\S]*?)`/g
+
+  for (const match of content.matchAll(templateRegex)) {
+    const sql = match[1].trim()
+
+    const looksLikeSql =
+      /\b(select|insert|update|delete|with)\b/i.test(sql) &&
+      /\b(from|into|delete)\b/i.test(sql)
+
+    if (!looksLikeSql) continue
+
+    const before = content.slice(0, match.index)
+    const exportMatch = before.match(/export\s+const\s+(\w+)/g)?.pop()
+
+    let name = 'unknown'
+    if (exportMatch) {
+      const m = exportMatch.match(/export\s+const\s+(\w+)/)
+      if (m) name = m[1]
+    }
+
+    results.push({ name, sql })
+  }
+
+  return results
+}
+
+function dedupeQueries(queries: ExtractedQuery[]): ExtractedQuery[] {
+  const seen = new Set<string>()
+
+  return queries.filter((q) => {
+    const key = `${q.name}::${q.sql}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function extractAllSql(content: string): ExtractedQuery[] {
+  return [
+    ...extractTaggedSql(content),
+    ...extractTemplateSql(content)
+  ]
+}
+
+function findSqlTsFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...findSqlTsFiles(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.sql.ts')) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+async function summarizeSql(name: string, sql: string) {
+  const prompt = `
+Explain the purpose of this SQL query in 1–2 sentences for a developer engineer.
+
+Query name: ${name}
+
+SQL:
+${sql}
+`
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4.1-mini',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You explain SQL queries used in a database dashboard.',
+      },
+      {
+        role: 'user',
+        content: prompt,
+      },
+    ],
+  })
+
+  return completion.choices[0].message.content?.trim()
+}
+
+function generateMarkdown(data: any[]): string {
+  const lines: string[] = []
+
+  lines.push('# Supabase Studio SQL Query Inventory')
+  lines.push('')
+  lines.push('Generated automatically from `apps/studio/data/**/*.sql.ts`.')
+  lines.push('')
+
+  for (const file of data) {
+    lines.push(`## ${file.file}`)
+    lines.push('')
+
+    if (!file.queries.length) {
+      lines.push('_No SQL queries detected._')
+      lines.push('')
+      continue
+    }
+
+    for (const query of file.queries) {
+      lines.push(`### ${query.name}`)
+      lines.push('')
+      lines.push(`**Type:** ${query.analysis.type}`)
+      lines.push('')
+
+      if (query.analysis.tables.length) {
+        lines.push('**Tables touched:**')
+        for (const table of query.analysis.tables) {
+          lines.push(`- ${table}`)
+        }
+        lines.push('')
+      }
+
+      if (query.purpose) {
+        lines.push('**Purpose:**')
+        lines.push(query.purpose)
+        lines.push('')
+      }
+
+      lines.push('```sql')
+      lines.push(query.sql)
+      lines.push('```')
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+async function main() {
+  const files = findSqlTsFiles(DATA_DIR)
+
+  const output: any[] = []
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8')
+
+    const queries = dedupeQueries(extractAllSql(content)).map((q) => ({
+      ...q,
+      analysis: analyzeSql(q.sql),
+      purpose: null,
+    }))
+
+    console.log("Queries found:", queries.length)
+
+    for (const q of queries) {
+      try {
+        q.purpose = await summarizeSql(q.name, q.sql)
+        console.log("Summarized:", q.name)
+      } catch (err) {
+        console.error("AI ERROR:", err)
+        q.purpose = null
+      }
+    }
+
+    output.push({
+      file: path.relative(STUDIO_DIR, file),
+      extractionStatus: queries.length > 0 ? 'ok' : 'no_sql_detected',
+      queries,
+    })
+  }
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+
+  fs.writeFileSync(
+    path.join(OUTPUT_DIR, 'studio-sql-inventory.json'),
+    JSON.stringify(output, null, 2)
+  )
+
+  const markdown = generateMarkdown(output)
+
+  fs.writeFileSync(
+    path.join(OUTPUT_DIR, 'studio-sql-inventory.md'),
+    markdown
+  )
+
+  console.log(
+    `Generated documentation for ${output.length} SQL files`
+  )
+}
+
+main()


### PR DESCRIPTION
## What kind of change does this PR introduce?
This pull request introduces a new script, `generate-studio-sql-docs.ts`, to automate the extraction, analysis, and documentation of SQL queries used within the Supabase Studio project. The script scans for `.sql.ts` files, extracts SQL queries, analyzes their usage, summarizes their purpose using OpenAI, and generates both JSON and Markdown documentation. This enhances visibility into database usage and aids in maintaining and understanding SQL queries across the codebase.

Here's an example of a generated Markdown file:
https://markdownlivepreview.com/ 
