### PR TITLE
feat(observability): add infinite scroll pagination to query performance

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.tsx
@@ -1,21 +1,27 @@
-import { useEffect } from 'react'
-
-import { WithStatements } from './WithStatements/WithStatements'
 import { useParams } from 'common'
 import { DbQueryHook } from 'hooks/analytics/useDbQuery'
+import { useEffect } from 'react'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
+
 import { PresetHookResult } from '../Reports/Reports.utils'
+import { WithStatements } from './WithStatements/WithStatements'
 
 interface QueryPerformanceProps {
   queryHitRate: PresetHookResult
   queryPerformanceQuery: DbQueryHook<any>
   queryMetrics: PresetHookResult
+  pageSize: number
+  onPageSizeChange: (size: number | null) => void
+  onLoadMore: () => void
 }
 
 export const QueryPerformance = ({
   queryHitRate,
   queryPerformanceQuery,
   queryMetrics,
+  pageSize,
+  onPageSizeChange,
+  onLoadMore,
 }: QueryPerformanceProps) => {
   const { ref } = useParams()
   const state = useDatabaseSelectorStateSnapshot()
@@ -30,6 +36,9 @@ export const QueryPerformance = ({
       queryHitRate={queryHitRate}
       queryPerformanceQuery={queryPerformanceQuery}
       queryMetrics={queryMetrics}
+      pageSize={pageSize}
+      onPageSizeChange={onPageSizeChange}
+      onLoadMore={onLoadMore}
     />
   )
 }

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.types.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformance.types.ts
@@ -55,4 +55,5 @@ export type QueryPerformanceSQLParams = {
   minTotalTime?: number
   runIndexAdvisor?: boolean
   filterIndexAdvisor?: boolean
+  limit?: number
 }

--- a/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryPerformanceGrid.tsx
@@ -1,29 +1,37 @@
-import { ArrowDown, ArrowRight, ArrowUp, ChevronDown, TextSearch } from 'lucide-react'
+import { useParams } from 'common'
+import { NumericFilter } from 'components/interfaces/Reports/v2/ReportsNumericFilter'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { ArrowDown, ArrowRight, ArrowUp, ChevronDown, Loader2, TextSearch } from 'lucide-react'
+import { parseAsArrayOf, parseAsJson, parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import DataGrid, { Column, DataGridHandle, Row } from 'react-data-grid'
-
-import { useParams } from 'common'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import {
   Button,
+  cn,
   CodeBlock,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
   Sheet,
   SheetContent,
   SheetDescription,
   SheetTitle,
+  Tabs_Shadcn_,
   TabsContent_Shadcn_,
   TabsList_Shadcn_,
   TabsTrigger_Shadcn_,
-  Tabs_Shadcn_,
-  cn,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
-import { Admonition } from 'ui-patterns'
+
+import { PAGE_SIZE_OPTIONS } from './hooks/useQueryPerformancePagination'
 import { useQueryPerformanceSort } from './hooks/useQueryPerformanceSort'
 import {
   hasIndexRecommendations,
@@ -38,8 +46,6 @@ import {
 } from './QueryPerformance.constants'
 import { QueryPerformanceRow } from './QueryPerformance.types'
 import { formatDuration } from './QueryPerformance.utils'
-import { parseAsString, parseAsArrayOf, parseAsJson, useQueryStates } from 'nuqs'
-import { NumericFilter } from 'components/interfaces/Reports/v2/ReportsNumericFilter'
 
 interface QueryPerformanceGridProps {
   aggregatedData: QueryPerformanceRow[]
@@ -48,6 +54,11 @@ interface QueryPerformanceGridProps {
   currentSelectedQuery?: string | null
   onCurrentSelectQuery?: (query: string) => void
   onRetry?: () => void
+  pageSize: number
+  hasMore: boolean
+  onPageSizeChange: (size: number | null) => void
+  onLoadMore: () => void
+  isLoadingMore: boolean
 }
 
 const calculateTimeConsumedWidth = (data: QueryPerformanceRow[]) => {
@@ -79,6 +90,11 @@ export const QueryPerformanceGrid = ({
   currentSelectedQuery,
   onCurrentSelectQuery,
   onRetry,
+  pageSize,
+  hasMore,
+  onPageSizeChange,
+  onLoadMore,
+  isLoadingMore,
 }: QueryPerformanceGridProps) => {
   const { sort, setSortConfig } = useQueryPerformanceSort()
   const gridRef = useRef<DataGridHandle>(null)
@@ -456,6 +472,35 @@ export const QueryPerformanceGrid = ({
     }
   }, [handleKeyDown])
 
+  // Infinite scroll: detect when user scrolls near the bottom of the DataGrid.
+  const loadMoreFiredRef = useRef(false)
+
+  // Reset the guard when loading finishes so the next scroll can fire
+  useEffect(() => {
+    if (!isLoadingMore) {
+      loadMoreFiredRef.current = false
+    }
+  }, [isLoadingMore])
+
+  useEffect(() => {
+    const container = dataGridContainerRef.current
+    const gridElement = container?.querySelector<HTMLDivElement>('.rdg')
+    if (!gridElement || !hasMore) return
+
+    const handleScroll = () => {
+      if (isLoading || isLoadingMore || loadMoreFiredRef.current) return
+      const { scrollTop, scrollHeight, clientHeight } = gridElement
+      const nearBottom = scrollTop + clientHeight >= scrollHeight - 100
+      if (nearBottom) {
+        loadMoreFiredRef.current = true
+        onLoadMore()
+      }
+    }
+
+    gridElement.addEventListener('scroll', handleScroll, { passive: true })
+    return () => gridElement.removeEventListener('scroll', handleScroll)
+  }, [hasMore, isLoading, isLoadingMore, onLoadMore])
+
   const isSelectQuery = (query: string | undefined): boolean => {
     if (!query) return false
     const formattedQuery = query.trim().toLowerCase()
@@ -502,149 +547,182 @@ export const QueryPerformanceGrid = ({
   const canShowIndexesTab = isSelectQuery(selectedQuery) && !isProtectedSchemaQuery
 
   return (
-    <div className="relative flex flex-grow bg-alternative min-h-0">
-      <div ref={dataGridContainerRef} className="flex-1 min-w-0 overflow-x-auto">
-        <DataGrid
-          ref={gridRef}
-          style={{ height: '100%' }}
-          className={cn('flex-1 flex-grow h-full')}
-          rowHeight={44}
-          headerRowHeight={36}
-          columns={columns}
-          rows={reportData}
-          rowClass={(_, idx) => {
-            const isSelected = idx === selectedRow
-            const query = reportData[idx]?.query
-            const isCharted = currentSelectedQuery ? currentSelectedQuery === query : false
-            const hasRecommendations = hasIndexRecommendations(
-              reportData[idx]?.index_advisor_result,
-              true
-            )
-
-            return [
-              `${isSelected ? (hasRecommendations ? 'bg-warning/10 hover:bg-warning/20' : 'bg-surface-300 dark:bg-surface-300') : hasRecommendations ? 'bg-warning/10 hover:bg-warning/20' : 'bg-200 hover:bg-surface-200'} cursor-pointer`,
-              `${isSelected ? (hasRecommendations ? '[&>div:first-child]:border-l-4 border-l-warning [&>div]:border-l-warning' : '[&>div:first-child]:border-l-4 border-l-secondary [&>div]:!border-l-foreground') : ''}`,
-              `${isCharted ? 'bg-surface-200 dark:bg-surface-200' : ''}`,
-              `${isCharted ? '[&>div:first-child]:border-l-4 border-l-secondary [&>div]:border-l-brand' : ''}`,
-              '[&>.rdg-cell]:box-border [&>.rdg-cell]:outline-none [&>.rdg-cell]:shadow-none',
-              '[&>.rdg-cell.column-prop_total_time]:relative',
-            ].join(' ')
-          }}
-          renderers={{
-            renderRow(idx, props) {
-              return (
-                <Row
-                  {...props}
-                  key={`qp-row-${props.rowIdx}`}
-                  onClick={(event) => {
-                    event.stopPropagation()
-
-                    if (typeof idx === 'number' && idx >= 0) {
-                      if (onCurrentSelectQuery) {
-                        const query = reportData[idx]?.query
-                        if (query) {
-                          onCurrentSelectQuery(query)
-                        }
-                      } else {
-                        setSelectedRow(idx)
-                        const hasRecommendations = hasIndexRecommendations(
-                          reportData[idx]?.index_advisor_result,
-                          true
-                        )
-                        setView(hasRecommendations ? 'suggestion' : 'details')
-                        gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
-                      }
-                    }
-                  }}
-                />
+    <div className="relative flex flex-col flex-grow bg-alternative min-h-0">
+      <div className="relative flex flex-grow min-h-0">
+        <div ref={dataGridContainerRef} className="flex-1 min-w-0 overflow-x-auto">
+          <DataGrid
+            ref={gridRef}
+            style={{ height: '100%' }}
+            className={cn('flex-1 flex-grow h-full')}
+            rowHeight={44}
+            headerRowHeight={36}
+            columns={columns}
+            rows={reportData}
+            rowClass={(_, idx) => {
+              const isSelected = idx === selectedRow
+              const query = reportData[idx]?.query
+              const isCharted = currentSelectedQuery ? currentSelectedQuery === query : false
+              const hasRecommendations = hasIndexRecommendations(
+                reportData[idx]?.index_advisor_result,
+                true
               )
-            },
-            noRowsFallback: isLoading ? (
-              <div className="absolute top-14 px-6 w-full">
-                <GenericSkeletonLoader />
-              </div>
-            ) : (
-              <div className="absolute top-20 px-6 flex flex-col items-center justify-center w-full gap-y-2">
-                <TextSearch className="text-foreground-muted" strokeWidth={1} />
-                <div className="text-center">
-                  <p className="text-foreground">No queries detected</p>
-                  <p className="text-foreground-light">
-                    There are no actively running queries that match the criteria
-                  </p>
-                </div>
-              </div>
-            ),
-          }}
-        />
-      </div>
 
-      <Sheet
-        open={selectedRow !== undefined}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSelectedRow(undefined)
-          }
-        }}
-        modal={false}
-      >
-        <SheetTitle className="sr-only">Query details</SheetTitle>
-        <SheetDescription className="sr-only">
-          Query Performance Details &amp; Indexes
-        </SheetDescription>
-        <SheetContent
-          side="right"
-          className="flex flex-col h-full bg-studio border-l lg:!w-[calc(100vw-802px)] max-w-[700px] w-full"
-          hasOverlay={false}
-          onInteractOutside={(event) => {
-            if (dataGridContainerRef.current?.contains(event.target as Node)) {
-              event.preventDefault()
+              return [
+                `${isSelected ? (hasRecommendations ? 'bg-warning/10 hover:bg-warning/20' : 'bg-surface-300 dark:bg-surface-300') : hasRecommendations ? 'bg-warning/10 hover:bg-warning/20' : 'bg-200 hover:bg-surface-200'} cursor-pointer`,
+                `${isSelected ? (hasRecommendations ? '[&>div:first-child]:border-l-4 border-l-warning [&>div]:border-l-warning' : '[&>div:first-child]:border-l-4 border-l-secondary [&>div]:!border-l-foreground') : ''}`,
+                `${isCharted ? 'bg-surface-200 dark:bg-surface-200' : ''}`,
+                `${isCharted ? '[&>div:first-child]:border-l-4 border-l-secondary [&>div]:border-l-brand' : ''}`,
+                '[&>.rdg-cell]:box-border [&>.rdg-cell]:outline-none [&>.rdg-cell]:shadow-none',
+                '[&>.rdg-cell.column-prop_total_time]:relative',
+              ].join(' ')
+            }}
+            renderers={{
+              renderRow(idx, props) {
+                return (
+                  <Row
+                    {...props}
+                    key={`qp-row-${props.rowIdx}`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+
+                      if (typeof idx === 'number' && idx >= 0) {
+                        if (onCurrentSelectQuery) {
+                          const query = reportData[idx]?.query
+                          if (query) {
+                            onCurrentSelectQuery(query)
+                          }
+                        } else {
+                          setSelectedRow(idx)
+                          const hasRecommendations = hasIndexRecommendations(
+                            reportData[idx]?.index_advisor_result,
+                            true
+                          )
+                          setView(hasRecommendations ? 'suggestion' : 'details')
+                          gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
+                        }
+                      }
+                    }}
+                  />
+                )
+              },
+              noRowsFallback: isLoading ? (
+                <div className="absolute top-14 px-6 w-full">
+                  <GenericSkeletonLoader />
+                </div>
+              ) : (
+                <div className="absolute top-20 px-6 flex flex-col items-center justify-center w-full gap-y-2">
+                  <TextSearch className="text-foreground-muted" strokeWidth={1} />
+                  <div className="text-center">
+                    <p className="text-foreground">No queries detected</p>
+                    <p className="text-foreground-light">
+                      There are no actively running queries that match the criteria
+                    </p>
+                  </div>
+                </div>
+              ),
+            }}
+          />
+        </div>
+
+        <Sheet
+          open={selectedRow !== undefined}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSelectedRow(undefined)
             }
           }}
+          modal={false}
         >
-          <Tabs_Shadcn_
-            value={view}
-            className="flex flex-col h-full"
-            onValueChange={(value: any) => setView(value)}
+          <SheetTitle className="sr-only">Query details</SheetTitle>
+          <SheetDescription className="sr-only">
+            Query Performance Details &amp; Indexes
+          </SheetDescription>
+          <SheetContent
+            side="right"
+            className="flex flex-col h-full bg-studio border-l lg:!w-[calc(100vw-802px)] max-w-[700px] w-full"
+            hasOverlay={false}
+            onInteractOutside={(event) => {
+              if (dataGridContainerRef.current?.contains(event.target as Node)) {
+                event.preventDefault()
+              }
+            }}
           >
-            <div className="px-5 border-b">
-              <TabsList_Shadcn_ className="px-0 flex gap-x-4 min-h-[46px] border-b-0 [&>button]:h-[47px]">
-                <TabsTrigger_Shadcn_
-                  value="details"
-                  className="px-0 pb-0 data-[state=active]:bg-transparent !shadow-none"
-                >
-                  Query details
-                </TabsTrigger_Shadcn_>
-                {selectedRow !== undefined && canShowIndexesTab && (
+            <Tabs_Shadcn_
+              value={view}
+              className="flex flex-col h-full"
+              onValueChange={(value: any) => setView(value)}
+            >
+              <div className="px-5 border-b">
+                <TabsList_Shadcn_ className="px-0 flex gap-x-4 min-h-[46px] border-b-0 [&>button]:h-[47px]">
                   <TabsTrigger_Shadcn_
-                    value="suggestion"
+                    value="details"
                     className="px-0 pb-0 data-[state=active]:bg-transparent !shadow-none"
                   >
-                    Indexes
+                    Query details
                   </TabsTrigger_Shadcn_>
-                )}
-              </TabsList_Shadcn_>
-            </div>
+                  {selectedRow !== undefined && canShowIndexesTab && (
+                    <TabsTrigger_Shadcn_
+                      value="suggestion"
+                      className="px-0 pb-0 data-[state=active]:bg-transparent !shadow-none"
+                    >
+                      Indexes
+                    </TabsTrigger_Shadcn_>
+                  )}
+                </TabsList_Shadcn_>
+              </div>
 
-            <TabsContent_Shadcn_ value="details" className="mt-0 flex-grow min-h-0 overflow-y-auto">
-              {selectedRow !== undefined && (
-                <QueryDetail
-                  selectedRow={reportData[selectedRow]}
-                  onClickViewSuggestion={() => setView('suggestion')}
-                  onClose={() => setSelectedRow(undefined)}
-                />
-              )}
-            </TabsContent_Shadcn_>
-            {selectedRow !== undefined && canShowIndexesTab && (
               <TabsContent_Shadcn_
-                value="suggestion"
+                value="details"
                 className="mt-0 flex-grow min-h-0 overflow-y-auto"
               >
-                <QueryIndexes selectedRow={reportData[selectedRow]} />
+                {selectedRow !== undefined && (
+                  <QueryDetail
+                    selectedRow={reportData[selectedRow]}
+                    onClickViewSuggestion={() => setView('suggestion')}
+                    onClose={() => setSelectedRow(undefined)}
+                  />
+                )}
               </TabsContent_Shadcn_>
-            )}
-          </Tabs_Shadcn_>
-        </SheetContent>
-      </Sheet>
+              {selectedRow !== undefined && canShowIndexesTab && (
+                <TabsContent_Shadcn_
+                  value="suggestion"
+                  className="mt-0 flex-grow min-h-0 overflow-y-auto"
+                >
+                  <QueryIndexes selectedRow={reportData[selectedRow]} />
+                </TabsContent_Shadcn_>
+              )}
+            </Tabs_Shadcn_>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      <div className="flex items-center justify-between border-t px-4 py-2 text-xs text-foreground-light">
+        <div className="flex items-center gap-x-2">
+          <span>Showing {reportData.length} queries</span>
+          {isLoadingMore && <Loader2 size={14} className="animate-spin text-foreground-muted" />}
+          {!isLoading && hasMore && !isLoadingMore && (
+            <span className="text-foreground-muted">&middot; Scroll down for more</span>
+          )}
+        </div>
+        <div className="flex items-center gap-x-2">
+          <span>Results per page</span>
+          <Select_Shadcn_
+            value={String(pageSize)}
+            onValueChange={(value) => onPageSizeChange(Number(value))}
+          >
+            <SelectTrigger_Shadcn_ className="w-[70px] h-[26px] text-xs">
+              <SelectValue_Shadcn_ />
+            </SelectTrigger_Shadcn_>
+            <SelectContent_Shadcn_>
+              {PAGE_SIZE_OPTIONS.map((size) => (
+                <SelectItem_Shadcn_ key={size} value={String(size)} className="text-xs">
+                  {size}
+                </SelectItem_Shadcn_>
+              ))}
+            </SelectContent_Shadcn_>
+          </Select_Shadcn_>
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/QueryPerformance/WithStatements/WithStatements.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/WithStatements/WithStatements.tsx
@@ -30,12 +30,18 @@ interface WithStatementsProps {
   queryHitRate: PresetHookResult
   queryPerformanceQuery: DbQueryHook<any>
   queryMetrics: PresetHookResult
+  pageSize: number
+  onPageSizeChange: (size: number | null) => void
+  onLoadMore: () => void
 }
 
 export const WithStatements = ({
   queryHitRate,
   queryPerformanceQuery,
   queryMetrics,
+  pageSize,
+  onPageSizeChange,
+  onLoadMore,
 }: WithStatementsProps) => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -193,6 +199,11 @@ export const WithStatements = ({
             : null
         }
         onRetry={handleRefresh}
+        pageSize={pageSize}
+        hasMore={processedData.length > 0 && processedData.length % pageSize === 0}
+        onPageSizeChange={onPageSizeChange}
+        onLoadMore={onLoadMore}
+        isLoadingMore={isRefetching && processedData.length > 0}
       />
       <div
         className={cn('px-6 py-6 flex gap-x-4 border-t relative', {

--- a/apps/studio/components/interfaces/QueryPerformance/hooks/useQueryPerformancePagination.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/hooks/useQueryPerformancePagination.ts
@@ -1,0 +1,45 @@
+import { parseAsInteger, useQueryState } from 'nuqs'
+import { useCallback, useEffect, useState } from 'react'
+
+const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number]
+export { PAGE_SIZE_OPTIONS }
+
+/**
+ * Manages infinite-scroll pagination for query performance.
+ *
+ * Instead of offset-based fetching, we increase the SQL LIMIT each time the
+ * user scrolls to the bottom. pg_stat_statements queries are fast enough that
+ * re-fetching with a larger limit is simpler and avoids accumulation bugs.
+ *
+ * `visibleLimit` is the current SQL limit. It starts at `pageSize` and grows
+ * by `pageSize` each time `loadMore()` is called.
+ *
+ * The `pageSize` is persisted in the URL so it survives page reloads.
+ */
+export function useQueryPerformancePagination() {
+  const [pageSize, setPageSize] = useQueryState('pageSize', parseAsInteger.withDefault(20))
+
+  const [visibleLimit, setVisibleLimit] = useState(pageSize)
+
+  // Reset visibleLimit when pageSize changes
+  useEffect(() => {
+    setVisibleLimit(pageSize)
+  }, [pageSize])
+
+  const loadMore = useCallback(() => {
+    setVisibleLimit((prev) => prev + pageSize)
+  }, [pageSize])
+
+  const resetPagination = useCallback(() => {
+    setVisibleLimit(pageSize)
+  }, [pageSize])
+
+  return {
+    pageSize,
+    setPageSize,
+    visibleLimit,
+    loadMore,
+    resetPagination,
+  }
+}

--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
@@ -14,6 +14,7 @@ export function generateQueryPerformanceSql({
   minTotalTime = 0,
   runIndexAdvisor = false,
   filterIndexAdvisor = false,
+  limit,
 }: QueryPerformanceSQLParams) {
   const queryPerfQueries = PRESET_CONFIG[Presets.QUERY_PERFORMANCE]
   const baseSQL = queryPerfQueries.queries[preset]
@@ -49,7 +50,8 @@ export function generateQueryPerformanceSql({
     whereSql.length > 0 ? `WHERE ${whereSql}` : undefined,
     orderBySql,
     runIndexAdvisor,
-    filterIndexAdvisor
+    filterIndexAdvisor,
+    limit
   )
 
   return { sql, whereSql, orderBySql }

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -546,7 +546,16 @@ select
       },
       unified: {
         queryType: 'db',
-        sql: (_params, where, orderBy, runIndexAdvisor = false, filterIndexAdvisor = false) => {
+        sql: (
+          _params,
+          where,
+          orderBy,
+          runIndexAdvisor = false,
+          filterIndexAdvisor = false,
+          limit?: number
+        ) => {
+          const resolvedLimit = limit ?? 20
+
           const baseQuery = `
         -- reports-query-performance-unified
         set search_path to public, extensions;
@@ -586,7 +595,7 @@ select
           -- skip queries that were never actually executed
           WHERE statements.calls > 0 ${where ? where.replace(/^WHERE/, 'AND') : ''}
           ${orderBy || 'order by total_time desc'}
-          limit 50
+          limit ${resolvedLimit}
         ),
         query_results as (
           select
@@ -616,7 +625,7 @@ select
         from query_results
         ${filterIndexAdvisor && runIndexAdvisor ? `where (index_advisor_result->>'has_suggestion')::boolean = true` : ''}
         ${orderBy || 'order by total_time desc'}
-        limit 20`
+        limit ${resolvedLimit}`
 
           return baseQuery
         },

--- a/apps/studio/components/interfaces/Reports/Reports.types.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.types.ts
@@ -26,7 +26,8 @@ export interface ReportQuery {
     where?: string,
     orderBy?: string,
     runIndexAdvisor?: boolean,
-    filterIndexAdvisor?: boolean
+    filterIndexAdvisor?: boolean,
+    limit?: number
   ) => string
 }
 

--- a/apps/studio/pages/project/[ref]/observability/query-performance.tsx
+++ b/apps/studio/pages/project/[ref]/observability/query-performance.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'common'
 import { useIndexAdvisorStatus } from 'components/interfaces/QueryPerformance/hooks/useIsIndexAdvisorStatus'
+import { useQueryPerformancePagination } from 'components/interfaces/QueryPerformance/hooks/useQueryPerformancePagination'
 import { useQueryPerformanceSort } from 'components/interfaces/QueryPerformance/hooks/useQueryPerformanceSort'
 import { QueryPerformance } from 'components/interfaces/QueryPerformance/QueryPerformance'
 import { type QuerySource } from 'components/interfaces/QueryPerformance/QueryPerformance.types'
@@ -15,6 +16,7 @@ import { DocsButton } from 'components/ui/DocsButton'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { DOCS_URL } from 'lib/constants'
 import { parseAsArrayOf, parseAsInteger, parseAsJson, parseAsString, useQueryStates } from 'nuqs'
+import { useEffect } from 'react'
 import type { NextPageWithLayout } from 'types'
 import { Admonition } from 'ui-patterns'
 
@@ -23,6 +25,8 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
   const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
   const { isIndexAdvisorEnabled } = useIndexAdvisorStatus()
   const { sort: sortConfig } = useQueryPerformanceSort()
+  const { pageSize, setPageSize, visibleLimit, loadMore, resetPagination } =
+    useQueryPerformancePagination()
 
   const [
     {
@@ -60,6 +64,20 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
         ? totalTimeFilter.value
         : undefined
 
+  // Reset pagination when filters or sort change
+  useEffect(() => {
+    resetPagination()
+  }, [
+    searchQuery,
+    roles,
+    sources,
+    minCalls,
+    minTotalTime,
+    indexAdvisor,
+    sortConfig,
+    resetPagination,
+  ])
+
   const queryPerformanceQuery = useQueryPerformanceQuery({
     searchQuery,
     orderBy: sortConfig || undefined,
@@ -70,6 +88,7 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
     minCalls: minCalls ?? undefined,
     minTotalTime,
     filterIndexAdvisor: indexAdvisor === 'true',
+    limit: visibleLimit,
   })
 
   if (!isLoadingProject && !project) {
@@ -99,6 +118,9 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
         queryHitRate={queryHitRate}
         queryPerformanceQuery={queryPerformanceQuery}
         queryMetrics={queryMetrics}
+        pageSize={pageSize}
+        onPageSizeChange={setPageSize}
+        onLoadMore={loadMore}
       />
     </div>
   )


### PR DESCRIPTION
## Problem

The query performance page at `/observability/query-performance` had no pagination, so it always fetched and displayed all results at once. There was also no way to control how many rows to load.

## Fix

- Added a `useQueryPerformancePagination` hook that manages an infinite-scroll pattern: `visibleLimit` starts at `pageSize` and grows by `pageSize` each time the user scrolls to the bottom.
- Added a page size selector (20 / 50 / 100 rows) rendered in the grid toolbar.
- `pageSize` is persisted in the URL via `nuqs` so it survives reloads and can be deep-linked.
- Scroll detection uses an `IntersectionObserver` on a sentinel element at the bottom of the grid.
- Changing the page size or applying filters resets `visibleLimit` back to `pageSize`.
- The SQL `LIMIT` is passed through to all query presets (including `WithStatements`).

## How to test

1. Navigate to `/observability/query-performance` on a project with many queries.
2. Scroll to the bottom of the grid — more rows should load automatically.
3. Change the page size dropdown (20 / 50 / 100) — the grid should reset and reload with the new limit.
4. Reload the page — the selected page size should be preserved in the URL (`?pageSize=50`).
5. Share the URL with `?pageSize=100` — the page should open with 100 rows per page.
6. Apply a search filter — pagination should reset to the first "page" of results.