### PR TITLE
chore: increase min credit top up to 300

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -49,8 +49,8 @@ const FORM_ID = 'credit-top-up'
 const FormSchema = z.object({
   amount: z.coerce
     .number()
-    .gte(100, 'Amount must be between $100 - $2000.')
-    .lte(2000, 'Amount must be between $100 - $2000.')
+    .gte(250, 'Amount must be between $250 - $2000.')
+    .lte(2000, 'Amount must be between $250 - $2000.')
     .int('Amount must be a whole number.'),
   paymentMethod: z.string(),
 })
@@ -78,7 +78,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
   const form = useForm<CreditTopUpForm>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      amount: 100,
+      amount: 250,
       paymentMethod: '',
     },
   })
@@ -268,7 +268,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                 name="amount"
                 render={({ field }) => (
                   <FormItemLayout label="Amount (USD)" className="gap-1">
-                    <Input_Shadcn_ {...field} type="number" placeholder="100" />
+                    <Input_Shadcn_ {...field} type="number" placeholder="250" />
                   </FormItemLayout>
                 )}
               />

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -268,7 +268,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                 name="amount"
                 render={({ field }) => (
                   <FormItemLayout label="Amount (USD)" className="gap-1">
-                    <Input_Shadcn_ {...field} type="number" placeholder="350" />
+                    <Input_Shadcn_ {...field} type="number" placeholder="300" />
                   </FormItemLayout>
                 )}
               />

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -49,8 +49,8 @@ const FORM_ID = 'credit-top-up'
 const FormSchema = z.object({
   amount: z.coerce
     .number()
-    .gte(250, 'Amount must be between $250 - $2000.')
-    .lte(2000, 'Amount must be between $250 - $2000.')
+    .gte(300, 'Amount must be between $300 - $2000.')
+    .lte(2000, 'Amount must be between $300 - $2000.')
     .int('Amount must be a whole number.'),
   paymentMethod: z.string(),
 })
@@ -78,7 +78,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
   const form = useForm<CreditTopUpForm>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      amount: 250,
+      amount: 300,
       paymentMethod: '',
     },
   })
@@ -268,7 +268,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                 name="amount"
                 render={({ field }) => (
                   <FormItemLayout label="Amount (USD)" className="gap-1">
-                    <Input_Shadcn_ {...field} type="number" placeholder="250" />
+                    <Input_Shadcn_ {...field} type="number" placeholder="350" />
                   </FormItemLayout>
                 )}
               />


### PR DESCRIPTION
Increases the minimum credit top-up to $300.

### Testing
- Head to `/org/_/billing`
- Assert that you're not able to do a top-up for less than $300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Increased the minimum credit top-up amount from 100 USD to 300 USD. Form defaults and placeholder text updated to reflect the new minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->