### PR TITLE
fix: suppress misleading toast when navigating away from a deleted project

### DIFF
--- a/apps/studio/components/interfaces/App/RouteValidationWrapper.tsx
+++ b/apps/studio/components/interfaces/App/RouteValidationWrapper.tsx
@@ -52,7 +52,7 @@ export const RouteValidationWrapper = ({ children }: PropsWithChildren<{}>) => {
     return excemptUrls.includes(router?.pathname)
   }
 
-  const { isError: isErrorProject } = useProjectDetailQuery({ ref })
+  const { isError: isErrorProject, error: projectError } = useProjectDetailQuery({ ref })
 
   const { data: organizations, isSuccess: orgsInitialized } = useOrganizationsQuery({
     enabled: isLoggedIn,
@@ -82,7 +82,10 @@ export const RouteValidationWrapper = ({ children }: PropsWithChildren<{}>) => {
 
     // A successful request to project details will validate access to both project and branches
     if (!!ref && isErrorProject) {
-      toast.error('You do not have access to this project')
+      // 404 means the project no longer exists (e.g. was deleted), not an access error
+      if (projectError?.code !== 404) {
+        toast.error('You do not have access to this project')
+      }
       router.push(DEFAULT_HOME)
       return
     }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a user deletes a project, the `useProjectDetailQuery` in `RouteValidationWrapper` returns an error (HTTP 404) because the project no longer exists. This triggers the `isErrorProject` effect, which shows a "You do not have access to this project" toast and redirects to the home page — even though the user intentionally deleted the project.

## What is the new behavior?

The error's HTTP status code is checked before showing the toast. A 404 response (project not found / deleted) silently redirects without showing the misleading access-denied toast. The toast is still shown for other error codes (e.g. 403 Forbidden), where the "no access" message is accurate.

## Additional context

Resolves FE-2831