### PR TITLE
fix(studio): add missing /mcp path to MCP server URL in ConnectSheet

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/useMcpUrl.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/useMcpUrl.ts
@@ -9,7 +9,7 @@ export function useMcpUrl(
   projectKeys: StepContentProps['projectKeys']
 ): string {
   const readonly = Boolean(state.mcpReadonly)
-  const baseUrl = IS_PLATFORM ? 'https://mcp.supabase.com' : (projectKeys.apiUrl ?? '')
+  const baseUrl = IS_PLATFORM ? 'https://mcp.supabase.com/mcp' : (projectKeys.apiUrl ?? '')
 
   return useMemo(() => {
     const params = new URLSearchParams()


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix — one-character fix that breaks MCP setup for all Studio users.

## What is the current behavior?

The Studio ConnectSheet generates MCP URLs using `https://mcp.supabase.com` (without the `/mcp` path), which returns a **404 error**. Users who copy the MCP config from the Studio get a broken setup.

Verified with curl:
- `https://mcp.supabase.com` → HTTP 404
- `https://mcp.supabase.com/mcp` → HTTP 401 (correct — requires auth)

Every other reference in the codebase already uses the correct URL with `/mcp`:
- `.mcp.json`
- `apps/docs/content/guides/getting-started/mcp.mdx`
- `apps/www/_blog/2025-10-03-remote-mcp-server.mdx`
- `apps/www/data/solutions/developers.tsx`

Only `apps/studio/components/interfaces/ConnectSheet/useMcpUrl.ts` was missing the path.

Closes #43961

## What is the new behavior?

The `baseUrl` in `useMcpUrl.ts` now correctly uses `https://mcp.supabase.com/mcp`, matching the rest of the codebase and the actual server endpoint.

## Additional context

Single-line change in `useMcpUrl.ts` line 12.