### PR TITLE
fix(studio): normalize SMS template newlines in auth provider form

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -14,7 +14,13 @@ export interface Provider {
   properties: {
     [x: string]: {
       title: string
-      type: 'boolean' | 'string' | 'select' | 'number'
+      type:
+        | 'boolean'
+        | 'string'
+        | 'select'
+        | 'number'
+        | 'multiline-string'
+        | 'datetime'
       enum: Enum[]
       show: {
         key: string

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -21,10 +21,10 @@ export interface Provider {
         | 'number'
         | 'multiline-string'
         | 'datetime'
-      enum: Enum[]
-      show: {
+      enum?: Enum[]
+      show?: {
         key: string
-        matches: string
+        matches?: string | string[]
       }
       description?: string
       descriptionOptional?: string

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils.ts
@@ -14,7 +14,7 @@ export const normalizeSmsTemplateValue = (key: string, value: unknown): unknown 
   return normalizeEscapedNewlines(value)
 }
 
-export const normalizeSmsTemplateValueTyped = <T extends string | boolean>(
+export const normalizeSmsTemplateValueTyped = <T extends string | boolean | number>(
   key: string,
   value: T
 ): T => normalizeSmsTemplateValue(key, value) as T

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils.ts
@@ -13,3 +13,8 @@ export const normalizeSmsTemplateValue = (key: string, value: unknown): unknown 
   if (key !== SMS_TEMPLATE_KEY) return value
   return normalizeEscapedNewlines(value)
 }
+
+export const normalizeSmsTemplateValueTyped = <T extends string | boolean>(
+  key: string,
+  value: T
+): T => normalizeSmsTemplateValue(key, value) as T

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils.ts
@@ -1,0 +1,15 @@
+export const SMS_TEMPLATE_KEY = 'SMS_TEMPLATE'
+
+/**
+ * Converts literal escaped newlines ("\\n") into real newlines.
+ * This keeps backwards compatibility for values previously saved as escaped text.
+ */
+export const normalizeEscapedNewlines = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+  return value.replace(/\\n/g, '\n')
+}
+
+export const normalizeSmsTemplateValue = (key: string, value: unknown): unknown => {
+  if (key !== SMS_TEMPLATE_KEY) return value
+  return normalizeEscapedNewlines(value)
+}

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -150,7 +150,6 @@ const FormField = ({
           id={name}
           name={name}
           disabled={disabled}
-          type={hidden ? 'password' : 'text'}
           label={properties.title}
           labelOptional={
             properties.descriptionOptional ? (

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -20,7 +20,7 @@ import { Button, Form, Input, Sheet, SheetContent, SheetFooter, SheetHeader, She
 import { Admonition } from 'ui-patterns'
 
 import { NO_REQUIRED_CHARACTERS } from '../Auth.constants'
-import { normalizeSmsTemplateValue } from './AuthProvidersForm.utils'
+import { normalizeSmsTemplateValueTyped } from './AuthProvidersForm.utils'
 import { AuthAlert } from './AuthAlert'
 import type { Provider } from './AuthProvidersForm.types'
 import FormField from './FormField'
@@ -78,19 +78,17 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       if (provider.title === 'SAML 2.0') {
         const configValue = (config as any)[key]
         initialValues[key] =
-          configValue || (provider.properties[key].type === 'boolean' ? false : '')
+          configValue ?? (provider.properties[key].type === 'boolean' ? false : '')
       } else {
         if (isDoubleNegative) {
           initialValues[key] = !(config as any)[key]
         } else {
           const configValue = (config as any)[key]
-          initialValues[key] = normalizeSmsTemplateValue(
+          initialValues[key] = normalizeSmsTemplateValueTyped(
             key,
-            configValue
-              ? configValue
-              : provider.properties[key].type === 'boolean'
-                ? false
-                : ''
+            (configValue ?? (provider.properties[key].type === 'boolean' ? false : '')) as
+              | string
+              | boolean
           )
         }
       }
@@ -99,10 +97,17 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
   })()
 
   const onSubmit = (values: any, { resetForm }: any) => {
-    const payload = Object.entries(values).reduce((acc, [key, value]) => {
-      acc[key] = normalizeSmsTemplateValue(key, value)
-      return acc
-    }, {} as Record<string, any>)
+    const payload = Object.entries(values).reduce(
+      (acc, [key, value]) => {
+        if (typeof value === 'string' || typeof value === 'boolean') {
+          acc[key] = normalizeSmsTemplateValueTyped(key, value)
+        } else {
+          acc[key] = value
+        }
+        return acc
+      },
+      {} as Record<string, any>
+    )
 
     Object.keys(values).map((x: string) => {
       if (doubleNegativeKeys.includes(x)) payload[x] = !values[x]

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -20,6 +20,7 @@ import { Button, Form, Input, Sheet, SheetContent, SheetFooter, SheetHeader, She
 import { Admonition } from 'ui-patterns'
 
 import { NO_REQUIRED_CHARACTERS } from '../Auth.constants'
+import { normalizeSmsTemplateValue } from './AuthProvidersForm.utils'
 import { AuthAlert } from './AuthAlert'
 import type { Provider } from './AuthProvidersForm.types'
 import FormField from './FormField'
@@ -83,11 +84,14 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
           initialValues[key] = !(config as any)[key]
         } else {
           const configValue = (config as any)[key]
-          initialValues[key] = configValue
-            ? configValue
-            : provider.properties[key].type === 'boolean'
-              ? false
-              : ''
+          initialValues[key] = normalizeSmsTemplateValue(
+            key,
+            configValue
+              ? configValue
+              : provider.properties[key].type === 'boolean'
+                ? false
+                : ''
+          )
         }
       }
     })
@@ -95,7 +99,11 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
   })()
 
   const onSubmit = (values: any, { resetForm }: any) => {
-    const payload = { ...values }
+    const payload = Object.entries(values).reduce((acc, [key, value]) => {
+      acc[key] = normalizeSmsTemplateValue(key, value)
+      return acc
+    }, {} as Record<string, any>)
+
     Object.keys(values).map((x: string) => {
       if (doubleNegativeKeys.includes(x)) payload[x] = !values[x]
       if (payload[x] === '') payload[x] = null

--- a/apps/studio/tests/components/Auth/AuthProvidersForm.utils.test.ts
+++ b/apps/studio/tests/components/Auth/AuthProvidersForm.utils.test.ts
@@ -1,0 +1,31 @@
+import {
+  normalizeEscapedNewlines,
+  normalizeSmsTemplateValue,
+  SMS_TEMPLATE_KEY,
+} from 'components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.utils'
+import { describe, expect, it } from 'vitest'
+
+describe('AuthProvidersForm.utils', () => {
+  describe('normalizeEscapedNewlines', () => {
+    it('converts escaped newlines to real newline characters', () => {
+      expect(normalizeEscapedNewlines('Line 1\\nLine 2')).toBe('Line 1\nLine 2')
+    })
+
+    it('preserves existing newline characters', () => {
+      expect(normalizeEscapedNewlines('Line 1\nLine 2')).toBe('Line 1\nLine 2')
+    })
+
+    it('returns non-string values unchanged', () => {
+      expect(normalizeEscapedNewlines(null)).toBeNull()
+      expect(normalizeEscapedNewlines(false)).toBe(false)
+      expect(normalizeEscapedNewlines(123)).toBe(123)
+    })
+  })
+
+  describe('normalizeSmsTemplateValue', () => {
+    it('normalizes only SMS_TEMPLATE field values', () => {
+      expect(normalizeSmsTemplateValue(SMS_TEMPLATE_KEY, 'a\\nb')).toBe('a\nb')
+      expect(normalizeSmsTemplateValue('OTHER_FIELD', 'a\\nb')).toBe('a\\nb')
+    })
+  })
+})


### PR DESCRIPTION
## What problem does this solve?

Fixes part of #6435 in Studio by improving SMS template handling in Auth Provider settings:
- Normalizes escaped `\n` sequences to real newline characters for `SMS_TEMPLATE`
- Ensures legacy values saved as escaped text are displayed correctly in the multiline field
- Removes invalid `type` prop passed to `Input.TextArea`
- Aligns provider field typing with actual schema usage (`multiline-string`, `datetime`)

## What changed?

- Added `normalizeEscapedNewlines` and `normalizeSmsTemplateValue` utilities
- Applied normalization when loading initial form values and when preparing submit payload
- Updated `Provider.properties[*].type` union to include `multiline-string` and `datetime`
- Removed invalid textarea `type` prop
- Added unit tests for newline normalization behavior

## How was this tested?

- `pnpm exec vitest run tests/components/Auth/AuthProvidersForm.utils.test.ts`
- 4 tests passing

> Note: Vercel deployment checks require team authorization (expected for external contributors).
