### PR TITLE
Couple of minor UI nudges in edge functions UI

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.constants.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.constants.ts
@@ -34,6 +34,7 @@ export const INVOCATION_TABS: InvocationTab[] = [
     language: 'js',
     hideLineNumbers: true,
     code: ({ functionName }) => `import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY)
 const { data, error } = await supabase.functions.invoke('${functionName}', {
   body: { name: 'Functions' },

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -13,6 +13,7 @@ import {
   Card,
   CardContent,
   CardFooter,
+  CardHeader,
   cn,
   CodeBlock,
   copyToClipboard,
@@ -182,11 +183,22 @@ export const EdgeFunctionDetails = () => {
                             layout="flex-row-reverse"
                             description={
                               <>
-                                Requires a JWT signed{' '}
-                                <em className="text-brand not-italic">only by the legacy secret</em>{' '}
-                                in the <code>Authorization</code> header. The <code>anon</code> key
-                                satisfies this. Recommended: OFF with JWT and custom auth logic in
-                                your function code.
+                                <p className="mb-2">
+                                  Requires a JWT signed{' '}
+                                  <em className="text-foreground not-italic">
+                                    only by the legacy secret
+                                  </em>{' '}
+                                  in the{' '}
+                                  <code className="text-code-inline !break-keep">
+                                    Authorization
+                                  </code>{' '}
+                                  header. The <code className="text-code-inline">anon</code> key
+                                  satisfies this.
+                                </p>
+                                <p>
+                                  Recommended: OFF with JWT and custom auth logic in your function
+                                  code.
+                                </p>
                               </>
                             }
                           >
@@ -265,15 +277,16 @@ export const EdgeFunctionDetails = () => {
                   })
 
                   return (
-                    <TabsContent key={tab.id} value={tab.id} className="mt-4 px-6">
+                    <TabsContent key={tab.id} value={tab.id}>
                       <CodeBlock
                         value={code}
+                        wrapperClassName="[&>div]:top-0 [&>div]:right-3 px-6"
                         className={cn(
-                          'p-0 text-xs !mt-0 border-none [&>code]:!whitespace-pre-wrap',
+                          'p-0 text-xs !mt-0 border-none ',
                           showKey ? '[&>code]:break-all' : '[&>code]:break-words'
                         )}
                         language={tab.language}
-                        wrapLines={true}
+                        wrapLines={false}
                         hideLineNumbers={tab.hideLineNumbers}
                         handleCopy={() => {
                           copyToClipboard(
@@ -313,7 +326,7 @@ export const EdgeFunctionDetails = () => {
                         description: 'Download the function to your local machine',
                         jsx: () => (
                           <>
-                            <span className="text-brand-600">supabase</span> functions download{' '}
+                            <span className="text-brand">supabase</span> functions download{' '}
                             {selectedFunction?.slug}
                           </>
                         ),

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.utils.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.utils.tsx
@@ -16,8 +16,7 @@ export const generateCLICommands = ({
       jsx: () => {
         return (
           <>
-            <span className="text-brand-600">supabase</span> functions deploy{' '}
-            {selectedFunction?.slug}
+            <span className="text-brand">supabase</span> functions deploy {selectedFunction?.slug}
           </>
         )
       },
@@ -29,8 +28,7 @@ export const generateCLICommands = ({
       jsx: () => {
         return (
           <>
-            <span className="text-brand-600">supabase</span> functions delete{' '}
-            {selectedFunction?.slug}
+            <span className="text-brand">supabase</span> functions delete {selectedFunction?.slug}
           </>
         )
       },
@@ -45,7 +43,7 @@ export const generateCLICommands = ({
       jsx: () => {
         return (
           <>
-            <span className="text-brand-600">supabase</span> secrets list
+            <span className="text-brand">supabase</span> secrets list
           </>
         )
       },
@@ -57,7 +55,7 @@ export const generateCLICommands = ({
       jsx: () => {
         return (
           <>
-            <span className="text-brand-600">supabase</span> secrets set NAME1=VALUE1 NAME2=VALUE2
+            <span className="text-brand">supabase</span> secrets set NAME1=VALUE1 NAME2=VALUE2
           </>
         )
       },
@@ -69,7 +67,7 @@ export const generateCLICommands = ({
       jsx: () => {
         return (
           <>
-            <span className="text-brand-600">supabase</span> secrets unset NAME1 NAME2
+            <span className="text-brand">supabase</span> secrets unset NAME1 NAME2
           </>
         )
       },
@@ -86,7 +84,7 @@ export const generateCLICommands = ({
       jsx: () => {
         return (
           <>
-            <span className="text-brand-600">curl</span> -L -X POST '{functionUrl}'{' '}
+            <span className="text-brand">curl</span> -L -X POST '{functionUrl}'{' '}
             {selectedFunction?.verify_jwt
               ? `-H
             'Authorization: Bearer [YOUR ANON KEY]' `

--- a/apps/studio/components/interfaces/Realtime/Inspector/EmptyRealtime.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/EmptyRealtime.tsx
@@ -6,6 +6,7 @@ import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import { AiIconAnimation, Button, Card, cn } from 'ui'
 
 import { AnimatedCursors } from './AnimatedCursors'
+import { DocsButton } from '@/components/ui/DocsButton'
 
 /**
  * Acts as a container component for the entire log display
@@ -93,13 +94,10 @@ export const EmptyRealtime = ({ projectRef }: { projectRef: string }) => {
             <p className="text-foreground-light text-sm mb-4 flex-1">
               Receive realtime messages in your application by listening to a channel
             </p>
-            <Button type="default" asChild>
-              <Link
-                href={`${DOCS_URL}/guides/realtime/subscribing-to-database-changes#listening-on-client-side`}
-              >
-                Read the guide
-              </Link>
-            </Button>
+            <DocsButton
+              abbrev={false}
+              href={`${DOCS_URL}/guides/realtime/subscribing-to-database-changes#listening-on-client-side`}
+            />
           </div>
         </Card>
       </div>

--- a/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
+++ b/apps/studio/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout.tsx
@@ -37,6 +37,7 @@ import {
   PopoverTrigger_Shadcn_,
   Separator,
 } from 'ui'
+import { TimestampInfo } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import {
   PageHeader,
@@ -293,23 +294,35 @@ const EdgeFunctionDetailsLayout = ({
                       </span>
                     </button>
                   </HoverCardTrigger>
-                  <HoverCardContent side="bottom" align="start" className="w-[320px] p-0">
+                  <HoverCardContent side="bottom" align="start" className="w-40 p-0">
                     {createdRelative && (
                       <div className="px-4 py-2 space-y-1">
                         <h3 className="heading-meta text-foreground-light">Created</h3>
-                        <p className="text-foreground">{createdRelative}</p>
+                        {!!selectedFunction && (
+                          <TimestampInfo
+                            className="text-sm"
+                            label={createdRelative}
+                            utcTimestamp={selectedFunction.created_at}
+                          />
+                        )}
                       </div>
                     )}
                     {updatedRelative && (
                       <div className="px-4 py-2 space-y-1">
                         <h3 className="heading-meta text-foreground-light">Last deployed</h3>
-                        <p className="text-foreground">{updatedRelative}</p>
+                        {!!selectedFunction && (
+                          <TimestampInfo
+                            className="text-sm"
+                            label={updatedRelative}
+                            utcTimestamp={selectedFunction.updated_at}
+                          />
+                        )}
                       </div>
                     )}
                     {selectedFunction?.version !== undefined && (
                       <div className="px-4 py-2 space-y-1">
                         <h3 className="heading-meta text-foreground-light">Deployments</h3>
-                        <p className="text-foreground">{selectedFunction.version}</p>
+                        <p className="text-sm text-foreground">{selectedFunction.version}</p>
                       </div>
                     )}
                   </HoverCardContent>


### PR DESCRIPTION
## Context

Just a couple of minor UI nudges as I came across on the edge functions page

- Added TimestampInfo for hover card + used `text-sm` for font size + reduce width to match content size
  - Before:
    <img width="393" height="271" alt="image" src="https://github.com/user-attachments/assets/3db351fd-80e8-47a9-b4e9-dff8613163ad" />
  - After:
    <img width="461" height="233" alt="image" src="https://github.com/user-attachments/assets/d4ac9edb-58fc-4820-b04f-c7753baf9ef5" />

- Use `text-code-inline` in here + avoid `text-brand` in text (use `text-foreground`) + added some spacing between the 2 sentences
  - Before:
    <img width="707" height="153" alt="image" src="https://github.com/user-attachments/assets/7d6b3acc-8bc6-454b-92ed-ab43227a9e07" />
  - After:
    <img width="710" height="169" alt="image" src="https://github.com/user-attachments/assets/b00fbf07-a6a3-4476-b417-d02225f02ce9" />

- Invoke code snippet adjust copy button placement + opt to not wrap lines (was awkward esp when there's no line numbers)
  - Before:
    <img width="730" height="278" alt="image" src="https://github.com/user-attachments/assets/d3c646d9-c893-44cc-8c25-86fc0ddac050" />
  - After:
    <img width="725" height="223" alt="image" src="https://github.com/user-attachments/assets/f75c0a28-04e3-48c5-903f-25e9bbe2d879" />

- Use `text-brand` consistently here instead of `text-brand-600`
  - Before:
    <img width="732" height="315" alt="image" src="https://github.com/user-attachments/assets/48cdf54f-43e1-44ef-b09b-66d6db351a5b" />
  - After:
    <img width="736" height="322" alt="image" src="https://github.com/user-attachments/assets/3f176ccc-ec35-4abb-8491-d9a498933a26" />
