### PR TITLE
fix(studio): accept TSV files in table editor import

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.tsx
@@ -1,13 +1,13 @@
 import dayjs from 'dayjs'
+import { DOCS_URL } from 'lib/constants'
+import { tryParseJson } from 'lib/helpers'
 import { has, includes } from 'lodash'
 import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import Papa from 'papaparse'
 import { toast } from 'sonner'
-
-import { DOCS_URL } from 'lib/constants'
-import { tryParseJson } from 'lib/helpers'
 import { Button } from 'ui'
+
 import {
   MAX_TABLE_EDITOR_IMPORT_CSV_SIZE,
   UPLOAD_FILE_EXTENSIONS,
@@ -173,13 +173,13 @@ export const acceptedFileExtension = (file: any) => {
 }
 
 export function flagInvalidFileImport(file: File): boolean {
-  if (!file || !UPLOAD_FILE_TYPES.includes(file.type) || !acceptedFileExtension(file)) {
-    toast.error("Couldn't import file: only CSV files are accepted")
+  if (!file || (!UPLOAD_FILE_TYPES.includes(file.type) && !acceptedFileExtension(file))) {
+    toast.error("Couldn't import file: only CSV and TSV files are accepted")
     return true
   } else if (file.size > MAX_TABLE_EDITOR_IMPORT_CSV_SIZE) {
     toast.error(
       <div className="space-y-1">
-        <p>The dashboard currently only supports importing of CSVs below 100MB.</p>
+        <p>The dashboard currently only supports importing of CSV/TSV files below 100MB.</p>
         <p>For bulk data loading, we recommend doing so directly through the database.</p>
         <Button asChild type="default" icon={<ExternalLink />} className="!mt-2">
           <Link


### PR DESCRIPTION
## Summary

Fixes #41493

TSV files were rejected with "only CSV files are accepted" despite the UI text and constants correctly listing TSV as a supported format.

**Root cause:** The file validation used OR logic (`||`) requiring **both** MIME type and file extension to pass. Some browsers/OSes report empty or incorrect MIME types for `.tsv` files (e.g., `application/octet-stream` instead of `text/tab-separated-values`), causing rejection even when the extension was valid.

**Fix:** Changed to AND logic (`&&`) so files are accepted if **either** the MIME type or the extension matches. Also updated error messages to mention TSV alongside CSV.

## Test plan

- [ ] Upload a `.csv` file - should still work
- [ ] Upload a `.tsv` file - should now work (previously rejected on some machines)
- [ ] Upload a `.txt` file - should be rejected with "only CSV and TSV files" message
- [ ] Upload a file larger than 100MB - error message now says "CSV/TSV files"

This contribution was developed with AI assistance (Claude Code).