### PR TITLE
fix(logs): render special characters in event_message properly

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
@@ -26,7 +26,7 @@ const LogRowCodeBlock = ({ value, className }: { value: string; className?: stri
       className
     )}
   >
-    {JSON.stringify(value, null, 2)}
+    {typeof value === 'string' ? value : JSON.stringify(value, null, 2)}
   </pre>
 )
 


### PR DESCRIPTION
In the log explorer's LogSelection component, special characters like \n (newlines) and \t (tabs) were being displayed literally instead of being rendered. This was because JSON.stringify was being used for all values, which escapes these characters.

Now string values are rendered directly, preserving newlines and tabs, while objects still use JSON.stringify for proper formatting.

Slack thread: https://supabase.slack.com/archives/C0161K73J1J/p1773308745191129?thread_ts=1773275727.200079&cid=C0161K73J1J

https://claude.ai/code/session_01117yL8Ww5VF4HNDJvyYF6X

## Before
<img width="846" height="346" alt="CleanShot 2026-03-12 at 10 59 57@2x" src="https://github.com/user-attachments/assets/3fa8ee95-0090-4941-905f-6cb13724ac53" />
  
## After
<img width="754" height="350" alt="CleanShot 2026-03-12 at 11 00 14@2x" src="https://github.com/user-attachments/assets/3c41e7f5-7a35-46f2-8bd1-c9b9a42c2a4d" />

