### PR TITLE
fix(ui-patterns): Eliminate broken ease tailwind class

### DIFF
--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -466,7 +466,7 @@ const MultiSelectorContent = React.forwardRef<HTMLDivElement, React.HTMLAttribut
             ? 'bottom-[calc(100%+0.25rem)] origin-bottom'
             : 'top-[calc(100%+0.25rem)] origin-top',
           open
-            ? 'opacity-100 translate-y-0 visible duration-150 ease-[.76,0,.23,1]'
+            ? 'opacity-100 translate-y-0 visible duration-150 ease-in-out'
             : cn('opacity-0 invisible duration-0', closedTranslationClass),
           className
         )}


### PR DESCRIPTION
In this PR:

Currently our Docs build produces this warning:

```
[0] warn - The class `ease-[.76,0,.23,1]` is ambiguous and matches multiple utilities.
[0] warn - If this is content and not a class, replace it with `ease-&lsqb;.76,0,.23,1&rsqb;` to silence this warning.
```

Tracking it down, it belongs to the `MultiSelect` component in our `ui-patterns` package. The duration of the modal containing the options is so fast (150ms) that custom easings do nothing in visual difference, so I replaced it for an in-out easing.