### PR TITLE
fix(self-hosted): increase timeouts for supavisor

### DIFF
--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -25,4 +25,4 @@ jobs:
             docker/
       - name: Run docker-compose up
         # Ensure all services can be started and healthy with default config
-        run: cd docker && cp .env.example .env && docker compose up --wait
+        run: cd docker && cp .env.example .env && docker compose up --wait --wait-timeout 180

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -600,7 +600,8 @@ services:
         ]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 30s
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Increase healthchecks timeouts for supavisor
- Add larger timeout for docker compose in smoke tests