### PR TITLE
feat: add docs button for custom auth providers

### DIFF
--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/index.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/index.tsx
@@ -1,6 +1,7 @@
 import { Badge } from 'ui'
 import {
   PageSection,
+  PageSectionAside,
   PageSectionContent,
   PageSectionDescription,
   PageSectionMeta,
@@ -8,6 +9,8 @@ import {
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
 
+import { DocsButton } from 'components/ui/DocsButton'
+import { DOCS_URL } from 'lib/constants'
 import { CustomAuthProvidersList } from './CustomAuthProvidersList'
 
 export const CustomAuthProviders = () => {
@@ -23,6 +26,9 @@ export const CustomAuthProviders = () => {
             Configure OAuth/OIDC providers for this project using your own issuer or endpoints.
           </PageSectionDescription>
         </PageSectionSummary>
+        <PageSectionAside>
+          <DocsButton href={`${DOCS_URL}/guides/auth/custom-oauth-providers`} />
+        </PageSectionAside>
       </PageSectionMeta>
       <PageSectionContent>
         <CustomAuthProvidersList />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add docs button for custom auth providers

## What is the current behavior?

no docs button

## What is the new behavior?

add docs button

<img width="1836" height="148" alt="image-VZhcSrrE@2x" src="https://github.com/user-attachments/assets/1e37d848-1195-4464-a542-e90d02ec08fc" />

