### PR TITLE
add blog url button support to features page.

### DIFF
--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -99,6 +99,10 @@ export type FeatureType = {
    */
   docsUrl?: string
   /**
+   * url to a related blog post
+   */
+  blogUrl?: string
+  /**
    * feature metadata on its status
    */
   status?: {
@@ -478,8 +482,6 @@ Supabase Read Replicas distribute read traffic across multiple databases. Use th
 ## Get Started
 
 Deploy your first Read Replica in minutes from Project Settings > Infrastructure. Choose a region—same region for analytics isolation, different region for geo-distribution. Select a compute size to match your workload.
-
-[Read blog post](https://supabase.com/blog/read-replicas-vs-bigger-compute)
 `,
     icon: Database,
     products: [PRODUCT_SHORTNAMES.DATABASE],

--- a/apps/www/pages/features/[slug].tsx
+++ b/apps/www/pages/features/[slug].tsx
@@ -222,10 +222,19 @@ const FeaturePage: React.FC<FeaturePageProps> = ({ feature, prevFeature, nextFea
               <div className="prose prose-docs">
                 <ReactMarkdown>{feature.description}</ReactMarkdown>
               </div>
-              {feature.docsUrl && (
-                <Button type="default" iconRight={<ChevronRight />} asChild>
-                  <Link href={feature.docsUrl}>Read Documentation</Link>
-                </Button>
+              {(feature.docsUrl || feature.blogUrl) && (
+                <div className="flex flex-wrap gap-2">
+                  {feature.docsUrl && (
+                    <Button type="default" iconRight={<ChevronRight />} asChild>
+                      <Link href={feature.docsUrl}>Read Documentation</Link>
+                    </Button>
+                  )}
+                  {feature.blogUrl && (
+                    <Button type="default" iconRight={<ChevronRight />} asChild>
+                      <Link href={feature.blogUrl}>Read Blog Post</Link>
+                    </Button>
+                  )}
+                </div>
               )}
               <div className="w-full flex items-center justify-between text-foreground-lighter text-sm border-y py-4">
                 <span>Share</span>


### PR DESCRIPTION
This pr adds a blog post button support to /features pages.

| Before | After |
|--------|--------|
| <img width="504" height="234" alt="Screenshot 2026-03-13 at 16 09 50" src="https://github.com/user-attachments/assets/62672e22-2b6e-478a-8d56-a1ca7b4c83d1" /> | <img width="450" height="253" alt="Screenshot 2026-03-13 at 16 08 44" src="https://github.com/user-attachments/assets/d45550cc-47a2-457e-bb77-abb3add54073" /> | 


