### PR TITLE
feat(studio): example of smaller sidebar entry point

### DIFF
--- a/apps/studio/components/interfaces/ErrorHandling/ErrorMatcherSidebarPanel.tsx
+++ b/apps/studio/components/interfaces/ErrorHandling/ErrorMatcherSidebarPanel.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Wrench } from 'lucide-react'
+import { useState } from 'react'
+import { Button, Dialog, DialogContent, DialogTitle, cn } from 'ui'
+import { WarningIcon } from 'ui-patterns/admonition'
+import type { SupportFormParams } from 'ui-patterns/ErrorDisplay'
+
+import { ErrorMatcher } from './ErrorMatcher'
+
+interface ErrorMatcherSidebarPanelProps {
+  title: string
+  error: string | { message: string }
+  supportFormParams?: SupportFormParams
+  className?: string
+}
+
+export function ErrorMatcherSidebarPanel({
+  title,
+  error,
+  supportFormParams,
+  className,
+}: ErrorMatcherSidebarPanelProps) {
+  const [open, setOpen] = useState(false)
+  const message = typeof error === 'string' ? error : error.message
+
+  return (
+    <>
+      <div
+        className={cn(
+          'rounded-lg border p-4 space-y-3',
+          'bg-warning-200 border-warning-500',
+          className
+        )}
+      >
+        <div className="flex items-start gap-2.5">
+          <div className="bg-warning p-0.5 text-background rounded flex-shrink-0 mt-0.5">
+            <WarningIcon className="w-2.5 h-2.5" />
+          </div>
+          <h3 className="font-medium text-sm text-foreground leading-snug">{title}</h3>
+        </div>
+
+        <pre className="text-xs font-mono text-warning-600 whitespace-pre-wrap break-words line-clamp-3 overflow-hidden">
+          {message}
+        </pre>
+
+        <Button
+          type="warning"
+          size="tiny"
+          icon={<Wrench size={12} />}
+          onClick={() => setOpen(true)}
+        >
+          Troubleshoot
+        </Button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent size="medium">
+          {/* Visually hidden — ErrorMatcher renders the visible title inside its card */}
+          <DialogTitle className="sr-only">{title}</DialogTitle>
+          <ErrorMatcher title={title} error={error} supportFormParams={supportFormParams} />
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -6,7 +6,7 @@ import { ExportDialog } from 'components/grid/components/header/ExportDialog'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import { SupaTable } from 'components/grid/types'
 import { ProtectedSchemaWarning } from 'components/interfaces/Database/ProtectedSchemaWarning'
-import { ErrorMatcher } from 'components/interfaces/ErrorHandling/ErrorMatcher'
+import { ErrorMatcherSidebarPanel } from 'components/interfaces/ErrorHandling/ErrorMatcherSidebarPanel'
 import EditorMenuListSkeleton from 'components/layouts/TableEditorLayout/EditorMenuListSkeleton'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { InfiniteListDefault, LoaderForIconMenuItems } from 'components/ui/InfiniteList'
@@ -277,7 +277,7 @@ export const TableEditorMenu = () => {
           {isLoading && <EditorMenuListSkeleton />}
 
           {isError && (
-            <ErrorMatcher
+            <ErrorMatcherSidebarPanel
               title="Failed to load tables"
               error={error ?? 'Failed to load tables'}
               supportFormParams={{ projectRef: project?.ref }}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Creates a smaller entry point for our Error Display component when used in sidebars and smaller areas.
