### PR TITLE
updated bundle size limits

### DIFF
--- a/apps/docs/content/troubleshooting/edge-function-bundle-size-issues.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-bundle-size-issues.mdx
@@ -8,7 +8,7 @@ database_id = "aaf9e673-64ae-460a-88e0-b83ea4963382"
 cli = [ "supabase-functions-deploy" ]
 ---
 
-Edge Functions have a 10MB source code limit. If your function exceeds this limit, deployment will fail.
+Edge Functions have a 20MB source code limit. If your function exceeds this limit, deployment will fail.
 
 ## Check your bundle size
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

[Edge function docs state:](https://supabase.com/docs/guides/functions/limits#:~:text=Maximum%20Function%20Size%3A%2020MB%20(After%20bundling%20using%20CLI))> Maximum Function Size: 20MB (After bundling using CLI)

However, the bundle size troubleshooting guide argues: 
> Edge Functions have a 10MB source code limit. If your function exceeds this limit, deployment will fail.

## What is the new behavior?

Updated the 10MB limit to 20MB in the troubleshooting docs
