### PR TITLE
Disable incident banner query in prod, only status page query

### DIFF
--- a/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
+++ b/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
@@ -22,9 +22,10 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
   const showIncidentBannerOverride =
     useFlag('ongoingIncident') || process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true'
 
-  // Both queries run in parallel on all environments.
-  const { data: allStatusPageEvents } = useIncidentStatusQuery()
-  const { data: incidentBannerData } = useQuery(incidentBannerQueryOptions())
+  const { data: allStatusPageEvents } = useIncidentStatusQuery({ enabled: IS_PROD })
+  const { data: incidentBannerData } = useQuery(
+    incidentBannerQueryOptions({ enabled: IS_NON_PROD })
+  )
 
   // In non-production: derive incidents from the incident-banner endpoint.
   // In production: derive incidents from the statuspage endpoint (existing behaviour).

--- a/apps/studio/data/platform/incident-banner-query.ts
+++ b/apps/studio/data/platform/incident-banner-query.ts
@@ -28,10 +28,10 @@ async function getIncidentBanner(signal?: AbortSignal): Promise<IncidentBannerDa
   return response.json()
 }
 
-export const incidentBannerQueryOptions = () =>
+export const incidentBannerQueryOptions = ({ enabled = IS_PLATFORM }: { enabled?: boolean } = {}) =>
   queryOptions({
     queryKey: platformKeys.incidentBanner(),
     queryFn: ({ signal }) => getIncidentBanner(signal),
     staleTime: 1000 * 60 * 5,
-    enabled: IS_PLATFORM,
+    enabled,
   })


### PR DESCRIPTION
## Context

Realised that we're calling both /incident-status and /incident-banner on prod
Which the latter is only meant for local/staging for now but its creating a lot of 500 requests

Changes here patches that