### PR TITLE
fix: remove client router filter

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -33,6 +33,9 @@ const nextConfig = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   assetPrefix: getAssetPrefix(),
   output: 'standalone',
+  experimental: {
+    clientRouterFilter: false,
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

We have users reporting random four oh fours in the dashboard. We can't reproduce locally, but this is pointing to an next js issue.

The reason is the users were getting appended a double /dashboard route. it all points to 80852 in next js, double base path. We added app dir recently as well 

https://github.com/vercel/next.js/issues/80852
