### PR TITLE
fix(studio): hide product menu in observability for self hosted

### DIFF
--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenu.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenu.tsx
@@ -164,46 +164,50 @@ const ObservabilityMenu = () => {
           : []),
       ],
     },
-    {
-      title: 'PRODUCT',
-      key: 'product-section',
-      items: [
-        {
-          name: 'Database',
-          key: 'database',
-          url: `/project/${ref}/observability/database${preservedQueryParams}`,
-        },
-        {
-          name: 'Data API',
-          key: 'postgrest',
-          url: `/project/${ref}/observability/postgrest${preservedQueryParams}`,
-        },
-        {
-          name: 'Auth',
-          key: 'auth',
-          url: `/project/${ref}/observability/auth${preservedQueryParams}`,
-        },
-        {
-          name: 'Edge Functions',
-          key: 'edge-functions',
-          url: `/project/${ref}/observability/edge-functions${preservedQueryParams}`,
-        },
-        ...(storageSupported
-          ? [
+    ...(IS_PLATFORM
+      ? [
+          {
+            title: 'PRODUCT',
+            key: 'product-section',
+            items: [
               {
-                name: 'Storage',
-                key: 'storage',
-                url: `/project/${ref}/observability/storage${preservedQueryParams}`,
+                name: 'Database',
+                key: 'database',
+                url: `/project/${ref}/observability/database${preservedQueryParams}`,
               },
-            ]
-          : []),
-        {
-          name: 'Realtime',
-          key: 'realtime',
-          url: `/project/${ref}/observability/realtime${preservedQueryParams}`,
-        },
-      ],
-    },
+              {
+                name: 'Data API',
+                key: 'postgrest',
+                url: `/project/${ref}/observability/postgrest${preservedQueryParams}`,
+              },
+              {
+                name: 'Auth',
+                key: 'auth',
+                url: `/project/${ref}/observability/auth${preservedQueryParams}`,
+              },
+              {
+                name: 'Edge Functions',
+                key: 'edge-functions',
+                url: `/project/${ref}/observability/edge-functions${preservedQueryParams}`,
+              },
+              ...(storageSupported
+                ? [
+                    {
+                      name: 'Storage',
+                      key: 'storage',
+                      url: `/project/${ref}/observability/storage${preservedQueryParams}`,
+                    },
+                  ]
+                : []),
+              {
+                name: 'Realtime',
+                key: 'realtime',
+                url: `/project/${ref}/observability/realtime${preservedQueryParams}`,
+              },
+            ],
+          },
+        ]
+      : []),
   ]
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

We still have a symlink to Query Performance on self hosted which links to our Observability section. As most Observability tools aren't available on self hosted, this hides the "Product" section of the sidebar when the user navigates to Query Performance. 
