### PR TITLE
feat(studio): move error code popover to shared data

### DIFF
--- a/apps/studio/components/interfaces/Auth/Overview/OverviewMetrics.tsx
+++ b/apps/studio/components/interfaces/Auth/Overview/OverviewMetrics.tsx
@@ -31,7 +31,7 @@ import {
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
 
-import { ErrorCodeTooltip } from '../../Settings/Logs/ErrorCodeTooltip'
+import { ErrorCodeTooltip } from 'components/ui/ErrorCodeTooltip/ErrorCodeTooltip'
 import {
   AuthErrorCodeRow,
   fetchTopAuthErrorCodes,

--- a/apps/studio/components/interfaces/Settings/Logs/ErrorCodeTooltip.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/ErrorCodeTooltip.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { useTheme } from 'next-themes'
 import { ExternalLink } from 'lucide-react'
+import { ERROR_CODES, ERROR_CODE_DOCS_URLS, HTTP_ERROR_CODES } from 'shared-data'
+import type { ErrorCodeService } from 'shared-data'
 
 import { useErrorCodesQuery } from 'data/content-api/docs-error-codes-query'
 import { Service } from 'data/graphql/graphql'
@@ -22,8 +24,9 @@ import {
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-const SERVICE_DOCS_URLS: Partial<Record<Service, string>> = {
-  [Service.Auth]: 'https://supabase.com/docs/guides/auth/debugging/error-codes',
+const SERVICE_MAP: Partial<Record<Service, ErrorCodeService>> = {
+  [Service.Auth]: 'auth',
+  [Service.Realtime]: 'realtime',
 }
 
 interface ErrorCodeTooltipProps {
@@ -38,16 +41,29 @@ export const ErrorCodeTooltip = ({ errorCode, service, children }: ErrorCodeTool
   const snap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
 
-  const { data, isPending } = useErrorCodesQuery({ code: errorCode, service }, { enabled: isOpen })
+  const mappedService = service ? SERVICE_MAP[service] : undefined
+  const sharedDataDef = mappedService
+    ? ERROR_CODES[mappedService]?.[errorCode] ??
+      HTTP_ERROR_CODES[mappedService]?.[Number(errorCode)]
+    : undefined
+
+  const { data, isPending } = useErrorCodesQuery(
+    { code: errorCode, service },
+    { enabled: isOpen && !sharedDataDef }
+  )
 
   const errors = data?.errors?.nodes?.filter((e) => !!e.message) ?? []
 
-  const docsUrl =
-    errors.map((e) => SERVICE_DOCS_URLS[e.service]).find(Boolean) ??
-    (service ? SERVICE_DOCS_URLS[service] : undefined)
+  const description = sharedDataDef?.description ?? errors[0]?.message
+  const docsUrl = mappedService
+    ? ERROR_CODE_DOCS_URLS[mappedService]
+    : errors
+        .map((e) =>
+          e.service ? ERROR_CODE_DOCS_URLS[e.service.toLowerCase() as ErrorCodeService] : undefined
+        )
+        .find(Boolean)
 
   const buildPrompt = () => {
-    const description = errors[0]?.message
     const servicePart = service ? ` in Supabase ${service}` : ''
     const descriptionPart = description ? `\n\nError description: ${description}` : ''
     return `I'm encountering error code \`${errorCode}\`${servicePart}.${descriptionPart}\n\nCan you explain what this error means and suggest steps to fix it?`
@@ -78,18 +94,18 @@ export const ErrorCodeTooltip = ({ errorCode, service, children }: ErrorCodeTool
           </div>
 
           <div className="px-4 py-3 space-y-2">
-            {isPending ? (
+            {isPending && !sharedDataDef ? (
               <div className="space-y-1.5">
                 <ShimmeringLoader className="w-full" />
                 <ShimmeringLoader className="w-4/5" />
                 <ShimmeringLoader className="w-3/5" />
               </div>
-            ) : errors.length === 0 ? (
+            ) : !description ? (
               <p className="text-sm text-foreground-lighter">
                 No description available for this error code.
               </p>
             ) : (
-              <p className="text-sm text-foreground leading-relaxed">{errors[0].message}</p>
+              <p className="text-sm text-foreground leading-relaxed">{description}</p>
             )}
           </div>
 

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
@@ -4,7 +4,7 @@ import type { LogData } from '../Logs.types'
 import { ResponseCodeFormatter, RowLayout, TextFormatter } from '../LogsFormatters'
 import { defaultRenderCell } from './DefaultPreviewColumnRenderer'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
-import { ErrorCodeTooltip } from '../ErrorCodeTooltip'
+import { ErrorCodeTooltip } from 'components/ui/ErrorCodeTooltip/ErrorCodeTooltip'
 
 const columns: Column<LogData>[] = [
   {

--- a/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
@@ -15,7 +15,7 @@ import {
 import { TimestampInfo } from 'ui-patterns'
 
 import { ErrorCodeDialog } from '../ErrorCodeDialog'
-import { ErrorCodeTooltip } from '../ErrorCodeTooltip'
+import { ErrorCodeTooltip } from 'components/ui/ErrorCodeTooltip/ErrorCodeTooltip'
 import type { LogSearchCallback, PreviewLogData } from '../Logs.types'
 import { ResponseCodeFormatter } from '../LogsFormatters'
 

--- a/apps/studio/components/ui/ErrorCodeTooltip/ErrorCodeTooltip.tsx
+++ b/apps/studio/components/ui/ErrorCodeTooltip/ErrorCodeTooltip.tsx
@@ -3,8 +3,6 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { useTheme } from 'next-themes'
 import { ExternalLink } from 'lucide-react'
-import { ERROR_CODES, ERROR_CODE_DOCS_URLS, HTTP_ERROR_CODES } from 'shared-data'
-import type { ErrorCodeService } from 'shared-data'
 
 import { useErrorCodesQuery } from 'data/content-api/docs-error-codes-query'
 import { Service } from 'data/graphql/graphql'
@@ -23,11 +21,7 @@ import {
   InfoIcon,
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
-
-const SERVICE_MAP: Partial<Record<Service, ErrorCodeService>> = {
-  [Service.Auth]: 'auth',
-  [Service.Realtime]: 'realtime',
-}
+import { getErrorCodeInfo } from './ErrorCodeTooltip.utils'
 
 interface ErrorCodeTooltipProps {
   errorCode: string
@@ -41,27 +35,17 @@ export const ErrorCodeTooltip = ({ errorCode, service, children }: ErrorCodeTool
   const snap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
 
-  const mappedService = service ? SERVICE_MAP[service] : undefined
-  const sharedDataDef = mappedService
-    ? ERROR_CODES[mappedService]?.[errorCode] ??
-      HTTP_ERROR_CODES[mappedService]?.[Number(errorCode)]
-    : undefined
+  const { definition, docsUrl: sharedDocsUrl } = getErrorCodeInfo(errorCode, service)
 
   const { data, isPending } = useErrorCodesQuery(
     { code: errorCode, service },
-    { enabled: isOpen && !sharedDataDef }
+    { enabled: isOpen && !definition }
   )
 
   const errors = data?.errors?.nodes?.filter((e) => !!e.message) ?? []
 
-  const description = sharedDataDef?.description ?? errors[0]?.message
-  const docsUrl = mappedService
-    ? ERROR_CODE_DOCS_URLS[mappedService]
-    : errors
-        .map((e) =>
-          e.service ? ERROR_CODE_DOCS_URLS[e.service.toLowerCase() as ErrorCodeService] : undefined
-        )
-        .find(Boolean)
+  const description = definition?.description ?? errors[0]?.message
+  const docsUrl = sharedDocsUrl
 
   const buildPrompt = () => {
     const servicePart = service ? ` in Supabase ${service}` : ''
@@ -94,7 +78,7 @@ export const ErrorCodeTooltip = ({ errorCode, service, children }: ErrorCodeTool
           </div>
 
           <div className="px-4 py-3 space-y-2">
-            {isPending && !sharedDataDef ? (
+            {isPending && !definition ? (
               <div className="space-y-1.5">
                 <ShimmeringLoader className="w-full" />
                 <ShimmeringLoader className="w-4/5" />

--- a/apps/studio/components/ui/ErrorCodeTooltip/ErrorCodeTooltip.utils.test.ts
+++ b/apps/studio/components/ui/ErrorCodeTooltip/ErrorCodeTooltip.utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { Service } from 'data/graphql/graphql'
+import { ERROR_CODE_DOCS_URLS } from 'shared-data'
+import { getErrorCodeInfo } from './ErrorCodeTooltip.utils'
+
+describe('getErrorCodeInfo', () => {
+  describe('when service is undefined', () => {
+    it('returns no definition and no docsUrl', () => {
+      const result = getErrorCodeInfo('bad_jwt', undefined)
+      expect(result.definition).toBeUndefined()
+      expect(result.docsUrl).toBeUndefined()
+    })
+  })
+
+  describe('when service is Storage (not in shared-data)', () => {
+    it('returns no definition and no docsUrl', () => {
+      const result = getErrorCodeInfo('some_code', Service.Storage)
+      expect(result.definition).toBeUndefined()
+      expect(result.docsUrl).toBeUndefined()
+    })
+  })
+
+  describe('auth service', () => {
+    it('returns definition for a known error code', () => {
+      const result = getErrorCodeInfo('bad_jwt', Service.Auth)
+      expect(result.definition).toBeDefined()
+      expect(result.definition?.description).toBeTypeOf('string')
+    })
+
+    it('returns the auth docs URL', () => {
+      const result = getErrorCodeInfo('bad_jwt', Service.Auth)
+      expect(result.docsUrl).toBe(ERROR_CODE_DOCS_URLS['auth'])
+    })
+
+    it('returns undefined definition for an unknown error code', () => {
+      const result = getErrorCodeInfo('not_a_real_code', Service.Auth)
+      expect(result.definition).toBeUndefined()
+    })
+
+    it('returns definition for a numeric HTTP error code', () => {
+      const result = getErrorCodeInfo('429', Service.Auth)
+      expect(result.definition).toBeDefined()
+      expect(result.definition?.description).toBeTypeOf('string')
+    })
+
+    it('returns undefined for a numeric code not in HTTP_ERROR_CODES', () => {
+      const result = getErrorCodeInfo('999', Service.Auth)
+      expect(result.definition).toBeUndefined()
+    })
+  })
+
+  describe('realtime service', () => {
+    it('returns the realtime docs URL', () => {
+      const result = getErrorCodeInfo('TopicNameRequired', Service.Realtime)
+      expect(result.docsUrl).toBe(ERROR_CODE_DOCS_URLS['realtime'])
+    })
+
+    it('returns definition for a known realtime error code', () => {
+      const result = getErrorCodeInfo('TopicNameRequired', Service.Realtime)
+      expect(result.definition).toBeDefined()
+      expect(result.definition?.description).toBeTypeOf('string')
+    })
+
+    it('returns undefined definition for an unknown realtime error code', () => {
+      const result = getErrorCodeInfo('not_a_real_code', Service.Realtime)
+      expect(result.definition).toBeUndefined()
+    })
+  })
+})

--- a/apps/studio/components/ui/ErrorCodeTooltip/ErrorCodeTooltip.utils.ts
+++ b/apps/studio/components/ui/ErrorCodeTooltip/ErrorCodeTooltip.utils.ts
@@ -1,0 +1,31 @@
+import {
+  ERROR_CODES,
+  ERROR_CODE_DOCS_URLS,
+  HTTP_ERROR_CODES,
+  type ErrorCodeDefinition,
+  type ErrorCodeService,
+} from 'shared-data'
+import { Service } from 'data/graphql/graphql'
+
+const SERVICE_MAP: Partial<Record<Service, ErrorCodeService>> = {
+  [Service.Auth]: 'auth',
+  [Service.Realtime]: 'realtime',
+}
+
+export interface ErrorCodeInfo {
+  definition: ErrorCodeDefinition | undefined
+  docsUrl: string | undefined
+}
+
+export function getErrorCodeInfo(errorCode: string, service: Service | undefined): ErrorCodeInfo {
+  const mappedService = service ? SERVICE_MAP[service] : undefined
+
+  const definition = mappedService
+    ? ERROR_CODES[mappedService]?.[errorCode] ??
+      HTTP_ERROR_CODES[mappedService]?.[Number(errorCode)]
+    : undefined
+
+  const docsUrl = mappedService ? ERROR_CODE_DOCS_URLS[mappedService] : undefined
+
+  return { definition, docsUrl }
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

As we now have the internal error code mapping in `shared-data`, thought it better to move away from the GraphQL endpoint and leave that for external use. The error code popovers in studio now rely on shared-data, meaning instant loads and no rate limiting.
