### PR TITLE
fix(studio): show removed edge functions in branch merge diff

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/EdgeFunctionsDiffPanel.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/EdgeFunctionsDiffPanel.tsx
@@ -173,7 +173,10 @@ export const EdgeFunctionsDiffPanel = ({
     return <Skeleton className="h-64" />
   }
 
-  const noChanges = diffResults.addedSlugs.length === 0 && diffResults.modifiedSlugs.length === 0
+  const noChanges =
+    diffResults.addedSlugs.length === 0 &&
+    diffResults.modifiedSlugs.length === 0 &&
+    diffResults.removedSlugs.length === 0
 
   if (noChanges) {
     return (
@@ -205,23 +208,22 @@ export const EdgeFunctionsDiffPanel = ({
           </div>
         </div>
       )}
-      {/* TODO: Removing functions is not supported yet */}
-      {/* {diffResults.removedSlugs.length > 0 && (
+      {diffResults.removedSlugs.length > 0 && (
         <div>
           <div className="space-y-4">
             {diffResults.removedSlugs.map((slug) => (
               <FunctionDiff
                 key={slug}
                 functionSlug={slug}
-                currentBody={EMPTY_ARR}
+                currentBody={EMPTY_FUNCTION_BODY}
                 mainBody={diffResults.removedBodiesMap[slug]!}
-                currentBranchRef={mainBranchRef}
+                currentBranchRef={currentBranchRef}
                 fileInfos={diffResults.functionFileInfo[slug] || EMPTY_ARR}
               />
             ))}
           </div>
         </div>
-      )} */}
+      )}
 
       {diffResults.modifiedSlugs.length > 0 && (
         <div className="space-y-4">

--- a/apps/studio/tests/features/branches/EdgeFunctionsDiffPanel.test.tsx
+++ b/apps/studio/tests/features/branches/EdgeFunctionsDiffPanel.test.tsx
@@ -1,0 +1,161 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EdgeFunctionsDiffPanel } from 'components/interfaces/BranchManagement/EdgeFunctionsDiffPanel'
+import type { EdgeFunctionsDiffResult } from 'hooks/branches/useEdgeFunctionsDiff'
+import { customRender as render } from 'tests/lib/custom-render'
+
+// Monaco editor does not work in jsdom
+vi.mock('@/components/ui/DiffEditor', () => ({
+  DiffEditor: ({ original, modified }: { original: string; modified: string }) => (
+    <div data-testid="diff-editor" data-original={original} data-modified={modified} />
+  ),
+}))
+
+const baseDiffResults: EdgeFunctionsDiffResult = {
+  addedSlugs: [],
+  removedSlugs: [],
+  modifiedSlugs: [],
+  addedBodiesMap: {},
+  removedBodiesMap: {},
+  currentBodiesMap: {},
+  mainBodiesMap: {},
+  functionFileInfo: {},
+  isLoading: false,
+  hasChanges: false,
+  refetchCurrentBranchFunctions: vi.fn(),
+  refetchMainBranchFunctions: vi.fn(),
+  clearDiffsOptimistically: vi.fn(),
+}
+
+describe('EdgeFunctionsDiffPanel', () => {
+  it('shows no-changes state when there are no added, modified, or removed functions', () => {
+    render(<EdgeFunctionsDiffPanel diffResults={baseDiffResults} currentBranchRef="branch-ref" />)
+
+    expect(screen.getByText('No changes detected between branches')).toBeInTheDocument()
+  })
+
+  it('does NOT show no-changes state when there are only removed functions', () => {
+    const diffResults: EdgeFunctionsDiffResult = {
+      ...baseDiffResults,
+      removedSlugs: ['my-function'],
+      removedBodiesMap: {
+        'my-function': {
+          files: [{ name: 'index.ts', content: 'Deno.serve(() => new Response("hello"))' }],
+        },
+      },
+      functionFileInfo: {
+        'my-function': [{ key: 'index.ts', status: 'removed' }],
+      },
+      hasChanges: true,
+    }
+
+    render(<EdgeFunctionsDiffPanel diffResults={diffResults} currentBranchRef="branch-ref" />)
+
+    expect(screen.queryByText('No changes detected between branches')).not.toBeInTheDocument()
+  })
+
+  it('renders removed function slugs as links', () => {
+    const diffResults: EdgeFunctionsDiffResult = {
+      ...baseDiffResults,
+      removedSlugs: ['deleted-fn'],
+      removedBodiesMap: {
+        'deleted-fn': {
+          files: [{ name: 'index.ts', content: 'export default () => {}' }],
+        },
+      },
+      functionFileInfo: {
+        'deleted-fn': [{ key: 'index.ts', status: 'removed' }],
+      },
+      hasChanges: true,
+    }
+
+    render(<EdgeFunctionsDiffPanel diffResults={diffResults} currentBranchRef="branch-ref" />)
+
+    expect(screen.getByText('deleted-fn')).toBeInTheDocument()
+  })
+
+  it('renders all removed function slugs when multiple functions are removed', () => {
+    const diffResults: EdgeFunctionsDiffResult = {
+      ...baseDiffResults,
+      removedSlugs: ['fn-alpha', 'fn-beta'],
+      removedBodiesMap: {
+        'fn-alpha': {
+          files: [{ name: 'index.ts', content: 'export default () => {}' }],
+        },
+        'fn-beta': {
+          files: [{ name: 'index.ts', content: 'export default () => {}' }],
+        },
+      },
+      functionFileInfo: {
+        'fn-alpha': [{ key: 'index.ts', status: 'removed' }],
+        'fn-beta': [{ key: 'index.ts', status: 'removed' }],
+      },
+      hasChanges: true,
+    }
+
+    render(<EdgeFunctionsDiffPanel diffResults={diffResults} currentBranchRef="branch-ref" />)
+
+    expect(screen.getByText('fn-alpha')).toBeInTheDocument()
+    expect(screen.getByText('fn-beta')).toBeInTheDocument()
+  })
+
+  it('shows a diff editor for each removed function file', () => {
+    const diffResults: EdgeFunctionsDiffResult = {
+      ...baseDiffResults,
+      removedSlugs: ['removed-fn'],
+      removedBodiesMap: {
+        'removed-fn': {
+          files: [{ name: 'index.ts', content: 'Deno.serve(() => new Response("bye"))' }],
+        },
+      },
+      functionFileInfo: {
+        'removed-fn': [{ key: 'index.ts', status: 'removed' }],
+      },
+      hasChanges: true,
+    }
+
+    render(<EdgeFunctionsDiffPanel diffResults={diffResults} currentBranchRef="branch-ref" />)
+
+    const editors = screen.getAllByTestId('diff-editor')
+    expect(editors.length).toBeGreaterThan(0)
+    // For a removed function: original is main content, modified is empty
+    expect(editors[0]).toHaveAttribute('data-modified', '')
+  })
+
+  it('shows added functions without no-changes state', () => {
+    const diffResults: EdgeFunctionsDiffResult = {
+      ...baseDiffResults,
+      addedSlugs: ['new-fn'],
+      addedBodiesMap: {
+        'new-fn': {
+          files: [{ name: 'index.ts', content: 'Deno.serve(() => new Response("hi"))' }],
+        },
+      },
+      functionFileInfo: {
+        'new-fn': [{ key: 'index.ts', status: 'added' }],
+      },
+      hasChanges: true,
+    }
+
+    render(<EdgeFunctionsDiffPanel diffResults={diffResults} currentBranchRef="branch-ref" />)
+
+    expect(screen.queryByText('No changes detected between branches')).not.toBeInTheDocument()
+    expect(screen.getByText('new-fn')).toBeInTheDocument()
+  })
+
+  it('renders a loading skeleton while data is loading', () => {
+    const diffResults: EdgeFunctionsDiffResult = {
+      ...baseDiffResults,
+      isLoading: true,
+    }
+
+    const { container } = render(
+      <EdgeFunctionsDiffPanel diffResults={diffResults} currentBranchRef="branch-ref" />
+    )
+
+    expect(screen.queryByText('No changes detected between branches')).not.toBeInTheDocument()
+    // Skeleton is rendered as a div with an animate-pulse class
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #44175

When an edge function is removed or disabled from `config.toml` on a preview branch, the **Edge Functions** tab on the merge page shows **"No changes detected between branches"** — hiding the deletion entirely. The function appears to still be deployed even though the branch removed it.

**Steps to reproduce:**
1. Enable branching on a Supabase project (Pro + GitHub integration)
2. Deploy an edge function on the main branch
3. Create a preview branch
4. On the branch, remove the `[functions.your-function]` section from `supabase/config.toml`
5. Push the branch
6. Open the merge page → **Edge Functions** tab

**Before:** "No changes detected between branches" — removal is completely invisible  
**After:** The removed function is shown with a deletion diff

## Root cause

`useEdgeFunctionsDiff` already computed `removedSlugs` correctly (functions on main that are absent from the branch). The rendering block for removed functions was **commented out** with a `TODO`:

```tsx
{/* TODO: Removing functions is not supported yet */}
{/* {diffResults.removedSlugs.length > 0 && ( ... )} */}
```

Three bugs inside the commented block also needed fixing before it could be enabled:

| Bug | Old code | Fixed code |
|-----|----------|------------|
| `noChanges` excluded removed slugs | `addedSlugs.length === 0 && modifiedSlugs.length === 0` | `&& removedSlugs.length === 0` added |
| Wrong `currentBody` type | `currentBody={EMPTY_ARR}` (`never[]`) | `currentBody={EMPTY_FUNCTION_BODY}` (`EdgeFunctionBodyData`) |
| Out-of-scope variable | `currentBranchRef={mainBranchRef}` (not in scope) | `currentBranchRef={currentBranchRef}` (prop) |

## Changes

- `apps/studio/components/interfaces/BranchManagement/EdgeFunctionsDiffPanel.tsx`
  - Fix `noChanges` guard to include `removedSlugs`
  - Uncomment and fix the removed-functions rendering block

## Tests

New file: `apps/studio/tests/features/branches/EdgeFunctionsDiffPanel.test.tsx`

- `noChanges` state only shown when all three slug arrays are empty
- Removed functions do **not** trigger "no changes" state (regression for the bug)
- Removed function slugs are rendered as links
- Multiple removed slugs are all rendered
- Diff editor receives empty `modified` value (correct deletion view)
- Added functions still render correctly (regression guard)
- Loading skeleton renders while `isLoading: true`

## Checklist

- [x] `npm run build` passes locally (no new type errors introduced — changes are additive)
- [x] Prettier formatting consistent with surrounding code
- [x] Tests added covering the fixed behaviour