### PR TITLE
fix: bump up runner due to resources

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: 'E2E tests'
     timeout-minutes: 60
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Our runners is running out of memory and CPU when running the build. Just trying to bump up the blacksmith runner so they match the build machine in Vercel.