### PR TITLE
fix(studio): prevent entity dropdown from disabling on empty search

### DIFF
--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -54,6 +54,7 @@ export const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelP
   const [selectedIndexType, setSelectedIndexType] = useState<string>(INDEX_TYPES[0].value)
   const [schemaDropdownOpen, setSchemaDropdownOpen] = useState(false)
   const [tableDropdownOpen, setTableDropdownOpen] = useState(false)
+  const [schemaSearchTerm, setSchemaSearchTerm] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
 
   const { data: schemas } = useSchemasQuery({
@@ -146,7 +147,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
     setSelectedIndexType(INDEX_TYPES[0].value)
   }, [selectedEntity])
 
-  const isSelectEntityDisabled = entityTypes.length === 0
+  const isSelectEntityDisabled = entityTypes.length === 0 && searchTerm.length === 0
 
   return (
     <SidePanel
@@ -188,9 +189,9 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
               >
                 <Command_Shadcn_>
                   <CommandInput_Shadcn_
-                    placeholder="Find table..."
-                    value={searchTerm}
-                    onValueChange={handleSearchChange}
+                    placeholder="Find schema..."
+                    value={schemaSearchTerm}
+                    onValueChange={setSchemaSearchTerm}
                   />
                   <CommandList_Shadcn_>
                     <CommandEmpty_Shadcn_>No schemas found</CommandEmpty_Shadcn_>


### PR DESCRIPTION
## Description                                                                                                                                                                            
  Fix entity dropdown in Create Index side panel getting incorrectly disabled when search returns no results.                                                                               
                                                                                                                                                                                            
  ## Related Issue                                          
  Fixes #41537                                                                                                                                                                              
              
  ## Changes Made                                                                                                                                                                           
  - Separate search states: Schema and entity dropdowns no longer share the same searchTerm state. Added schemaSearchTerm for the schema dropdown.
  - Fix disabled logic: isSelectEntityDisabled now checks entityTypes.length === 0 && searchTerm.length === 0, so the dropdown only disables when the schema genuinely has no tables, not
  when a search returns empty results.                                                                                                                                                      
  - Fix placeholder: Schema dropdown placeholder changed from "Find table..." to "Find schema...".                                                                                          
                                                                                                                                                                                            
  ## Checklist                                                                                                                                                                              
  - [x] Linter passes                                       
  - [x] Follows existing code patterns