### PR TITLE
fix(studio): hide observability pages for self-hosted

### DIFF
--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
@@ -82,7 +82,7 @@ const ObservabilityLayoutContent = ({
 
   const { reportsAll } = useIsFeatureEnabled(['reports:all'])
 
-  if (reportsAll) {
+  if (IS_PLATFORM && reportsAll) {
     return (
       <ProjectLayout
         product="Observability"
@@ -102,7 +102,7 @@ const ObservabilityLayout = (props: PropsWithChildren<ObservabilityLayoutProps>)
   const { ref } = useParams()
   const { reportsAll } = useIsFeatureEnabled(['reports:all'])
 
-  if (reportsAll) {
+  if (IS_PLATFORM && reportsAll) {
     return <ObservabilityLayoutContent {...props} />
   } else {
     return <UnknownInterface urlBack={`/project/${ref}`} />


### PR DESCRIPTION
…M is false

The ObservabilityLayout was only checking the `reportsAll` feature flag but not the `IS_PLATFORM` constant. This allowed observability pages to be accessible via direct URL in self-hosted/CLI environments even though the navigation link was properly hidden.

This fix adds the IS_PLATFORM check to both the outer ObservabilityLayout component and the inner ObservabilityLayoutContent component, ensuring the entire observability section is hidden when IS_PLATFORM is false.

Related Slack thread: https://supabase.slack.com/archives/C0161K73J1J/p1773752943123579?thread_ts=1773750843.380749&cid=C0161K73J1J

https://claude.ai/code/session_01Co33g4nXpJReDTp62sddxT

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
