### PR TITLE
docs: fix undefined variable host used in Drizzle connection snippet

### DIFF
--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -80,9 +80,9 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
     import { drizzle } from 'drizzle-orm/postgres-js'
     import postgres from 'postgres'
 
-    let connectionString = process.env.DATABASE_URL
-    if (host.includes('postgres:postgres@supabase_db_')) {
-      const url = URL.parse(host)!
+    let connectionString = process.env.DATABASE_URL!
+    if (connectionString.includes('postgres:postgres@supabase_db_')) {
+      const url = new URL(connectionString)
       url.hostname = url.hostname.split('_')[1]
       connectionString = url.href
     }

--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -67,7 +67,8 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
     Connect to your database using the Connection Pooler.
 
     From the project  [**Connect** panel](/dashboard/project/_?showConnect=true), copy the URI from the "Shared Pooler" option and save it as the `DATABASE_URL` environment variable. Remember to replace the password placeholder with your actual database password.
-In local development, DATABASE_URL might need to be adapted to work with Docker name resolution:to work with Doc
+
+    In local development, `DATABASE_URL` might need to be adapted to work with Docker name resolution.
 
     </StepHikeCompact.Details>
 
@@ -95,4 +96,4 @@ In local development, DATABASE_URL might need to be adapted to work with Docker 
 
   </StepHikeCompact.Step>
 
-</StepHikeCompact>In local development, DATABASE_URL might need to be adapted to work with Docker name resolution.
+</StepHikeCompact>

--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -67,8 +67,7 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
     Connect to your database using the Connection Pooler.
 
     From the project  [**Connect** panel](/dashboard/project/_?showConnect=true), copy the URI from the "Shared Pooler" option and save it as the `DATABASE_URL` environment variable. Remember to replace the password placeholder with your actual database password.
-
-    In local SUPABASE_DB_URL require to be adapted to work with Docker resolver
+In local development, DATABASE_URL might need to be adapted to work with Docker name resolution:to work with Doc
 
     </StepHikeCompact.Details>
 
@@ -96,4 +95,4 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
 
   </StepHikeCompact.Step>
 
-</StepHikeCompact>
+</StepHikeCompact>In local development, DATABASE_URL might need to be adapted to work with Docker name resolution.


### PR DESCRIPTION
Fixes #43920

## What kind of change does this PR introduce?
- Documentation update

## What is the current behavior?
The Drizzle ORM connection snippet uses an undeclared/undefined `host` variable for string manipulation. 

## What is the new behavior?
Replaces `host` with `connectionString` per the issue's suggestion, effectively fixing the `ReferenceError: host is not defined` that developers encounter when copying the snippet.