### PR TITLE
chore(studio): nits

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
@@ -37,11 +37,11 @@ export const OrganizationCard = ({
       onClick={onClick}
       description={
         <div className="flex items-center justify-between text-xs text-foreground-light font-sans">
-          <div className="flex items-center gap-x-1.5">
+          <div className="flex items-center gap-x-1">
             <span>{organization.plan.name} Plan</span>
             {numProjects > 0 && (
               <>
-                <span>·</span>
+                <span className="text-foreground-lighter">·</span>
                 <span>
                   {numProjects} project{numProjects > 1 ? 's' : ''}
                 </span>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -139,7 +139,7 @@ export const PrimaryNode = ({ data }: NodeProps<PrimaryNodeData>) => {
                 <span className="text-sm text-foreground-light">{region.region}</span>
                 {projectHomepageShowInstanceSize && (
                   <>
-                    <span className="text-sm text-foreground-light">•</span>
+                    <span className="text-sm text-foreground-lighter">·</span>
                     <span className="text-sm text-foreground-light">{computeSize}</span>
                   </>
                 )}
@@ -291,7 +291,7 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
                 <span>{region.region}</span>
                 {projectHomepageShowInstanceSize && !!computeSize && (
                   <>
-                    <span>•</span>
+                    <span className="text-foreground-lighter">·</span>
                     <span>{computeSize}</span>
                   </>
                 )}

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -348,6 +348,7 @@ const ProjectLinks = () => {
           }
         })}
       </SidebarGroup>
+      <Separator className="w-[calc(100%-1rem)] mx-auto" />
       {/* Settings routes to be added in with project/org nav */}
       <SidebarGroup className="gap-0.5">
         {settingsRoutes.map((route, i) => (


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI nit changes

## What is the current behavior?

- We use big dots `•` to separate semantically different sets of text that are in the same row
  - This looks a bit odd given how large the dot is to text
- We put _Project Settings_ in its own sidebar section but without a separator like all other sidebar sections

## What is the new behavior?

- Use the smaller dots `·` to separate text
- Place a separator above _Project Settings_ in sidebar

| Before | After |
| --- | --- |
| <img width="1342" height="711" alt="AWS Healthy  Toolshed  Supabase-70BD1825-8077-4D1B-84C1-831A4ADAFC0B" src="https://github.com/user-attachments/assets/70246009-a3c7-4b5c-8d75-122140a637d1" /> | <img width="1342" height="711" alt="AWS Healthy  Toolshed  Supabase" src="https://github.com/user-attachments/assets/e3fc13e4-923d-472e-aaf9-d689e890697b" /> |