### PR TITLE
Gildasgarcia/fe 2423 allow reordering columns in schema visualiser via handles

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -38,6 +38,7 @@ import { SchemaGraphContextProvider, SchemaGraphContextType } from './SchemaGrap
 import { SchemaGraphLegend } from './SchemaGraphLegend'
 import { getGraphDataFromTables, getLayoutedElementsViaDagre } from './Schemas.utils'
 import { TableNode } from './SchemaTableNode'
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 
 // [Joshen] Persisting logic: Only save positions to local storage WHEN a node is moved OR when explicitly clicked to reset layout
 
@@ -122,7 +123,7 @@ export const SchemaGraph = () => {
     saveNodePositions()
   }
 
-  const saveNodePositions = () => {
+  const saveNodePositions = useStaticEffectEvent(() => {
     if (schema === undefined) return console.error('Schema is required')
 
     const nodes = reactFlowInstance.getNodes()
@@ -132,7 +133,7 @@ export const SchemaGraph = () => {
       }, {})
       setStoredPositions(nodesPositionData)
     }
-  }
+  })
 
   const downloadImage = (format: 'png' | 'svg') => {
     const reactflowViewport = document.querySelector('.react-flow__viewport') as HTMLElement
@@ -381,7 +382,7 @@ export const SchemaGraph = () => {
                   minZoom={0.8}
                   maxZoom={1.8}
                   proOptions={{ hideAttribution: true }}
-                  onNodeDragStop={() => saveNodePositions()}
+                  onNodeDragStop={saveNodePositions}
                 >
                   <Background
                     gap={16}

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -62,6 +62,7 @@ const itemHeight = 'h-[22px]'
 const hiddenNodeConnector = '!h-px !w-px !min-w-0 !min-h-0 !cursor-grab !border-0 !opacity-0'
 
 export const TableNode = memo(function TableNode({
+  id,
   data,
   targetPosition,
   sourcePosition,
@@ -72,6 +73,7 @@ export const TableNode = memo(function TableNode({
   const router = useRouter()
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
   const [columns, persistColumns] = useTableOrderedColumns({
+    nodeId: id,
     projectRef: project?.ref,
     table: data,
   })

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -1,3 +1,21 @@
+import {
+  closestCenter,
+  DndContext,
+  MeasuringStrategy,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  arrayMove,
+  defaultAnimateLayoutChanges,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  type AnimateLayoutChanges,
+} from '@dnd-kit/sortable'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { buildTableEditorUrl } from 'components/grid/SupabaseGrid.utils'
 import { TableEditor } from 'icons'
@@ -6,6 +24,7 @@ import {
   DiamondIcon,
   Edit,
   Fingerprint,
+  GripVertical,
   Hash,
   InfoIcon,
   Key,
@@ -13,7 +32,7 @@ import {
   Table2,
 } from 'lucide-react'
 import { useRouter } from 'next/router'
-import { Handle, NodeProps } from 'reactflow'
+import { Handle, Position, useReactFlow, type NodeProps } from 'reactflow'
 import {
   Button,
   cn,
@@ -28,30 +47,20 @@ import {
 } from 'ui'
 
 import { useSchemaGraphContext } from './SchemaGraphContext'
+import type { TableNodeColumnData, TableNodeData } from './SchemaTableNode.types'
+import { useTableOrderedColumns } from './useTableOrderedColumns'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 
 // ReactFlow is scaling everything by the factor of 2
 export const TABLE_NODE_WIDTH = 320
 export const TABLE_NODE_ROW_HEIGHT = 40
 
-export type TableNodeData = {
-  id: number
-  schema: string
-  name: string
-  ref?: string
-  isForeign: boolean
-  description: string
-  columns: {
-    id: string
-    isPrimary: boolean
-    isNullable: boolean
-    isUnique: boolean
-    isIdentity: boolean
-    name: string
-    format: string
-  }[]
-}
+const itemHeight = 'h-[22px]'
+// Important styles is a nasty hack to use Handles (required for edges calculations), but do not show them in the UI.
+// ref: https://github.com/wbkd/react-flow/discussions/2698
+const hiddenNodeConnector = '!h-px !w-px !min-w-0 !min-h-0 !cursor-grab !border-0 !opacity-0'
 
 export const TableNode = ({
   data,
@@ -59,20 +68,29 @@ export const TableNode = ({
   sourcePosition,
   placeholder,
 }: NodeProps<TableNodeData> & { placeholder?: boolean }) => {
-  // Important styles is a nasty hack to use Handles (required for edges calculations), but do not show them in the UI.
-  // ref: https://github.com/wbkd/react-flow/discussions/2698
-  const hiddenNodeConnector = '!h-px !w-px !min-w-0 !min-h-0 !cursor-grab !border-0 !opacity-0'
   const schemaGraphContext = useSchemaGraphContext()
   const { data: project } = useSelectedProjectQuery()
-  const { can: canUpdateColumns } = useAsyncCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_WRITE,
-    'columns'
-  )
   const router = useRouter()
-  const itemHeight = 'h-[22px]'
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
+  const [columns, persistColumns] = useTableOrderedColumns({
+    projectRef: project?.ref,
+    table: data,
+  })
+  const handleDragEnd = useStaticEffectEvent((event: DragEndEvent) => {
+    const { active, over } = event
+
+    if (over) {
+      const overIndex = columns.findIndex((column) => column.id === over.id)
+      const activeIndex = columns.findIndex((column) => column.id === active.id)
+      if (activeIndex !== overIndex) {
+        const newColumns = arrayMove(columns, activeIndex, overIndex)
+        persistColumns(newColumns)
+      }
+    }
+  })
 
   return (
-    <>
+    <article>
       {data.isForeign ? (
         <header className="text-[0.55rem] px-2 py-1 border-[0.5px] rounded-[4px] bg-alternative flex gap-1 items-center">
           {data.name}
@@ -87,7 +105,7 @@ export const TableNode = ({
         </header>
       ) : (
         <div
-          className="border-[0.5px] overflow-hidden rounded-[4px] shadow-sm"
+          className="border-[0.5px] rounded-[4px] shadow-sm"
           style={{ width: TABLE_NODE_WIDTH / 2 }}
         >
           <header
@@ -163,132 +181,200 @@ export const TableNode = ({
               ) : null
             }
           </header>
-
-          {data.columns.map((column) => (
-            <div
-              className={cn(
-                'text-[8px] leading-5 relative flex flex-row justify-items-start',
-                'bg-surface-100',
-                'border-t',
-                'border-t-[0.5px]',
-                'hover:bg-scale-500 transition cursor-default',
-                'group',
-                'pr-1',
-                itemHeight
-              )}
-              data-testid={`${data.name}/${column.name}`}
-              key={column.id}
+          <main className="flex flex-col relative">
+            <DndContext
+              sensors={sensors}
+              onDragEnd={handleDragEnd}
+              modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+              collisionDetection={closestCenter}
+              measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
             >
-              <div
-                className={cn(
-                  'gap-[0.24rem] flex mx-2 align-middle items-center justify-start',
-                  column.isPrimary && 'basis-1/5'
-                )}
-              >
-                {column.isPrimary && (
-                  <Key
-                    size={8}
-                    strokeWidth={1}
-                    className={cn(
-                      // 'sb-grid-column-header__inner__primary-key'
-                      'flex-shrink-0',
-                      'text-light'
-                    )}
+              <SortableContext items={columns} strategy={verticalListSortingStrategy}>
+                {columns.map((column) => (
+                  <SchemaTableColumn
+                    key={column.id}
+                    column={column}
+                    table={data}
+                    targetPosition={targetPosition}
+                    sourcePosition={sourcePosition}
                   />
-                )}
-                {column.isNullable && (
-                  <DiamondIcon size={8} strokeWidth={1} className="flex-shrink-0 text-light" />
-                )}
-                {!column.isNullable && (
-                  <DiamondIcon
-                    size={8}
-                    strokeWidth={1}
-                    fill="currentColor"
-                    className="flex-shrink-0 text-light"
-                  />
-                )}
-                {column.isUnique && (
-                  <Fingerprint size={8} strokeWidth={1} className="flex-shrink-0 text-light" />
-                )}
-                {column.isIdentity && (
-                  <Hash size={8} strokeWidth={1} className="flex-shrink-0 text-light" />
-                )}
-              </div>
-              <div className="flex w-full justify-between min-w-0">
-                <span
-                  className="text-ellipsis overflow-hidden whitespace-nowrap min-w-0 max-w-[80%]"
-                  title={column.name}
-                >
-                  {column.name}
-                </span>
-                <span className="flex-shrink-0 pl-2 pr-1 inline-flex justify-end font-mono text-lighter text-[0.4rem] group-hover:hidden">
-                  {column.format}
-                </span>
-              </div>
-              {targetPosition && (
-                <Handle
-                  type="target"
-                  id={column.id}
-                  position={targetPosition}
-                  className={cn(hiddenNodeConnector, '!left-0')}
-                />
-              )}
-              {sourcePosition && (
-                <Handle
-                  type="source"
-                  id={column.id}
-                  position={sourcePosition}
-                  className={cn(hiddenNodeConnector, '!right-0')}
-                />
-              )}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="text"
-                    // Use opacity to hide the button so that it remains accessible (users can tab to it)
-                    className="opacity-0 focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 absolute right-0 top-1/2 -translate-y-1/2 px-0 mr-1 w-[16px] h-[16px] rounded"
-                  >
-                    <MoreVertical size={10} />
-                    <span className="sr-only">
-                      {data.name} {column.name} actions
-                    </span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent side="bottom" align="end" className="w-32">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuItem
-                        disabled={!canUpdateColumns}
-                        onClick={() => schemaGraphContext.onEditColumn(data.id, column.id)}
-                        className="space-x-2"
-                      >
-                        <Edit size={12} />
-                        <p>Edit column</p>
-                      </DropdownMenuItem>
-                    </TooltipTrigger>
-                    {!canUpdateColumns && (
-                      <TooltipContent side="bottom">
-                        Additional permissions required to edit column
-                      </TooltipContent>
-                    )}
-                  </Tooltip>
-
-                  <DropdownMenuItem
-                    className="space-x-2"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      copyToClipboard(column.name)
-                    }}
-                  >
-                    <Copy size={12} />
-                    <span>Copy name</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          ))}
+                ))}
+              </SortableContext>
+            </DndContext>
+          </main>
         </div>
       )}
-    </>
+    </article>
+  )
+}
+
+const animateLayoutChanges: AnimateLayoutChanges = (args) =>
+  defaultAnimateLayoutChanges({ ...args, wasDragging: true })
+
+const SchemaTableColumn = ({
+  column,
+  table,
+  targetPosition,
+  sourcePosition,
+}: {
+  column: TableNodeColumnData
+  table: TableNodeData
+  targetPosition: Position | undefined
+  sourcePosition: Position | undefined
+}) => {
+  const schemaGraphContext = useSchemaGraphContext()
+  const reactFlowInstance = useReactFlow()
+
+  const { can: canUpdateColumns } = useAsyncCheckPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'columns'
+  )
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: column.id,
+    animateLayoutChanges,
+  })
+
+  // Ensure we handle the current react flow zoom as it would mess up the dragged element position otherwise
+  const style = {
+    transform: transform
+      ? `translate3d(0px, ${transform.y / reactFlowInstance.getZoom()}px, 0)`
+      : undefined,
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'text-[8px] leading-5 relative flex flex-row justify-items-start',
+        'bg-surface-100',
+        'border-t',
+        'border-t-[0.5px]',
+        'hover:bg-scale-500 transition cursor-default',
+        'group',
+        'pr-1',
+        'will-change-transform',
+        itemHeight,
+        isDragging && 'opacity-70 z-10 shadow-md'
+      )}
+      data-testid={`${table.name}/${column.name}`}
+    >
+      <div
+        className={cn(
+          'gap-[0.24rem] flex ml-1 mr-2 align-middle items-center justify-start',
+          column.isPrimary && 'basis-1/5'
+        )}
+      >
+        <Button
+          type="text"
+          className="px-0 w-[16px] h-[16px] rounded nodrag nopan touch-none cursor-grab"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical size={8} />
+          <span className="sr-only">Drag to reorder column</span>
+        </Button>
+        {column.isPrimary && (
+          <Key
+            size={8}
+            strokeWidth={1}
+            className={cn(
+              // 'sb-grid-column-header__inner__primary-key'
+              'flex-shrink-0',
+              'text-light'
+            )}
+          />
+        )}
+        {column.isNullable ? (
+          <DiamondIcon size={8} strokeWidth={1} className="flex-shrink-0 text-light" />
+        ) : (
+          <DiamondIcon
+            size={8}
+            strokeWidth={1}
+            fill="currentColor"
+            className="flex-shrink-0 text-light"
+          />
+        )}
+        {column.isUnique && (
+          <Fingerprint size={8} strokeWidth={1} className="flex-shrink-0 text-light" />
+        )}
+        {column.isIdentity && (
+          <Hash size={8} strokeWidth={1} className="flex-shrink-0 text-light" />
+        )}
+      </div>
+      <div className="flex w-full justify-between min-w-0">
+        <span
+          className="text-ellipsis overflow-hidden whitespace-nowrap min-w-0 max-w-[80%]"
+          title={column.name}
+        >
+          {column.name}
+        </span>
+        <span className="flex-shrink-0 pl-2 pr-1 inline-flex justify-end font-mono text-lighter text-[0.4rem] group-hover:hidden">
+          {column.format}
+        </span>
+      </div>
+      {targetPosition && (
+        <Handle
+          type="target"
+          id={column.id}
+          position={targetPosition}
+          className={cn(hiddenNodeConnector, '!left-0')}
+        />
+      )}
+      {sourcePosition && (
+        <Handle
+          type="source"
+          id={column.id}
+          position={sourcePosition}
+          className={cn(hiddenNodeConnector, '!right-0')}
+        />
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="text"
+            // Use opacity to hide the button so that it remains accessible (users can tab to it)
+            className="opacity-0 focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 absolute right-0 top-1/2 -translate-y-1/2 px-0 mr-1 w-[16px] h-[16px] rounded"
+          >
+            <MoreVertical size={10} />
+            <span className="sr-only">
+              {table.name} {column.name} actions
+            </span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="end" className="w-32">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuItem
+                disabled={!canUpdateColumns}
+                onClick={() => schemaGraphContext.onEditColumn(table.id, column.id)}
+                className="space-x-2"
+              >
+                <Edit size={12} />
+                <p>Edit column</p>
+              </DropdownMenuItem>
+            </TooltipTrigger>
+            {!canUpdateColumns && (
+              <TooltipContent side="bottom">
+                Additional permissions required to edit column
+              </TooltipContent>
+            )}
+          </Tooltip>
+
+          <DropdownMenuItem
+            className="space-x-2"
+            onClick={(e) => {
+              e.stopPropagation()
+              copyToClipboard(column.name)
+            }}
+          >
+            <Copy size={12} />
+            <span>Copy name</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -83,7 +83,7 @@ export const TableNode = memo(function TableNode({
     if (over) {
       const overIndex = columns.findIndex((column) => column.id === over.id)
       const activeIndex = columns.findIndex((column) => column.id === active.id)
-      if (activeIndex !== overIndex) {
+      if (activeIndex >= 0 && overIndex >= 0 && activeIndex !== overIndex) {
         const newColumns = arrayMove(columns, activeIndex, overIndex)
         persistColumns(newColumns)
       }

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -10,11 +10,9 @@ import {
 import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import {
   arrayMove,
-  defaultAnimateLayoutChanges,
   SortableContext,
   useSortable,
   verticalListSortingStrategy,
-  type AnimateLayoutChanges,
 } from '@dnd-kit/sortable'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { buildTableEditorUrl } from 'components/grid/SupabaseGrid.utils'
@@ -32,6 +30,7 @@ import {
   Table2,
 } from 'lucide-react'
 import { useRouter } from 'next/router'
+import { memo } from 'react'
 import { Handle, Position, useReactFlow, type NodeProps } from 'reactflow'
 import {
   Button,
@@ -62,12 +61,12 @@ const itemHeight = 'h-[22px]'
 // ref: https://github.com/wbkd/react-flow/discussions/2698
 const hiddenNodeConnector = '!h-px !w-px !min-w-0 !min-h-0 !cursor-grab !border-0 !opacity-0'
 
-export const TableNode = ({
+export const TableNode = memo(function TableNode({
   data,
   targetPosition,
   sourcePosition,
   placeholder,
-}: NodeProps<TableNodeData> & { placeholder?: boolean }) => {
+}: NodeProps<TableNodeData> & { placeholder?: boolean }) {
   const schemaGraphContext = useSchemaGraphContext()
   const { data: project } = useSelectedProjectQuery()
   const router = useRouter()
@@ -206,12 +205,9 @@ export const TableNode = ({
       )}
     </article>
   )
-}
+})
 
-const animateLayoutChanges: AnimateLayoutChanges = (args) =>
-  defaultAnimateLayoutChanges({ ...args, wasDragging: true })
-
-const SchemaTableColumn = ({
+const SchemaTableColumn = memo(function SchemaTableColumn({
   column,
   table,
   targetPosition,
@@ -221,7 +217,7 @@ const SchemaTableColumn = ({
   table: TableNodeData
   targetPosition: Position | undefined
   sourcePosition: Position | undefined
-}) => {
+}) {
   const schemaGraphContext = useSchemaGraphContext()
   const reactFlowInstance = useReactFlow()
 
@@ -232,7 +228,6 @@ const SchemaTableColumn = ({
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: column.id,
-    animateLayoutChanges,
   })
 
   // Ensure we handle the current react flow zoom as it would mess up the dragged element position otherwise
@@ -252,10 +247,10 @@ const SchemaTableColumn = ({
         'bg-surface-100',
         'border-t',
         'border-t-[0.5px]',
-        'hover:bg-scale-500 transition cursor-default',
+        'hover:bg-scale-500 cursor-default',
         'group',
         'pr-1',
-        'will-change-transform',
+        // 'will-change-transform',
         itemHeight,
         isDragging && 'opacity-70 z-10 shadow-md'
       )}
@@ -377,4 +372,4 @@ const SchemaTableColumn = ({
       </DropdownMenu>
     </div>
   )
-}
+})

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.types.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.types.ts
@@ -1,0 +1,19 @@
+export type TableNodeColumnData = {
+  id: string
+  isPrimary: boolean
+  isNullable: boolean
+  isUnique: boolean
+  isIdentity: boolean
+  name: string
+  format: string
+}
+
+export type TableNodeData = {
+  id: number
+  schema: string
+  name: string
+  ref?: string
+  isForeign: boolean
+  description: string
+  columns: TableNodeColumnData[]
+}

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+
+import { TableNodeColumnData } from './SchemaTableNode.types'
+import { getOrderedColumns } from './SchemaTableNode.utils'
+
+describe('getOrderedColumns', () => {
+  const idColumn = {
+    id: 'id',
+    name: 'id',
+    format: '',
+    isIdentity: true,
+    isNullable: false,
+    isPrimary: true,
+    isUnique: true,
+  }
+  const column1 = {
+    id: 'column1',
+    name: 'column1',
+    format: '',
+    isIdentity: false,
+    isNullable: true,
+    isPrimary: false,
+    isUnique: false,
+  }
+  const column2 = {
+    id: 'column2',
+    name: 'column2',
+    format: '',
+    isIdentity: false,
+    isNullable: true,
+    isPrimary: false,
+    isUnique: false,
+  }
+  const column3 = {
+    id: 'column3',
+    name: 'column3',
+    format: '',
+    isIdentity: false,
+    isNullable: true,
+    isPrimary: false,
+    isUnique: false,
+  }
+
+  const tableColumns: Array<TableNodeColumnData> = [idColumn, column1, column2]
+
+  test('return the columns directly if no persisted order is provided', () => {
+    expect(getOrderedColumns(tableColumns, undefined)).toEqual(tableColumns)
+  })
+
+  test('return the columns ordered as in the persisted order if provided', () => {
+    expect(getOrderedColumns(tableColumns, ['id', 'column2', 'column1'])).toEqual([
+      idColumn,
+      column2,
+      column1,
+    ])
+  })
+
+  test('return the columns ordered as in the persisted order if provided with new columns at the end', () => {
+    expect(getOrderedColumns([...tableColumns, column3], ['id', 'column2', 'column1'])).toEqual([
+      idColumn,
+      column2,
+      column1,
+      column3
+    ])
+  })
+
+  test('return the columns ordered as in the persisted order with deleted columns removed', () => {
+    expect(getOrderedColumns([idColumn, column1], ['id', 'column2', 'column1'])).toEqual([
+      idColumn,
+      column1,
+    ])
+  })
+
+  test('return the columns ordered as in the persisted order with deleted columns removed and new columns at the end', () => {
+    expect(getOrderedColumns([idColumn, column1, column3], ['id', 'column2', 'column1'])).toEqual([
+      idColumn,
+      column1,
+      column3
+    ])
+  })
+})

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.test.ts
@@ -60,7 +60,7 @@ describe('getOrderedColumns', () => {
       idColumn,
       column2,
       column1,
-      column3
+      column3,
     ])
   })
 
@@ -75,7 +75,7 @@ describe('getOrderedColumns', () => {
     expect(getOrderedColumns([idColumn, column1, column3], ['id', 'column2', 'column1'])).toEqual([
       idColumn,
       column1,
-      column3
+      column3,
     ])
   })
 })

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.ts
@@ -1,0 +1,26 @@
+import { TableNodeColumnData } from "./SchemaTableNode.types"
+
+export const getOrderedColumns = (tableColumns: Array<TableNodeColumnData>, persistedColumnIdsOrder: Array<string> | undefined) => {
+  if (!persistedColumnIdsOrder) {
+    return tableColumns
+  }
+
+  const columnsById: Record<string, TableNodeColumnData> = {}
+  tableColumns.forEach((column) => {
+    columnsById[column.id] = column
+  })
+
+  // The original table may have been modified (columns added or removed)
+  // Make sure to remove columns that don't exist anymore from the persisted ones
+  const cleanColumns = persistedColumnIdsOrder.filter((columnId) =>
+    tableColumns.some((column) => column.id === columnId)
+  )
+
+  // Make sure we add the new columns at the end of the persisted ones if needed
+  const missingColumns = tableColumns.filter((column) => !cleanColumns.includes(column.id))
+  const orderedColumns = cleanColumns
+    .map((columnId) => columnsById[columnId])
+    .concat(missingColumns)
+
+  return orderedColumns
+}

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.ts
@@ -15,12 +15,13 @@ export const getOrderedColumns = (
 
   // The original table may have been modified (columns added or removed)
   // Make sure to remove columns that don't exist anymore from the persisted ones
-  const cleanColumns = persistedColumnIdsOrder.filter((columnId) =>
-    tableColumns.some((column) => column.id === columnId)
-  )
+  const cleanColumns = persistedColumnIdsOrder.filter((columnId) => !!columnsById[columnId])
+
+  // Precompute a set of cleaned column IDs for efficient lookups
+  const cleanColumnsIdSet = new Set(cleanColumns)
 
   // Make sure we add the new columns at the end of the persisted ones if needed
-  const missingColumns = tableColumns.filter((column) => !cleanColumns.includes(column.id))
+  const missingColumns = tableColumns.filter((column) => !cleanColumnsIdSet.has(column.id))
   const orderedColumns = cleanColumns
     .map((columnId) => columnsById[columnId])
     .concat(missingColumns)

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.utils.ts
@@ -1,6 +1,9 @@
-import { TableNodeColumnData } from "./SchemaTableNode.types"
+import { TableNodeColumnData } from './SchemaTableNode.types'
 
-export const getOrderedColumns = (tableColumns: Array<TableNodeColumnData>, persistedColumnIdsOrder: Array<string> | undefined) => {
+export const getOrderedColumns = (
+  tableColumns: Array<TableNodeColumnData>,
+  persistedColumnIdsOrder: Array<string> | undefined
+) => {
   if (!persistedColumnIdsOrder) {
     return tableColumns
   }

--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -8,7 +8,8 @@ import 'reactflow/dist/style.css'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { tryParseJson } from 'lib/helpers'
 
-import { TABLE_NODE_ROW_HEIGHT, TABLE_NODE_WIDTH, TableNodeData } from './SchemaTableNode'
+import { TABLE_NODE_ROW_HEIGHT, TABLE_NODE_WIDTH } from './SchemaTableNode'
+import { TableNodeData } from './SchemaTableNode.types'
 
 const NODE_SEP = 25
 const RANK_SEP = 50

--- a/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
@@ -1,18 +1,22 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useMemo } from 'react'
+import { useReactFlow, useUpdateNodeInternals } from 'reactflow'
 
 import { TableNodeColumnData, TableNodeData } from './SchemaTableNode.types'
 
 type SetColumnsFunction = (columns: Array<TableNodeColumnData>) => void
 
 export const useTableOrderedColumns = ({
+  nodeId,
   projectRef,
   table,
 }: {
+  nodeId: string
   projectRef: string | undefined
   table: TableNodeData
 }): [Array<TableNodeColumnData>, SetColumnsFunction] => {
+  const updateNodeInternals = useUpdateNodeInternals()
   const [columns, setColumns] = useLocalStorage<string[] | undefined>(
     LOCAL_STORAGE_KEYS.SCHEMA_VISUALIZER_TABLE_COLUMNS(projectRef as string, table.id),
     undefined
@@ -21,29 +25,30 @@ export const useTableOrderedColumns = ({
   return useMemo(() => {
     const persistColumns = (columns: Array<TableNodeColumnData>) => {
       setColumns(columns.map((column) => column.id))
+      // Ask reactflow to update the node handles (links between nodes)
+      updateNodeInternals(nodeId)
     }
 
     if (!columns) {
       return [table.columns, persistColumns]
     }
 
-    const columnsById = table.columns.reduce(
-      (acc, column) => {
-        return {
-          ...acc,
-          [column.id]: column,
-        }
-      },
-      {} as Record<string, TableNodeColumnData>
-    )
+    const columnsById: Record<string, TableNodeColumnData> = {}
+    table.columns.forEach((column) => {
+      columnsById[column.id] = column
+    })
 
     // The original table may have been modified (columns added or removed)
     // Make sure to remove columns that don't exist anymore from the persisted ones
-    const cleanColumns = columns.filter(columnId => table.columns.some(column => column.id === columnId))
+    const cleanColumns = columns.filter((columnId) =>
+      table.columns.some((column) => column.id === columnId)
+    )
 
     // Make sure we add the new columns at the end of the persisted ones if needed
-    const missingColumns = table.columns.filter(column => !cleanColumns.includes(column.id))
-    const orderedColumn = cleanColumns.map((columnId) => columnsById[columnId]).concat(missingColumns)
+    const missingColumns = table.columns.filter((column) => !cleanColumns.includes(column.id))
+    const orderedColumn = cleanColumns
+      .map((columnId) => columnsById[columnId])
+      .concat(missingColumns)
 
     return [orderedColumn, persistColumns]
   }, [columns, table.columns, setColumns])

--- a/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
@@ -1,0 +1,44 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useLocalStorage } from 'hooks/misc/useLocalStorage'
+import { useMemo } from 'react'
+
+import { TableNodeColumnData, TableNodeData } from './SchemaTableNode.types'
+
+type SetColumnsFunction = (columns: Array<TableNodeColumnData>) => void
+
+export const useTableOrderedColumns = ({
+  projectRef,
+  table,
+}: {
+  projectRef: string | undefined
+  table: TableNodeData
+}): [Array<TableNodeColumnData>, SetColumnsFunction] => {
+  const [columns, setColumns] = useLocalStorage<string[] | undefined>(
+    LOCAL_STORAGE_KEYS.SCHEMA_VISUALIZER_TABLE_COLUMNS(projectRef as string, table.id),
+    undefined
+  )
+
+  return useMemo(() => {
+    const persistColumns = (columns: Array<TableNodeColumnData>) => {
+      setColumns(columns.map((column) => column.id))
+    }
+
+    if (!columns) {
+      return [table.columns, persistColumns]
+    }
+
+    const columnsById = table.columns.reduce(
+      (acc, column) => {
+        return {
+          ...acc,
+          [column.id]: column,
+        }
+      },
+      {} as Record<string, TableNodeColumnData>
+    )
+
+    const orderedColumn = columns.map((columnId) => columnsById[columnId])
+
+    return [orderedColumn, persistColumns]
+  }, [columns, table.columns, setColumns])
+}

--- a/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
@@ -37,7 +37,8 @@ export const useTableOrderedColumns = ({
       {} as Record<string, TableNodeColumnData>
     )
 
-    const orderedColumn = columns.map((columnId) => columnsById[columnId])
+    const missingColumns = table.columns.filter(column => !columns.includes(column.id))
+    const orderedColumn = columns.map((columnId) => columnsById[columnId]).concat(missingColumns)
 
     return [orderedColumn, persistColumns]
   }, [columns, table.columns, setColumns])

--- a/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
@@ -37,8 +37,13 @@ export const useTableOrderedColumns = ({
       {} as Record<string, TableNodeColumnData>
     )
 
-    const missingColumns = table.columns.filter(column => !columns.includes(column.id))
-    const orderedColumn = columns.map((columnId) => columnsById[columnId]).concat(missingColumns)
+    // The original table may have been modified (columns added or removed)
+    // Make sure to remove columns that don't exist anymore from the persisted ones
+    const cleanColumns = columns.filter(columnId => table.columns.some(column => column.id === columnId))
+
+    // Make sure we add the new columns at the end of the persisted ones if needed
+    const missingColumns = table.columns.filter(column => !cleanColumns.includes(column.id))
+    const orderedColumn = cleanColumns.map((columnId) => columnsById[columnId]).concat(missingColumns)
 
     return [orderedColumn, persistColumns]
   }, [columns, table.columns, setColumns])

--- a/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
@@ -32,7 +32,6 @@ export const useTableOrderedColumns = ({
 
     const orderedColumns = getOrderedColumns(table.columns, columns)
 
-
     return [orderedColumns, persistColumns]
   }, [columns, nodeId, updateNodeInternals, setColumns, table.columns])
 }

--- a/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useTableOrderedColumns.ts
@@ -1,9 +1,10 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useMemo } from 'react'
-import { useReactFlow, useUpdateNodeInternals } from 'reactflow'
+import { useUpdateNodeInternals } from 'reactflow'
 
 import { TableNodeColumnData, TableNodeData } from './SchemaTableNode.types'
+import { getOrderedColumns } from './SchemaTableNode.utils'
 
 type SetColumnsFunction = (columns: Array<TableNodeColumnData>) => void
 
@@ -29,27 +30,9 @@ export const useTableOrderedColumns = ({
       updateNodeInternals(nodeId)
     }
 
-    if (!columns) {
-      return [table.columns, persistColumns]
-    }
+    const orderedColumns = getOrderedColumns(table.columns, columns)
 
-    const columnsById: Record<string, TableNodeColumnData> = {}
-    table.columns.forEach((column) => {
-      columnsById[column.id] = column
-    })
 
-    // The original table may have been modified (columns added or removed)
-    // Make sure to remove columns that don't exist anymore from the persisted ones
-    const cleanColumns = columns.filter((columnId) =>
-      table.columns.some((column) => column.id === columnId)
-    )
-
-    // Make sure we add the new columns at the end of the persisted ones if needed
-    const missingColumns = table.columns.filter((column) => !cleanColumns.includes(column.id))
-    const orderedColumn = cleanColumns
-      .map((columnId) => columnsById[columnId])
-      .concat(missingColumns)
-
-    return [orderedColumn, persistColumns]
-  }, [columns, table.columns, setColumns])
+    return [orderedColumns, persistColumns]
+  }, [columns, nodeId, updateNodeInternals, setColumns, table.columns])
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -72,6 +72,8 @@ export const LOCAL_STORAGE_KEYS = {
   // Track position of nodes for schema visualizer
   SCHEMA_VISUALIZER_POSITIONS: (ref: string, schemaId: number) =>
     `schema-visualizer-positions-${ref}-${schemaId}`,
+  SCHEMA_VISUALIZER_TABLE_COLUMNS: (ref: string, tableId: number) =>
+    `schema-visualizer-table-columns-${ref}-${tableId}`,
   // Used for allowing the main nav panel to expand on hover
   EXPAND_NAVIGATION_PANEL: 'supabase-expand-navigation-panel',
   GITHUB_AUTHORIZATION_STATE: 'supabase-github-authorization-state',


### PR DESCRIPTION
## Problem

Users should be able to reorder columns directly in the schema visualiser

## Solution

- Allow users to drag/drop columns
- Persist custom ordering in local storage


https://github.com/user-attachments/assets/b5527fa4-7f06-43e0-bafb-17408cc82d8e


