### PR TITLE
feat: allow newlines in SMS OTP templates for WebOTP support

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -106,6 +106,14 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       payload.PASSWORD_REQUIRED_CHARACTERS = ''
     }
 
+    // [Fix] Support newlines in SMS templates for WebOTP support (Issue #6435)
+    if (typeof payload.SMS_TEMPLATE === 'string') {
+      payload.SMS_TEMPLATE = payload.SMS_TEMPLATE.replace(/\\n/g, '\n')
+    }
+    if (typeof payload.MFA_PHONE_TEMPLATE === 'string') {
+      payload.MFA_PHONE_TEMPLATE = payload.MFA_PHONE_TEMPLATE.replace(/\\n/g, '\n')
+    }
+
     updateAuthConfig(
       { projectRef: projectRef!, config: payload },
       {


### PR DESCRIPTION
This PR addresses issue #6435 by allowing users to include newlines in their SMS OTP templates. 

**The Problem:**
The WebOTP API requires SMS messages to contain at least one newline to be automatically handled by mobile devices. Users reported that literal line breaks or "\n" strings were not working.

**The Solution:**
Added a transformation logic in the Studio's `ProviderForm` to convert literal "\n" strings into real newline characters before saving the configuration. This allows users to conform to the WebOTP format requirements directly from the dashboard.

Closes #6435