### PR TITLE
fix(studio): harden local logs/triggers error handling

### DIFF
--- a/apps/studio/pages/api/platform/pg-meta/[ref]/triggers.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/triggers.ts
@@ -26,7 +26,8 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
 
   if (response.error) {
     const { code, message } = response.error
-    return res.status(code).json({ message })
+    const statusCode = typeof code === 'number' ? code : 500
+    return res.status(statusCode).json({ message })
   } else {
     return res.status(200).json(response)
   }

--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
@@ -17,19 +17,60 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       assert(typeof ref === 'string', 'Invalid or missing ref parameter')
       assert(typeof name === 'string', 'Invalid or missing name parameter')
 
-      const { data, error } = await retrieveAnalyticsData({
-        name,
-        params,
-        projectRef: ref,
-      })
+      try {
+        const { data, error } = await retrieveAnalyticsData({
+          name,
+          params,
+          projectRef: ref,
+        })
 
-      if (data) {
-        return res.status(200).json(data)
-      } else {
-        return res.status(500).json({ error: { message: error.message } })
+        if (data) {
+          return res.status(200).json(data)
+        }
+
+        if (error && shouldUseLocalLogsFallback(name, error)) {
+          return res.status(200).json({
+            result: [],
+            error: { message: formatLocalLogsUnavailableMessage(error) },
+          })
+        }
+
+        return res.status(500).json({ error: { message: error?.message ?? 'Unknown error' } })
+      } catch (error) {
+        if (shouldUseLocalLogsFallback(name, error)) {
+          return res.status(200).json({
+            result: [],
+            error: { message: formatLocalLogsUnavailableMessage(error) },
+          })
+        }
+
+        throw error
       }
     default:
       res.setHeader('Allow', ['GET', 'POST'])
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
   }
+}
+
+function shouldUseLocalLogsFallback(name: string, error: unknown) {
+  if (name !== 'logs.all') return false
+
+  const message = error instanceof Error ? error.message : ''
+  if (!message) return false
+
+  return [
+    'PROJECT_ANALYTICS_URL is required',
+    'LOGFLARE_PRIVATE_ACCESS_TOKEN is required',
+    'fetch failed',
+    'ECONNREFUSED',
+  ].some((pattern) => message.includes(pattern))
+}
+
+function formatLocalLogsUnavailableMessage(error: unknown) {
+  const reason = error instanceof Error ? ` Root cause: ${error.message}` : ''
+
+  return (
+    'Local analytics is unavailable. Enable analytics in supabase/config.toml with [analytics] enabled = true, then restart with `supabase stop && supabase start`.' +
+    reason
+  )
 }

--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
@@ -44,7 +44,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           })
         }
 
-        throw error
+        return res.status(500).json({
+          error: {
+            message: error instanceof Error ? error.message : 'Unknown error',
+          },
+        })
       }
     default:
       res.setHeader('Allow', ['GET', 'POST'])

--- a/apps/studio/tests/components/Database/database-triggers-query.test.tsx
+++ b/apps/studio/tests/components/Database/database-triggers-query.test.tsx
@@ -1,0 +1,98 @@
+import { waitFor } from '@testing-library/react'
+import {
+  useDatabaseHooksQuery,
+  useDatabaseTriggersQuery,
+} from 'data/database-triggers/database-triggers-query'
+import { get } from 'data/fetchers'
+import { customRenderHook } from 'tests/lib/custom-render'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('data/fetchers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('data/fetchers')>()
+  return {
+    ...actual,
+    get: vi.fn(),
+  }
+})
+
+describe('database-triggers-query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns triggers from all schemas for trigger list pages', async () => {
+    vi.mocked(get).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'trigger_public',
+          schema: 'public',
+          table: 'profiles',
+          function_schema: 'public',
+          function_args: [],
+        },
+        {
+          id: 2,
+          name: 'trigger_auth',
+          schema: 'auth',
+          table: 'users',
+          function_schema: 'auth',
+          function_args: [],
+        },
+      ],
+      error: null,
+    } as any)
+
+    const { result } = customRenderHook(() =>
+      useDatabaseTriggersQuery({ projectRef: 'default', connectionString: null })
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.data?.[0]?.schema).toBe('public')
+    expect(result.current.data?.[1]?.schema).toBe('auth')
+  })
+
+  it('keeps hook-specific filtering scoped to hooks query', async () => {
+    vi.mocked(get).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'valid_hook',
+          schema: 'public',
+          function_schema: 'supabase_functions',
+          function_args: [],
+        },
+        {
+          id: 2,
+          name: 'net_hook_with_args',
+          schema: 'net',
+          function_schema: 'supabase_functions',
+          function_args: ['arg'],
+        },
+        {
+          id: 3,
+          name: 'custom_schema_trigger',
+          schema: 'public',
+          function_schema: 'public',
+          function_args: [],
+        },
+      ],
+      error: null,
+    } as any)
+
+    const { result } = customRenderHook(() =>
+      useDatabaseHooksQuery({ projectRef: 'default', connectionString: null })
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data?.[0].name).toBe('valid_hook')
+  })
+})

