### PR TITLE
fix(billing): clarify service restriction reset delay after billing cycle

### DIFF
--- a/apps/docs/content/guides/platform/billing-faq.mdx
+++ b/apps/docs/content/guides/platform/billing-faq.mdx
@@ -140,7 +140,7 @@ The Fair Use Policy is generally applied to all projects of the restricted organ
 
 To remove restrictions, you will need to address the issue that caused the restriction. This could be reducing your usage, paying overdue invoices, updating your payment method, or any other issue that caused the restriction. Once the issue is resolved, the restriction will be lifted.
 
-Restrictions due to usage limits are lifted with the next billing cycle as your quota refills at the beginning of each cycle. You can see when your current billing cycle ends on the [billing page](/dashboard/org/_/billing) under "Upcoming Invoice". You can also lift restrictions immediately by [upgrading](/dashboard/org/_/billing?panel=subscriptionPlan) to Pro (if on Free Plan) or by [disabling spend cap](/dashboard/org/_/billing?panel=costControl) (if on Pro Plan with spend cap enabled).
+Restrictions due to usage limits are lifted once your quota refills at the start of the next billing cycle. Note that there may be a short delay after your billing period resets before restrictions are fully lifted. You can see when your current billing cycle ends on the [billing page](/dashboard/org/_/billing) under "Upcoming Invoice". You can also lift restrictions immediately by [upgrading](/dashboard/org/_/billing?panel=subscriptionPlan) to Pro (if on Free Plan) or by [disabling spend cap](/dashboard/org/_/billing?panel=costControl) (if on Pro Plan with spend cap enabled).
 
 ## Reports and invoices
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
@@ -156,7 +156,7 @@ export const Restriction = () => {
               <span className="text-foreground">
                 {dayjs(org.restriction_data['grace_period_end']).format('DD MMM, YYYY')}
               </span>
-              . Fair Use Policy applies now. Stay below your plan’s quota or{' '}
+              . Fair Use Policy applies now. Stay below your plan's quota or{' '}
               {org.plan.id === 'free' ? 'upgrade your plan' : 'disable spend cap'} if you expect to
               exceed it. If you exceed your quota, requests will respond with a 402 status code.
             </p>
@@ -193,9 +193,9 @@ export const Restriction = () => {
           <AlertDescription_Shadcn_>
             <p>
               Fair Use Policy applies and your service is restricted. Your projects are not able to
-              serve requests and will respond with a 402 status code. You have exceeded your plan’s
-              quota{violationLabels && ` ${violationLabels}`}.{‘ ‘}
-              {org.plan.id === ‘free’ ? ‘Upgrade your plan’ : ‘Disable spend cap’} to lift
+              serve requests and will respond with a 402 status code. You have exceeded your plan's
+              quota{violationLabels && ` ${violationLabels}`}.{' '}
+              {org.plan.id === 'free' ? 'Upgrade your plan' : 'Disable spend cap'} to lift
               restrictions immediately, or wait until your quota refills at the start of your next
               billing period. Note that there may be a short delay after your billing period resets
               before restrictions are fully lifted.

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
@@ -194,9 +194,11 @@ export const Restriction = () => {
             <p>
               Fair Use Policy applies and your service is restricted. Your projects are not able to
               serve requests and will respond with a 402 status code. You have exceeded your plan’s
-              quota{violationLabels && ` ${violationLabels}`}.{' '}
-              {org.plan.id === 'free' ? 'Upgrade your plan' : 'Disable spend cap'} to lift
-              restrictions or wait until your quota refills on your next billing period.
+              quota{violationLabels && ` ${violationLabels}`}.{‘ ‘}
+              {org.plan.id === ‘free’ ? ‘Upgrade your plan’ : ‘Disable spend cap’} to lift
+              restrictions immediately, or wait until your quota refills at the start of your next
+              billing period. Note that there may be a short delay after your billing period resets
+              before restrictions are fully lifted.
             </p>
             <div className="flex items-center gap-x-2 mt-3">
               <Button key="upgrade-button" asChild type="default">


### PR DESCRIPTION
## Summary

Customers were upgrading to Pro to clear service restrictions, unaware that restrictions aren't lifted immediately when the billing cycle resets — there's a delay. This adds a clarifying note to both the docs FAQ and the Studio restricted alert so users know what to expect.

Note: upgrading your plan or disabling spend cap *does* lift restrictions immediately (unchanged). The delay only applies to the billing-cycle-reset path for usage-limit violations.

## Changes

- `billing-faq.mdx`: Removes the implication that restrictions clear the moment the billing period resets; adds "Note that there may be a short delay after your billing period resets before restrictions are fully lifted"
- `Restriction.tsx`: Updates the restricted alert to make clear that upgrading lifts restrictions immediately, while the billing-reset path may have a delay

## Testing

To test the Studio banner, find or create an org with `restriction_status === 'restricted'`, or temporarily hardcode `shownAlert = 'restricted'` in `Restriction.tsx` to preview:

- [x] Restricted alert reads clearly and distinguishes immediate (upgrade) vs delayed (billing reset) paths
- [x] Docs FAQ answer under "How can I remove restrictions" reads correctly with the new caveat

## Linear
- fixes GROWTH-704