### PR TITLE
chore(self-hosted): update image versions 2026-03-16

### DIFF
--- a/docker/docker-compose.rustfs.yml
+++ b/docker/docker-compose.rustfs.yml
@@ -16,7 +16,7 @@ services:
       timeout: 10s
       retries: 5
     volumes:
-      - rustfs-data:/data:z
+      - rustfs-data:/data
 
   rustfs-createbucket:
     image: rustfs/rc

--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -15,7 +15,7 @@ services:
       timeout: 10s
       retries: 5
     volumes:
-      - minio-data:/data:z
+      - minio-data:/data
 
   minio-createbucket:
     image: cgr.dev/chainguard/minio-client:latest-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 # Usage
-#   Start:              docker compose up
-#   With helpers:       docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up
+#   Start:              docker compose up -d
 #   Stop:               docker compose down
-#   Destroy:            docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml down -v --remove-orphans
+#   Dev mode:           docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up -d
 #   Reset everything:  ./reset.sh
+#
 
 name: supabase
 
@@ -252,7 +252,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.76.5
+    image: supabase/realtime:v2.78.15
     restart: unless-stopped
     depends_on:
       db:
@@ -281,6 +281,7 @@ services:
       DB_ENC_KEY: supabaserealtime
       API_JWT_SECRET: ${JWT_SECRET}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      METRICS_JWT_SECRET: ${JWT_SECRET}
       ERL_AFLAGS: -proto_dist inet_tcp
       DNS_NODES: "''"
       RLIMIT_NOFILE: "10000"
@@ -292,7 +293,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.37.8
+    image: supabase/storage-api:v1.44.2
     restart: unless-stopped
     depends_on:
       db:
@@ -315,12 +316,14 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+      start_period: 10s
     environment:
       ANON_KEY: ${ANON_KEY}
       SERVICE_KEY: ${SERVICE_ROLE_KEY}
       POSTGREST_URL: http://rest:3000
       PGRST_JWT_SECRET: ${JWT_SECRET}
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      STORAGE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       REQUEST_ALLOW_X_FORWARDED_PATH: "true"
       FILE_SIZE_LIMIT: 52428800
       STORAGE_BACKEND: file

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -413,7 +413,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.70.3
+    image: supabase/edge-runtime:v1.71.2
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:Z

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -391,7 +391,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.70.3
+    image: supabase/edge-runtime:v1.71.2
     restart: unless-stopped
     volumes:
       - ./volumes/functions:/home/deno/functions:Z

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 # Usage
-#   Start:              docker compose up
-#   With helpers:       docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up
+#   Start:              docker compose up -d
 #   Stop:               docker compose down
-#   Destroy:            docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml down -v --remove-orphans
+#   Dev mode:           docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up -d
 #   Reset everything:  ./reset.sh
+#
 
 name: supabase
 
@@ -266,7 +266,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.76.5
+    image: supabase/realtime:v2.78.15
     restart: unless-stopped
     depends_on:
       db:
@@ -299,6 +299,7 @@ services:
       #API_JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
 
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      METRICS_JWT_SECRET: ${JWT_SECRET}
       ERL_AFLAGS: -proto_dist inet_tcp
       DNS_NODES: "''"
       RLIMIT_NOFILE: "10000"
@@ -310,7 +311,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.37.8
+    image: supabase/storage-api:v1.44.2
     restart: unless-stopped
     depends_on:
       db:
@@ -333,6 +334,7 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+      start_period: 10s
     environment:
       ANON_KEY: ${ANON_KEY}
       SERVICE_KEY: ${SERVICE_ROLE_KEY}
@@ -345,6 +347,7 @@ services:
       #JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
 
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      STORAGE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       REQUEST_ALLOW_X_FORWARDED_PATH: "true"
       FILE_SIZE_LIMIT: 52428800
       STORAGE_BACKEND: file

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -226,7 +226,7 @@ services:
 
   rest:
     container_name: supabase-rest
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.6
     restart: unless-stopped
     depends_on:
       db:
@@ -553,7 +553,7 @@ services:
   # Update the DATABASE_URL if you are using an external Postgres database
   supavisor:
     container_name: supabase-pooler
-    image: supabase/supavisor:2.7.4
+    image: supabase/supavisor:2.8.0
     restart: unless-stopped
     ports:
       - ${POSTGRES_PORT}:5432

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -266,7 +266,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.78.15
+    image: supabase/realtime:v2.76.5
     restart: unless-stopped
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -577,7 +577,7 @@ services:
   # Update the DATABASE_URL if you are using an external Postgres database
   supavisor:
     container_name: supabase-pooler
