### PR TITLE
fix(studio): distinguish NULL from "use default" when inserting rows

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -95,7 +95,7 @@ export const RowEditor = ({
     const updatedProperties = Object.keys(changes)
     const updatedFields = rowFields.map((field) => {
       if (updatedProperties.includes(field.name)) {
-        return { ...field, value: changes[field.name] }
+        return { ...field, value: changes[field.name], isUserModified: true }
       } else {
         return field
       }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types.ts
@@ -18,4 +18,5 @@ export interface RowField {
   isNullable: boolean
   isIdentity: boolean
   isPrimaryKey: boolean
+  isUserModified?: boolean
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.test.ts
@@ -713,4 +713,80 @@ describe('generateRowObjectFromFields - additional cases', () => {
     const result = generateRowObjectFromFields(fields)
     expect(result).toEqual({})
   })
+
+  it('should include null values for user-modified fields when includeNullProperties is false', () => {
+    const fields: RowField[] = [
+      createField({
+        name: 'optional_field',
+        format: 'text',
+        value: null,
+        isUserModified: true,
+      }),
+      createField({
+        name: 'untouched_field',
+        format: 'text',
+        value: null,
+        isUserModified: false,
+      }),
+      createField({
+        name: 'active_field',
+        format: 'text',
+        value: 'value',
+      }),
+    ]
+    const result = generateRowObjectFromFields(fields, false)
+    expect(result).toEqual({ optional_field: null, active_field: 'value' })
+  })
+
+  it('should omit null values for non-user-modified fields', () => {
+    const fields: RowField[] = [
+      createField({
+        name: 'count',
+        format: 'int4',
+        value: '',
+        isUserModified: false,
+      }),
+    ]
+    const result = generateRowObjectFromFields(fields)
+    expect(result).toEqual({})
+  })
+
+  it('should include null for user-modified boolean set to null', () => {
+    const fields: RowField[] = [
+      createField({
+        name: 'active',
+        format: 'bool',
+        value: 'null',
+        isUserModified: true,
+      }),
+    ]
+    const result = generateRowObjectFromFields(fields)
+    expect(result).toEqual({ active: null })
+  })
+
+  it('should omit null for non-user-modified boolean set to null', () => {
+    const fields: RowField[] = [
+      createField({
+        name: 'active',
+        format: 'bool',
+        value: 'null',
+        isUserModified: false,
+      }),
+    ]
+    const result = generateRowObjectFromFields(fields)
+    expect(result).toEqual({})
+  })
+
+  it('should include null for user-modified non-text field with empty value', () => {
+    const fields: RowField[] = [
+      createField({
+        name: 'count',
+        format: 'int4',
+        value: '',
+        isUserModified: true,
+      }),
+    ]
+    const result = generateRowObjectFromFields(fields)
+    expect(result).toEqual({ count: null })
+  })
 })

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -80,6 +80,7 @@ export const generateRowFields = (
       isNullable: column.is_nullable,
       isIdentity: column.is_identity,
       isPrimaryKey: primaryKeyColumns.includes(column.name),
+      isUserModified: row !== undefined,
     }
   })
 }
@@ -182,11 +183,6 @@ const convertInputDatetimeToPostgresDatetime = (format: string, value: string | 
   }
 }
 
-// [Joshen] JFYI this presents a small problem in particular when creating a new row
-// given that we don't include null properties. Because of that if the column has a default
-// value, the column value will then always be the default value, instead of null
-// which may be considered a bug if e.g for a boolean column the user specifically selects "NULL" option
-// This would probably also apply to other column types like numbers (e.g user specifically wants a null value)
 export const generateRowObjectFromFields = (
   fields: RowField[],
   includeNullProperties = false
@@ -224,7 +220,16 @@ export const generateRowObjectFromFields = (
       rowObject[field.name] = value
     }
   })
-  return includeNullProperties ? rowObject : omitBy(rowObject, isNull)
+
+  if (includeNullProperties) return rowObject
+
+  // For new rows, keep null values for fields the user explicitly modified
+  // so that we distinguish between "use DB default" (untouched) and "insert NULL" (user set to null)
+  return omitBy(rowObject, (value, key) => {
+    if (!isNull(value)) return false
+    const field = fields.find((f) => f.name === key)
+    return field ? !field.isUserModified : true
+  })
 }
 
 export const generateUpdateRowPayload = (originalRow: any, fields: RowField[]) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When inserting a new row via the Studio dashboard, setting a column to NULL 
results in the column being omitted from the INSERT statement, so PostgreSQL 
uses the column's default value instead. The dashboard doesn't distinguish 
between "user explicitly chose NULL" and "user didn't touch this field."

Fixes #43548

## What is the new behavior?
Added an `isUserModified` flag to `RowField` that tracks whether the user 
explicitly changed a field. When generating the INSERT payload:
- **Untouched fields** with null values are omitted → DB default applies
- **User-modified fields** with null values are kept → NULL is inserted

## Files changed
- `RowEditor.types.ts` — Added `isUserModified?: boolean` to RowField interface
- `RowEditor.utils.ts` — Updated `generateRowFields` and `generateRowObjectFromFields`
- `RowEditor.tsx` — Set `isUserModified: true` in `onUpdateField`
- `RowEditor.utils.test.ts` — Added 6 new tests (57 total, all passing)