### PR TITLE
docs: fix network restrictions API example JSON key

### DIFF
--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -36,7 +36,7 @@ curl -X POST "https://api.supabase.com/v1/projects/$PROJECT_REF/network-restrict
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "db_allowed_cidrs": [
+    "dbAllowedCidrs": [
       "192.168.0.1/24",
     ]
   }'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The Network Restrictions guide’s Management API example used `db_allowed_cidrs` in the JSON body. That does not match the API, so the example does not work correctly when copied.

Fixes #44164

## What is the new behavior?

The curl example now uses `dbAllowedCidrs`, consistent with the [Update network restrictions](https://supabase.com/docs/reference/api/v1-update-network-restrictions) Management API reference.

## Additional context

N/A (documentation-only change; no visual changes).