### PR TITLE
ci: fix mgmt api docs generator

### DIFF
--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -21,6 +21,7 @@ jobs:
           sparse-checkout: |
             apps/docs
             patches
+            packages/generator
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm


### PR DESCRIPTION
The [`docs-mgmt-api-update` workflow](https://github.com/supabase/supabase/blob/master/.github/workflows/docs-mgmt-api-update.yml#L21) uses `sparse-checkout`, only pulling `apps/docs` and patches. After PR #42987, the Makefile's `redocly` commands were changed to run via `pnpm exec` `redocly` from `packages/generator`, but that directory was  never checked out, causing the can't `cd` error. Adding `packages/generator` to `sparse-checkout` makes the existing Makefile dependency explicit in the workflow.   