### PR TITLE
fix(studio): fall back to legacy connect dialog when connectSection flag is unresolved

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -77,7 +77,6 @@ export const LayoutHeader = ({
   const gitlessBranching = useIsBranching2Enabled()
 
   const connectSectionVariant = usePHFlag<ConnectSectionVariant | false>('connectSection')
-  const isFlagResolved = connectSectionVariant !== undefined
   const isConnectSheetEnabled = connectSectionVariant === 'connect'
 
   const [commandMenuEnabled] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.HOTKEY_COMMAND_MENU, true)
@@ -280,7 +279,7 @@ export const LayoutHeader = ({
         </div>
       </header>
 
-      {isFlagResolved ? isConnectSheetEnabled ? <ConnectSheet /> : <Connect /> : null}
+      {isConnectSheetEnabled ? <ConnectSheet /> : <Connect />}
     </>
   )
 }


### PR DESCRIPTION
## Summary

When the `connectSection` PostHog flag is unresolved (`undefined`) — e.g. during loading or if PostHog is unreachable — the header Connect button renders nothing (`null`), making it a no-op. This changes the fallback to render the legacy `<Connect />` dialog instead, so the button always works.

## Changes

- Remove `isFlagResolved` gate in `LayoutHeader` — render `<Connect />` (legacy) whenever `connectSection !== 'connect'`, including when `undefined`

## Testing

Tested on Vercel preview:
- [x] Flag returns `'connect'` — ConnectSheet opens
- [x] Flag returns `'getting-started'` or `false` — legacy Connect dialog opens
- [x] Flag is `undefined` (unresolved) — legacy Connect dialog opens instead of nothing