### PR TITLE
Fix typo in LangChain guide  "Prepare you database" → "Prepare your database"

### DIFF
--- a/apps/docs/content/guides/ai/langchain.mdx
+++ b/apps/docs/content/guides/ai/langchain.mdx
@@ -9,7 +9,7 @@ sidebar_label: 'LangChain'
 
 ## Initializing your database
 
-Prepare you database with the relevant tables:
+Prepare your database with the relevant tables:
 
 <Tabs
   scrollable


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The LangChain guide has a typo: "Prepare you database with the relevant tables"

## What is the new behavior?

Fixed to: "Prepare your database with the relevant tables"

## Additional context

Small typo fix in apps/docs/content/guides/ai/langchain.mdx