### PR TITLE
fix(Docs): Improve await error handling on external content sources.

### DIFF
--- a/apps/docs/app/guides/ai/python/[slug]/page.tsx
+++ b/apps/docs/app/guides/ai/python/[slug]/page.tsx
@@ -83,9 +83,20 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetchRevalidatePerDay(
-    `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
-  )
+  let response: Response
+  try {
+    response = await fetchRevalidatePerDay(
+      `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
+    )
+  } catch (err) {
+    throw new Error(`Failed to fetch Python vecs docs from GitHub (network error): ${err}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Python vecs docs from GitHub: ${response.status} ${response.statusText}`
+    )
+  }
 
   let content = await response.text()
   content = removeRedundantH1(content)

--- a/apps/docs/app/guides/deployment/ci/[slug]/page.tsx
+++ b/apps/docs/app/guides/deployment/ci/[slug]/page.tsx
@@ -82,9 +82,20 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetchRevalidatePerDay(
-    `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
-  )
+  let response: Response
+  try {
+    response = await fetchRevalidatePerDay(
+      `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
+    )
+  } catch (err) {
+    throw new Error(`Failed to fetch CI docs from GitHub (network error): ${err}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch CI docs from GitHub: ${response.status} ${response.statusText}`
+    )
+  }
 
   const content = removeRedundantH1(await response.text())
 

--- a/apps/docs/app/guides/deployment/terraform/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/deployment/terraform/[[...slug]]/page.tsx
@@ -115,9 +115,20 @@ const getContent = async ({ slug }: Params) => {
     `${terraformDocsOrg}/${terraformDocsRepo}/blob/${terraformDocsBranch}/${useRoot ? '' : `${terraformDocsDocsDir}/`}${remoteFile}`
   )
 
-  let response = await fetchRevalidatePerDay(
-    `https://raw.githubusercontent.com/${terraformDocsOrg}/${terraformDocsRepo}/${terraformDocsBranch}/${useRoot ? '' : `${terraformDocsDocsDir}/`}${remoteFile}`
-  )
+  let response: Response
+  try {
+    response = await fetchRevalidatePerDay(
+      `https://raw.githubusercontent.com/${terraformDocsOrg}/${terraformDocsRepo}/${terraformDocsBranch}/${useRoot ? '' : `${terraformDocsDocsDir}/`}${remoteFile}`
+    )
+  } catch (err) {
+    throw new Error(`Failed to fetch Terraform docs from GitHub (network error): ${err}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Terraform docs from GitHub: ${response.status} ${response.statusText}`
+    )
+  }
 
   let rawContent = await response.text()
   // Strip out HTML comments

--- a/apps/docs/app/guides/deployment/terraform/reference/page.tsx
+++ b/apps/docs/app/guides/deployment/terraform/reference/page.tsx
@@ -394,10 +394,19 @@ const TerraformReferencePage = async () => {
  * Fetch JSON schema from external repo
  */
 const getSchema = async () => {
-  let response = await fetchRevalidatePerDay(
-    `https://raw.githubusercontent.com/${terraformDocsOrg}/${terraformDocsRepo}/${terraformDocsBranch}/${terraformDocsDocsDir}/schema.json`
-  )
-  if (!response.ok) throw Error('Failed to fetch Terraform JSON schema from GitHub')
+  let response: Response
+  try {
+    response = await fetchRevalidatePerDay(
+      `https://raw.githubusercontent.com/${terraformDocsOrg}/${terraformDocsRepo}/${terraformDocsBranch}/${terraformDocsDocsDir}/schema.json`
+    )
+  } catch (err) {
+    throw new Error(`Failed to fetch Terraform JSON schema from GitHub (network error): ${err}`)
+  }
+
+  if (!response.ok)
+    throw Error(
+      `Failed to fetch Terraform JSON schema from GitHub: ${response.status} ${response.statusText}`
+    )
 
   const schema = await response.json()
 

--- a/apps/docs/app/guides/graphql/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/graphql/[[...slug]]/page.tsx
@@ -136,10 +136,21 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetch(
-    `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`,
-    { cache: 'force-cache', next: { tags: [REVALIDATION_TAGS.GRAPHQL] } }
-  )
+  let response: Response
+  try {
+    response = await fetch(
+      `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`,
+      { cache: 'force-cache', next: { tags: [REVALIDATION_TAGS.GRAPHQL] } }
+    )
+  } catch (err) {
+    throw new Error(`Failed to fetch GraphQL docs from GitHub (network error): ${err}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch GraphQL docs from GitHub: ${response.status} ${response.statusText}`
+    )
+  }
 
   const content = await response.text()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

In this PR we handle the rejected Promises coming from fetched federated sources of content to avoid build `TIMEOUT` errors and get the actual reason.