### PR TITLE
feat(read-replicas): bump up max read replicas for small instances

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
@@ -12,7 +12,7 @@ import { DocsButton } from '@/components/ui/DocsButton'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
 import { useEnablePhysicalBackupsMutation } from '@/data/database/enable-physical-backups-mutation'
 import { useProjectDetailQuery } from '@/data/projects/project-detail-query'
-import { MAX_REPLICAS_ABOVE_XL, MAX_REPLICAS_BELOW_XL } from '@/data/read-replicas/replicas-query'
+import { READ_REPLICAS_MAX_COUNT } from '@/data/read-replicas/replicas-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
@@ -222,11 +222,11 @@ export const ReadReplicaEligibilityWarnings = () => {
         title={`You can only deploy up to ${maxNumberOfReplicas} read replicas at once`}
       >
         <p>If you'd like to spin up another read replica, please drop an existing replica first.</p>
-        {maxNumberOfReplicas === MAX_REPLICAS_BELOW_XL && (
+        {maxNumberOfReplicas < READ_REPLICAS_MAX_COUNT && (
           <>
             <p>
               Alternatively, you may deploy up to{' '}
-              <span className="text-foreground">{MAX_REPLICAS_ABOVE_XL}</span> replicas if your
+              <span className="text-foreground">{READ_REPLICAS_MAX_COUNT}</span> replicas if your
               project is on an XL compute or higher.
             </p>
             <UpgradePlanButton

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica.ts
@@ -3,8 +3,8 @@ import { useMemo } from 'react'
 
 import { useOverdueInvoicesQuery } from '@/data/invoices/invoices-overdue-query'
 import {
-  MAX_REPLICAS_ABOVE_XL,
-  MAX_REPLICAS_BELOW_XL,
+  getMaxReplicas,
+  READ_REPLICA_COMPUTE_CAPS,
   useReadReplicasQuery,
 } from '@/data/read-replicas/replicas-query'
 import { useProjectAddonsQuery } from '@/data/subscriptions/project-addons-query'
@@ -41,14 +41,10 @@ export const useCheckEligibilityDeployReplica = () => {
   const currentComputeAddon = addons?.selected_addons.find(
     (addon) => addon.type === 'compute_instance'
   )?.variant.identifier
-  const isMinimallyOnSmallCompute =
-    currentComputeAddon !== undefined && currentComputeAddon !== 'ci_micro'
 
-  const maxNumberOfReplicas = ['ci_micro', 'ci_small', 'ci_medium', 'ci_large'].includes(
-    currentComputeAddon ?? 'ci_micro'
-  )
-    ? MAX_REPLICAS_BELOW_XL
-    : MAX_REPLICAS_ABOVE_XL
+  const isBelowSmallCompute =
+    currentComputeAddon === undefined || READ_REPLICA_COMPUTE_CAPS[currentComputeAddon] === 0
+  const maxNumberOfReplicas = getMaxReplicas(currentComputeAddon)
   const isReachedMaxReplicas =
     (databases ?? []).filter((db) => db.identifier !== projectRef).length >= maxNumberOfReplicas
 
@@ -62,11 +58,10 @@ export const useCheckEligibilityDeployReplica = () => {
     isAWSProvider &&
     hasReadReplicaAccess &&
     isWalgEnabled &&
-    currentComputeAddon !== undefined &&
     !hasOverdueInvoices &&
     !isAwsK8s &&
     !isProWithSpendCapEnabled &&
-    isMinimallyOnSmallCompute
+    !isBelowSmallCompute
 
   return {
     can: canDeployReplica,
@@ -74,7 +69,7 @@ export const useCheckEligibilityDeployReplica = () => {
     isAWSProvider,
     isAwsK8s,
     isPgVersionBelow15: currentPgVersion < 15,
-    isBelowSmallCompute: !isMinimallyOnSmallCompute,
+    isBelowSmallCompute,
     isWalgNotEnabled: !isWalgEnabled,
     isProWithSpendCapEnabled,
     isReachedMaxReplicas,

--- a/apps/studio/data/read-replicas/replicas-query.test.ts
+++ b/apps/studio/data/read-replicas/replicas-query.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getMaxReplicas,
+  READ_REPLICA_COMPUTE_CAPS,
+  READ_REPLICAS_MAX_COUNT,
+} from './replicas-query'
+
+describe('getMaxReplicas', () => {
+  it('returns 0 for ineligible compute sizes (pico, nano, micro)', () => {
+    expect(getMaxReplicas('ci_pico')).toBe(0)
+    expect(getMaxReplicas('ci_nano')).toBe(0)
+    expect(getMaxReplicas('ci_micro')).toBe(0)
+  })
+
+  it('returns 4 for ci_small', () => {
+    expect(getMaxReplicas('ci_small')).toBe(4)
+  })
+
+  it('returns 4 for ci_medium', () => {
+    expect(getMaxReplicas('ci_medium')).toBe(4)
+  })
+
+  it('returns 4 for ci_large', () => {
+    expect(getMaxReplicas('ci_large')).toBe(4)
+  })
+
+  it('returns READ_REPLICAS_MAX_COUNT for ci_xlarge and above', () => {
+    expect(getMaxReplicas('ci_xlarge')).toBe(READ_REPLICAS_MAX_COUNT)
+    expect(getMaxReplicas('ci_2xlarge')).toBe(READ_REPLICAS_MAX_COUNT)
+  })
+
+  it('returns READ_REPLICAS_MAX_COUNT for any unknown compute tier', () => {
+    expect(getMaxReplicas('unknown_tier')).toBe(READ_REPLICAS_MAX_COUNT)
+  })
+
+  it('returns READ_REPLICAS_MAX_COUNT when no compute addon is provided', () => {
+    expect(getMaxReplicas(undefined)).toBe(READ_REPLICAS_MAX_COUNT)
+  })
+
+  it('all eligible READ_REPLICA_COMPUTE_CAPS are greater than 0 and at most READ_REPLICAS_MAX_COUNT', () => {
+    for (const [key, cap] of Object.entries(READ_REPLICA_COMPUTE_CAPS)) {
+      if (cap > 0) {
+        expect(cap).toBeLessThanOrEqual(READ_REPLICAS_MAX_COUNT)
+      }
+    }
+  })
+})

--- a/apps/studio/data/read-replicas/replicas-query.ts
+++ b/apps/studio/data/read-replicas/replicas-query.ts
@@ -9,8 +9,23 @@ import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-export const MAX_REPLICAS_BELOW_XL = 2
-export const MAX_REPLICAS_ABOVE_XL = 5
+/**
+ * Unless explicitly defined here, caps default to `READ_REPLICAS_MAX_COUNT`.
+ */
+export const READ_REPLICA_COMPUTE_CAPS: Record<string, number> = {
+  ci_pico: 0,
+  ci_nano: 0,
+  ci_micro: 0,
+  ci_small: 4,
+  ci_medium: 4,
+  ci_large: 4,
+}
+
+export const READ_REPLICAS_MAX_COUNT = 5
+
+export function getMaxReplicas(computeAddon?: string): number {
+  return READ_REPLICA_COMPUTE_CAPS[`${computeAddon}`] ?? READ_REPLICAS_MAX_COUNT
+}
 
 export type ReadReplicasVariables = {
   projectRef?: string

--- a/apps/studio/tests/components/Database/Replication/ReadReplicaEligibilityWarnings.test.tsx
+++ b/apps/studio/tests/components/Database/Replication/ReadReplicaEligibilityWarnings.test.tsx
@@ -1,0 +1,87 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ReadReplicaEligibilityWarnings } from '@/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings'
+import { useCheckEligibilityDeployReplica } from '@/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica'
+import { READ_REPLICAS_MAX_COUNT } from '@/data/read-replicas/replicas-query'
+import { customRender } from '@/tests/lib/custom-render'
+
+vi.mock(
+  'components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/useCheckEligibilityDeployReplica'
+)
+vi.mock('data/projects/project-detail-query', () => ({
+  useProjectDetailQuery: () => ({ data: undefined, isSuccess: false }),
+}))
+vi.mock('data/database/enable-physical-backups-mutation', () => ({
+  useEnablePhysicalBackupsMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+vi.mock('hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: () => ({ data: { slug: 'test-org' } }),
+}))
+vi.mock('hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({ data: { dbVersion: 'supabase-postgres-15.1.0' } }),
+}))
+
+const eligibility = (delta: Record<string, unknown>) => ({
+  can: false,
+  hasOverdueInvoices: false,
+  isAWSProvider: true,
+  isAwsK8s: false,
+  isPgVersionBelow15: false,
+  isBelowSmallCompute: false,
+  isWalgNotEnabled: false,
+  isProWithSpendCapEnabled: false,
+  isReachedMaxReplicas: false,
+  maxNumberOfReplicas: READ_REPLICAS_MAX_COUNT,
+  ...delta,
+})
+
+describe('ReadReplicaEligibilityWarnings – below small compute', () => {
+  it('shows upgrade CTA when project is on pico, nano, or micro compute', () => {
+    vi.mocked(useCheckEligibilityDeployReplica).mockReturnValue(
+      eligibility({ isBelowSmallCompute: true })
+    )
+
+    customRender(<ReadReplicaEligibilityWarnings />)
+
+    expect(
+      screen.getByText('Project required to at least be on a Small compute')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "This is to ensure that read replicas can keep up with the primary databases' activities."
+      )
+    ).toBeInTheDocument()
+  })
+})
+
+describe('ReadReplicaEligibilityWarnings – max replicas reached', () => {
+  it('shows upsell to upgrade compute when below the default cap (e.g. ci_small/medium/large → 4 replicas)', () => {
+    vi.mocked(useCheckEligibilityDeployReplica).mockReturnValue(
+      eligibility({ isReachedMaxReplicas: true, maxNumberOfReplicas: 4 })
+    )
+
+    customRender(<ReadReplicaEligibilityWarnings />)
+
+    expect(
+      screen.getByText('You can only deploy up to 4 read replicas at once')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/you may deploy up to/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /change compute size/i })).toBeInTheDocument()
+  })
+
+  it('does NOT show the compute upsell when already at the default cap (XL+)', () => {
+    vi.mocked(useCheckEligibilityDeployReplica).mockReturnValue(
+      eligibility({ isReachedMaxReplicas: true, maxNumberOfReplicas: READ_REPLICAS_MAX_COUNT })
+    )
+
+    customRender(<ReadReplicaEligibilityWarnings />)
+
+    expect(
+      screen.getByText(`You can only deploy up to ${READ_REPLICAS_MAX_COUNT} read replicas at once`)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/you may deploy up to/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/XL compute or higher/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /change compute size/i })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
INDATA-193
BACKEND: <https://github.com/supabase/platform/pull/30575>

<img width="1199" height="1005" alt="Screenshot 2026-04-03 at 11 54 29" src="https://github.com/user-attachments/assets/38e9d676-449f-45c0-9e07-f273312a812f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated read replica limit configuration to provide more consistent behavior across different compute tiers.

* **Tests**
  * Added comprehensive test coverage for read replica eligibility checks and replica limit calculations based on compute tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->