### PR TITLE
fix(studio): cron job form incorrectly parses functions without schema prefix

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -59,10 +59,22 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a sql snippet command when the command is using a SQL function from the search path', () => {
+  it('should return a sql function command with public schema when the command has no schema (fixes #41508)', () => {
     const command = 'SELECT test_cron_function()'
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
-      type: 'sql_snippet',
+      type: 'sql_function',
+      schema: 'public',
+      functionName: 'test_cron_function',
+      snippet: command,
+    })
+  })
+
+  it('should correctly parse function name into Function name field, not Schema field (fixes #41508)', () => {
+    const command = 'SELECT truncate_uploaded_images()'
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      type: 'sql_function',
+      schema: 'public',
+      functionName: 'truncate_uploaded_images',
       snippet: command,
     })
   })

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -127,20 +127,39 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
     }
   }
 
-  const regexDBFunction = /select\s+[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\s*\(\)/g
-  if (command.toLocaleLowerCase().match(regexDBFunction)) {
-    const [schemaName, functionName] = command
-      .replace('SELECT ', '')
-      .replace(/\(.*\);*/, '')
-
+  // Handle SELECT schema.functionname() - explicit schema
+  const regexDBFunctionWithSchema = /select\s+[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\s*\(\)/i
+  if (regexDBFunctionWithSchema.test(command)) {
+    const parts = command
+      .replace(/^\s*select\s+/i, '')
+      .replace(/\(.*\)\s*;?\s*$/, '')
       .trim()
       .split('.')
 
-    return {
-      type: 'sql_function',
-      schema: schemaName,
-      functionName: functionName,
-      snippet: originalCommand,
+    if (parts.length >= 2) {
+      const schemaName = parts[0]
+      const functionName = parts.slice(1).join('.')
+      return {
+        type: 'sql_function',
+        schema: schemaName,
+        functionName,
+        snippet: originalCommand,
+      }
+    }
+  }
+
+  // Handle SELECT functionname() - no schema, default to public (fixes #41508)
+  const regexDBFunctionNoSchema = /^\s*select\s+[a-zA-Z0-9_]+\s*\(\s*\)\s*;?\s*$/i
+  if (regexDBFunctionNoSchema.test(command)) {
+    const match = command.match(/^\s*select\s+([a-zA-Z0-9_]+)\s*\(\s*\)/i)
+    const functionName = match?.[1] || ''
+    if (functionName) {
+      return {
+        type: 'sql_function',
+        schema: 'public',
+        functionName,
+        snippet: originalCommand,
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #41508

When editing a cron job with a database function like `SELECT truncate_uploaded_images()` (no schema prefix), the function name was incorrectly shown in the Schema field instead of the Function name field.

This fix:
- Parses unqualified function calls as schema='public', functionName='functionname'
- Improves schema-qualified parsing to correctly split schema and function name

Made with [Cursor](https://cursor.com)