### PR TITLE
fix(www): update log drains pricing from $10 to $60 in blog post

### DIFF
--- a/apps/www/_blog/2026-03-05-log-drains-now-available-on-pro.mdx
+++ b/apps/www/_blog/2026-03-05-log-drains-now-available-on-pro.mdx
@@ -116,7 +116,7 @@ Supabase sends logs in small batches over HTTP. Your vendor stores and indexes t
 
 ## Pricing
 
-- $10 per drain per project
+- $60 per drain per project
 - $0.20 per million events
 - $0.09 per GB egress
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update wrong pricing on blog post

## What is the current behavior?

Pricing is shown as $10 when it should be $60

## What is the new behavior?

Pricing is show as $60

## Additional context

N/A
