### PR TITLE
feat(logs): show edge function name in logs FE-2798

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
@@ -1,8 +1,10 @@
 import { Column } from 'react-data-grid'
+import { TimestampInfo } from 'ui-patterns/TimestampInfo'
+
 import type { LogData } from '../Logs.types'
+import { extractEdgeFunctionName } from '../Logs.utils'
 import { ResponseCodeFormatter, RowLayout, TextFormatter } from '../LogsFormatters'
 import { defaultRenderCell } from './DefaultPreviewColumnRenderer'
-import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 
 const columns: Column<LogData>[] = [
   {
@@ -13,11 +15,13 @@ const columns: Column<LogData>[] = [
       if (!props.row.status_code && !props.row.method) {
         return defaultRenderCell(props)
       }
+      const functionName = extractEdgeFunctionName(props.row.pathname)
       return (
         <RowLayout>
           <TimestampInfo utcTimestamp={props.row.timestamp!} />
           <ResponseCodeFormatter value={String(props.row.status_code)} />
           <TextFormatter value={String(props.row.method)} />
+          {functionName && <TextFormatter value={functionName} />}
           <TextFormatter value={String(props.row.id)} />
         </RowLayout>
       )

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -110,5 +110,9 @@ describe('Logs.utils', () => {
     test('handles pathname with no slashes', () => {
       expect(extractEdgeFunctionName('my-function')).toBe('my-function')
     })
+
+    test('handles trailing slash', () => {
+      expect(extractEdgeFunctionName('/functions/v1/hello-world-1/')).toBe('hello-world-1')
+    })
   })
 })

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest'
 
 import type { LogData } from './Logs.types'
-import { buildLogsPrompt, extractEdgeFunctionName, formatLogsAsJson, formatLogsAsMarkdown } from './Logs.utils'
+import {
+  buildLogsPrompt,
+  extractEdgeFunctionName,
+  formatLogsAsJson,
+  formatLogsAsMarkdown,
+} from './Logs.utils'
 
 const createLog = (overrides: Partial<LogData> = {}): LogData => ({
   id: 'test-id',

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import type { LogData } from './Logs.types'
-import { buildLogsPrompt, formatLogsAsJson, formatLogsAsMarkdown } from './Logs.utils'
+import { buildLogsPrompt, extractEdgeFunctionName, formatLogsAsJson, formatLogsAsMarkdown } from './Logs.utils'
 
 const createLog = (overrides: Partial<LogData> = {}): LogData => ({
   id: 'test-id',
@@ -81,6 +81,29 @@ describe('Logs.utils', () => {
       const rows: LogData[] = [createLog({ id: '1', event_message: 'single error' })]
       const result = buildLogsPrompt(rows)
       expect(result).toContain('1 Supabase log entry')
+    })
+  })
+
+  describe('extractEdgeFunctionName', () => {
+    test('extracts function name from full pathname', () => {
+      expect(extractEdgeFunctionName('/functions/v1/hello-world-1')).toBe('hello-world-1')
+    })
+
+    test('returns empty string for null', () => {
+      expect(extractEdgeFunctionName(null)).toBe('')
+    })
+
+    test('returns empty string for undefined', () => {
+      expect(extractEdgeFunctionName(undefined)).toBe('')
+    })
+
+    test('returns empty string for non-string values', () => {
+      expect(extractEdgeFunctionName(42)).toBe('')
+      expect(extractEdgeFunctionName({})).toBe('')
+    })
+
+    test('handles pathname with no slashes', () => {
+      expect(extractEdgeFunctionName('my-function')).toBe('my-function')
     })
   })
 })

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -810,7 +810,7 @@ const LOG_TABLE_TO_SERVICE_LABEL: Record<string, string> = {
 
 export function extractEdgeFunctionName(pathname: unknown): string {
   if (typeof pathname !== 'string' || !pathname) return ''
-  const parts = pathname.split('/')
+  const parts = pathname.split('/').filter(Boolean)
   return parts[parts.length - 1] ?? ''
 }
 

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -205,7 +205,7 @@ ${orderBy}
 limit ${limit}
 `
       }
-      return `select id, ${table}.timestamp, event_message, response.status_code, request.method, m.function_id, m.execution_time_ms, m.deployment_id, m.version from ${table}
+      return `select id, ${table}.timestamp, event_message, response.status_code, request.method, request.pathname, m.function_id, m.execution_time_ms, m.deployment_id, m.version from ${table}
   ${joins}
   ${where}
   ${orderBy}
@@ -806,6 +806,12 @@ const LOG_TABLE_TO_SERVICE_LABEL: Record<string, string> = {
   pg_upgrade_logs: 'Postgres upgrade',
   pg_cron_logs: 'pg_cron',
   etl_replication_logs: 'ETL',
+}
+
+export function extractEdgeFunctionName(pathname: unknown): string {
+  if (typeof pathname !== 'string' || !pathname) return ''
+  const parts = pathname.split('/')
+  return parts[parts.length - 1] ?? ''
 }
 
 function extractServiceLabelFromSql(sql: string): string | null {


### PR DESCRIPTION
## Problem

The edge function logs table at `/observability/logs/edge-functions-logs` did not show which edge function was called. Users had to open individual log entries to find the function name, even though the information is available in the log data.

## Fix

- Added `request.pathname` to the SQL SELECT query for `function_edge_logs` so the pathname is returned with each row.
- Added `extractEdgeFunctionName` utility that parses the last path segment from the pathname (e.g. `/functions/v1/hello-world-1` becomes `hello-world-1`).
- Updated `FunctionsEdgeColumnRender` to display the function name between the HTTP method and the log ID columns.
- Added unit tests for `extractEdgeFunctionName` covering normal paths, null/undefined, non-string values, and pathnames without slashes.

<img width="1472" height="776" alt="CleanShot 2026-03-19 at 13 18 47@2x" src="https://github.com/user-attachments/assets/e437f7df-7aab-4ea5-b421-95bab3923605" />


## How to test

- Navigate to Logs and Analytics, then Edge Functions logs.
- Confirm each row now shows the function name (e.g. `hello-world-1`) between the HTTP method and the log ID.
- Confirm rows without a pathname (e.g. non-platform or self-hosted) still render without errors.
- Confirm clicking a row still opens the log detail panel correctly.