-    image: supabase/supavisor:2.8.0
+    image: supabase/supavisor:2.7.4
     restart: unless-stopped
     ports:
       - ${POSTGRES_PORT}:5432

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2026.02.16-sha-26c615c
+    image: supabase/studio:2026.03.16-sha-5528817
     restart: unless-stopped
     healthcheck:
       test:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -241,7 +241,7 @@ services:
 
   rest:
     container_name: supabase-rest
-    image: postgrest/postgrest:v14.5
+    image: postgrest/postgrest:v14.6
     restart: unless-stopped
     depends_on:
       db:
@@ -577,7 +577,7 @@ services:
   # Update the DATABASE_URL if you are using an external Postgres database
   supavisor:
     container_name: supabase-pooler
-    image: supabase/supavisor:2.7.4
+    image: supabase/supavisor:2.8.0
     restart: unless-stopped
     ports:
       - ${POSTGRES_PORT}:5432

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,9 +1,11 @@
 # Docker Image Versions
 
 ## 2025-03-16
+- postgrest/postgrest:v14.6 (prev postgrest/postgrest:v14.5)
 - supabase/realtime:v2.78.15 (prev supabase/realtime:v2.76.5)
 - supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)
 - supabase/edge-runtime:v1.71.2 (prev supabase/edge-runtime:v1.70.3)
+- supabase/supavisor:2.8.0 (prev 2.7.4)
 
 ## 2026-02-16
 - supabase/studio:2026.02.16-sha-26c615c (prev supabase/studio:2026.01.27-sha-6aa59ff)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,6 +1,7 @@
 # Docker Image Versions
 
 ## 2025-03-16
+- supabase/studio:2026.03.16-sha-5528817 (prev supabase/studio:2026.02.16-sha-26c615c)
 - postgrest/postgrest:v14.6 (prev postgrest/postgrest:v14.5)
 - supabase/realtime:v2.78.15 (prev supabase/realtime:v2.76.5)
 - supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -3,7 +3,6 @@
 ## 2025-03-16
 - supabase/studio:2026.03.16-sha-5528817 (prev supabase/studio:2026.02.16-sha-26c615c)
 - postgrest/postgrest:v14.6 (prev postgrest/postgrest:v14.5)
-- supabase/realtime:v2.78.15 (prev supabase/realtime:v2.76.5)
 - supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)
 - supabase/edge-runtime:v1.71.2 (prev supabase/edge-runtime:v1.70.3)
 - supabase/supavisor:2.8.0 (prev 2.7.4)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,5 +1,10 @@
 # Docker Image Versions
 
+## 2025-03-16
+- supabase/realtime:v2.78.15 (prev supabase/realtime:v2.76.5)
+- supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)
+- supabase/edge-runtime:v1.71.2 (prev supabase/edge-runtime:v1.70.3)
+
 ## 2026-02-16
 - supabase/studio:2026.02.16-sha-26c615c (prev supabase/studio:2026.01.27-sha-6aa59ff)
 - supabase/gotrue:v2.186.0 (prev supabase/gotrue:v2.185.0)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -2,6 +2,7 @@
 
 ## 2025-03-16
 - supabase/studio:2026.03.16-sha-5528817 (prev supabase/studio:2026.02.16-sha-26c615c)
+- kong/kong:3.9.1 (prev kong:2.8.1)
 - postgrest/postgrest:v14.6 (prev postgrest/postgrest:v14.5)
 - supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)
 - supabase/edge-runtime:v1.71.2 (prev supabase/edge-runtime:v1.70.3)

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -5,7 +5,6 @@
 - postgrest/postgrest:v14.6 (prev postgrest/postgrest:v14.5)
 - supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)
 - supabase/edge-runtime:v1.71.2 (prev supabase/edge-runtime:v1.70.3)
-- supabase/supavisor:2.8.0 (prev 2.7.4)
 
 ## 2026-02-16
 - supabase/studio:2026.02.16-sha-26c615c (prev supabase/studio:2026.01.27-sha-6aa59ff)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

1. Update `docker-compose.yml` and `versions.md`:

```
- supabase/studio:2026.03.16-sha-5528817 (prev supabase/studio:2026.02.16-sha-26c615c)
- kong/kong:3.9.1 (prev kong:2.8.1)
- postgrest/postgrest:v14.6 (prev postgrest/postgrest:v14.5)
- supabase/storage-api:v1.44.2 (prev supabase/storage-api:v1.37.8)
- supabase/edge-runtime:v1.71.2 (prev supabase/edge-runtime:v1.70.3)
```

2. Add `METRICS_JWT_SECRET` to Realtime configuration

3. Add `STORAGE_PUBLIC_URL` to Storage configuration