### PR TITLE
chore: update InviteUserModal to use rhf

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
@@ -3,7 +3,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { useUserInviteMutation } from 'data/auth/user-invite-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useForm } from 'react-hook-form'
+import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   Button,
@@ -24,6 +24,7 @@ export type InviteUserModalProps = {
 const formSchema = z.object({
   email: z.string().min(1, 'Please enter a valid email').email('Please enter a valid email'),
 })
+const formId = 'invite-user-form'
 
 const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
   const { ref: projectRef } = useParams()
@@ -43,11 +44,11 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
     'invite_user'
   )
 
-  const onInviteUser = async (values: any) => {
+  const onInviteUser: SubmitHandler<z.infer<typeof formSchema>> = async (values) => {
     if (!projectRef) return console.error('Project ref is required')
     inviteUser({ projectRef, email: values.email })
   }
-  const formId = 'invite-user-form'
+
   return (
     <Modal
       hideFooter

--- a/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
@@ -1,19 +1,35 @@
+import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Mail } from 'lucide-react'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { useUserInviteMutation } from 'data/auth/user-invite-mutation'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { Button, Form, Input, Modal } from 'ui'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import {
+  Button,
+  Form_Shadcn_,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Input_Shadcn_,
+  Modal,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import * as z from 'zod'
 
 export type InviteUserModalProps = {
   visible: boolean
   setVisible: (visible: boolean) => void
 }
 
+const formSchema = z.object({
+  email: z.string().min(1, 'Please enter a valid email').email('Please enter a valid email'),
+})
+
 const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
   const { ref: projectRef } = useParams()
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+  })
 
   const handleToggle = () => setVisible(!visible)
   const { mutate: inviteUser, isPending: isInviting } = useUserInviteMutation({
@@ -27,25 +43,11 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
     'invite_user'
   )
 
-  const validate = (values: any) => {
-    const errors: any = {}
-    const emailValidateRegex =
-      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
-
-    if (values.email.length === 0) {
-      errors.email = 'Please enter a valid email'
-    } else if (!emailValidateRegex.test(values.email)) {
-      errors.email = `${values.email} is an invalid email`
-    }
-
-    return errors
-  }
-
   const onInviteUser = async (values: any) => {
     if (!projectRef) return console.error('Project ref is required')
     inviteUser({ projectRef, email: values.email })
   }
-
+  const formId = 'invite-user-form'
   return (
     <Modal
       hideFooter
@@ -55,40 +57,36 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
       header="Invite a new user"
       onCancel={handleToggle}
     >
-      <Form
-        validateOnBlur={false}
-        initialValues={{ email: '' }}
-        validate={validate}
-        onSubmit={onInviteUser}
-      >
-        {() => (
-          <>
-            <Modal.Content>
-              <Input
-                id="email"
-                className="w-full"
-                label="User email"
-                icon={<Mail />}
-                type="email"
-                name="email"
-                placeholder="User email"
-              />
-            </Modal.Content>
+      <Form_Shadcn_ {...form}>
+        <Modal.Content>
+          <form id={formId} onSubmit={form.handleSubmit(onInviteUser)}>
+            <FormField_Shadcn_
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="User email">
+                  <FormControl_Shadcn_ className="relative col-span-6">
+                    <Input_Shadcn_ {...field} />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </form>
+        </Modal.Content>
 
-            <Modal.Content>
-              <Button
-                block
-                size="small"
-                htmlType="submit"
-                loading={isInviting}
-                disabled={!canInviteUsers || isInviting}
-              >
-                Invite user
-              </Button>
-            </Modal.Content>
-          </>
-        )}
-      </Form>
+        <Modal.Content>
+          <Button
+            form={formId}
+            block
+            size="small"
+            htmlType="submit"
+            loading={isInviting}
+            disabled={!canInviteUsers || isInviting}
+          >
+            Invite user
+          </Button>
+        </Modal.Content>
+      </Form_Shadcn_>
     </Modal>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
@@ -60,7 +60,7 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
     >
       <Form_Shadcn_ {...form}>
         <Modal.Content>
-          <form id={formId} onSubmit={form.handleSubmit(onInviteUser)}>
+          <form id={formId} onSubmit={form.handleSubmit(onInviteUser)} noValidate>
             <FormField_Shadcn_
               control={form.control}
               name="email"

--- a/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/InviteUserModal.tsx
@@ -30,6 +30,9 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
   const { ref: projectRef } = useParams()
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: '',
+    },
   })
 
   const handleToggle = () => setVisible(!visible)
@@ -46,7 +49,14 @@ const InviteUserModal = ({ visible, setVisible }: InviteUserModalProps) => {
 
   const onInviteUser: SubmitHandler<z.infer<typeof formSchema>> = async (values) => {
     if (!projectRef) return console.error('Project ref is required')
-    inviteUser({ projectRef, email: values.email })
+    inviteUser(
+      { projectRef, email: values.email },
+      {
+        onSuccess: () => {
+          form.reset()
+        },
+      }
+    )
   }
 
   return (


### PR DESCRIPTION
## Problem

- The InviteUserModal still use `formik` and we want to remove it in favour of `react-hook-form` to keep only one form library
- The InviteUserModal do not follow the design system guidelines

## Solution

- Migrate to `react-hook-form`
- Apply the design system guidelines

## Screenshots

Before:
<img width="432" height="264" alt="image" src="https://github.com/user-attachments/assets/3eb1ce5e-de29-4ca2-aad9-677822756b2a" />

After:
<img width="454" height="312" alt="image" src="https://github.com/user-attachments/assets/feb2efc9-ab33-4ffc-9eed-1d14ab0a1dac" />
