### PR TITLE
fix(studio): escape quotes in enum type creation and editing SQL

### DIFF
--- a/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-create-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
+import { toast } from 'sonner'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+
 import { enumeratedTypesKeys } from './keys'
 
 export type EnumeratedTypeCreateVariables = {
@@ -23,11 +23,15 @@ export async function createEnumeratedType({
   description,
   values,
 }: EnumeratedTypeCreateVariables) {
-  const createSql = `create type "${schema}"."${name}" as enum (${values
-    .map((x) => `'${x}'`)
+  const escapedSchema = schema.replace(/"/g, '""')
+  const escapedName = name.replace(/"/g, '""')
+  const createSql = `create type "${escapedSchema}"."${escapedName}" as enum (${values
+    .map((x) => `'${x.replace(/'/g, "''")}'`)
     .join(', ')});`
   const commentSql =
-    description !== undefined ? `comment on type "${schema}"."${name}" is '${description}';` : ''
+    description !== undefined
+      ? `comment on type "${escapedSchema}"."${escapedName}" is '${description.replace(/'/g, "''")}';`
+      : ''
   const sql = wrapWithTransaction(`${createSql} ${commentSql}`)
   const { result } = await executeSql({ projectRef, connectionString, sql })
   return result

--- a/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
+++ b/apps/studio/data/enumerated-types/enumerated-type-update-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-
 import { executeSql } from 'data/sql/execute-sql-query'
 import { wrapWithTransaction } from 'data/sql/utils/transaction'
+import { toast } from 'sonner'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+
 import { enumeratedTypesKeys } from './keys'
 
 export type EnumeratedTypeUpdateVariables = {
@@ -23,9 +23,15 @@ export async function updateEnumeratedType({
   description,
   values = [],
 }: EnumeratedTypeUpdateVariables) {
+  const escapedSchema = schema.replace(/"/g, '""')
+  const escapedOriginalName = name.original.replace(/"/g, '""')
+  const escapedUpdatedName = name.updated.replace(/"/g, '""')
+
   const statements: string[] = []
   if (name.original !== name.updated) {
-    statements.push(`alter type "${schema}"."${name.original}" rename to "${name.updated}";`)
+    statements.push(
+      `alter type "${escapedSchema}"."${escapedOriginalName}" rename to "${escapedUpdatedName}";`
+    )
   }
   if (values.length > 0) {
     values.forEach((x, idx) => {
@@ -34,24 +40,24 @@ export async function updateEnumeratedType({
           // Consider if any new enums were added before any existing enums
           const firstExistingEnumValue = values.find((x) => !x.isNew)
           statements.push(
-            `alter type "${schema}"."${name.updated}" add value '${x.updated}' before '${firstExistingEnumValue?.original}';`
+            `alter type "${escapedSchema}"."${escapedUpdatedName}" add value '${x.updated.replace(/'/g, "''")}' before '${firstExistingEnumValue?.original.replace(/'/g, "''")}';`
           )
         } else {
           statements.push(
-            `alter type "${schema}"."${name.updated}" add value '${x.updated}' after '${
-              values[idx - 1].updated
-            }';`
+            `alter type "${escapedSchema}"."${escapedUpdatedName}" add value '${x.updated.replace(/'/g, "''")}' after '${values[idx - 1].updated.replace(/'/g, "''")}';`
           )
         }
       } else if (x.original !== x.updated) {
         statements.push(
-          `alter type "${schema}"."${name.updated}" rename value '${x.original}' to '${x.updated}';`
+          `alter type "${escapedSchema}"."${escapedUpdatedName}" rename value '${x.original.replace(/'/g, "''")}' to '${x.updated.replace(/'/g, "''")}';`
         )
       }
     })
   }
   if (description !== undefined) {
-    statements.push(`comment on type "${schema}"."${name.updated}" is '${description}';`)
+    statements.push(
+      `comment on type "${escapedSchema}"."${escapedUpdatedName}" is '${description.replace(/'/g, "''")}';`
+    )
   }
 
   const sql = wrapWithTransaction(statements.join(' '))


### PR DESCRIPTION
## Summary

Fixes #41371

Enum values, names, and descriptions containing quotes were interpolated directly into SQL strings without escaping, causing errors when users entered values like `it's` or names containing double quotes.

**Changes:**
- Escape single quotes in enum values and descriptions using standard SQL literal escaping (`'` -> `''`)
- Escape double quotes in schema and type name identifiers (`"` -> `""`)
- Applied to both create and update enum mutations

This follows the same escaping pattern already used elsewhere in the codebase (e.g., `database-event-trigger-delete-mutation.ts`, `table-index-advisor-query.ts`).

## Test plan

- [ ] Create an enum type with a value containing a single quote (e.g., `it's`)
- [ ] Create an enum type with a description containing a single quote
- [ ] Edit an enum type and add a value containing a single quote
- [ ] Rename an enum type to a name containing a double quote
- [ ] Verify all operations succeed without SQL errors

This contribution was developed with AI assistance (Claude Code).