### PR TITLE
fix: prevent unnecessary dialog after saving a new edge function

### DIFF
--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -146,7 +146,7 @@ const NewFunctionPage = () => {
   const {
     mutate: deployFunction,
     isPending: isDeploying,
-    isSuccess: hasDeployed
+    isSuccess: hasDeployed,
   } = useEdgeFunctionDeployMutation({
     // [Joshen] To investigate: For some reason, the invalidation for list of edge functions isn't triggering
     onSuccess: () => {
@@ -285,10 +285,7 @@ const NewFunctionPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template])
 
-  const hasUnsavedChanges = useMemo(
-    () => !isEqual(INITIAL_FILES, files),
-    [files]
-  )
+  const hasUnsavedChanges = useMemo(() => !isEqual(INITIAL_FILES, files), [files])
 
   return (
     <PageLayout

--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -143,14 +143,22 @@ const NewFunctionPage = () => {
     },
   })
 
-  const { mutate: deployFunction, isPending: isDeploying } = useEdgeFunctionDeployMutation({
+  const {
+    mutate: deployFunction,
+    isPending: isDeploying,
+    isSuccess: hasDeployed
+  } = useEdgeFunctionDeployMutation({
     // [Joshen] To investigate: For some reason, the invalidation for list of edge functions isn't triggering
     onSuccess: () => {
       toast.success('Successfully deployed edge function')
       const functionName = form.getValues('functionName')
-      if (ref && functionName) {
-        router.push(`/project/${ref}/functions/${functionName}/details`)
-      }
+      // Allow the mutation state (isSuccess) to propagate before navigating
+      // to prevent unnecessary dialog about unsaved changes
+      setTimeout(() => {
+        if (ref && functionName) {
+          router.push(`/project/${ref}/functions/${functionName}/details`)
+        }
+      }, 150)
     },
   })
 
@@ -277,7 +285,10 @@ const NewFunctionPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template])
 
-  const hasUnsavedChanges = useMemo(() => !isEqual(INITIAL_FILES, files), [files])
+  const hasUnsavedChanges = useMemo(
+    () => !isEqual(INITIAL_FILES, files),
+    [files]
+  )
 
   return (
     <PageLayout
@@ -415,7 +426,7 @@ const NewFunctionPage = () => {
           </Button>
         </form>
       </Form_Shadcn_>
-      <PreventNavigationOnUnsavedChanges hasChanges={hasUnsavedChanges} />
+      <PreventNavigationOnUnsavedChanges hasChanges={hasUnsavedChanges && !hasDeployed} />
     </PageLayout>
   )
 }


### PR DESCRIPTION
## Problem

After deploying a new edge function where you actually modified the code from the initial template, a dialog appears about unsaved changes.

## Solution

We must check that even though the files have changed from the initial ones, we actually saved them by deploying the function. 

However, because we trigger the navigation in the mutation `onSuccess` side effect, it happens before react can update the state that would prevent the dialog from appearing.