### PR TITLE
fix: studio docker build fails because of package patches

### DIFF
--- a/.github/workflows/studio-docker-build.yml
+++ b/.github/workflows/studio-docker-build.yml
@@ -1,0 +1,36 @@
+name: Studio Docker Build
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Cancel old builds on new commit for same workflow + branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    name: 'Studio Docker Build'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            studio:
+              - 'packages/pg-meta/**'
+              - 'apps/studio/**'
+              - 'apps/ui-library/**'
+              - 'apps/design-system/**'
+              - 'e2e/studio/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/studio-e2e-test.yml'
+      - name: Build
+        if: steps.filter.outputs.studio == 'true'
+        run: docker build . -f apps/studio/Dockerfile --target production -t supabase-studio:local --build-arg NEXT_PUBLIC_STUDIO_AUTH_MODE=supabase --no-cache

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -17,13 +17,13 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN apt-get update -qq && \
   apt-get install -y --no-install-recommends \
   git \
-  python3 \ 
+  python3 \
   ca-certificates \
-  build-essential && \ 
+  build-essential && \
   rm -rf /var/lib/apt/lists/* && \
   update-ca-certificates
 
-RUN npm install -g pnpm@10.16.1
+RUN npm install -g pnpm@10.24.0
 
 WORKDIR /app
 
@@ -31,12 +31,13 @@ WORKDIR /app
 FROM base AS turbo
 COPY . .
 
-RUN pnpm dlx turbo@2.3.3 prune studio --docker
+RUN pnpm dlx turbo@2.8.13 prune studio --docker
 
 # Install dev dependencies (only if needed)
 FROM base AS deps
 COPY --from=turbo /app/out/json ./
 COPY --from=turbo /app/out/pnpm-lock.yaml ./
+COPY ./patches/ ./patches
 
 # No need to clean cache because production uses standalone build
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preinstall": "npx only-allow pnpm",
     "build": "turbo run build",
     "build:studio": "turbo run build --filter=studio",
+    "build:studio:docker": "docker build . -f apps/studio/Dockerfile --target production -t supabase-studio:local --build-arg NEXT_PUBLIC_STUDIO_AUTH_MODE=supabase --no-cache",
     "build:design-system": "turbo run build --filter=design-system",
     "build:docs": "turbo run build --filter=docs",
     "clean": "turbo run clean --parallel && rimraf -G node_modules/{*,.bin,.modules.yaml}",


### PR DESCRIPTION
## Problem

The docker build for studio fails because pnpm patches are not included

## Solution

- bump pnpm version in Dockefile to match the one used by the repo
- bump turbo version in Dockerfile to use one that handles pnpm patches
- add a script to test the build locally
- add a github action to validate the build on each PR