### PR TITLE
docs: add SolidStart SSR examples to server-side auth guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -81,6 +81,14 @@ SUPABASE_PUBLISHABLE_KEY=supabase_publishable_key
 ```
 
 </TabPanel>
+<TabPanel id="solidstart" label="SolidStart">
+
+```bash .env
+VITE_SUPABASE_URL=supabase_project_url
+VITE_SUPABASE_PUBLISHABLE_KEY=supabase_publishable_key
+```
+
+</TabPanel>
 <TabPanel id="react-router" label="React Router">
 
 ```bash .env
@@ -535,6 +543,75 @@ export default function Index() {
   const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY);
 
   return ...
+}
+```
+
+</TabPanel>
+</Tabs>
+
+## Congratulations
+
+You can now use any Supabase features from your client or server code!
+
+</TabPanel>
+
+<TabPanel id="solidstart" label="SolidStart">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="solidstart-server"
+  queryGroup="environment"
+>
+<TabPanel id="solidstart-server" label="Server API route">
+
+```ts routes/api/hello.ts
+import { APIEvent } from '@solidjs/start/server'
+import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
+
+export async function GET({ request }: APIEvent) {
+  const headers = new Headers()
+
+  const supabase = createServerClient(
+    import.meta.env.VITE_SUPABASE_URL,
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY,
+    {
+      cookies: {
+        getAll() {
+          return parseCookieHeader(request.headers.get('Cookie') ?? '')
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            headers.append('Set-Cookie', serializeCookieHeader(name, value, options))
+          })
+        },
+      },
+    }
+  )
+
+  await supabase.auth.getUser()
+
+  return new Response(JSON.stringify({ ok: true }), {
+    headers,
+  })
+}
+```
+
+</TabPanel>
+
+<TabPanel id="solidstart-browser" label="Browser component">
+
+```tsx routes/index.tsx
+import { createBrowserClient } from '@supabase/ssr'
+
+export default function Home() {
+  const supabase = createBrowserClient(
+    import.meta.env.VITE_SUPABASE_URL,
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY
+  )
+
+  return <div>Supabase client ready</div>
 }
 ```
 

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -567,7 +567,7 @@ You can now use any Supabase features from your client or server code!
 <TabPanel id="solidstart-server" label="Server API route">
 
 ```ts routes/api/hello.ts
-import { APIEvent } from '@solidjs/start/server'
+import { type APIEvent } from '@solidjs/start/server'
 import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
 
 export async function GET({ request }: APIEvent) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

The server-side auth guide includes framework examples for Next.js, SvelteKit, Astro, Remix, React Router, Express, and Hono, but does not include SolidStart examples.

## What is the new behavior?

- Adds a SolidStart tab in the environment variable section.
- Adds a SolidStart section in the create-client guide with:
  - Server API route example using `createServerClient` and cookie adapters.
  - Browser component example using `createBrowserClient`.

## Additional context

Closes #31014