### PR TITLE
chore: Add `credentials: omit` when calling into /incident API endpoints

### DIFF
--- a/apps/studio/data/platform/incident-banner-query.ts
+++ b/apps/studio/data/platform/incident-banner-query.ts
@@ -21,6 +21,7 @@ async function getIncidentBanner(signal?: AbortSignal): Promise<IncidentBannerDa
   const response = await fetch(`${BASE_PATH}/api/incident-banner`, {
     signal,
     method: 'GET',
+    credentials: 'omit',
     headers: { 'Content-Type': 'application/json' },
   })
   if (!response.ok) throw new Error(`Failed to fetch incident banner: ${response.statusText}`)

--- a/apps/studio/data/platform/incident-status-query.ts
+++ b/apps/studio/data/platform/incident-status-query.ts
@@ -12,6 +12,7 @@ export async function getIncidentStatus(
   const response = await fetch(`${BASE_PATH}/api/incident-status`, {
     signal,
     method: 'GET',
+    credentials: 'omit',
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
`/incident-status` and `/incident-banner` are not cached because they include auth cookies which busts Vercel cache. This PR add `credentials: omit` since they calls don't need auth cookies and they're same for all users.