### PR TITLE
fix(studio): smol design bug on connect dialog mode selector

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
@@ -244,7 +244,7 @@ interface ModeSelectorProps {
 
 export function ModeSelector({ modes, selected, onChange }: ModeSelectorProps) {
   return (
-    <div className="grid grid-cols-4 rounded-lg border">
+    <div className="grid grid-cols-4 rounded-lg border overflow-hidden">
       {modes.map((mode) => (
         <button
           key={mode.id}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Small visual gremlin @jordienr spotted:

| Before | After |
|--------|--------|
| <img width="415" height="352" alt="Screenshot 2026-03-23 at 17 29 17" src="https://github.com/user-attachments/assets/70031cf9-de02-4957-ad00-79f92b842382" /> | <img width="373" height="311" alt="Screenshot 2026-03-23 at 17 32 31" src="https://github.com/user-attachments/assets/f14d0968-29b7-40da-9f56-e721e324b46d" /> | 


