### PR TITLE
fix: wording when an account was already linked and add option to create new orgs

### DIFF
--- a/apps/studio/data/partners/stripe-fabric-confirm-mutation.ts
+++ b/apps/studio/data/partners/stripe-fabric-confirm-mutation.ts
@@ -7,16 +7,21 @@ import type { ResponseError, UseCustomMutationOptions } from '@/types'
 type ConfirmAccountRequestVariables = {
   arId: string
   organizationId?: number
+  organizationName?: string
 }
 
-async function confirmAccountRequest({ arId, organizationId }: ConfirmAccountRequestVariables) {
+async function confirmAccountRequest({
+  arId,
+  organizationId,
+  organizationName,
+}: ConfirmAccountRequestVariables) {
   if (!arId) throw new Error('Account request ID is required')
 
   const { data, error } = await post(
     '/platform/stripe/fabric/provisioning/account_requests/{id}/confirm',
     {
       params: { path: { id: arId } },
-      body: { organization_id: organizationId },
+      body: { organization_id: organizationId, organization_name: organizationName },
     }
   )
 

--- a/apps/studio/pages/partners/stripe/fabric/login.tsx
+++ b/apps/studio/pages/partners/stripe/fabric/login.tsx
@@ -85,7 +85,7 @@ const StripeFabricLoginPage = () => {
       ? 'Organization Linked'
       : 'Organization Created'
   const successDescription = isReauth
-    ? `Your Stripe account is connected to ${linkedOrg?.name}.`
+    ? null
     : isLinking
       ? 'Your Supabase organization has been linked to your Stripe account.'
       : 'Your Supabase organization has been created and linked to your Stripe account.'
@@ -101,7 +101,7 @@ const StripeFabricLoginPage = () => {
         ) : isConfirmed ? (
           <>
             <h2 className="py-2 text-lg font-medium">{successTitle}</h2>
-            <p className="text-foreground-light">{successDescription}</p>
+            {successDescription && <p className="text-foreground-light">{successDescription}</p>}
             <p className="pt-4 text-sm text-foreground-lighter">You can close this window.</p>
           </>
         ) : isPending ? (
@@ -136,7 +136,7 @@ const StripeFabricLoginPage = () => {
               <>
                 <p className="mt-4 text-sm text-foreground-light text-center">
                   Your organization <strong>{linkedOrg.name}</strong> is already linked to your
-                  Stripe account. Approve to continue.
+                  Stripe account.
                 </p>
                 <div className="py-6">
                   <Button
@@ -145,7 +145,7 @@ const StripeFabricLoginPage = () => {
                     disabled={isConfirming}
                     onClick={() => handleApprove()}
                   >
-                    Approve
+                    Continue
                   </Button>
                 </div>
               </>

--- a/apps/studio/pages/partners/stripe/fabric/login.tsx
+++ b/apps/studio/pages/partners/stripe/fabric/login.tsx
@@ -7,6 +7,7 @@ import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Button,
+  Input_Shadcn_,
   LogoLoader,
   WarningIcon,
 } from 'ui'
@@ -32,6 +33,8 @@ const StripeFabricLoginPage = () => {
 
   const [selectedOrg, setSelectedOrg] = useState<OrgSummary | null>(null)
   const [orgConfirmed, setOrgConfirmed] = useState(false)
+  const [creatingNewOrg, setCreatingNewOrg] = useState(false)
+  const [newOrgName, setNewOrgName] = useState('')
 
   const {
     data: accountRequest,
@@ -57,9 +60,9 @@ const StripeFabricLoginPage = () => {
     }
   }, [router.isReady, ar_id, router])
 
-  const handleApprove = async (organizationId?: number) => {
+  const handleApprove = async (organizationId?: number, organizationName?: string) => {
     if (!ar_id || isConfirming) return
-    confirmAccountRequest({ arId: ar_id, organizationId })
+    confirmAccountRequest({ arId: ar_id, organizationId, organizationName })
   }
 
   // linked_organization is set when an org is already linked to this Stripe account+org pair
@@ -76,19 +79,19 @@ const StripeFabricLoginPage = () => {
 
   const loadingText = isReauth
     ? 'Completing authorization...'
-    : isLinking
-      ? 'Linking your organization...'
-      : 'Setting up your organization...'
+    : creatingNewOrg || orgCount === 0
+      ? 'Creating your organization...'
+      : 'Linking your organization...'
   const successTitle = isReauth
     ? 'Authorization Complete'
-    : isLinking
-      ? 'Organization Linked'
-      : 'Organization Created'
+    : creatingNewOrg || orgCount === 0
+      ? 'Organization Created'
+      : 'Organization Linked'
   const successDescription = isReauth
     ? null
-    : isLinking
-      ? 'Your Supabase organization has been linked to your Stripe account.'
-      : 'Your Supabase organization has been created and linked to your Stripe account.'
+    : creatingNewOrg || orgCount === 0
+      ? 'Your Supabase organization has been created and linked to your Stripe account.'
+      : 'Your Supabase organization has been linked to your Stripe account.'
 
   return (
     <APIAuthorizationLayout>
@@ -166,14 +169,52 @@ const StripeFabricLoginPage = () => {
                   </Button>
                 </div>
               </>
+            ) : creatingNewOrg ? (
+              // User chose to create a new org — show name input
+              <>
+                <p className="mt-4 text-sm text-foreground-light text-center">
+                  A new <strong>Free</strong> organization will be created and linked to your Stripe
+                  account for provisioning Supabase resources.
+                </p>
+                <div className="mt-4 w-80 flex flex-col gap-3">
+                  <Input_Shadcn_
+                    type="text"
+                    placeholder="Organization name"
+                    value={newOrgName}
+                    onChange={(e) => setNewOrgName(e.target.value)}
+                    maxLength={64}
+                    autoFocus
+                  />
+                </div>
+                <div className="py-6 flex flex-col items-center gap-3">
+                  <Button
+                    size="large"
+                    type="primary"
+                    disabled={isConfirming || newOrgName.trim().length === 0}
+                    onClick={() => handleApprove(undefined, newOrgName.trim())}
+                  >
+                    Create and Approve
+                  </Button>
+                  <button
+                    className="text-sm text-foreground-lighter underline hover:text-foreground-light"
+                    onClick={() => {
+                      setCreatingNewOrg(false)
+                      setNewOrgName('')
+                    }}
+                  >
+                    Back
+                  </button>
+                </div>
+              </>
             ) : orgCount === 1 ? (
-              // Exactly one org — show its name and approve directly
+              // Exactly one org — show its name and option to create new
               <>
                 <p className="mt-4 text-sm text-foreground-light text-center">
                   Your organization <strong>{userOrgs[0].name}</strong> will be linked to your
-                  Stripe account.
+                  Stripe account. Supabase resources from Stripe will be provisioned into this
+                  organization.
                 </p>
-                <div className="py-6">
+                <div className="py-6 flex flex-col items-center gap-3">
                   <Button
                     size="large"
                     type="primary"
@@ -182,13 +223,20 @@ const StripeFabricLoginPage = () => {
                   >
                     Approve
                   </Button>
+                  <button
+                    className="text-sm text-foreground-lighter underline hover:text-foreground-light"
+                    onClick={() => setCreatingNewOrg(true)}
+                  >
+                    or create a new free organization
+                  </button>
                 </div>
               </>
             ) : !orgConfirmed ? (
               // 2+ orgs — show picker
               <>
                 <p className="mt-4 text-sm text-foreground-light text-center">
-                  Select the organization you'd like to link to your Stripe account.
+                  Select the organization you'd like to link to your Stripe account. Supabase
+                  resources from Stripe will be provisioned into this organization.
                 </p>
                 <div className="mt-4 w-96">
                   <OrganizationSelector
@@ -202,6 +250,12 @@ const StripeFabricLoginPage = () => {
                     maxOrgsToShow={3}
                     canCreateNewOrg={false}
                   />
+                  <button
+                    className="mt-3 w-full text-sm text-foreground-lighter underline hover:text-foreground-light"
+                    onClick={() => setCreatingNewOrg(true)}
+                  >
+                    or create a new free organization
+                  </button>
                 </div>
               </>
             ) : (

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -3205,6 +3205,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/projects/{ref}/restore/status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets the latest restore initiated event for a project if a project is restored */
+    get: operations['UnpauseController_getRestoreInitiatedEvent']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/projects/{ref}/restore/versions': {
     parameters: {
       query?: never
@@ -4848,6 +4865,7 @@ export interface components {
     }
     ConfirmRequestDto: {
       organization_id?: number
+      organization_name?: string
     }
     ConfirmResponseDto: {
       organization_slug: string
@@ -5031,6 +5049,7 @@ export interface components {
     }
     CreateInvitationBody: {
       email: string
+      require_sso?: boolean
       role_id: number
       role_scoped_projects?: string[]
     }
@@ -8390,6 +8409,9 @@ export interface components {
       /** @enum {string|null} */
       need_pitr: 'critical' | 'warning' | null
       project: string
+    }
+    ProjectRestoreInitiatedEventResponse: {
+      restore_initiated_on: string | null
     }
     ProjectSensitivityResponse: {
       is_sensitive: boolean
@@ -22270,6 +22292,49 @@ export interface operations {
       }
       /** @description Failed to unpause project */
       500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  UnpauseController_getRestoreInitiatedEvent: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ProjectRestoreInitiatedEventResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
         headers: {
           [name: string]: unknown
         }


### PR DESCRIPTION
Minor tweak related to [this comment](https://linear.app/supabase/issue/API-917/include-stripe-icon-for-orgs-created-via-stripe-fabric#comment-18343910). This is when an account was already linked.


<img width="750" height="369" alt="image" src="https://github.com/user-attachments/assets/1c10c10f-7179-4023-ac11-7496bb6b80fd" />


<img width="771" height="600" alt="image" src="https://github.com/user-attachments/assets/55b0f90a-32e4-42a0-996d-ac46cb881e60" />

Fixes https://linear.app/supabase/issue/API-935/add-the-ability-to-create-a-new-free-organization-as-part-of-the-link