### PR TITLE
fix: hide tax id banner for billing partner orgs

### DIFF
--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -23,6 +23,7 @@ export const TaxIdBanner = () => {
   const shouldFetch = Boolean(
     !!slug &&
     org?.plan?.id !== 'free' &&
+    !org.billing_partner &&
     isDismissLoaded &&
     !isDismissed &&
     !!org?.organization_missing_tax_id
@@ -39,6 +40,7 @@ export const TaxIdBanner = () => {
     router.pathname.includes('sign-in') ||
     !org ||
     org.plan?.id === 'free' ||
+    org.billing_partner ||
     !isDismissLoaded ||
     isDismissed ||
     !org.organization_missing_tax_id ||

--- a/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/TaxIdBanner.tsx
@@ -23,7 +23,7 @@ export const TaxIdBanner = () => {
   const shouldFetch = Boolean(
     !!slug &&
     org?.plan?.id !== 'free' &&
-    !org.billing_partner &&
+    !org?.billing_partner &&
     isDismissLoaded &&
     !isDismissed &&
     !!org?.organization_missing_tax_id


### PR DESCRIPTION
### Changes
- (shouldFetch): `!org.billing_partner` - prevents the unnecessary API call to fetch the customer profile for partner orgs.
- (early return guard): `org.billing_partner` - returns null (hides the banner) when the org has a billing partner.