--- a/apps/studio/tests/pages/api/platform/analytics-endpoints.test.ts
+++ b/apps/studio/tests/pages/api/platform/analytics-endpoints.test.ts
@@ -1,0 +1,71 @@
+import { createMocks } from 'node-mocks-http'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import handler from '../../../../pages/api/platform/projects/[ref]/analytics/endpoints/[name]'
+import { retrieveAnalyticsData } from 'lib/api/self-hosted/logs'
+
+vi.mock('lib/api/self-hosted/logs', () => ({
+  retrieveAnalyticsData: vi.fn(),
+}))
+
+describe('/api/platform/projects/[ref]/analytics/endpoints/[name]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns upstream analytics payload on success', async () => {
+    vi.mocked(retrieveAnalyticsData).mockResolvedValue({
+      data: { result: [{ id: '1' }] },
+      error: undefined,
+    })
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { ref: 'default', name: 'logs.all' },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(JSON.parse(res._getData())).toEqual({ result: [{ id: '1' }] })
+  })
+
+  it('falls back gracefully for local logs when analytics is unavailable', async () => {
+    vi.mocked(retrieveAnalyticsData).mockResolvedValue({
+      data: undefined,
+      error: new Error('PROJECT_ANALYTICS_URL is required'),
+    })
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { ref: 'default', name: 'logs.all' },
+    })
+
+    await handler(req, res)
+
+    const body = JSON.parse(res._getData())
+    expect(res._getStatusCode()).toBe(200)
+    expect(body.result).toEqual([])
+    expect(body.error.message).toContain('Local analytics is unavailable')
+    expect(body.error.message).toContain('supabase/config.toml')
+  })
+
+  it('keeps non-log analytics errors as 500 responses', async () => {
+    vi.mocked(retrieveAnalyticsData).mockResolvedValue({
+      data: undefined,
+      error: new Error('Some upstream failure'),
+    })
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { ref: 'default', name: 'auth.metrics' },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(500)
+    expect(JSON.parse(res._getData())).toEqual({
+      error: { message: 'Some upstream failure' },
+    })
+  })
+})

--- a/apps/studio/tests/pages/api/platform/pg-meta-triggers.test.ts
+++ b/apps/studio/tests/pages/api/platform/pg-meta-triggers.test.ts
@@ -1,0 +1,51 @@
+import { createMocks } from 'node-mocks-http'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import handler from '../../../../pages/api/platform/pg-meta/[ref]/triggers'
+import { fetchGet } from 'data/fetchers'
+
+vi.mock('data/fetchers', () => ({
+  fetchGet: vi.fn(),
+}))
+
+vi.mock('lib/api/apiHelpers', () => ({
+  constructHeaders: vi.fn(() => ({})),
+}))
+
+describe('/api/platform/pg-meta/[ref]/triggers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults to 500 when upstream error has no status code', async () => {
+    vi.mocked(fetchGet).mockResolvedValue({
+      error: { message: 'Upstream unavailable' },
+    } as any)
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { ref: 'default' },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(500)
+    expect(JSON.parse(res._getData())).toEqual({ message: 'Upstream unavailable' })
+  })
+
+  it('preserves upstream status code when provided', async () => {
+    vi.mocked(fetchGet).mockResolvedValue({
+      error: { code: 503, message: 'Service unavailable' },
+    } as any)
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { ref: 'default' },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(503)
+    expect(JSON.parse(res._getData())).toEqual({ message: 'Service unavailable' })
+  })
+})


### PR DESCRIPTION
Fixes #18891

## Problem

In local Studio (`supabase start`), two failure paths were noisy/fragile:

1. Logs endpoint (`/platform/projects/{ref}/analytics/endpoints/logs.all`) could return 500 when local analytics/logflare was unavailable.
2. Trigger fetch route could pass through an undefined upstream status code on error, causing unstable refresh behavior.

## Solution

- `apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts`
  - Added local fallback for `logs.all` when analytics is unavailable (missing env/assertion/connection failure).
  - Returns `200` with `result: []` and an actionable error message instead of transport-level 500.
  - Non-log analytics endpoints keep existing 500 behavior.

- `apps/studio/pages/api/platform/pg-meta/[ref]/triggers.ts`
  - Default to HTTP 500 when upstream error code is missing.
  - Preserve upstream status code when present.

## Tests

Added targeted regressions:

- `apps/studio/tests/pages/api/platform/analytics-endpoints.test.ts`
- `apps/studio/tests/pages/api/platform/pg-meta-triggers.test.ts`
- `apps/studio/tests/components/Database/database-triggers-query.test.tsx`

Covered:
- logs success passthrough
- local logs fallback behavior
- non-log 500 regression
- trigger missing-code fallback
- trigger upstream code passthrough
- trigger query schema coverage (hooks filter remains scoped)

## Verification

Run:
- `pnpm exec vitest run tests/components/Database/database-triggers-query.test.tsx tests/pages/api/platform/analytics-endpoints.test.ts tests/pages/api/platform/pg-meta-triggers.test.ts`

Result:
- 7 tests passed

## Manual check (local)

1. `supabase start`
2. Open `http://localhost:54323`
3. Logs > Postgres Logs
4. Database > Triggers
5. Refresh Triggers page and confirm stable behavior