### PR TITLE
docs(auth): Add OAuth PKCE example for SSR

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -744,6 +744,13 @@ language="typescript"
 </TabPanel>
 </Tabs>
 
+## Sign in with OAuth
+
+If you need OAuth sign-in in an SSR app, use the PKCE flow and redirect to
+`data.url` on the server before handling the callback route.
+
+<$Partial path="oauth_pkce_flow.mdx" />
+
 ## Caching considerations
 
 If your app uses ISR (Incremental Static Regeneration) or is deployed behind a CDN, caching of HTTP responses can cause users to receive another user's session. When a session is refreshed, the new token is written to the response via `Set-Cookie`. If that response is cached and served to a different user, that user will be signed in as the wrong person.


### PR DESCRIPTION
This surfaces the PKCE OAuth example in the SSR client guide so SvelteKit users can
see the `redirect(data.url)` pattern directly in the docs.

It keeps the guidance in the SSR auth flow where readers already are, instead of
burying the callback behavior in a less visible partial.

Fixes #23618