### PR TITLE
fix: Fix Studio breaking for Team users

### DIFF
--- a/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
+++ b/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
@@ -45,15 +45,16 @@ export function UpdateBillingAddressModal() {
     'stripe.customer'
   )
 
-  const shouldShow =
+  const shouldShow = Boolean(
     IS_PLATFORM &&
-    showMissingAddressModal &&
-    !!org &&
-    org.plan.id !== 'free' &&
-    org.organization_missing_address &&
-    !org.billing_partner &&
-    permissionsLoaded &&
-    canBillingWrite
+      showMissingAddressModal &&
+      org &&
+      org.plan.id !== 'free' &&
+      org.organization_missing_address &&
+      !org.billing_partner &&
+      permissionsLoaded &&
+      canBillingWrite
+  )
 
   const {
     data: customerProfile,


### PR DESCRIPTION
This PR fixes an issue which caused the Studio to break for Team users. It was caused because non-boolean value was passed to `enabled`.