### PR TITLE
fix(Docs): Add cache-control and default to HTML content

### DIFF
--- a/apps/docs/app/api/guides-md/[...slug]/route.ts
+++ b/apps/docs/app/api/guides-md/[...slug]/route.ts
@@ -14,7 +14,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ slu
   try {
     const content = await fs.readFile(filePath, 'utf-8')
     return new NextResponse(content, {
-      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=86400, stale-while-revalidate',
+      },
     })
   } catch {
     return new NextResponse('Not found', { status: 404 })

--- a/apps/docs/app/api/guides-md/[...slug]/route.ts
+++ b/apps/docs/app/api/guides-md/[...slug]/route.ts
@@ -16,7 +16,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ slu
     return new NextResponse(content, {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',
-        'Cache-Control': 'public, max-age=86400, stale-while-revalidate',
+        'Cache-Control': 'public, max-age=86400, stale-while-revalidate=3600',
       },
     })
   } catch {

--- a/apps/docs/components/GuidesSidebar.tsx
+++ b/apps/docs/components/GuidesSidebar.tsx
@@ -30,7 +30,15 @@ function AiTools({ className }: { className?: string }) {
 
     try {
       const res = await fetch(mdUrl)
-      const text = await res.text()
+      let text: string
+
+      if (res.ok) {
+        text = await res.text()
+      } else {
+        // Default to HTML content within the article when no .md file is available.
+        text = document.getElementById('sb-docs-guide-main-article')?.innerHTML ?? ''
+      }
+
       await navigator.clipboard.writeText(text)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently we don't cache markdown responses, this adds one full day of validation.

On top of that, we default to article HTML content when markdown files are not available, this is temporary. In the future we will look case by case for external content sources and reconcile them internally so we have them available too.