### PR TITLE
bugfix: failing data api granular controls

### DIFF
--- a/apps/studio/data/privileges/exposed-function-counts-query.ts
+++ b/apps/studio/data/privileges/exposed-function-counts-query.ts
@@ -3,7 +3,7 @@ import { queryOptions } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 
-import { privilegeKeys } from './keys'
+import { IGNORED_SCHEMAS, privilegeKeys } from './keys'
 
 export type ExposedFunctionCountsVariables = {
   projectRef?: string
@@ -23,7 +23,7 @@ export async function getExposedFunctionCounts(
   if (!projectRef) throw new Error('projectRef is required')
   if (!selectedSchemas) throw new Error('selectedSchemas is required')
 
-  const sql = getExposedFunctionCountsSql({ selectedSchemas })
+  const sql = getExposedFunctionCountsSql({ selectedSchemas, ignoredSchemas: IGNORED_SCHEMAS })
 
   const { result } = await executeSql(
     {

--- a/apps/studio/data/privileges/exposed-functions-infinite-query.ts
+++ b/apps/studio/data/privileges/exposed-functions-infinite-query.ts
@@ -3,10 +3,7 @@ import { infiniteQueryOptions } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 
-import { privilegeKeys } from './keys'
-import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
-
-export const IGNORED_SCHEMAS = [...INTERNAL_SCHEMAS, 'pg_catalog']
+import { IGNORED_SCHEMAS, privilegeKeys } from './keys'
 export const EXPOSED_FUNCTIONS_PAGE_LIMIT = 50
 
 export type ExposedFunctionsVariables = {

--- a/apps/studio/data/privileges/exposed-table-counts-query.ts
+++ b/apps/studio/data/privileges/exposed-table-counts-query.ts
@@ -3,7 +3,7 @@ import { queryOptions } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 
-import { privilegeKeys } from './keys'
+import { IGNORED_SCHEMAS, privilegeKeys } from './keys'
 
 export type ExposedTableCountsVariables = {
   projectRef?: string
@@ -23,7 +23,7 @@ export async function getExposedTableCounts(
   if (!projectRef) throw new Error('projectRef is required')
   if (!selectedSchemas) throw new Error('selectedSchemas is required')
 
-  const sql = getExposedTableCountsSql({ selectedSchemas })
+  const sql = getExposedTableCountsSql({ selectedSchemas, ignoredSchemas: IGNORED_SCHEMAS })
 
   const { result } = await executeSql(
     {

--- a/apps/studio/data/privileges/exposed-tables-infinite-query.ts
+++ b/apps/studio/data/privileges/exposed-tables-infinite-query.ts
@@ -3,10 +3,7 @@ import { infiniteQueryOptions } from '@tanstack/react-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import type { ResponseError } from 'types'
 
-import { privilegeKeys } from './keys'
-import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
-
-const IGNORED_SCHEMAS = [...INTERNAL_SCHEMAS, 'pg_catalog']
+import { IGNORED_SCHEMAS, privilegeKeys } from './keys'
 export const EXPOSED_TABLES_PAGE_LIMIT = 50
 
 export type ExposedTablesVariables = {

--- a/apps/studio/data/privileges/keys.ts
+++ b/apps/studio/data/privileges/keys.ts
@@ -1,3 +1,7 @@
+import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
+
+export const IGNORED_SCHEMAS = [...INTERNAL_SCHEMAS, 'pg_catalog']
+
 export const privilegeKeys = {
   tablePrivilegesList: (projectRef: string | undefined) =>
     ['projects', projectRef, 'database', 'table-privileges'] as const,

--- a/packages/pg-meta/src/sql/studio/privileges.ts
+++ b/packages/pg-meta/src/sql/studio/privileges.ts
@@ -9,7 +9,8 @@ function getTableGrantsCTEs({
   search,
   ignoredSchemas = [],
 }: { search?: string; ignoredSchemas?: string[] } = {}) {
-  const IGNORED_SCHEMAS_LIST = ignoredSchemas.map((s) => `'${s}'`).join(', ')
+  const IGNORED_SCHEMAS_LIST = ignoredSchemas.length ? literal(ignoredSchemas) : ''
+  const searchPattern = search ? literal(`%${search}%`) : ''
 
   return /* SQL */ `
     table_privileges as (
@@ -46,7 +47,7 @@ function getTableGrantsCTEs({
         on pr.oid = acl.grantee
       where c.relkind in ('r', 'p', 'v', 'm', 'f')
         ${IGNORED_SCHEMAS_LIST ? `and n.nspname not in (${IGNORED_SCHEMAS_LIST})` : ''}
-        ${search ? `and (n.nspname || '.' || c.relname) ilike '%${search}%'` : ''}
+        ${searchPattern ? `and (n.nspname || '.' || c.relname) ilike ${searchPattern}` : ''}
       group by c.oid, n.nspname, c.relname, c.relkind
     ),
     table_grants as (

--- a/packages/pg-meta/src/sql/studio/privileges.ts
+++ b/packages/pg-meta/src/sql/studio/privileges.ts
@@ -45,7 +45,7 @@ function getTableGrantsCTEs({
       left join pg_roles pr
         on pr.oid = acl.grantee
       where c.relkind in ('r', 'p', 'v', 'm', 'f')
-        and n.nspname not in (${IGNORED_SCHEMAS_LIST})
+        ${IGNORED_SCHEMAS_LIST ? `and n.nspname not in (${IGNORED_SCHEMAS_LIST})` : ''}
         ${search ? `and (n.nspname || '.' || c.relname) ilike '%${search}%'` : ''}
       group by c.oid, n.nspname, c.relname, c.relkind
     ),
@@ -116,16 +116,23 @@ export function getExposedTablesSql({
   `
 }
 
-export function getExposedTableCountsSql({ selectedSchemas }: { selectedSchemas: string[] }) {
+export function getExposedTableCountsSql({
+  selectedSchemas,
+  ignoredSchemas = [],
+}: {
+  selectedSchemas: string[]
+  ignoredSchemas?: string[]
+}) {
   const schemasList =
     selectedSchemas.length > 0 ? selectedSchemas.map((s) => `'${s}'`).join(', ') : "''"
 
   return /* SQL */ `
-    with ${getTableGrantsCTEs()}
+    with ${getTableGrantsCTEs({ ignoredSchemas })}
     select
       count(*)::int as total_count,
-      (count(*) filter (where status = 'granted' and schema_name in (${schemasList})))::int as grants_count
+      (count(*) filter (where status = 'granted'))::int as grants_count
     from table_grants
+    where schema_name in (${schemasList})
   `
 }
 
@@ -161,7 +168,7 @@ function getFunctionGrantsCTEs({
       left join pg_roles pr
         on pr.oid = acl.grantee
       where p.prokind in ('f', 'w')
-        and n.nspname not in (${IGNORED_SCHEMAS_LIST})
+        ${IGNORED_SCHEMAS_LIST ? `and n.nspname not in (${IGNORED_SCHEMAS_LIST})` : ''}
         ${search ? `and (n.nspname || '.' || p.proname) ilike '%${search}%'` : ''}
       group by n.nspname, p.proname
     ),
@@ -216,16 +223,23 @@ export function getExposedFunctionsSql({
   `
 }
 
-export function getExposedFunctionCountsSql({ selectedSchemas }: { selectedSchemas: string[] }) {
+export function getExposedFunctionCountsSql({
+  selectedSchemas,
+  ignoredSchemas = [],
+}: {
+  selectedSchemas: string[]
+  ignoredSchemas?: string[]
+}) {
   const schemasList =
     selectedSchemas.length > 0 ? selectedSchemas.map((s) => `'${s}'`).join(', ') : "''"
 
   return /* SQL */ `
-    with ${getFunctionGrantsCTEs()}
+    with ${getFunctionGrantsCTEs({ ignoredSchemas })}
     select
       count(*)::int as total_count,
-      (count(*) filter (where status = 'granted' and schema_name in (${schemasList})))::int as grants_count
+      (count(*) filter (where status = 'granted'))::int as grants_count
     from function_grants
+    where schema_name in (${schemasList})
   `
 }
 


### PR DESCRIPTION
In the Data API tab: 
* Fixed a logic issue whereby the dropdowns for tables were accurately reflected by exposed schemas but the counts in the dropdown header were not
* Fixed a syntax issue causing the NOT IN clause of the dropdown counts to generate invalid SQL if no schemas were ignored.

Fixes PRODSEC-83