### PR TITLE
fix: adjust proxy configs for new api keys and auth

### DIFF
--- a/docker/docker-compose.caddy.yml
+++ b/docker/docker-compose.caddy.yml
@@ -2,6 +2,8 @@ services:
 
   kong:
     ports: !reset []
+    environment:
+      KONG_PORT_MAPS: "443:8000,443:8443"
 
   caddy:
     container_name: supabase-caddy
@@ -13,6 +15,8 @@ services:
       - "443:443/udp"
     depends_on:
       kong:
+        condition: service_healthy
+      studio:
         condition: service_healthy
     environment:
       PROXY_DOMAIN: ${PROXY_DOMAIN}

--- a/docker/docker-compose.nginx.yml
+++ b/docker/docker-compose.nginx.yml
@@ -2,6 +2,8 @@ services:
 
   kong:
     ports: !reset []
+    environment:
+      KONG_PORT_MAPS: "443:8000,443:8443"
 
   nginx:
     container_name: supabase-nginx
@@ -12,6 +14,8 @@ services:
       - "443:443"
     depends_on:
       kong:
+        condition: service_healthy
+      studio:
         condition: service_healthy
     environment:
       PROXY_DOMAIN: ${PROXY_DOMAIN}

--- a/docker/volumes/proxy/caddy/Caddyfile
+++ b/docker/volumes/proxy/caddy/Caddyfile
@@ -1,26 +1,8 @@
 {$PROXY_DOMAIN} {
-    @supabase_api path /auth/v1/* /rest/v1/* /graphql/v1/* /realtime/v1/* /functions/v1/* /mcp
+    @supabase_api path /auth/v1/* /rest/v1/* /graphql/v1 /realtime/v1/* /storage/v1/* /functions/v1/* /mcp
 
     handle @supabase_api {
         reverse_proxy kong:8000
-    }
-
-    handle_path /storage/v1/* {
-        # CORS headers for Storage (bypasses Kong, which normally handles CORS)
-        @cors_preflight method OPTIONS
-        handle @cors_preflight {
-            header Access-Control-Allow-Origin *
-            header Access-Control-Allow-Methods "GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS"
-            header Access-Control-Allow-Headers *
-            respond 204
-        }
-
-        header Access-Control-Allow-Origin *
-
-        reverse_proxy storage:5000 {
-            # Required for TUS resumable upload Location headers and S3 signature verification.
-            header_up X-Forwarded-Prefix /{http.request.orig_uri.path.0}/{http.request.orig_uri.path.1}
-        }
     }
 
     handle {

--- a/docker/volumes/proxy/nginx/supabase-nginx.conf.tpl
+++ b/docker/volumes/proxy/nginx/supabase-nginx.conf.tpl
@@ -50,6 +50,10 @@ server {
         proxy_pass http://kong_upstream;
     }
 
+    location /graphql {
+        proxy_pass http://kong_upstream;
+    }
+
     location /realtime/v1/ {
         proxy_pass http://kong_upstream;
 
@@ -67,39 +71,17 @@ server {
     }
 
     location /storage/v1/ {
-        proxy_pass http://storage:5000/;
+        proxy_pass http://kong_upstream;
+
         proxy_buffering off;
+        proxy_request_buffering off;
 
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header X-Forwarded-Port $server_port;
-
-        # Required for TUS resumable upload Location headers and S3 signature verification.
-        proxy_set_header X-Forwarded-Prefix /storage/v1;
+        chunked_transfer_encoding off;
 
         client_max_body_size 0;
-
-        # CORS headers for Storage (bypasses Kong, which normally handles CORS)
-        if ($request_method = OPTIONS) {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' '*';
-            add_header 'Content-Length' 0;
-            add_header 'Content-Type' 'text/plain charset=UTF-8';
-            return 204;
-        }
-
-        add_header 'Access-Control-Allow-Origin' '*';
     }
 
     location /functions {
-        proxy_pass http://kong_upstream;
-    }
-
-    location /graphql {
         proxy_pass http://kong_upstream;
     }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Fix graphql route
- Do not proxy directly to Storage, otherwise new `sb_` keys won't work (see PR #43554)
- Add `KONG_PORT_MAPS` to proxy overlays (without that S3 protocol will currently break)

(An alternative to `KONG_PORT_MAPS` would be using `KONG_TRUSTED_IPS: "0.0.0.0/0,::/0"` as Kong is only reachable internally - but it's also fragile, configuration-wise.)
