### PR TITLE
Fix missing edge when deploying a new RR, and add some small qol tidbits

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaEligibilityWarnings.tsx
@@ -208,7 +208,9 @@ export const ReadReplicaEligibilityWarnings = () => {
           source="read-replicas"
           addon="spendCap"
           className="mt-2"
-        />
+        >
+          Disable spend cap
+        </UpgradePlanButton>
       </Admonition>
     )
   }

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Edges.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Edges.tsx
@@ -1,0 +1,102 @@
+import { useParams } from 'common'
+import { useReplicationLagQuery } from 'data/read-replicas/replica-lag-query'
+import { formatDatabaseID } from 'data/read-replicas/replicas.utils'
+import { Loader2, X } from 'lucide-react'
+import type { EdgeProps } from 'reactflow'
+import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath } from 'reactflow'
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+export const SmoothstepEdge = ({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd,
+  data,
+}: EdgeProps) => {
+  const { ref } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const { type, identifier, isComingUp, isReplicating, isFailed, shiftEdgeEnd } = data || {}
+  const formattedId = type === 'replica' ? formatDatabaseID(identifier ?? '') : identifier
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  })
+
+  const {
+    data: lagDuration,
+    isPending: isLoading,
+    isError,
+  } = useReplicationLagQuery(
+    {
+      id: identifier,
+      projectRef: ref,
+      connectionString: project?.connectionString,
+    },
+    { enabled: type === 'replica' && isReplicating, refetchInterval: 10000 }
+  )
+  const lagValue = Number(lagDuration?.toFixed(2) ?? 0).toLocaleString()
+  const hasReplicationLagData = data !== undefined && !isError && isReplicating
+
+  return (
+    <>
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+
+      {isFailed && (
+        <EdgeLabelRenderer>
+          <div
+            className={cn('bg-surface-100 p-1 rounded absolute nodrag nopan border')}
+            style={{
+              transform: `translate(-50%, -50%) translate(${targetX - 30}px,${targetY}px)`,
+            }}
+          >
+            <X size={12} strokeWidth={4} className="text-destructive" />
+          </div>
+        </EdgeLabelRenderer>
+      )}
+
+      {(isComingUp || hasReplicationLagData) && (
+        <EdgeLabelRenderer>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={cn(
+                  'bg-surface-100 py-1 rounded absolute nodrag nopan border',
+                  isLoading || isComingUp ? 'px-1' : 'px-1.5'
+                )}
+                style={{
+                  transform: `translate(-50%, -50%) translate(${shiftEdgeEnd ? targetX - 30 : labelX}px,${shiftEdgeEnd ? targetY : labelY}px)`,
+                  pointerEvents: 'all',
+                }}
+              >
+                {isLoading || isComingUp ? (
+                  <Loader2 size={12} className="animate-spin" />
+                ) : (
+                  <p className="font-mono text-xs">{lagValue}s</p>
+                )}
+              </div>
+            </TooltipTrigger>
+            {!isComingUp && (
+              <TooltipContent side="bottom" align="center">
+                {isLoading
+                  ? `Checking replication lag for replica ID: ${formattedId}`
+                  : `Replication lag (seconds) for replica ID: ${formattedId}`}
+              </TooltipContent>
+            )}
+          </Tooltip>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.tsx
@@ -59,7 +59,11 @@ export const PrimaryDatabaseNode = () => {
           src={`${BASE_PATH}/img/regions/${project?.region}.svg`}
         />
       )}
-      {hasReplication && <Handle type="source" position={Position.Right} className="opacity-25" />}
+      <Handle
+        type="source"
+        position={Position.Right}
+        className={hasReplication ? 'opacity-25' : 'opacity-0'}
+      />
     </NodeContainer>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/index.tsx
@@ -16,6 +16,9 @@ import { timeout } from '@/lib/helpers'
 
 import 'reactflow/dist/style.css'
 
+import { SmoothstepEdge } from './Edges'
+import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
+
 export const ReplicationDiagram = () => {
   return (
     <ReactFlowProvider>
@@ -30,6 +33,8 @@ const nodeTypes = {
   readReplica: ReadReplicaNode,
 }
 
+const edgeTypes = { smoothstep: SmoothstepEdge }
+
 const ReplicationDiagramContent = () => {
   const reactFlow = useReactFlow()
   const { resolvedTheme } = useTheme()
@@ -39,7 +44,10 @@ const ReplicationDiagramContent = () => {
   const { data: databases = [], isSuccess: isSuccessReplicas } = useReadReplicasQuery({
     projectRef,
   })
-  const readReplicas = databases.filter((x) => x.identifier !== projectRef)
+  const readReplicas = useMemo(
+    () => databases.filter((x) => x.identifier !== projectRef),
+    [databases, projectRef]
+  )
 
   const { data, isSuccess: isSuccessDestinations } = useReplicationDestinationsQuery({
     projectRef,
@@ -82,6 +90,20 @@ const ReplicationDiagramContent = () => {
             opacity: isReplicating ? 1 : 0.4,
             strokeDasharray: isReplicating ? undefined : '5 5',
           },
+          data: {
+            type: 'replica',
+            identifier: x.identifier,
+            shiftEdgeEnd: readReplicas.length + destinations.length > 1,
+            isReplicating,
+            isComingUp: [
+              REPLICA_STATUS.COMING_UP,
+              REPLICA_STATUS.INIT_READ_REPLICA,
+              REPLICA_STATUS.UNKNOWN,
+            ].includes(x.status),
+            isFailed: [REPLICA_STATUS.ACTIVE_UNHEALTHY, REPLICA_STATUS.INIT_FAILED].includes(
+              x.status
+            ),
+          },
         }
       }),
       ...destinations.map((x) => {
@@ -103,6 +125,14 @@ const ReplicationDiagramContent = () => {
             opacity: isReplicating ? 1 : 0.4,
             strokeDasharray: isReplicating ? undefined : '5 5',
           },
+          data: {
+            type: 'etl',
+            identifier: x.id,
+            shiftEdgeEnd: readReplicas.length + destinations.length > 1,
+            isReplicating,
+            isComingUp: ['starting'].includes(statusName ?? ''),
+            isFailed: ['failed'].includes(statusName ?? ''),
+          },
         }
       }),
     ]
@@ -122,7 +152,9 @@ const ReplicationDiagramContent = () => {
   }
 
   useEffect(() => {
-    if (nodes.length > 0 && isSuccessDestinations && isSuccessReplicas) setReactFlow()
+    if (nodes.length > 0 && isSuccessDestinations && isSuccessReplicas) {
+      setReactFlow()
+    }
   }, [nodes, isSuccessDestinations, isSuccessReplicas])
 
   return (
@@ -141,6 +173,7 @@ const ReplicationDiagramContent = () => {
         defaultNodes={[]}
         defaultEdges={[]}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         proOptions={{ hideAttribution: true }}
       >
         <Background color={backgroundPatternColor} />


### PR DESCRIPTION
## Context

Edge between replica and primary DB was missing when the replica is first initialized, so this PR primarily fixes that.

## Other changes
Also just adding in some tiny QoL nudges
- Add replication lag if its a read replica
- Add a loader edge label if the target is coming up
- Add a "X" edge label if the target status failed

<img width="752" height="171" alt="image" src="https://github.com/user-attachments/assets/c77eae12-1608-4c05-a0bc-66204f3e125e" />

<img width="684" height="396" alt="image" src="https://github.com/user-attachments/assets/f15f0914-0915-4cf3-8c28-8a80b3f97d54" />
