### PR TITLE
docs(swift): add explicit Xcode target setup to fix build errors

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
@@ -31,7 +31,7 @@ hideToc: true
 
       In Xcode, navigate to **File > Add Package Dependencies...** and enter the repository URL `https://github.com/supabase/supabase-swift` in the search bar. For detailed instructions, see Apple's [tutorial on adding package dependencies](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app).
 
-      Make sure to add `Supabase` product package as a dependency to your application target.
+      After adding the package, you must explicitly add the `Supabase` library to your app target. Select your project in the navigator, choose your app target under **Targets**, go to the **General** tab, scroll to **Frameworks, Libraries, and Embedded Content**, and click **+** to add `Supabase`. Without this step, Xcode may fail to build with a "No such module 'Supabase'" error.
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
@@ -27,6 +27,8 @@ Add the [supabase-swift](https://github.com/supabase/supabase-swift) dependency.
 
 Add the `https://github.com/supabase/supabase-swift` package to your app. For instructions, see the [Apple tutorial on adding package dependencies](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app).
 
+After adding the package, select your project in the navigator, choose your app target under **Targets**, go to the **General** tab, scroll to **Frameworks, Libraries, and Embedded Content**, and click **+** to add the `Supabase` library. Without this step, Xcode may fail to build with a "No such module 'Supabase'" error.
+
 Create a helper file to initialize the Supabase client.
 You need the API URL and the key that you copied [earlier](#get-api-details).
 These variables will be exposed on the application, and that's completely fine since you have

--- a/apps/docs/docs/ref/swift/installing.mdx
+++ b/apps/docs/docs/ref/swift/installing.mdx
@@ -22,6 +22,8 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
 
     If you use Xcode, follow [Apple's dependencies guide](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to add supabase-swift to your project. Use https://github.com/supabase-community/supabase-swift.git for the url when Xcode asks.
 
+    After adding the package dependency, you must also add the `Supabase` library to your target. In Xcode, select your project in the navigator, then select your app target under "Targets". Under the "General" tab, scroll to "Frameworks, Libraries, and Embedded Content" and click the "+" button. Search for and add the `Supabase` library (or a subset such as `Auth`, `Realtime`, `Postgrest`, `Functions`, or `Storage`). Without this step, you may encounter a "No such module 'Supabase'" build error.
+
     If you don't want the full Supabase environment, you can add individual packages, such as Functions, `Auth`, `Realtime`, `Storage`, or `PostgREST`.
 
   </RefSubLayout.Details>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Swift installation docs across three pages tell users to add the `supabase-swift` package via Swift Package Manager / Xcode, but do not explain that the `Supabase` library must also be explicitly added to the app target under **Frameworks, Libraries, and Embedded Content**. This causes Xcode builds to fail with a `No such module 'Supabase'` error, as reported in issue #38509 and [supabase/discussions#19764](https://github.com/orgs/supabase/discussions/19764).

## What is the new behavior?

All three Swift documentation pages now include step-by-step instructions for adding the `Supabase` library to the app target in Xcode:

- **Swift reference docs** (`docs/ref/swift/installing.mdx`): Added a paragraph after the Xcode package-add step explaining how to navigate to Targets > General > Frameworks, Libraries, and Embedded Content to add the library.
- **iOS SwiftUI quickstart** (`guides/getting-started/quickstarts/ios-swiftui.mdx`): Replaced the vague "Make sure to add `Supabase` product package as a dependency to your application target" with explicit Xcode navigation steps and error context.
- **Swift tutorial** (`guides/getting-started/tutorials/with-swift.mdx`): Added the same explicit instructions after the package installation step.

## Additional context

Fixes #38509