### PR TITLE
chore(docs): add Colum Ferry to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -51,6 +51,7 @@ Chris Martin
 Chris Stockton
 Chris Ward
 Clayton Kast
+Colum Ferry
 Craig Cannon
 Cuong Do
 Daniel Velázquez Lara


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to `humans.txt` to add `Colum Ferry`
 
## What is the current behavior?

`Colum Ferry` does not exist in `humans.txt`

## What is the new behavior?

`Colum Ferry` exists in `humans.txt`

