### PR TITLE
chore(studio): add telemetry for data API access toggle rollout

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -296,6 +296,7 @@ export const ApiAccessToggle = ({
   const handleMasterToggle = (checked: boolean) => {
     if (!handler.isSuccess) return
     if (!isSchemaExposed) return
+    if (!isNewRecord) return
 
     track('table_api_access_toggle_clicked', {
       newState: checked ? 'enabled' : 'disabled',

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -296,12 +296,13 @@ export const ApiAccessToggle = ({
   const handleMasterToggle = (checked: boolean) => {
     if (!handler.isSuccess) return
     if (!isSchemaExposed) return
-    if (!isNewRecord) return
 
-    track('table_api_access_toggle_clicked', {
-      newState: checked ? 'enabled' : 'disabled',
-      schemaName: schemaName ?? 'unknown',
-    })
+    if (isNewRecord) {
+      track('table_api_access_toggle_clicked', {
+        newState: checked ? 'enabled' : 'disabled',
+        schemaName: schemaName ?? 'unknown',
+      })
+    }
 
     if (checked) {
       handler.data?.restorePreviousPrivileges()

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -297,7 +297,10 @@ export const ApiAccessToggle = ({
     if (!handler.isSuccess) return
     if (!isSchemaExposed) return
 
-    track('table_api_access_toggle_clicked', { newState: checked ? 'enabled' : 'disabled' })
+    track('table_api_access_toggle_clicked', {
+      newState: checked ? 'enabled' : 'disabled',
+      schemaName: schemaName ?? 'unknown',
+    })
 
     if (checked) {
       handler.data?.restorePreviousPrivileges()

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -21,6 +21,7 @@ import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
 import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
+import { useTrack } from 'lib/telemetry/track'
 import { defaultPrivilegesQueryOptions } from '@/data/privileges/default-privileges-query'
 import { useTableApiAccessQuery } from '@/data/privileges/table-api-access-query'
 import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
@@ -282,6 +283,7 @@ export const ApiAccessToggle = ({
   isNewRecord,
   handler,
 }: ApiAccessToggleComponentProps): ReactNode => {
+  const track = useTrack()
   const isPending = handler.isPending
   const isError = handler.isError
   const isSchemaExposed = handler.data?.schemaExposed
@@ -294,6 +296,8 @@ export const ApiAccessToggle = ({
   const handleMasterToggle = (checked: boolean) => {
     if (!handler.isSuccess) return
     if (!isSchemaExposed) return
+
+    track('table_api_access_toggle_clicked', { newState: checked ? 'enabled' : 'disabled' })
 
     if (checked) {
       handler.data?.restorePreviousPrivileges()

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -46,6 +46,7 @@ import { useCustomContent } from 'hooks/custom-content/useCustomContent'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useDataApiGrantTogglesEnabled } from 'hooks/misc/useDataApiGrantTogglesEnabled'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { usePHFlag } from 'hooks/ui/useFlag'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
 import { withAuth } from 'hooks/misc/withAuth'
@@ -96,6 +97,10 @@ const Wizard: NextPageWithLayout = () => {
   const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
   const cloudProviderEnabled = useFlag('enableFlyCloudProvider')
   const isDataApiGrantTogglesEnabled = useDataApiGrantTogglesEnabled()
+  // Read the raw flag for telemetry — useDataApiGrantTogglesEnabled coerces undefined→false,
+  // which would record false for users whose flags haven't loaded yet. The raw value preserves
+  // undefined (omitted from PostHog) so we only record true/false when the flag is resolved.
+  const tableEditorApiAccessToggleFlag = usePHFlag<boolean>('tableEditorApiAccessToggle')
 
   const showNonProdFields = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod'
   const isNotOnHigherPlan = !['team', 'enterprise', 'platform'].includes(currentOrg?.plan.id ?? '')
@@ -259,7 +264,7 @@ const Wizard: NextPageWithLayout = () => {
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),
           useOrioleDb: form.getValues('useOrioleDb'),
-          tableEditorApiAccessToggleEnabled: isDataApiGrantTogglesEnabled,
+          tableEditorApiAccessToggleEnabled: tableEditorApiAccessToggleFlag ?? undefined,
         },
         {
           project: res.ref,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -259,6 +259,7 @@ const Wizard: NextPageWithLayout = () => {
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),
           useOrioleDb: form.getValues('useOrioleDb'),
+          secureByDefault: isDataApiGrantTogglesEnabled,
         },
         {
           project: res.ref,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -259,7 +259,7 @@ const Wizard: NextPageWithLayout = () => {
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),
           useOrioleDb: form.getValues('useOrioleDb'),
-          secureByDefault: isDataApiGrantTogglesEnabled,
+          revokedPublicDefaultGrants: isDataApiGrantTogglesEnabled,
         },
         {
           project: res.ref,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -259,7 +259,7 @@ const Wizard: NextPageWithLayout = () => {
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),
           useOrioleDb: form.getValues('useOrioleDb'),
-          revokedPublicDefaultGrants: isDataApiGrantTogglesEnabled,
+          tableEditorApiAccessToggleEnabled: isDataApiGrantTogglesEnabled,
         },
         {
           project: res.ref,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -264,7 +264,9 @@ const Wizard: NextPageWithLayout = () => {
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),
           useOrioleDb: form.getValues('useOrioleDb'),
-          tableEditorApiAccessToggleEnabled: tableEditorApiAccessToggleFlag ?? undefined,
+          ...(tableEditorApiAccessToggleFlag !== undefined && {
+            tableEditorApiAccessToggleEnabled: tableEditorApiAccessToggleFlag,
+          }),
         },
         {
           project: res.ref,

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -323,12 +323,12 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      */
     useOrioleDb?: boolean
     /**
-     * Whether the secure-by-default flag was active, revoking default privileges
-     * for anon/authenticated/service_role on the public schema at project creation.
-     * true = revoke SQL appended (tableEditorApiAccessToggle enabled)
-     * false = default grants left intact
+     * Whether default privileges for anon/authenticated/service_role on the public
+     * schema were revoked at project creation (tableEditorApiAccessToggle enabled).
+     * true = revoke SQL appended, tables not exposed to Data API by default
+     * false = default grants left intact (existing behavior)
      */
-    secureByDefault?: boolean
+    revokedPublicDefaultGrants?: boolean
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -322,6 +322,13 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      * false = "Postgres" (default)
      */
     useOrioleDb?: boolean
+    /**
+     * Whether the secure-by-default flag was active, revoking default privileges
+     * for anon/authenticated/service_role on the public schema at project creation.
+     * true = revoke SQL appended (tableEditorApiAccessToggle enabled)
+     * false = default grants left intact
+     */
+    secureByDefault?: boolean
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -323,12 +323,12 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      */
     useOrioleDb?: boolean
     /**
-     * Whether default privileges for anon/authenticated/service_role on the public
-     * schema were revoked at project creation (tableEditorApiAccessToggle enabled).
-     * true = revoke SQL appended, tables not exposed to Data API by default
-     * false = default grants left intact (existing behavior)
+     * Whether the tableEditorApiAccessToggle PostHog flag was enabled for this user,
+     * meaning the project was created with default public schema grants revoked.
+     * true = user is in the staged rollout cohort (revoke SQL ran at creation)
+     * false = user is outside the rollout (default grants left intact)
      */
-    revokedPublicDefaultGrants?: boolean
+    tableEditorApiAccessToggleEnabled?: boolean
   }
   groups: TelemetryGroups
 }
@@ -349,6 +349,25 @@ export interface ProjectCreationSimpleVersionConfirmModalOpenedEvent {
     instanceSize?: string
   }
   groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
+ * User toggled Data API access on a table via the switch in the table editor side panel.
+ * Only fires for new tables — editing existing tables links out to the settings page instead.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/editor
+ */
+export interface TableApiAccessToggleClickedEvent {
+  action: 'table_api_access_toggle_clicked'
+  properties: {
+    /**
+     * The resulting state of the toggle after the click.
+     */
+    newState: 'enabled' | 'disabled'
+  }
+  groups: TelemetryGroups
 }
 
 /**
@@ -3041,6 +3060,7 @@ export type TelemetryEvent =
   | ProjectCreationRlsOptionExperimentExposedEvent
   | ProjectCreationSimpleVersionSubmittedEvent
   | ProjectCreationSimpleVersionConfirmModalOpenedEvent
+  | TableApiAccessToggleClickedEvent
   | ProjectCreationInitialStepPromptIntendedEvent
   | ProjectCreationInitialStepSubmittedEvent
   | ProjectCreationSecondStepPromptIntendedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -291,10 +291,10 @@ export interface ProjectCreationRlsOptionExperimentExposedEvent {
  */
 export interface ProjectCreationSimpleVersionSubmittedEvent {
   action: 'project_creation_simple_version_submitted'
-  /**
-   * the instance size selected in the project creation form
-   */
   properties: {
+    /**
+     * The instance size selected in the project creation form.
+     */
     instanceSize?: string
     /**
      * Whether the automatic RLS event trigger option was enabled
@@ -327,6 +327,7 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      * meaning the project was created with default public schema grants revoked.
      * true = user is in the staged rollout cohort (revoke SQL ran at creation)
      * false = user is outside the rollout (default grants left intact)
+     * omitted = PostHog flags had not loaded at the time of project creation
      */
     tableEditorApiAccessToggleEnabled?: boolean
   }
@@ -366,6 +367,10 @@ export interface TableApiAccessToggleClickedEvent {
      * The resulting state of the toggle after the click.
      */
     newState: 'enabled' | 'disabled'
+    /**
+     * The schema containing the table being created.
+     */
+    schemaName: string
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
## Problem

PR #43704 added the `tableEditorApiAccessToggle` flag to revoke default privileges on project creation, but there's no PostHog instrumentation to measure the rollout or understand how users respond to the new behavior.

## Changes

**1. Flag state on project creation** (`project_creation_simple_version_submitted`)

Adds `tableEditorApiAccessToggleEnabled` property — reads the raw PostHog flag via `usePHFlag` rather than going through `useDataApiGrantTogglesEnabled`, which coerces `undefined` (flag still loading) to `false` and would silently poison the data. When the flag hasn't loaded, the property is omitted from the event entirely.

**2. Per-table toggle tracking** (`table_api_access_toggle_clicked`)

New event that fires when a user flips the Data API access switch in the table editor side panel (new tables only — existing tables link out to settings). Tracks `newState: 'enabled' | 'disabled'` and `schemaName` so we can distinguish public-schema toggles from custom schemas.

Together these let us answer: what % of projects have the new defaults, and how do those users respond (do they opt tables back in, and in which schemas)?

Part of the Secure by Default initiative (#43704)