### PR TITLE
feat(assistant): upgrade default models to gpt-5.4-nano and gpt-5.3-codex

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -72,14 +72,14 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   const selectedModel = useMemo<AssistantModel>(() => {
     // While entitlements are loading, use the stored model without enforcing access
     if (isLoadingEntitlements) {
-      return snap.model ?? 'gpt-5-mini'
+      return snap.model ?? 'gpt-5.4-nano'
     }
 
-    const defaultModel: AssistantModel = hasAccessToAdvanceModel ? 'gpt-5' : 'gpt-5-mini'
+    const defaultModel: AssistantModel = hasAccessToAdvanceModel ? 'gpt-5.3-codex' : 'gpt-5.4-nano'
     const model = snap.model ?? defaultModel
 
-    if (!hasAccessToAdvanceModel && model === 'gpt-5') {
-      return 'gpt-5-mini'
+    if (!hasAccessToAdvanceModel && model === 'gpt-5.3-codex') {
+      return 'gpt-5.4-nano'
     }
 
     return model

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
@@ -45,9 +45,9 @@ export interface FormProps {
   /* If currently editing an existing message */
   isEditing?: boolean
   /* The currently selected AI model */
-  selectedModel: 'gpt-5' | 'gpt-5-mini'
+  selectedModel: 'gpt-5.3-codex' | 'gpt-5.4-nano'
   /* Callback when a model is chosen */
-  onSelectModel: (model: 'gpt-5' | 'gpt-5-mini') => void
+  onSelectModel: (model: 'gpt-5.3-codex' | 'gpt-5.4-nano') => void
 }
 
 const AssistantChatFormComponent = forwardRef<HTMLFormElement, FormProps>(

--- a/apps/studio/components/ui/AIAssistantPanel/ModelSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/ModelSelector.tsx
@@ -19,8 +19,8 @@ import {
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 
 interface ModelSelectorProps {
-  selectedModel: 'gpt-5' | 'gpt-5-mini'
-  onSelectModel: (model: 'gpt-5' | 'gpt-5-mini') => void
+  selectedModel: 'gpt-5.3-codex' | 'gpt-5.4-nano'
+  onSelectModel: (model: 'gpt-5.3-codex' | 'gpt-5.4-nano') => void
 }
 
 export const ModelSelector = ({ selectedModel, onSelectModel }: ModelSelectorProps) => {
@@ -35,8 +35,8 @@ export const ModelSelector = ({ selectedModel, onSelectModel }: ModelSelectorPro
 
   const upgradeHref = `/org/${slug ?? '_'}/billing?panel=subscriptionPlan&source=ai-assistant-model`
 
-  const handleSelectModel = (model: 'gpt-5' | 'gpt-5-mini') => {
-    if (model === 'gpt-5' && !hasAccessToAdvanceModel) {
+  const handleSelectModel = (model: 'gpt-5.3-codex' | 'gpt-5.4-nano') => {
+    if (model === 'gpt-5.3-codex' && !hasAccessToAdvanceModel) {
       setOpen(false)
       void router.push(upgradeHref)
       return
@@ -62,21 +62,21 @@ export const ModelSelector = ({ selectedModel, onSelectModel }: ModelSelectorPro
           <CommandList_Shadcn_>
             <CommandGroup_Shadcn_>
               <CommandItem_Shadcn_
-                value="gpt-5-mini"
-                onSelect={() => handleSelectModel('gpt-5-mini')}
+                value="gpt-5.4-nano"
+                onSelect={() => handleSelectModel('gpt-5.4-nano')}
                 className="flex justify-between"
               >
-                <span>gpt-5-mini</span>
-                {selectedModel === 'gpt-5-mini' && <Check className="h-3.5 w-3.5" />}
+                <span>gpt-5.4-nano</span>
+                {selectedModel === 'gpt-5.4-nano' && <Check className="h-3.5 w-3.5" />}
               </CommandItem_Shadcn_>
               <CommandItem_Shadcn_
-                value="gpt-5"
-                onSelect={() => handleSelectModel('gpt-5')}
+                value="gpt-5.3-codex"
+                onSelect={() => handleSelectModel('gpt-5.3-codex')}
                 className="flex justify-between"
               >
-                <span>gpt-5</span>
+                <span>gpt-5.3-codex</span>
                 {hasAccessToAdvanceModel ? (
-                  selectedModel === 'gpt-5' ? (
+                  selectedModel === 'gpt-5.3-codex' ? (
                     <Check className="h-3.5 w-3.5" />
                   ) : null
                 ) : (
@@ -89,7 +89,7 @@ export const ModelSelector = ({ selectedModel, onSelectModel }: ModelSelectorPro
                       </div>
                     </TooltipTrigger>
                     <TooltipContent side="right">
-                      gpt-5 is available on Pro plans and above
+                      gpt-5.3-codex is available on Pro plans and above
                     </TooltipContent>
                   </Tooltip>
                 )}

--- a/apps/studio/evals/assistant.eval.ts
+++ b/apps/studio/evals/assistant.eval.ts
@@ -26,7 +26,7 @@ Eval('Assistant', {
   data: () => dataset,
   task: async (input) => {
     const result = await generateAssistantResponse({
-      model: openai('gpt-5-mini'),
+      model: openai('gpt-5.4-nano'),
       messages: [{ id: '1', role: 'user', parts: [{ type: 'text', text: input.prompt }] }],
       tools: await getMockTools(input.mockTables ? { list_tables: input.mockTables } : undefined),
     })

--- a/apps/studio/lib/ai/model.test.ts
+++ b/apps/studio/lib/ai/model.test.ts
@@ -67,8 +67,8 @@ describe('getModel', () => {
     })
 
     expect(model).toEqual('openai-model')
-    // Default openai model in registry is gpt-5-mini
-    expect(openai).toHaveBeenCalledWith('gpt-5-mini')
+    // Default openai model in registry is gpt-5.4-nano
+    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(promptProviderOptions).toBeUndefined()
   })
 
@@ -80,20 +80,20 @@ describe('getModel', () => {
     expect(error).toEqual(new Error(ModelErrorMessage))
   })
 
-  it('returns specified provider and model when provided (openai gpt-5)', async () => {
+  it('returns specified provider and model when provided (openai gpt-5.3-codex)', async () => {
     vi.mocked(bedrockModule.checkAwsCredentials).mockResolvedValue(false)
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.IS_THROTTLED = 'false'
 
     const { model, error } = await getModel({
       provider: 'openai',
-      model: 'gpt-5',
+      model: 'gpt-5.3-codex',
       routingKey: 'rk',
       isLimited: false,
     })
 
     expect(error).toBeUndefined()
     expect(model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5')
+    expect(openai).toHaveBeenCalledWith('gpt-5.3-codex')
   })
 })

--- a/apps/studio/lib/ai/model.utils.test.ts
+++ b/apps/studio/lib/ai/model.utils.test.ts
@@ -12,7 +12,7 @@ describe('model.utils', () => {
 
     it('should return correct default for openai provider', () => {
       const result = getDefaultModelForProvider('openai')
-      expect(result).toBe('gpt-5-mini')
+      expect(result).toBe('gpt-5.4-nano')
     })
 
     it('should return correct default for anthropic provider', () => {
@@ -39,8 +39,8 @@ describe('model.utils', () => {
     it('should have openai provider with models', () => {
       expect(PROVIDERS.openai).toBeDefined()
       expect(PROVIDERS.openai.models).toBeDefined()
-      expect(Object.keys(PROVIDERS.openai.models)).toContain('gpt-5')
-      expect(Object.keys(PROVIDERS.openai.models)).toContain('gpt-5-mini')
+      expect(Object.keys(PROVIDERS.openai.models)).toContain('gpt-5.3-codex')
+      expect(Object.keys(PROVIDERS.openai.models)).toContain('gpt-5.4-nano')
     })
 
     it('should have anthropic provider with models', () => {

--- a/apps/studio/lib/ai/model.utils.test.ts
+++ b/apps/studio/lib/ai/model.utils.test.ts
@@ -82,7 +82,7 @@ describe('model.utils', () => {
     it('should have openai provider with providerOptions', () => {
       expect(PROVIDERS.openai.providerOptions).toBeDefined()
       expect(PROVIDERS.openai.providerOptions?.openai).toBeDefined()
-      expect(PROVIDERS.openai.providerOptions?.openai?.reasoningEffort).toBe('minimal')
+      expect(PROVIDERS.openai.providerOptions?.openai?.reasoningEffort).toBe('low')
     })
   })
 })

--- a/apps/studio/lib/ai/model.utils.ts
+++ b/apps/studio/lib/ai/model.utils.ts
@@ -2,7 +2,7 @@ export type ProviderName = 'bedrock' | 'openai' | 'anthropic'
 
 export type BedrockModel = 'anthropic.claude-3-7-sonnet-20250219-v1:0' | 'openai.gpt-oss-120b-1:0'
 
-export type OpenAIModel = 'gpt-5' | 'gpt-5-mini'
+export type OpenAIModel = 'gpt-5.3-codex' | 'gpt-5.4-nano'
 
 export type AnthropicModel = 'claude-sonnet-4-20250514' | 'claude-3-5-haiku-20241022'
 
@@ -49,8 +49,8 @@ export const PROVIDERS: ProviderRegistry = {
   },
   openai: {
     models: {
-      'gpt-5': { default: false },
-      'gpt-5-mini': { default: true },
+      'gpt-5.3-codex': { default: false },
+      'gpt-5.4-nano': { default: true },
     },
     providerOptions: {
       openai: {

--- a/apps/studio/lib/ai/model.utils.ts
+++ b/apps/studio/lib/ai/model.utils.ts
@@ -54,7 +54,7 @@ export const PROVIDERS: ProviderRegistry = {
     },
     providerOptions: {
       openai: {
-        reasoningEffort: 'minimal',
+        reasoningEffort: 'low',
       },
     },
   },

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -53,7 +53,7 @@ const requestBodySchema = z.object({
   chatId: z.string().optional(),
   chatName: z.string().optional(),
   orgSlug: z.string().optional(),
-  model: z.enum(['gpt-5', 'gpt-5-mini']).optional(),
+  model: z.enum(['gpt-5.3-codex', 'gpt-5.4-nano']).optional(),
 })
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: JwtPayload) {
@@ -135,7 +135,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
     providerOptions,
   } = await getModel({
     provider: 'openai',
-    model: requestedModel ?? 'gpt-5',
+    model: requestedModel ?? 'gpt-5.3-codex',
     routingKey: projectRef,
     isLimited,
   })

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -22,7 +22,7 @@ export type AssistantMessageType = MessageType
 
 export type SqlSnippet = string | { label: string; content: string }
 
-export type AssistantModel = 'gpt-5' | 'gpt-5-mini'
+export type AssistantModel = 'gpt-5.3-codex' | 'gpt-5.4-nano'
 
 type ChatSession = {
   id: string
@@ -64,7 +64,7 @@ const INITIAL_AI_ASSISTANT: AiAssistantData = {
   tables: [],
   chats: {},
   activeChatId: undefined,
-  model: 'gpt-5',
+  model: 'gpt-5.3-codex',
   context: {},
 }
 


### PR DESCRIPTION
Upgrades the assistant's default OpenAI models:

- **Free tier**: `gpt-5-mini` → `gpt-5.4-nano` — newer gen, cheaper (0.8× input / 0.625× output), better coding benchmarks (+6.7pp SWE-bench Pro)
- **Paid tiers**: `gpt-5` → `gpt-5.3-codex` — coding-specialized, +15pp SWE-bench Pro, 25% faster, 1.4× cost increase

Evals show no quality regressions across all scorers (completeness, goal completion, tool usage, SQL validity all flat). Token usage and latency improved significantly with nano.

Closes AI-509