### PR TITLE
chore: add telemetry to track other AI link usage

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/ErrorCodeTooltip.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/ErrorCodeTooltip.tsx
@@ -120,6 +120,7 @@ export const ErrorCodeTooltip = ({ errorCode, service, children }: ErrorCodeTool
               label="Fix with AI"
               buildPrompt={buildPrompt}
               onOpenAssistant={handleOpenAssistant}
+              telemetrySource="error_code"
               copyLabel="Copy Markdown"
               showExternalAI
               extraDropdownItems={

--- a/apps/studio/components/interfaces/Settings/Logs/MultiSelectActionBar.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/MultiSelectActionBar.tsx
@@ -82,6 +82,7 @@ export function MultiSelectActionBar({
           label="Explain with AI"
           buildPrompt={() => buildLogsPrompt(selectedRowsData, queryType, sqlQuery)}
           onOpenAssistant={handleOpenAiAssistant}
+          telemetrySource="log_explorer"
         />
 
         <Button

--- a/apps/studio/components/ui/AiAssistantDropdown.tsx
+++ b/apps/studio/components/ui/AiAssistantDropdown.tsx
@@ -3,7 +3,6 @@ import { Chatgpt, Claude } from 'icons'
 import { useTrack } from 'lib/telemetry/track'
 import { Check, ChevronDown, Copy } from 'lucide-react'
 import { ComponentProps, ReactNode, useEffect, useState } from 'react'
-
 import {
   AiIconAnimation,
   Button,
@@ -22,8 +21,20 @@ import {
 type TelemetrySource = AiAssistantSource
 
 const EXTERNAL_AI_TOOLS = [
-  { label: 'Ask ChatGPT', url: 'https://chatgpt.com/', promptParam: 'q', icon: Chatgpt, toolId: 'chatgpt' as const },
-  { label: 'Ask Claude', url: 'https://claude.ai/new', promptParam: 'q', icon: Claude, toolId: 'claude' as const },
+  {
+    label: 'Ask ChatGPT',
+    url: 'https://chatgpt.com/',
+    promptParam: 'q',
+    icon: Chatgpt,
+    toolId: 'chatgpt' as const,
+  },
+  {
+    label: 'Ask Claude',
+    url: 'https://claude.ai/new',
+    promptParam: 'q',
+    icon: Claude,
+    toolId: 'claude' as const,
+  },
 ]
 
 export interface AiAssistantDropdownItem {

--- a/apps/studio/components/ui/AiAssistantDropdown.tsx
+++ b/apps/studio/components/ui/AiAssistantDropdown.tsx
@@ -1,4 +1,4 @@
-import { AiPromptCopiedEvent } from 'common/telemetry-constants'
+import { AiAssistantSource } from 'common/telemetry-constants'
 import { Chatgpt, Claude } from 'icons'
 import { useTrack } from 'lib/telemetry/track'
 import { Check, ChevronDown, Copy } from 'lucide-react'
@@ -19,11 +19,11 @@ import {
   TooltipTrigger,
 } from 'ui'
 
-type TelemetrySource = AiPromptCopiedEvent['properties']['source']
+type TelemetrySource = AiAssistantSource
 
 const EXTERNAL_AI_TOOLS = [
-  { label: 'Ask ChatGPT', url: 'https://chatgpt.com/', promptParam: 'q', icon: Chatgpt },
-  { label: 'Ask Claude', url: 'https://claude.ai/new', promptParam: 'q', icon: Claude },
+  { label: 'Ask ChatGPT', url: 'https://chatgpt.com/', promptParam: 'q', icon: Chatgpt, toolId: 'chatgpt' as const },
+  { label: 'Ask Claude', url: 'https://claude.ai/new', promptParam: 'q', icon: Claude, toolId: 'claude' as const },
 ]
 
 export interface AiAssistantDropdownItem {
@@ -95,10 +95,18 @@ export function AiAssistantDropdown({
       '_blank',
       'noreferrer'
     )
+
+    if (telemetrySource) {
+      track('ai_external_tool_clicked', { source: telemetrySource, tool: tool.toolId })
+    }
   }
 
   const handleOpenAssistant = () => {
     onOpenAssistant()
+
+    if (telemetrySource) {
+      track('ai_assistant_dropdown_button_clicked', { source: telemetrySource })
+    }
   }
 
   const buttonContent = (

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2577,6 +2577,20 @@ export interface QueryPerformanceAIExplanationButtonClickedEvent {
 }
 
 /**
+ * Source/location where AI assistant actions originate from.
+ */
+export type AiAssistantSource =
+  | 'explain_visualizer'
+  | 'query_performance'
+  | 'sql_debug'
+  | 'lint_detail'
+  | 'advisor_section'
+  | 'advisor_widget'
+  | 'branch_review'
+  | 'log_explorer'
+  | 'error_code'
+
+/**
  * User copied an AI prompt to clipboard instead of using the built-in assistant.
  * This allows users to paste the prompt into external AI tools (Cursor, Claude, etc.)
  *
@@ -2589,14 +2603,45 @@ export interface AiPromptCopiedEvent {
     /**
      * Source/location where the prompt was copied from
      */
-    source:
-      | 'explain_visualizer'
-      | 'query_performance'
-      | 'sql_debug'
-      | 'lint_detail'
-      | 'advisor_section'
-      | 'advisor_widget'
-      | 'branch_review'
+    source: AiAssistantSource
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * User clicked the main AI assistant button in the dropdown.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AiAssistantDropdownButtonClickedEvent {
+  action: 'ai_assistant_dropdown_button_clicked'
+  properties: {
+    /**
+     * Source/location where the button was clicked
+     */
+    source: AiAssistantSource
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * User clicked an external AI tool link (ChatGPT or Claude) in the dropdown.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AiExternalToolClickedEvent {
+  action: 'ai_external_tool_clicked'
+  properties: {
+    /**
+     * Source/location where the link was clicked
+     */
+    source: AiAssistantSource
+    /**
+     * Which external AI tool was selected
+     */
+    tool: 'chatgpt' | 'claude'
   }
   groups: TelemetryGroups
 }
@@ -2945,6 +2990,8 @@ export type TelemetryEvent =
   | AdvisorAssistantButtonClickedEvent
   | QueryPerformanceAIExplanationButtonClickedEvent
   | AiPromptCopiedEvent
+  | AiAssistantDropdownButtonClickedEvent
+  | AiExternalToolClickedEvent
   | RequestUpgradeModalOpenedEvent
   | RequestUpgradeSubmittedEvent
   | DashboardErrorCreatedEvent


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Added tracker when the main ai button was pressed
- Added new event to track "Open in" third party apps 
- Added 2 missing telemetry sources 