### PR TITLE
fix(studio): show queue changes label for queued table edits

### DIFF
--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import { ChevronDown } from 'lucide-react'
+import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useEffect, useRef, useState } from 'react'
 import type { RenderEditCellProps } from 'react-data-grid'
 
@@ -42,10 +43,12 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
 }: BaseEditorProps<TRow, TSummaryRow>) {
   const ref = useRef<HTMLInputElement>(null)
   const format = FORMAT_MAP[type]
+  const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
 
   const value = row[column.key as keyof TRow] as unknown as string
   const [inputValue, setInputValue] = useState(value)
   const timeValue = inputValue ? Number(dayjs(inputValue, format)) : inputValue
+  const applyChangesLabel = isQueueOperationsEnabled ? 'Queue changes' : 'Save changes'
 
   const saveChanges = (value: string | null) => {
     if ((typeof value === 'string' && value.length === 0) || timeValue === 'Invalid Date') return
@@ -126,7 +129,7 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
               <div className="px-1.5 h-[22px] rounded bg-surface-300 border border-strong flex items-center justify-center">
                 <span className="text-[10px]">⏎</span>
               </div>
-              <p className="text-xs text-foreground-light">Save changes</p>
+              <p className="text-xs text-foreground-light">{applyChangesLabel}</p>
             </div>
             <div className="flex items-center space-x-2">
               <div className="px-1 h-[22px] rounded bg-surface-300 border border-strong flex items-center justify-center">

--- a/apps/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/apps/studio/components/grid/components/editor/JsonEditor.tsx
@@ -4,6 +4,7 @@ import type { RenderEditCellProps } from 'react-data-grid'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
+import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { isValueTruncated } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
@@ -56,6 +57,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   const { id: _id } = useParams()
   const id = _id ? Number(_id) : undefined
   const { data: project } = useSelectedProjectQuery()
+  const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
 
   const { data: selectedTable } = useTableEditorQuery({
     projectRef: project?.ref,
@@ -74,6 +76,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   const isTruncated = isValueTruncated(initialValue)
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const [value, setValue] = useState<string | null>(jsonString)
+  const applyChangesLabel = isQueueOperationsEnabled ? 'Queue changes' : 'Save changes'
 
   const { mutate: getCellValue, isPending, isSuccess } = useGetCellValueMutation()
 
@@ -187,7 +190,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
                     <div className="px-1.5 py-[2.5px] rounded bg-selection border border-strong flex items-center justify-center">
                       <span className="text-[10px]">⏎</span>
                     </div>
-                    <p className="text-xs text-foreground-light">Save changes</p>
+                    <p className="text-xs text-foreground-light">{applyChangesLabel}</p>
                   </div>
                   <div className="flex items-center space-x-2">
                     <div className="px-1 py-[2.5px] rounded bg-selection border border-strong flex items-center justify-center">

--- a/apps/studio/components/grid/components/editor/TextEditor.tsx
+++ b/apps/studio/components/grid/components/editor/TextEditor.tsx
@@ -46,6 +46,7 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
   const [value, setValue] = useState<string | null>(initialValue)
   const [isConfirmNextModalOpen, setIsConfirmNextModalOpen] = useState(false)
   const { isQueueEnabled } = useTableRowOperations()
+  const applyChangesLabel = isQueueEnabled ? 'Queue changes' : 'Save changes'
 
   const { mutate: getCellValue, isPending, isSuccess } = useGetCellValueMutation()
 
@@ -145,7 +146,7 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
                       <div className="px-1.5 py-[2.5px] rounded bg-surface-300 border border-strong flex items-center justify-center">
                         <span className="text-[10px]">⏎</span>
                       </div>
-                      <p className="text-xs text-foreground-light">Save changes</p>
+                      <p className="text-xs text-foreground-light">{applyChangesLabel}</p>
                     </div>
                     <div className="flex items-center space-x-2">
                       <div className="px-1 py-[2.5px] rounded bg-surface-300 border border-strong flex items-center justify-center">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -21,6 +21,7 @@ import {
   validateFields,
 } from './RowEditor.utils'
 import { TextEditor } from './TextEditor'
+import { useIsQueueOperationsEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 
 export interface RowEditorProps {
   row?: Dictionary<any>
@@ -43,6 +44,10 @@ export const RowEditor = ({
   saveChanges = noop,
   updateEditorDirty = noop,
 }: RowEditorProps) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
+  const applyChangesLabel = isQueueOperationsEnabled ? 'Queue changes' : 'Save'
+
   const [errors, setErrors] = useState<Dictionary<any>>({})
   const [rowFields, setRowFields] = useState<RowField[]>([])
 
@@ -64,7 +69,6 @@ export const RowEditor = ({
     (rowField: any) => !rowField.isNullable
   )
 
-  const { data: project } = useSelectedProjectQuery()
   const { data } = useForeignKeyConstraintsQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
@@ -182,7 +186,7 @@ export const RowEditor = ({
           loading={loading}
           formId={formId}
           backButtonLabel="Cancel"
-          applyButtonLabel="Save"
+          applyButtonLabel={applyChangesLabel}
           closePanel={closePanel}
           hideApply={!editable}
           visible={visible}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { useTableRowOperations } from 'components/grid/hooks/useTableRowOperations'
 import { type GeneratedPolicy } from 'components/interfaces/Auth/Policies/Policies.utils'
+import { useIsQueueOperationsEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { DiscardChangesConfirmationDialog } from 'components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
 import { databasePoliciesKeys } from 'data/database-policies/keys'
 import { useDatabasePublicationCreateMutation } from 'data/database-publications/database-publications-create-mutation'
@@ -196,6 +197,7 @@ export const SidePanelEditor = ({
   const { data: project } = useSelectedProjectQuery()
   const { data: org } = useSelectedOrganizationQuery()
   const isApiGrantTogglesEnabled = useDataApiGrantTogglesEnabled()
+  const isQueueOperationsEnabled = useIsQueueOperationsEnabled()
   const { updateRow, addRow, isEditPending } = useTableRowOperations()
 
   const [isEdited, setIsEdited] = useState<boolean>(false)
@@ -963,7 +965,7 @@ export const SidePanelEditor = ({
         row={(snap.sidePanel?.type === 'json' && snap.sidePanel.jsonValue.row) || {}}
         column={(snap.sidePanel?.type === 'json' && snap.sidePanel.jsonValue.column) || ''}
         backButtonLabel="Cancel"
-        applyButtonLabel="Save changes"
+        applyButtonLabel={isQueueOperationsEnabled ? 'Queue changes' : 'Save changes'}
         readOnly={!editable}
         closePanel={onClosePanel}
         onSaveJSON={onSaveColumnValue}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When Queue table operations is enabled, Table Editor cell edit affordances still say `Save changes`, even though the edit is queued for later review and save.

## What is the new behavior?

Cell edit affordances in the Table Editor now say `Queue changes` when the Queue table operations feature preview is enabled, and continue to say `Save changes` otherwise.

| Before | After |
| --- | --- |
| <img width="640" height="796" alt="CleanShot 2026-03-25 at 17 55 20@2x" src="https://github.com/user-attachments/assets/e0de99f0-2c08-4723-8f79-a7489ebdd355" /> | <img width="672" height="838" alt="CleanShot 2026-03-25 at 17 55 08@2x-68362D24-A25C-41D5-920C-38B85E816F54" src="https://github.com/user-attachments/assets/7b437259-673c-46c7-85df-51f1daa8826b" /> |

## Additional context

This updates the inline text, JSON, and date/time editors, plus the JSON side-panel cell editor path.
