### PR TITLE
fix(studio): SSOConfig field widths

### DIFF
--- a/apps/studio/components/interfaces/Organization/SSO/AttributeMapping.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/AttributeMapping.tsx
@@ -1,6 +1,5 @@
 import { Plus, Trash } from 'lucide-react'
-import { UseFormReturn, useFieldArray } from 'react-hook-form'
-
+import { useFieldArray, UseFormReturn } from 'react-hook-form'
 import {
   Button,
   FormControl_Shadcn_,
@@ -10,6 +9,7 @@ import {
   Input_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
 import type { SSOConfigFormSchema } from './SSOConfig'
 
 type ProviderAttribute = 'emailMapping' | 'userNameMapping' | 'firstNameMapping' | 'lastNameMapping'
@@ -131,7 +131,7 @@ export const AttributeMapping = ({
       }
       className="gap-1"
     >
-      <div className="grid w-full max-w-sm min-w-0 gap-2 justify-start">
+      <div className="grid w-full max-w-sm min-w-0 gap-3">
         <MappingFieldArray form={form} fieldName={emailField} label="email" required />
         <MappingFieldArray
           form={form}
@@ -178,7 +178,7 @@ const MappingFieldArray = ({
     <div className="w-full min-w-0 space-y-1">
       <div className="flex items-center justify-between gap-2">
         <span className="text-foreground-light">{label}</span>
-        {required ? <></> : <span className="text-foreground-muted">Optional</span>}
+        {!required ? <span className="text-foreground-muted">Optional</span> : null}
       </div>
       <div className="grid w-full min-w-0 gap-2">
         {fields.map((field, idx) => (
@@ -210,7 +210,7 @@ const MappingFieldArray = ({
         ))}
 
         <Button
-          type="text"
+          type="default"
           icon={<Plus className="w-4 h-4" />}
           onClick={() => append({ value: '' })}
           className="w-auto self-start justify-self-start"

--- a/apps/studio/components/interfaces/Organization/SSO/AttributeMapping.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/AttributeMapping.tsx
@@ -119,7 +119,7 @@ export const AttributeMapping = ({
           <p>Map SSO attributes to user fields</p>
           <div className="flex flex-col gap-y-2 my-2 mt-4">
             <p>Presets for supported identity providers:</p>
-            <div className="flex items-center gap-x-2">
+            <div className="flex flex-wrap items-center gap-2">
               {PROVIDER_PRESETS.map((preset) => (
                 <Button key={preset.name} type="outline" onClick={() => applyPreset(preset)}>
                   {preset.name}
@@ -131,7 +131,7 @@ export const AttributeMapping = ({
       }
       className="gap-1"
     >
-      <div className="grid gap-2 justify-start">
+      <div className="grid w-full max-w-sm min-w-0 gap-2 justify-start">
         <MappingFieldArray form={form} fieldName={emailField} label="email" required />
         <MappingFieldArray
           form={form}
@@ -175,20 +175,25 @@ const MappingFieldArray = ({
   })
 
   return (
-    <div className="w-96 space-y-1">
-      <div className="flex justify-between items-center">
+    <div className="w-full min-w-0 space-y-1">
+      <div className="flex items-center justify-between gap-2">
         <span className="text-foreground-light">{label}</span>
         {required ? <></> : <span className="text-foreground-muted">Optional</span>}
       </div>
-      <div className="grid gap-2 w-full">
+      <div className="grid w-full min-w-0 gap-2">
         {fields.map((field, idx) => (
-          <div key={field.id} className="flex gap-2 items-start">
+          <div key={field.id} className="flex min-w-0 items-start gap-2">
             <FormField_Shadcn_
               name={`${fieldName}.${idx}.value`}
               render={({ field }) => (
-                <FormItem_Shadcn_ className="flex-1">
+                <FormItem_Shadcn_ className="min-w-0 flex-1">
                   <FormControl_Shadcn_>
-                    <Input_Shadcn_ {...field} placeholder={placeholder} autoComplete="off" />
+                    <Input_Shadcn_
+                      {...field}
+                      className="min-w-0"
+                      placeholder={placeholder}
+                      autoComplete="off"
+                    />
                   </FormControl_Shadcn_>
                   <FormMessage_Shadcn_ />
                 </FormItem_Shadcn_>
@@ -197,7 +202,7 @@ const MappingFieldArray = ({
             <Button
               type="default"
               icon={<Trash size={12} />}
-              className="h-[34px] w-[34px]"
+              className="h-[34px] w-[34px] shrink-0"
               disabled={fields.length <= 1}
               onClick={() => remove(idx)}
             />

--- a/apps/studio/components/interfaces/Organization/SSO/SSODomains.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSODomains.tsx
@@ -1,6 +1,5 @@
 import { Plus, Trash } from 'lucide-react'
 import { useFieldArray, useForm } from 'react-hook-form'
-
 import {
   Button,
   FormControl_Shadcn_,
@@ -10,6 +9,7 @@ import {
   Input_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
 import { SSOConfigFormSchema } from './SSOConfig'
 
 export const SSODomains = ({ form }: { form: ReturnType<typeof useForm<SSOConfigFormSchema>> }) => {
@@ -25,7 +25,7 @@ export const SSODomains = ({ form }: { form: ReturnType<typeof useForm<SSOConfig
         layout="flex-row-reverse"
         description="Provide one or more domains"
       >
-        <div className="grid gap-2 w-96">
+        <div className="grid gap-3 w-96">
           {fields.map((field, idx) => (
             <div key={field.id} className="flex gap-2 items-top">
               <FormField_Shadcn_
@@ -51,7 +51,7 @@ export const SSODomains = ({ form }: { form: ReturnType<typeof useForm<SSOConfig
           ))}
           <div>
             <Button
-              type="text"
+              type="default"
               icon={<Plus className="w-4 h-4" />}
               size="tiny"
               onClick={() => append({ value: '' })}

--- a/apps/studio/components/interfaces/Organization/SSO/SSODomains.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSODomains.tsx
@@ -25,7 +25,7 @@ export const SSODomains = ({ form }: { form: ReturnType<typeof useForm<SSOConfig
         layout="flex-row-reverse"
         description="Provide one or more domains"
       >
-        <div className="grid gap-3 w-96">
+        <div className="grid gap-2 w-96">
           {fields.map((field, idx) => (
             <div key={field.id} className="flex gap-2 items-top">
               <FormField_Shadcn_

--- a/apps/studio/components/interfaces/Organization/SSO/SSOMetadata.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOMetadata.tsx
@@ -1,7 +1,6 @@
 import { Upload } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
-
 import {
   Button,
   FormControl_Shadcn_,
@@ -15,6 +14,7 @@ import {
   TabsTrigger_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
 import { SSOConfigFormSchema } from './SSOConfig'
 
 export const SSOMetadata = ({
@@ -110,7 +110,6 @@ export const SSOMetadata = ({
                     />
                     <Button
                       type="default"
-                      size="small"
                       icon={<Upload className="w-4 h-4" />}
                       onClick={() => fileInputRef.current?.click()}
                     >


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI fix.

## What is the current behavior?

Form contents overflow horizontally on `SSOConfig`’s `AttributeMapping` section.

## What is the new behavior?

These form contents no longer overflow.

| Before | After |
| --- | --- |
| <img width="1096" height="997" alt="SSO  Organization Settings  Toolshed  Supabase-BB366F67-15C9-40A3-8CB7-C0DA7363A2EC" src="https://github.com/user-attachments/assets/daabcba2-408a-4d44-8bf6-beb0c21d12ed" /> | <img width="1096" height="997" alt="SSO  Organization Settings  Toolshed  Supabase-550B04A9-5B3C-4BCE-9CE3-C4B5F516BE35" src="https://github.com/user-attachments/assets/741f6178-7633-4c6d-87cd-6fdd5d0e4606" /> |
