### PR TITLE
fix(studio): allow multiline text in MFA SMS template

### DIFF
--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -24,6 +24,7 @@ import {
   Form_Shadcn_,
   Input_Shadcn_,
   PrePostTab,
+  Textarea_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
   SelectTrigger_Shadcn_,
@@ -497,10 +498,10 @@ export const MfaAuthSettingsForm = () => {
                         description="To format the OTP code use `{{ .Code }}`"
                       >
                         <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            type="text"
+                          <Textarea_Shadcn_
                             {...field}
                             disabled={!canUpdateConfig || !hasAccessToMFA}
+                            rows={4}
                           />
                         </FormControl_Shadcn_>
                       </FormItemLayout>


### PR DESCRIPTION
I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

What kind of change does this PR introduce?
Bug fix / UI Enhancement

What is the current behavior?
Currently, the "Phone verification message" (MFA_PHONE_TEMPLATE) field in the MFA Auth Settings form uses a single-line Input component. This prevents users from naturally pressing "Enter" to add newlines to their MFA SMS templates, which is required for certain APIs like WebOTP.

(Related to the context of Issue #6435)

What is the new behavior?
Changed the Input_Shadcn_ component to a Textarea_Shadcn_ component (with rows={4}) for the MFA_PHONE_TEMPLATE field inside MfaAuthSettingsForm.tsx. This allows users to easily input, view, and save multi-line SMS templates for Multi-Factor Authentication.

Additional context
This is an alternative/learning PR inspired by Issue #6435. While PR #41956 addresses the newline issue in the primary Auth Providers SMS form, the MFA Settings SMS form still used the single-line input. This PR applies the same multiline text area fix to the MFA settings to ensure consistency across the Studio UI.