### PR TITLE
fix(storage): use correct prefix in fetchMoreFolderContents pagination

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -395,7 +395,10 @@ function createStorageExplorerState({
     }) => {
       state.setColumnIsLoadingMore(index)
 
-      const prefix = state.openedFolders.map((folder) => folder.name).join('/')
+      const prefix = state.openedFolders
+        .slice(0, index + 1)
+        .map((folder) => folder.name)
+        .join('/')
       const options = {
         limit: LIMIT,
         offset: column.items.length,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In the Storage Explorer column view, `fetchMoreFolderContents` computes the API prefix using **all** `openedFolders` instead of slicing to the target column index. This causes "load more" pagination in non-leaf columns to fetch objects from the wrong directory.

For example, if folders A → B → C are open and the user scrolls down in the root column, the additional items are fetched from path `A/B/C` instead of the root.

Reported in #43799.

## What is the new behavior?

`fetchMoreFolderContents` now uses `.slice(0, index + 1)` to compute the prefix, matching the existing logic in `fetchFolderContents` (L335-338).

## Additional context

`fetchFolderContents` correctly slices:

```typescript
// L335-338
const prefix = state.openedFolders
  .slice(0, index + 1)
  .map((folder) => folder.name)
  .join('/')
```

`fetchMoreFolderContents` was missing the slice:

```typescript
// L398 (before fix)
const prefix = state.openedFolders
  .map((folder) => folder.name)
  .join('/')
```

This was missed during the refactor in #43541. The fix is a single `.slice(0, index + 1)` addition to align both functions.

Fixes #43799