### PR TITLE
fix: escape regex control character

### DIFF
--- a/apps/studio/lib/api/edgeFunctions.test.ts
+++ b/apps/studio/lib/api/edgeFunctions.test.ts
@@ -4,10 +4,10 @@ import { isValidEdgeFunctionURL } from './edgeFunctions'
 
 describe('isValidEdgeFunctionURL', () => {
   const validEdgeFunctionUrls = [
-    'https://projectref.supabase.co/functions/v1/hello-world',
-    'https://projectref.supabase.red/functions/v1/hello-world',
-    'https://projectref.supabase.red/functions/v3/hello-world',
-    'https://projectref.supabase.red/functions/v3/hello-world',
+    'https://uniquetwentychararef.supabase.co/functions/v1/hello-world',
+    'https://uniquetwentychararef.supabase.red/functions/v1/hello-world',
+    'https://uniquetwentychararef.supabase.red/functions/v3/hello-world',
+    'https://uniquetwentychararef.supabase.red/functions/v3/hello-world',
   ]
 
   const validLocalEdgeFunctionsUrls = [

--- a/apps/studio/lib/api/edgeFunctions.ts
+++ b/apps/studio/lib/api/edgeFunctions.ts
@@ -9,7 +9,7 @@ export const isValidEdgeFunctionURL = (url: string, isPlatform: boolean) => {
 
   if (!isPlatform) {
     const regexValidLocalEdgeFunctionURL = new RegExp(
-      /^https?:\/\/[^\\s/?#]+\/functions\/v[0-9]{1}\/.*$/
+      /^https?:\/\/[^\s/?#]+\/functions\/v[0-9]{1}\/.*$/
     )
 
     return regexValidLocalEdgeFunctionURL.test(url)

--- a/apps/studio/lib/api/edgeFunctions.ts
+++ b/apps/studio/lib/api/edgeFunctions.ts
@@ -9,14 +9,14 @@ export const isValidEdgeFunctionURL = (url: string, isPlatform: boolean) => {
 
   if (!isPlatform) {
     const regexValidLocalEdgeFunctionURL = new RegExp(
-      '^https?://[^\\s/?#]+/functions/v[0-9]{1}/.*$'
+      /^https?:\/\/[^\\s/?#]+\/functions\/v[0-9]{1}\/.*$/
     )
 
     return regexValidLocalEdgeFunctionURL.test(url)
   }
 
   const regexValidEdgeFunctionURL = new RegExp(
-    '^https://[a-z]*.supabase.(red|co)/functions/v[0-9]{1}/.*$'
+    /^https:\/\/[a-z]{20}\.supabase\.(red|co)\/functions\/v[0-9]{1}\/.*$/
   )
 
   return regexValidEdgeFunctionURL.test(url)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

regex control character, `.` is not escaped.

## What is the new behavior?

Escapes control characters and makes regex a little stricter. Use regex literal
