### PR TITLE
fix(studio): fix cron job form scroll by removing nested overflow-auto

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.tsx
@@ -295,7 +295,7 @@ export const CreateCronJobSheet = ({ open, selectedCronJob, onClose }: CreateCro
               <Form_Shadcn_ {...form}>
                 <form
                   id={FORM_ID}
-                  className="flex-grow overflow-auto"
+                  className="flex-grow"
                   onSubmit={form.handleSubmit(onSubmit)}
                 >
                   <SheetSection>


### PR DESCRIPTION
## Summary
- Fixes the scroll issue in the cron job creation/edit form where users could not scroll to access all fields when form content overflows the viewport
- The root cause was a nested `overflow-auto` on both the outer wrapper `<div>` and the inner `<form>` element, creating competing scroll contexts that prevented proper scrolling
- Removed `overflow-auto` from the `<form>` element since the parent `<div>` already handles scrolling via `overflow-auto flex-grow`

## What changed
**File:** `apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.tsx`

The `<form>` element's className was changed from `"flex-grow overflow-auto"` to `"flex-grow"`, leaving scroll handling solely to the parent container.

Fixes #44146

## Test plan
- [ ] Open the Supabase Dashboard and navigate to Integrations
- [ ] Create a new cron job
- [ ] Verify that the form scrolls smoothly when content overflows the viewport
- [ ] Verify that all fields (name, schedule, type selection, and type-specific fields) remain accessible via scrolling
- [ ] Test editing an existing cron job to verify scroll also works in edit mode