### PR TITLE
Add datconnlimit resolution to troubleshooting guide

### DIFF
--- a/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
+++ b/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
@@ -1,0 +1,26 @@
+---
+title = "Database: \"Error: too many connections for database \"postgres\"\""
+topics = [ "database" ]
+keywords = []
+---
+
+When getting an error where your connections are overwhelmed `Error: too many connections for database "postgres"`
+
+**Why This Occurs:**
+This issue occurs when `datconnlimit` gets modified. The default value for `datconnlimit` is -1.
+https://www.postgresql.org/docs/current/catalog-pg-database.html
+
+**To check and resolve:**
+
+1.  **Check the value for `datconnlimit` using the query below**
+
+    ```bash
+    select datconnlimit from pg_database where datname='postgres';
+    ```
+
+    - If the value you see is 0 or any other value other than -1, proceed with the next step.
+
+2.  **Update `datconnlimit` to DEFAULT**
+    ```bash
+    ALTER DATABASE postgres CONNECTION LIMIT DEFAULT;
+    ```

--- a/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
+++ b/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
@@ -7,6 +7,7 @@ keywords = []
 When getting an error where your connections are overwhelmed `Error: too many connections for database "postgres"`
 
 ## Why this occurs
+
 This issue occurs when `datconnlimit` gets modified. The default value for `datconnlimit` is -1.
 https://www.postgresql.org/docs/current/catalog-pg-database.html
 

--- a/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
+++ b/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
@@ -6,7 +6,7 @@ keywords = []
 
 When getting an error where your connections are overwhelmed `Error: too many connections for database "postgres"`
 
-**Why This Occurs:**
+## Why This Occurs
 This issue occurs when `datconnlimit` gets modified. The default value for `datconnlimit` is -1.
 https://www.postgresql.org/docs/current/catalog-pg-database.html
 

--- a/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
+++ b/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
@@ -6,7 +6,7 @@ keywords = []
 
 When getting an error where your connections are overwhelmed `Error: too many connections for database "postgres"`
 
-## Why This Occurs
+## Why this Occurs
 This issue occurs when `datconnlimit` gets modified. The default value for `datconnlimit` is -1.
 https://www.postgresql.org/docs/current/catalog-pg-database.html
 

--- a/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
+++ b/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
@@ -6,7 +6,7 @@ keywords = []
 
 When getting an error where your connections are overwhelmed `Error: too many connections for database "postgres"`
 
-## Why this Occurs
+## Why this occurs
 This issue occurs when `datconnlimit` gets modified. The default value for `datconnlimit` is -1.
 https://www.postgresql.org/docs/current/catalog-pg-database.html
 

--- a/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
+++ b/apps/docs/content/troubleshooting/too-many-connections-for-database-postgres.mdx
@@ -10,7 +10,7 @@ When getting an error where your connections are overwhelmed `Error: too many co
 This issue occurs when `datconnlimit` gets modified. The default value for `datconnlimit` is -1.
 https://www.postgresql.org/docs/current/catalog-pg-database.html
 
-**To check and resolve:**
+## To check and resolve
 
 1.  **Check the value for `datconnlimit` using the query below**
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update based on https://www.postgresql.org/docs/current/catalog-pg-database.html

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide for the PostgreSQL "too many connections" error.
  * Describes how to diagnose connection-limit settings and detect non-default configurations.
  * Offers recommended recovery steps to restore default connection limits and safely recover affected databases, with links to relevant PostgreSQL documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->