### PR TITLE
Cleaning up troubleshooting guide categories (Edge Functions)

### DIFF
--- a/apps/docs/content/troubleshooting/how-can-i-revoke-execution-of-a-postgresql-function-2GYb0A.mdx
+++ b/apps/docs/content/troubleshooting/how-can-i-revoke-execution-of-a-postgresql-function-2GYb0A.mdx
@@ -2,7 +2,7 @@
 title = "How can I revoke execution of a Postgres function?"
 github_url = "https://github.com/orgs/supabase/discussions/17606"
 date_created = "2023-09-21T03:04:41+00:00"
-topics = [ "database", "functions" ]
+topics = [ "database" ]
 keywords = [ "functions", "permissions" ]
 database_id = "b7edb30b-beee-40ae-9b4f-666ef6411bb6"
 

--- a/apps/docs/content/troubleshooting/manually-created-databases-are-not-visible-in-the-supabase-dashboard-4415aa.mdx
+++ b/apps/docs/content/troubleshooting/manually-created-databases-are-not-visible-in-the-supabase-dashboard-4415aa.mdx
@@ -1,6 +1,6 @@
 ---
 title = "'Manually created databases are not visible in the Supabase Dashboard'"
-topics = [ "auth", "cli", "database", "functions", "platform", "storage" ]
+topics = [ "database"]
 keywords = []
 database_id = "f6420e72-ea67-4825-b3f7-e722ea5c0d96"
 ---

--- a/apps/docs/content/troubleshooting/new-variable-is-null-in-a-trigger-function--l9AOZ.mdx
+++ b/apps/docs/content/troubleshooting/new-variable-is-null-in-a-trigger-function--l9AOZ.mdx
@@ -2,7 +2,7 @@
 title = "NEW variable is null in a trigger function."
 github_url = "https://github.com/orgs/supabase/discussions/15934"
 date_created = "2023-07-20T19:05:52+00:00"
-topics = [ "database", "functions" ]
+topics = [ "database" ]
 keywords = [ "trigger", "function", "statement", "row", "NEW", "OLD", "SQL" ]
 database_id = "f5cabb97-aae3-4fb5-b597-4e7857821753"
 ---

--- a/apps/docs/content/troubleshooting/postgrest-not-recognizing-new-columns-or-functions-bd75f5.mdx
+++ b/apps/docs/content/troubleshooting/postgrest-not-recognizing-new-columns-or-functions-bd75f5.mdx
@@ -1,6 +1,6 @@
 ---
 title = "PostgREST not recognizing new columns, tables, views or functions"
-topics = [ "cli", "platform", "database", "functions" ]
+topics = [ "platform", "database" ]
 keywords = []
 database_id = "c3481097-1a32-4e94-b4f6-7aeb88132a41"
 ---

--- a/apps/docs/content/troubleshooting/running-explain-analyze-on-functions.mdx
+++ b/apps/docs/content/troubleshooting/running-explain-analyze-on-functions.mdx
@@ -1,6 +1,6 @@
 ---
 title = "Running EXPLAIN ANALYZE on functions"
-topics = [ "database", "functions" ]
+topics = [ "database" ]
 keywords = []
 database_id = "1d62cace-c0f6-47a0-8690-002a797da33b"
 

--- a/apps/docs/content/troubleshooting/running-explain-analyze-on-functions.mdx
+++ b/apps/docs/content/troubleshooting/running-explain-analyze-on-functions.mdx
@@ -1,7 +1,7 @@
 ---
 title = "Running EXPLAIN ANALYZE on functions"
 topics = [ "database" ]
-keywords = []
+keywords = ["postgres", "EXPLAIN", "database functions"]
 database_id = "1d62cace-c0f6-47a0-8690-002a797da33b"
 
 [api]

--- a/apps/docs/content/troubleshooting/supabase-storage-inefficient-folder-operations-and-hierarchical-rls-challenges-b05a4d.mdx
+++ b/apps/docs/content/troubleshooting/supabase-storage-inefficient-folder-operations-and-hierarchical-rls-challenges-b05a4d.mdx
@@ -1,6 +1,6 @@
 ---
 title = "'Supabase Storage: Inefficient folder operations and hierarchical RLS challenges'"
-topics = [ "functions", "storage" ]
+topics = [ "storage" ]
 keywords = []
 database_id = "3b52daf2-d78d-4630-8e9f-8bf5d90208bf"
 ---

--- a/apps/docs/content/troubleshooting/using-sqlalchemy-with-supabase-FUqebT.mdx
+++ b/apps/docs/content/troubleshooting/using-sqlalchemy-with-supabase-FUqebT.mdx
@@ -2,7 +2,7 @@
 title = "Using SQLAlchemy with Supabase"
 github_url = "https://github.com/orgs/supabase/discussions/27071"
 date_created = "2024-06-06T16:27:43+00:00"
-topics = [ "database", "supavisor", "self-hosting", "functions" ]
+topics = [ "database", "supavisor", "self-hosting" ]
 keywords = [ "sqlalchemy", "ipv6", "pool", "database", "connection" ]
 database_id = "da4efcda-cd02-4001-965b-f0294300152f"
 ---

--- a/apps/docs/content/troubleshooting/why-do-i-see-auth--api-requests-in-the-dashboard-my-app-has-no-users-CyadiO.mdx
+++ b/apps/docs/content/troubleshooting/why-do-i-see-auth--api-requests-in-the-dashboard-my-app-has-no-users-CyadiO.mdx
@@ -2,7 +2,7 @@
 title = "Why do I see Auth & API requests in the dashboard? My app has no users"
 github_url = "https://github.com/orgs/supabase/discussions/21579"
 date_created = "2024-02-26T21:39:41+00:00"
-topics = [ "auth", "platform", "database", "realtime", "functions" ]
+topics = [ "auth", "platform", "database", "realtime" ]
 keywords = [ "dashboard", "health", "endpoints" ]
 database_id = "f85935d8-e871-4463-8288-f118f4e24afd"
 ---


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Many troubleshooting guides referencing Postgres functions were placed in the edge function category

## What is the new behavior?

Removed  the "function" topic filter for guides that are unrelated to edge functions

