### PR TITLE
docs: fix undefined variable in Drizzle connection snippet

### DIFF
--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -80,9 +80,9 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
     import { drizzle } from 'drizzle-orm/postgres-js'
     import postgres from 'postgres'
 
-    let connectionString = process.env.DATABASE_URL
-    if (host.includes('postgres:postgres@supabase_db_')) {
-      const url = URL.parse(host)!
+    let connectionString = process.env.DATABASE_URL!
+    if (connectionString.includes('postgres:postgres@supabase_db_')) {
+      const url = new URL(connectionString)
       url.hostname = url.hostname.split('_')[1]
       connectionString = url.href
     }


### PR DESCRIPTION
## Summary

Fix the Drizzle guide snippet so it no longer references an undefined `host` variable.

## Problem

The example in `apps/docs/content/guides/database/drizzle.mdx` used:

- `host.includes(...)`
- `URL.parse(host)`

But `host` was never defined in the snippet, so the example was broken as written.

## Solution

Updated the snippet to:

- use the existing `connectionString` variable instead of `host`
- parse the URL with `new URL(connectionString)`
- mark `process.env.DATABASE_URL` as required in the example with `!`

## Verification

- Reviewed the final diff to confirm only the Drizzle guide changed
- Ran `git diff --check`
- Re-read the snippet in context to confirm the example is internally consistent

## Issue reference

Closes #43920