### PR TITLE
feat(studio): make filter bar ui its own row

### DIFF
--- a/apps/studio/components/grid/components/header/HeaderNew.tsx
+++ b/apps/studio/components/grid/components/header/HeaderNew.tsx
@@ -65,17 +65,19 @@ export const HeaderNew = ({
 
   return (
     <div>
-      <div className="flex flex-wrap min-h-10 items-center bg-dash-sidebar dark:bg-surface-100 px-1.5 py-1.5 gap-2">
+      <div className="flex flex-wrap min-h-10 items-center bg-dash-sidebar dark:bg-surface-100 py-1.5 gap-2">
         {customHeader ? (
-          customHeader
+          <div className="flex-1 px-1.5">{customHeader}</div>
         ) : snap.selectedRows.size > 0 ? (
-          <RowHeader tableQueriesEnabled={tableQueriesEnabled} />
+          <div className="flex-1 px-1.5">
+            <RowHeader tableQueriesEnabled={tableQueriesEnabled} />
+          </div>
         ) : (
-          <div className="flex-1 min-w-[300px] flex items-center gap-2">
+          <div className="w-full flex items-center gap-2 px-1.5 pb-1.5 border-b border-border">
             <FilterPopoverNew isRefetching={isRefetching} />
           </div>
         )}
-        <div className="flex items-center gap-2 overflow-x-auto">
+        <div className="flex items-center gap-2 overflow-x-auto px-1.5">
           {!customHeader && snap.selectedRows.size === 0 && (
             <SortPopover tableQueriesEnabled={tableQueriesEnabled} />
           )}

--- a/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
@@ -207,7 +207,7 @@ export const FilterPopoverNew = ({ isRefetching = false }: FilterPopoverProps) =
         actions={actions}
         isLoading={isGenerating}
         variant="pill"
-        className="bg-transparent border-0 overflow-visible"
+        className="bg-transparent border-0 overflow-visible px-1.5"
         icon={icon}
       />
     </div>

--- a/packages/ui-patterns/src/FilterBar/FilterCondition.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterCondition.tsx
@@ -265,7 +265,7 @@ export function FilterCondition({
     <div
       ref={wrapperRef}
       className={cn(
-        'flex items-stretch px-0 py-1 bg-muted group shrink-0',
+        'flex items-stretch px-0 h-[26px] bg-muted group shrink-0',
         variant === 'pill' ? 'rounded border' : 'border-r',
         isHighlighted && 'ring-2 ring-primary'
       )}

--- a/packages/ui-patterns/src/FilterBar/FilterGroup.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterGroup.tsx
@@ -139,11 +139,11 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
         path.length > 0
           ? "before:content-['('] before:text-foreground-muted after:content-[')'] after:text-foreground-muted"
           : ''
-      } ${isRootGroup ? 'flex-1 min-w-0' : ''} ${variant === 'pill' ? 'py-2' : ''}`}
+      } ${isRootGroup ? 'flex-1 min-w-0' : ''}`}
     >
       <div
         className={cn(
-          'flex items-stretch flex-wrap',
+          'flex items-center flex-wrap',
           isRootGroup ? 'flex-1 min-w-0' : '',
           variant === 'pill' ? 'gap-1' : 'gap-0'
         )}
@@ -195,7 +195,7 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
                 onFocus={() => handleGroupFreeformFocus(path)}
                 onBlur={handleFreeformBlur}
                 onKeyDown={handleFreeformKeyDown}
-                className="border-none bg-transparent text-xs focus:outline-none focus:ring-0 focus:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 w-full flex-1 h-auto min-w-0 px-2 py-0"
+                className="border-none bg-transparent text-xs focus:outline-none focus:ring-0 focus:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 w-full flex-1 h-auto min-w-0 px-2 py-1"
                 placeholder={
                   group.conditions.length === 0 ? emptyPlaceholder : 'Add more filters...'
                 }
@@ -207,7 +207,7 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
                 data-form-type="other"
               />
             ) : (
-              <div className="relative inline-block">
+              <div className="relative inline-block py-1">
                 <Input_Shadcn_
                   ref={freeformInputRef}
                   type="text"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

To reduce cramping on all viewports, we're giving the filter bar ui a full width row to breathe. It still wraps round if you have a lot of items in one field. This originates from [this](https://github.com/orgs/supabase/discussions/42461#discussioncomment-16207141) user discussion.

| Before | After |
|--------|--------|
| <img width="1085" height="181" alt="Screenshot 2026-03-20 at 14 46 27" src="https://github.com/user-attachments/assets/745f89dc-44c8-4387-8ab8-88a36f727b0d" /> | <img width="1076" height="194" alt="Screenshot 2026-03-20 at 14 46 42" src="https://github.com/user-attachments/assets/9675a072-0ea9-4fdb-96b7-0a0b0e60a17f" /> | 
