### PR TITLE
chore(billing): make update billing address modal non-dismissable

### DIFF
--- a/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
+++ b/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
@@ -128,6 +128,7 @@ export function UpdateBillingAddressModal() {
     >
       <DialogContent
         size="medium"
+        hideClose
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >

--- a/apps/studio/tests/components/Billing/UpdateBillingAddressModal.test.tsx
+++ b/apps/studio/tests/components/Billing/UpdateBillingAddressModal.test.tsx
@@ -175,17 +175,4 @@ describe('UpdateBillingAddressModal', () => {
     render(<UpdateBillingAddressModal />)
     expect(screen.queryByText('Save address')).not.toBeInTheDocument()
   })
-
-  it('dismisses on close button click', async () => {
-    render(<UpdateBillingAddressModal />)
-    expect(await screen.findByText('Billing address required')).toBeInTheDocument()
-
-    // Click the X (close) button in DialogContent
-    const closeButton = screen.getByRole('button', { name: /close/i })
-    await userEvent.click(closeButton)
-
-    await waitFor(() => {
-      expect(screen.queryByText('Billing address required')).not.toBeInTheDocument()
-    })
-  })
 })


### PR DESCRIPTION
### Summary

This PR removes the visible close button from the billing address required modal to make it non dismissable, since the majority of users on paid orgs are still not filling their billing address.

The modal already prevents dismissal via Esc and outside/backdrop interaction, and this change preserves that behavior. The existing submit flow is unchanged, so the modal still closes after a successful billing address update.

### Manual testing:

1. Open Studio in a state where the billing address required modal appears.
2. Confirm the top-right close button is no longer shown.
3. Press Esc and verify the modal remains open.
4. Click outside the modal / on the backdrop and verify the modal remains open.
5. Submit a valid billing address and verify the modal closes after a successful save.

For testing whether an update successfully closes the modal, you can:

- You can create a free org without a billing address
- You will need to tweak this logic (on the frontend)

```
const shouldShow = Boolean(
  IS_PLATFORM &&
  // showMissingAddressModal &&
  org &&
  // org.plan.id !== 'free' &&
  org.organization_missing_address &&
  !org.billing_partner &&
  permissionsLoaded &&
  canBillingWrite
)
```

- Tweak the backend logic which computes `organization_missing_address` to exclude free orgs