### PR TITLE
Add usercentrics to script src CSP

### DIFF
--- a/apps/studio/csp.js
+++ b/apps/studio/csp.js
@@ -112,6 +112,7 @@ module.exports.getCSP = function getCSP() {
     SUPABASE_ASSETS_URL,
     STAPE_URL,
     POSTHOG_URL,
+    USERCENTRICS_URLS,
   ]
   const FRAME_SRC_URLS = [
     HCAPTCHA_ASSET_URL,


### PR DESCRIPTION
## Context

Addresses a CSP issue for usercentrics script src on prod
<img width="462" height="154" alt="image" src="https://github.com/user-attachments/assets/b1a8a1d5-a01e-49d2-80d6-8acf70546374" />

Just adds usercentrics to script src, previously was only in default src