### PR TITLE
chore: remove TypeScript build error ignoring from next.config.js in `studio`

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -604,11 +604,6 @@ const nextConfig = {
     maxInactiveAge: 24 * 60 * 60 * 1000,
     pagesBufferLength: 100,
   },
-  typescript: {
-    // Typechecking is run via GitHub Action only for efficiency
-    // For production, we run typechecks separate from the build command (pnpm typecheck && pnpm build)
-    ignoreBuildErrors: true,
-  },
 }
 
 // Make sure adding Sentry options is the last code to run before exporting, to


### PR DESCRIPTION
This pull request makes a small configuration change to the Next.js application. The TypeScript build option that allowed build errors to be ignored has been removed from `next.config.js`. This means type errors will now cause the build to fail, improving code quality by catching issues earlier.

- Removed the `typescript.ignoreBuildErrors` option from `next.config.js`, so builds will now fail if there are TypeScript errors.