### PR TITLE
Change URL param string for destination panel type as it conflicts with Connect Modal

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -36,7 +36,7 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
   const { hasAccess: hasETLReplicationAccess } = useCheckEntitlements('replication.etl')
 
   const [urlDestinationType, setDestinationType] = useQueryState(
-    'type',
+    'destinationType',
     parseAsStringEnum<DestinationType>([
       'Read Replica',
       'BigQuery',

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -18,7 +18,7 @@ export const DestinationTypeSelection = () => {
   ).length
 
   const [urlDestinationType, setDestinationType] = useQueryState(
-    'type',
+    'destinationType',
     parseAsStringEnum<DestinationType>([
       'Read Replica',
       'BigQuery',

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -56,7 +56,7 @@ export const Destinations = () => {
   const [statusRefetchInterval, setStatusRefetchInterval] = useState<number | false>(5000)
 
   const [_, setDestinationType] = useQueryState(
-    'type',
+    'destinationType',
     parseAsStringEnum<DestinationType>([
       'Read Replica',
       'BigQuery',


### PR DESCRIPTION
## Context

Small one - while on the database replication page, if you open the Connect Dialog and change the "type" field, the destination panel opens up. Happening cause the string for `useQueryState` conflicts here - both are using `type`

Fix is just to update the string for `useQueryState` for the DestinationPanel component, changed it to `destinationType`