### PR TITLE
fix(studio): allow graphql_public schema in exposed schemas

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -125,7 +125,10 @@ export const PostgrestConfig = () => {
   const schemas = useMemo(
     () =>
       allSchemas
-        .filter((x) => !INTERNAL_SCHEMAS.some((schema) => schema === x.name))
+        .filter((x) => {
+          if (x.name === 'graphql_public') return true
+          return !INTERNAL_SCHEMAS.includes(x.name)
+        })
         .map((x) => {
           return {
             id: x.id,


### PR DESCRIPTION
Fix `graphql_public` schema not showing in legacy exposed schemas selector

## Summary
- The `graphql_public` schema was getting filtered out of the exposed schemas multi-select when the API grant toggles feature flag is disabled
- `ExposedSchemaSelector` (new mode) already had an exception for `graphql_public` – this just adds the same exception to the legacy mode's schema filter

## Test plan
- [ ] Disable the `tableEditorApiAccessToggle` feature flag
- [ ] Go to Settings > API > exposed schemas
- [ ] Confirm `graphql_public` appears in the schema list and is selectable