### PR TITLE
fix(studio): hide observability from sidebar for self-hosted

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CreateCommands.tsx
@@ -363,17 +363,20 @@ export function useCreateCommands(options?: CommandOptions) {
       .filter(Boolean) as ICommand[]
   }, [ref, allIntegrations, installedIntegrationIds])
 
+  // Observability commands are only available on the platform, not for self-hosted/CLI
   const observabilityCommands = useMemo(
     () => [
-      ...(IS_PLATFORM && reportsEnabled
-        ? ([
-            {
-              id: 'create-observability-report',
-              name: 'Create Custom Report',
-              route: `/project/${ref}/observability/api-overview?newReport=true`,
-              icon: () => <Telescope />,
-            },
-          ].filter(Boolean) as ICommand[])
+      ...(IS_PLATFORM
+        ? reportsEnabled
+          ? ([
+              {
+                id: 'create-observability-report',
+                name: 'Create Custom Report',
+                route: `/project/${ref}/observability/api-overview?newReport=true`,
+                icon: () => <Telescope />,
+              },
+            ].filter(Boolean) as ICommand[])
+          : []
         : []),
     ],
     [ref, reportsEnabled]

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -141,16 +141,19 @@ export const generateOtherRoutes = (
       icon: <Lightbulb size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/advisors/security`),
     },
-    ...(IS_PLATFORM && reportsEnabled
-      ? [
-          {
-            key: 'observability',
-            label: 'Observability',
-            disabled: !isProjectActive,
-            icon: <Telescope size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/observability`),
-          },
-        ]
+    // Observability is only available on the platform, not for self-hosted/CLI
+    ...(IS_PLATFORM
+      ? reportsEnabled
+        ? [
+            {
+              key: 'observability',
+              label: 'Observability',
+              disabled: !isProjectActive,
+              icon: <Telescope size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
+              link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/observability`),
+            },
+          ]
+        : []
       : []),
     {
       key: 'logs',


### PR DESCRIPTION
Ensure the observability link in the sidebar and command menu are properly guarded by IS_PLATFORM to prevent them from showing in self-hosted or CLI environments.

The logic is functionally the same (IS_PLATFORM && reportsEnabled), but restructured with IS_PLATFORM as the outer check for clarity, and added comments explaining the platform-only restriction.

https://claude.ai/code/session_01PG2TEGaSxaXZfXkbSBU3kQ

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
