### PR TITLE
fix: hide CSV import on empty table when table is not editable

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -97,8 +97,10 @@ export const Grid = memo(
 
       const { mutate: sendEvent } = useSendEventMutation()
 
+      const isEditable = snap.editable
+
       const { isDraggedOver, onDragOver, onFileDrop } = useCsvFileDrop({
-        enabled: isTableEmpty && !isForeignTable,
+        enabled: isTableEmpty && !isForeignTable && isEditable,
         onFileDropped: (file) => tableEditorSnap.onImportData(valtioRef(file)),
         onTelemetryEvent: (eventName) => {
           sendEvent({
@@ -278,7 +280,7 @@ export const Grid = memo(
                             started.
                           </p>
                         </div>
-                      ) : (
+                      ) : isEditable ? (
                         <div className="flex flex-col items-center gap-4 mt-4">
                           <Button
                             type="default"
@@ -301,7 +303,7 @@ export const Grid = memo(
                             or drag and drop a CSV file here
                           </p>
                         </div>
-                      )}
+                      ) : null}
                     </div>
                   ) : (
                     <div className="flex flex-col items-center justify-center">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a table is empty, the Table Editor shows an "Import data from CSV" button and accepts CSV drag-and-drop regardless of whether the table is actually editable. This means users can import data into:

- Protected schema tables (e.g. `auth.instances`, `auth.users`)
- Views and materialized views
- Tables the user doesn't have permission to edit

The `Header` component already correctly checks `snap.editable` before showing the import button, but the empty-table view in `Grid.tsx` is missing this check.

Related: #41358

## What is the new behavior?

The empty table view now checks `snap.editable` before:
1. Showing the "Import data from CSV" button
2. Enabling CSV drag-and-drop via `useCsvFileDrop`

For non-editable tables, the empty state just shows "This table is empty" without the import option — consistent with how the Header already hides the Insert dropdown for non-editable tables.

## Additional context

This is a minimal fix (2 lines of logic changed) that reuses the same `snap.editable` flag the Header already relies on. There was a previous attempt at this (#41362) but it went stale — this approach is simpler and follows the existing pattern in the codebase.