### PR TITLE
fix: cannot create nor edit foreign keys from schema visualiser

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -364,6 +364,7 @@ export const ColumnEditor = ({
       >
         <FormSectionContent loading={false} className="lg:!col-span-8">
           <ColumnForeignKey
+            tableId={selectedTable.id}
             column={columnFields}
             relations={fkRelations}
             closePanel={closePanel}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -1,10 +1,10 @@
 import { useParams } from 'common'
-import { useState } from 'react'
-import { Button } from 'ui'
-
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { useState } from 'react'
+import { Button } from 'ui'
+
 import { ForeignKeySelector } from '../ForeignKeySelector/ForeignKeySelector'
 import type { ForeignKey } from '../ForeignKeySelector/ForeignKeySelector.types'
 import type { ColumnField } from '../SidePanelEditor.types'
@@ -12,6 +12,7 @@ import { ForeignKeyRow } from '../TableEditor/ForeignKeysManagement/ForeignKeyRo
 import { checkIfRelationChanged } from '../TableEditor/ForeignKeysManagement/ForeignKeysManagement.utils'
 
 interface ColumnForeignKeyProps {
+  tableId?: number
   column: ColumnField
   relations: ForeignKey[]
   closePanel: () => void
@@ -20,6 +21,7 @@ interface ColumnForeignKeyProps {
 }
 
 const ColumnForeignKey = ({
+  tableId,
   column,
   relations,
   closePanel,
@@ -29,7 +31,6 @@ const ColumnForeignKey = ({
   const { id: _id } = useParams()
   const [open, setOpen] = useState(false)
   const [selectedFk, setSelectedFk] = useState<ForeignKey>()
-
   const { data: project } = useSelectedProjectQuery()
   const { data } = useForeignKeyConstraintsQuery({
     projectRef: project?.ref,
@@ -41,7 +42,7 @@ const ColumnForeignKey = ({
   const { data: table } = useTableEditorQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    id,
+    id: tableId ?? id,
   })
   const formattedColumnsForFkSelector = (table?.columns ?? []).map((c) => {
     return {


### PR DESCRIPTION
## Problem

Users cannot create nor edit foreign keys when editing a table or a column from the schema visualiser

## Solution

The foreign key edition component is always reading the current table from the URL parameters. However, in the context of the schema visualiser, the parameter does not exist.

Allows to override it from the side panel editor context

## How to test

- Create two tables
- Go to the schema visualiser and edit one of the table
- Click the _Add foreign key relation_ and add a foreign key to the other table

- Edit one of the foreign key column
- You should be able to edit the relation