### PR TITLE
fix(assistant): sanitize backslash-escaped apostrophes in SQL

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -1,5 +1,8 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/router'
+import { useRef, useState, type DragEvent, type PropsWithChildren } from 'react'
+
 import { useParams } from 'common'
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { entityTypeKeys } from 'data/entity-types/keys'
@@ -10,11 +13,7 @@ import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useChangedSync } from 'hooks/misc/useChanged'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
-import { fixSqlBackslashEscapes } from 'lib/ai/util'
 import { useProfile } from 'lib/profile'
-import { useRouter } from 'next/router'
-import { useRef, useState, type DragEvent, type PropsWithChildren } from 'react'
-
 import { DEFAULT_CHART_CONFIG, QueryBlock } from '../QueryBlock/QueryBlock'
 import { identifyQueryType } from './AIAssistant.utils'
 import { ConfirmFooter } from './ConfirmFooter'
@@ -96,7 +95,7 @@ export const DisplayBlockRenderer = ({
   const isDraggableToReports = canCreateSQLSnippet && (isReportsPage || isHomePage)
   const label = initialArgs.label || 'SQL Results'
   const [isWriteQuery, setIsWriteQuery] = useState<boolean>(initialArgs.isWriteQuery || false)
-  const sqlQuery = fixSqlBackslashEscapes(initialArgs.sql)
+  const sqlQuery = initialArgs.sql
 
   const { database: primaryDatabase } = usePrimaryDatabase({ projectRef: ref })
 

--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -1,8 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/router'
-import { useRef, useState, type DragEvent, type PropsWithChildren } from 'react'
-
 import { useParams } from 'common'
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { entityTypeKeys } from 'data/entity-types/keys'
@@ -13,7 +10,11 @@ import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useChangedSync } from 'hooks/misc/useChanged'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
+import { fixSqlBackslashEscapes } from 'lib/ai/util'
 import { useProfile } from 'lib/profile'
+import { useRouter } from 'next/router'
+import { useRef, useState, type DragEvent, type PropsWithChildren } from 'react'
+
 import { DEFAULT_CHART_CONFIG, QueryBlock } from '../QueryBlock/QueryBlock'
 import { identifyQueryType } from './AIAssistant.utils'
 import { ConfirmFooter } from './ConfirmFooter'
@@ -95,7 +96,7 @@ export const DisplayBlockRenderer = ({
   const isDraggableToReports = canCreateSQLSnippet && (isReportsPage || isHomePage)
   const label = initialArgs.label || 'SQL Results'
   const [isWriteQuery, setIsWriteQuery] = useState<boolean>(initialArgs.isWriteQuery || false)
-  const sqlQuery = initialArgs.sql
+  const sqlQuery = fixSqlBackslashEscapes(initialArgs.sql)
 
   const { database: primaryDatabase } = usePrimaryDatabase({ projectRef: ref })
 

--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -127,4 +127,30 @@ export const dataset: AssistantEvalCase[] = [
         'Verifies template URLs like https://<project-ref>.supabase.co/auth/v1/callback are excluded from URL validity scoring',
     },
   },
+  {
+    input: {
+      prompt:
+        'Insert some sample rows into the messages table. Use the content: "We\'ll be in touch soon", "Don\'t hesitate to ask", and "It\'s a great day"',
+      mockTables: {
+        public: [
+          {
+            name: 'messages',
+            rls_enabled: false,
+            columns: [
+              { name: 'id', data_type: 'bigint' },
+              { name: 'content', data_type: 'text' },
+            ],
+          },
+        ],
+      },
+    },
+    expected: {
+      requiredTools: ['execute_sql'],
+    },
+    metadata: {
+      category: ['sql_generation'],
+      description:
+        "Verifies apostrophes in SQL string literals are properly escaped (e.g., 'We''ll' not 'We'll')",
+    },
+  },
 ]

--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -130,7 +130,7 @@ export const dataset: AssistantEvalCase[] = [
   {
     input: {
       prompt:
-        'Insert some sample rows into the messages table. Use the content: "We\'ll be in touch soon", "Don\'t hesitate to ask", and "It\'s a great day". Escape apostrophes in SQL string literals using a backslash (e.g. \'We\\\'ll\').',
+        "Execute this SQL exactly as written:\nINSERT INTO messages (content) VALUES ('We\\'ll be in touch soon'), ('Don\\'t hesitate to ask'), ('It\\'s a great day');",
       mockTables: {
         public: [
           {

--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -130,7 +130,7 @@ export const dataset: AssistantEvalCase[] = [
   {
     input: {
       prompt:
-        'Insert some sample rows into the messages table. Use the content: "We\'ll be in touch soon", "Don\'t hesitate to ask", and "It\'s a great day"',
+        'Insert some sample rows into the messages table. Use the content: "We\'ll be in touch soon", "Don\'t hesitate to ask", and "It\'s a great day". Escape apostrophes in SQL string literals using a backslash (e.g. \'We\\\'ll\').',
       mockTables: {
         public: [
           {
@@ -150,7 +150,7 @@ export const dataset: AssistantEvalCase[] = [
     metadata: {
       category: ['sql_generation'],
       description:
-        "Verifies apostrophes in SQL string literals are properly escaped (e.g., 'We''ll' not 'We'll')",
+        "Adversarial check to verify Assistant recovers from MySQL-style backslash escapes (\\') and converts them to PostgreSQL double-apostrophes ('') before execution",
     },
   },
 ]

--- a/apps/studio/lib/ai/tools/rendering-tools.ts
+++ b/apps/studio/lib/ai/tools/rendering-tools.ts
@@ -1,11 +1,14 @@
 import { tool } from 'ai'
+import { fixSqlBackslashEscapes } from 'lib/ai/util'
 import { z } from 'zod'
 
 export const getRenderingTools = () => ({
   execute_sql: tool({
     description: 'Asks the user to execute a SQL statement and return the results',
     inputSchema: z.object({
-      sql: z.string().describe('The SQL statement to execute.'),
+      // Transform at parse time so the corrected SQL is what gets stored in
+      // toolCall.input — ensuring evals and logs reflect what actually runs.
+      sql: z.string().describe('The SQL statement to execute.').transform(fixSqlBackslashEscapes),
       label: z.string().describe('A short 2-4 word label for the SQL statement.'),
       chartConfig: z
         .object({

--- a/apps/studio/lib/ai/tools/rendering-tools.ts
+++ b/apps/studio/lib/ai/tools/rendering-tools.ts
@@ -1,11 +1,12 @@
 import { tool } from 'ai'
 import { z } from 'zod'
+import { fixSqlBackslashEscapes } from 'lib/ai/util'
 
 export const getRenderingTools = () => ({
   execute_sql: tool({
     description: 'Asks the user to execute a SQL statement and return the results',
     inputSchema: z.object({
-      sql: z.string().describe('The SQL statement to execute.'),
+      sql: z.string().transform(fixSqlBackslashEscapes).describe('The SQL statement to execute.'),
       label: z.string().describe('A short 2-4 word label for the SQL statement.'),
       chartConfig: z
         .object({

--- a/apps/studio/lib/ai/tools/rendering-tools.ts
+++ b/apps/studio/lib/ai/tools/rendering-tools.ts
@@ -1,12 +1,11 @@
 import { tool } from 'ai'
 import { z } from 'zod'
-import { fixSqlBackslashEscapes } from 'lib/ai/util'
 
 export const getRenderingTools = () => ({
   execute_sql: tool({
     description: 'Asks the user to execute a SQL statement and return the results',
     inputSchema: z.object({
-      sql: z.string().describe('The SQL statement to execute.').transform(fixSqlBackslashEscapes),
+      sql: z.string().describe('The SQL statement to execute.'),
       label: z.string().describe('A short 2-4 word label for the SQL statement.'),
       chartConfig: z
         .object({

--- a/apps/studio/lib/ai/tools/rendering-tools.ts
+++ b/apps/studio/lib/ai/tools/rendering-tools.ts
@@ -6,7 +6,7 @@ export const getRenderingTools = () => ({
   execute_sql: tool({
     description: 'Asks the user to execute a SQL statement and return the results',
     inputSchema: z.object({
-      sql: z.string().transform(fixSqlBackslashEscapes).describe('The SQL statement to execute.'),
+      sql: z.string().describe('The SQL statement to execute.').transform(fixSqlBackslashEscapes),
       label: z.string().describe('A short 2-4 word label for the SQL statement.'),
       chartConfig: z
         .object({

--- a/apps/studio/lib/ai/util.test.ts
+++ b/apps/studio/lib/ai/util.test.ts
@@ -1,5 +1,47 @@
 import { describe, it, expect } from 'vitest'
-import { selectWeightedKey } from './util'
+import { fixSqlBackslashEscapes, selectWeightedKey } from './util'
+
+describe('fixSqlBackslashEscapes', () => {
+  // `\\'` in a TS double-quoted string = literal backslash + apostrophe —
+  // the invalid MySQL-style escape that LLMs sometimes emit.
+
+  it('converts backslash-apostrophe to double-apostrophe', () => {
+    expect(fixSqlBackslashEscapes("INSERT INTO t (c) VALUES ('We\\'ll be in touch')")).toBe(
+      "INSERT INTO t (c) VALUES ('We''ll be in touch')"
+    )
+  })
+
+  it('handles multiple backslash-apostrophes in one string', () => {
+    expect(fixSqlBackslashEscapes("VALUES ('Don\\'t stop, it\\'s fine')")).toBe(
+      "VALUES ('Don''t stop, it''s fine')"
+    )
+  })
+
+  it('handles multiple string literals in one query', () => {
+    expect(fixSqlBackslashEscapes("INSERT INTO t (a, b) VALUES ('We\\'ll', 'It\\'s ready')")).toBe(
+      "INSERT INTO t (a, b) VALUES ('We''ll', 'It''s ready')"
+    )
+  })
+
+  it('leaves already-correct double apostrophes unchanged', () => {
+    const sql = "INSERT INTO t (c) VALUES ('We''ll be in touch')"
+    expect(fixSqlBackslashEscapes(sql)).toBe(sql)
+  })
+
+  it('leaves SQL with no apostrophes unchanged', () => {
+    const sql = 'SELECT 1 + 1'
+    expect(fixSqlBackslashEscapes(sql)).toBe(sql)
+  })
+
+  it('handles the real-world failure case from the original bug report', () => {
+    // Model generated: 'Welcome to our new blog! We\'ll share tutorials and updates here.'
+    const input =
+      "INSERT INTO posts (title, content) VALUES ('Intro', 'Welcome! We\\'ll share tutorials here.')"
+    const expected =
+      "INSERT INTO posts (title, content) VALUES ('Intro', 'Welcome! We''ll share tutorials here.')"
+    expect(fixSqlBackslashEscapes(input)).toBe(expected)
+  })
+})
 
 describe('selectWeightedKey', () => {
   it('should return a valid key from the weights object', async () => {

--- a/apps/studio/lib/ai/util.test.ts
+++ b/apps/studio/lib/ai/util.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect } from 'vitest'
 import { fixSqlBackslashEscapes, selectWeightedKey } from './util'
 
 describe('fixSqlBackslashEscapes', () => {
-  // `\\'` in a TS double-quoted string = literal backslash + apostrophe —
-  // the invalid MySQL-style escape that LLMs sometimes emit.
-
   it('converts backslash-apostrophe to double-apostrophe', () => {
     expect(fixSqlBackslashEscapes("INSERT INTO t (c) VALUES ('We\\'ll be in touch')")).toBe(
       "INSERT INTO t (c) VALUES ('We''ll be in touch')"
@@ -33,13 +30,15 @@ describe('fixSqlBackslashEscapes', () => {
     expect(fixSqlBackslashEscapes(sql)).toBe(sql)
   })
 
-  it('handles the real-world failure case from the original bug report', () => {
-    // Model generated: 'Welcome to our new blog! We\'ll share tutorials and updates here.'
-    const input =
-      "INSERT INTO posts (title, content) VALUES ('Intro', 'Welcome! We\\'ll share tutorials here.')"
-    const expected =
-      "INSERT INTO posts (title, content) VALUES ('Intro', 'Welcome! We''ll share tutorials here.')"
-    expect(fixSqlBackslashEscapes(input)).toBe(expected)
+  it('leaves backslash-apostrophe inside dollar-quoted strings unchanged', () => {
+    const sql = "SELECT $$We\\'ll do it$$ AS greeting"
+    expect(fixSqlBackslashEscapes(sql)).toBe(sql)
+  })
+
+  it('fixes regular strings but leaves dollar-quoted strings unchanged', () => {
+    expect(
+      fixSqlBackslashEscapes("INSERT INTO t (a, b) VALUES ('We\\'ll', $$Don\\'t escape$$)")
+    ).toBe("INSERT INTO t (a, b) VALUES ('We''ll', $$Don\\'t escape$$)")
   })
 })
 

--- a/apps/studio/lib/ai/util.ts
+++ b/apps/studio/lib/ai/util.ts
@@ -1,4 +1,19 @@
 /**
+ * Fixes backslash-escaped apostrophes in SQL string literals.
+ *
+ * Some LLMs use MySQL-style `\'` escapes in SQL. PostgreSQL (with the default
+ * `standard_conforming_strings = on`) does not treat backslash as an escape
+ * character, so `'We\'ll'` is a syntax error. The correct form is `'We''ll'`.
+ *
+ * `\'` is invalid in every PostgreSQL string context: in regular strings it
+ * breaks parsing, and in `E''` escape strings `''` is equally valid. So a
+ * global replacement is safe.
+ */
+export function fixSqlBackslashEscapes(sql: string): string {
+  return sql.replace(/\\'/g, "''")
+}
+
+/**
  * Selects a key from weighted choices using consistent hashing
  * on an input string.
  *

--- a/apps/studio/lib/ai/util.ts
+++ b/apps/studio/lib/ai/util.ts
@@ -1,13 +1,6 @@
 /**
- * Fixes backslash-escaped apostrophes in SQL string literals.
- *
- * Some LLMs use MySQL-style `\'` escapes in SQL. PostgreSQL (with the default
- * `standard_conforming_strings = on`) does not treat backslash as an escape
- * character, so `'We\'ll'` is a syntax error. The correct form is `'We''ll'`.
- *
- * `\'` is invalid in every PostgreSQL string context: in regular strings it
- * breaks parsing, and in `E''` escape strings `''` is equally valid. So a
- * global replacement is safe.
+ * LLMs sometimes emit MySQL-style `\'` escapes in SQL. PostgreSQL doesn't
+ * treat backslash as an escape character, so replace `\'` → `''` globally.
  */
 export function fixSqlBackslashEscapes(sql: string): string {
   return sql.replace(/\\'/g, "''")

--- a/apps/studio/lib/ai/util.ts
+++ b/apps/studio/lib/ai/util.ts
@@ -1,9 +1,12 @@
 /**
  * LLMs sometimes emit MySQL-style `\'` escapes in SQL. PostgreSQL doesn't
- * treat backslash as an escape character, so replace `\'` → `''` globally.
+ * treat backslash as an escape character, so replace `\'` → `''`.
+ * Dollar-quoted strings (e.g. `$$...$$`) are left untouched.
  */
 export function fixSqlBackslashEscapes(sql: string): string {
-  return sql.replace(/\\'/g, "''")
+  return sql.replace(/\$([^$]*)\$[\s\S]*?\$\1\$|\\'/g, (match, dollarTag) =>
+    dollarTag !== undefined ? match : "''"
+  )
 }
 
 /**


### PR DESCRIPTION
Fix for the LLM occasionally generating MySQL-style `\'` escapes in SQL, which are invalid in PostgreSQL.

Example trace where this happened in the wild: ([Braintrust](https://www.braintrust.dev/app/supabase.io/p/Assistant/review?tab=experiment&r=5fcf1b12-8584-455c-9e9a-bdc0fa3ed21c&s=5fcf1b12-8584-455c-9e9a-bdc0fa3ed21c&o=0627ada8-b567-4117-9fe8-49d847cb73a7&review=1))

**Changes**
- Adds `fixSqlBackslashEscapes` to convert `\'` → `''` before SQL is executed
- Unit tests + adversarial eval dataset case

Compare the results of the adversarial test case:
- `master`: 0% SQL Validity ([Braintrust](https://www.braintrust.dev/app/supabase.io/p/Dev%20(mattrossman%2FAssistant)/trace?object_type=experiment&object_id=b469cbf7-4d6f-429c-9819-6c4099294123&r=dce5a29b-2fde-44c3-80f8-4e14d1f657c0&s=dce5a29b-2fde-44c3-80f8-4e14d1f657c0))
- This branch: 100% SQL Validity ([Braintrust](https://www.braintrust.dev/app/supabase.io/p/Assistant/trace?object_type=experiment&object_id=160e9ce0-e320-4f6d-8aa7-c5ad7e01fbd2&r=d75ef0e3-90ed-42a7-9ef3-8bf69592f193&s=0eeca492-dbe6-451e-8d81-127caff30320))

Closes AI-400