### PR TITLE
feat(billing): show billing address modal to users other than owners/admins

### DIFF
--- a/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
+++ b/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
@@ -158,7 +158,8 @@ export function UpdateBillingAddressModal() {
                 Tax ID is also required.
                 <br />
                 <br />
-                Please ask an organization administrator or owner to update it.
+                Please ask an organization administrator or owner to update it as soon as possible
+                to avoid service restrictions.
               </>
             )}
           </DialogDescription>

--- a/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
+++ b/apps/studio/components/interfaces/App/UpdateBillingAddressModal.tsx
@@ -40,10 +40,18 @@ export function UpdateBillingAddressModal() {
   const { data: org } = useSelectedOrganizationQuery()
   const slug = org?.slug
 
-  const { can: canBillingWrite, isSuccess: permissionsLoaded } = useAsyncCheckPermissions(
+  const { can: canBillingRead, isSuccess: billingReadLoaded } = useAsyncCheckPermissions(
+    PermissionAction.BILLING_READ,
+    'stripe.customer'
+  )
+  const { can: canBillingWrite, isSuccess: billingWriteLoaded } = useAsyncCheckPermissions(
     PermissionAction.BILLING_WRITE,
     'stripe.customer'
   )
+
+  const permissionsLoaded = billingReadLoaded && billingWriteLoaded
+  const canViewModal = canBillingRead || canBillingWrite
+  const canManageBillingAddress = canBillingWrite
 
   const shouldShow = Boolean(
     IS_PLATFORM &&
@@ -53,22 +61,29 @@ export function UpdateBillingAddressModal() {
     org.organization_missing_address &&
     !org.billing_partner &&
     permissionsLoaded &&
-    canBillingWrite
+    canViewModal
   )
 
   const {
     data: customerProfile,
     isSuccess: profileLoaded,
     isError: profileError,
-  } = useOrganizationCustomerProfileQuery({ slug }, { enabled: shouldShow && !dismissed && !!slug })
+  } = useOrganizationCustomerProfileQuery(
+    { slug },
+    { enabled: shouldShow && !dismissed && !!slug && canManageBillingAddress }
+  )
 
   const {
     data: taxId,
     isSuccess: taxIdLoaded,
     isError: taxIdError,
-  } = useOrganizationTaxIdQuery({ slug }, { enabled: shouldShow && !dismissed && !!slug })
+  } = useOrganizationTaxIdQuery(
+    { slug },
+    { enabled: shouldShow && !dismissed && !!slug && canManageBillingAddress }
+  )
 
-  const open = shouldShow && !dismissed && !profileError && !taxIdError
+  const open =
+    shouldShow && !dismissed && (!canManageBillingAddress || (!profileError && !taxIdError))
 
   const initialCustomerData = useMemo<Partial<BillingCustomerDataFormValues>>(
     () => ({
@@ -128,44 +143,55 @@ export function UpdateBillingAddressModal() {
     >
       <DialogContent
         size="medium"
+        hideClose={canManageBillingAddress}
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
         <DialogHeader>
           <DialogTitle>Billing address required</DialogTitle>
           <DialogDescription>
-            Please provide a billing address for your organization. If you are a registered business
-            and have a Tax ID, please add your Tax ID too.
+            {canManageBillingAddress ? (
+              'Please provide a billing address for your organization. If you are a registered business and have a Tax ID, please add your Tax ID too.'
+            ) : (
+              <>
+                Your organization requires a billing address. If you are a registered business, a
+                Tax ID is also required.
+                <br />
+                <br />
+                Please ask an organization administrator or owner to update it.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
-        {!profileLoaded || !taxIdLoaded ? (
-          <DialogSection>
-            <div className="space-y-2">
-              <ShimmeringLoader />
-              <ShimmeringLoader className="w-3/4" />
-              <ShimmeringLoader className="w-1/2" />
-            </div>
-          </DialogSection>
-        ) : (
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(handleSubmit)}>
-              <DialogSection className="max-h-[60vh] overflow-y-auto">
-                <BillingCustomerDataForm form={form} />
-              </DialogSection>
-              <DialogFooter>
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  loading={isSubmitting}
-                  disabled={!isDirty || isSubmitting}
-                >
-                  Save address
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        )}
+        {canManageBillingAddress &&
+          (!profileLoaded || !taxIdLoaded ? (
+            <DialogSection>
+              <div className="space-y-2">
+                <ShimmeringLoader />
+                <ShimmeringLoader className="w-3/4" />
+                <ShimmeringLoader className="w-1/2" />
+              </div>
+            </DialogSection>
+          ) : (
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(handleSubmit)}>
+                <DialogSection className="max-h-[60vh] overflow-y-auto">
+                  <BillingCustomerDataForm form={form} />
+                </DialogSection>
+                <DialogFooter>
+                  <Button
+                    type="primary"
+                    htmlType="submit"
+                    loading={isSubmitting}
+                    disabled={!isDirty || isSubmitting}
+                  >
+                    Save address
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          ))}
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
### Summary

This PR updates the billing address required modal so it also shows for users with billing read access but without billing write access, such as developers and users with read-only acess.

For users with BILLING_WRITE, the existing blocking behavior remains in place:

- the modal has no visible close button
- it closes only after a successful billing address update

For users with BILLING_READ but not BILLING_WRITE, the modal now:

- the modal includes a visible close button
- no editable billing form is shown
- the copy tells the user to ask an organization administrator or owner to update the billing address

<img width="1280" height="626" alt="Screenshot 2026-03-24 at 7 18 49 PM" src="https://github.com/user-attachments/assets/ddc5e90d-c7d8-4d67-a138-59a5a5baf71b" />

### Manual testing

#### Admins/owners

1. As a user with BILLING_WRITE, open an org that is missing a billing address.
2. Confirm the modal appears with the billing address form.
3. Confirm there is no visible close button.
4. Submit a valid billing address and verify the modal closes after a successful save.

For testing whether an update successfully closes the modal, you can:

-  You can create a free org without a billing address
- You will need to tweak this logic (on the frontend)

```
const shouldShow = Boolean(
  IS_PLATFORM &&
  // showMissingAddressModal &&
  org &&
  // org.plan.id !== 'free' &&
  org.organization_missing_address &&
  !org.billing_partner &&
  permissionsLoaded &&
  canViewModal
)
```

- Tweak the backend logic which computes `organization_missing_address` to exclude free orgs

#### Developers/users with readp-only access

1. As a user with BILLING_READ but not BILLING_WRITE, open an org that is missing a billing address.
2. Confirm the modal appears with informational copy only and no editable form.
3. Click the close button and verify the modal dismisses.