### PR TITLE
feat(assistant): track chat IDs in PostHog events

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -238,7 +238,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           rating,
           category: result.category,
           ...(reason && { reason }),
-          sessionId: state.activeChatId,
+          chatId: state.activeChatId,
         })
       } catch (error) {
         console.error('Failed to rate message:', error)
@@ -327,9 +327,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     setValue('')
 
     if (finalContent.includes('Help me to debug')) {
-      track('assistant_debug_submitted', { sessionId: snap.activeChatId })
+      track('assistant_debug_submitted', { chatId: snap.activeChatId })
     } else {
-      track('assistant_prompt_submitted', { sessionId: snap.activeChatId })
+      track('assistant_prompt_submitted', { chatId: snap.activeChatId })
     }
   }
 

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -238,7 +238,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           rating,
           category: result.category,
           ...(reason && { reason }),
-          sessionId: snap.activeChatId,
+          sessionId: state.activeChatId,
         })
       } catch (error) {
         console.error('Failed to rate message:', error)
@@ -249,7 +249,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
         })
       }
     },
-    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, track, state, snap]
+    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, track, state]
   )
 
   const isContextExceededError =

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -13,7 +13,7 @@ import { SIDEBAR_KEYS } from 'components/layouts/ProjectLayout/LayoutSidebar/Lay
 import { useCheckOpenAIKeyQuery } from 'data/ai/check-api-key-query'
 import { useRateMessageMutation } from 'data/ai/rate-message-mutation'
 import { useTablesQuery } from 'data/tables/tables-query'
-import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useTrack } from 'lib/telemetry/track'
 import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { useOrgAiOptInLevel } from 'hooks/misc/useOrgOptedIntoAi'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
@@ -142,7 +142,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     })
   }, [project?.ref, project?.connectionString, selectedOrganizationRef.current?.slug, state])
 
-  const { mutate: sendEvent } = useSendEventMutation()
+  const track = useTrack()
 
   const {
     messages: chatMessages,
@@ -234,17 +234,11 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           spanId: state.messageSpanIds[messageId],
         })
 
-        sendEvent({
-          action: 'assistant_message_rating_submitted',
-          properties: {
-            rating,
-            category: result.category,
-            ...(reason && { reason }),
-          },
-          groups: {
-            project: project.ref,
-            organization: selectedOrganization.slug,
-          },
+        track('assistant_message_rating_submitted', {
+          rating,
+          category: result.category,
+          ...(reason && { reason }),
+          sessionId: snap.activeChatId,
         })
       } catch (error) {
         console.error('Failed to rate message:', error)
@@ -255,7 +249,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
         })
       }
     },
-    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, sendEvent, state]
+    [chatMessages, project?.ref, selectedOrganization?.slug, rateMessage, track, state, snap]
   )
 
   const isContextExceededError =
@@ -333,21 +327,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     setValue('')
 
     if (finalContent.includes('Help me to debug')) {
-      sendEvent({
-        action: 'assistant_debug_submitted',
-        groups: {
-          project: ref ?? 'Unknown',
-          organization: selectedOrganization?.slug ?? 'Unknown',
-        },
-      })
+      track('assistant_debug_submitted', { sessionId: snap.activeChatId })
     } else {
-      sendEvent({
-        action: 'assistant_prompt_submitted',
-        groups: {
-          project: ref ?? 'Unknown',
-          organization: selectedOrganization?.slug ?? 'Unknown',
-        },
-      })
+      track('assistant_prompt_submitted', { sessionId: snap.activeChatId })
     }
   }
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -667,6 +667,10 @@ export interface SqlEditorResultCopyJsonClickedEvent {
  */
 export interface AssistantPromptSubmittedEvent {
   action: 'assistant_prompt_submitted'
+  properties: {
+    /** UUID of the chat session in which the prompt was submitted */
+    sessionId: string
+  }
   groups: TelemetryGroups
 }
 
@@ -678,6 +682,10 @@ export interface AssistantPromptSubmittedEvent {
  */
 export interface AssistantDebugSubmittedEvent {
   action: 'assistant_debug_submitted'
+  properties: {
+    /** UUID of the chat session in which the debug request was submitted */
+    sessionId: string
+  }
   groups: TelemetryGroups
 }
 
@@ -1479,6 +1487,10 @@ export interface AssistantMessageRatingSubmittedEvent {
       | 'debugging'
       | 'general_help'
       | 'other'
+    /** Optional reason provided by the user when rating negatively */
+    reason?: string
+    /** UUID of the chat session in which the message was rated */
+    sessionId: string
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -669,7 +669,7 @@ export interface AssistantPromptSubmittedEvent {
   action: 'assistant_prompt_submitted'
   properties: {
     /** UUID of the chat session in which the prompt was submitted */
-    sessionId?: string
+    chatId?: string
   }
   groups: TelemetryGroups
 }
@@ -684,7 +684,7 @@ export interface AssistantDebugSubmittedEvent {
   action: 'assistant_debug_submitted'
   properties: {
     /** UUID of the chat session in which the debug request was submitted */
-    sessionId?: string
+    chatId?: string
   }
   groups: TelemetryGroups
 }
@@ -1490,7 +1490,7 @@ export interface AssistantMessageRatingSubmittedEvent {
     /** Optional reason provided by the user when rating negatively */
     reason?: string
     /** UUID of the chat session in which the message was rated */
-    sessionId?: string
+    chatId?: string
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -669,7 +669,7 @@ export interface AssistantPromptSubmittedEvent {
   action: 'assistant_prompt_submitted'
   properties: {
     /** UUID of the chat session in which the prompt was submitted */
-    sessionId: string
+    sessionId?: string
   }
   groups: TelemetryGroups
 }
@@ -684,7 +684,7 @@ export interface AssistantDebugSubmittedEvent {
   action: 'assistant_debug_submitted'
   properties: {
     /** UUID of the chat session in which the debug request was submitted */
-    sessionId: string
+    sessionId?: string
   }
   groups: TelemetryGroups
 }
@@ -1490,7 +1490,7 @@ export interface AssistantMessageRatingSubmittedEvent {
     /** Optional reason provided by the user when rating negatively */
     reason?: string
     /** UUID of the chat session in which the message was rated */
-    sessionId: string
+    sessionId?: string
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
Adds `chatId` (the chat UUID) to the three assistant PostHog events so we can count distinct chat sessions in PostHog. This naming is consistent with how we name the field in Braintrust logs.

Also migrates from the deprecated `useSendEventMutation` hook to `useTrack` — groups (project/org) are still sent automatically by `useTrack`.

Closes AI-519