### PR TITLE
fix: Bucket policies actions menu is hidden on Safari

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -107,7 +107,7 @@ export const PolicyRow = ({
           )}
         </div>
       </TableCell>
-      <TableCell className="w-0 text-right whitespace-nowrap">
+      <TableCell className="text-right whitespace-nowrap">
         {!isLocked && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesBucketRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesBucketRow.tsx
@@ -71,7 +71,7 @@ export const StoragePoliciesBucketRow = forwardRef<HTMLDivElement, StoragePolici
                   <TableHead className="w-[40%]">Name</TableHead>
                   <TableHead className="w-[20%]">Command</TableHead>
                   <TableHead className="w-[30%]">Applied to</TableHead>
-                  <TableHead className="w-0 text-right">
+                  <TableHead className="text-right">
                     <span className="sr-only">Actions</span>
                   </TableHead>
                 </TableRow>


### PR DESCRIPTION
## Problem

<img width="848" height="308" alt="image" src="https://github.com/user-attachments/assets/cafd09ef-5f74-4e47-bdea-05ad056a4a71" />

## Solution

<img width="845" height="328" alt="image" src="https://github.com/user-attachments/assets/62e03189-a539-4fa1-a80b-25285573973e" />

Tested on Safari, Chrome and Firefox