### PR TITLE
chore: Add exponential backoff to the incident queries

### DIFF
--- a/apps/studio/data/platform/incident-banner-query.ts
+++ b/apps/studio/data/platform/incident-banner-query.ts
@@ -31,7 +31,9 @@ export const incidentBannerQueryOptions = () =>
   queryOptions({
     queryKey: platformKeys.incidentBanner(),
     queryFn: ({ signal }) => getIncidentBanner(signal),
-    // exponential backoff retry starting at 4s, 16s, 64s, 256s, up to 5 minutes
+    refetchOnWindowFocus: false,
+    // exponential backoff retry starting at 4s, 16s, 64s, 256s etc. Hard capped at 5 minutes to prevent excessively
+    // long retry delays.
     retryDelay: (attemptIndex) => Math.min(1000 * 4 ** attemptIndex, 1000 * 60 * 5),
     staleTime: 1000 * 60 * 5,
     enabled: IS_PLATFORM,

--- a/apps/studio/data/platform/incident-banner-query.ts
+++ b/apps/studio/data/platform/incident-banner-query.ts
@@ -31,6 +31,8 @@ export const incidentBannerQueryOptions = () =>
   queryOptions({
     queryKey: platformKeys.incidentBanner(),
     queryFn: ({ signal }) => getIncidentBanner(signal),
+    // exponential backoff retry starting at 4s, 16s, 64s, 256s, up to 5 minutes
+    retryDelay: (attemptIndex) => Math.min(1000 * 4 ** attemptIndex, 1000 * 60 * 5),
     staleTime: 1000 * 60 * 5,
     enabled: IS_PLATFORM,
   })

--- a/apps/studio/data/platform/incident-status-query.ts
+++ b/apps/studio/data/platform/incident-status-query.ts
@@ -40,7 +40,9 @@ export const useIncidentStatusQuery = <TData = IncidentStatusData>(
   useQuery<IncidentStatusData, IncidentStatusError, TData>({
     queryKey: platformKeys.incidentStatus(),
     queryFn: ({ signal }) => getIncidentStatus(signal),
-    // exponential backoff retry starting at 4s, 16s, 64s, 256s, up to 5 minutes
+    refetchOnWindowFocus: false,
+    // exponential backoff retry starting at 4s, 16s, 64s, 256s etc. Hard capped at 5 minutes to prevent excessively
+    // long retry delays.
     retryDelay: (attemptIndex) => Math.min(1000 * 4 ** attemptIndex, 1000 * 60 * 5),
     staleTime: 1000 * 60 * 5, // 5 minutes to match API cache
     ...options,

--- a/apps/studio/data/platform/incident-status-query.ts
+++ b/apps/studio/data/platform/incident-status-query.ts
@@ -40,6 +40,8 @@ export const useIncidentStatusQuery = <TData = IncidentStatusData>(
   useQuery<IncidentStatusData, IncidentStatusError, TData>({
     queryKey: platformKeys.incidentStatus(),
     queryFn: ({ signal }) => getIncidentStatus(signal),
+    // exponential backoff retry starting at 4s, 16s, 64s, 256s, up to 5 minutes
+    retryDelay: (attemptIndex) => Math.min(1000 * 4 ** attemptIndex, 1000 * 60 * 5),
     staleTime: 1000 * 60 * 5, // 5 minutes to match API cache
     ...options,
     // Enable in platform mode, or in test environment for E2E testing


### PR DESCRIPTION
The incident queries have been hammering statuspage and incident.io API endpoints which has resulted in 429 and 75% of all requests failing. 

This PR sets the retry on fail to 4s, 16s, 64s, 256s and 300s. Previously it was set to 2s, 4s, 8s, 16s and 32s.