### PR TITLE
chore: refactor `<PreventNavigationOnUnsavedChanges>` by extracting a `usePreventNavigationOnUnsavedChanges` hook

### DIFF
--- a/apps/studio/components/ui-patterns/Dialogs/PreventNavigationOnUnsavedChanges.tsx
+++ b/apps/studio/components/ui-patterns/Dialogs/PreventNavigationOnUnsavedChanges.tsx
@@ -1,11 +1,8 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import { BASE_PATH } from 'lib/constants'
-
 import {
   DiscardChangesConfirmationDialog,
   type DiscardChangesConfirmationDialogProps,
 } from './DiscardChangesConfirmationDialog'
+import { usePreventNavigationOnUnsavedChanges } from '@/hooks/ui/usePreventNavigationOnUnsavedChanges'
 
 export const PreventNavigationOnUnsavedChanges = ({
   hasChanges,
@@ -14,56 +11,15 @@ export const PreventNavigationOnUnsavedChanges = ({
   DiscardChangesConfirmationDialogProps,
   'visible' | 'onClose' | 'onCancel'
 >) => {
-  const router = useRouter()
-  const [navigateUrl, setNavigateUrl] = useState<string>()
-  const [confirmNavigate, setConfirmNavigate] = useState(false)
-
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (hasChanges) {
-        e.preventDefault()
-        e.returnValue = '' // deprecated, but older browsers still require this
-      }
-    }
-
-    const handleBrowseAway = (url: string) => {
-      if (hasChanges && !confirmNavigate) {
-        setNavigateUrl(url)
-        throw 'Route change declined' // Just to prevent the route change
-        return
-      }
-      setNavigateUrl(undefined)
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    router.events.on('routeChangeStart', handleBrowseAway)
-
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-      router.events.off('routeChangeStart', handleBrowseAway)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [confirmNavigate, hasChanges])
-
-  const handleCancel = () => {
-    setNavigateUrl(undefined)
-  }
-
-  const handleClose = () => {
-    setConfirmNavigate(true)
-    let urlToNavigate = navigateUrl ?? '/'
-    if (BASE_PATH && urlToNavigate.startsWith(BASE_PATH)) {
-      urlToNavigate = urlToNavigate.slice(BASE_PATH.length) || '/'
-    }
-    if (!urlToNavigate.startsWith('/')) urlToNavigate = `/${urlToNavigate}`
-    setNavigateUrl(undefined)
-    router.push(urlToNavigate)
-  }
+  const { handleCancel, handleConfirm, shouldConfirm } = usePreventNavigationOnUnsavedChanges({
+    hasChanges,
+  })
 
   return (
     <DiscardChangesConfirmationDialog
-      visible={!!navigateUrl}
+      visible={shouldConfirm}
       onCancel={handleCancel}
-      onClose={handleClose}
+      onClose={handleConfirm}
       {...props}
     />
   )

--- a/apps/studio/hooks/ui/usePreventNavigationOnUnsavedChanges.ts
+++ b/apps/studio/hooks/ui/usePreventNavigationOnUnsavedChanges.ts
@@ -1,0 +1,93 @@
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useState } from 'react'
+
+import { useStaticEffectEvent } from '../useStaticEffectEvent'
+import { BASE_PATH } from '@/lib/constants'
+
+interface UsePreventNavigationOnUnsavedChangesOptions {
+  /*
+   * Boolean indicating whether there are changes that would be lost if users navigate to another
+   * page or close the browser tab
+   */
+  hasChanges: boolean
+}
+
+interface UsePreventNavigationOnUnsavedChangesReturn {
+  /*
+   * Cancel the navigation and keep the changes
+   */
+  handleCancel: () => void
+  /*
+   * Confirm the navigation and loose the changes
+   */
+  handleConfirm: () => void
+  /*
+   * Boolean indicating whether UI to request users confirmation for the navigation should be
+   * displayed
+   */
+  shouldConfirm: boolean
+}
+
+/*
+ * Hook that prevent navigation when users could loose their changes.
+ * It prevents both NextJS and browser navigation (such as when closing the tab)
+ */
+export const usePreventNavigationOnUnsavedChanges = ({
+  hasChanges,
+}: UsePreventNavigationOnUnsavedChangesOptions): UsePreventNavigationOnUnsavedChangesReturn => {
+  const router = useRouter()
+  const [navigateUrl, setNavigateUrl] = useState<string>()
+  const [confirmNavigate, setConfirmNavigate] = useState(false)
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasChanges) {
+        e.preventDefault()
+        e.returnValue = '' // deprecated, but older browsers still require this
+      }
+    }
+
+    const handleBrowseAway = (url: string) => {
+      if (hasChanges && !confirmNavigate) {
+        setNavigateUrl(url)
+        throw 'Route change declined' // Just to prevent the route change
+        return
+      }
+      setNavigateUrl(undefined)
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    router.events.on('routeChangeStart', handleBrowseAway)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      router.events.off('routeChangeStart', handleBrowseAway)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confirmNavigate, hasChanges])
+
+  const handleCancel = useStaticEffectEvent(() => {
+    console.log('CANCEL')
+    setNavigateUrl(undefined)
+  })
+
+  const handleConfirm = useStaticEffectEvent(() => {
+    console.log('CONFIRM')
+    setConfirmNavigate(true)
+    let urlToNavigate = navigateUrl ?? '/'
+    if (BASE_PATH && urlToNavigate.startsWith(BASE_PATH)) {
+      urlToNavigate = urlToNavigate.slice(BASE_PATH.length) || '/'
+    }
+    if (!urlToNavigate.startsWith('/')) urlToNavigate = `/${urlToNavigate}`
+    setNavigateUrl(undefined)
+    router.push(urlToNavigate)
+  })
+
+  return useMemo(
+    () => ({
+      handleCancel,
+      handleConfirm,
+      shouldConfirm: !!navigateUrl,
+    }),
+    [navigateUrl, handleCancel, handleConfirm]
+  )
+}

