### PR TITLE
chore: Remove unactionable warning polluting CI

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -1,4 +1,5 @@
 import { AuthClient, navigatorLock, User } from '@supabase/auth-js'
+import { isBrowser } from './helpers'
 
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
 export const AUTH_DEBUG_KEY =
@@ -37,6 +38,10 @@ const shouldDetectSessionInUrl = process.env.NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_
   : true
 
 const navigatorLockEnabled = !!(shouldEnableNavigatorLock && globalThis?.navigator?.locks)
+
+if (isBrowser && shouldEnableNavigatorLock && !globalThis?.navigator?.locks) {
+  console.warn('This browser does not support the Navigator Locks API. Please update it.')
+}
 
 const tabId = Math.random().toString(16).substring(2)
 

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -38,10 +38,6 @@ const shouldDetectSessionInUrl = process.env.NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_
 
 const navigatorLockEnabled = !!(shouldEnableNavigatorLock && globalThis?.navigator?.locks)
 
-if (shouldEnableNavigatorLock && !globalThis?.navigator?.locks) {
-  console.warn('This browser does not support the Navigator Locks API. Please update it.')
-}
-
 const tabId = Math.random().toString(16).substring(2)
 
 let dbHandle = new Promise<IDBDatabase | null>((accept, _) => {


### PR DESCRIPTION
This log pollutes the whole build with no action available.

The Locks API is only present in Node 24, which it's more a team/company decision. Not sure if users will even see this.

It pollutes every build log inspection:

<img width="833" height="634" alt="Screenshot 2026-03-13 at 11 36 47" src="https://github.com/user-attachments/assets/e0a06fc6-2d57-40e9-bfc2-5a95d5f54bb1" />
