### PR TITLE
Fix table editor transactions

### DIFF
--- a/apps/studio/components/grid/components/grid/ColumnHeader.tsx
+++ b/apps/studio/components/grid/components/grid/ColumnHeader.tsx
@@ -1,10 +1,10 @@
+import pgMeta from '@supabase/pg-meta'
 import type { XYCoord } from 'dnd-core'
 import { ArrowRight, Key, Lightbulb, Link, Lock } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
 
 import { getForeignKeyCascadeAction } from 'components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils'
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import {
@@ -206,12 +206,12 @@ function renderColumnIcon(
                   {foreignKey?.targetColumnName}
                 </p>
               </div>
-              {foreignKey?.updateAction !== FOREIGN_KEY_CASCADE_ACTION.NO_ACTION && (
+              {foreignKey?.updateAction !== pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION && (
                 <p className="text-xs !text-foreground mt-1">
                   On update: {getForeignKeyCascadeAction(foreignKey?.updateAction)}
                 </p>
               )}
-              {foreignKey?.deletionAction !== FOREIGN_KEY_CASCADE_ACTION.NO_ACTION && (
+              {foreignKey?.deletionAction !== pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION && (
                 <p className="text-xs !text-foreground mt-1">
                   On delete: {getForeignKeyCascadeAction(foreignKey?.deletionAction)}
                 </p>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -1,8 +1,9 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
+import pgMeta from '@supabase/pg-meta'
+
 import { isNull } from 'lodash'
 import type { Dictionary } from 'types'
 
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import type { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
 import type { RetrievedTableColumn, RetrieveTableResult } from 'data/tables/table-retrieve-query'
 import { uuidv4 } from 'lib/helpers'
@@ -229,8 +230,8 @@ export const getColumnForeignKey = (
     const foreignKeyMeta = foreignKeys.find((fk) => fk.id === foreignKey.id)
     return {
       ...foreignKey,
-      deletion_action: foreignKeyMeta?.deletion_action ?? FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
-      update_action: foreignKeyMeta?.update_action ?? FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
+      deletion_action: foreignKeyMeta?.deletion_action ?? pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
+      update_action: foreignKeyMeta?.update_action ?? pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
     }
   }
 }
@@ -243,13 +244,13 @@ const formatArrayToPostgresArray = (arrayString: string) => {
 
 export const getForeignKeyCascadeAction = (action?: string) => {
   switch (action) {
-    case FOREIGN_KEY_CASCADE_ACTION.CASCADE:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.CASCADE:
       return 'Cascade'
-    case FOREIGN_KEY_CASCADE_ACTION.RESTRICT:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.RESTRICT:
       return 'Restrict'
-    case FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT:
       return 'Set default'
-    case FOREIGN_KEY_CASCADE_ACTION.SET_NULL:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.SET_NULL:
       return 'Set NULL'
     default:
       return undefined

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.constants.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.constants.ts
@@ -1,9 +1,9 @@
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
+import pgMeta from '@supabase/pg-meta'
 
 export const FOREIGN_KEY_CASCADE_OPTIONS = [
-  { key: 'no-action', label: 'No action', value: FOREIGN_KEY_CASCADE_ACTION.NO_ACTION },
-  { key: 'cascade', label: 'Cascade', value: FOREIGN_KEY_CASCADE_ACTION.CASCADE },
-  { key: 'restrict', label: 'Restrict', value: FOREIGN_KEY_CASCADE_ACTION.RESTRICT },
-  { key: 'set-default', label: 'Set default', value: FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT },
-  { key: 'set-null', label: 'Set NULL', value: FOREIGN_KEY_CASCADE_ACTION.SET_NULL },
+  { key: 'no-action', label: 'No action', value: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION },
+  { key: 'cascade', label: 'Cascade', value: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.CASCADE },
+  { key: 'restrict', label: 'Restrict', value: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.RESTRICT },
+  { key: 'set-default', label: 'Set default', value: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT },
+  { key: 'set-null', label: 'Set NULL', value: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.SET_NULL },
 ]

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -1,4 +1,5 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
+import pgMeta from '@supabase/pg-meta'
 import { sortBy } from 'lodash'
 import { ArrowRight, Database, HelpCircle, Loader2, Table, X } from 'lucide-react'
 import { Fragment, useEffect, useState } from 'react'
@@ -13,7 +14,6 @@ import {
 
 import { DocsButton } from 'components/ui/DocsButton'
 import InformationBox from 'components/ui/InformationBox'
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useTableQuery } from 'data/tables/table-retrieve-query'
 import { useTablesQuery } from 'data/tables/tables-query'
@@ -33,8 +33,8 @@ const EMPTY_STATE: ForeignKey = {
   schema: 'public',
   table: '',
   columns: [] as { source: string; target: string }[],
-  deletionAction: FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
-  updateAction: FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
+  deletionAction: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
+  updateAction: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
 }
 
 interface ForeignKeySelectorProps {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
@@ -1,4 +1,4 @@
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
+import pgMeta from '@supabase/pg-meta'
 import type { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
 import { HelpCircle } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
@@ -29,7 +29,7 @@ export const generateCascadeActionDescription = (
   const actionName = getForeignKeyCascadeAction(cascadeAction) ?? 'No action'
 
   switch (cascadeAction) {
-    case FOREIGN_KEY_CASCADE_ACTION.NO_ACTION:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION:
       return (
         <>
           <span className="text-foreground-light">{actionName}</span>: {actionVerb} a record from{' '}
@@ -38,7 +38,7 @@ export const generateCascadeActionDescription = (
           existing in this table that reference it
         </>
       )
-    case FOREIGN_KEY_CASCADE_ACTION.CASCADE:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.CASCADE:
       return (
         <>
           <span className="text-foreground-light">{actionName}</span>: {actionVerb} a record from{' '}
@@ -47,7 +47,7 @@ export const generateCascadeActionDescription = (
           reference it in this table
         </>
       )
-    case FOREIGN_KEY_CASCADE_ACTION.RESTRICT:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.RESTRICT:
       return (
         <>
           <span className="text-foreground-light">{actionName}</span>
@@ -65,7 +65,7 @@ export const generateCascadeActionDescription = (
           existing referencing rows from this table.
         </>
       )
-    case FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT:
       return (
         <>
           <span className="text-foreground-light">{actionName}</span>: {actionVerb} a record from{' '}
@@ -74,7 +74,7 @@ export const generateCascadeActionDescription = (
           <span className="text-amber-900 opacity-75">default value</span>
         </>
       )
-    case FOREIGN_KEY_CASCADE_ACTION.SET_NULL:
+    case pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.SET_NULL:
       return (
         <>
           <span className="text-foreground-light">{actionName}</span>: {actionVerb} a record from{' '}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.createTable.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.createTable.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
+import pgMeta from '@supabase/pg-meta'
 import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField } from './SidePanelEditor.types'
 
@@ -288,8 +288,8 @@ describe('createTable', () => {
         schema: 'public',
         table: 'users',
         columns: [{ source: 'user_id', target: 'id' }],
-        deletionAction: FOREIGN_KEY_CASCADE_ACTION.CASCADE,
-        updateAction: FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
+        deletionAction: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.CASCADE,
+        updateAction: pgMeta.tableEditor.FOREIGN_KEY_CASCADE_ACTION.NO_ACTION,
       },
     ]
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -5,7 +5,6 @@ import type { SupaRow } from 'components/grid/types'
 import { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import SparkBar from 'components/ui/SparkBar'
 import { deleteDatabaseColumn } from 'data/database-columns/database-column-delete-mutation'
-import { updateDatabaseColumn } from 'data/database-columns/database-column-update-mutation'
 import { createDatabasePolicy } from 'data/database-policies/database-policy-create-mutation'
 import type { Constraint } from 'data/database/constraints-query'
 import { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
@@ -182,6 +181,66 @@ const updateForeignKey = async ({
   })
 }
 
+const getUpdateForeignKeysSQL = ({
+  table,
+  foreignKeys,
+  existingForeignKeyRelations,
+}: {
+  table: { schema: string; name: string }
+  foreignKeys: ForeignKey[]
+  existingForeignKeyRelations: ForeignKeyConstraint[]
+}) => {
+  const sqlStatements: Array<string> = []
+  // Foreign keys will get updated here accordingly
+  const relationsToAdd = foreignKeys.filter((x) => typeof x.id === 'string')
+  if (relationsToAdd.length > 0) {
+    sqlStatements.push(
+      pgMeta.tableEditor.getAddForeignKeySQL({
+        schema: table.schema,
+        table: table.name,
+        foreignKeys: relationsToAdd,
+      })
+    )
+  }
+
+  const relationsToRemove = foreignKeys.filter((x) => x.toRemove)
+  if (relationsToRemove.length > 0) {
+    sqlStatements.push(
+      pgMeta.tableEditor.getRemoveForeignKeySQL({
+        schema: table.schema,
+        table: table.name,
+        foreignKeys: relationsToRemove,
+      })
+    )
+  }
+
+  const remainingRelations = foreignKeys.filter((x) => typeof x.id === 'number' && !x.toRemove)
+  const relationsToUpdate = remainingRelations.filter((x) => {
+    const existingRelation = existingForeignKeyRelations.find((y) => x.id === y.id)
+    if (existingRelation !== undefined) {
+      return checkIfRelationChanged(existingRelation as unknown as ForeignKeyConstraint, x)
+    } else return false
+  })
+  if (relationsToUpdate.length > 0) {
+    sqlStatements.push(
+      pgMeta.tableEditor.getRemoveForeignKeySQL({
+        schema: table.schema,
+        table: table.name,
+        foreignKeys,
+      })
+    )
+    sqlStatements.push(
+      pgMeta.tableEditor.getAddForeignKeySQL({
+        schema: table.schema,
+        table: table.name,
+        foreignKeys,
+      })
+    )
+  }
+
+  return sqlStatements.join('; ')
+}
+
 /**
  * The methods below involve several contexts due to the UI flow of the
  * dashboard and hence do not sit within their own stores
@@ -281,7 +340,6 @@ export const createColumn = async ({
   }
 }
 
-/** TODO: Refactor to do in a single transaction */
 export const updateColumn = async ({
   projectRef,
   connectionString,
@@ -307,24 +365,33 @@ export const updateColumn = async ({
 }) => {
   try {
     const { isPrimaryKey, ...formattedPayload } = payload
-    await updateDatabaseColumn({
-      projectRef,
-      connectionString,
-      originalColumn,
-      payload: formattedPayload,
+    const { sql: updateColumnSQL } = pgMeta.columns.update(originalColumn, {
+      name: payload.name,
+      type: payload.type,
+      drop_default: payload.dropDefault,
+      default_value: payload.defaultValue,
+      default_value_format: payload.defaultValueFormat,
+      is_identity: payload.isIdentity,
+      identity_generation: payload.identityGeneration,
+      is_nullable: payload.isNullable,
+      is_unique: payload.isUnique,
+      comment: payload.comment,
+      check: payload.check,
+      no_transaction: true,
     })
+    const sqlStatements = [updateColumnSQL]
 
     if (!skipPKCreation && isPrimaryKey !== undefined) {
       const existingPrimaryKeys = selectedTable.primary_keys.map((x) => x.name)
 
       // Primary key is getting updated for the column
       if (existingPrimaryKeys.length > 0 && primaryKey !== undefined) {
-        await dropConstraint(
-          projectRef,
-          connectionString,
-          originalColumn.schema,
-          originalColumn.table,
-          primaryKey.name
+        sqlStatements.push(
+          pgMeta.tableEditor.getDropConstraintSQL({
+            schema: originalColumn.schema,
+            table: originalColumn.table,
+            name: primaryKey.name,
+          })
         )
       }
 
@@ -334,26 +401,31 @@ export const updateColumn = async ({
         : existingPrimaryKeys.filter((x) => x !== columnName)
 
       if (primaryKeyColumns.length) {
-        await addPrimaryKey(
-          projectRef,
-          connectionString,
-          originalColumn.schema,
-          originalColumn.table,
-          primaryKeyColumns
+        sqlStatements.push(
+          pgMeta.tableEditor.getAddPrimaryKeySQL({
+            schema: originalColumn.schema,
+            table: originalColumn.table,
+            columns: primaryKeyColumns,
+          })
         )
       }
     }
 
     // Then update foreign keys
     if (foreignKeyRelations.length > 0) {
-      await updateForeignKeys({
-        projectRef,
-        connectionString,
+      sqlStatements.push(getUpdateForeignKeysSQL({
         table: { schema: originalColumn.schema, name: originalColumn.table },
         foreignKeys: foreignKeyRelations,
         existingForeignKeyRelations,
-      })
+      }))
     }
+
+    await executeSql({
+      projectRef,
+      connectionString,
+      sql: `BEGIN; ${sqlStatements.join('; ')}; COMMIT;`,
+      queryKey: ['column', 'update', originalColumn.id],
+    })
 
     if (!skipSuccessMessage) toast.success(`Successfully updated column "${originalColumn.name}"`)
   } catch (error: any) {
@@ -520,7 +592,7 @@ export const createTable = async ({
       is_unique: columnPayload.isUnique,
       comment: columnPayload.comment,
       check: columnPayload.check,
-      no_transaction: true
+      no_transaction: true,
     })
     sqlStatements.push(columnSQL)
   }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -4,7 +4,6 @@ import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
 import type { SupaRow } from 'components/grid/types'
 import { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import SparkBar from 'components/ui/SparkBar'
-import { createDatabaseColumn } from 'data/database-columns/database-column-create-mutation'
 import { deleteDatabaseColumn } from 'data/database-columns/database-column-delete-mutation'
 import { updateDatabaseColumn } from 'data/database-columns/database-column-update-mutation'
 import { createDatabasePolicy } from 'data/database-policies/database-policy-create-mutation'
@@ -121,7 +120,11 @@ const addForeignKey = async ({
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
 }) => {
-  const query = pgMeta.tableEditor.getAddForeignKeySQL({ table, foreignKeys })
+  const query = pgMeta.tableEditor.getAddForeignKeySQL({
+    schema: table.schema,
+    table: table.name,
+    foreignKeys,
+  })
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -141,7 +144,11 @@ const removeForeignKey = async ({
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
 }) => {
-  const query = pgMeta.tableEditor.getRemoveForeignKeySQL({ table, foreignKeys })
+  const query = pgMeta.tableEditor.getRemoveForeignKeySQL({
+    schema: table.schema,
+    table: table.name,
+    foreignKeys,
+  })
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -162,8 +169,8 @@ const updateForeignKey = async ({
   foreignKeys: ForeignKey[]
 }) => {
   const query = `
-  ${pgMeta.tableEditor.getRemoveForeignKeySQL({ table, foreignKeys })}
-  ${pgMeta.tableEditor.getAddForeignKeySQL({ table, foreignKeys })}
+  ${pgMeta.tableEditor.getRemoveForeignKeySQL({ schema: table.schema, table: table.name, foreignKeys })}
+  ${pgMeta.tableEditor.getAddForeignKeySQL({ schema: table.schema, table: table.name, foreignKeys })}
   `
     .replace(/\s+/g, ' ')
     .trim()
@@ -180,7 +187,6 @@ const updateForeignKey = async ({
  * dashboard and hence do not sit within their own stores
  */
 
-/** TODO: Refactor to do in a single transaction */
 export const createColumn = async ({
   projectRef,
   connectionString,
@@ -204,47 +210,66 @@ export const createColumn = async ({
   try {
     // Once pg-meta supports composite keys, we can remove this logic
     const { isPrimaryKey, ...formattedPayload } = payload
-    await createDatabaseColumn({
-      projectRef: projectRef,
-      connectionString: connectionString,
-      payload: formattedPayload,
+    const { sql: createColumnSQL } = pgMeta.columns.create({
+      schema: payload.schema,
+      table: payload.table,
+      name: payload.name,
+      type: payload.type,
+      default_value: payload.defaultValue,
+      default_value_format: payload.defaultValueFormat,
+      is_identity: payload.isIdentity,
+      identity_generation: payload.identityGeneration,
+      is_nullable: payload.isNullable,
+      is_primary_key: payload.isPrimaryKey,
+      is_unique: payload.isUnique,
+      comment: payload.comment,
+      check: payload.check,
+      no_transaction: true,
     })
+    const sqlStatements = [createColumnSQL]
 
     // Firing createColumn in createTable will bypass this block
     if (isPrimaryKey) {
-      toast.loading('Assigning primary key to column...', { id: toastId })
       // Same logic in createTable: Remove any primary key constraints first (we'll add it back later)
       const existingPrimaryKeys = selectedTable.primary_keys.map((x) => x.name)
 
       if (existingPrimaryKeys.length > 0 && primaryKey !== undefined) {
-        await dropConstraint(
-          projectRef,
-          connectionString,
-          payload.schema,
-          payload.table,
-          primaryKey.name
+        sqlStatements.push(
+          pgMeta.tableEditor.getDropConstraintSQL({
+            schema: payload.schema,
+            table: payload.table,
+            name: primaryKey.name,
+          })
         )
       }
 
       const primaryKeyColumns = existingPrimaryKeys.concat([formattedPayload.name])
-      await addPrimaryKey(
-        projectRef,
-        connectionString,
-        payload.schema,
-        payload.table,
-        primaryKeyColumns
+      sqlStatements.push(
+        pgMeta.tableEditor.getAddPrimaryKeySQL({
+          schema: payload.schema,
+          table: payload.table,
+          columns: primaryKeyColumns,
+        })
       )
     }
 
     // Then add the foreign key constraints here
     if (foreignKeyRelations.length > 0) {
-      await addForeignKey({
-        projectRef,
-        connectionString,
-        table: { schema: payload.schema, name: payload.table },
-        foreignKeys: foreignKeyRelations,
-      })
+      sqlStatements.push(
+        pgMeta.tableEditor.getAddForeignKeySQL({
+          schema: payload.schema,
+          table: payload.table,
+          foreignKeys: foreignKeyRelations,
+        })
+      )
     }
+
+    await executeSql({
+      projectRef,
+      connectionString,
+      sql: `BEGIN; ${sqlStatements.join('; ')}; COMMIT;`,
+      queryKey: ['column', 'create'],
+    })
 
     if (!skipSuccessMessage) {
       toast.success(`Successfully created column "${formattedPayload.name}"`, { id: toastId })
@@ -515,7 +540,8 @@ export const createTable = async ({
   // 5. Add foreign key constraints
   if (foreignKeyRelations.length > 0) {
     const fkSql = pgMeta.tableEditor.getAddForeignKeySQL({
-      table: { schema: payload.schema, name: payload.name },
+      schema: payload.schema,
+      table: payload.name,
       foreignKeys: foreignKeyRelations,
     })
     // Remove trailing semicolon since we join with semicolons

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -489,7 +489,7 @@ export const createTable = async ({
   const sqlStatements: string[] = []
 
   // 1. Create table SQL
-  const { sql: createTableSql } = pgMeta.tables.create(payload)
+  const { sql: createTableSql } = pgMeta.tables.create({ ...payload, no_transaction: true })
   sqlStatements.push(createTableSql)
 
   // 2. Enable RLS if configured
@@ -520,6 +520,7 @@ export const createTable = async ({
       is_unique: columnPayload.isUnique,
       comment: columnPayload.comment,
       check: columnPayload.check,
+      no_transaction: true
     })
     sqlStatements.push(columnSQL)
   }
@@ -554,7 +555,7 @@ export const createTable = async ({
   await executeSql({
     projectRef,
     connectionString,
-    sql: sqlStatements.join(';\n'),
+    sql: `begin; ${sqlStatements.join(';\n')}; commit;`,
     queryKey: ['table', 'create-with-columns'],
   })
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -1,4 +1,4 @@
-import pgMeta from '@supabase/pg-meta'
+import pgMeta, { type ForeignKey } from '@supabase/pg-meta'
 import { Query } from '@supabase/pg-meta/src/query'
 import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
 import type { SupaRow } from 'components/grid/types'
@@ -9,7 +9,6 @@ import { deleteDatabaseColumn } from 'data/database-columns/database-column-dele
 import { updateDatabaseColumn } from 'data/database-columns/database-column-update-mutation'
 import { createDatabasePolicy } from 'data/database-policies/database-policy-create-mutation'
 import type { Constraint } from 'data/database/constraints-query'
-import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
 import { databaseKeys } from 'data/database/keys'
 import { entityTypeKeys } from 'data/entity-types/keys'
@@ -23,10 +22,10 @@ import { tableRowKeys } from 'data/table-rows/keys'
 import { executeWithRetry } from 'data/table-rows/table-rows-query'
 import { tableKeys } from 'data/tables/keys'
 import {
-  RetrieveTableResult,
-  RetrievedTableColumn,
   getTable,
   getTableQuery,
+  RetrievedTableColumn,
+  RetrieveTableResult,
 } from 'data/tables/table-retrieve-query'
 import {
   UpdateTableBody,
@@ -44,7 +43,6 @@ import {
   generateCreateColumnPayload,
   generateUpdateColumnPayload,
 } from './ColumnEditor/ColumnEditor.utils'
-import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePanelEditor.types'
 import { checkIfRelationChanged } from './TableEditor/ForeignKeysManagement/ForeignKeysManagement.utils'
 import type { ImportContent } from './TableEditor/TableEditor.types'
@@ -80,23 +78,6 @@ export function getRowFromSidePanel(
   }
 }
 
-/**
- * The functions below are basically just queries but may be supported directly
- * from the pg-meta library in the future
- */
-const getAddPrimaryKeySQL = ({
-  schema,
-  table,
-  columns,
-}: {
-  schema: string
-  table: string
-  columns: string[]
-}) => {
-  const primaryKeyColumns = columns.map((col) => `"${col}"`).join(', ')
-  return `ALTER TABLE "${schema}"."${table}" ADD PRIMARY KEY (${primaryKeyColumns})`
-}
-
 const addPrimaryKey = async (
   projectRef: string,
   connectionString: string | undefined | null,
@@ -104,7 +85,7 @@ const addPrimaryKey = async (
   table: string,
   columns: string[]
 ) => {
-  const query = getAddPrimaryKeySQL({ schema, table, columns })
+  const query = pgMeta.tableEditor.getAddPrimaryKeySQL({ schema, table, columns })
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -120,56 +101,13 @@ const dropConstraint = async (
   table: string,
   name: string
 ) => {
-  const query = `ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${name}"`
+  const query = pgMeta.tableEditor.getDropConstraintSQL({ schema, table, name })
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
     sql: query,
     queryKey: ['drop-constraint'],
   })
-}
-
-const getAddForeignKeySQL = ({
-  table,
-  foreignKeys,
-}: {
-  table: { schema: string; name: string }
-  foreignKeys: ForeignKey[]
-}) => {
-  const getOnDeleteSql = (action: string) =>
-    action === FOREIGN_KEY_CASCADE_ACTION.CASCADE
-      ? 'ON DELETE CASCADE'
-      : action === FOREIGN_KEY_CASCADE_ACTION.RESTRICT
-        ? 'ON DELETE RESTRICT'
-        : action === FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT
-          ? 'ON DELETE SET DEFAULT'
-          : action === FOREIGN_KEY_CASCADE_ACTION.SET_NULL
-            ? 'ON DELETE SET NULL'
-            : ''
-  const getOnUpdateSql = (action: string) =>
-    action === FOREIGN_KEY_CASCADE_ACTION.CASCADE
-      ? 'ON UPDATE CASCADE'
-      : action === FOREIGN_KEY_CASCADE_ACTION.RESTRICT
-        ? 'ON UPDATE RESTRICT'
-        : ''
-  return (
-    foreignKeys
-      .map((relation) => {
-        const { deletionAction, updateAction } = relation
-        const onDeleteSql = getOnDeleteSql(deletionAction)
-        const onUpdateSql = getOnUpdateSql(updateAction)
-        return `
-      ALTER TABLE "${table.schema}"."${table.name}"
-      ADD FOREIGN KEY (${relation.columns.map((column) => `"${column.source}"`).join(',')})
-      REFERENCES "${relation.schema}"."${relation.table}" (${relation.columns.map((column) => `"${column.target}"`).join(',')})
-      ${onUpdateSql}
-      ${onDeleteSql}
-    `
-          .replace(/\s+/g, ' ')
-          .trim()
-      })
-      .join(';') + ';'
-  )
 }
 
 const addForeignKey = async ({
@@ -183,34 +121,13 @@ const addForeignKey = async ({
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
 }) => {
-  const query = getAddForeignKeySQL({ table, foreignKeys })
+  const query = pgMeta.tableEditor.getAddForeignKeySQL({ table, foreignKeys })
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
     sql: query,
     queryKey: ['foreign-keys'],
   })
-}
-
-const getRemoveForeignKeySQL = ({
-  table,
-  foreignKeys,
-}: {
-  table: { schema: string; name: string }
-  foreignKeys: ForeignKey[]
-}) => {
-  return (
-    foreignKeys
-      .map((relation) =>
-        `
-ALTER TABLE IF EXISTS "${table.schema}"."${table.name}"
-DROP CONSTRAINT IF EXISTS "${relation.name}"
-`
-          .replace(/\s+/g, ' ')
-          .trim()
-      )
-      .join(';') + ';'
-  )
 }
 
 const removeForeignKey = async ({
@@ -224,7 +141,7 @@ const removeForeignKey = async ({
   table: { schema: string; name: string }
   foreignKeys: ForeignKey[]
 }) => {
-  const query = getRemoveForeignKeySQL({ table, foreignKeys })
+  const query = pgMeta.tableEditor.getRemoveForeignKeySQL({ table, foreignKeys })
   return await executeSql({
     projectRef: projectRef,
     connectionString: connectionString,
@@ -245,8 +162,8 @@ const updateForeignKey = async ({
   foreignKeys: ForeignKey[]
 }) => {
   const query = `
-  ${getRemoveForeignKeySQL({ table, foreignKeys })}
-  ${getAddForeignKeySQL({ table, foreignKeys })}
+  ${pgMeta.tableEditor.getRemoveForeignKeySQL({ table, foreignKeys })}
+  ${pgMeta.tableEditor.getAddForeignKeySQL({ table, foreignKeys })}
   `
     .replace(/\s+/g, ' ')
     .trim()
@@ -256,22 +173,6 @@ const updateForeignKey = async ({
     sql: query,
     queryKey: ['foreign-keys'],
   })
-}
-
-const getUpdateIdentitySequenceSQL = ({
-  schema,
-  table,
-  column,
-}: {
-  schema: string
-  table: string
-  column: string
-}) => {
-  return `SELECT setval('"${schema}"."${table}_${column}_seq"', (SELECT COALESCE(MAX("${column}"), 1) FROM "${schema}"."${table}"))`
-}
-
-const getEnableRLSSQL = ({ schema, table }: { schema: string; table: string }) => {
-  return `ALTER TABLE "${schema}"."${table}" ENABLE ROW LEVEL SECURITY`
 }
 
 /**
@@ -457,12 +358,12 @@ export const duplicateTable = async (
   await executeSql({
     projectRef,
     connectionString,
-    sql: [
-      `CREATE TABLE "${sourceTableSchema}"."${duplicatedTableName}" (LIKE "${sourceTableSchema}"."${sourceTableName}" INCLUDING ALL);`,
-      payload.comment != undefined
-        ? `comment on table "${sourceTableSchema}"."${duplicatedTableName}" is '${payload.comment}';`
-        : '',
-    ].join('\n'),
+    sql: pgMeta.tableEditor.getDuplicateTableSQL({
+      sourceTableName,
+      sourceTableSchema,
+      duplicatedTableName,
+      comment: payload.comment,
+    }),
   })
   await queryClient.invalidateQueries({ queryKey: tableKeys.list(projectRef, sourceTableSchema) })
 
@@ -481,7 +382,11 @@ export const duplicateTable = async (
     await executeSql({
       projectRef,
       connectionString,
-      sql: `INSERT INTO "${sourceTableSchema}"."${duplicatedTableName}" SELECT * FROM "${sourceTableSchema}"."${sourceTableName}";`,
+      sql: pgMeta.tableEditor.getDuplicateRowsSQL({
+        sourceTableName,
+        sourceTableSchema,
+        duplicatedTableName,
+      }),
     })
 
     // Insert into does not copy over auto increment sequences, so we manually do it next if any
@@ -491,7 +396,12 @@ export const duplicateTable = async (
       await executeSql({
         projectRef,
         connectionString,
-        sql: `SELECT setval('"${sourceTableSchema}"."${duplicatedTableName}_${column.name}_seq"', (SELECT MAX("${column.name}") FROM "${sourceTableSchema}"."${sourceTableName}"));`,
+        sql: pgMeta.tableEditor.getDuplicateIdentitySequenceSQL({
+          sourceTableName,
+          sourceTableSchema,
+          duplicatedTableName,
+          columnName: column.name,
+        }),
       })
     })
   }
@@ -559,7 +469,10 @@ export const createTable = async ({
 
   // 2. Enable RLS if configured
   if (isRLSEnabled) {
-    const enableRLSSQL = getEnableRLSSQL({ schema: payload.schema, table: payload.name })
+    const enableRLSSQL = pgMeta.tableEditor.getEnableRLSSQL({
+      schema: payload.schema,
+      table: payload.name,
+    })
     sqlStatements.push(enableRLSSQL)
   }
 
@@ -591,7 +504,7 @@ export const createTable = async ({
     .filter((column) => column.isPrimaryKey)
     .map((column) => column.name)
   if (primaryKeyColumns.length > 0) {
-    const primaryKeySQL = getAddPrimaryKeySQL({
+    const primaryKeySQL = pgMeta.tableEditor.getAddPrimaryKeySQL({
       schema: payload.schema,
       table: payload.name,
       columns: primaryKeyColumns,
@@ -601,7 +514,7 @@ export const createTable = async ({
 
   // 5. Add foreign key constraints
   if (foreignKeyRelations.length > 0) {
-    const fkSql = getAddForeignKeySQL({
+    const fkSql = pgMeta.tableEditor.getAddForeignKeySQL({
       table: { schema: payload.schema, name: payload.name },
       foreignKeys: foreignKeyRelations,
     })
@@ -766,7 +679,7 @@ export const createTable = async ({
     if (identityColumns.length > 0) {
       const updateSequenceSQL = identityColumns
         .map((column) =>
-          getUpdateIdentitySequenceSQL({
+          pgMeta.tableEditor.getUpdateIdentitySequenceSQL({
             schema: table.schema,
             table: table.name,
             column: column.name,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -4,7 +4,6 @@ import type { PostgresPrimaryKey } from '@supabase/postgres-meta'
 import type { SupaRow } from 'components/grid/types'
 import { GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import SparkBar from 'components/ui/SparkBar'
-import { deleteDatabaseColumn } from 'data/database-columns/database-column-delete-mutation'
 import { createDatabasePolicy } from 'data/database-policies/database-policy-create-mutation'
 import type { Constraint } from 'data/database/constraints-query'
 import { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
@@ -20,7 +19,6 @@ import { tableRowKeys } from 'data/table-rows/keys'
 import { executeWithRetry } from 'data/table-rows/table-rows-query'
 import { tableKeys } from 'data/tables/keys'
 import {
-  getTable,
   getTableQuery,
   RetrievedTableColumn,
   RetrieveTableResult,
@@ -74,38 +72,6 @@ export function getRowFromSidePanel(
     default:
       return undefined
   }
-}
-
-const addPrimaryKey = async (
-  projectRef: string,
-  connectionString: string | undefined | null,
-  schema: string,
-  table: string,
-  columns: string[]
-) => {
-  const query = pgMeta.tableEditor.getAddPrimaryKeySQL({ schema, table, columns })
-  return await executeSql({
-    projectRef: projectRef,
-    connectionString: connectionString,
-    sql: query,
-    queryKey: ['primary-keys'],
-  })
-}
-
-const dropConstraint = async (
-  projectRef: string,
-  connectionString: string | undefined | null,
-  schema: string,
-  table: string,
-  name: string
-) => {
-  const query = pgMeta.tableEditor.getDropConstraintSQL({ schema, table, name })
-  return await executeSql({
-    projectRef: projectRef,
-    connectionString: connectionString,
-    sql: query,
-    queryKey: ['drop-constraint'],
-  })
 }
 
 const addForeignKey = async ({
@@ -246,6 +212,75 @@ const getUpdateForeignKeysSQL = ({
  * dashboard and hence do not sit within their own stores
  */
 
+const getCreateColumnSQL = ({
+  payload,
+  selectedTable,
+  primaryKey,
+  foreignKeyRelations = [],
+}: {
+  payload: CreateColumnPayload
+  selectedTable: RetrieveTableResult
+  primaryKey?: Constraint
+  foreignKeyRelations?: ForeignKey[]
+}) => {
+  // Once pg-meta supports composite keys, we can remove this logic
+  const { isPrimaryKey, ...formattedPayload } = payload
+  const { sql: createColumnSQL } = pgMeta.columns.create({
+    schema: payload.schema,
+    table: payload.table,
+    name: payload.name,
+    type: payload.type,
+    default_value: payload.defaultValue,
+    default_value_format: payload.defaultValueFormat,
+    is_identity: payload.isIdentity,
+    identity_generation: payload.identityGeneration,
+    is_nullable: payload.isNullable,
+    is_primary_key: payload.isPrimaryKey,
+    is_unique: payload.isUnique,
+    comment: payload.comment,
+    check: payload.check,
+    no_transaction: true,
+  })
+  const sqlStatements = [createColumnSQL]
+
+  // Firing createColumn in createTable will bypass this block
+  if (isPrimaryKey) {
+    // Same logic in createTable: Remove any primary key constraints first (we'll add it back later)
+    const existingPrimaryKeys = selectedTable.primary_keys.map((x) => x.name)
+
+    if (existingPrimaryKeys.length > 0 && primaryKey !== undefined) {
+      sqlStatements.push(
+        pgMeta.tableEditor.getDropConstraintSQL({
+          schema: payload.schema,
+          table: payload.table,
+          name: primaryKey.name,
+        })
+      )
+    }
+
+    const primaryKeyColumns = existingPrimaryKeys.concat([formattedPayload.name])
+    sqlStatements.push(
+      pgMeta.tableEditor.getAddPrimaryKeySQL({
+        schema: payload.schema,
+        table: payload.table,
+        columns: primaryKeyColumns,
+      })
+    )
+  }
+
+  // Then add the foreign key constraints here
+  if (foreignKeyRelations.length > 0) {
+    sqlStatements.push(
+      pgMeta.tableEditor.getAddForeignKeySQL({
+        schema: payload.schema,
+        table: payload.table,
+        foreignKeys: foreignKeyRelations,
+      })
+    )
+  }
+  return sqlStatements.join('; ')
+}
+
 export const createColumn = async ({
   projectRef,
   connectionString,
@@ -267,77 +302,106 @@ export const createColumn = async ({
 }) => {
   const toastId = _toastId ?? toast.loading(`Creating column "${payload.name}"...`)
   try {
-    // Once pg-meta supports composite keys, we can remove this logic
-    const { isPrimaryKey, ...formattedPayload } = payload
-    const { sql: createColumnSQL } = pgMeta.columns.create({
-      schema: payload.schema,
-      table: payload.table,
-      name: payload.name,
-      type: payload.type,
-      default_value: payload.defaultValue,
-      default_value_format: payload.defaultValueFormat,
-      is_identity: payload.isIdentity,
-      identity_generation: payload.identityGeneration,
-      is_nullable: payload.isNullable,
-      is_primary_key: payload.isPrimaryKey,
-      is_unique: payload.isUnique,
-      comment: payload.comment,
-      check: payload.check,
-      no_transaction: true,
+    const sqlStatements = getCreateColumnSQL({
+      payload,
+      selectedTable,
+      primaryKey,
+      foreignKeyRelations,
     })
-    const sqlStatements = [createColumnSQL]
-
-    // Firing createColumn in createTable will bypass this block
-    if (isPrimaryKey) {
-      // Same logic in createTable: Remove any primary key constraints first (we'll add it back later)
-      const existingPrimaryKeys = selectedTable.primary_keys.map((x) => x.name)
-
-      if (existingPrimaryKeys.length > 0 && primaryKey !== undefined) {
-        sqlStatements.push(
-          pgMeta.tableEditor.getDropConstraintSQL({
-            schema: payload.schema,
-            table: payload.table,
-            name: primaryKey.name,
-          })
-        )
-      }
-
-      const primaryKeyColumns = existingPrimaryKeys.concat([formattedPayload.name])
-      sqlStatements.push(
-        pgMeta.tableEditor.getAddPrimaryKeySQL({
-          schema: payload.schema,
-          table: payload.table,
-          columns: primaryKeyColumns,
-        })
-      )
-    }
-
-    // Then add the foreign key constraints here
-    if (foreignKeyRelations.length > 0) {
-      sqlStatements.push(
-        pgMeta.tableEditor.getAddForeignKeySQL({
-          schema: payload.schema,
-          table: payload.table,
-          foreignKeys: foreignKeyRelations,
-        })
-      )
-    }
 
     await executeSql({
       projectRef,
       connectionString,
-      sql: `BEGIN; ${sqlStatements.join('; ')}; COMMIT;`,
+      sql: `BEGIN; ${sqlStatements}; COMMIT;`,
       queryKey: ['column', 'create'],
     })
 
     if (!skipSuccessMessage) {
-      toast.success(`Successfully created column "${formattedPayload.name}"`, { id: toastId })
+      toast.success(`Successfully created column "${payload.name}"`, { id: toastId })
     }
     return { error: undefined }
   } catch (error: any) {
     toast.error(`An error occurred while creating the column "${payload.name}"`, { id: toastId })
     return { error }
   }
+}
+
+const getUpdateColumnSQL = ({
+  originalColumn,
+  payload,
+  selectedTable,
+  primaryKey,
+  foreignKeyRelations = [],
+  existingForeignKeyRelations = [],
+  skipPKCreation,
+}: {
+  originalColumn: RetrievedTableColumn
+  payload: UpdateColumnPayload
+  selectedTable: RetrieveTableResult
+  primaryKey?: Constraint
+  foreignKeyRelations?: ForeignKey[]
+  existingForeignKeyRelations?: ForeignKeyConstraint[]
+  skipPKCreation?: boolean
+}) => {
+  const { isPrimaryKey, ...formattedPayload } = payload
+  const { sql: updateColumnSQL } = pgMeta.columns.update(originalColumn, {
+    name: payload.name,
+    type: payload.type,
+    drop_default: payload.dropDefault,
+    default_value: payload.defaultValue,
+    default_value_format: payload.defaultValueFormat,
+    is_identity: payload.isIdentity,
+    identity_generation: payload.identityGeneration,
+    is_nullable: payload.isNullable,
+    is_unique: payload.isUnique,
+    comment: payload.comment,
+    check: payload.check,
+    no_transaction: true,
+  })
+  const sqlStatements = [updateColumnSQL]
+
+  if (!skipPKCreation && isPrimaryKey !== undefined) {
+    const existingPrimaryKeys = selectedTable.primary_keys.map((x) => x.name)
+
+    // Primary key is getting updated for the column
+    if (existingPrimaryKeys.length > 0 && primaryKey !== undefined) {
+      sqlStatements.push(
+        pgMeta.tableEditor.getDropConstraintSQL({
+          schema: originalColumn.schema,
+          table: originalColumn.table,
+          name: primaryKey.name,
+        })
+      )
+    }
+
+    const columnName = formattedPayload.name ?? originalColumn.name
+    const primaryKeyColumns = isPrimaryKey
+      ? existingPrimaryKeys.concat([columnName])
+      : existingPrimaryKeys.filter((x) => x !== columnName)
+
+    if (primaryKeyColumns.length) {
+      sqlStatements.push(
+        pgMeta.tableEditor.getAddPrimaryKeySQL({
+          schema: originalColumn.schema,
+          table: originalColumn.table,
+          columns: primaryKeyColumns,
+        })
+      )
+    }
+  }
+
+  // Then update foreign keys
+  if (foreignKeyRelations.length > 0) {
+    sqlStatements.push(
+      getUpdateForeignKeysSQL({
+        table: { schema: originalColumn.schema, name: originalColumn.table },
+        foreignKeys: foreignKeyRelations,
+        existingForeignKeyRelations,
+      })
+    )
+  }
+
+  return sqlStatements.join('; ')
 }
 
 export const updateColumn = async ({
@@ -364,66 +428,20 @@ export const updateColumn = async ({
   skipSuccessMessage?: boolean
 }) => {
   try {
-    const { isPrimaryKey, ...formattedPayload } = payload
-    const { sql: updateColumnSQL } = pgMeta.columns.update(originalColumn, {
-      name: payload.name,
-      type: payload.type,
-      drop_default: payload.dropDefault,
-      default_value: payload.defaultValue,
-      default_value_format: payload.defaultValueFormat,
-      is_identity: payload.isIdentity,
-      identity_generation: payload.identityGeneration,
-      is_nullable: payload.isNullable,
-      is_unique: payload.isUnique,
-      comment: payload.comment,
-      check: payload.check,
-      no_transaction: true,
+    const sqlStatements = getUpdateColumnSQL({
+      originalColumn,
+      payload,
+      selectedTable,
+      primaryKey,
+      foreignKeyRelations,
+      existingForeignKeyRelations,
+      skipPKCreation,
     })
-    const sqlStatements = [updateColumnSQL]
-
-    if (!skipPKCreation && isPrimaryKey !== undefined) {
-      const existingPrimaryKeys = selectedTable.primary_keys.map((x) => x.name)
-
-      // Primary key is getting updated for the column
-      if (existingPrimaryKeys.length > 0 && primaryKey !== undefined) {
-        sqlStatements.push(
-          pgMeta.tableEditor.getDropConstraintSQL({
-            schema: originalColumn.schema,
-            table: originalColumn.table,
-            name: primaryKey.name,
-          })
-        )
-      }
-
-      const columnName = formattedPayload.name ?? originalColumn.name
-      const primaryKeyColumns = isPrimaryKey
-        ? existingPrimaryKeys.concat([columnName])
-        : existingPrimaryKeys.filter((x) => x !== columnName)
-
-      if (primaryKeyColumns.length) {
-        sqlStatements.push(
-          pgMeta.tableEditor.getAddPrimaryKeySQL({
-            schema: originalColumn.schema,
-            table: originalColumn.table,
-            columns: primaryKeyColumns,
-          })
-        )
-      }
-    }
-
-    // Then update foreign keys
-    if (foreignKeyRelations.length > 0) {
-      sqlStatements.push(getUpdateForeignKeysSQL({
-        table: { schema: originalColumn.schema, name: originalColumn.table },
-        foreignKeys: foreignKeyRelations,
-        existingForeignKeyRelations,
-      }))
-    }
 
     await executeSql({
       projectRef,
       connectionString,
-      sql: `BEGIN; ${sqlStatements.join('; ')}; COMMIT;`,
+      sql: `BEGIN; ${sqlStatements}; COMMIT;`,
       queryKey: ['column', 'update', originalColumn.id],
     })
 
@@ -805,7 +823,6 @@ export const createTable = async ({
   return { table, failedPolicies }
 }
 
-/** TODO: Refactor to do in a single transaction */
 export const updateTable = async ({
   projectRef,
   connectionString,
@@ -830,6 +847,7 @@ export const updateTable = async ({
   organizationSlug?: string
 }) => {
   const queryClient = getQueryClient()
+  const sqlStatements: Array<string> = []
 
   // Prepare a check to see if primary keys to the tables were updated or not
   const primaryKeyColumns = columns
@@ -844,19 +862,22 @@ export const updateTable = async ({
     // an additional check when removing PK if the column in the PK was removed
     // So doing this one step earlier, lets us skip that additional check.
     if (primaryKey !== undefined) {
-      await dropConstraint(projectRef, connectionString, table.schema, table.name, primaryKey.name)
+      sqlStatements.push(
+        pgMeta.tableEditor.getDropConstraintSQL({
+          schema: table.schema,
+          table: table.name,
+          name: primaryKey.name,
+        })
+      )
     }
   }
 
   if (Object.keys(payload).length > 0) {
-    await updateTableMutation({
-      projectRef,
-      connectionString,
-      id: table.id,
-      name: table.name,
-      schema: table.schema,
-      payload,
-    })
+    const { sql: updateTableSQL } = pgMeta.tables.update(
+      { id: table.id, name: table.name, schema: table.schema },
+      payload
+    )
+    sqlStatements.push(updateTableSQL)
   }
 
   // Track RLS enablement if it's being turned on
@@ -881,83 +902,58 @@ export const updateTable = async ({
     }
   }
 
-  const updatedTable = await queryClient.fetchQuery({
-    queryKey: tableKeys.retrieve(
-      projectRef,
-      payload.name ?? table.name,
-      payload.schema ?? table.schema
-    ),
-    queryFn: ({ signal }) =>
-      getTable(
-        {
-          projectRef,
-          connectionString,
-          name: payload.name ?? table.name,
-          schema: payload.schema ?? table.schema,
-        },
-        signal
-      ),
-  })
-
-  const originalColumns = updatedTable.columns ?? []
+  const originalColumns = table.columns ?? []
   const columnIds = columns.map((column) => column.id)
 
   // Delete any removed columns
   const columnsToRemove = originalColumns.filter((column) => !columnIds.includes(column.id))
   for (const column of columnsToRemove) {
-    toast.loading(`Removing column ${column.name} from ${updatedTable.name}`, { id: toastId })
-    await deleteDatabaseColumn({
-      projectRef,
-      connectionString,
-      column,
-    })
+    const { sql } = pgMeta.columns.remove({ ...column, table: payload.name ?? column.name })
+    sqlStatements.push(sql)
   }
 
   // Add any new columns / Update any existing columns
   let hasError = false
   for (const column of columns) {
     if (!column.id.includes(table.id.toString())) {
-      toast.loading(`Adding column ${column.name} to ${updatedTable.name}`, { id: toastId })
       // Ensure that columns do not created as primary key first, cause the primary key will
       // be added later on further down in the code
-      const columnPayload = generateCreateColumnPayload(updatedTable, {
-        ...column,
-        isPrimaryKey: false,
-      })
-      const { error } = await createColumn({
-        projectRef: projectRef,
-        connectionString: connectionString,
-        payload: columnPayload,
-        selectedTable: updatedTable,
-        skipSuccessMessage: true,
-        toastId,
-      })
-      if (!!error) hasError = true
+      const columnPayload = generateCreateColumnPayload(
+        { ...table, name: payload.name ?? table.name },
+        {
+          ...column,
+          table: payload.name ?? column.name,
+          isPrimaryKey: false,
+        }
+      )
+      sqlStatements.push(
+        getCreateColumnSQL({
+          payload: columnPayload,
+          selectedTable: { ...table, name: payload.name ?? table.name },
+          primaryKey,
+          foreignKeyRelations,
+        })
+      )
     } else {
       const originalColumn = find(table.columns, { id: column.id })
       if (originalColumn) {
-        const columnPayload = generateUpdateColumnPayload(originalColumn, updatedTable, column)
+        const columnPayload = generateUpdateColumnPayload(originalColumn, table, column)
         if (!isEmpty(columnPayload)) {
-          toast.loading(`Updating column ${column.name} from ${updatedTable.name}`, { id: toastId })
-
-          const res = await updateColumn({
-            projectRef: projectRef,
-            connectionString: connectionString,
-            // Use the updated table name and schema since the table might have been renamed
-            originalColumn: {
-              ...originalColumn,
-              table: updatedTable.name,
-              schema: updatedTable.schema,
-            },
-            payload: columnPayload,
-            selectedTable: updatedTable,
-            skipPKCreation: true,
-            skipSuccessMessage: true,
-          })
-          if (res?.error) {
-            hasError = true
-            toast.error(`Failed to update column "${column.name}": ${res.error.message}`)
-          }
+          sqlStatements.push(
+            getUpdateColumnSQL({
+              originalColumn: {
+                ...originalColumn,
+                table: payload.name ?? column.name,
+                schema: table.schema,
+              },
+              payload: columnPayload,
+              selectedTable: { ...table, name: payload.name ?? table.name },
+              primaryKey,
+              foreignKeyRelations,
+              existingForeignKeyRelations,
+              skipPKCreation: true,
+            })
+          )
         }
       }
     }
@@ -965,22 +961,28 @@ export const updateTable = async ({
 
   // Then add back the primary keys again
   if (isPrimaryKeyUpdated && primaryKeyColumns.length > 0) {
-    await addPrimaryKey(
-      projectRef,
-      connectionString,
-      updatedTable.schema,
-      updatedTable.name,
-      primaryKeyColumns
-    )
+    const primaryKeySQL = pgMeta.tableEditor.getAddPrimaryKeySQL({
+      schema: table.schema,
+      table: payload.name ?? table.name,
+      columns: primaryKeyColumns,
+    })
+    sqlStatements.push(primaryKeySQL)
   }
 
   // Foreign keys will get updated here accordingly
-  await updateForeignKeys({
+  sqlStatements.push(
+    getUpdateForeignKeysSQL({
+      table: { name: payload.name ?? table.name, schema: table.schema },
+      foreignKeys: foreignKeyRelations,
+      existingForeignKeyRelations,
+    })
+  )
+
+  await executeSql({
     projectRef,
     connectionString,
-    table: updatedTable,
-    foreignKeys: foreignKeyRelations,
-    existingForeignKeyRelations,
+    sql: `begin; ${sqlStatements.join(';\n')}; commit;`,
+    queryKey: ['table', 'update-with-columns', table.id],
   })
 
   await Promise.all([

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -303,11 +303,7 @@ testRunner('table editor', () => {
     await page.getByRole('menuitem', { name: 'Edit table' }).click()
     await page.getByTestId('table-name-input').fill(tableNameUpdated)
     await page.getByRole('textbox', { name: 'pw_column' }).fill(columnNameUpdated)
-    const updateTablePromise = waitForApiResponse(page, 'pg-meta', ref, 'query?key=column-update', {
-      method: 'POST',
-    })
     await page.getByRole('button', { name: 'Save' }).click()
-    await updateTablePromise // update table
     await waitForTableToLoad(page, ref) // load tables
     await expect(page.getByLabel(`View ${tableNameUpdated}`, { exact: true })).toBeVisible()
     await expect(page.getByLabel(`View ${tableNameGridEditor}`, { exact: true })).not.toBeVisible()

--- a/packages/pg-meta/src/index.ts
+++ b/packages/pg-meta/src/index.ts
@@ -25,6 +25,8 @@ export { getIndexWorkerStatusSQL } from './sql/studio/auth/get-index-worker-stat
 export { type OptimizedSearchColumns } from './sql/studio/auth/get-users-types'
 export { getPaginatedUsersSQL, type UsersCursor } from './sql/studio/auth/get-users-paginated'
 export { getUsersCountSQL } from './sql/studio/auth/get-users-count'
+import * as tableEditor from './sql/studio/table-editor'
+export type { ForeignKey } from './sql/studio/table-editor'
 
 export default {
   roles,
@@ -46,4 +48,5 @@ export default {
   indexes,
   columnPrivileges,
   query,
+  tableEditor,
 }

--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -120,6 +120,7 @@ function create({
   is_unique = false,
   comment,
   check,
+  no_transaction = false,
 }: {
   schema: string
   table: string
@@ -134,6 +135,7 @@ function create({
   is_unique?: boolean
   comment?: string
   check?: string
+  no_transaction?: boolean
 }): { sql: string } {
   let defaultValueClause = ''
   if (is_identity) {
@@ -165,17 +167,22 @@ function create({
       : `COMMENT ON COLUMN ${ident(schema)}.${ident(table)}.${ident(name)} IS ${literal(comment)}`
 
   const sql = `
-BEGIN;
-  ALTER TABLE ${ident(schema)}.${ident(table)} ADD COLUMN ${ident(name)} ${typeIdent(type)}
-    ${defaultValueClause}
-    ${isNullableClause}
-    ${isPrimaryKeyClause}
-    ${isUniqueClause}
-    ${checkSql};
-  ${commentSql};
-COMMIT;`
+ALTER TABLE ${ident(schema)}.${ident(table)} ADD COLUMN ${ident(name)} ${typeIdent(type)}
+  ${defaultValueClause}
+  ${isNullableClause}
+  ${isPrimaryKeyClause}
+  ${isUniqueClause}
+  ${checkSql};
+${commentSql};`
 
-  return { sql }
+  if (no_transaction) return { sql }
+
+  return {
+    sql: `
+BEGIN;
+  ${sql}
+COMMIT;`,
+  }
 }
 
 // TODO: make this more robust - use type_id or type_schema + type_name instead of just type.

--- a/packages/pg-meta/src/pg-meta-columns.ts
+++ b/packages/pg-meta/src/pg-meta-columns.ts
@@ -211,6 +211,7 @@ function update(
     is_unique,
     comment,
     check,
+    no_transaction = false
   }: {
     name?: string
     type?: string
@@ -223,6 +224,7 @@ function update(
     is_unique?: boolean
     comment?: string | null
     check?: string | null
+    no_transaction?: boolean
   }
 ): { sql: string } {
   const nameSql =
@@ -374,7 +376,6 @@ $$;
   // NOTE: nameSql must be last. defaultValueSql must be after typeSql.
   // identitySql must be after isNullableSql.
   const sql = `
-BEGIN;
   ${isNullableSql}
   ${typeSql}
   ${defaultValueSql}
@@ -382,10 +383,15 @@ BEGIN;
   ${isUniqueSql}
   ${commentSql}
   ${checkSql}
-  ${nameSql}
-COMMIT;`
+  ${nameSql}`
 
-  return { sql }
+  if (no_transaction) return { sql }
+
+  return {
+    sql: `
+    BEGIN;
+      ${sql}
+    COMMIT;` }
 }
 
 function remove(

--- a/packages/pg-meta/src/pg-meta-tables.ts
+++ b/packages/pg-meta/src/pg-meta-tables.ts
@@ -141,14 +141,20 @@ type TableCreateParams = {
   name: string
   schema?: string
   comment?: string | null
+  no_transaction?: boolean
 }
 
-function create({ name, schema = 'public', comment }: TableCreateParams): { sql: string } {
+function create({ name, schema = 'public', comment, no_transaction = false }: TableCreateParams): {
+  sql: string
+} {
   const tableSql = `CREATE TABLE ${ident(schema)}.${ident(name)} ();`
   const commentSql =
     comment != undefined
       ? `COMMENT ON TABLE ${ident(schema)}.${ident(name)} IS ${literal(comment)};`
       : ''
+
+  if (no_transaction) return { sql: `${tableSql} ${commentSql}` }
+
   const sql = `BEGIN; ${tableSql} ${commentSql} COMMIT;`
   return { sql }
 }

--- a/packages/pg-meta/src/sql/studio/table-editor/constraints.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/constraints.ts
@@ -1,0 +1,9 @@
+export const getDropConstraintSQL = ({
+  schema,
+  table,
+  name,
+}: {
+  schema: string
+  table: string
+  name: string
+}) => `ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${name}"`

--- a/packages/pg-meta/src/sql/studio/table-editor/constraints.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/constraints.ts
@@ -1,3 +1,5 @@
+import { ident } from "../../../pg-format"
+
 export const getDropConstraintSQL = ({
   schema,
   table,
@@ -6,4 +8,4 @@ export const getDropConstraintSQL = ({
   schema: string
   table: string
   name: string
-}) => `ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${name}"`
+}) => `ALTER TABLE ${ident(schema)}.${ident(table)} DROP CONSTRAINT ${ident(name)}`

--- a/packages/pg-meta/src/sql/studio/table-editor/foreign-keys.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/foreign-keys.ts
@@ -1,0 +1,85 @@
+export const getAddForeignKeySQL = ({
+  table,
+  foreignKeys,
+}: {
+  table: { schema: string; name: string }
+  foreignKeys: ForeignKey[]
+}) => {
+  const getOnDeleteSql = (action: string) =>
+    action === FOREIGN_KEY_CASCADE_ACTION.CASCADE
+      ? 'ON DELETE CASCADE'
+      : action === FOREIGN_KEY_CASCADE_ACTION.RESTRICT
+        ? 'ON DELETE RESTRICT'
+        : action === FOREIGN_KEY_CASCADE_ACTION.SET_DEFAULT
+          ? 'ON DELETE SET DEFAULT'
+          : action === FOREIGN_KEY_CASCADE_ACTION.SET_NULL
+            ? 'ON DELETE SET NULL'
+            : ''
+  const getOnUpdateSql = (action: string) =>
+    action === FOREIGN_KEY_CASCADE_ACTION.CASCADE
+      ? 'ON UPDATE CASCADE'
+      : action === FOREIGN_KEY_CASCADE_ACTION.RESTRICT
+        ? 'ON UPDATE RESTRICT'
+        : ''
+  return (
+    foreignKeys
+      .map((relation) => {
+        const { deletionAction, updateAction } = relation
+        const onDeleteSql = getOnDeleteSql(deletionAction)
+        const onUpdateSql = getOnUpdateSql(updateAction)
+        return `
+      ALTER TABLE "${table.schema}"."${table.name}"
+      ADD FOREIGN KEY (${relation.columns.map((column) => `"${column.source}"`).join(', ')})
+      REFERENCES "${relation.schema}"."${relation.table}" (${relation.columns.map((column) => `"${column.target}"`).join(', ')})
+      ${onUpdateSql}
+      ${onDeleteSql}
+    `
+          .replace(/\s+/g, ' ')
+          .trim()
+      })
+      .join(';') + ';'
+  )
+}
+
+export const getRemoveForeignKeySQL = ({
+  table,
+  foreignKeys,
+}: {
+  table: { schema: string; name: string }
+  foreignKeys: ForeignKey[]
+}) => {
+  return (
+    foreignKeys
+      .map((relation) =>
+        `
+ALTER TABLE IF EXISTS "${table.schema}"."${table.name}"
+DROP CONSTRAINT IF EXISTS "${relation.name}"
+`
+          .replace(/\s+/g, ' ')
+          .trim()
+      )
+      .join(';') + ';'
+  )
+}
+
+
+export interface ForeignKey {
+  id?: number | string
+  name?: string
+  tableId?: number
+
+  schema: string
+  table: string
+  columns: { source: string; sourceType?: string; target: string; targetType?: string }[]
+  deletionAction: string
+  updateAction: string
+  toRemove?: boolean
+}
+
+export enum FOREIGN_KEY_CASCADE_ACTION {
+  NO_ACTION = 'a',
+  RESTRICT = 'r',
+  CASCADE = 'c',
+  SET_NULL = 'n',
+  SET_DEFAULT = 'd',
+}

--- a/packages/pg-meta/src/sql/studio/table-editor/foreign-keys.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/foreign-keys.ts
@@ -1,10 +1,12 @@
-import { ident } from "../../../pg-format";
+import { ident } from '../../../pg-format'
 
 export const getAddForeignKeySQL = ({
   table,
+  schema,
   foreignKeys,
 }: {
-  table: { schema: string; name: string }
+  schema: string
+  table: string
   foreignKeys: ForeignKey[]
 }) => {
   const getOnDeleteSql = (action: string) =>
@@ -30,7 +32,7 @@ export const getAddForeignKeySQL = ({
         const onDeleteSql = getOnDeleteSql(deletionAction)
         const onUpdateSql = getOnUpdateSql(updateAction)
         return `
-      ALTER TABLE ${ident(table.schema)}.${ident(table.name)}
+      ALTER TABLE ${ident(schema)}.${ident(table)}
       ADD FOREIGN KEY (${relation.columns.map((column) => ident(column.source)).join(', ')})
       REFERENCES ${ident(relation.schema)}.${ident(relation.table)} (${relation.columns.map((column) => ident(column.target)).join(', ')})
       ${onUpdateSql}
@@ -45,16 +47,18 @@ export const getAddForeignKeySQL = ({
 
 export const getRemoveForeignKeySQL = ({
   table,
+  schema,
   foreignKeys,
 }: {
-  table: { schema: string; name: string }
+  schema: string
+  table: string
   foreignKeys: ForeignKey[]
 }) => {
   return (
     foreignKeys
       .map((relation) =>
         `
-ALTER TABLE IF EXISTS ${ident(table.schema)}.${ident(table.name)}
+ALTER TABLE IF EXISTS ${ident(schema)}.${ident(table)}
 DROP CONSTRAINT IF EXISTS ${ident(relation.name)}
 `
           .replace(/\s+/g, ' ')
@@ -63,7 +67,6 @@ DROP CONSTRAINT IF EXISTS ${ident(relation.name)}
       .join(';') + ';'
   )
 }
-
 
 export interface ForeignKey {
   id?: number | string

--- a/packages/pg-meta/src/sql/studio/table-editor/foreign-keys.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/foreign-keys.ts
@@ -1,3 +1,5 @@
+import { ident } from "../../../pg-format";
+
 export const getAddForeignKeySQL = ({
   table,
   foreignKeys,
@@ -28,9 +30,9 @@ export const getAddForeignKeySQL = ({
         const onDeleteSql = getOnDeleteSql(deletionAction)
         const onUpdateSql = getOnUpdateSql(updateAction)
         return `
-      ALTER TABLE "${table.schema}"."${table.name}"
-      ADD FOREIGN KEY (${relation.columns.map((column) => `"${column.source}"`).join(', ')})
-      REFERENCES "${relation.schema}"."${relation.table}" (${relation.columns.map((column) => `"${column.target}"`).join(', ')})
+      ALTER TABLE ${ident(table.schema)}.${ident(table.name)}
+      ADD FOREIGN KEY (${relation.columns.map((column) => ident(column.source)).join(', ')})
+      REFERENCES ${ident(relation.schema)}.${ident(relation.table)} (${relation.columns.map((column) => ident(column.target)).join(', ')})
       ${onUpdateSql}
       ${onDeleteSql}
     `
@@ -52,8 +54,8 @@ export const getRemoveForeignKeySQL = ({
     foreignKeys
       .map((relation) =>
         `
-ALTER TABLE IF EXISTS "${table.schema}"."${table.name}"
-DROP CONSTRAINT IF EXISTS "${relation.name}"
+ALTER TABLE IF EXISTS ${ident(table.schema)}.${ident(table.name)}
+DROP CONSTRAINT IF EXISTS ${ident(relation.name)}
 `
           .replace(/\s+/g, ' ')
           .trim()

--- a/packages/pg-meta/src/sql/studio/table-editor/identity.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/identity.ts
@@ -1,0 +1,26 @@
+export const getUpdateIdentitySequenceSQL = ({
+  schema,
+  table,
+  column,
+}: {
+  schema: string
+  table: string
+  column: string
+}) => {
+  return `SELECT setval('"${schema}"."${table}_${column}_seq"', (SELECT COALESCE(MAX("${column}"), 1) FROM "${schema}"."${table}"))`
+}
+
+
+export const getDuplicateIdentitySequenceSQL = ({
+  columnName,
+  duplicatedTableName,
+  sourceTableName,
+  sourceTableSchema,
+}: {
+  columnName: string
+  duplicatedTableName: string
+  sourceTableName: string
+  sourceTableSchema: string
+}) => {
+  return `SELECT setval('"${sourceTableSchema}"."${duplicatedTableName}_${columnName}_seq"', (SELECT MAX("${columnName}") FROM "${sourceTableSchema}"."${sourceTableName}"));`
+}

--- a/packages/pg-meta/src/sql/studio/table-editor/identity.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/identity.ts
@@ -1,3 +1,5 @@
+import { ident } from "../../../pg-format"
+
 export const getUpdateIdentitySequenceSQL = ({
   schema,
   table,
@@ -7,7 +9,7 @@ export const getUpdateIdentitySequenceSQL = ({
   table: string
   column: string
 }) => {
-  return `SELECT setval('"${schema}"."${table}_${column}_seq"', (SELECT COALESCE(MAX("${column}"), 1) FROM "${schema}"."${table}"))`
+  return `SELECT setval('${ident(schema)}.${ident(`${table}_${column}_seq`)}', (SELECT COALESCE(MAX(${ident(column)}), 1) FROM ${ident(schema)}.${ident(table)}))`
 }
 
 
@@ -22,5 +24,5 @@ export const getDuplicateIdentitySequenceSQL = ({
   sourceTableName: string
   sourceTableSchema: string
 }) => {
-  return `SELECT setval('"${sourceTableSchema}"."${duplicatedTableName}_${columnName}_seq"', (SELECT MAX("${columnName}") FROM "${sourceTableSchema}"."${sourceTableName}"));`
+  return `SELECT setval('${ident(sourceTableSchema)}.${ident(`${duplicatedTableName}_${columnName}_seq`)}', (SELECT MAX(${ident(columnName)}) FROM ${ident(sourceTableSchema)}.${ident(sourceTableName)}));`
 }

--- a/packages/pg-meta/src/sql/studio/table-editor/index.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/index.ts
@@ -1,0 +1,6 @@
+export * from './constraints'
+export * from './identity'
+export * from './foreign-keys'
+export * from './primary-keys'
+export * from './rls'
+export * from './table'

--- a/packages/pg-meta/src/sql/studio/table-editor/primary-keys.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/primary-keys.ts
@@ -1,0 +1,16 @@
+/**
+ * The functions below are basically just queries but may be supported directly
+ * from the pg-meta library in the future
+ */
+export const getAddPrimaryKeySQL = ({
+  schema,
+  table,
+  columns,
+}: {
+  schema: string
+  table: string
+  columns: string[]
+}) => {
+  const primaryKeyColumns = columns.map((col) => `"${col}"`).join(', ')
+  return `ALTER TABLE "${schema}"."${table}" ADD PRIMARY KEY (${primaryKeyColumns})`
+}

--- a/packages/pg-meta/src/sql/studio/table-editor/primary-keys.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/primary-keys.ts
@@ -1,3 +1,5 @@
+import { ident } from "../../../pg-format"
+
 /**
  * The functions below are basically just queries but may be supported directly
  * from the pg-meta library in the future
@@ -11,6 +13,6 @@ export const getAddPrimaryKeySQL = ({
   table: string
   columns: string[]
 }) => {
-  const primaryKeyColumns = columns.map((col) => `"${col}"`).join(', ')
-  return `ALTER TABLE "${schema}"."${table}" ADD PRIMARY KEY (${primaryKeyColumns})`
+  const primaryKeyColumns = columns.map((col) => ident(col)).join(', ')
+  return `ALTER TABLE ${ident(schema)}.${ident(table)} ADD PRIMARY KEY (${primaryKeyColumns})`
 }

--- a/packages/pg-meta/src/sql/studio/table-editor/rls.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/rls.ts
@@ -1,0 +1,3 @@
+export const getEnableRLSSQL = ({ schema, table }: { schema: string; table: string }) => {
+  return `ALTER TABLE "${schema}"."${table}" ENABLE ROW LEVEL SECURITY`
+}

--- a/packages/pg-meta/src/sql/studio/table-editor/rls.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/rls.ts
@@ -1,3 +1,5 @@
+import { ident } from "../../../pg-format";
+
 export const getEnableRLSSQL = ({ schema, table }: { schema: string; table: string }) => {
-  return `ALTER TABLE "${schema}"."${table}" ENABLE ROW LEVEL SECURITY`
+  return `ALTER TABLE ${ident(schema)}.${ident(table)} ENABLE ROW LEVEL SECURITY`
 }

--- a/packages/pg-meta/src/sql/studio/table-editor/table.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/table.ts
@@ -1,0 +1,30 @@
+export const getDuplicateTableSQL = ({
+  comment,
+  duplicatedTableName,
+  sourceTableName,
+  sourceTableSchema,
+}: {
+  comment?: string | null
+  duplicatedTableName: string
+  sourceTableName: string
+  sourceTableSchema: string
+}) => {
+  return [
+    `CREATE TABLE "${sourceTableSchema}"."${duplicatedTableName}" (LIKE "${sourceTableSchema}"."${sourceTableName}" INCLUDING ALL);`,
+    comment != undefined
+      ? `comment on table "${sourceTableSchema}"."${duplicatedTableName}" is '${comment}';`
+      : '',
+  ].join('\n')
+}
+
+export const getDuplicateRowsSQL = ({
+  duplicatedTableName,
+  sourceTableName,
+  sourceTableSchema,
+}: {
+  duplicatedTableName: string
+  sourceTableName: string
+  sourceTableSchema: string
+}) => {
+  return `INSERT INTO "${sourceTableSchema}"."${duplicatedTableName}" SELECT * FROM "${sourceTableSchema}"."${sourceTableName}";`
+}

--- a/packages/pg-meta/src/sql/studio/table-editor/table.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/table.ts
@@ -1,3 +1,5 @@
+import { ident } from '../../../pg-format'
+
 export const getDuplicateTableSQL = ({
   comment,
   duplicatedTableName,
@@ -10,9 +12,9 @@ export const getDuplicateTableSQL = ({
   sourceTableSchema: string
 }) => {
   return [
-    `CREATE TABLE "${sourceTableSchema}"."${duplicatedTableName}" (LIKE "${sourceTableSchema}"."${sourceTableName}" INCLUDING ALL);`,
+    `CREATE TABLE ${ident(sourceTableSchema)}.${ident(duplicatedTableName)} (LIKE ${ident(sourceTableSchema)}.${ident(sourceTableName)} INCLUDING ALL);`,
     comment != undefined
-      ? `comment on table "${sourceTableSchema}"."${duplicatedTableName}" is '${comment}';`
+      ? `comment on table ${ident(sourceTableSchema)}.${ident(duplicatedTableName)} is '${comment}';`
       : '',
   ].join('\n')
 }
@@ -26,5 +28,5 @@ export const getDuplicateRowsSQL = ({
   sourceTableName: string
   sourceTableSchema: string
 }) => {
-  return `INSERT INTO "${sourceTableSchema}"."${duplicatedTableName}" SELECT * FROM "${sourceTableSchema}"."${sourceTableName}";`
+  return `INSERT INTO ${ident(sourceTableSchema)}.${ident(duplicatedTableName)} SELECT * FROM ${ident(sourceTableSchema)}.${ident(sourceTableName)};`
 }


### PR DESCRIPTION
## Problem

When creating or updating tables or columns, we send several distinct sql statements. When an error occurs, we may have already executed parts of the operation. This leads to confusing moments. For instance, if you create a table and provide an invalid default for one of its columns, it will create the table without the column. The sidebars stays open but you can't click _Save_ again after fixing the column as it tries to re-create the table that already exist.

## Solution

- [x] Extract sql queries to `supabase/pg-meta`
- [x] Build statements for each sub operation instead of sending multiple queries and wrap them in single transaction