--- a/apps/studio/hooks/ui/usePreventNavigationOnUnsavedChanges.ts
+++ b/apps/studio/hooks/ui/usePreventNavigationOnUnsavedChanges.ts
@@ -66,12 +66,10 @@ export const usePreventNavigationOnUnsavedChanges = ({
   }, [confirmNavigate, hasChanges])
 
   const handleCancel = useStaticEffectEvent(() => {
-    console.log('CANCEL')
     setNavigateUrl(undefined)
   })
 
   const handleConfirm = useStaticEffectEvent(() => {
-    console.log('CONFIRM')
     setConfirmNavigate(true)
     let urlToNavigate = navigateUrl ?? '/'
     if (BASE_PATH && urlToNavigate.startsWith(BASE_PATH)) {

--- a/apps/studio/hooks/ui/usePreventNavigationOnUnsavedChanges.ts
+++ b/apps/studio/hooks/ui/usePreventNavigationOnUnsavedChanges.ts
@@ -18,7 +18,7 @@ interface UsePreventNavigationOnUnsavedChangesReturn {
    */
   handleCancel: () => void
   /*
-   * Confirm the navigation and loose the changes
+   * Confirm the navigation and lose the changes
    */
   handleConfirm: () => void
   /*
@@ -29,7 +29,7 @@ interface UsePreventNavigationOnUnsavedChangesReturn {
 }
 
 /*
- * Hook that prevent navigation when users could loose their changes.
+ * Hook that prevents navigation when users could lose their changes.
  * It prevents both NextJS and browser navigation (such as when closing the tab)
  */
 export const usePreventNavigationOnUnsavedChanges = ({


### PR DESCRIPTION
## Problem

We want `ui-patterns` to contain only visual components but https://github.com/supabase/supabase/pull/43577 introduced a component with logic about navigation

## Solution

Extract the logic part into a hook and use it in the component.
Next step will be to remove this component and use `<DiscardChangesConfirmationDialog>` directly along the hook where needed

## How to test

Check that the fixes from #43577 still work:

On staging, for each case:
- Authentication email templates
- Observability reports
- Edge functions creation
- Edge functions edition

Test:
- Modify the template/report/function
- Navigate away using either the sidebar link, the browser back button or closing the tab
- Cancel navigation in the confirmation dialog
- Navigation should be prevented and you should not loose your changes

Test:
- Modify the template/report/function
- Navigate away using either the sidebar link, the browser back button or closing the tab
- Confirm navigation in the confirmation dialog
- Navigation should not be prevented and you should have lost your changes
