### PR TITLE
fix: annoying and confusing bugs with queue operations in table editor

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -93,7 +93,9 @@ export const SupabaseGrid = ({
     if (!mounted) setMounted(true)
   }, [])
 
-  const operations = tableEditorSnap.operationQueue.operations as QueuedOperation[]
+  const operations = (tableEditorSnap.operationQueue.operations as QueuedOperation[]).filter(
+    (op) => op.tableId === tableId
+  )
   const baseRows = data?.rows ?? EMPTY_ARR
   const rows = formatGridDataWithOperationValues({ operations, rows: baseRows })
 

--- a/apps/studio/components/grid/utils/queueOperationUtils.test.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.test.ts
@@ -390,10 +390,7 @@ describe('formatGridDataWithOperationValues', () => {
   })
 
   test('should correctly delete a row after adding a new row (ADD then DELETE)', () => {
-    const rows = [
-      makeRow(0, { id: 1, name: 'Alice' }),
-      makeRow(1, { id: 2, name: 'Bob' }),
-    ]
+    const rows = [makeRow(0, { id: 1, name: 'Alice' }), makeRow(1, { id: 2, name: 'Bob' })]
     const addOp = makeAddOp('-100', { name: 'New Row' })
     const deleteOp = makeDeleteOp({ id: 1 }, rows[0])
 

--- a/apps/studio/components/grid/utils/queueOperationUtils.test.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.test.ts
@@ -389,6 +389,53 @@ describe('formatGridDataWithOperationValues', () => {
     expect(result[1]).toMatchObject({ __tempId: '-100', name: 'Row 1' })
   })
 
+  test('should correctly delete a row after adding a new row (ADD then DELETE)', () => {
+    const rows = [
+      makeRow(0, { id: 1, name: 'Alice' }),
+      makeRow(1, { id: 2, name: 'Bob' }),
+    ]
+    const addOp = makeAddOp('-100', { name: 'New Row' })
+    const deleteOp = makeDeleteOp({ id: 1 }, rows[0])
+
+    const result = formatGridDataWithOperationValues({
+      operations: [addOp, deleteOp],
+      rows,
+    })
+
+    expect(result).toHaveLength(3)
+    // New row should be preserved at position 0
+    expect(result[0]).toMatchObject({ __tempId: '-100', name: 'New Row' })
+    expect(result[0].__isDeleted).toBeUndefined()
+    // Deleted row should be marked
+    expect(result[1].__isDeleted).toBe(true)
+    expect(result[1].id).toBe(1)
+    // Other row unaffected
+    expect(result[2]).toEqual(rows[1])
+  })
+
+  test('should correctly edit a row after adding a new row (ADD then EDIT)', () => {
+    const rows = [makeRow(0, { id: 1, name: 'Alice' })]
+    const addOp = makeAddOp('-100', { name: 'New Row' })
+    const editOp = makeEditOp({
+      payload: {
+        rowIdentifiers: { id: 1 },
+        columnName: 'name',
+        oldValue: 'Alice',
+        newValue: 'Updated Alice',
+        table: {} as any,
+      },
+    })
+
+    const result = formatGridDataWithOperationValues({
+      operations: [addOp, editOp],
+      rows,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ __tempId: '-100', name: 'New Row' })
+    expect(result[1].name).toBe('Updated Alice')
+  })
+
   test('should handle EDIT_CELL_CONTENT with composite primary keys', () => {
     const rows = [makeRow(0, { tenant_id: 'a', user_id: 1, name: 'Alice' })]
     const op = makeEditOp({

--- a/apps/studio/components/grid/utils/queueOperationUtils.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.ts
@@ -152,7 +152,7 @@ export const formatGridDataWithOperationValues = ({
   operations.forEach((op) => {
     if (op.type === QueuedOperationType.EDIT_CELL_CONTENT) {
       const { rowIdentifiers, columnName, newValue } = op.payload
-      const rowIdx = rows.findIndex((row) => rowMatchesIdentifiers(row, rowIdentifiers))
+      const rowIdx = formattedRows.findIndex((row) => rowMatchesIdentifiers(row, rowIdentifiers))
       if (rowIdx !== -1) {
         formattedRows[rowIdx] = { ...formattedRows[rowIdx], [columnName]: newValue }
       }
@@ -177,9 +177,9 @@ export const formatGridDataWithOperationValues = ({
       }
     } else if (op.type === QueuedOperationType.DELETE_ROW) {
       const { rowIdentifiers } = op.payload
-      const rowMatches = rows.find((row) => rowMatchesIdentifiers(row, rowIdentifiers))
-      if (rowMatches) {
-        formattedRows[rowMatches.idx] = { ...rowMatches, __isDeleted: true }
+      const rowIdx = formattedRows.findIndex((row) => rowMatchesIdentifiers(row, rowIdentifiers))
+      if (rowIdx !== -1) {
+        formattedRows[rowIdx] = { ...formattedRows[rowIdx], __isDeleted: true }
       }
     }
   })

--- a/e2e/studio/features/queue-table-operations.spec.ts
+++ b/e2e/studio/features/queue-table-operations.spec.ts
@@ -627,6 +627,61 @@ test.describe('Queue Table Operations', () => {
     await expect(page.getByRole('gridcell', { name: 'row to edit' })).not.toBeVisible()
   })
 
+  test('newly added row is preserved after deleting another row', async ({ page, ref }) => {
+    const tableName = `${tableNamePrefix}_add_then_del`
+    const columnName = 'name'
+
+    await using _ = await withSetupCleanup(
+      async () => {
+        await createTable(tableName, columnName, [
+          { name: 'existing row' },
+        ])
+      },
+      async () => {
+        await dropTable(tableName)
+      }
+    )
+
+    await page.goto(toUrl(`/project/${ref}/editor?schema=public`))
+    await enableQueueOperations(page)
+    await page.reload()
+    await waitForTableToLoad(page, ref)
+
+    await page.getByRole('button', { name: `View ${tableName}`, exact: true }).click()
+    await page.waitForURL(/\/editor\/\d+\?schema=public$/)
+
+    // Add a new row
+    await page.getByTestId('table-editor-insert-new-row').click()
+    await page.getByRole('menuitem', { name: 'Insert row Insert a new row' }).click()
+    await page.getByTestId(`${columnName}-input`).fill('new row')
+    await page.getByTestId('action-bar-save-row').click()
+
+    await expect(page.getByText('1 pending change')).toBeVisible()
+    await expect(page.getByRole('gridcell', { name: 'new row' })).toBeVisible()
+
+    // Delete the existing row
+    const cellToDelete = page.getByRole('gridcell', { name: 'existing row' })
+    await cellToDelete.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Delete row' }).click()
+
+    await expect(page.getByText('2 pending changes')).toBeVisible()
+
+    // The newly added row should still be visible and not replaced
+    await expect(page.getByRole('gridcell', { name: 'new row' })).toBeVisible()
+
+    // Save and verify
+    await page.getByRole('button', { name: /Review/ }).click()
+    const sidePanel = page.getByRole('dialog')
+    await expect(sidePanel.getByText('1 row addition')).toBeVisible()
+    await expect(sidePanel.getByText('1 row deletion')).toBeVisible()
+
+    await sidePanel.getByRole('button', { name: /^Save/ }).click()
+    await expect(page.getByText('Changes saved successfully')).toBeVisible()
+
+    await expect(page.getByRole('gridcell', { name: 'new row' })).toBeVisible()
+    await expect(page.getByRole('gridcell', { name: 'existing row' })).not.toBeVisible()
+  })
+
   test('pending changes persist when switching between tables', async ({ page, ref }) => {
     const tableName1 = `${tableNamePrefix}_persist1`
     const tableName2 = `${tableNamePrefix}_persist2`

--- a/e2e/studio/features/queue-table-operations.spec.ts
+++ b/e2e/studio/features/queue-table-operations.spec.ts
@@ -736,6 +736,53 @@ test.describe('Queue Table Operations', () => {
     await expect(page.getByRole('gridcell', { name: 'pending in table 2' })).toBeVisible()
   })
 
+  test('pending row changes do not leak across tables', async ({ page, ref }) => {
+    const tableName1 = `${tableNamePrefix}_leak1`
+    const tableName2 = `${tableNamePrefix}_leak2`
+    const columnName = 'name'
+
+    await using _ = await withSetupCleanup(
+      async () => {
+        await createTable(tableName1, columnName)
+        await createTable(tableName2, columnName)
+      },
+      async () => {
+        await dropTable(tableName1)
+        await dropTable(tableName2)
+      }
+    )
+
+    await page.goto(toUrl(`/project/${ref}/editor?schema=public`))
+    await enableQueueOperations(page)
+    await page.reload()
+    await waitForTableToLoad(page, ref)
+
+    await page.getByRole('button', { name: `View ${tableName1}`, exact: true }).click()
+    await page.waitForURL(/\/editor\/\d+\?schema=public$/)
+
+    await page.getByTestId('table-editor-insert-new-row').click()
+    await page.getByRole('menuitem', { name: 'Insert row Insert a new row' }).click()
+    await page.getByTestId(`${columnName}-input`).fill('only in table 1')
+    await page.getByTestId('action-bar-save-row').click()
+
+    await expect(page.getByText('1 pending change')).toBeVisible()
+
+    // Navigate to table 2 — pending row from table 1 should not appear
+    await page.getByRole('button', { name: `View ${tableName2}`, exact: true }).click()
+    await expect(page.getByRole('gridcell', { name: 'only in table 1' })).not.toBeVisible()
+
+    // Add a row in table 2
+    await page.getByTestId('table-editor-insert-new-row').click()
+    await page.getByRole('menuitem', { name: 'Insert row Insert a new row' }).click()
+    await page.getByTestId(`${columnName}-input`).fill('only in table 2')
+    await page.getByTestId('action-bar-save-row').click()
+
+    // Navigate back to table 1 — pending row from table 2 should not appear
+    await page.getByRole('button', { name: `View ${tableName1}`, exact: true }).click()
+    await expect(page.getByRole('gridcell', { name: 'only in table 1' })).toBeVisible()
+    await expect(page.getByRole('gridcell', { name: 'only in table 2' })).not.toBeVisible()
+  })
+
   test('editing multiple columns via side panel queues all changes', async ({ page, ref }) => {
     const tableName = `${tableNamePrefix}_multi_col`
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

  - Index mismatch on ADD then DELETE/EDIT: formatGridDataWithOperationValues was searching the original rows array for DELETE_ROW and EDIT_CELL_CONTENT operations, then using those indices on the modified formattedRows array (which had  been shifted by ADD_ROW's unshift). Both now search formattedRows directly.
  - Cross-table operation leaking: The entire operation queue was passed to formatGridDataWithOperationValues without filtering by the current table, causing pending ADD_ROW and DELETE_ROW operations from one table to appear in other  tables. Operations are now filtered by tableId before rendering.