### PR TITLE
fix: reset identity sequences after CSV import to prevent unique key violations

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { getUpdateIdentitySequenceSQL } from '@supabase/pg-meta'
 import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
@@ -9,6 +10,7 @@ import {
 import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { type GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import { DiscardChangesConfirmationDialog } from 'components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
+import { executeSql } from 'data/sql/execute-sql-query'
 import { databasePoliciesKeys } from 'data/database-policies/keys'
 import { useDatabasePublicationCreateMutation } from 'data/database-publications/database-publications-create-mutation'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
@@ -957,6 +959,30 @@ export const SidePanelEditor = ({
       if (res.error) {
         toast.error(`Failed to import data: ${res.error.message}`, { id: toastId })
         return resolve()
+      }
+    }
+
+    // For identity columns, manually raise the sequences to avoid unique key violations
+    const identityColumns = (selectedTable.columns ?? []).filter((col) => col.is_identity)
+    if (identityColumns.length > 0) {
+      const updateSequenceSQL = identityColumns
+        .map((col) =>
+          getUpdateIdentitySequenceSQL({
+            schema: selectedTable.schema,
+            table: selectedTable.name,
+            column: col.name,
+          })
+        )
+        .join(';\n')
+      try {
+        await executeSql({
+          projectRef: project.ref,
+          connectionString: project.connectionString,
+          sql: updateSequenceSQL,
+          queryKey: ['sequences', 'update-batch'],
+        })
+      } catch (error) {
+        console.warn('Failed to update identity sequences after import:', error)
       }
     }
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -10,7 +10,6 @@ import {
 import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { type GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
 import { DiscardChangesConfirmationDialog } from 'components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
-import { executeSql } from 'data/sql/execute-sql-query'
 import { databasePoliciesKeys } from 'data/database-policies/keys'
 import { useDatabasePublicationCreateMutation } from 'data/database-publications/database-publications-create-mutation'
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
@@ -22,6 +21,7 @@ import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 import { entityTypeKeys } from 'data/entity-types/keys'
 import { lintKeys } from 'data/lint/keys'
 import { privilegeKeys } from 'data/privileges/keys'
+import { executeSql } from 'data/sql/execute-sql-query'
 import { tableEditorKeys } from 'data/table-editor/keys'
 import { isTableLike, type Entity } from 'data/table-editor/table-editor-types'
 import { tableRowKeys } from 'data/table-rows/keys'
@@ -983,6 +983,9 @@ export const SidePanelEditor = ({
         })
       } catch (error) {
         console.warn('Failed to update identity sequences after import:', error)
+        toast.warning(
+          'Data imported but identity sequences could not be updated. New inserts may need manual ID assignment until sequences are reset.'
+        )
       }
     }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When importing data via CSV into an existing table with identity columns, PostgreSQL sequences are not updated to reflect the imported values. This causes unique key violations on subsequent inserts because the sequence still starts from 1 (or its previous value), conflicting with the imported IDs.

Fixes #43993

## What is the new behavior?

After a successful CSV import into an existing table, the identity column sequences are now reset to the maximum value in the table using `setval()`. This mirrors the existing behavior in the `createTable` flow (SidePanelEditor.utils.tsx) which already correctly handles this case.

The sequence reset is non-blocking — if it fails, the import still succeeds (data is already inserted) and a warning is logged.

## Additional context

The fix reuses the existing `getUpdateIdentitySequenceSQL` utility from `@supabase/pg-meta` which is already battle-tested in the table creation flow. The only difference is that `onImportData` works with `RetrieveTableResult` columns (snake_case `is_identity`) rather than the internal editor format (camelCase `isIdentity`).